### PR TITLE
Apply missing update phpstan req at target-repository

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "phpstan/phpstan": ">=0.12.86 <=0.12.88"
+        "phpstan/phpstan": ">=0.12.86 <=0.12.90"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
It currently still uses `>=0.12.86 <=0.12.88` which should be updated as well.