### PR TITLE
[Scoped 7.1] Run bin/rector in rector-prefixed-downgraded to ensure AUTO_IMPORT_NAMES applied

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -58,6 +58,7 @@ jobs:
             -   run: |
                     cp -R build/target-repository/. rector-prefixed-downgraded
                     cp -R templates rector-prefixed-downgraded/
+                    cd rector-prefixed-downgraded && bin/rector && rm -rf rector.php && cd ..
 
             # 6. clone remote repository, so we can push it
             -

--- a/build/target-repository/rector.php
+++ b/build/target-repository/rector.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/rules',
+        __DIR__ . '/packages',
+        __DIR__ . '/config/set',
+    ]);
+
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+
+    $parameters->set(Option::SKIP, [
+        // test paths
+        '*/Fixture/*',
+        '*/Fixture*/*',
+        '*/Source/*',
+        '*/Source*/*',
+        '*/Expected/*',
+        '*/Expected*/*',
+    ]);
+
+    $parameters->set(Option::ENABLE_CACHE, true);
+};

--- a/build/target-repository/rector.php
+++ b/build/target-repository/rector.php
@@ -16,16 +16,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     ]);
 
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
-
-    $parameters->set(Option::SKIP, [
-        // test paths
-        '*/Fixture/*',
-        '*/Fixture*/*',
-        '*/Source/*',
-        '*/Source*/*',
-        '*/Expected/*',
-        '*/Expected*/*',
-    ]);
-
     $parameters->set(Option::ENABLE_CACHE, true);
 };


### PR DESCRIPTION
To ensure make auto import names applied in generated prefixed to avoid long fqcn like this:


https://github.com/rectorphp/rector/blob/907c0dcefa8532110bf07bd83f179de908b57c86/src/Bootstrap/RectorConfigsResolver.php#L32

to be changed to : 

```php
    public function resolveFromConfigFileInfo(SmartFileInfo $configFileInfo) : array
```

as already in use statement.