### PR TITLE
DX: Report more precise errors in `VerifyRectorServiceExistsCompilerPass`

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -210,7 +210,8 @@ parameters:
         -
             message: '#Call to function is_string\(\) with float will always evaluate to false#'
             path: src/PhpParser/Printer/BetterStandardPrinter.php
-            
+
+        # class_exists is forbidden to enforce static reflection, but at this point it works for us
         -
             message:  '#Function "class_exists\(\)" cannot be used/left in the code#'
             path: src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php         

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -211,7 +211,7 @@ parameters:
             message: '#Call to function is_string\(\) with float will always evaluate to false#'
             path: src/PhpParser/Printer/BetterStandardPrinter.php
 
-        # class_exists is forbidden to enforce static reflection, but at this point it works for us
+        # class_exists is forbidden to enforce static reflection, but in a compiler pass we want runtime autoloading
         -
             message:  '#Function "class_exists\(\)" cannot be used/left in the code#'
             path: src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php         

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -210,6 +210,10 @@ parameters:
         -
             message: '#Call to function is_string\(\) with float will always evaluate to false#'
             path: src/PhpParser/Printer/BetterStandardPrinter.php
+            
+        -
+            message:  '#Function "class_exists\(\)" cannot be used/left in the code#'
+            path: src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php         
 
         # known values from other methods
         -

--- a/src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php
@@ -27,7 +27,7 @@ final class VerifyRectorServiceExistsCompilerPass implements CompilerPassInterfa
 
             if (!class_exists($class)) {
                 throw new ShouldNotHappenException(
-                    sprintf('Rector rule "%s" not found, please verify that the class exists.', $class)
+                    sprintf('Rector rule "%s" not found, please verify that the class exists and is autoloadable.', $class)
                 );
             }
 

--- a/src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php
@@ -7,6 +7,7 @@ namespace Rector\Core\DependencyInjection\CompilerPass;
 use Nette\Utils\Strings;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\Rector\AbstractRector;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -24,9 +25,15 @@ final class VerifyRectorServiceExistsCompilerPass implements CompilerPassInterfa
                 continue;
             }
 
+            if (!class_exists($class)) {
+                throw new ShouldNotHappenException(
+                    sprintf('Rector rule "%s" not found, please verify that the rule exists.', $class)
+                );
+            }
+
             if (! is_a($class, RectorInterface::class, true)) {
                 throw new ShouldNotHappenException(
-                    sprintf('Rector rule "%s" not found, please verify that the rule exists', $class)
+                    sprintf('Rector rule "%s" should extend "%s" or implement "%s".', $class, AbstractRector::class, RectorInterface::class)
                 );
             }
         }

--- a/src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/VerifyRectorServiceExistsCompilerPass.php
@@ -27,7 +27,7 @@ final class VerifyRectorServiceExistsCompilerPass implements CompilerPassInterfa
 
             if (!class_exists($class)) {
                 throw new ShouldNotHappenException(
-                    sprintf('Rector rule "%s" not found, please verify that the rule exists.', $class)
+                    sprintf('Rector rule "%s" not found, please verify that the class exists.', $class)
                 );
             }
 


### PR DESCRIPTION
before this change, rector always reports `Rector rule "%s" not found, please verify that the rule exists.` no matter whether the rector rule was not found at all, or it a class was found but did not implement the proper interface