### PR TITLE
make sure windows uses LF, for files, which we expect to always use LF, no matter the platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
+# make sure windows uses LF for files, which we expect to always use LF, no matter the platform
+*.yaml		text eol=lf
+*.json		text eol=lf
+*.xml		text eol=lf
+
 # testing Windows spaces - https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings
 packages-tests/FileFormatter/ValueObject/Fixture/composer_carriage_return_line_feed.json json eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 *.yaml		text eol=lf
 *.json		text eol=lf
 *.xml		text eol=lf
+*.md		text eol=lf
 
 # testing Windows spaces - https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings
 packages-tests/FileFormatter/ValueObject/Fixture/composer_carriage_return_line_feed.json json eol=crlf


### PR DESCRIPTION
this change fixes the following test-errors on windows:

```
4) Rector\Tests\FileFormatter\Formatter\JsonFileFormatter\JsonFileFormatterTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 #Warning: Strings contain different line endings!
-'{
-	"name": "foo/bar",
-	"description": "A foo bar baz extension",
-	"license": "GPL-2.0-or-later"
-}
+'{
+	"name": "foo/bar",
+	"description": "A foo bar baz extension",
+	"license": "GPL-2.0-or-later"
+}
 '

5) Rector\Tests\FileFormatter\Formatter\XmlFileFormatter\XmlFileFormatterTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 #Warning: Strings contain different line endings!
-'<?xml version="1.0"?>
+'<?xml version="1.0"?>

 <catalog>
 	<book id="bk101">
 		<author>Gambardella, Matthew</author>
@@ @@
 		<description>An in-depth look at creating applications
 		with XML.</description>
 	</book>
-</catalog>
+</catalog>
 '

6) Rector\Tests\FileFormatter\Formatter\YamlFileFormatter\YamlFileFormatterTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 #Warning: Strings contain different line endings!
-'martin:
-    name: Martin
-    job: Developer
-    skills:
-        - python
-        - perl
-        - pascal
+'martin:
+    name: Martin
+    job: Developer
+    skills:
+        - python
+        - perl
+        - pascal
 '

 7) Rector\Tests\FileFormatter\ValueObject\NewLineTest::testFromFiles with data set "Xml file with line feed" (Symplify\SmartFileSystem\SmartFileInfo Object (...), '\n')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 #Warning: Strings contain different line endings!
-'
+'
 '
 ```

tested in https://github.com/rectorphp/rector-src/pull/99

see github-action logs
before: https://github.com/rectorphp/rector-src/pull/99/checks?check_run_id=2677137859
after: https://github.com/rectorphp/rector-src/pull/99/checks?check_run_id=2677399492