### PR TITLE
[Downgrade PHP 7.3] Add DowngradeIsCountableRector

### DIFF
--- a/config/set/downgrade-php73.php
+++ b/config/set/downgrade-php73.php
@@ -21,4 +21,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeTrailingCommasInFunctionCallsRector::class);
     $services->set(DowngradeArrayKeyFirstLastRector::class);
     $services->set(SetCookieOptionsArrayToArgumentsRector::class);
+    $services->set(\Rector\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector::class);
 };

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -35,7 +35,8 @@ final class PHPStanStaticTypeMapper
         throw new NotImplementedYetException(__METHOD__ . ' for ' . get_class($type));
     }
 
-    public function mapToPhpParserNode(Type $type, ?string $kind = null): Name | NullableType | UnionType | null {
+    public function mapToPhpParserNode(Type $type, ?string $kind = null): Name | NullableType | UnionType | null
+    {
         foreach ($this->typeMappers as $typeMapper) {
             if (! is_a($type, $typeMapper->getNodeClass(), true)) {
                 continue;

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/DowngradeIsCountableRectorTest.php
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/DowngradeIsCountableRectorTest.php
@@ -4,19 +4,24 @@ declare(strict_types=1);
 
 namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector;
 
+use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DowngradeIsCountableRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(\Symplify\SmartFileSystem\SmartFileInfo $fileInfo): void
+    public function test(SmartFileInfo $fileInfo): void
     {
         $this->doTestFileInfo($fileInfo);
     }
 
-    public function provideData(): \Iterator
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
     {
         return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/DowngradeIsCountableRectorTest.php
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/DowngradeIsCountableRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeIsCountableRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(\Symplify\SmartFileSystem\SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/Fixture/some_class.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/Fixture/some_class.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector\Fixture;
+
+$items = [];
+return is_countable($items);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector\Fixture;
+
+$items = [];
+return is_array($items) || $items instanceof \Countable;
+
+?>

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(Rector\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector::class);
+};

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector/config/configured_rule.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use Rector\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector;
+
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
-    $services->set(Rector\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector::class);
+    $services->set(DowngradeIsCountableRector::class);
 };

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp73\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Name\FullyQualified;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -35,15 +39,15 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<\PhpParser\Node>>
+     * @return array<class-string<Node>>
      */
     public function getNodeTypes(): array
     {
-        return [\PhpParser\Node\Expr\FuncCall::class];
+        return [FuncCall::class];
     }
 
     /**
-     * @param \PhpParser\Node\Expr\FuncCall $node
+     * @param FuncCall $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -52,10 +56,8 @@ CODE_SAMPLE
         }
 
         $isArrayFuncCall = $this->nodeFactory->createFuncCall('is_array', $node->args);
-        $instanceofCountable = new Node\Expr\Instanceof_($node->args[0]->value, new Node\Name\FullyQualified(
-            'Countable'
-        ));
+        $instanceof = new Instanceof_($node->args[0]->value, new FullyQualified('Countable'));
 
-        return new Node\Expr\BinaryOp\BooleanOr($isArrayFuncCall, $instanceofCountable);
+        return new BooleanOr($isArrayFuncCall, $instanceof);
     }
 }

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeIsCountableRector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp73\Rector\FuncCall;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/is-countable
+ *
+ * @see \Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector\DowngradeIsCountableRectorTest
+ */
+final class DowngradeIsCountableRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Downgrade is_countable() to former version', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$items = [];
+return is_countable($items);
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+$items = [];
+return is_array($items) || $items instanceof Countable;
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<\PhpParser\Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [\PhpParser\Node\Expr\FuncCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node, 'is_countable')) {
+            return null;
+        }
+
+        $isArrayFuncCall = $this->nodeFactory->createFuncCall('is_array', $node->args);
+        $instanceofCountable = new Node\Expr\Instanceof_($node->args[0]->value, new Node\Name\FullyQualified(
+            'Countable'
+        ));
+
+        return new Node\Expr\BinaryOp\BooleanOr($isArrayFuncCall, $instanceofCountable);
+    }
+}


### PR DESCRIPTION
We're missing this rule for Rector code.
Discovered in https://github.com/rectorphp/rector-src/pull/113/files