### PR TITLE
XmlFileFormatter: utilize EditorConfigConfiguration for newline generation

### DIFF
--- a/packages/FileFormatter/Formatter/XmlFileFormatter.php
+++ b/packages/FileFormatter/Formatter/XmlFileFormatter.php
@@ -54,7 +54,7 @@ final class XmlFileFormatter implements FileFormatterInterface
         $this->padChar = $editorConfigConfiguration->getIndentStyleCharacter();
         $this->indent = $editorConfigConfiguration->getIndentSize();
 
-        $newFileContent = $this->formatXml($file->getFileContent());
+        $newFileContent = $this->formatXml($file->getFileContent(), $editorConfigConfiguration);
 
         $newFileContent .= $editorConfigConfiguration->getFinalNewline();
 
@@ -70,7 +70,7 @@ final class XmlFileFormatter implements FileFormatterInterface
         return $editorConfigConfigurationBuilder;
     }
 
-    private function formatXml(string $xml): string
+    private function formatXml(string $xml, EditorConfigConfiguration $editorConfigConfiguration): string
     {
         $output = '';
         $this->depth = 0;
@@ -78,11 +78,11 @@ final class XmlFileFormatter implements FileFormatterInterface
         $parts = $this->getXmlParts($xml);
 
         if (str_starts_with($parts[0], '<?xml')) {
-            $output = array_shift($parts) . PHP_EOL;
+            $output = array_shift($parts) . $editorConfigConfiguration->getNewline();
         }
 
         foreach ($parts as $part) {
-            $output .= $this->getOutputForPart($part);
+            $output .= $this->getOutputForPart($part, $editorConfigConfiguration);
         }
 
         return trim($output);
@@ -97,16 +97,16 @@ final class XmlFileFormatter implements FileFormatterInterface
         return explode("\n", $withNewLines);
     }
 
-    private function getOutputForPart(string $part): string
+    private function getOutputForPart(string $part, EditorConfigConfiguration $editorConfigConfiguration): string
     {
         $output = '';
         $this->runPre($part);
 
         if ($this->preserveWhitespace) {
-            $output .= $part . PHP_EOL;
+            $output .= $part . $editorConfigConfiguration->getNewline();
         } else {
             $part = trim($part);
-            $output .= $this->getPaddedString($part) . PHP_EOL;
+            $output .= $this->getPaddedString($part) . $editorConfigConfiguration->getNewline();
         }
 
         $this->runPost($part);


### PR DESCRIPTION
Should fix a failling test on windows (not yet verified)

```

4) Rector\Tests\FileFormatter\Formatter\XmlFileFormatter\XmlFileFormatterTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
52
Failed asserting that two strings are identical.
53
--- Expected
54
+++ Actual
55
@@ @@
56
 #Warning: Strings contain different line endings!
57
-'<?xml version="1.0"?>
58
-<catalog>
59
-	<book id="bk101">
60
-		<author>Gambardella, Matthew</author>
61
-		<title>XML Developer's Guide</title>
62
-		<genre>Computer</genre>
63
-		<price>44.95</price>
64
-		<publish_date>2000-10-01</publish_date>
65
-		<description>An in-depth look at creating applications
66
-		with XML.</description>
67
-	</book>
68
+'<?xml version="1.0"?>
69
+<catalog>
70
+	<book id="bk101">
71
+		<author>Gambardella, Matthew</author>
72
+		<title>XML Developer's Guide</title>
73
+		<genre>Computer</genre>
74
+		<price>44.95</price>
75
+		<publish_date>2000-10-01</publish_date>
76
+		<description>An in-depth look at creating applications
77
+		with XML.</description>
78
+	</book>
79
 </catalog>
80
 '

```