### PR TITLE
[Doc] Add CONTRIBUTING.md to point target development repo rector-src

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -58,6 +58,7 @@ jobs:
             -   run: |
                     cp -R build/target-repository/. rector-prefixed-downgraded
                     cp -R templates rector-prefixed-downgraded/
+                    cp CONTRIBUTING.md rector-prefixed-downgraded/
 
             # 6. clone remote repository, so we can push it
             -

--- a/.github/workflows/build_scoped_rector_php70.yaml
+++ b/.github/workflows/build_scoped_rector_php70.yaml
@@ -82,6 +82,7 @@ jobs:
             -   run: |
                     cp -R build/target-repository-php70/. rector-prefixed-downgraded-php70
                     cp -R templates rector-prefixed-downgraded-php70/
+                    cp CONTRIBUTING.md rector-prefixed-downgraded-php70/
 
             # 6. clone remote repository, so we can push it
             -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+## How to Contribute
+
+Contributions here are more than welcomed! You can contribute to [rector-src](https://github.com/rectorphp/rector-src) repository.
+
+There 3 rules will highly increase changes to get your PR merged:
+
+- **1 feature per pull-request**
+- **new features need tests**
+- CI must pass... you can mimic it locally by running
+
+    ```bash
+    composer complete-check
+    ```
+
+- Do you need to fix coding standards?
+
+    ```bash
+    composer fix-cs
+    ```
+
+We would be happy to accept PRs that follow these guidelines.

--- a/README.md
+++ b/README.md
@@ -15,23 +15,7 @@ Code of this repository requires PHP 8. For `rector/rector` package user the bui
 
 ## How to Contribute
 
-Contributions here are more than welcomed! There 3 rules will highly increase changes to get your PR merged:
-
-- **1 feature per pull-request**
-- **new features need tests**
-- CI must pass... you can mimic it locally by running
-
-    ```bash
-    composer complete-check
-    ```
-
-- Do you need to fix coding standards?
-
-    ```bash
-    composer fix-cs
-    ```
-
-We would be happy to accept PRs that follow these guidelines.
+Please read [contributing guideline](/CONTRIBUTING.md) for how to contribute to rector.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Based on https://github.com/rectorphp/rector/issues/6431#issuecomment-843267700 . The current `CONTRIBUTING.md` seems was left over https://github.com/rectorphp/rector/blob/main/CONTRIBUTING.md