### PR TITLE
fix FileRelocationResolverTest on windows

### DIFF
--- a/rules-tests/PSR4/FileRelocationResolverTest.php
+++ b/rules-tests/PSR4/FileRelocationResolverTest.php
@@ -34,6 +34,9 @@ final class FileRelocationResolverTest extends AbstractTestCase
             $newClass
         );
 
+        // we expect a path containing the dir-separator of the current platform
+        $expectedNewFileLocation = str_replace("/", DIRECTORY_SEPARATOR, $expectedNewFileLocation);
+
         $this->assertSame($expectedNewFileLocation, $newFileLocation);
     }
 

--- a/rules/PSR4/FileRelocationResolver.php
+++ b/rules/PSR4/FileRelocationResolver.php
@@ -161,8 +161,8 @@ final class FileRelocationResolver
     ): string {
         // A. first "dir has changed" dummy detection
         $relativeFilePathParts = Strings::split(
-            $oldSmartFileInfo->getRelativeFilePath(),
-            '#' . DIRECTORY_SEPARATOR . '#'
+            $this->normalizeDirectorySeparator($oldSmartFileInfo->getRelativeFilePath()),
+            '#' . preg_quote(DIRECTORY_SEPARATOR, '#') . '#'
         );
 
         foreach ($relativeFilePathParts as $key => $relativeFilePathPart) {
@@ -177,5 +177,9 @@ final class FileRelocationResolver
         }
 
         return implode(DIRECTORY_SEPARATOR, $relativeFilePathParts);
+    }
+
+    private function normalizeDirectorySeparator(string $path):string {
+        return str_replace('/', DIRECTORY_SEPARATOR, $path);
     }
 }


### PR DESCRIPTION
fixes 

```
$ vendor/bin/phpunit rules-tests/PSR4/FileRelocationResolverTest.php --debug
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Test 'Rector\Tests\PSR4\FileRelocationResolverTest::test with data set #0 ('C:\xampp7.3\htdocs\rector-src...le.php', 'Rector\Tests\PSR4\Source\SomeFile', 'Rector\Tests\PSR10\Source\SomeFile', 'rules-tests/PSR10/Source/SomeFile.php')' started
Test 'Rector\Tests\PSR4\FileRelocationResolverTest::test with data set #0 ('C:\xampp7.3\htdocs\rector-src...le.php', 'Rector\Tests\PSR4\Source\SomeFile', 'Rector\Tests\PSR10\Source\SomeFile', 'rules-tests/PSR10/Source/SomeFile.php')' ended


Time: 00:00.678, Memory: 30.00 MB

There was 1 failure:

1) Rector\Tests\PSR4\FileRelocationResolverTest::test with data set #0 ('C:\xampp7.3\htdocs\rector-src...le.php', 'Rector\Tests\PSR4\Source\SomeFile', 'Rector\Tests\PSR10\Source\SomeFile', 'rules-tests/PSR10/Source/SomeFile.php')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'rules-tests/PSR10/Source/SomeFile.php'
+'rules-tests/PSR4/Source/SomeFile.php'
```