### PR TITLE
[GitAttributes] Add e2e directory to .gitattributes

### DIFF
--- a/build/target-repository/.gitattributes
+++ b/build/target-repository/.gitattributes
@@ -21,6 +21,7 @@ Dockerfile export-ignore
 docs/images export-ignore
 .docker export-ignore
 .github export-ignore
+e2e export-ignore
 .dockerignore export-ignore
 
 # testing Windows spaces - https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings


### PR DESCRIPTION
To remove `e2e` on required via composer: 

```bash
$ composer require rector/rector
$ tree -L 1 -a vendor/rector/rector/
vendor/rector/rector/
├── LICENSE
├── README.md
├── UPGRADE.md
├── bin
├── bootstrap.php
├── composer.json
├── config
├── docs
├── e2e       <-- to remove this
├── packages
├── preload.php
├── rules
├── src
├── templates
├── upgrade
└── vendor

10 directories, 6 files
```