### PR TITLE
[Util] Early strtolower() on StaticRectorStrings::isInArrayInsensitive()

### DIFF
--- a/src/Util/StaticRectorStrings.php
+++ b/src/Util/StaticRectorStrings.php
@@ -37,8 +37,9 @@ final class StaticRectorStrings
      */
     public static function isInArrayInsensitive(string $checkedItem, array $array): bool
     {
+        $checkedItem = strtolower($checkedItem);
         foreach ($array as $singleArray) {
-            if (strtolower($singleArray) === strtolower($checkedItem)) {
+            if (strtolower($singleArray) === $checkedItem) {
                 return true;
             }
         }


### PR DESCRIPTION
instead of run strtolower inside foreach, make variable and early assign for strtolower.