### PR TITLE
[Naming] @param doc should follow variable renamed on RenamePropertyToMatchTypeRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -79,11 +79,6 @@ final class PhpDocInfo
         $this->markAsChanged();
     }
 
-    public function setPhpDocNode(PhpDocNode $phpDocNode): void
-    {
-        $this->phpDocNode = $phpDocNode;
-    }
-
     public function getPhpDocNode(): PhpDocNode
     {
         return $this->phpDocNode;

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -79,6 +79,11 @@ final class PhpDocInfo
         $this->markAsChanged();
     }
 
+    public function setPhpDocNode(PhpDocNode $phpDocNode): void
+    {
+        $this->phpDocNode = $phpDocNode;
+    }
+
     public function getPhpDocNode(): PhpDocNode
     {
         return $this->phpDocNode;

--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/rename_param_doc.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/rename_param_doc.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\FixturePhp80;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+
+final class RenameParamDoc
+{
+    /**
+     * @param FuncCall|StaticCall|MethodCall $call
+     */
+    public function __construct(
+        private Expr $call
+    ) {
+    }
+
+    /**
+     * @return FuncCall|StaticCall|MethodCall
+     */
+    public function getCall(): Expr
+    {
+        return $this->call;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\FixturePhp80;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+
+final class RenameParamDoc
+{
+    /**
+     * @param FuncCall|StaticCall|MethodCall $expr
+     */
+    public function __construct(
+        private Expr $expr
+    ) {
+    }
+
+    /**
+     * @return FuncCall|StaticCall|MethodCall
+     */
+    public function getCall(): Expr
+    {
+        return $this->expr;
+    }
+}
+
+?>

--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/rename_param_doc.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/rename_param_doc.php.inc
@@ -2,27 +2,21 @@
 
 namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\FixturePhp80;
 
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 
 final class RenameParamDoc
 {
     /**
-     * @param FuncCall|StaticCall|MethodCall $call
+     * @param ClassAnalyzer $analyzer
      */
     public function __construct(
-        private Expr $call
+        private ClassAnalyzer $analyzer
     ) {
     }
 
-    /**
-     * @return FuncCall|StaticCall|MethodCall
-     */
-    public function getCall(): Expr
+    public function getAnalyzer(): ClassAnalyzer
     {
-        return $this->call;
+        return $this->analyzer;
     }
 }
 
@@ -32,27 +26,21 @@ final class RenameParamDoc
 
 namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\FixturePhp80;
 
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 
 final class RenameParamDoc
 {
     /**
-     * @param FuncCall|StaticCall|MethodCall $expr
+     * @param ClassAnalyzer $classAnalyzer
      */
     public function __construct(
-        private Expr $expr
+        private ClassAnalyzer $classAnalyzer
     ) {
     }
 
-    /**
-     * @return FuncCall|StaticCall|MethodCall
-     */
-    public function getCall(): Expr
+    public function getAnalyzer(): ClassAnalyzer
     {
-        return $this->expr;
+        return $this->classAnalyzer;
     }
 }
 


### PR DESCRIPTION
The variable in `@param` should follow the changed to new variable name.