### PR TITLE
[Php80] Skip callable type on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type.php.inc
@@ -10,7 +10,7 @@ final class SkipCallableType
     /**
      * @param mixed[] $cache
      */
-    public function __construct(callable $fallback)
+    public function __construct(callable $fallback, private array $cache = [])
     {
         $this->fallback = $fallback;
     }

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class SkipCallableType
+{
+    /** @var callable */
+    private $fallback;
+
+    /**
+     * @param mixed[] $cache
+     */
+    public function __construct(callable $fallback)
+    {
+        $this->fallback = $fallback;
+    }
+}
+
+?>

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Php80\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -94,6 +95,10 @@ CODE_SAMPLE
             $param = $promotionCandidate->getParam();
 
             if ($param->variadic) {
+                continue;
+            }
+
+            if ($param->type instanceof Identifier && $this->isName($param->type, 'callable')) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6421