### PR TITLE
[Php74] Skip AddLiteralSeparatorToNumberRector on already formatted literals

### DIFF
--- a/rules-tests/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector/Fixture/skip_already_formatted.php.inc
+++ b/rules-tests/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector/Fixture/skip_already_formatted.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector\Fixture;
+
+class SkipAlreadyFormatted
+{
+    function donate(int $amount = 10_000_00)
+    {
+        echo $amount;
+    }
+}

--- a/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
+++ b/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
@@ -142,9 +142,13 @@ CODE_SAMPLE
         $oldTokens = $file->getOldTokens();
 
         foreach ($oldTokens[$startToken] as $token) {
-            if (is_string($token) && str_contains($token, '_')) {
-                return true;
+            if (! is_string($token)) {
+                continue;
             }
+            if (! str_contains($token, '_')) {
+                continue;
+            }
+            return true;
         }
 
         if ($numericValueAsString < $this->limitValue) {

--- a/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
+++ b/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\LNumber;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -134,6 +135,18 @@ CODE_SAMPLE
      */
     private function shouldSkip(Node $node, string $numericValueAsString): bool
     {
+        /** @var int $startToken */
+        $startToken = $node->getAttribute(AttributeKey::START_TOKEN_POSITION);
+        /** @var File $file */
+        $file = $node->getAttribute(AttributeKey::FILE);
+        $oldTokens = $file->getOldTokens();
+
+        foreach ($oldTokens[$startToken] as $token) {
+            if (is_string($token) && str_contains($token, '_')) {
+                return true;
+            }
+        }
+
         if ($numericValueAsString < $this->limitValue) {
             return true;
         }

--- a/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
+++ b/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
@@ -24,7 +24,7 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
      * @param mixed $resource
      * @param null|string $type
      */
-    public function load($resource, $type = null): void
+    public function load($resource, string $type = null): void
     {
         // this call collects root values
         $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
@@ -36,9 +36,9 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
 
     public function import(
         $resource,
-        $type = null,
+        string $type = null,
         $ignoreErrors = false,
-        $sourceResource = null,
+        string $sourceResource = null,
         $exclude = null
     ): void {
         // this call collects root values


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6188