### PR TITLE
remove last empty token on new printed content; go for newline by default as best practise conventions

### DIFF
--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -9,7 +9,6 @@ use Rector\ChangesReporting\ValueObjectFactory\ErrorFactory;
 use Rector\Core\Application\FileDecorator\FileDiffFileDecorator;
 use Rector\Core\Application\FileProcessor;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesCollector;
-use Rector\Core\Application\FileSystem\RemovedAndAddedFilesProcessor;
 use Rector\Core\Configuration\Configuration;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;

--- a/src/PhpParser/Printer/NodesWithFileDestinationPrinter.php
+++ b/src/PhpParser/Printer/NodesWithFileDestinationPrinter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\Printer;
 
-use Nette\Utils\Strings;
-use PhpParser\Lexer;
 use Rector\FileSystemRector\Contract\FileWithNodesInterface;
 use Rector\PostRector\Application\PostFileProcessor;
 
@@ -13,7 +11,6 @@ final class NodesWithFileDestinationPrinter
 {
     public function __construct(
         private BetterStandardPrinter $betterStandardPrinter,
-        private Lexer $lexer,
         private PostFileProcessor $postFileProcessor
     ) {
     }
@@ -21,23 +18,6 @@ final class NodesWithFileDestinationPrinter
     public function printNodesWithFileDestination(FileWithNodesInterface $fileWithNodes): string
     {
         $nodes = $this->postFileProcessor->traverse($fileWithNodes->getNodes());
-        $prettyPrintContent = $this->betterStandardPrinter->prettyPrintFile($nodes);
-
-        return $this->resolveLastEmptyLine($prettyPrintContent);
-    }
-
-    /**
-     * Add empty line in the end, if it is in the original tokens
-     */
-    private function resolveLastEmptyLine(string $prettyPrintContent): string
-    {
-        $tokens = $this->lexer->getTokens();
-        $lastToken = array_pop($tokens);
-
-        if ($lastToken && isset($lastToken[1]) && Strings::contains($lastToken[1], "\n")) {
-            $prettyPrintContent = trim($prettyPrintContent) . PHP_EOL;
-        }
-
-        return $prettyPrintContent;
+        return $this->betterStandardPrinter->prettyPrintFile($nodes);
     }
 }


### PR DESCRIPTION
- Closes https://github.com/rectorphp/rector-src/pull/10
- Closes https://github.com/rectorphp/rector/issues/6403