### PR TITLE
[DeadCode] Prevent RemoveUnusedAssignVariableRector removing variables used in compact()

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector/Fixture/skip_in_compact.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector/Fixture/skip_in_compact.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class SkipInCompact
+{
+    public function run()
+    {
+        $value = 'foobar';
+        return compact('value');
+    }
+}

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector.php
@@ -6,11 +6,14 @@ namespace Rector\DeadCode\Rector\Assign;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
 use PHPStan\Analyser\Scope;
+use Rector\Core\NodeAnalyzer\CompactFuncCallAnalyzer;
 use Rector\Core\Rector\AbstractRector;
+use Rector\DeadCode\NodeAnalyzer\UsedVariableNameAnalyzer;
 use Rector\DeadCode\NodeFinder\NextVariableUsageNodeFinder;
 use Rector\DeadCode\NodeFinder\PreviousVariableAssignNodeFinder;
 use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
@@ -25,10 +28,12 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveUnusedAssignVariableRector extends AbstractRector
 {
     public function __construct(
+        private CompactFuncCallAnalyzer $compactFuncCallAnalyzer,
         private NextVariableUsageNodeFinder $nextVariableUsageNodeFinder,
         private PreviousVariableAssignNodeFinder $previousVariableAssignNodeFinder,
         private ScopeNestingComparator $scopeNestingComparator,
-        private SideEffectNodeDetector $sideEffectNodeDetector
+        private SideEffectNodeDetector $sideEffectNodeDetector,
+        private UsedVariableNameAnalyzer $usedVariableNameAnalyzer
     ) {
     }
 
@@ -89,6 +94,10 @@ CODE_SAMPLE
         }
 
         if ($this->isVariableTypeInScope($node) && ! $this->isPreviousVariablePartOfOverridingAssign($node)) {
+            return null;
+        }
+
+        if ($this->isInCompact($node)) {
             return null;
         }
 
@@ -164,5 +173,21 @@ CODE_SAMPLE
     {
         $parent = $assign->getAttribute(AttributeKey::PARENT_NODE);
         return $parent instanceof Assign;
+    }
+
+    private function isInCompact(Assign $assign): bool
+    {
+        $variable = $assign->var;
+
+        if (! $variable instanceof Variable) {
+            return false;
+        }
+
+        return (bool) $this->betterNodeFinder->findFirstNext($variable, function (Node $node) use ($variable): bool {
+            if ($node instanceof FuncCall) {
+                return $this->compactFuncCallAnalyzer->isInCompact($node, $variable);
+            }
+            return false;
+        });
     }
 }

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector.php
@@ -177,11 +177,8 @@ CODE_SAMPLE
 
     private function isInCompact(Assign $assign): bool
     {
+        /** @var Variable $variable */
         $variable = $assign->var;
-
-        if (! $variable instanceof Variable) {
-            return false;
-        }
 
         return (bool) $this->betterNodeFinder->findFirstNext($variable, function (Node $node) use ($variable): bool {
             if ($node instanceof FuncCall) {


### PR DESCRIPTION
Thanks for the great tool!

I've run into an issue where `RemoveUnusedAssignVariableRector` removes variables used in `compact()`.

E.g.

```diff
public function run()
{
-   $value = 'foobar';
    return compact('value');
}
```

I noticed this has been recently fixed in `RemoveUnusedVariableAssignRector` (https://github.com/rectorphp/rector/pull/6103) so I've tried to apply a similar approach here.

I'm not confident that I know what I'm doing in this code base so I would appreciate a thorough review and welcome any feedback.

Thanks again!