### PR TITLE
Add failing test fixture for PropertyTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_simple_classnames.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_simple_classnames.php.inc
@@ -4,7 +4,6 @@ namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRe
 
 class Rocket {}
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
 
 class Product
 {

--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_simple_classnames.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_simple_classnames.php.inc
@@ -1,6 +1,5 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
 
 class Rocket {}
 

--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_simple_classnames.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_simple_classnames.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
+
+class Rocket {}
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
+
+class Product
+{
+    private $availableProducts = ['Rocket' => 'Rocket Framework'];
+}


### PR DESCRIPTION
when a array contains a simple string, it is beeing infered to be a class-string.

for strings without a namespace the chance its really a class-name is rather low IMO.
I would expect rector to not infer a `class-string` from a pretty simple literal string like `Rocket`


# Failing Test for PropertyTypeDeclarationRector

Based on https://getrector.org/demo/1ebd59b3-d072-66a0-a8d5-ad41b9d46677