### PR TITLE
[Dir] Always use realpath() on sys_get_temp_dir()

### DIFF
--- a/config/parameters.php
+++ b/config/parameters.php
@@ -31,5 +31,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // cache
     $parameters->set(Option::ENABLE_CACHE, false);
-    $parameters->set(Option::CACHE_DIR, sys_get_temp_dir() . '/rector_cached_files');
+    $parameters->set(Option::CACHE_DIR, realpath(sys_get_temp_dir()) . '/rector_cached_files');
 };

--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
@@ -111,7 +111,7 @@ final class TagValueNodeReprintTest extends AbstractTestCase
 
     private function createFixtureFileInfo(TrioContent $trioContent, SmartFileInfo $fixturefileInfo): SmartFileInfo
     {
-        $temporaryFileName = sys_get_temp_dir() . '/rector/tests/' . $fixturefileInfo->getRelativePathname();
+        $temporaryFileName = realpath(sys_get_temp_dir()) . '/rector/tests/' . $fixturefileInfo->getRelativePathname();
         $firstValue = $trioContent->getFirstValue();
 
         $smartFileSystem = new SmartFileSystem();

--- a/packages-tests/Caching/Detector/config.php
+++ b/packages-tests/Caching/Detector/config.php
@@ -7,5 +7,5 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::CACHE_DIR, sys_get_temp_dir() . '/_rector_cached_files_test');
+    $parameters->set(Option::CACHE_DIR, realpath(sys_get_temp_dir()) . '/_rector_cached_files_test');
 };

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -38,7 +38,7 @@ final class PHPStanServicesFactory
 
         $existingAdditionalConfigFiles = array_filter($additionalConfigFiles, 'file_exists');
 
-        $this->container = $containerFactory->create(sys_get_temp_dir(), $existingAdditionalConfigFiles, []);
+        $this->container = $containerFactory->create(realpath(sys_get_temp_dir()), $existingAdditionalConfigFiles, []);
     }
 
     /**

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -38,7 +38,9 @@ final class PHPStanServicesFactory
 
         $existingAdditionalConfigFiles = array_filter($additionalConfigFiles, 'file_exists');
 
-        $this->container = $containerFactory->create(realpath(sys_get_temp_dir()), $existingAdditionalConfigFiles, []);
+        /** @var string $tempDir */
+        $tempDir = realpath(sys_get_temp_dir());
+        $this->container = $containerFactory->create($tempDir, $existingAdditionalConfigFiles, []);
     }
 
     /**

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -92,7 +92,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
 
     protected function getFixtureTempDirectory(): string
     {
-        return sys_get_temp_dir() . '/_temp_fixture_easy_testing';
+        return realpath(sys_get_temp_dir()) . '/_temp_fixture_easy_testing';
     }
 
     private function doTestFileMatchesExpectedContent(

--- a/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/skip_method_call_property_call.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/skip_method_call_property_call.php.inc
@@ -13,7 +13,7 @@ final class SkipMethodCallPropertyCall
             $robotLoader->addDirectory($directory);
         }
 
-        $robotLoader->setTempDirectory(sys_get_temp_dir() . '/_rector_finder');
+        $robotLoader->setTempDirectory(realpath(sys_get_temp_dir()) . '/_rector_finder');
         $robotLoader->acceptFiles = [$name];
         $robotLoader->rebuild();
     }

--- a/src/HttpKernel/RectorKernel.php
+++ b/src/HttpKernel/RectorKernel.php
@@ -57,13 +57,13 @@ final class RectorKernel extends Kernel
         }
 
         // manually configured, so it can be replaced in phar
-        return sys_get_temp_dir() . '/rector/cache';
+        return realpath(sys_get_temp_dir()) . '/rector/cache';
     }
 
     public function getLogDir(): string
     {
         // manually configured, so it can be replaced in phar
-        return sys_get_temp_dir() . '/rector/log';
+        return realpath(sys_get_temp_dir()) . '/rector/log';
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void


### PR DESCRIPTION
To handle different result on MacOS which `/private/var` pointed to '/var` that can cause error like the following:

```bash
1) Rector\Doctrine\Tests\Rector\Class_\TranslationBehaviorRector\TranslationBehaviorRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...), Rector\FileSystemRector\ValueObject\AddedFileWithContent Object (...))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/var/folders/dv/m3gvpzh94t59l94qz3w2dgfr0000gn/T/_temp_fixture_easy_testing/SomeClassTranslation.php'
+'/private/var/folders/dv/m3gvpzh94t59l94qz3w2dgfr0000gn/T/_temp_fixture_easy_testing/SomeClassTranslation.php'
```