### PR TITLE
[DeadCode] Keep Assign expr on RemoveUnusedVariableAssignRector for impure function

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -487,8 +487,16 @@ parameters:
             path: packages/StaticTypeMapper/PhpDocParser/UnionTypeMapper.php #17
 
         -
-            message: '#Class with base "StaticTypeMapper" name is already used in "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\StaticTypeMapper", "Rector\\StaticTypeMapper\\StaticTypeMapper"\. Use unique name to make classes easy to recognize#'
+            message: '#Class with base "UnionTypeMapper" name is already used in "Rector\\StaticTypeMapper\\PhpDocParser\\UnionTypeMapper", "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\UnionTypeMapper"\. Use unique name to make classes easy to recognize#'
+            path: packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php #17
+
+        -
+            message: '#Class with base "StaticTypeMapper" name is already used in "Rector\\StaticTypeMapper\\StaticTypeMapper", "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\StaticTypeMapper"\. Use unique name to make classes easy to recognize#'
             path: packages/StaticTypeMapper/StaticTypeMapper.php #31
+
+        -
+            message: '#Class with base "StaticTypeMapper" name is already used in "Rector\\StaticTypeMapper\\StaticTypeMapper", "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\StaticTypeMapper"\. Use unique name to make classes easy to recognize#'
+            path: packages/PHPStanStaticTypeMapper/TypeMapper/StaticTypeMapper.php #21
 
         # false positive
         - '#Attribute class JetBrains\\PhpStorm\\Immutable does not exist#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -487,16 +487,8 @@ parameters:
             path: packages/StaticTypeMapper/PhpDocParser/UnionTypeMapper.php #17
 
         -
-            message: '#Class with base "UnionTypeMapper" name is already used in "Rector\\StaticTypeMapper\\PhpDocParser\\UnionTypeMapper", "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\UnionTypeMapper"\. Use unique name to make classes easy to recognize#'
-            path: packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php #17
-
-        -
-            message: '#Class with base "StaticTypeMapper" name is already used in "Rector\\StaticTypeMapper\\StaticTypeMapper", "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\StaticTypeMapper"\. Use unique name to make classes easy to recognize#'
+            message: '#Class with base "StaticTypeMapper" name is already used in "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\StaticTypeMapper", "Rector\\StaticTypeMapper\\StaticTypeMapper"\. Use unique name to make classes easy to recognize#'
             path: packages/StaticTypeMapper/StaticTypeMapper.php #31
-
-        -
-            message: '#Class with base "StaticTypeMapper" name is already used in "Rector\\StaticTypeMapper\\StaticTypeMapper", "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\StaticTypeMapper"\. Use unique name to make classes easy to recognize#'
-            path: packages/PHPStanStaticTypeMapper/TypeMapper/StaticTypeMapper.php #21
 
         # false positive
         - '#Attribute class JetBrains\\PhpStorm\\Immutable does not exist#'

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/on_ob_get_clean.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/on_ob_get_clean.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class OnObGetClean
+{
+    public function run()
+    {
+        echo 'run';
+    }
+
+    public function execute()
+    {
+        ob_start();
+
+        $this->run();
+
+        $result = ob_get_clean();
+
+        echo 'done';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class OnObGetClean
+{
+    public function run()
+    {
+        echo 'run';
+    }
+
+    public function execute()
+    {
+        ob_start();
+
+        $this->run();
+
+        ob_get_clean();
+
+        echo 'done';
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -22,6 +22,7 @@ use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\PhpParser\Comparing\ConditionSearcher;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\NodeAnalyzer\UsedVariableNameAnalyzer;
+use Rector\DeadCode\SideEffect\PureFunctionDetector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -35,7 +36,8 @@ final class RemoveUnusedVariableAssignRector extends AbstractRector
         private ReservedKeywordAnalyzer $reservedKeywordAnalyzer,
         private CompactFuncCallAnalyzer $compactFuncCallAnalyzer,
         private ConditionSearcher $conditionSearcher,
-        private UsedVariableNameAnalyzer $usedVariableNameAnalyzer
+        private UsedVariableNameAnalyzer $usedVariableNameAnalyzer,
+        private PureFunctionDetector $pureFunctionDetector
     ) {
     }
 
@@ -102,6 +104,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isImpureFunction($node->expr)) {
+            return $node->expr;
+        }
+
         if ($node->expr instanceof MethodCall || $node->expr instanceof StaticCall) {
             // keep the expr, can have side effect
             return $node->expr;
@@ -109,6 +115,15 @@ CODE_SAMPLE
 
         $this->removeNode($node);
         return $node;
+    }
+
+    private function isImpureFunction(Expr $expr): bool
+    {
+        if (! $expr instanceof FuncCall) {
+            return false;
+        }
+
+        return ! $this->pureFunctionDetector->detect($expr);
     }
 
     private function shouldSkip(Assign $assign): bool

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -104,11 +104,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isImpureFunction($node->expr)) {
-            return $node->expr;
-        }
-
-        if ($node->expr instanceof MethodCall || $node->expr instanceof StaticCall) {
+        if ($node->expr instanceof MethodCall || $node->expr instanceof StaticCall || $this->isImpureFunction(
+            $node->expr
+        )) {
             // keep the expr, can have side effect
             return $node->expr;
         }

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -30,7 +30,7 @@ final class PureFunctionDetector
         'header', 'header_remove', 'http_response_code', 'setcookie',
 
         // output buffer
-        'ob_start', 'ob_end_clean', 'readfile', 'printf', 'var_dump', 'phpinfo',
+        'ob_start', 'ob_end_clean', 'ob_get_clean', 'readfile', 'printf', 'var_dump', 'phpinfo',
         'ob_implicit_flush', 'vprintf',
 
         // mcrypt


### PR DESCRIPTION
Remove variable of assign, but keep assign expr when assign expr is an impure function.