### PR TITLE
[Naming] Keep underscore in RenameForeachValueVariableToMatchExprVariableRector

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/keep_underscore.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/keep_underscore.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class KeepUnderscore
+{
+    public function run()
+    {
+        $customer_names = [];
+        foreach ($customer_names as $customer_name) {
+          echo $customer_name;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class KeepUnderscore
+{
+    public function run()
+    {
+        $customer_names = [];
+        foreach ($customer_names as $customer_name) {
+          echo $customer_name;
+        }
+    }
+}
+
+?>

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -18,9 +18,9 @@ final class InflectorSingularResolver
 
     /**
      * @var string
-     * @see https://regex101.com/r/lbQaGC/1
+     * @see https://regex101.com/r/lbQaGC/3
      */
-    private const CAMELCASE_REGEX = '#(?<camelcase>([a-z]+|[A-Z]{1,}[a-z]+))#';
+    private const CAMELCASE_REGEX = '#(?<camelcase>([a-z]+|[A-Z]{1,}[a-z]+|_))#';
 
     /**
      * @var string
@@ -64,7 +64,7 @@ final class InflectorSingularResolver
             $singularValueVarName .= $this->inflector->singularize($camelCase['camelcase']);
         }
 
-        if ($singularValueVarName === '') {
+        if ($singularValueVarName === '' || $singularValueVarName === '_') {
             return $currentName;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6479