### PR TITLE
[DowngradePhp80] Allow Expr type for DowngradeClassOnObjectToGetClassRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/ClassConstFetch/DowngradeClassOnObjectToGetClassRector/Fixture/func_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/ClassConstFetch/DowngradeClassOnObjectToGetClassRector/Fixture/func_call.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\ClassConstFetch\DowngradeClassOnObjectToGetClassRector\Fixture;
+
+use stdClass;
+
+function test()
+{
+    return new stdClass;
+}
+
+class SomeFuncCall
+{
+    public function run()
+    {
+        return test()::class;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\ClassConstFetch\DowngradeClassOnObjectToGetClassRector\Fixture;
+
+use stdClass;
+
+function test()
+{
+    return new stdClass;
+}
+
+class SomeFuncCall
+{
+    public function run()
+    {
+        return get_class(test());
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/ClassConstFetch/DowngradeClassOnObjectToGetClassRector.php
+++ b/rules/DowngradePhp80/Rector/ClassConstFetch/DowngradeClassOnObjectToGetClassRector.php
@@ -8,9 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -21,11 +18,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeClassOnObjectToGetClassRector extends AbstractRector
 {
-    /**
-     * @var string
-     */
-    private const GET_CLASS = 'get_class';
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change $object::class to get_class($object)', [
@@ -70,15 +62,7 @@ CODE_SAMPLE
         if (! $this->isName($node->name, 'class')) {
             return null;
         }
-        if ($node->class instanceof Variable) {
-            return new FuncCall(new Name(self::GET_CLASS), [new Arg($node->class)]);
-        }
-        if ($node->class instanceof PropertyFetch) {
-            return new FuncCall(new Name(self::GET_CLASS), [new Arg($node->class)]);
-        }
-        if ($node->class instanceof StaticPropertyFetch) {
-            return new FuncCall(new Name(self::GET_CLASS), [new Arg($node->class)]);
-        }
-        return null;
+
+        return new FuncCall(new Name('get_class'), [new Arg($node->class)]);
     }
 }

--- a/rules/DowngradePhp80/Rector/ClassConstFetch/DowngradeClassOnObjectToGetClassRector.php
+++ b/rules/DowngradePhp80/Rector/ClassConstFetch/DowngradeClassOnObjectToGetClassRector.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp80\Rector\ClassConstFetch;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
@@ -60,6 +61,10 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         if (! $this->isName($node->name, 'class')) {
+            return null;
+        }
+
+        if (! $node->class instanceof Expr) {
             return null;
         }
 


### PR DESCRIPTION
Apply changes when `$node->name` named 'class' for `ClassConstFetch` for `Expr`