### PR TITLE
[DowngradePhp72] Improve DowngradeParameterTypeWideningRector performance

### DIFF
--- a/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
@@ -21,23 +21,13 @@ final class ClassLikeWithTraitsClassMethodResolver
     }
 
     /**
-     * @param Class_|Interface_ $classLike
+     * @param ClassReflection $ancestors
      * @return ClassMethod[]
      */
-    public function resolve(ClassLike $classLike): array
+    public function resolve(array $ancestors): array
     {
-        $scope = $classLike->getAttribute(AttributeKey::SCOPE);
-        if (! $scope instanceof Scope) {
-            return [];
-        }
-
-        $classReflection = $scope->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
-            return [];
-        }
-
         $classMethods = [];
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+        foreach ($ancestors as $ancestorClassReflection) {
             $ancestorClassLike = $this->nodeRepository->findClassLike($ancestorClassReflection->getName());
             if (! $ancestorClassLike instanceof ClassLike) {
                 continue;

--- a/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
@@ -23,8 +23,8 @@ final class ClassLikeWithTraitsClassMethodResolver
     public function resolve(array $ancestors): array
     {
         $classMethods = [];
-        foreach ($ancestors as $ancestorClassReflection) {
-            $ancestorClassLike = $this->nodeRepository->findClassLike($ancestorClassReflection->getName());
+        foreach ($ancestors as $ancestor) {
+            $ancestorClassLike = $this->nodeRepository->findClassLike($ancestor->getName());
             if (! $ancestorClassLike instanceof ClassLike) {
                 continue;
             }

--- a/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
@@ -4,14 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\DowngradePhp72\NodeAnalyzer;
 
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Interface_;
-use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class ClassLikeWithTraitsClassMethodResolver
 {

--- a/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ClassLikeWithTraitsClassMethodResolver.php
@@ -17,7 +17,7 @@ final class ClassLikeWithTraitsClassMethodResolver
     }
 
     /**
-     * @param ClassReflection $ancestors
+     * @param ClassReflection[] $ancestors
      * @return ClassMethod[]
      */
     public function resolve(array $ancestors): array

--- a/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
@@ -20,7 +20,7 @@ final class ParamContravariantDetector
     /**
      * @param ClassReflection[] $ancestors
      */
-    public function hasParentMethod(ClassReflection $classReflection, array $ancestors, ?string $classMethodName): bool
+    public function hasParentMethod(ClassReflection $classReflection, array $ancestors, string $classMethodName): bool
     {
         foreach ($ancestors as $ancestorClassReflection) {
             if ($classReflection === $ancestorClassReflection) {
@@ -35,7 +35,7 @@ final class ParamContravariantDetector
         return false;
     }
 
-    public function hasChildMethod(ClassReflection $classReflection, ?string $classMethodName): bool
+    public function hasChildMethod(ClassReflection $classReflection, string $classMethodName): bool
     {
         $classLikes = $this->nodeRepository->findClassesAndInterfacesByType($classReflection->getName());
         foreach ($classLikes as $classLike) {

--- a/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
@@ -6,17 +6,9 @@ namespace Rector\DowngradePhp72\NodeAnalyzer;
 
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Reflection\ClassReflection;
-use Rector\NodeCollector\NodeCollector\NodeRepository;
-use Rector\NodeNameResolver\NodeNameResolver;
 
 final class ParamContravariantDetector
 {
-    public function __construct(
-        private NodeNameResolver $nodeNameResolver,
-        private NodeRepository $nodeRepository
-    ) {
-    }
-
     /**
      * @param ClassReflection[] $ancestors
      */

--- a/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp72\NodeAnalyzer;
 
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -18,13 +17,8 @@ final class ParamContravariantDetector
     ) {
     }
 
-    public function hasParentMethod(ClassMethod $classMethod, Scope $scope): bool
+    public function hasParentMethod(ClassMethod $classMethod, ClassReflection $classReflection): bool
     {
-        $classReflection = $scope->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
-            return false;
-        }
-
         foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
             if ($classReflection === $ancestorClassReflection) {
                 continue;
@@ -39,13 +33,8 @@ final class ParamContravariantDetector
         return false;
     }
 
-    public function hasChildMethod(ClassMethod $classMethod, Scope $classScope): bool
+    public function hasChildMethod(ClassMethod $classMethod, ClassReflection $classReflection): bool
     {
-        $classReflection = $classScope->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
-            return false;
-        }
-
         $methodName = $this->nodeNameResolver->getName($classMethod);
 
         $classLikes = $this->nodeRepository->findClassesAndInterfacesByType($classReflection->getName());

--- a/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\DowngradePhp72\NodeAnalyzer;
 
-use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -22,12 +21,13 @@ final class ParamContravariantDetector
      */
     public function hasParentMethod(ClassReflection $classReflection, array $ancestors, string $classMethodName): bool
     {
-        foreach ($ancestors as $ancestorClassReflection) {
-            if ($classReflection === $ancestorClassReflection) {
+        foreach ($ancestors as $ancestor) {
+            if ($classReflection === $ancestor) {
                 continue;
             }
+            $ancestorHasMethod = $ancestor->hasMethod($classMethodName);
 
-            if ($ancestorClassReflection->hasMethod($classMethodName)) {
+            if ($ancestorHasMethod) {
                 return true;
             }
         }

--- a/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
@@ -17,14 +17,16 @@ final class ParamContravariantDetector
     ) {
     }
 
-    public function hasParentMethod(ClassMethod $classMethod, ClassReflection $classReflection): bool
+    /**
+     * @param ClassReflection[] $ancestors
+     */
+    public function hasParentMethod(ClassReflection $classReflection, array $ancestors, ?string $classMethodName): bool
     {
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+        foreach ($ancestors as $ancestorClassReflection) {
             if ($classReflection === $ancestorClassReflection) {
                 continue;
             }
 
-            $classMethodName = $this->nodeNameResolver->getName($classMethod);
             if ($ancestorClassReflection->hasMethod($classMethodName)) {
                 return true;
             }
@@ -33,13 +35,11 @@ final class ParamContravariantDetector
         return false;
     }
 
-    public function hasChildMethod(ClassMethod $classMethod, ClassReflection $classReflection): bool
+    public function hasChildMethod(ClassReflection $classReflection, ?string $classMethodName): bool
     {
-        $methodName = $this->nodeNameResolver->getName($classMethod);
-
         $classLikes = $this->nodeRepository->findClassesAndInterfacesByType($classReflection->getName());
         foreach ($classLikes as $classLike) {
-            $currentClassMethod = $classLike->getMethod($methodName);
+            $currentClassMethod = $classLike->getMethod($classMethodName);
             if ($currentClassMethod !== null) {
                 return true;
             }

--- a/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParamContravariantDetector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DowngradePhp72\NodeAnalyzer;
 
+use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Reflection\ClassReflection;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -35,9 +36,11 @@ final class ParamContravariantDetector
         return false;
     }
 
-    public function hasChildMethod(ClassReflection $classReflection, string $classMethodName): bool
+    /**
+     * @param ClassLike[] $classLikes
+     */
+    public function hasChildMethod(array $classLikes, string $classMethodName): bool
     {
-        $classLikes = $this->nodeRepository->findClassesAndInterfacesByType($classReflection->getName());
         foreach ($classLikes as $classLike) {
             $currentClassMethod = $classLike->getMethod($classMethodName);
             if ($currentClassMethod !== null) {

--- a/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
@@ -23,19 +23,21 @@ final class ParentChildClassMethodTypeResolver
     /**
      * @return array<class-string, Type>
      * @param ClassReflection[] $ancestors
+     * @param ClassReflection[] $interfaces
      */
     public function resolve(
         ClassReflection $classReflection,
         string $methodName,
         int $paramPosition,
-        array $ancestors
+        array $ancestors,
+        array $interfaces
     ): array {
         $parameterTypesByClassName = [];
 
         // include types of class scope in case of trait
         if ($classReflection->isTrait()) {
             $parameterTypesByInterfaceName = $this->resolveInterfaceTypeByClassName(
-                $classReflection,
+                $interfaces,
                 $methodName,
                 $paramPosition
             );
@@ -74,13 +76,14 @@ final class ParentChildClassMethodTypeResolver
     }
 
     /**
+     * @param ClassReflection[] $interfaces
      * @return array<class-string, Type>
      */
-    private function resolveInterfaceTypeByClassName(ClassReflection $classReflection, string $methodName, int $position): array
+    private function resolveInterfaceTypeByClassName(array $interfaces, string $methodName, int $position): array
     {
         $typesByClassName = [];
 
-        foreach ($classReflection->getInterfaces() as $interfaceClassReflection) {
+        foreach ($interfaces as $interfaceClassReflection) {
             if (! $interfaceClassReflection->hasMethod($methodName)) {
                 continue;
             }

--- a/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
@@ -80,11 +80,8 @@ final class ParentChildClassMethodTypeResolver
     {
         $typesByClassName = [];
 
+        /** @var ClassReflection $currentClassReflection */
         $currentClassReflection = $scope->getClassReflection();
-        if (! $currentClassReflection instanceof ClassReflection) {
-            return [];
-        }
-
         foreach ($currentClassReflection->getInterfaces() as $interfaceClassReflection) {
             if (! $interfaceClassReflection->hasMethod($methodName)) {
                 continue;

--- a/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\DowngradePhp72\NodeAnalyzer;
 
-use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Type;
@@ -27,15 +26,14 @@ final class ParentChildClassMethodTypeResolver
     public function resolve(
         ClassReflection $classReflection,
         string $methodName,
-        int $paramPosition,
-        Scope $scope
+        int $paramPosition
     ): array {
         $parameterTypesByClassName = [];
 
         // include types of class scope in case of trait
         if ($classReflection->isTrait()) {
             $parameterTypesByInterfaceName = $this->resolveInterfaceTypeByClassName(
-                $scope,
+                $classReflection,
                 $methodName,
                 $paramPosition
             );
@@ -76,13 +74,11 @@ final class ParentChildClassMethodTypeResolver
     /**
      * @return array<class-string, Type>
      */
-    private function resolveInterfaceTypeByClassName(Scope $scope, string $methodName, int $position): array
+    private function resolveInterfaceTypeByClassName(ClassReflection $classReflection, string $methodName, int $position): array
     {
         $typesByClassName = [];
 
-        /** @var ClassReflection $currentClassReflection */
-        $currentClassReflection = $scope->getClassReflection();
-        foreach ($currentClassReflection->getInterfaces() as $interfaceClassReflection) {
+        foreach ($classReflection->getInterfaces() as $interfaceClassReflection) {
             if (! $interfaceClassReflection->hasMethod($methodName)) {
                 continue;
             }

--- a/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
@@ -22,11 +22,13 @@ final class ParentChildClassMethodTypeResolver
 
     /**
      * @return array<class-string, Type>
+     * @param ClassReflection[] $ancestors
      */
     public function resolve(
         ClassReflection $classReflection,
         string $methodName,
-        int $paramPosition
+        int $paramPosition,
+        array $ancestors
     ): array {
         $parameterTypesByClassName = [];
 
@@ -40,7 +42,7 @@ final class ParentChildClassMethodTypeResolver
             $parameterTypesByClassName = array_merge($parameterTypesByClassName, $parameterTypesByInterfaceName);
         }
 
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+        foreach ($ancestors as $ancestorClassReflection) {
             if (! $ancestorClassReflection->hasMethod($methodName)) {
                 continue;
             }

--- a/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/ParentChildClassMethodTypeResolver.php
@@ -44,23 +44,24 @@ final class ParentChildClassMethodTypeResolver
             $parameterTypesByClassName = array_merge($parameterTypesByClassName, $parameterTypesByInterfaceName);
         }
 
-        foreach ($ancestors as $ancestorClassReflection) {
-            if (! $ancestorClassReflection->hasMethod($methodName)) {
+        foreach ($ancestors as $ancestor) {
+            $ancestorHasMethod = $ancestor->hasMethod($methodName);
+            if (! $ancestorHasMethod) {
                 continue;
             }
 
             $parameterType = $this->nativeTypeClassTreeResolver->resolveParameterReflectionType(
-                $ancestorClassReflection,
+                $ancestor,
                 $methodName,
                 $paramPosition
             );
 
-            $parameterTypesByClassName[$ancestorClassReflection->getName()] = $parameterType;
+            $parameterTypesByClassName[$ancestor->getName()] = $parameterType;
 
             // collect other children
-            if ($ancestorClassReflection->isInterface() || $ancestorClassReflection->isClass()) {
+            if ($ancestor->isInterface() || $ancestor->isClass()) {
                 $interfaceParameterTypesByClassName = $this->collectInterfaceImplenters(
-                    $ancestorClassReflection,
+                    $ancestor,
                     $methodName,
                     $paramPosition
                 );
@@ -83,18 +84,19 @@ final class ParentChildClassMethodTypeResolver
     {
         $typesByClassName = [];
 
-        foreach ($interfaces as $interfaceClassReflection) {
-            if (! $interfaceClassReflection->hasMethod($methodName)) {
+        foreach ($interfaces as $interface) {
+            $interfaceHasMethod = $interface->hasMethod($methodName);
+            if (! $interfaceHasMethod) {
                 continue;
             }
 
             $parameterType = $this->nativeTypeClassTreeResolver->resolveParameterReflectionType(
-                $interfaceClassReflection,
+                $interface,
                 $methodName,
                 $position
             );
 
-            $typesByClassName[$interfaceClassReflection->getName()] = $parameterType;
+            $typesByClassName[$interface->getName()] = $parameterType;
         }
 
         return $typesByClassName;

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -189,10 +189,8 @@ CODE_SAMPLE
     {
         // It already has no type => nothing to do - check original param, as it could have been removed by this rule
         $originalParam = $param->getAttribute(AttributeKey::ORIGINAL_NODE);
-        if ($originalParam instanceof Param) {
-            if ($originalParam->type === null) {
-                return;
-            }
+        if ($originalParam instanceof Param && $originalParam->type === null) {
+            return;
         } elseif ($param->type === null) {
             return;
         }

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -219,7 +219,7 @@ CODE_SAMPLE
             return true;
         }
 
-        $classMethodName = $this->nodeNameResolver->getName($classMethod);
+        $classMethodName = (string) $this->nodeNameResolver->getName($classMethod);
         if ($this->paramContravariantDetector->hasChildMethod($classReflection, $classMethodName)) {
             return false;
         }

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -149,7 +149,11 @@ CODE_SAMPLE
     /**
      * The topmost class is the source of truth, so we go only down to avoid up/down collission
      */
-    private function refactorClassMethod(ClassMethod $classMethod, Scope $scope, ClassReflection $classReflection): ?ClassMethod
+    private function refactorClassMethod(
+        ClassMethod $classMethod,
+        Scope $scope,
+        ClassReflection $classReflection
+    ): ?ClassMethod
     {
         /** @var string $methodName */
         $methodName = $this->nodeNameResolver->getName($classMethod);
@@ -191,7 +195,8 @@ CODE_SAMPLE
         $originalParam = $param->getAttribute(AttributeKey::ORIGINAL_NODE);
         if ($originalParam instanceof Param && $originalParam->type === null) {
             return;
-        } elseif ($param->type === null) {
+        }
+        if ($param->type === null) {
             return;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -96,7 +96,12 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isEmptyClassReflection($scope)) {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        if ($this->isEmptyClassReflection($classReflection)) {
             return null;
         }
 
@@ -113,7 +118,7 @@ CODE_SAMPLE
             }
 
             // refactor here
-            if ($this->refactorClassMethod($classMethod, $scope) !== null) {
+            if ($this->refactorClassMethod($classMethod, $scope, $classReflection) !== null) {
                 $hasChanged = true;
             }
         }
@@ -144,13 +149,8 @@ CODE_SAMPLE
     /**
      * The topmost class is the source of truth, so we go only down to avoid up/down collission
      */
-    private function refactorClassMethod(ClassMethod $classMethod, Scope $scope): ?ClassMethod
+    private function refactorClassMethod(ClassMethod $classMethod, Scope $scope, ClassReflection $classReflection): ?ClassMethod
     {
-        $classReflection = $scope->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
-            return null;
-        }
-
         /** @var string $methodName */
         $methodName = $this->nodeNameResolver->getName($classMethod);
 
@@ -220,13 +220,8 @@ CODE_SAMPLE
         return ! $this->paramContravariantDetector->hasParentMethod($classMethod, $classScope);
     }
 
-    private function isEmptyClassReflection(Scope $scope): bool
+    private function isEmptyClassReflection(ClassReflection $classReflection): bool
     {
-        $classReflection = $scope->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
-            return true;
-        }
-
         if ($classReflection->isInterface()) {
             return false;
         }

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -120,7 +120,7 @@ CODE_SAMPLE
             }
 
             // refactor here
-            if ($this->refactorClassMethod($classMethod, $scope, $classReflection) !== null) {
+            if ($this->refactorClassMethod($classMethod, $classReflection) !== null) {
                 $hasChanged = true;
             }
         }
@@ -153,7 +153,6 @@ CODE_SAMPLE
      */
     private function refactorClassMethod(
         ClassMethod $classMethod,
-        Scope $scope,
         ClassReflection $classReflection
     ): ?ClassMethod
     {

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -170,7 +170,7 @@ CODE_SAMPLE
             );
 
             $uniqueTypes = $this->typeFactory->uniquateTypes($parameterTypesByParentClassLikes);
-            if (count($uniqueTypes) <= 1) {
+            if (! isset($uniqueTypes[1])) {
                 continue;
             }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -116,13 +116,14 @@ CODE_SAMPLE
         /** @var ClassReflection[] $ancestors */
         $ancestors = $classReflection->getAncestors();
         $classLikes = $this->nodeRepository->findClassesAndInterfacesByType($classReflection->getName());
+        $interfaces = $classReflection->getInterfaces();
         foreach ($classMethods as $classMethod) {
             if ($this->skipClassMethod($classMethod, $classReflection, $ancestors, $classLikes)) {
                 continue;
             }
 
             // refactor here
-            if ($this->refactorClassMethod($classMethod, $classReflection, $ancestors) !== null) {
+            if ($this->refactorClassMethod($classMethod, $classReflection, $ancestors, $interfaces) !== null) {
                 $hasChanged = true;
             }
         }
@@ -153,8 +154,9 @@ CODE_SAMPLE
     /**
      * The topmost class is the source of truth, so we go only down to avoid up/down collission
      * @param ClassReflection[] $ancestors
+     * @param ClassReflection[] $interfaces
      */
-    private function refactorClassMethod(ClassMethod $classMethod, ClassReflection $classReflection, array $ancestors): ?ClassMethod {
+    private function refactorClassMethod(ClassMethod $classMethod, ClassReflection $classReflection, array $ancestors, array $interfaces): ?ClassMethod {
         /** @var string $methodName */
         $methodName = $this->nodeNameResolver->getName($classMethod);
 
@@ -171,7 +173,8 @@ CODE_SAMPLE
                 $classReflection,
                 $methodName,
                 $position,
-                $ancestors
+                $ancestors,
+                $interfaces
             );
 
             $uniqueTypes = $this->typeFactory->uniquateTypes($parameterTypesByParentClassLikes);

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Interface_;
 use PHPStan\Analyser\Scope;
@@ -114,8 +115,9 @@ CODE_SAMPLE
 
         /** @var ClassReflection[] $ancestors */
         $ancestors = $classReflection->getAncestors();
+        $classLikes = $this->nodeRepository->findClassesAndInterfacesByType($classReflection->getName());
         foreach ($classMethods as $classMethod) {
-            if ($this->skipClassMethod($classMethod, $classReflection, $ancestors)) {
+            if ($this->skipClassMethod($classMethod, $classReflection, $ancestors, $classLikes)) {
                 continue;
             }
 
@@ -204,8 +206,9 @@ CODE_SAMPLE
 
     /**
      * @param ClassReflection[] $ancestors
+     * @param ClassLike[] $classLikes
      */
-    private function skipClassMethod(ClassMethod $classMethod, ClassReflection $classReflection, array $ancestors): bool
+    private function skipClassMethod(ClassMethod $classMethod, ClassReflection $classReflection, array $ancestors, array $classLikes): bool
     {
         if ($classMethod->isMagic()) {
             return true;
@@ -217,7 +220,7 @@ CODE_SAMPLE
 
         /** @var string $classMethodName */
         $classMethodName = $this->nodeNameResolver->getName($classMethod);
-        if ($this->paramContravariantDetector->hasChildMethod($classReflection, $classMethodName)) {
+        if ($this->paramContravariantDetector->hasChildMethod($classLikes, $classMethodName)) {
             return false;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -215,6 +215,7 @@ CODE_SAMPLE
             return true;
         }
 
+        /** @var string $classMethodName */
         $classMethodName = $this->nodeNameResolver->getName($classMethod);
         if ($this->paramContravariantDetector->hasChildMethod($classReflection, $classMethodName)) {
             return false;

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -122,7 +122,7 @@ CODE_SAMPLE
             }
 
             // refactor here
-            if ($this->refactorClassMethod($classMethod, $classReflection) !== null) {
+            if ($this->refactorClassMethod($classMethod, $classReflection, $ancestors) !== null) {
                 $hasChanged = true;
             }
         }
@@ -152,8 +152,9 @@ CODE_SAMPLE
 
     /**
      * The topmost class is the source of truth, so we go only down to avoid up/down collission
+     * @param ClassReflection[] $ancestors
      */
-    private function refactorClassMethod(ClassMethod $classMethod, ClassReflection $classReflection): ?ClassMethod {
+    private function refactorClassMethod(ClassMethod $classMethod, ClassReflection $classReflection, array $ancestors): ?ClassMethod {
         /** @var string $methodName */
         $methodName = $this->nodeNameResolver->getName($classMethod);
 
@@ -169,7 +170,8 @@ CODE_SAMPLE
             $parameterTypesByParentClassLikes = $this->parentChildClassMethodTypeResolver->resolve(
                 $classReflection,
                 $methodName,
-                $position
+                $position,
+                $ancestors
             );
 
             $uniqueTypes = $this->typeFactory->uniquateTypes($parameterTypesByParentClassLikes);

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -166,8 +166,7 @@ CODE_SAMPLE
             $parameterTypesByParentClassLikes = $this->parentChildClassMethodTypeResolver->resolve(
                 $classReflection,
                 $methodName,
-                $position,
-                $scope
+                $position
             );
 
             $uniqueTypes = $this->typeFactory->uniquateTypes($parameterTypesByParentClassLikes);

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -113,7 +113,7 @@ CODE_SAMPLE
         $classMethods = $this->classLikeWithTraitsClassMethodResolver->resolve($node);
 
         foreach ($classMethods as $classMethod) {
-            if ($this->skipClassMethod($classMethod, $scope)) {
+            if ($this->skipClassMethod($classMethod, $classReflection)) {
                 continue;
             }
 
@@ -202,7 +202,7 @@ CODE_SAMPLE
         $param->type = null;
     }
 
-    private function skipClassMethod(ClassMethod $classMethod, Scope $classScope): bool
+    private function skipClassMethod(ClassMethod $classMethod, ClassReflection $classReflection): bool
     {
         if ($classMethod->isMagic()) {
             return true;
@@ -212,11 +212,11 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->paramContravariantDetector->hasChildMethod($classMethod, $classScope)) {
+        if ($this->paramContravariantDetector->hasChildMethod($classMethod, $classReflection)) {
             return false;
         }
 
-        return ! $this->paramContravariantDetector->hasParentMethod($classMethod, $classScope);
+        return ! $this->paramContravariantDetector->hasParentMethod($classMethod, $classReflection);
     }
 
     private function isEmptyClassReflection(ClassReflection $classReflection): bool

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -151,11 +151,7 @@ CODE_SAMPLE
     /**
      * The topmost class is the source of truth, so we go only down to avoid up/down collission
      */
-    private function refactorClassMethod(
-        ClassMethod $classMethod,
-        ClassReflection $classReflection
-    ): ?ClassMethod
-    {
+    private function refactorClassMethod(ClassMethod $classMethod, ClassReflection $classReflection): ?ClassMethod {
         /** @var string $methodName */
         $methodName = $this->nodeNameResolver->getName($classMethod);
 
@@ -219,7 +215,7 @@ CODE_SAMPLE
             return true;
         }
 
-        $classMethodName = (string) $this->nodeNameResolver->getName($classMethod);
+        $classMethodName = $this->nodeNameResolver->getName($classMethod);
         if ($this->paramContravariantDetector->hasChildMethod($classReflection, $classMethodName)) {
             return false;
         }

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -111,10 +111,10 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
-        $classMethods = $this->classLikeWithTraitsClassMethodResolver->resolve($node);
-
         /** @var ClassReflection[] $ancestors */
         $ancestors = $classReflection->getAncestors();
+        $classMethods = $this->classLikeWithTraitsClassMethodResolver->resolve($ancestors);
+
         $classLikes = $this->nodeRepository->findClassesAndInterfacesByType($classReflection->getName());
         $interfaces = $classReflection->getInterfaces();
         foreach ($classMethods as $classMethod) {


### PR DESCRIPTION
- Early skip when `$scope->getClassReflection()` is not ClassReflection instead of check in each loop.
- Remove unneded pass Scope on already ClassReflection used in ParentChildClassMethodTypeResolver
- change `count($uniqueTypes) <= 1` to `! isset($uniqueTypes[1])` as array_values always start from 0
- use ClassReflection type hint for ParamContravariantDetector methods
- get ancestors and class method name early before loop
- early get classes and interfaces by type before loop
- remove unused dependencies
- get all interfaces early before loop

Fixes https://github.com/rectorphp/rector/issues/6435