### PR TITLE
[Php80] Remove this->isAtLeastPhpVersion() check on ClassOnObjectRector

### DIFF
--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/PropertyTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/PropertyTypeResolverTest.php
@@ -31,7 +31,7 @@ final class PropertyTypeResolverTest extends AbstractNodeTypeResolverTest
         $resolvedType = $this->nodeTypeResolver->resolve($propertyNodes[$nodePosition]);
 
         // type is as expected
-        $expectedTypeClass = get_class($expectedType);
+        $expectedTypeClass = $expectedType::class;
         $this->assertInstanceOf($expectedTypeClass, $resolvedType);
 
         $expectedTypeAsString = $this->getStringFromType($expectedType);

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -506,7 +506,7 @@ final class PhpDocInfo
             }
         }
 
-        throw new NotImplementedYetException(get_class($phpDocTagValueNode));
+        throw new NotImplementedYetException($phpDocTagValueNode::class);
     }
 
     private function isFnmatch(string $currentValue, string $desiredValue): bool

--- a/packages/ChangesReporting/ValueObject/RectorWithLineChange.php
+++ b/packages/ChangesReporting/ValueObject/RectorWithLineChange.php
@@ -19,7 +19,7 @@ final class RectorWithLineChange
      */
     public function getRectorClass(): string
     {
-        return get_class($this->rector);
+        return $this->rector::class;
     }
 
     public function getLine(): int

--- a/packages/ListReporting/Output/ConsoleOutputFormatter.php
+++ b/packages/ListReporting/Output/ConsoleOutputFormatter.php
@@ -25,7 +25,7 @@ final class ConsoleOutputFormatter implements ShowOutputFormatterInterface
         $this->outputStyle->title('Loaded Rector rules');
 
         foreach ($rectors as $rector) {
-            $this->outputStyle->writeln(' * ' . get_class($rector));
+            $this->outputStyle->writeln(' * ' . $rector::class);
         }
 
         $message = sprintf('%d loaded Rectors', $rectorCount);

--- a/packages/NodeNameResolver/Error/InvalidNameNodeReporter.php
+++ b/packages/NodeNameResolver/Error/InvalidNameNodeReporter.php
@@ -32,7 +32,7 @@ final class InvalidNameNodeReporter
      */
     public function reportInvalidNodeForName(Node $node): void
     {
-        $message = sprintf('Pick more specific node than "%s", e.g. "$node->name"', get_class($node));
+        $message = sprintf('Pick more specific node than "%s", e.g. "$node->name"', $node::class);
 
         $file = $this->currentFileProvider->getFile();
 

--- a/packages/NodeRemoval/BreakingRemovalGuard.php
+++ b/packages/NodeRemoval/BreakingRemovalGuard.php
@@ -28,9 +28,9 @@ final class BreakingRemovalGuard
 
         throw new ShouldNotHappenException(sprintf(
             'Node "%s" on line %d is child of "%s", so it cannot be removed as it would break PHP code. Change or remove the parent node instead.',
-            get_class($node),
+            $node::class,
             $node->getLine(),
-            get_class($parentNode)
+            $parentNode::class
         ));
     }
 

--- a/packages/NodeTypeResolver/NodeTypeResolver/CastTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/CastTypeResolver.php
@@ -56,6 +56,6 @@ final class CastTypeResolver implements NodeTypeResolverInterface
             return new ArrayType(new MixedType(), new MixedType());
         }
 
-        throw new NotImplementedYetException(get_class($node));
+        throw new NotImplementedYetException($node::class);
     }
 }

--- a/packages/NodeTypeResolver/PHPStan/TypeHasher.php
+++ b/packages/NodeTypeResolver/PHPStan/TypeHasher.php
@@ -45,7 +45,7 @@ final class TypeHasher
         }
 
         if ($type instanceof ConstantType) {
-            return get_class($type) . $type->getValue();
+            return $type::class . $type->getValue();
         }
 
         if ($type instanceof UnionType) {

--- a/packages/NodeTypeResolver/TypeComparator/ScalarTypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/ScalarTypeComparator.php
@@ -19,8 +19,8 @@ final class ScalarTypeComparator
     {
         if ($firstType instanceof StringType && $secondType instanceof StringType) {
             // prevents "class-string" vs "string"
-            $firstTypeClass = get_class($firstType);
-            $secondTypeClass = get_class($secondType);
+            $firstTypeClass = $firstType::class;
+            $secondTypeClass = $secondType::class;
 
             return $firstTypeClass === $secondTypeClass;
         }

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -32,7 +32,7 @@ final class PHPStanStaticTypeMapper
             return $typeMapper->mapToPHPStanPhpDocTypeNode($type);
         }
 
-        throw new NotImplementedYetException(__METHOD__ . ' for ' . get_class($type));
+        throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);
     }
 
     public function mapToPhpParserNode(Type $type, ?string $kind = null): Name | NullableType | UnionType | null
@@ -45,6 +45,6 @@ final class PHPStanStaticTypeMapper
             return $typeMapper->mapToPhpParserNode($type, $kind);
         }
 
-        throw new NotImplementedYetException(__METHOD__ . ' for ' . get_class($type));
+        throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);
     }
 }

--- a/packages/ReadWrite/NodeAnalyzer/ReadExprAnalyzer.php
+++ b/packages/ReadWrite/NodeAnalyzer/ReadExprAnalyzer.php
@@ -31,6 +31,6 @@ final class ReadExprAnalyzer
             return $readNodeAnalyzer->isRead($expr);
         }
 
-        throw new NotImplementedYetException(get_class($expr));
+        throw new NotImplementedYetException($expr::class);
     }
 }

--- a/packages/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
+++ b/packages/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
@@ -39,6 +39,6 @@ final class PhpParserNodeMapper
             }
         }
 
-        throw new NotImplementedYetException(get_class($node));
+        throw new NotImplementedYetException($node::class);
     }
 }

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -73,7 +73,7 @@ final class StaticTypeMapper
             return $this->mapPHPStanPhpDocTypeNodeToPHPStanType($phpDocTagValueNode->type, $node);
         }
 
-        throw new NotImplementedYetException(__METHOD__ . ' for ' . get_class($phpDocTagValueNode));
+        throw new NotImplementedYetException(__METHOD__ . ' for ' . $phpDocTagValueNode::class);
     }
 
     public function mapPHPStanPhpDocTypeNodeToPHPStanType(TypeNode $typeNode, Node $node): Type

--- a/rules/DeadCode/ConditionResolver.php
+++ b/rules/DeadCode/ConditionResolver.php
@@ -40,7 +40,7 @@ final class ConditionResolver
             return null;
         }
 
-        $binaryClass = get_class($expr);
+        $binaryClass = $expr::class;
 
         if ($this->isVersionCompareFuncCall($expr->left)) {
             /** @var FuncCall $funcCall */

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -77,7 +77,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $nodeClass = get_class($node);
+        $nodeClass = $node::class;
         if (! isset(self::CAST_CLASS_TO_NODE_TYPE[$nodeClass])) {
             return null;
         }

--- a/rules/DowngradePhp71/TypeDeclaration/PhpDocFromTypeDeclarationDecorator.php
+++ b/rules/DowngradePhp71/TypeDeclaration/PhpDocFromTypeDeclarationDecorator.php
@@ -112,7 +112,7 @@ final class PhpDocFromTypeDeclarationDecorator
         if ($returnType instanceof UnionType) {
             $returnType = $this->typeUnwrapper->unwrapNullableType($returnType);
         }
-        return is_a($returnType, get_class($requireType), true);
+        return is_a($returnType, $requireType::class, true);
     }
 
     /**

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -129,14 +129,14 @@ CODE_SAMPLE
     {
         $parentNode = $callNode->getAttribute(AttributeKey::PARENT_NODE);
 
-        $callNodeClass = get_class($callNode);
+        $callNodeClass = $callNode::class;
 
         while ($parentNode) {
             $usedNodes = $this->betterNodeFinder->find($parentNode, function (Node $node) use (
                 $callNodeClass,
                 $callNode
             ): bool {
-                $nodeClass = get_class($node);
+                $nodeClass = $node::class;
                 if ($callNodeClass !== $nodeClass) {
                     return false;
                 }

--- a/rules/Php80/Rector/FuncCall/ClassOnObjectRector.php
+++ b/rules/Php80/Rector/FuncCall/ClassOnObjectRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use Rector\Core\Rector\AbstractRector;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -63,10 +62,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isAtLeastPhpVersion(PhpVersionFeature::CLASS_ON_OBJECT)) {
-            return null;
-        }
-
         if (! $this->nodeNameResolver->isName($node, 'get_class')) {
             return null;
         }

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -163,7 +163,7 @@ final class VisibilityManipulator
             '"%s" only accepts "%s" types. "%s" given.',
             $location,
             implode('", "', self::ALLOWED_NODE_TYPES),
-            get_class($node)
+            $node::class
         ));
     }
 

--- a/rules/TypeDeclaration/Exception/ConflictingPriorityException.php
+++ b/rules/TypeDeclaration/Exception/ConflictingPriorityException.php
@@ -17,9 +17,9 @@ final class ConflictingPriorityException extends Exception
             'There are 2 type inferers with %d priority:%s- %s%s- %s.%sChange value in "getPriority()" method in one of them to different value',
             $firstPriorityAwareTypeInferer->getPriority(),
             PHP_EOL,
-            get_class($firstPriorityAwareTypeInferer),
+            $firstPriorityAwareTypeInferer::class,
             PHP_EOL,
-            get_class($secondPriorityAwareTypeInferer),
+            $secondPriorityAwareTypeInferer::class,
             PHP_EOL
         );
 

--- a/rules/TypeDeclaration/TypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeNormalizer.php
@@ -43,7 +43,7 @@ final class TypeNormalizer
             foreach ($unionType->getTypes() as $unionedType) {
                 if ($unionedType instanceof ConstantStringType) {
                     $stringType = new StringType();
-                    $nonConstantValueTypes[get_class($stringType)] = $stringType;
+                    $nonConstantValueTypes[$stringType::class] = $stringType;
                 } elseif ($unionedType instanceof ObjectType) {
                     $nonConstantValueTypes[] = $unionedType;
                 } else {

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -34,7 +34,7 @@ final class BootstrapFilesIncluder
             } catch (Throwable $throwable) {
                 $errorMessage = sprintf(
                     '"%s" thrown in "%s" on line %d while loading bootstrap file %s: %s',
-                    get_class($throwable),
+                    $throwable::class,
                     $throwable->getFile(),
                     $throwable->getLine(),
                     $bootstrapFile,

--- a/src/Exclusion/ExclusionManager.php
+++ b/src/Exclusion/ExclusionManager.php
@@ -55,7 +55,7 @@ final class ExclusionManager
 
         /** @var PhpDocTagNode[] $noRectorTags */
         $noRectorTags = array_merge($phpDocInfo->getTagsByName('noRector'), $phpDocInfo->getTagsByName('norector'));
-        $rectorClass = get_class($phpRector);
+        $rectorClass = $phpRector::class;
 
         foreach ($noRectorTags as $noRectorTag) {
             if (! $noRectorTag->value instanceof GenericTagValueNode) {

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -77,8 +77,8 @@ final class NodeComparator
             return false;
         }
 
-        $firstClass = get_class($firstNode);
-        $secondClass = get_class($secondNode);
+        $firstClass = $firstNode::class;
+        $secondClass = $secondNode::class;
 
         return $firstClass === $secondClass;
     }

--- a/src/PhpParser/Node/AssignAndBinaryMap.php
+++ b/src/PhpParser/Node/AssignAndBinaryMap.php
@@ -92,7 +92,7 @@ final class AssignAndBinaryMap
 
     public function getAlternative(Node $node): ?string
     {
-        $nodeClass = get_class($node);
+        $nodeClass = $node::class;
 
         if ($node instanceof AssignOp) {
             return self::ASSIGN_OP_TO_BINARY_OP_CLASSES[$nodeClass] ?? null;
@@ -107,7 +107,7 @@ final class AssignAndBinaryMap
 
     public function getInversed(BinaryOp $binaryOp): ?string
     {
-        $nodeClass = get_class($binaryOp);
+        $nodeClass = $binaryOp::class;
         return self::BINARY_OP_TO_INVERSE_CLASSES[$nodeClass] ?? null;
     }
 

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -604,7 +604,7 @@ final class NodeFactory
             return $arrayItem;
         }
 
-        $nodeClass = is_object($item) ? get_class($item) : $item;
+        $nodeClass = is_object($item) ? $item::class : $item;
         throw new NotImplementedYetException(sprintf(
             'Not implemented yet. Go to "%s()" and add check for "%s" node.',
             __METHOD__,

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -94,6 +94,6 @@ final class InlineCodeParser
             return $this->betterStandardPrinter->print($expr);
         }
 
-        throw new ShouldNotHappenException(get_class($expr) . ' ' . __METHOD__);
+        throw new ShouldNotHappenException($expr::class . ' ' . __METHOD__);
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -227,7 +227,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
      */
     final public function enterNode(Node $node)
     {
-        $nodeClass = get_class($node);
+        $nodeClass = $node::class;
         if (! $this->isMatchingNodeType($nodeClass)) {
             return null;
         }
@@ -276,7 +276,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             $this->connectParentNodes($node);
 
             // is different node type? do not traverse children to avoid looping
-            if (get_class($originalNode) !== get_class($node)) {
+            if ($originalNode::class !== $node::class) {
                 $this->infiniteLoopValidator->process($node, $originalNode, static::class);
 
                 // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown

--- a/src/Validation/InfiniteLoopValidator.php
+++ b/src/Validation/InfiniteLoopValidator.php
@@ -34,7 +34,7 @@ final class InfiniteLoopValidator
         // special case
         if ($createdByRule === $rectorClass) {
             // does it contain the same node type as input?
-            $originalNodeClass = get_class($originalNode);
+            $originalNodeClass = $originalNode::class;
 
             $hasNestedOriginalNodeType = $this->betterNodeFinder->findInstanceOf($node, $originalNodeClass);
             if ($hasNestedOriginalNodeType !== []) {

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -156,11 +156,6 @@ final class PhpVersionFeature
     /**
      * @var int
      */
-    public const CLASS_ON_OBJECT = PhpVersion::PHP_80;
-
-    /**
-     * @var int
-     */
     public const STATIC_RETURN_TYPE = PhpVersion::PHP_80;
 
     /**


### PR DESCRIPTION
`ClassOnObjectRector` is on `Php80` namespace and in php-80 config set so no need to check `$this->isAtLeastPhpVersion(PhpVersionFeature::CLASS_ON_OBJECT)`

Also remove unused `PhpVersionFeature::CLASS_ON_OBJECT` constant.

Part of https://github.com/rectorphp/rector-src/pull/159