### PR TITLE
FX do not allow rector rules packages installed with latest 0.11 rector

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -22,6 +22,12 @@
     "conflict": {
         "phpstan/phpdoc-parser": "<=0.5.3",
         "phpstan/phpstan": "<=0.12.82",
-        "rector/rector-prefixed": "*"
+        "rector/rector-prefixed": "*",
+        "rector/rector-phpunit": "*",
+        "rector/rector-symfony": "*",
+        "rector/rector-doctrine": "*",
+        "rector/rector-nette": "*",
+        "rector/rector-nette-to-symfony": "*",
+        "rector/rector-cakephp": "*"
     }
 }


### PR DESCRIPTION
All these rules are now bundled. Having them installed as separate packages will result in unpredicted behavior.

Follow up from https://github.com/rectorphp/rector-symfony/issues/12