### PR TITLE
Fix copy-paste errors in rule docs

### DIFF
--- a/rules/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector.php
+++ b/rules/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector.php
@@ -53,7 +53,7 @@ final class ManualJsonStringToJsonEncodeArrayRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add extra space before new assign set', [
+        return new RuleDefinition('Convert manual JSON string to JSON::encode array', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass

--- a/rules/DowngradePhp73/Rector/String_/DowngradeFlexibleHeredocSyntaxRector.php
+++ b/rules/DowngradePhp73/Rector/String_/DowngradeFlexibleHeredocSyntaxRector.php
@@ -25,7 +25,7 @@ final class DowngradeFlexibleHeredocSyntaxRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Changes heredoc/nowdoc that contains closing word to safe wrapper name',
+            'Remove indentation from heredoc/nowdoc',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfContinueToMultiContinueRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfContinueToMultiContinueRector.php
@@ -26,7 +26,7 @@ final class ChangeOrIfContinueToMultiContinueRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Changes if && to early return', [
+        return new RuleDefinition('Changes if || to early return', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 class SomeClass

--- a/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
+++ b/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
@@ -36,7 +36,7 @@ final class RenameParamToMatchTypeRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Rename variable to match new ClassType', [
+        return new RuleDefinition('Rename param to match ClassType', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass

--- a/rules/Php52/Rector/Property/VarToPublicPropertyRector.php
+++ b/rules/Php52/Rector/Property/VarToPublicPropertyRector.php
@@ -17,7 +17,7 @@ final class VarToPublicPropertyRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Remove unused private method', [
+        return new RuleDefinition('Change property modifier from `var` to `public`', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeController

--- a/rules/Php70/Rector/FunctionLike/ExceptionHandlerTypehintRector.php
+++ b/rules/Php70/Rector/FunctionLike/ExceptionHandlerTypehintRector.php
@@ -31,7 +31,7 @@ final class ExceptionHandlerTypehintRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Changes property `@var` annotations from annotation to type.',
+            'Change typehint from `Exception` to `Throwable`.',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/Php80/Rector/FuncCall/TokenGetAllToObjectRector.php
+++ b/rules/Php80/Rector/FuncCall/TokenGetAllToObjectRector.php
@@ -35,7 +35,7 @@ final class TokenGetAllToObjectRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Complete missing constructor dependency instance by type',
+            'Convert `token_get_all` to `PhpToken::getAll`',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -28,7 +28,7 @@ final class ReturnTypeFromReturnNewRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add return type void to function like without any return', [
+        return new RuleDefinition('Add return type to function like with return new', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass


### PR DESCRIPTION
Some rule docs were mindlessly copied from other rules, and don't make any sense.
- `ReturnTypeFromReturnNewRector` copied from `AddVoidReturnTypeWhereNoReturnRector`
- `SensitiveDefineRector` copied from `SensitiveConstantNameRector`
- `DowngradeFlexibleHeredocSyntaxRector` copied from `SensitiveHereNowDocRector`
- `ChangeOrIfContinueToMultiContinueRector` copied from `ChangeAndIfToEarlyReturnRector`
- `ExceptionHandlerTypehintRector` copied from `TypedPropertyRector`
- `TokenGetAllToObjectRector` copied from `CompleteMissingDependencyInNewRector`
- `VarToPublicPropertyRector` copied from `RemoveUnusedPrivateMethodRector`
- `RenameParamToMatchTypeRector` copied from `RenameVariableToMatchNewTypeRector`