### PR TITLE
[Core] Early assign $smartFileInfo->getPathname() to variable for RemovedAndAddedFilesCollector::isFileRemoved()

### DIFF
--- a/src/Application/FileSystem/RemovedAndAddedFilesCollector.php
+++ b/src/Application/FileSystem/RemovedAndAddedFilesCollector.php
@@ -36,8 +36,13 @@ final class RemovedAndAddedFilesCollector
 
     public function isFileRemoved(SmartFileInfo $smartFileInfo): bool
     {
+        if ($this->removedFileInfos === []) {
+            return false;
+        }
+
+        $smartFileInfoPathName = $smartFileInfo->getPathname();
         foreach ($this->removedFileInfos as $removedFileInfo) {
-            if ($removedFileInfo->getPathname() !== $smartFileInfo->getPathname()) {
+            if ($removedFileInfo->getPathname() !== $smartFileInfoPathName) {
                 continue;
             }
 

--- a/src/Application/FileSystem/RemovedAndAddedFilesCollector.php
+++ b/src/Application/FileSystem/RemovedAndAddedFilesCollector.php
@@ -40,9 +40,9 @@ final class RemovedAndAddedFilesCollector
             return false;
         }
 
-        $smartFileInfoPathName = $smartFileInfo->getPathname();
+        $pathname = $smartFileInfo->getPathname();
         foreach ($this->removedFileInfos as $removedFileInfo) {
-            if ($removedFileInfo->getPathname() !== $smartFileInfoPathName) {
+            if ($removedFileInfo->getPathname() !== $pathname) {
                 continue;
             }
 


### PR DESCRIPTION
instead of re-call `$smartFileInfo->getPathname()` in a loop. 