### PR TITLE
[Core] Add ExternalFullyQualifiedAnalyzer to check external FullyQualified extends/interface/traits

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -23,6 +23,7 @@ use Rector\Privatization\Rector\Property\PrivatizeLocalPropertyToPrivateProperty
 use Rector\Restoration\Rector\ClassMethod\InferParamFromClassMethodReturnRector;
 use Rector\Restoration\ValueObject\InferParamFromClassMethodReturn;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
@@ -114,6 +115,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ReturnTypeDeclarationRector::class => [
             __DIR__ . '/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php',
             __DIR__ . '/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php',
+            __DIR__ . '/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php',
+        ],
+
+        AddVoidReturnTypeWhereNoReturnRector::class => [
             __DIR__ . '/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php',
         ],
 

--- a/rules-tests/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector/Fixture/skip_nullable_string_from_external_trait.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector/Fixture/skip_nullable_string_from_external_trait.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\Class_\DowngradeParameterTypeWideningRector\Fixture;
+
+use Rector\Tests\DowngradePhp72\Rector\Class_\DowngradeParameterTypeWideningRector\Source\NullableStringTrait;
+
+final class SkipNullableStringFromExternalTrait
+{
+    use NullableStringTrait;
+
+    public function load(string $value = null)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector/Source/NullableStringTrait.php
+++ b/rules-tests/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector/Source/NullableStringTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\Class_\DowngradeParameterTypeWideningRector\Source;
+
+trait NullableStringTrait
+{
+    public function load(string $value = null)
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_from_external_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_from_external_void.php.inc
@@ -2,17 +2,11 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
 
-use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source\ExternalForVoid;
 
-final class SkipFromExternalVoid extends PhpFileLoader
+final class SkipFromExternalVoid extends ExternalForVoid
 {
-    public function import(
-        $resource,
-        string $type = null,
-        $ignoreErrors = false,
-        string $sourceResource = null,
-        $exclude = null
-    )
+    public function run()
     {
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_from_external_void_interface.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_from_external_void_interface.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source\ExternalForVoidInterface;
+
+final class SkipFromExternalVoidInterface implements ExternalForVoidInterface
+{
+    public function run()
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_from_external_void_trait.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_from_external_void_trait.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source\ExternalForVoidTrait;
+
+final class SkipFromExternalVoidTrait
+{
+    use ExternalForVoidTrait;
+
+    public function run()
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/ExternalForVoid.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/ExternalForVoid.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source;
+
+class ExternalForVoid
+{
+    public function run()
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/ExternalForVoidInterface.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/ExternalForVoidInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source;
+
+interface ExternalForVoidInterface
+{
+    public function run();
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/ExternalForVoidTrait.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/ExternalForVoidTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source;
+
+trait ExternalForVoidTrait
+{
+    public function run()
+    {
+    }
+}

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -110,11 +110,7 @@ CODE_SAMPLE
 
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $node->extends;
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends)) {
-            return null;
-        }
-
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalTrait($node->getTraitUses())) {
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $node->getTraitUses())) {
             return null;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -111,7 +111,11 @@ CODE_SAMPLE
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $node->extends;
         $traitUses = $node->getTraitUses();
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $traitUses)) {
+        $externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
+            $extends,
+            $traitUses
+        );
+        if ($externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait) {
             return null;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -108,10 +108,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $extends = $node instanceof Interface_
-            ? $node->extends
-            : [$node->extends];
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends)) {
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($node->extends)) {
             return null;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp72\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->hasExternalFullyQualified($node)) {
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalFullyQualifieds($node)) {
             return null;
         }
 
@@ -135,24 +135,6 @@ CODE_SAMPLE
         }
 
         return null;
-    }
-
-    /**
-     * @param Class_|Interface_ $node
-     */
-    private function hasExternalFullyQualified(Node $node): bool
-    {
-        /** @var FullyQualified[]|FullyQualified|null $extends */
-        $extends = $node->extends;
-        /** @var FullyQualified[] $implements */
-        $implements = $node instanceof Class_ ? $node->implements : [];
-        $traitUses = $node->getTraitUses();
-
-        return $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
-            $extends,
-            $implements,
-            $traitUses
-        );
     }
 
     /**

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -108,7 +108,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($node->extends)) {
+        /** @var FullyQualified[]|FullyQualified|null $extends */
+        $extends = $node->extends;
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends)) {
             return null;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -111,11 +111,10 @@ CODE_SAMPLE
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $node->extends;
         $traitUses = $node->getTraitUses();
-        $externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
             $extends,
             $traitUses
-        );
-        if ($externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait) {
+        )) {
             return null;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -108,13 +108,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var FullyQualified[]|FullyQualified|null $extends */
-        $extends = $node->extends;
-        $traitUses = $node->getTraitUses();
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
-            $extends,
-            $traitUses
-        )) {
+        if ($this->hasExternalFullyQualified($node)) {
             return null;
         }
 
@@ -141,6 +135,24 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    /**
+     * @param Class_|Interface_ $node
+     */
+    private function hasExternalFullyQualified(Node $node): bool
+    {
+        /** @var FullyQualified[]|FullyQualified|null $extends */
+        $extends = $node->extends;
+        /** @var FullyQualified[] $implements */
+        $implements = $node instanceof Class_ ? $node->implements : [];
+        $traitUses = $node->getTraitUses();
+
+        return $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
+            $extends,
+            $implements,
+            $traitUses
+        );
     }
 
     /**

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -110,7 +110,8 @@ CODE_SAMPLE
 
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $node->extends;
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $node->getTraitUses())) {
+        $traitUses = $node->getTraitUses();
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $traitUses)) {
             return null;
         }
 

--- a/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/Class_/DowngradeParameterTypeWideningRector.php
@@ -114,6 +114,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalTrait($node->getTraitUses())) {
+            return null;
+        }
+
         $hasChanged = false;
         /** @var ClassReflection[] $ancestors */
         $ancestors = $classReflection->getAncestors();

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclaration\Rector\FunctionLike;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -244,10 +243,14 @@ CODE_SAMPLE
             return false;
         }
 
-        $hasExternalClassOrInterface = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($classLike->extends);
+        $hasExternalClassOrInterface = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface(
+            $classLike->extends
+        );
         $hasExternalTrait = $this->externalFullyQualifiedAnalyzer->hasExternalTrait($classLike->getTraitUses());
-
-        if ($hasExternalClassOrInterface || $hasExternalTrait) {
+        if ($hasExternalClassOrInterface) {
+            return $functionLike->returnType === null && $this->isName($inferredReturnNode, 'void');
+        }
+        if ($hasExternalTrait) {
             return $functionLike->returnType === null && $this->isName($inferredReturnNode, 'void');
         }
 

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -246,16 +246,8 @@ CODE_SAMPLE
 
         /** @var FullyQualified|null $extends */
         $extends = $classLike->extends;
-        $hasExternalClassOrInterface = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends);
-        $hasExternalTrait = $this->externalFullyQualifiedAnalyzer->hasExternalTrait($classLike->getTraitUses());
-        if ($hasExternalClassOrInterface) {
-            return $functionLike->returnType === null && $this->isName($inferredReturnNode, 'void');
-        }
-        if ($hasExternalTrait) {
-            return $functionLike->returnType === null && $this->isName($inferredReturnNode, 'void');
-        }
-
-        return false;
+        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $classLike->getTraitUses());
+        return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName($inferredReturnNode, 'void');
     }
 
     private function isNullableTypeSubType(Type $currentType, Type $inferedType): bool

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -249,8 +249,15 @@ CODE_SAMPLE
         /** @var FullyQualified[] $implements */
         $implements = $classLike->implements;
         $traitUses = $classLike->getTraitUses();
-        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $implements, $traitUses);
-        return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName($inferredReturnNode, 'void');
+        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
+            $extends,
+            $implements,
+            $traitUses
+        );
+        return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName(
+            $inferredReturnNode,
+            'void'
+        );
     }
 
     private function isNullableTypeSubType(Type $currentType, Type $inferedType): bool

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -244,16 +244,7 @@ CODE_SAMPLE
             return false;
         }
 
-        /** @var FullyQualified|null $extends */
-        $extends = $classLike->extends;
-        /** @var FullyQualified[] $implements */
-        $implements = $classLike->implements;
-        $traitUses = $classLike->getTraitUses();
-        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
-            $extends,
-            $implements,
-            $traitUses
-        );
+        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalFullyQualifieds($classLike);
         return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName(
             $inferredReturnNode,
             'void'

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -247,7 +247,7 @@ CODE_SAMPLE
         /** @var FullyQualified|null $extends */
         $extends = $classLike->extends;
         /** @var FullyQualified[] $implements */
-        $implements = $classLike->implements;
+        $implements = $classLike->implements ?? [];
         $traitUses = $classLike->getTraitUses();
         $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $implements, $traitUses);
         return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName($inferredReturnNode, 'void');

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -246,7 +246,8 @@ CODE_SAMPLE
 
         /** @var FullyQualified|null $extends */
         $extends = $classLike->extends;
-        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $classLike->getTraitUses());
+        $traitUses = $classLike->getTraitUses();
+        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $traitUses);
         return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName($inferredReturnNode, 'void');
     }
 

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -7,6 +7,7 @@ namespace Rector\TypeDeclaration\Rector\FunctionLike;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -243,9 +244,9 @@ CODE_SAMPLE
             return false;
         }
 
-        $hasExternalClassOrInterface = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface(
-            $classLike->extends
-        );
+        /** @var FullyQualified|null $extends */
+        $extends = $classLike->extends;
+        $hasExternalClassOrInterface = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends);
         $hasExternalTrait = $this->externalFullyQualifiedAnalyzer->hasExternalTrait($classLike->getTraitUses());
         if ($hasExternalClassOrInterface) {
             return $functionLike->returnType === null && $this->isName($inferredReturnNode, 'void');

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -247,7 +247,7 @@ CODE_SAMPLE
         /** @var FullyQualified|null $extends */
         $extends = $classLike->extends;
         /** @var FullyQualified[] $implements */
-        $implements = $classLike->implements ?? [];
+        $implements = $classLike->implements;
         $traitUses = $classLike->getTraitUses();
         $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $implements, $traitUses);
         return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName($inferredReturnNode, 'void');

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -245,7 +245,13 @@ CODE_SAMPLE
         }
 
         $hasExternalClassOrInterface = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($classLike->extends);
-        return $functionLike->returnType === null && $hasExternalClassOrInterface && $this->isName($inferredReturnNode, 'void');
+        $hasExternalTrait = $this->externalFullyQualifiedAnalyzer->hasExternalTrait($classLike->getTraitUses());
+
+        if ($hasExternalClassOrInterface || $hasExternalTrait) {
+            return $functionLike->returnType === null && $this->isName($inferredReturnNode, 'void');
+        }
+
+        return false;
     }
 
     private function isNullableTypeSubType(Type $currentType, Type $inferedType): bool

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclaration\Rector\FunctionLike;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -244,7 +243,9 @@ CODE_SAMPLE
             return false;
         }
 
-        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalFullyQualifieds($classLike);
+        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalFullyQualifieds(
+            $classLike
+        );
         return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName(
             $inferredReturnNode,
             'void'

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -246,8 +246,10 @@ CODE_SAMPLE
 
         /** @var FullyQualified|null $extends */
         $extends = $classLike->extends;
+        /** @var FullyQualified[] $implements */
+        $implements = $classLike->implements;
         $traitUses = $classLike->getTraitUses();
-        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $traitUses);
+        $hasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $implements, $traitUses);
         return $functionLike->returnType === null && $hasExternalClassOrInterfaceOrTrait && $this->isName($inferredReturnNode, 'void');
     }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclaration\TypeInferer;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -49,9 +48,7 @@ final class SilentVoidResolver
             return false;
         }
 
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalFullyQualifieds(
-            $classLike
-        )) {
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalFullyQualifieds($classLike)) {
             return false;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -51,9 +51,12 @@ final class SilentVoidResolver
 
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $classLike->extends;
+        /** @var FullyQualified[] $implements */
+        $implements = $classLike->implements;
         $traitUses = $classLike->getTraitUses();
         if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
             $extends,
+            $implements,
             $traitUses
         )) {
             return false;

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -52,7 +52,11 @@ final class SilentVoidResolver
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $classLike->extends;
         $traitUses = $classLike->getTraitUses();
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $traitUses)) {
+        $externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
+            $extends,
+            $traitUses
+        );
+        if ($externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait) {
             return false;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -18,13 +18,15 @@ use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\Trait_;
 use PhpParser\Node\Stmt\TryCatch;
+use Rector\Core\NodeAnalyzer\ExternalFullyQualifiedAnalyzer;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class SilentVoidResolver
 {
     public function __construct(
-        private BetterNodeFinder $betterNodeFinder
+        private BetterNodeFinder $betterNodeFinder,
+        private ExternalFullyQualifiedAnalyzer $externalFullyQualifiedAnalyzer
     ) {
     }
 
@@ -46,10 +48,19 @@ final class SilentVoidResolver
         if ($this->betterNodeFinder->hasInstancesOf((array) $functionLike->stmts, [Yield_::class])) {
             return false;
         }
+
         if ($classLike->extends instanceof FullyQualified) {
             return false;
         }
-        if ($classLike->getTraitUses() !== []) {
+
+        $extends = $classLike instanceof Interface_
+            ? $classLike->extends
+            : [$classLike->extends];
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends)) {
+            return false;
+        }
+
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalTrait($classLike->getTraitUses())) {
             return false;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -51,7 +51,8 @@ final class SilentVoidResolver
 
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $classLike->extends;
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $classLike->getTraitUses())) {
+        $traitUses = $classLike->getTraitUses();
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $traitUses)) {
             return false;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -52,7 +52,7 @@ final class SilentVoidResolver
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $classLike->extends;
         /** @var FullyQualified[] $implements */
-        $implements = $classLike->implements;
+        $implements = $classLike->implements ?? [];
         $traitUses = $classLike->getTraitUses();
         if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
             $extends,

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -49,10 +49,6 @@ final class SilentVoidResolver
             return false;
         }
 
-        if ($classLike->extends instanceof FullyQualified) {
-            return false;
-        }
-
         $extends = $classLike instanceof Interface_
             ? $classLike->extends
             : [$classLike->extends];

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -49,15 +49,8 @@ final class SilentVoidResolver
             return false;
         }
 
-        /** @var FullyQualified[]|FullyQualified|null $extends */
-        $extends = $classLike->extends;
-        /** @var FullyQualified[] $implements */
-        $implements = $classLike->implements;
-        $traitUses = $classLike->getTraitUses();
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
-            $extends,
-            $implements,
-            $traitUses
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalFullyQualifieds(
+            $classLike
         )) {
             return false;
         }

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -49,10 +49,7 @@ final class SilentVoidResolver
             return false;
         }
 
-        $extends = $classLike instanceof Interface_
-            ? $classLike->extends
-            : [$classLike->extends];
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends)) {
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($classLike->extends)) {
             return false;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -52,7 +52,7 @@ final class SilentVoidResolver
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $classLike->extends;
         /** @var FullyQualified[] $implements */
-        $implements = $classLike->implements ?? [];
+        $implements = $classLike->implements;
         $traitUses = $classLike->getTraitUses();
         if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
             $extends,

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -51,11 +51,7 @@ final class SilentVoidResolver
 
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $classLike->extends;
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends)) {
-            return false;
-        }
-
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalTrait($classLike->getTraitUses())) {
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait($extends, $classLike->getTraitUses())) {
             return false;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -52,11 +52,10 @@ final class SilentVoidResolver
         /** @var FullyQualified[]|FullyQualified|null $extends */
         $extends = $classLike->extends;
         $traitUses = $classLike->getTraitUses();
-        $externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait = $this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterfaceOrTrait(
             $extends,
             $traitUses
-        );
-        if ($externalFullyQualifiedAnalyzerHasExternalClassOrInterfaceOrTrait) {
+        )) {
             return false;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -49,7 +49,9 @@ final class SilentVoidResolver
             return false;
         }
 
-        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($classLike->extends)) {
+        /** @var FullyQualified[]|FullyQualified|null $extends */
+        $extends = $classLike->extends;
+        if ($this->externalFullyQualifiedAnalyzer->hasExternalClassOrInterface($extends)) {
             return false;
         }
 

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\NodeAnalyzer;
+
+use PhpParser\Node\Name\FullyQualified;
+use Rector\NodeCollector\NodeCollector\NodeRepository;
+use Rector\NodeNameResolver\NodeNameResolver;
+
+final class ExternalFullyQualifiedAnalyzer
+{
+    public function __construct(
+        private NodeNameResolver $nodeNameResolver,
+        private NodeRepository $nodeRepository
+    )
+    {
+    }
+
+    /**
+     * @param FullyQualified[]|mixed[] $traits
+     */
+    public function hasExternalClassOrInterface(array $fullyQualifiedClassLikes): bool
+    {
+        if ($fullyQualifiedClassLikes === []) {
+            return false;
+        }
+
+        foreach ($fullyQualifiedClassLikes as $classLike) {
+            if (! $classLike instanceof FullyQualified) {
+                return false;
+            }
+
+            /** @var string $traitName */
+            $className = $this->nodeNameResolver->getName($classLike);
+            $isClassFound     = (bool) $this->nodeRepository->findClass($className);
+            $isInterfaceFound = (bool) $this->nodeRepository->findInterface($className);
+
+            if ($isClassFound || $isInterfaceFound) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param FullyQualified[]|mixed[] $fullyQualifiedTraits
+     */
+    public function hasExternalTrait(array $fullyQualifiedTraits): bool
+    {
+        if ($fullyQualifiedTraits === []) {
+            return false;
+        }
+
+        foreach ($fullyQualifiedTraits as $trait) {
+            if (! $trait instanceof FullyQualified) {
+                return false;
+            }
+
+            /** @var string $traitName */
+            $traitName = $this->nodeNameResolver->getName($trait);
+            $isTraitFound = (bool) $this->nodeRepository->findTrait($traitName);
+
+            if (! $isTraitFound) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\TraitUse;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeNameResolver\NodeNameResolver;
-use PhpParser\Node\Stmt\TraitUse;
 
 final class ExternalFullyQualifiedAnalyzer
 {
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
         private NodeRepository $nodeRepository
-    )
-    {
+    ) {
     }
 
     /**
@@ -35,13 +34,15 @@ final class ExternalFullyQualifiedAnalyzer
             $fullyQualifiedClassLikes = [$fullyQualifiedClassLikes];
         }
 
-        foreach ($fullyQualifiedClassLikes as $classLike) {
+        foreach ($fullyQualifiedClassLikes as $fullyQualifiedClassLike) {
             /** @var string $className */
-            $className = $this->nodeNameResolver->getName($classLike);
-            $isClassFound     = (bool) $this->nodeRepository->findClass($className);
+            $className = $this->nodeNameResolver->getName($fullyQualifiedClassLike);
+            $isClassFound = (bool) $this->nodeRepository->findClass($className);
             $isInterfaceFound = (bool) $this->nodeRepository->findInterface($className);
-
-            if ($isClassFound || $isInterfaceFound) {
+            if ($isClassFound) {
+                continue;
+            }
+            if ($isInterfaceFound) {
                 continue;
             }
 

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -22,8 +22,12 @@ final class ExternalFullyQualifiedAnalyzer
 
     public function hasExternalFullyQualifieds(ClassLike $classLike): bool
     {
-        /** @var FullyQualified[] $extends */
+        /** @var FullyQualified|FullyQualified[] $extends */
         $extends = $classLike instanceof Trait_ ? [] : ($classLike->extends ?? []);
+        /** @var FullyQualified[] $extends */
+        $extends = $extends instanceof FullyQualified
+            ? [$extends]
+            : $extends;
 
         /** @var FullyQualified[] $implements */
         $implements = $classLike instanceof Class_ ? $classLike->implements : [];

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\Core\NodeAnalyzer;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeNameResolver\NodeNameResolver;
+use PhpParser\Node\Stmt\TraitUse;
 
 final class ExternalFullyQualifiedAnalyzer
 {
@@ -47,25 +48,29 @@ final class ExternalFullyQualifiedAnalyzer
     }
 
     /**
-     * @param FullyQualified[]|mixed[] $fullyQualifiedTraits
+     * @param TraitUse[] $traitUses
      */
-    public function hasExternalTrait(array $fullyQualifiedTraits): bool
+    public function hasExternalTrait(array $traitUses): bool
     {
-        if ($fullyQualifiedTraits === []) {
+        if ($traitUses === []) {
             return false;
         }
 
-        foreach ($fullyQualifiedTraits as $trait) {
-            if (! $trait instanceof FullyQualified) {
-                return false;
-            }
+        foreach ($traitUses as $traitUse) {
+            $traits = $traitUse->traits;
 
-            /** @var string $traitName */
-            $traitName = $this->nodeNameResolver->getName($trait);
-            $isTraitFound = (bool) $this->nodeRepository->findTrait($traitName);
+            foreach ($traits as $trait) {
+                if (! $trait instanceof FullyQualified) {
+                    return false;
+                }
 
-            if (! $isTraitFound) {
-                return true;
+                /** @var string $traitName */
+                $traitName = $this->nodeNameResolver->getName($trait);
+                $isTraitFound = (bool) $this->nodeRepository->findTrait($traitName);
+
+                if (! $isTraitFound) {
+                    return true;
+                }
             }
         }
 

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
-use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\TraitUse;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
@@ -19,7 +18,7 @@ final class ExternalFullyQualifiedAnalyzer
     }
 
     /**
-     * @param Name|FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
+     * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
      */
     public function hasExternalClassOrInterface($fullyQualifiedClassLikes): bool
     {
@@ -31,7 +30,7 @@ final class ExternalFullyQualifiedAnalyzer
             return false;
         }
 
-        if ($fullyQualifiedClassLikes instanceof Name) {
+        if ($fullyQualifiedClassLikes instanceof FullyQualified) {
             $fullyQualifiedClassLikes = [$fullyQualifiedClassLikes];
         }
 

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\TraitUse;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
@@ -18,7 +19,7 @@ final class ExternalFullyQualifiedAnalyzer
     }
 
     /**
-     * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
+     * @param Name|FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
      */
     public function hasExternalClassOrInterface($fullyQualifiedClassLikes): bool
     {
@@ -30,7 +31,7 @@ final class ExternalFullyQualifiedAnalyzer
             return false;
         }
 
-        if ($fullyQualifiedClassLikes instanceof FullyQualified) {
+        if ($fullyQualifiedClassLikes instanceof Name) {
             $fullyQualifiedClassLikes = [$fullyQualifiedClassLikes];
         }
 

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -21,7 +21,7 @@ final class ExternalFullyQualifiedAnalyzer
      * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
      * @param TraitUse[] $traitUses
      */
-    public function hasExternalClassOrInterfaceOrTrait($fullyQualifiedClassLikes, array $traitUses)
+    public function hasExternalClassOrInterfaceOrTrait($fullyQualifiedClassLikes, array $traitUses): bool
     {
         $hasExternalClassOrInterface = $this->hasExternalClassOrInterface($fullyQualifiedClassLikes);
         if ($hasExternalClassOrInterface) {

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -22,7 +22,7 @@ final class ExternalFullyQualifiedAnalyzer
 
     public function hasExternalFullyQualifieds(ClassLike $classLike): bool
     {
-        /** @var FullyQualified|FullyQualified[]|null $extends */
+        /** @var FullyQualified|FullyQualified[] $extends */
         $extends = $classLike instanceof Trait_ ? [] : ($classLike->extends ?? []);
 
         /** @var FullyQualified[] $implements */

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -19,8 +19,22 @@ final class ExternalFullyQualifiedAnalyzer
 
     /**
      * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
+     * @param TraitUse[] $traitUses
      */
-    public function hasExternalClassOrInterface($fullyQualifiedClassLikes): bool
+    public function hasExternalClassOrInterfaceOrTrait($fullyQualifiedClassLikes, array $traitUses)
+    {
+        $hasExternalClassOrInterface = $this->hasExternalClassOrInterface($fullyQualifiedClassLikes);
+        if ($hasExternalClassOrInterface) {
+            return true;
+        }
+
+        return $this->hasExternalTrait($traitUses);
+    }
+
+    /**
+     * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
+     */
+    private function hasExternalClassOrInterface($fullyQualifiedClassLikes): bool
     {
         if ($fullyQualifiedClassLikes === []) {
             return false;
@@ -55,7 +69,7 @@ final class ExternalFullyQualifiedAnalyzer
     /**
      * @param TraitUse[] $traitUses
      */
-    public function hasExternalTrait(array $traitUses): bool
+    private function hasExternalTrait(array $traitUses): bool
     {
         if ($traitUses === []) {
             return false;

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Interface_;
-use PhpParser\Node\Stmt\Trait_;
 use PhpParser\Node\Stmt\TraitUse;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -23,11 +22,10 @@ final class ExternalFullyQualifiedAnalyzer
 
     public function hasExternalFullyQualifieds(ClassLike $classLike): bool
     {
-        if ($classLike instanceof Trait_) {
-            $extends = [];
-        } else {
-            /** @var Class_|Interface_ $classLike */
+        if ($classLike instanceof Class_ || $classLike instanceof Interface_) {
             $extends = $classLike->extends ?? [];
+        } else {
+            $extends = [];
         }
 
         /** @var FullyQualified[] $extends */

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -22,7 +22,7 @@ final class ExternalFullyQualifiedAnalyzer
 
     public function hasExternalFullyQualifieds(ClassLike $classLike): bool
     {
-        /** @var FullyQualified|FullyQualified[] $extends */
+        /** @var FullyQualified[] $extends */
         $extends = $classLike instanceof Trait_ ? [] : ($classLike->extends ?? []);
 
         /** @var FullyQualified[] $implements */

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -19,20 +19,24 @@ final class ExternalFullyQualifiedAnalyzer
     }
 
     /**
-     * @param FullyQualified[]|mixed[] $traits
+     * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
      */
-    public function hasExternalClassOrInterface(array $fullyQualifiedClassLikes): bool
+    public function hasExternalClassOrInterface($fullyQualifiedClassLikes): bool
     {
         if ($fullyQualifiedClassLikes === []) {
             return false;
         }
 
-        foreach ($fullyQualifiedClassLikes as $classLike) {
-            if (! $classLike instanceof FullyQualified) {
-                return false;
-            }
+        if ($fullyQualifiedClassLikes === null) {
+            return false;
+        }
 
-            /** @var string $traitName */
+        if ($fullyQualifiedClassLikes instanceof FullyQualified) {
+            $fullyQualifiedClassLikes = [$fullyQualifiedClassLikes];
+        }
+
+        foreach ($fullyQualifiedClassLikes as $classLike) {
+            /** @var string $className */
             $className = $this->nodeNameResolver->getName($classLike);
             $isClassFound     = (bool) $this->nodeRepository->findClass($className);
             $isInterfaceFound = (bool) $this->nodeRepository->findInterface($className);

--- a/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
+++ b/src/NodeAnalyzer/ExternalFullyQualifiedAnalyzer.php
@@ -19,11 +19,12 @@ final class ExternalFullyQualifiedAnalyzer
 
     /**
      * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
+     * @param FullyQualified[] $implements
      * @param TraitUse[] $traitUses
      */
-    public function hasExternalClassOrInterfaceOrTrait($fullyQualifiedClassLikes, array $traitUses): bool
+    public function hasExternalClassOrInterfaceOrTrait($fullyQualifiedClassLikes, array $implements, array $traitUses): bool
     {
-        $hasExternalClassOrInterface = $this->hasExternalClassOrInterface($fullyQualifiedClassLikes);
+        $hasExternalClassOrInterface = $this->hasExternalClassOrInterface($fullyQualifiedClassLikes, $implements);
         if ($hasExternalClassOrInterface) {
             return true;
         }
@@ -33,8 +34,9 @@ final class ExternalFullyQualifiedAnalyzer
 
     /**
      * @param FullyQualified|FullyQualified[]|null $fullyQualifiedClassLikes
+     * @param FullyQualified[] $implements
      */
-    private function hasExternalClassOrInterface($fullyQualifiedClassLikes): bool
+    private function hasExternalClassOrInterface($fullyQualifiedClassLikes, array $implements): bool
     {
         if ($fullyQualifiedClassLikes === []) {
             return false;
@@ -48,6 +50,7 @@ final class ExternalFullyQualifiedAnalyzer
             $fullyQualifiedClassLikes = [$fullyQualifiedClassLikes];
         }
 
+        $fullyQualifiedClassLikes = array_merge($fullyQualifiedClassLikes, $implements);
         foreach ($fullyQualifiedClassLikes as $fullyQualifiedClassLike) {
             /** @var string $className */
             $className = $this->nodeNameResolver->getName($fullyQualifiedClassLike);


### PR DESCRIPTION
Re-open of https://github.com/rectorphp/rector-src/pull/152 . 

The `src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php` need to be skipped for `AddVoidReturnTypeWhereNoReturnRector` as always loaded early.