### PR TITLE
Test: `EncapsedStringsToSprintfRector` + `RemoveDeadInstanceOfRector`

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -500,3 +500,7 @@ parameters:
 
         # cache hacking
         - '#"@var_export\(new \\Symplify\\EasyCodingStandard\\Caching\\ValueObject\\CacheItem\(\$variableKey, \$data\), true\)" is forbidden to use#'
+
+        -
+            message: '#Missing sprintf\(\) function for a mask#'
+            path: rules/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector.php #124

--- a/tests/Issues/Issue6481/EncapsedStringsInsideDeadInstanceTest.php
+++ b/tests/Issues/Issue6481/EncapsedStringsInsideDeadInstanceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6481;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/6481
+ */
+final class EncapsedStringsInsideDeadInstanceTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6481/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6481/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6481\Fixture;
+
+class Fixture
+{
+    public function test(): void {
+        $lorem = new \DateTime();
+        $ipsum = "";
+
+        if ($lorem instanceof \DateTime) {
+            echo "$ipsum";
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6481\Fixture;
+
+class Fixture
+{
+    public function test(): void {
+        $lorem = new \DateTime();
+        $ipsum = "";
+
+        echo sprintf('%s', $ipsum);
+    }
+}
+
+?>

--- a/tests/Issues/Issue6481/config/configured_rule.php
+++ b/tests/Issues/Issue6481/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
+use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(EncapsedStringsToSprintfRector::class);
+    $services->set(RemoveDeadInstanceOfRector::class);
+};


### PR DESCRIPTION
Closes rectorphp/rector#6481
Fixed by #201 @samsonasik 
See nikic/PHP-Parser#780