### PR TITLE
Fix fatal error when bootstrap file does not exist

### DIFF
--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -26,7 +26,7 @@ final class BootstrapFilesIncluder
 
         foreach ($bootstrapFiles as $bootstrapFile) {
             if (! is_file($bootstrapFile)) {
-                throw new ShouldNotHappenException('Bootstrap file %s does not exist.', $bootstrapFile);
+                throw new ShouldNotHappenException(sprintf('Bootstrap file "%s" does not exist.', $bootstrapFile));
             }
 
             try {


### PR DESCRIPTION
When the option bootstrap_files contains a file that does not exist, `vendor/bin/rector process` will crashing with fatal error.

```
PHP Fatal error:  Uncaught TypeError: Exception::__construct(): Argument #2 ($code) must be of type int, string given in /home/runner/work/coding-standard/coding-standard/vendor/rector/rector/src/Exception/ShouldNotHappenException.php:22
```
It is missing `sprintf()` here
https://github.com/rectorphp/rector-src/blob/298c97a3bc72aed972935eea80eae14de2fca35e/src/Autoloading/BootstrapFilesIncluder.php#L29