### PR TITLE
Add failing test fixture for PropertyTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_mixed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_mixed.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
+
+class ParameterBag
+{
+    public $params;
+
+    public function __construct()
+    {
+        $this->params = func_get_args();
+    }
+
+    public function addParam($param)
+    {
+        $this->params[] = $param;
+    }
+
+    public function unwrap()
+    {
+        return $this->params;
+    }
+}
+?>


### PR DESCRIPTION
After reading the source of [PropertyTypeDeclarationRector](https://github.com/rectorphp/rector/blob/dba6b872023403763dd6882dd7aa96f2ab091332/rules/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector.php#L82-L88) I got the feeling that this rector should never produce a `mixed` phpdoc type.

with the added test-case I can reproduce a case where it does though.

I think this is not expected?

# Failing Test for PropertyTypeDeclarationRector
Based on https://getrector.org/demo/1ebd59aa-0794-689a-b49b-511f5d5982ba