### PR TITLE
[Downgrade PHP 8.0] Add DowngradeAttributeToAnnotationRector

### DIFF
--- a/config/set/downgrade-php80.php
+++ b/config/set/downgrade-php80.php
@@ -33,4 +33,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeClassOnObjectToGetClassRector::class);
     $services->set(DowngradeNullsafeToTernaryOperatorRector::class);
     $services->set(DowngradeTrailingCommasInParamUseRector::class);
+    $services->set(\Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector::class);
 };

--- a/packages/PhpAttribute/Printer/DoctrineAnnotationFactory.php
+++ b/packages/PhpAttribute/Printer/DoctrineAnnotationFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PhpAttribute\Printer;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Scalar\String_;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class DoctrineAnnotationFactory
+{
+    public function __construct(
+        private BetterStandardPrinter $betterStandardPrinter
+    ) {
+    }
+
+    public function createFromAttribute(Attribute $attribute, string $className): DoctrineAnnotationTagValueNode
+    {
+        $items = $this->createItemsFromArgs($attribute->args);
+        return new DoctrineAnnotationTagValueNode($className, null, $items);
+    }
+
+    /**
+     * @param Arg[] $args
+     * @return mixed[]
+     */
+    private function createItemsFromArgs(array $args): array
+    {
+        $items = [];
+        foreach ($args as $arg) {
+            if ($arg->value instanceof String_) {
+                // standardize double quotes for annotations
+                $arg->value->setAttribute(AttributeKey::KIND, String_::KIND_DOUBLE_QUOTED);
+            }
+
+            $itemValue = $this->betterStandardPrinter->print($arg->value);
+            if ($arg->name !== null) {
+                $name = $this->betterStandardPrinter->print($arg->name);
+                $items[$name] = $itemValue;
+            } else {
+                $items[] = $itemValue;
+            }
+        }
+
+        return $items;
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/DowngradeAttributeToAnnotationRectorTest.php
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/DowngradeAttributeToAnnotationRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeAttributeToAnnotationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/some_class.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/some_class.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+final class SymfonyRoute
+{
+    #[Route(path: '/path', name: 'action')]
+    public function action()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+final class SymfonyRoute
+{
+    /**
+     * @\Symfony\Component\Routing\Annotation\Route(path="/path", name="action")
+     */
+    public function action()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/symfony_required.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/symfony_required.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+use Symfony\Contracts\Service\Attribute\Required;
+
+final class SymfonyRequired
+{
+    #[Required]
+    public function action()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+use Symfony\Contracts\Service\Attribute\Required;
+
+final class SymfonyRequired
+{
+    /**
+     * @required
+     */
+    public function action()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/config/configured_rule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
+use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(DowngradeAttributeToAnnotationRector::class)
+        ->call('configure', [[
+            DowngradeAttributeToAnnotationRector::ATTRIBUTE_TO_ANNOTATION => ValueObjectInliner::inline([
+                new DowngradeAttributeToAnnotation(
+                    'Symfony\Component\Routing\Annotation\Route',
+                    'Symfony\Component\Routing\Annotation\Route'
+                ),
+                new DowngradeAttributeToAnnotation('Symfony\Contracts\Service\Attribute\Required', 'required'),
+            ]),
+        ]]);
+};

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Rector\Class_;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
+use Rector\PhpAttribute\Printer\DoctrineAnnotationFactory;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @changelog https://php.watch/articles/php-attributes#syntax
+ *
+ * @see \Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\DowngradeAttributeToAnnotationRectorTest
+ */
+final class DowngradeAttributeToAnnotationRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    public const ATTRIBUTE_TO_ANNOTATION = 'attribute_to_annotation';
+
+    /**
+     * @var DowngradeAttributeToAnnotation[]
+     */
+    private array $attributesToAnnotations = [];
+
+    public function __construct(
+        private DoctrineAnnotationFactory $doctrineAnnotationFactory
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Refactor PHP attribute markers to annotations notation', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+use Symfony\Component\Routing\Annotation\Route;
+
+class SymfonyRoute
+{
+    #[Route(path: '/path', name: 'action')]
+    public function action()
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Symfony\Component\Routing\Annotation\Route;
+
+class SymfonyRoute
+{
+    /**
+     * @Route("/path", name="action")
+     */
+    public function action()
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                [
+                    self::ATTRIBUTE_TO_ANNOTATION => [
+                        new DowngradeAttributeToAnnotation(
+                            'Symfony\Component\Routing\Annotation\Route',
+                            'Symfony\Component\Routing\Annotation\Route'
+                        ),
+                    ],
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class, ClassMethod::class, Property::class];
+    }
+
+    /**
+     * @param Class_|ClassMethod|Property $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $key => $attribute) {
+                $attributeToAnnotation = $this->matchAttributeToAnnotation($attribute, $this->attributesToAnnotations);
+                if (! $attributeToAnnotation instanceof DowngradeAttributeToAnnotation) {
+                    continue;
+                }
+
+                unset($attrGroup->attrs[$key]);
+
+                if (! Strings::contains($attributeToAnnotation->getTag(), '\\')) {
+                    $phpDocInfo->addPhpDocTagNode(
+                        new PhpDocTagNode('@' . $attributeToAnnotation->getTag(), new GenericTagValueNode(''))
+                    );
+                } else {
+                    $doctrineAnnotation = $this->doctrineAnnotationFactory->createFromAttribute(
+                        $attribute,
+                        $attributeToAnnotation->getTag()
+                    );
+                    $phpDocInfo->addTagValueNode($doctrineAnnotation);
+                }
+            }
+        }
+
+        // cleanup empty attr groups
+        $this->cleanupEmptyAttrGroups($node);
+
+        return $node;
+    }
+
+    /**
+     * @param array<string, DowngradeAttributeToAnnotation[]> $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $attributesToAnnotations = $configuration[self::ATTRIBUTE_TO_ANNOTATION] ?? [];
+        Assert::allIsInstanceOf($attributesToAnnotations, DowngradeAttributeToAnnotation::class);
+
+        $this->attributesToAnnotations = $attributesToAnnotations;
+    }
+
+    private function cleanupEmptyAttrGroups(ClassMethod | Property | Class_ $node): void
+    {
+        foreach ($node->attrGroups as $key => $attrGroup) {
+            if (count($attrGroup->attrs) !== 0) {
+                continue;
+            }
+
+            unset($node->attrGroups[$key]);
+        }
+    }
+
+    /**
+     * @param DowngradeAttributeToAnnotation[] $attributesToAnnotations
+     */
+    private function matchAttributeToAnnotation(
+        Attribute $attribute,
+        array $attributesToAnnotations
+    ): ?DowngradeAttributeToAnnotation {
+        foreach ($attributesToAnnotations as $attributeToAnnotation) {
+            if (! $this->isName($attribute->name, $attributeToAnnotation->getAttributeClass())) {
+                continue;
+            }
+
+            return $attributeToAnnotation;
+        }
+
+        return null;
+    }
+}

--- a/rules/DowngradePhp80/ValueObject/DowngradeAttributeToAnnotation.php
+++ b/rules/DowngradePhp80/ValueObject/DowngradeAttributeToAnnotation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\ValueObject;
+
+final class DowngradeAttributeToAnnotation
+{
+    /**
+     * @param class-string $attributeClass
+     * @param class-string|string $tag
+     */
+    public function __construct(
+        private string $attributeClass,
+        private string $tag
+    ) {
+    }
+
+    public function getAttributeClass(): string
+    {
+        return $this->attributeClass;
+    }
+
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+}


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/4156


Needed for Rector downgrade of `#[Required]` attribute from Symfony