### PR TITLE
Skip FormatPerservingPrinterTest on windows

### DIFF
--- a/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
+++ b/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
@@ -34,6 +34,10 @@ final class FormatPerservingPrinterTest extends AbstractTestCase
 
     public function testFileModeIsPreserved(): void
     {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('file modes are not supported on windows.');
+        }
+        
         mkdir(__DIR__ . '/Fixture');
         touch(__DIR__ . '/Fixture/file.php');
 


### PR DESCRIPTION
file-mod is not a concept on windows, therefore is this test not usefull / will always fail