### PR TITLE
[PHP 8.0] Downgrade `str_contains()`

### DIFF
--- a/config/set/downgrade-php80.php
+++ b/config/set/downgrade-php80.php
@@ -10,6 +10,7 @@ use Rector\DowngradePhp80\Rector\ClassConstFetch\DowngradeClassOnObjectToGetClas
 use Rector\DowngradePhp80\Rector\ClassMethod\DowngradeStaticTypeDeclarationRector;
 use Rector\DowngradePhp80\Rector\ClassMethod\DowngradeTrailingCommasInParamUseRector;
 use Rector\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector;
+use Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrContainsRector;
 use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector;
 use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeUnionTypeDeclarationRector;
 use Rector\DowngradePhp80\Rector\NullsafeMethodCall\DowngradeNullsafeToTernaryOperatorRector;
@@ -27,6 +28,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeStaticTypeDeclarationRector::class);
     $services->set(DowngradePropertyPromotionRector::class);
     $services->set(DowngradeNonCapturingCatchesRector::class);
+    $services->set(DowngradeStrContainsRector::class);
     $services->set(DowngradeMatchToSwitchRector::class);
     $services->set(DowngradeClassOnObjectToGetClassRector::class);
     $services->set(DowngradeNullsafeToTernaryOperatorRector::class);

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/DowngradeStrContainsRectorTest.php
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/DowngradeStrContainsRectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeStrContainsRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeStrContainsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     * @requires PHP 8.0
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+! str_contains('abc', 'b');
+
+?>
+-----
+<?php
+
+strstr('abc', 'b') === false;
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains.php.inc
@@ -6,6 +6,6 @@
 -----
 <?php
 
-strstr('abc', 'b') === false;
+strpos('abc', 'b') === false;
 
 ?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains_with_mixed.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains_with_mixed.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+! str_contains($haystack, 'ab');
+! str_contains('abc', $needle);
+
+?>
+-----
+<?php
+
+strpos($haystack, 'ab') === false;
+strpos('abc', $needle) === false;
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains_with_variables.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/not_str_contains_with_variables.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+! str_contains($haystack, $needle);
+
+?>
+-----
+<?php
+
+strpos($haystack, $needle) === false;
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php.inc
@@ -6,6 +6,6 @@ str_contains('abc', 'b');
 -----
 <?php
 
-strstr('abc', 'b') !== false;
+strpos('abc', 'b') !== false;
 
 ?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+str_contains('abc', 'b');
+
+?>
+-----
+<?php
+
+strstr('abc', 'b') !== false;
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php_with_mixed.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php_with_mixed.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+str_contains($haystack, 'ab');
+str_contains('abc', $needle);
+
+?>
+-----
+<?php
+
+strpos($haystack, 'ab') !== false;
+strpos('abc', $needle) !== false;
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php_with_variables.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/Fixture/str_contains.php_with_variables.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+str_contains($haystack, $needle);
+
+?>
+-----
+<?php
+
+strpos($haystack, $needle) !== false;
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrContainsRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeStrContainsRector::class);
+};

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
@@ -24,7 +24,7 @@ final class DowngradeStrContainsRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Replace str_contains() with strstr() !== false',
+            'Replace str_contains() with strpos() !== false',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
@@ -42,7 +42,7 @@ class SomeClass
 {
     public function run()
     {
-        return strstr('abc', 'a') !== false;
+        return strpos('abc', 'a') !== false;
     }
 }
 CODE_SAMPLE
@@ -75,7 +75,7 @@ CODE_SAMPLE
         $haystack = $funcCall->args[0]->value;
         /** @var string $needle */
         $needle = $funcCall->args[1]->value;
-        $funcCall = $this->nodeFactory->createFuncCall('strstr', [$haystack, $needle]);
+        $funcCall = $this->nodeFactory->createFuncCall('strpos', [$haystack, $needle]);
 
         if ($node instanceof BooleanNot) {
             return new Identical($funcCall, $this->nodeFactory->createFalse());

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
@@ -71,10 +71,9 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var string $haystack */
         $haystack = $funcCall->args[0]->value;
-        /** @var string $needle */
         $needle = $funcCall->args[1]->value;
+        
         $funcCall = $this->nodeFactory->createFuncCall('strpos', [$haystack, $needle]);
 
         if ($node instanceof BooleanNot) {

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/str_contains
+ *
+ * @see Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeStrContainsRector\DowngradeStrContainsRectorTest
+ */
+final class DowngradeStrContainsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace str_contains() with strstr() !== false',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return str_contains('abc', 'a');
+    }
+}
+CODE_SAMPLE
+,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return strstr('abc', 'a') !== false;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class, BooleanNot::class];
+    }
+
+    /**
+     * @param FuncCall|BooleanNot $node
+     * @return Identical|NotIdentical|null The refactored node.
+     */
+    public function refactor(Node $node): Identical | NotIdentical | null
+    {
+        $funcCall = $this->matchStrContainsOrNotStrContains($node);
+
+        if (! $funcCall instanceof FuncCall) {
+            return null;
+        }
+
+        /** @var string $haystack */
+        $haystack = $funcCall->args[0]->value;
+        /** @var string $needle */
+        $needle = $funcCall->args[1]->value;
+        $funcCall = $this->nodeFactory->createFuncCall('strstr', [$haystack, $needle]);
+
+        if ($node instanceof BooleanNot) {
+            return new Identical($funcCall, $this->nodeFactory->createFalse());
+        }
+        return new NotIdentical($funcCall, $this->nodeFactory->createFalse());
+    }
+
+    /**
+     * @param FuncCall|BooleanNot $expr
+     * @return FuncCall
+     */
+    private function matchStrContainsOrNotStrContains(Expr $expr): ?FuncCall
+    {
+        $expr = ($expr instanceof BooleanNot) ? $expr->expr : $expr;
+
+        if ($expr instanceof FuncCall) {
+            if ($this->isName($expr, 'str_contains')) {
+                return $expr;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Adds a rector for downgrading calls to PHP 8.0's `str_contains()` to `strpos() !== false` (ditto for `! str_contains()`).

`strpos()` used over `strstr()` because, as the returned substring is of no interest, `strpos()` is a less memory-intensive way of getting the same result as `strstr()`.

Partially closes https://github.com/rectorphp/rector/issues/6315