### PR TITLE
Remove unused --output-file option, now direct on demo page

### DIFF
--- a/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -8,7 +8,6 @@ use Nette\Utils\Strings;
 use Rector\ChangesReporting\Annotation\RectorsChangelogResolver;
 use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
 use Rector\Core\Configuration\Configuration;
-use Rector\Core\Configuration\Option;
 use Rector\Core\Contract\Console\OutputStyleInterface;
 use Rector\Core\ValueObject\Application\RectorError;
 use Rector\Core\ValueObject\ProcessResult;
@@ -36,16 +35,6 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
 
     public function report(ProcessResult $processResult): void
     {
-        if ($this->configuration->getOutputFile()) {
-            $message = sprintf(
-                'Option "--%s" can be used only with "--%s %s"',
-                Option::OPTION_OUTPUT_FILE,
-                Option::OPTION_OUTPUT_FORMAT,
-                'json'
-            );
-            $this->outputStyle->error($message);
-        }
-
         if ($this->configuration->shouldShowDiffs()) {
             $this->reportFileDiffs($processResult->getFileDiffs());
         }

--- a/packages/ChangesReporting/Output/JsonOutputFormatter.php
+++ b/packages/ChangesReporting/Output/JsonOutputFormatter.php
@@ -70,13 +70,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         }
 
         $json = Json::encode($errorsArray, Json::PRETTY);
-
-        $outputFile = $this->configuration->getOutputFile();
-        if ($outputFile !== null) {
-            $this->smartFileSystem->dumpFile($outputFile, $json . PHP_EOL);
-        } else {
-            echo $json . PHP_EOL;
-        }
+        echo $json . PHP_EOL;
     }
 
     /**

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -37,8 +37,6 @@ final class Configuration
 
     private ParameterProvider $parameterProvider;
 
-    private ?string $outputFile = null;
-
     private bool $showDiffs = true;
 
     private ?BootstrapConfigs $bootstrapConfigs = null;
@@ -62,10 +60,6 @@ final class Configuration
         $this->showProgressBar = $this->canShowProgressBar($input);
         $this->showDiffs = ! (bool) $input->getOption(Option::OPTION_NO_DIFFS);
         $this->isCacheDebug = (bool) $input->getOption(Option::CACHE_DEBUG);
-
-        /** @var string|null $outputFileOption */
-        $outputFileOption = $input->getOption(Option::OPTION_OUTPUT_FILE);
-        $this->outputFile = $this->sanitizeOutputFileValue($outputFileOption);
 
         $this->outputFormat = (string) $input->getOption(Option::OPTION_OUTPUT_FORMAT);
 
@@ -98,11 +92,6 @@ final class Configuration
         }
 
         return $this->showProgressBar;
-    }
-
-    public function getOutputFile(): ?string
-    {
-        return $this->outputFile;
     }
 
     public function shouldClearCache(): bool
@@ -200,15 +189,6 @@ final class Configuration
 
         $optionOutputFormat = $input->getOption(Option::OPTION_OUTPUT_FORMAT);
         return $optionOutputFormat === ConsoleOutputFormatter::NAME;
-    }
-
-    private function sanitizeOutputFileValue(?string $outputFileOption): ?string
-    {
-        if ($outputFileOption === '') {
-            return null;
-        }
-
-        return $outputFileOption;
     }
 
     /**

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -66,11 +66,6 @@ final class Option
     /**
      * @var string
      */
-    public const OPTION_OUTPUT_FILE = 'output-file';
-
-    /**
-     * @var string
-     */
     public const OPTION_CLEAR_CACHE = 'clear-cache';
 
     /**

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -95,13 +95,6 @@ final class ProcessCommand extends Command
             'Hide diffs of changed files. Useful e.g. for nicer CI output.'
         );
 
-        $this->addOption(
-            Option::OPTION_OUTPUT_FILE,
-            null,
-            InputOption::VALUE_REQUIRED,
-            'Location for file to dump result in. Useful for Docker or automated processes'
-        );
-
         $this->addOption(Option::CACHE_DEBUG, null, InputOption::VALUE_NONE, 'Debug changed file cache');
         $this->addOption(Option::OPTION_CLEAR_CACHE, null, InputOption::VALUE_NONE, 'Clear unchaged files cache');
     }


### PR DESCRIPTION
I'm refactoring `Configuration` to value object as prequel to parallel run and came across this unused option.

The demo uses direct output since version 0.11, so this option is not needed anymore

See https://github.com/rectorphp/getrector.org/blob/20859c8d114c76fa947cfad4e0da2e30abbb7b2e/packages/Demo/DemoRunner.php#L46