### PR TITLE
MovingFilesTrait: fixed assertFilesWereAdded on windows

### DIFF
--- a/packages/Testing/PHPUnit/Behavior/MovingFilesTrait.php
+++ b/packages/Testing/PHPUnit/Behavior/MovingFilesTrait.php
@@ -50,13 +50,13 @@ trait MovingFilesTrait
             $expectedFilePathWithContent = $expectedAddedFileWithContents[$key];
 
             $this->assertSame(
-                $expectedFilePathWithContent->getFilePath(),
-                $addedFilePathWithContent->getFilePath()
+                realpath($expectedFilePathWithContent->getFilePath()),
+                realpath($addedFilePathWithContent->getFilePath())
             );
 
             $this->assertSame(
-                $expectedFilePathWithContent->getFileContent(),
-                $addedFilePathWithContent->getFileContent()
+                $this->normalizeNewlines($expectedFilePathWithContent->getFileContent()),
+                $this->normalizeNewlines($addedFilePathWithContent->getFileContent())
             );
         }
     }
@@ -77,5 +77,9 @@ trait MovingFilesTrait
         }
 
         return $addedFilePathsWithContents;
+    }
+
+    private function normalizeNewlines(string $content): string {
+        return str_replace(DIRECTORY_SEPARATOR, "\n", $content);
     }
 }


### PR DESCRIPTION
fixes (et all)

```
$ vendor/bin/phpunit rules-tests/Autodiscovery/Rector/Class_/MoveValueObjectsToValueObjectDirectoryRector/MoveValueObjectsToValueObjectDirectoryRectorTest.php
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

FFF.                                                                4 / 4 (100%)

Time: 00:01.251, Memory: 44.00 MB

There were 3 failures:

1) Rector\Tests\Autodiscovery\Rector\Class_\MoveValueObjectsToValueObjectDirectoryRector\MoveValueObjectsToValueObjectDirectoryRectorTest::test with data set #1 (Symplify\SmartFileSystem\SmartFileInfo Object (...), Rector\FileSystemRector\ValueObject\AddedFileWithContent Object (...))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'C:\Users\staabm\AppData\Local\Temp/_temp_fixture_easy_testing/ValueObject/SomeName.php'
+'../../../Users/staabm/AppData/Local/Temp/_temp_fixture_easy_testing\ValueObject\SomeName.php'

C:\xampp7.3\htdocs\rector-src\packages\Testing\PHPUnit\Behavior\MovingFilesTrait.php:54
C:\xampp7.3\htdocs\rector-src\packages\Testing\PHPUnit\Behavior\MovingFilesTrait.php:26
C:\xampp7.3\htdocs\rector-src\rules-tests\Autodiscovery\Rector\Class_\MoveValueObjectsToValueObjectDirectoryRector\MoveValueObjectsToValueObjectDirectoryRectorTest.php:23

2) Rector\Tests\Autodiscovery\Rector\Class_\MoveValueObjectsToValueObjectDirectoryRector\MoveValueObjectsToValueObjectDirectoryRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...), Rector\FileSystemRector\ValueObject\AddedFileWithContent Object (...))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'C:\Users\staabm\AppData\Local\Temp/_temp_fixture_easy_testing/ValueObject/PrimitiveValueObject.php'
+'../../../Users/staabm/AppData/Local/Temp/_temp_fixture_easy_testing\ValueObject\PrimitiveValueObject.php'

C:\xampp7.3\htdocs\rector-src\packages\Testing\PHPUnit\Behavior\MovingFilesTrait.php:54
C:\xampp7.3\htdocs\rector-src\packages\Testing\PHPUnit\Behavior\MovingFilesTrait.php:26
C:\xampp7.3\htdocs\rector-src\rules-tests\Autodiscovery\Rector\Class_\MoveValueObjectsToValueObjectDirectoryRector\MoveValueObjectsToValueObjectDirectoryRectorTest.php:23

3) Rector\Tests\Autodiscovery\Rector\Class_\MoveValueObjectsToValueObjectDirectoryRector\MoveValueObjectsToValueObjectDirectoryRectorTest::test with data set #2 (Symplify\SmartFileSystem\SmartFileInfo Object (...), Rector\FileSystemRector\ValueObject\AddedFileWithContent Object (...))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'C:\Users\staabm\AppData\Local\Temp/_temp_fixture_easy_testing/ValueObject/MeSearch.php'
+'../../../Users/staabm/AppData/Local/Temp/_temp_fixture_easy_testing\ValueObject\MeSearch.php'

C:\xampp7.3\htdocs\rector-src\packages\Testing\PHPUnit\Behavior\MovingFilesTrait.php:54
C:\xampp7.3\htdocs\rector-src\packages\Testing\PHPUnit\Behavior\MovingFilesTrait.php:26
C:\xampp7.3\htdocs\rector-src\rules-tests\Autodiscovery\Rector\Class_\MoveValueObjectsToValueObjectDirectoryRector\MoveValueObjectsToValueObjectDirectoryRectorTest.php:23
```