### PR TITLE
Improve DowngradeStreamIsattyRector when stream_isatty is available

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector/Fixture/return_is.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector/Fixture/return_is.php.inc
@@ -21,11 +21,19 @@ class SomeClass
     public function run($stream)
     {
         $streamIsatty = function ($stream) {
+            if (\function_exists('stream_isatty')) {
+                return stream_isatty($stream);
+            }
+            if (!\is_resource($stream)) {
+                trigger_error('stream_isatty() expects parameter 1 to be resource, ' . \gettype($stream) . ' given', \E_USER_WARNING);
+                return false;
+            }
             if ('\\' === \DIRECTORY_SEPARATOR) {
                 $stat = @fstat($stream);
+                // Check if formatted mode is S_IFCHR
                 return $stat ? 020000 === ($stat['mode'] & 0170000) : false;
             }
-            return @posix_isatty($stream);
+            return \function_exists('posix_isatty') && @posix_isatty($stream);
         };
         return $streamIsatty($stream);
     }

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector/Fixture/return_or.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector/Fixture/return_or.php.inc
@@ -32,11 +32,19 @@ final class UnionOr
     public static function detectColors(): bool
     {
         $streamIsatty = function ($stream) {
+            if (\function_exists('stream_isatty')) {
+                return stream_isatty($stream);
+            }
+            if (!\is_resource($stream)) {
+                trigger_error('stream_isatty() expects parameter 1 to be resource, ' . \gettype($stream) . ' given', \E_USER_WARNING);
+                return false;
+            }
             if ('\\' === \DIRECTORY_SEPARATOR) {
                 $stat = @fstat($stream);
+                // Check if formatted mode is S_IFCHR
                 return $stat ? 020000 === ($stat['mode'] & 0170000) : false;
             }
-            return @posix_isatty($stream);
+            return \function_exists('posix_isatty') && @posix_isatty($stream);
         };
         return (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')
             && getenv('NO_COLOR') === false // https://no-color.org

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector/Fixture/some_class.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector/Fixture/some_class.php.inc
@@ -21,11 +21,19 @@ class SomeClass
     public function run($stream)
     {
         $streamIsatty = function ($stream) {
+            if (\function_exists('stream_isatty')) {
+                return stream_isatty($stream);
+            }
+            if (!\is_resource($stream)) {
+                trigger_error('stream_isatty() expects parameter 1 to be resource, ' . \gettype($stream) . ' given', \E_USER_WARNING);
+                return false;
+            }
             if ('\\' === \DIRECTORY_SEPARATOR) {
                 $stat = @fstat($stream);
+                // Check if formatted mode is S_IFCHR
                 return $stat ? 020000 === ($stat['mode'] & 0170000) : false;
             }
-            return @posix_isatty($stream);
+            return \function_exists('posix_isatty') && @posix_isatty($stream);
         };
         $isStream = $streamIsatty($stream);
     }

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector.php
@@ -49,11 +49,23 @@ class SomeClass
     public function run($stream)
     {
         $streamIsatty = function ($stream) {
+            if (\function_exists('stream_isatty')) {
+                return stream_isatty($stream);
+            }
+
+            if (!\is_resource($stream)) {
+                trigger_error('stream_isatty() expects parameter 1 to be resource, '.\gettype($stream).' given', \E_USER_WARNING);
+
+                return false;
+            }
+
             if ('\\' === \DIRECTORY_SEPARATOR) {
                 $stat = @fstat($stream);
-                return $stat ? 020000 === ($stat['mode'] & 0170000) : false;
+                // Check if formatted mode is S_IFCHR
+                return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
             }
-            return @posix_isatty($stream);
+
+            return \function_exists('posix_isatty') && @posix_isatty($stream);
         };
         $isStream = $streamIsatty($stream);
     }

--- a/rules/DowngradePhp72/snippet/isatty_closure.php.inc
+++ b/rules/DowngradePhp72/snippet/isatty_closure.php.inc
@@ -1,6 +1,10 @@
 <?php
 
 function ($stream) {
+    if (\function_exists('stream_isatty')) {
+        return stream_isatty($stream);
+    }
+
     if (!\is_resource($stream)) {
         trigger_error('stream_isatty() expects parameter 1 to be resource, '.\gettype($stream).' given', \E_USER_WARNING);
 

--- a/rules/DowngradePhp72/snippet/isatty_closure.php.inc
+++ b/rules/DowngradePhp72/snippet/isatty_closure.php.inc
@@ -1,9 +1,17 @@
 <?php
 
 function ($stream) {
+    if (!\is_resource($stream)) {
+        trigger_error('stream_isatty() expects parameter 1 to be resource, '.\gettype($stream).' given', \E_USER_WARNING);
+
+        return false;
+    }
+
     if ('\\' === \DIRECTORY_SEPARATOR) {
         $stat = @fstat($stream);
-        return $stat ? 020000 === ($stat['mode'] & 0170000) : false;
+        // Check if formatted mode is S_IFCHR
+        return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
     }
-    return @posix_isatty($stream);
+
+    return \function_exists('posix_isatty') && @posix_isatty($stream);
 };


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/6416

I had originally believed that `symfony/console` might have a solution that'd work better as it inverts the order of operations. Further investigation showed that Rector already sourced the implementation from Symfony's Polyfills. Running under the assumption that the [implementation in `symfony/polyfill-php72`](https://github.com/symfony/polyfill-php72/blob/main/Php72.php#L134-L149) is highly used & tested, `rules/DowngradePhp72/snippet/isatty_closure.php.inc` has been updated to use the latest implementation. 

In practice, this adds a `function_exists` call verifying that `posix_isatty` is available which is not always the case.

Additionally, given it appears the intent is to downgrade to support lower minimum requirements, this change also adds a check to see if `stream_isatty` is available and uses the originally intended function when found. My hope here is that PHP >=7.2 is fully supported with mostly unmodified function calls, while <7.2 is supported with the polyfill implementation.