### PR TITLE
add DockerHub overview update workflow

### DIFF
--- a/build/target-repository/.github/workflows/publish_docker_images.yaml
+++ b/build/target-repository/.github/workflows/publish_docker_images.yaml
@@ -29,6 +29,14 @@ jobs:
                   username: ${{ secrets.DOCKER_USERNAME }}
                   password: ${{ secrets.DOCKER_PASSWORD }}
 
+            - name: Update DockerHub overview
+              uses: peter-evans/dockerhub-description@v2
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+                  repository: rector/rector
+                  readme-filepath: ./docs/how_to_run_rector_in_docker.md
+
             - name: Build images
               run: |
                   DOCKER_TAGS=""


### PR DESCRIPTION
fixes https://github.com/rectorphp/rector/issues/6457

Requires DockerHub password to run, and I believe this is the only way to update overview constantly with a path other than README.md.