### PR TITLE
PropertyTypeDeclarationRector: support `phpstan` and `psalm` prefixed `@var`

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -104,9 +104,9 @@ final class PhpDocInfo
         return $this->betterTokenIterator->count();
     }
 
-    public function getVarTagValueNode(): ?VarTagValueNode
+    public function getVarTagValueNode(string $tagName = '@var'): ?VarTagValueNode
     {
-        return $this->phpDocNode->getVarTagValues()[0] ?? null;
+        return $this->phpDocNode->getVarTagValues($tagName)[0] ?? null;
     }
 
     /**
@@ -160,9 +160,9 @@ final class PhpDocInfo
         return null;
     }
 
-    public function getVarType(): Type
+    public function getVarType(string $tagName = '@var'): Type
     {
-        return $this->getTypeOrMixed($this->getVarTagValueNode());
+        return $this->getTypeOrMixed($this->getVarTagValueNode($tagName));
     }
 
     public function getReturnType(): Type

--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_phpstan_var_annotated.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_phpstan_var_annotated.php.inc
@@ -7,7 +7,15 @@ final class DemoFile
     /**
      * @phpstan-var array<self::VALUE*, string>
      */
-    private static $availableValues = [
+    private static $availableValuesPhpstan = [
+        self::VALUE_ON => '&#128161; veröffentlicht',
+        self::VALUE_OFF => '&#10060; nicht veröffentlicht',
+    ];
+
+    /**
+     * @psalm-var array<self::VALUE*, string>
+     */
+    private static $availableValuesPsalm = [
         self::VALUE_ON => '&#128161; veröffentlicht',
         self::VALUE_OFF => '&#10060; nicht veröffentlicht',
     ];

--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_phpstan_var_annotated.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/skip_phpstan_var_annotated.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @phpstan-var array<self::VALUE*, string>
+     */
+    private static $availableValues = [
+        self::VALUE_ON => '&#128161; veröffentlicht',
+        self::VALUE_OFF => '&#10060; nicht veröffentlicht',
+    ];
+}

--- a/rules/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector.php
@@ -83,7 +83,13 @@ CODE_SAMPLE
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         // is already set
-        if (! $phpDocInfo->getVarType() instanceof MixedType) {
+        if (! $phpDocInfo->getVarType('@var') instanceof MixedType) {
+            return null;
+        }
+        if (! $phpDocInfo->getVarType('@phpstan-var') instanceof MixedType) {
+            return null;
+        }
+        if (! $phpDocInfo->getVarType('@psalm-var') instanceof MixedType) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector.php
@@ -83,14 +83,11 @@ CODE_SAMPLE
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         // is already set
-        if (! $phpDocInfo->getVarType('@var') instanceof MixedType) {
-            return null;
-        }
-        if (! $phpDocInfo->getVarType('@phpstan-var') instanceof MixedType) {
-            return null;
-        }
-        if (! $phpDocInfo->getVarType('@psalm-var') instanceof MixedType) {
-            return null;
+        foreach(['@var', '@phpstan-var', '@psalm-var'] as $tagName) {
+            $varType = $phpDocInfo->getVarType($tagName);
+            if (!$varType  instanceof MixedType) {
+                return null;
+            }
         }
 
         $type = $this->propertyTypeInferer->inferProperty($node);


### PR DESCRIPTION
`PropertyTypeDeclarationRector` should not add another `@var` annotation when a `@phpstan-var` is already declared

# Failing Test for PropertyTypeDeclarationRector

Based on https://getrector.org/demo/1ebd59d8-8604-6094-9c71-1f6d7ff1a1c6