### PR TITLE
[CodingStyle] Fix newline before new assign set

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/multiple.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/multiple.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $value = new Value;
+        $value->setValue(5);
+        $value2 = new Value;
+        $value2->setValue(1);
+        $value3 = new Value;
+        $value3->setValue(1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $value = new Value;
+        $value->setValue(5);
+
+        $value2 = new Value;
+        $value2->setValue(1);
+
+        $value3 = new Value;
+        $value3->setValue(1);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/multiple.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/multiple.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
 
-final class Fixture
+final class Multiple
 {
     public function run()
     {
@@ -21,7 +21,7 @@ final class Fixture
 
 namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
 
-final class Fixture
+final class Multiple
 {
     public function run()
     {

--- a/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
@@ -77,21 +77,23 @@ CODE_SAMPLE
         $this->reset();
 
         $hasChanged = false;
+        $newStmts = [];
 
         foreach ((array) $node->stmts as $key => $stmt) {
             $currentStmtVariableName = $this->resolveCurrentStmtVariableName($stmt);
 
             if ($this->shouldAddEmptyLine($currentStmtVariableName, $node, $key)) {
                 $hasChanged = true;
-                // insert newline before
-                $stmts = (array) $node->stmts;
-                array_splice($stmts, $key, 0, [new Nop()]);
-                $node->stmts = $stmts;
+                // insert newline before stmt
+                $newStmts[] = new Nop();
             }
+            $newStmts[] = $stmt;
 
             $this->previousPreviousStmtVariableName = $this->previousStmtVariableName;
             $this->previousStmtVariableName = $currentStmtVariableName;
         }
+
+        $node->stmts = $newStmts;
 
         return $hasChanged ? $node : null;
     }

--- a/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
@@ -131,7 +131,7 @@ CODE_SAMPLE
         }
 
         // this is already empty line before
-        return ! $this->isPreceededByEmptyLine($node, $key);
+        return ! $this->isPrecededByEmptyLine($node, $key);
     }
 
     /**
@@ -171,7 +171,7 @@ CODE_SAMPLE
     /**
      * @param ClassMethod|Function_|Closure $node
      */
-    private function isPreceededByEmptyLine(Node $node, int $key): bool
+    private function isPrecededByEmptyLine(Node $node, int $key): bool
     {
         if ($node->stmts === null) {
             return false;


### PR DESCRIPTION
fixes https://github.com/rectorphp/rector/issues/6501

I just changed the way to add newlines, because adding newlines directly to `$node->stmts` inside foreach loop was breaking the loop (and logic).