### PR TITLE
Add failing test fixture for TypedPropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/demo_file.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class DemoFile
+{
+    private $result;
+    
+    public function __construct(?array $result) {
+        $this->result = $result;
+    }
+    
+    public function getResult(): ?array
+    {
+        return $this->result;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class DemoFile
+{
+    private ?array $result;
+    
+    public function __construct(?array $result) {
+        $this->result = $result;
+    }
+    
+    public function getResult(): ?array
+    {
+        return $this->result;
+    }
+}
+?>


### PR DESCRIPTION
Based on https://getrector.org/demo/a915c37a-85bc-4f11-ad2f-1bcf1963b214

Property should not have a default initialization value.

Refs: https://github.com/rectorphp/rector/issues/6474