### PR TITLE
AnnotationExtractor: fix tests on windows

### DIFF
--- a/packages/ChangesReporting/Annotation/AnnotationExtractor.php
+++ b/packages/ChangesReporting/Annotation/AnnotationExtractor.php
@@ -25,13 +25,11 @@ final class AnnotationExtractor
             return null;
         }
 
-        // @see https://regex101.com/r/oYGaWU/1
-        $pattern = '#' . preg_quote($annotation, '#') . '\s+(?<content>.*?)$#m';
+        // @see https://3v4l.org/ouYfB
+        // uses '\r?\n' instead of '$' because windows compat
+        $pattern = '#' . preg_quote($annotation, '#') . '\s+(?<content>.*?)\r?\n#m';
         $matches = Strings::match($docComment, $pattern);
 
-        if ($matches) {
-            return rtrim($matches['content']);
-        }
-        return null;
+        return $matches['content'] ?? null;
     }
 }

--- a/packages/ChangesReporting/Annotation/AnnotationExtractor.php
+++ b/packages/ChangesReporting/Annotation/AnnotationExtractor.php
@@ -29,7 +29,7 @@ final class AnnotationExtractor
         $pattern = '#' . preg_quote($annotation, '#') . '\s+(?<content>.*?)$#m';
         $matches = Strings::match($docComment, $pattern);
 
-        if ($matches && isset($matches['content'])) {
+        if ($matches) {
             return rtrim($matches['content']);
         }
         return null;

--- a/packages/ChangesReporting/Annotation/AnnotationExtractor.php
+++ b/packages/ChangesReporting/Annotation/AnnotationExtractor.php
@@ -28,6 +28,6 @@ final class AnnotationExtractor
         // @see https://regex101.com/r/oYGaWU/1
         $pattern = '#' . preg_quote($annotation, '#') . '\s+(?<content>.*?)$#m';
         $matches = Strings::match($docComment, $pattern);
-        return $matches['content'] ?? null;
+        return trim($matches['content']) ?? null;
     }
 }

--- a/packages/ChangesReporting/Annotation/AnnotationExtractor.php
+++ b/packages/ChangesReporting/Annotation/AnnotationExtractor.php
@@ -28,6 +28,10 @@ final class AnnotationExtractor
         // @see https://regex101.com/r/oYGaWU/1
         $pattern = '#' . preg_quote($annotation, '#') . '\s+(?<content>.*?)$#m';
         $matches = Strings::match($docComment, $pattern);
-        return trim($matches['content']) ?? null;
+
+        if ($matches && $matches['content']) {
+            return trim($matches['content']);
+        }
+        return null;
     }
 }

--- a/packages/ChangesReporting/Annotation/AnnotationExtractor.php
+++ b/packages/ChangesReporting/Annotation/AnnotationExtractor.php
@@ -29,8 +29,8 @@ final class AnnotationExtractor
         $pattern = '#' . preg_quote($annotation, '#') . '\s+(?<content>.*?)$#m';
         $matches = Strings::match($docComment, $pattern);
 
-        if ($matches && $matches['content']) {
-            return trim($matches['content']);
+        if ($matches && isset($matches['content'])) {
+            return rtrim($matches['content']);
         }
         return null;
     }

--- a/packages/ChangesReporting/Annotation/RectorsChangelogResolver.php
+++ b/packages/ChangesReporting/Annotation/RectorsChangelogResolver.php
@@ -32,11 +32,6 @@ final class RectorsChangelogResolver
         $rectorClassesToChangelogUrls = [];
         foreach ($rectorClasses as $rectorClass) {
             $changelogUrl = $this->annotationExtractor->extractAnnotationFromClass($rectorClass, '@changelog');
-
-            if ($changelogUrl) {
-                $changelogUrl = trim($changelogUrl);
-            }
-
             $rectorClassesToChangelogUrls[$rectorClass] = $changelogUrl;
         }
 

--- a/packages/ChangesReporting/Annotation/RectorsChangelogResolver.php
+++ b/packages/ChangesReporting/Annotation/RectorsChangelogResolver.php
@@ -32,6 +32,11 @@ final class RectorsChangelogResolver
         $rectorClassesToChangelogUrls = [];
         foreach ($rectorClasses as $rectorClass) {
             $changelogUrl = $this->annotationExtractor->extractAnnotationFromClass($rectorClass, '@changelog');
+
+            if ($changelogUrl) {
+                $changelogUrl = trim($changelogUrl);
+            }
+
             $rectorClassesToChangelogUrls[$rectorClass] = $changelogUrl;
         }
 


### PR DESCRIPTION
fixes failing windows test
```
1) Rector\Tests\ChangesReporting\Annotation\AnnotationExtractorTest::testExtractAnnotationFromClass with data set "Class with changelog annotation" ('Rector\Tests\ChangesReporting...ngelog', '@changelog', 'rectorphp/...iew.md')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'rectorphp/rector@master/docs/rector_rules_overview.md'
+'rectorphp/rector@master/docs/rector_rules_overview.md
'

2) Rector\Tests\ChangesReporting\Annotation\AppliedRectorsChangelogResolver\RectorsChangelogResolverTest::test
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
-    'Rector\Tests\ChangesReporting\Annotation\AppliedRectorsChangelogResolver\Source\RectorWithChangelog' => 'rectorphp/rector@master/docs/rector_rules_overview.md'
+    'Rector\Tests\ChangesReporting\Annotation\AppliedRectorsChangelogResolver\Source\RectorWithChangelog' => 'https://github.com/rectorphp/rector/blob/master/docs/rector_rules_overview.md\r
+'
 )
 ```