### PR TITLE
Add new method createFromClassWithItems in PhpAttributeGroupFactory

### DIFF
--- a/packages-tests/PhpAttribute/Printer/PhpAttributeGroupFactoryTest.php
+++ b/packages-tests/PhpAttribute/Printer/PhpAttributeGroupFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\PhpAttribute\Printer;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\AttributeGroup;
+use Rector\PhpAttribute\Printer\PhpAttributeGroupFactory;
+use Rector\Testing\PHPUnit\AbstractTestCase;
+
+class PhpAttributeGroupFactoryTest extends AbstractTestCase
+{
+    private PhpAttributeGroupFactory $phpAttributeGroupFactory;
+
+    protected function setUp(): void
+    {
+        $this->boot();
+
+        $this->phpAttributeGroupFactory = $this->getService(PhpAttributeGroupFactory::class);
+    }
+
+    public function testCreateFromClassWithItems(): void
+    {
+        $attributeGroup = $this->phpAttributeGroupFactory->createFromClassWithItems(
+            'Symfony\Component\Routing\Annotation\Route',
+            ['path' => '/path', 'name' => 'action']
+        );
+
+        self::assertInstanceOf(AttributeGroup::class, $attributeGroup);
+    }
+
+    public function testCreateArgsFromItems(): void
+    {
+        $method = new \ReflectionMethod($this->phpAttributeGroupFactory, 'createArgsFromItems');
+        $method->setAccessible(true);
+        $args = $method->invokeArgs($this->phpAttributeGroupFactory, [['path' => '/path', 'name' => 'action']]);
+
+        self::assertIsArray($args);
+        self::assertCount(2, $args);
+        self::assertContainsOnlyInstancesOf(Arg::class, $args);
+    }
+}

--- a/packages/PhpAttribute/Printer/PhpAttributeGroupFactory.php
+++ b/packages/PhpAttribute/Printer/PhpAttributeGroupFactory.php
@@ -37,6 +37,18 @@ final class PhpAttributeGroupFactory
         return new AttributeGroup([$attribute]);
     }
 
+    /**
+     * @param mixed[] $items
+     */
+    public function createFromClassWithItems(string $attributeClass, array $items): AttributeGroup
+    {
+        $fullyQualified = new FullyQualified($attributeClass);
+        $args = $this->createArgsFromItems($items);
+        $attribute = new Attribute($fullyQualified, $args);
+
+        return new AttributeGroup([$attribute]);
+    }
+
     public function create(
         DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
         AnnotationToAttribute $annotationToAttribute


### PR DESCRIPTION
I need this new method to be able to explode one annotation into multiple attributes.