### PR TITLE
[PHP 8.0] Add DoctrineAnnotationClassToAttributeRector

### DIFF
--- a/packages/PhpAttribute/Printer/PhpAttributeGroupFactory.php
+++ b/packages/PhpAttribute/Printer/PhpAttributeGroupFactory.php
@@ -24,7 +24,12 @@ final class PhpAttributeGroupFactory
 {
     public function createFromSimpleTag(AnnotationToAttribute $annotationToAttribute): AttributeGroup
     {
-        $fullyQualified = new FullyQualified($annotationToAttribute->getAttributeClass());
+        return $this->createFromClass($annotationToAttribute->getAttributeClass());
+    }
+
+    public function createFromClass(string $attributeClass): AttributeGroup
+    {
+        $fullyQualified = new FullyQualified($attributeClass);
         $attribute = new Attribute($fullyQualified);
         return new AttributeGroup([$attribute]);
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -479,3 +479,7 @@ parameters:
         -
             message: '#Do not use chained method calls#'
             path: packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+
+        -
+            message: '#Function "dump_node\(\)" cannot be used/left in the code#'
+            path: src/functions/node_helper.php

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/DoctrineAnnotationClassToAttributeRectorTest.php
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/DoctrineAnnotationClassToAttributeRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DoctrineAnnotationClassToAttributeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/none_target.php.inc
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/none_target.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+/**
+ * @Annotation
+ */
+final class NoneTarget
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+#[\Attribute]
+final class NoneTarget
+{
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/required_value.php.inc
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/required_value.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+use Doctrine\Common\Annotations\Annotation\Required;
+
+/**
+ * @annotation
+ */
+final class RequiredValue
+{
+    /** @Required */
+    public $requiredField;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+use Doctrine\Common\Annotations\Annotation\Required;
+
+#[\Attribute]
+final class RequiredValue
+{
+    public function __construct(public $requiredField)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/some_class.php.inc
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/some_class.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * @Annotation
+ * @Target({"METHOD"})
+ */
+class SomeAnnotation
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class SomeAnnotation
+{
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/target_method_property_class.php.inc
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/Fixture/target_method_property_class.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * @Annotation
+ * @Target({"METHOD", "PROPERTY", "CLASS"})
+ */
+final class TargetMethodPropertyClass
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\Fixture;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_CLASS)]
+final class TargetMethodPropertyClass
+{
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DoctrineAnnotationClassToAttributeRector::class);
+};

--- a/rules/Arguments/Rector/MethodCall/ValueObjectWrapArgRector.php
+++ b/rules/Arguments/Rector/MethodCall/ValueObjectWrapArgRector.php
@@ -19,6 +19,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Arguments\Rector\MethodCall\ValueObjectWrapArgRector\ValueObjectWrapArgRectorTest
@@ -111,7 +112,10 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->valueObjectWrapArgs = $configuration[self::VALUE_OBJECT_WRAP_ARGS] ?? [];
+        $valueObjectWrapArgs = $configuration[self::VALUE_OBJECT_WRAP_ARGS] ?? [];
+        Assert::allIsInstanceOf($valueObjectWrapArgs, ValueObjectWrapArg::class);
+
+        $this->valueObjectWrapArgs = $valueObjectWrapArgs;
     }
 
     private function wrapInNewWithType(ObjectType $newObjectType, Expr $expr): New_

--- a/rules/Composer/Rector/AddPackageToRequireComposerRector.php
+++ b/rules/Composer/Rector/AddPackageToRequireComposerRector.php
@@ -10,6 +10,7 @@ use Rector\Composer\ValueObject\PackageAndVersion;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Composer\Rector\AddPackageToRequireComposerRector\AddPackageToRequireComposerRectorTest
@@ -67,6 +68,8 @@ CODE_SAMPLE
     public function configure(array $configuration): void
     {
         $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? [];
+        Assert::allIsInstanceOf($packagesAndVersions, PackageAndVersion::class);
+
         $this->versionGuard->validate($packagesAndVersions);
         $this->packagesAndVersions = $packagesAndVersions;
     }

--- a/rules/Composer/Rector/AddPackageToRequireDevComposerRector.php
+++ b/rules/Composer/Rector/AddPackageToRequireDevComposerRector.php
@@ -10,6 +10,7 @@ use Rector\Composer\ValueObject\PackageAndVersion;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Composer\Rector\AddPackageToRequireDevComposerRector\AddPackageToRequireDevComposerRectorTest
@@ -70,6 +71,8 @@ CODE_SAMPLE
     public function configure(array $configuration): void
     {
         $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? [];
+        Assert::allIsInstanceOf($packagesAndVersions, PackageAndVersion::class);
+
         $this->versionGuard->validate($packagesAndVersions);
         $this->packageAndVersions = $packagesAndVersions;
     }

--- a/rules/Composer/Rector/ChangePackageVersionComposerRector.php
+++ b/rules/Composer/Rector/ChangePackageVersionComposerRector.php
@@ -10,6 +10,7 @@ use Rector\Composer\ValueObject\PackageAndVersion;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Composer\Rector\ChangePackageVersionComposerRector\ChangePackageVersionComposerRectorTest
@@ -73,6 +74,8 @@ CODE_SAMPLE
     public function configure(array $configuration): void
     {
         $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? [];
+        Assert::allIsInstanceOf($packagesAndVersions, PackageAndVersion::class);
+
         $this->versionGuard->validate($packagesAndVersions);
         $this->packagesAndVersions = $packagesAndVersions;
     }

--- a/rules/Composer/Rector/RenamePackageComposerRector.php
+++ b/rules/Composer/Rector/RenamePackageComposerRector.php
@@ -9,6 +9,7 @@ use Rector\Composer\ValueObject\RenamePackage;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Composer\Rector\RenamePackageComposerRector\RenamePackageComposerRectorTest
@@ -78,6 +79,8 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->renamePackages = $configuration[self::RENAME_PACKAGES] ?? [];
+        $renamePackages = $configuration[self::RENAME_PACKAGES] ?? [];
+        Assert::allIsInstanceOf($renamePackages, RenamePackage::class);
+        $this->renamePackages = $renamePackages;
     }
 }

--- a/rules/Composer/Rector/ReplacePackageAndVersionComposerRector.php
+++ b/rules/Composer/Rector/ReplacePackageAndVersionComposerRector.php
@@ -10,6 +10,7 @@ use Rector\Composer\ValueObject\ReplacePackageAndVersion;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Composer\Rector\ReplacePackageAndVersionComposerRector\ReplacePackageAndVersionComposerRectorTest
@@ -78,6 +79,8 @@ CODE_SAMPLE
     public function configure(array $configuration): void
     {
         $replacePackagesAndVersions = $configuration[self::REPLACE_PACKAGES_AND_VERSIONS] ?? [];
+        Assert::allIsInstanceOf($replacePackagesAndVersions, ReplacePackageAndVersion::class);
+
         $this->versionGuard->validate($replacePackagesAndVersions);
         $this->replacePackagesAndVersions = $replacePackagesAndVersions;
     }

--- a/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\MixedType;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
+use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
+use Rector\Core\Rector\AbstractRector;
+use Rector\PhpAttribute\Printer\PhpAttributeGroupFactory;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://php.watch/articles/php-attributes#syntax
+ *
+ * @see https://github.com/doctrine/annotations/blob/1.13.x/lib/Doctrine/Common/Annotations/Annotation/Target.php
+ * @see https://github.com/doctrine/annotations/blob/c66f06b7c83e9a2a7523351a9d5a4b55f885e574/docs/en/custom.rst#annotation-required
+ *
+ * @see \Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\DoctrineAnnotationClassToAttributeRectorTest
+ */
+final class DoctrineAnnotationClassToAttributeRector extends AbstractRector
+{
+    /**
+     * @see https://github.com/doctrine/annotations/blob/e6e7b7d5b45a2f2abc5460cc6396480b2b1d321f/lib/Doctrine/Common/Annotations/Annotation/Target.php#L24-L29
+     * @var array<string, string>
+     */
+    private const TARGET_TO_CONSTANT_MAP = [
+        'METHOD' => 'TARGET_METHOD',
+        'PROPERTY' => 'TARGET_PROPERTY',
+        'CLASS' => 'TARGET_CLASS',
+        'FUNCTION' => 'TARGET_FUNCTION',
+        'ALL' => 'TARGET_ALL',
+<<<<<<< HEAD
+=======
+        // special case
+        'ANNOTATION' => 'TARGET_CLASS',
+>>>>>>> 2d68f859f ([PHP 8.0] Add DoctrineAnnotationClassToAttributeRector)
+    ];
+
+    public function __construct(
+        private PhpDocTagRemover $phpDocTagRemover,
+        private PhpAttributeGroupFactory $phpAttributeGroupFactory
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Refactor Doctrine @annotation annotated class to a PHP 8.0 attribute class', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * @Annotation
+ * @Target({"METHOD"})
+ */
+class SomeAnnotation
+{
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class SomeAnnotation
+{
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        if (! $phpDocInfo->hasByNames(['Annotation', 'annotation'])) {
+            return null;
+        }
+
+        $this->phpDocTagRemover->removeByName($phpDocInfo, 'annotation');
+        $this->phpDocTagRemover->removeByName($phpDocInfo, 'Annotation');
+
+        $attributeGroup = $this->phpAttributeGroupFactory->createFromClass('Attribute');
+        $this->decorateTarget($phpDocInfo, $attributeGroup);
+
+        foreach ($node->getProperties() as $property) {
+            $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
+            if (! $propertyPhpDocInfo instanceof PhpDocInfo) {
+                continue;
+            }
+
+            $requiredDoctrineAnnotationTagValueNode = $propertyPhpDocInfo->getByAnnotationClass(
+                'Doctrine\Common\Annotations\Annotation\Required'
+            );
+            if (! $requiredDoctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
+                continue;
+            }
+
+            $this->phpDocTagRemover->removeTagValueFromNode(
+                $propertyPhpDocInfo,
+                $requiredDoctrineAnnotationTagValueNode
+            );
+
+            // require in constructor
+            $propertyName = $this->getName($property);
+            $this->addConstructorDependencyToClass($node, new MixedType(), $propertyName, Class_::MODIFIER_PUBLIC);
+            $this->removeNode($property);
+        }
+
+        $node->attrGroups[] = $attributeGroup;
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, mixed> $targetValues
+     * @return ClassConstFetch[]
+     */
+    private function resolveFlags(array $targetValues): array
+    {
+        $flags = [];
+        foreach (self::TARGET_TO_CONSTANT_MAP as $target => $constant) {
+            if (! in_array($target, $targetValues, true)) {
+                continue;
+            }
+
+            $flags[] = $this->nodeFactory->createClassConstFetch('Attribute', $constant);
+        }
+
+        return $flags;
+    }
+
+    /**
+     * @param ClassConstFetch[] $flags
+     * @return ClassConstFetch|BitwiseOr|null
+     */
+    private function createFlagCollection(array $flags): ?Expr
+    {
+        if ($flags === []) {
+            return null;
+        }
+
+        $flagCollection = array_shift($flags);
+        foreach ($flags as $flag) {
+            $flagCollection = new BitwiseOr($flagCollection, $flag);
+        }
+
+        return $flagCollection;
+    }
+
+    private function decorateTarget(PhpDocInfo $phpDocInfo, AttributeGroup $attributeGroup): void
+    {
+        $targetDoctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass(
+            'Doctrine\Common\Annotations\Annotation\Target'
+        );
+
+        if (! $targetDoctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
+            return;
+        }
+
+        $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $targetDoctrineAnnotationTagValueNode);
+
+        $targets = $targetDoctrineAnnotationTagValueNode->getSilentValue();
+        if (! $targets instanceof CurlyListNode) {
+            return;
+        }
+
+        $targetValues = $targets->getValuesWithExplicitSilentAndWithoutQuotes();
+
+        $flags = $this->resolveFlags($targetValues);
+        $flagCollection = $this->createFlagCollection($flags);
+        if ($flagCollection === null) {
+            return;
+        }
+
+        $attributeGroup->attrs[0]->args[] = new Arg($flagCollection);
+    }
+}

--- a/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
@@ -41,11 +41,8 @@ final class DoctrineAnnotationClassToAttributeRector extends AbstractRector
         'CLASS' => 'TARGET_CLASS',
         'FUNCTION' => 'TARGET_FUNCTION',
         'ALL' => 'TARGET_ALL',
-<<<<<<< HEAD
-=======
         // special case
         'ANNOTATION' => 'TARGET_CLASS',
->>>>>>> 2d68f859f ([PHP 8.0] Add DoctrineAnnotationClassToAttributeRector)
     ];
 
     public function __construct(

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;

--- a/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
+++ b/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
@@ -16,6 +16,7 @@ use Rector\Restoration\ValueObject\CompleteImportForPartialAnnotation;
 use Symplify\Astral\ValueObject\NodeBuilder\UseBuilder;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Restoration\Rector\Namespace_\CompleteImportForPartialAnnotationRector\CompleteImportForPartialAnnotationRectorTest
@@ -99,17 +100,20 @@ CODE_SAMPLE
     }
 
     /**
-     * @param CompleteImportForPartialAnnotation[][] $configuration
+     * @param array<string, CompleteImportForPartialAnnotation[]> $configuration
      */
     public function configure(array $configuration): void
     {
+        $useImportsToRestore = $configuration[self::USE_IMPORTS_TO_RESTORE] ?? [];
+        Assert::allIsInstanceOf($useImportsToRestore, CompleteImportForPartialAnnotation::class);
+
         $default = [
             new CompleteImportForPartialAnnotation('Doctrine\ORM\Mapping', 'ORM'),
             new CompleteImportForPartialAnnotation('Symfony\Component\Validator\Constraints', 'Assert'),
             new CompleteImportForPartialAnnotation('JMS\Serializer\Annotation', 'Serializer'),
         ];
 
-        $this->useImportsToRestore = array_merge($configuration[self::USE_IMPORTS_TO_RESTORE] ?? [], $default);
+        $this->useImportsToRestore = array_merge($useImportsToRestore, $default);
     }
 
     private function addImportToNamespaceIfMissing(

--- a/rules/Transform/Rector/MethodCall/ReplaceParentCallByPropertyCallRector.php
+++ b/rules/Transform/Rector/MethodCall/ReplaceParentCallByPropertyCallRector.php
@@ -11,6 +11,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Transform\ValueObject\ReplaceParentCallByPropertyCall;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Transform\Rector\MethodCall\ReplaceParentCallByPropertyCallRector\ReplaceParentCallByPropertyCallRectorTest
@@ -97,6 +98,9 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->parentCallToProperties = $configuration[self::PARENT_CALLS_TO_PROPERTIES] ?? [];
+        $parentCallToProperties = $configuration[self::PARENT_CALLS_TO_PROPERTIES] ?? [];
+        Assert::allIsInstanceOf($parentCallToProperties, ReplaceParentCallByPropertyCall::class);
+
+        $this->parentCallToProperties = $parentCallToProperties;
     }
 }


### PR DESCRIPTION
```diff
+use Attribute;
-use Doctrine\Common\Annotations\Annotation\Required;
-use Doctrine\Common\Annotations\Annotation\Target;

-/**
- * @Annotation
- * @Target({"METHOD"})
- */
+#[Attribute(Attribute::TARGET_METHOD)]
 class SomeAnnotation
```

- all or configurable



Closes https://github.com/rectorphp/rector/issues/6429