### PR TITLE
[Php80] Annotation attribute should keep order original annotation comment

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -110,6 +110,14 @@ final class PhpDocInfo
     /**
      * @return array<PhpDocTagNode>
      */
+    public function getAllTags(): array
+    {
+        return $this->phpDocNode->getTags();
+    }
+
+    /**
+     * @return array<PhpDocTagNode>
+     */
     public function getTagsByName(string $name): array
     {
         $name = $this->annotationNaming->normalizeName($name);

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -483,7 +483,8 @@ final class PhpDocInfo
         $this->isSingleLine = false;
     }
 
-    public function getNode(): \PhpParser\Node {
+    public function getNode(): \PhpParser\Node
+    {
         return $this->node;
     }
 

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/donot_reorder_annotation.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/donot_reorder_annotation.php.inc
@@ -40,36 +40,31 @@ class News
 
 namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureAutoImported;
 
-use Doctrine\ORM\Mapping\Table;
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\GeneratedValue;
-use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * News
  */
-#[Table(name: 'news')]
-#[Entity(repositoryClass: 'DoctrineFixtureDemo\Repository\NewsRepository')]
+#[\Doctrine\ORM\Mapping\Table(name: 'news')]
+#[\Doctrine\ORM\Mapping\Entity(repositoryClass: 'DoctrineFixtureDemo\Repository\NewsRepository')]
 class News
 {
     /**
      * @var integer
      */
-    #[Column(name: 'id', type: 'bigint', nullable: false)]
-    #[Id]
-    #[GeneratedValue(strategy: 'IDENTITY')]
+    #[\Doctrine\ORM\Mapping\Column(name: 'id', type: 'bigint', nullable: false)]
+    #[\Doctrine\ORM\Mapping\Id]
+    #[\Doctrine\ORM\Mapping\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
     /**
      * @var string
      */
-    #[Column(name: 'title', type: 'string', length: 50, nullable: false)]
+    #[\Doctrine\ORM\Mapping\Column(name: 'title', type: 'string', length: 50, nullable: false)]
     private $title;
     /**
      * @var string
      */
-    #[Column(name: 'content', type: 'string', length: 255, nullable: false)]
+    #[\Doctrine\ORM\Mapping\Column(name: 'content', type: 'string', length: 255, nullable: false)]
     private $content;
 }
 

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/multiple_same_attribute.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/multiple_same_attribute.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureAutoImported;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\ChangeTrackingPolicy;
+
+/**
+ * @Entity
+ * @ChangeTrackingPolicy("DEFERRED_IMPLICIT")
+ * @ChangeTrackingPolicy("NOTIFY")
+ */
+class User
+{
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureAutoImported;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\ChangeTrackingPolicy;
+
+#[\Doctrine\ORM\Mapping\Entity]
+#[\Doctrine\ORM\Mapping\ChangeTrackingPolicy('DEFERRED_IMPLICIT')]
+#[\Doctrine\ORM\Mapping\ChangeTrackingPolicy('NOTIFY')]
+class User
+{
+}
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixtureAutoImported/donot_reorder_annotation.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixtureAutoImported/donot_reorder_annotation.php.inc
@@ -1,0 +1,76 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureAutoImported;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * News
+ *
+ * @ORM\Table(name="news")
+ * @ORM\Entity(repositoryClass="DoctrineFixtureDemo\Repository\NewsRepository")
+ */
+class News
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="bigint", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="title", type="string", length=50, nullable=false)
+     */
+    private $title;
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="content", type="string", length=255, nullable=false)
+     */
+    private $content;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureAutoImported;
+
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * News
+ */
+#[Table(name: 'news')]
+#[Entity(repositoryClass: 'DoctrineFixtureDemo\Repository\NewsRepository')]
+class News
+{
+    /**
+     * @var integer
+     */
+    #[Column(name: 'id', type: 'bigint', nullable: false)]
+    #[Id]
+    #[GeneratedValue(strategy: 'IDENTITY')]
+    private $id;
+    /**
+     * @var string
+     */
+    #[Column(name: 'title', type: 'string', length: 50, nullable: false)]
+    private $title;
+    /**
+     * @var string
+     */
+    #[Column(name: 'content', type: 'string', length: 255, nullable: false)]
+    private $content;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixtureAutoImported/donot_sort_annotation.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixtureAutoImported/donot_sort_annotation.php.inc
@@ -1,0 +1,76 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureAutoImported;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * News
+ *
+ * @ORM\Table(name="news")
+ * @ORM\Entity(repositoryClass="DoctrineFixtureDemo\Repository\NewsRepository")
+ */
+class News
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="bigint", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="title", type="string", length=50, nullable=false)
+     */
+    private $title;
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="content", type="string", length=255, nullable=false)
+     */
+    private $content;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureAutoImported;
+
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * News
+ */
+#[Table(name: 'news')]
+#[Entity(repositoryClass: 'DoctrineFixtureDemo\Repository\NewsRepository')]
+class News
+{
+    /**
+     * @var integer
+     */
+    #[Column(name: 'id', type: 'bigint', nullable: false)]
+    #[Id]
+    #[GeneratedValue(strategy: 'IDENTITY')]
+    private $id;
+    /**
+     * @var string
+     */
+    #[Column(name: 'title', type: 'string', length: 50, nullable: false)]
+    private $title;
+    /**
+     * @var string
+     */
+    #[Column(name: 'content', type: 'string', length: 255, nullable: false)]
+    private $content;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -41,6 +41,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'Symfony\Component\Validator\Constraints\Choice',
                     'Symfony\Component\Validator\Constraints\Choice'
                 ),
+
+                new AnnotationToAttribute('Doctrine\ORM\Mapping\Table', 'Doctrine\ORM\Mapping\Table'),
+                new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity', 'Doctrine\ORM\Mapping\Entity'),
+                new AnnotationToAttribute('Doctrine\ORM\Mapping\Id', 'Doctrine\ORM\Mapping\Id'),
+                new AnnotationToAttribute(
+                    'Doctrine\ORM\Mapping\GeneratedValue',
+                    'Doctrine\ORM\Mapping\GeneratedValue'
+                ),
+                new AnnotationToAttribute('Doctrine\ORM\Mapping\Column', 'Doctrine\ORM\Mapping\Column'),
             ]),
         ]]);
 };

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -50,6 +50,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'Doctrine\ORM\Mapping\GeneratedValue'
                 ),
                 new AnnotationToAttribute('Doctrine\ORM\Mapping\Column', 'Doctrine\ORM\Mapping\Column'),
+                new AnnotationToAttribute('Doctrine\ORM\Mapping\ChangeTrackingPolicy', 'Doctrine\ORM\Mapping\ChangeTrackingPolicy'),
             ]),
         ]]);
 };

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
         }
 
         $hasNewAttrGroups = false;
-        $tags = $phpDocInfo->getPhpDocNode()->getTags();
+        $tags = $phpDocInfo->getAllTags();
 
         foreach ($tags as $key => $tag) {
             foreach ($this->annotationsToAttributes as $annotationToAttribute) {

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -147,7 +147,7 @@ CODE_SAMPLE
     private function processApplyAttrGroups(array $tags, PhpDocInfo $phpDocInfo, Node $node): bool
     {
         $hasNewAttrGroups = false;
-        foreach ($tags as $key => $tag) {
+        foreach ($tags as $tag) {
             foreach ($this->annotationsToAttributes as $annotationToAttribute) {
                 $annotationToAttributeTag = $annotationToAttribute->getTag();
                 if ($phpDocInfo->hasByName($annotationToAttributeTag)) {
@@ -155,7 +155,7 @@ CODE_SAMPLE
                     $this->phpDocTagRemover->removeByName($phpDocInfo, $annotationToAttributeTag);
 
                     // 2. add attributes
-                    $node->attrGroups[$key] = $this->phpAttributeGroupFactory->createFromSimpleTag(
+                    $node->attrGroups[] = $this->phpAttributeGroupFactory->createFromSimpleTag(
                         $annotationToAttribute
                     );
 
@@ -174,7 +174,7 @@ CODE_SAMPLE
                 // 2. add attributes
                 /** @var DoctrineAnnotationTagValueNode $tagValue */
                 $tagValue = $tag->value;
-                $node->attrGroups[$key] = $this->phpAttributeGroupFactory->create(
+                $node->attrGroups[] = $this->phpAttributeGroupFactory->create(
                     $tagValue,
                     $annotationToAttribute
                 );

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -188,15 +188,15 @@ CODE_SAMPLE
     }
 
     private function shouldSkip(
-        PhpDocTagValueNode $tagValue,
+        PhpDocTagValueNode $phpDocTagValueNode,
         PhpDocInfo $phpDocInfo,
         string $annotationToAttributeTag
     ): bool {
         $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass($annotationToAttributeTag);
-        if ($tagValue !== $doctrineAnnotationTagValueNode) {
+        if ($phpDocTagValueNode !== $doctrineAnnotationTagValueNode) {
             return true;
         }
 
-        return ! $tagValue instanceof DoctrineAnnotationTagValueNode;
+        return ! $phpDocTagValueNode instanceof DoctrineAnnotationTagValueNode;
     }
 }


### PR DESCRIPTION
Annotation attribute should keep order original annotation comment. This is failing fixture that: 

```
     * @ORM\Column(name="id", type="bigint", nullable=false)     
     * @ORM\Id  
     *  @ORM\GeneratedValue(strategy="IDENTITY")
```

should have the same order:

```
    #[Column(name: 'id', type: 'bigint', nullable: false)]    
    #[Id]   
    #[GeneratedValue(strategy: 'IDENTITY')]
```