### PR TITLE
[ci] build PHP70 only on prefixed branches

### DIFF
--- a/.github/workflows/build_scoped_rector_php70.yaml
+++ b/.github/workflows/build_scoped_rector_php70.yaml
@@ -3,11 +3,13 @@
 name: Build Scoped Rector PHP 7.0
 
 on:
-    push:
-        branches:
-            - main
-        tags:
-            - '*'
+#    push:
+#        branches:
+#            - main
+#        tags:
+#            - '*'
+    pull_request:
+        - php70-*
 
 env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361


### PR DESCRIPTION
@samsonasik Currently this workflow makes CI fail everytime. I've got some confusing feedback that Rector is broken and it was caused by another PR contributors.

This should make sure the `main` branch is clean and you can invoke the build with a propper branch name.
Maybe the syntax is sligthly differnt, but the idea should be clear.