### PR TITLE
FileRelocationResolverTest: fix RegexpException on windows

### DIFF
--- a/rules/PSR4/FileRelocationResolver.php
+++ b/rules/PSR4/FileRelocationResolver.php
@@ -162,6 +162,7 @@ final class FileRelocationResolver
         // A. first "dir has changed" dummy detection
         $relativeFilePathParts = Strings::split(
             $oldSmartFileInfo->getRelativeFilePath(),
+            // the windows dir separator would be interpreted as a regex-escape char, therefore quote it.
             '#' . preg_quote(DIRECTORY_SEPARATOR, '#') . '#'
         );
 

--- a/rules/PSR4/FileRelocationResolver.php
+++ b/rules/PSR4/FileRelocationResolver.php
@@ -162,7 +162,7 @@ final class FileRelocationResolver
         // A. first "dir has changed" dummy detection
         $relativeFilePathParts = Strings::split(
             $oldSmartFileInfo->getRelativeFilePath(),
-            '#' . DIRECTORY_SEPARATOR . '#'
+            '#' . preg_quote(DIRECTORY_SEPARATOR, '#') . '#'
         );
 
         foreach ($relativeFilePathParts as $key => $relativeFilePathPart) {


### PR DESCRIPTION
```
1) Rector\Tests\PSR4\FileRelocationResolverTest::test with data set #0 ('C:\xampp7.3\htdocs\rector-src...le.php', 'Rector\Tests\PSR4\Source\SomeFile', 'Rector\Tests\PSR10\Source\SomeFile', 'rules-tests/PSR10/Source/SomeFile.php')
Nette\Utils\RegexpException: No ending delimiter '#' found in pattern: #\#

C:\xampp7.3\htdocs\rector-src\vendor\nette\utils\src\Utils\Strings.php:539
C:\xampp7.3\htdocs\rector-src\vendor\nette\utils\src\Utils\Callback.php:76
C:\xampp7.3\htdocs\rector-src\vendor\nette\utils\src\Utils\Callback.php:84
C:\xampp7.3\htdocs\rector-src\vendor\nette\utils\src\Utils\Strings.php:540
C:\xampp7.3\htdocs\rector-src\vendor\nette\utils\src\Utils\Strings.php:475
C:\xampp7.3\htdocs\rector-src\rules\PSR4\FileRelocationResolver.php:165
C:\xampp7.3\htdocs\rector-src\rules\PSR4\FileRelocationResolver.php:65
C:\xampp7.3\htdocs\rector-src\rules-tests\PSR4\FileRelocationResolverTest.php:32
```