### PR TITLE
Final reflection update touches

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -21,12 +21,12 @@ jobs:
             matrix:
                 repository_name:
                     # must be repository name, e.g. https://github.com/rectorphp/rector-nette
-                    - rectorphp/rector-nette
                     - rectorphp/rector-symfony
-                    - rectorphp/rector-laravel
                     - rectorphp/rector-phpunit
-                    - rectorphp/rector-cakephp
                     - rectorphp/rector-doctrine
+                    - rectorphp/rector-laravel
+                    - rectorphp/rector-nette
+                    - rectorphp/rector-cakephp
                     - sabbelasichon/typo3-rector
 
         steps:

--- a/rector.php
+++ b/rector.php
@@ -25,89 +25,93 @@ use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     // include sets
-    $containerConfigurator->import(SetList::CODING_STYLE);
-    $containerConfigurator->import(SetList::CODE_QUALITY);
-    $containerConfigurator->import(SetList::CODE_QUALITY_STRICT);
-    $containerConfigurator->import(SetList::DEAD_CODE);
-    $containerConfigurator->import(SetList::PRIVATIZATION);
-    $containerConfigurator->import(SetList::NAMING);
-    $containerConfigurator->import(SetList::TYPE_DECLARATION);
-    $containerConfigurator->import(SetList::PHP_71);
-    $containerConfigurator->import(SetList::PHP_72);
-    $containerConfigurator->import(SetList::PHP_73);
-    $containerConfigurator->import(SetList::PHP_74);
-    $containerConfigurator->import(SetList::PHP_80);
-    $containerConfigurator->import(SetList::EARLY_RETURN);
-    $containerConfigurator->import(SetList::TYPE_DECLARATION_STRICT);
-    $containerConfigurator->import(NetteSetList::NETTE_UTILS_CODE_QUALITY);
-    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_CODE_QUALITY);
+//    $containerConfigurator->import(SetList::CODING_STYLE);
+//    $containerConfigurator->import(SetList::CODE_QUALITY);
+//    $containerConfigurator->import(SetList::CODE_QUALITY_STRICT);
+//    $containerConfigurator->import(SetList::DEAD_CODE);
+//    $containerConfigurator->import(SetList::PRIVATIZATION);
+//    $containerConfigurator->import(SetList::NAMING);
+//    $containerConfigurator->import(SetList::TYPE_DECLARATION);
+//    $containerConfigurator->import(SetList::PHP_71);
+//    $containerConfigurator->import(SetList::PHP_72);
+//    $containerConfigurator->import(SetList::PHP_73);
+//    $containerConfigurator->import(SetList::PHP_74);
+//    $containerConfigurator->import(SetList::PHP_80);
+//    $containerConfigurator->import(SetList::EARLY_RETURN);
+//    $containerConfigurator->import(SetList::TYPE_DECLARATION_STRICT);
+//    $containerConfigurator->import(NetteSetList::NETTE_UTILS_CODE_QUALITY);
+//    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_CODE_QUALITY);
 
     $configuration = ValueObjectInliner::inline([
         new InferParamFromClassMethodReturn(AbstractRector::class, 'refactor', 'getNodeTypes'),
     ]);
 
     $services = $containerConfigurator->services();
-    $services->set(InferParamFromClassMethodReturnRector::class)
-        ->call('configure', [[
-            InferParamFromClassMethodReturnRector::INFER_PARAMS_FROM_CLASS_METHOD_RETURNS => $configuration,
-        ]]);
 
-    $services->set(PreferThisOrSelfMethodCallRector::class)
-        ->call('configure', [[
-            PreferThisOrSelfMethodCallRector::TYPE_TO_PREFERENCE => [
-                TestCase::class => PreferenceSelfThis::PREFER_THIS,
-            ],
-        ]]);
-
-    $parameters = $containerConfigurator->parameters();
-
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/rules',
-        __DIR__ . '/rules-tests',
-        __DIR__ . '/packages',
-        __DIR__ . '/packages-tests',
-        __DIR__ . '/tests',
-        __DIR__ . '/utils',
-        __DIR__ . '/config/set',
-    ]);
-
-    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
-
-    $parameters->set(Option::SKIP, [
-        // buggy in refactoring
-        AddSeeTestAnnotationRector::class,
-        // buggy in check ReflectionNamedType
-        ChangeReflectionTypeToStringToGetNameRector::class,
-
-        StringClassNameToClassConstantRector::class,
-        // some classes in config might not exist without dev dependencies
-        SplitStringClassConstantToClassConstFetchRector::class,
-
-        RemoveUnreachableStatementRector::class => [
-            __DIR__ . '/rules/Php70/Rector/FuncCall/MultiDirnameRector.php',
-        ],
-
-        PrivatizeLocalPropertyToPrivatePropertyRector::class => [__DIR__ . '/src/Rector/AbstractRector.php'],
-
-        ReturnTypeDeclarationRector::class => [
-            __DIR__ . '/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php',
-            __DIR__ . '/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php',
-            __DIR__ . '/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php',
-        ],
-
-        AddVoidReturnTypeWhereNoReturnRector::class => [
-            __DIR__ . '/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php',
-        ],
-
-        // test paths
-        '*/Fixture/*',
-        '*/Fixture*/*',
-        '*/Source/*',
-        '*/Source*/*',
-        '*/Expected/*',
-        '*/Expected*/*',
-    ]);
-
-    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan-for-rector.neon');
+    $services->set(\Rector\Php80\Rector\ClassMethod\OptionalParametersAfterRequiredRector::class);
+//
+//
+//    $services->set(InferParamFromClassMethodReturnRector::class)
+//        ->call('configure', [[
+//            InferParamFromClassMethodReturnRector::INFER_PARAMS_FROM_CLASS_METHOD_RETURNS => $configuration,
+//        ]]);
+//
+//    $services->set(PreferThisOrSelfMethodCallRector::class)
+//        ->call('configure', [[
+//            PreferThisOrSelfMethodCallRector::TYPE_TO_PREFERENCE => [
+//                TestCase::class => PreferenceSelfThis::PREFER_THIS,
+//            ],
+//        ]]);
+//
+//    $parameters = $containerConfigurator->parameters();
+//
+//    $parameters->set(Option::PATHS, [
+//        __DIR__ . '/src',
+//        __DIR__ . '/rules',
+//        __DIR__ . '/rules-tests',
+//        __DIR__ . '/packages',
+//        __DIR__ . '/packages-tests',
+//        __DIR__ . '/tests',
+//        __DIR__ . '/utils',
+//        __DIR__ . '/config/set',
+//    ]);
+//
+//    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+//
+//    $parameters->set(Option::SKIP, [
+//        // buggy in refactoring
+//        AddSeeTestAnnotationRector::class,
+//        // buggy in check ReflectionNamedType
+//        ChangeReflectionTypeToStringToGetNameRector::class,
+//
+//        StringClassNameToClassConstantRector::class,
+//        // some classes in config might not exist without dev dependencies
+//        SplitStringClassConstantToClassConstFetchRector::class,
+//
+//        RemoveUnreachableStatementRector::class => [
+//            __DIR__ . '/rules/Php70/Rector/FuncCall/MultiDirnameRector.php',
+//        ],
+//
+//        PrivatizeLocalPropertyToPrivatePropertyRector::class => [__DIR__ . '/src/Rector/AbstractRector.php'],
+//
+//        ReturnTypeDeclarationRector::class => [
+//            __DIR__ . '/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php',
+//            __DIR__ . '/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php',
+//            __DIR__ . '/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php',
+//        ],
+//
+//        AddVoidReturnTypeWhereNoReturnRector::class => [
+//            __DIR__ . '/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php',
+//        ],
+//
+//        // test paths
+//        '*/Fixture/*',
+//        '*/Fixture*/*',
+//        '*/Source/*',
+//        '*/Source*/*',
+//        '*/Expected/*',
+//        '*/Expected*/*',
+//    ]);
+//
+//    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan-for-rector.neon');
 };

--- a/rules-tests/Php80/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Source/vendor/SomeOutsideClass.php
+++ b/rules-tests/Php80/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Source/vendor/SomeOutsideClass.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Php80\Rector\ClassMethod\OptionalParametersAfterRequiredR
 
 final class SomeOutsideClass
 {
-    public function __construct($optional = 1, $required)
+    public function __construct($required, $optional = 1)
     {
     }
 }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
@@ -6,7 +6,6 @@ namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -64,7 +64,7 @@ final class ReflectionResolver
         }
 
         foreach ($classes as $class) {
-            $methodReflection = $this->resolveNativeClassMethodReflection($class, $methodName);
+            $methodReflection = $this->resolveMethodReflection($class, $methodName);
             if ($methodReflection instanceof MethodReflection) {
                 return $methodReflection;
             }

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -32,8 +32,11 @@ final class ReflectionResolver
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
+        if ($classReflection->hasMethod($methodName)) {
+            return $classReflection->getNativeMethod($methodName);
+        }
 
-        return $classReflection->hasMethod($methodName) ? $classReflection->getNativeMethod($methodName) : null;
+        return null;
     }
 
     /**


### PR DESCRIPTION
@samsonasik @sabbelasichon FYI, The reflection migration is finished now :+1: 

2 important changes:

* to get method reflection from a method call, static call, class name + method name etc., use `Rector\Core\Reflection\ReflectionResolver`
   * see https://github.com/rectorphp/rector-src/blob/main/src/Reflection/ReflectionResolver.php

* to get `ClassMethod`, `Class_` node (AST) from a class name + method name, use `Rector\Core\PhpParser\AstResolver` - its for read-only analysis of specific nodes
    * see https://github.com/rectorphp/rector-src/blob/main/src/PhpParser/AstResolver.php    