### PR TITLE
[BUGFIX] Remove redundant new line

### DIFF
--- a/packages/FileFormatter/Formatter/YamlFileFormatter.php
+++ b/packages/FileFormatter/Formatter/YamlFileFormatter.php
@@ -29,8 +29,6 @@ final class YamlFileFormatter implements FileFormatterInterface
 
         $newFileContent = Yaml::dump($yaml, 99, $editorConfigConfiguration->getIndentSize());
 
-        $newFileContent .= $editorConfigConfiguration->getFinalNewline();
-
         $file->changeFileContent($newFileContent);
     }
 


### PR DESCRIPTION
- During the Yaml::dump a final new line is already added. No need to add it twice