### PR TITLE
[CodeQualityStrict] Skip MoveVariableDeclarationNearReferenceRector when next is inline HTML

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocInlineHtml/config/configured_rule.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocInlineHtml/config/configured_rule.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
+use Rector\Tests\BetterPhpDocParser\PhpDocInlineHtml\Source\InlineHtmlRector;
+
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Rector\Core\Configuration\Option;
-use ViewScopeRector\Inferer\Rocket\TestFileLocator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $parameters = $containerConfigurator->parameters();
 
-    $services->set(\Rector\Tests\BetterPhpDocParser\PhpDocInlineHtml\Source\InlineHtmlRector::class);
+    $services->set(InlineHtmlRector::class);
 };

--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_next_inline_html.php.inc
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_next_inline_html.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
+
+function test() {
+  $title = 'abc';
+  ?>
+  <h1>
+    <?php echo $title; ?>
+  </h1>
+  <?php
+}
+
+?>

--- a/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\While_;
@@ -156,6 +157,10 @@ CODE_SAMPLE
         /** @var Node|null $next */
         $next = $expression->getAttribute(AttributeKey::NEXT_NODE);
         if (! $next instanceof Node) {
+            return null;
+        }
+
+        if ($next instanceof InlineHTML) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6455