### PR TITLE
Add failing test fixture for AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/apiplatform.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/apiplatform.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @ApiPlatform\Core\Annotation\ApiResource(
+ *     routePrefix="/demo/",
+ * )
+ */
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+final class DemoFile
+{
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+#[\ApiPlatform\Core\Annotation\ApiResource(routePrefix: '/demo/')]
+final class DemoFile
+{
+}
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/apiplatform.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/apiplatform.php.inc
@@ -1,12 +1,12 @@
 <?php
 
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
 /**
  * @ApiPlatform\Core\Annotation\ApiResource(
  *     routePrefix="/demo/",
  * )
  */
-namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
-
 final class DemoFile
 {
 }


### PR DESCRIPTION
# Failing Test for AnnotationToAttributeRector

Based on https://getrector.org/demo/f345dae3-9a60-4fc3-b838-d2f21ddbccf4