### PR TITLE
[Core] Early $smartFileInfo->getPathname() on NonPhpFileProcessor::supports()

### DIFF
--- a/src/NonPhpFile/NonPhpFileProcessor.php
+++ b/src/NonPhpFile/NonPhpFileProcessor.php
@@ -37,8 +37,9 @@ final class NonPhpFileProcessor implements FileProcessorInterface
         $smartFileInfo = $file->getSmartFileInfo();
 
         // bug in path extension
+        $pathname = $smartFileInfo->getPathname();
         foreach ($this->getSupportedFileExtensions() as $supportedFileExtension) {
-            if (\str_ends_with($smartFileInfo->getPathname(), '.' . $supportedFileExtension)) {
+            if (\str_ends_with($pathname, '.' . $supportedFileExtension)) {
                 return true;
             }
         }


### PR DESCRIPTION
instead of call in loop.