### PR TITLE
[TypeDeclaration] Do not duplicate piped array return on ReturnTypeDeclarationRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -234,6 +234,7 @@ final class UnionTypeMapper implements TypeMapperInterface
             $phpParserUnionedTypes[] = $phpParserNode;
         }
 
+        $phpParserUnionedTypes = array_unique($phpParserUnionedTypes);
         return new PhpParserUnionType($phpParserUnionedTypes);
     }
 

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/do_not_duplicate_array_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/do_not_duplicate_array_return.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+final class DoNotDuplicateArrayReturn
+{
+    /**
+     * @return bool|mixed[]|float|string[]
+     */
+    public function go($number)
+    {
+        return execute();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+final class DoNotDuplicateArrayReturn
+{
+    /**
+     * @return bool|mixed[]|float|string[]
+     */
+    public function go($number): bool|array|float
+    {
+        return execute();
+    }
+}
+
+?>


### PR DESCRIPTION
`array` piped should be only defined once, it currently got twice:

```bash
-    public function go($number): bool|array|float
+    public function go($number): bool|array|float|array
```