### PR TITLE
Add failing test fixture for AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/imported_attributes.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/imported_attributes.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+/**
+ * @UniqueEntity(
+ *     fields={"parent", "code"},
+ *     errorPath="code",
+ *     message="Already exists!",
+ *     ignoreNull=false,
+ *     groups={"default", "update"}
+ * )
+ */
+#[Table('Foo')]
+#[Entity]
+namespace Rector\Php80\Tests\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+class Foo
+{}


### PR DESCRIPTION
# Failing Test for AnnotationToAttributeRector

Based on https://getrector.org/demo/4c7348a5-8a07-4f85-aa4d-e462f672dae8

See https://github.com/rectorphp/rector/issues/6495