### PR TITLE
added `$kind` param to `TypeMapperInterface->mapToPHPStanPhpDocTypeNode()`

### DIFF
--- a/packages/PHPStanStaticTypeMapper/Contract/TypeMapperInterface.php
+++ b/packages/PHPStanStaticTypeMapper/Contract/TypeMapperInterface.php
@@ -10,6 +10,7 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Type;
+use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;
 
 interface TypeMapperInterface
 {
@@ -19,12 +20,12 @@ interface TypeMapperInterface
     public function getNodeClass(): string;
 
     /**
-     * @param 'property'|'return'|null $kind
+     * @param TypeKind::*|null $kind
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode;
 
     /**
-     * @param 'property'|'param'|null $kind
+     * @param TypeKind::*|null $kind
      *
      * @return Name|NullableType|UnionType|null
      */

--- a/packages/PHPStanStaticTypeMapper/Contract/TypeMapperInterface.php
+++ b/packages/PHPStanStaticTypeMapper/Contract/TypeMapperInterface.php
@@ -18,9 +18,14 @@ interface TypeMapperInterface
      */
     public function getNodeClass(): string;
 
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode;
+    /**
+     * @param 'property'|'return'|null $kind
+     */
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode;
 
     /**
+     * @param 'property'|'param'|null $kind
+     *
      * @return Name|NullableType|UnionType|null
      */
     public function mapToPhpParserNode(Type $type, ?string $kind = null): ?Node;

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -22,7 +22,10 @@ final class PHPStanStaticTypeMapper
     ) {
     }
 
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    /**
+     * @param 'property'|'return'|null $kind
+     */
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         foreach ($this->typeMappers as $typeMapper) {
             if (! is_a($type, $typeMapper->getNodeClass(), true)) {
@@ -35,6 +38,9 @@ final class PHPStanStaticTypeMapper
         throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);
     }
 
+    /**
+     * @param 'property'|'param'|null $kind
+     */
     public function mapToPhpParserNode(Type $type, ?string $kind = null): Name | NullableType | UnionType | null
     {
         foreach ($this->typeMappers as $typeMapper) {

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -11,6 +11,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
+use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;
 
 final class PHPStanStaticTypeMapper
 {
@@ -23,7 +24,7 @@ final class PHPStanStaticTypeMapper
     }
 
     /**
-     * @param 'property'|'return'|null $kind
+     * @param TypeKind::*|null $kind
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
@@ -39,7 +40,7 @@ final class PHPStanStaticTypeMapper
     }
 
     /**
-     * @param 'property'|'param'|null $kind
+     * @param TypeKind::*|null $kind
      */
     public function mapToPhpParserNode(Type $type, ?string $kind = null): Name | NullableType | UnionType | null
     {

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -12,7 +12,7 @@ use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 
-final class PHPStanStaticTypeMapper implements TypeMapperInterface
+final class PHPStanStaticTypeMapper
 {
     /**
      * @param TypeMapperInterface[] $typeMappers
@@ -22,7 +22,7 @@ final class PHPStanStaticTypeMapper implements TypeMapperInterface
     ) {
     }
 
-    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
     {
         foreach ($this->typeMappers as $typeMapper) {
             if (! is_a($type, $typeMapper->getNodeClass(), true)) {
@@ -46,10 +46,5 @@ final class PHPStanStaticTypeMapper implements TypeMapperInterface
         }
 
         throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);
-    }
-
-    public function getNodeClass(): string
-    {
-        throw new NotImplementedYetException(__METHOD__ );
     }
 }

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -32,7 +32,7 @@ final class PHPStanStaticTypeMapper
                 continue;
             }
 
-            return $typeMapper->mapToPHPStanPhpDocTypeNode($type);
+            return $typeMapper->mapToPHPStanPhpDocTypeNode($type, $kind);
         }
 
         throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -12,7 +12,7 @@ use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 
-final class PHPStanStaticTypeMapper
+final class PHPStanStaticTypeMapper implements TypeMapperInterface
 {
     /**
      * @param TypeMapperInterface[] $typeMappers
@@ -22,7 +22,7 @@ final class PHPStanStaticTypeMapper
     ) {
     }
 
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         foreach ($this->typeMappers as $typeMapper) {
             if (! is_a($type, $typeMapper->getNodeClass(), true)) {
@@ -46,5 +46,10 @@ final class PHPStanStaticTypeMapper
         }
 
         throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);
+    }
+
+    public function getNodeClass(): string
+    {
+        throw new NotImplementedYetException(__METHOD__ );
     }
 }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
@@ -67,7 +67,7 @@ final class ArrayTypeMapper implements TypeMapperInterface
     /**
      * @param ArrayType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         $itemType = $type->getItemType();
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/BooleanTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/BooleanTypeMapper.php
@@ -33,7 +33,7 @@ final class BooleanTypeMapper implements TypeMapperInterface
     /**
      * @param BooleanType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         if ($this->isFalseBooleanTypeWithUnion($type)) {
             return new IdentifierTypeNode('false');

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/CallableTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/CallableTypeMapper.php
@@ -14,6 +14,7 @@ use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareCallableTypeNode;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
+use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;
 use Symfony\Contracts\Service\Attribute\Required;
 
 final class CallableTypeMapper implements TypeMapperInterface
@@ -49,7 +50,7 @@ final class CallableTypeMapper implements TypeMapperInterface
      */
     public function mapToPhpParserNode(Type $type, ?string $kind = null): ?Node
     {
-        if ($kind === 'property') {
+        if ($kind === TypeKind::KIND_PROPERTY) {
             return null;
         }
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/CallableTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/CallableTypeMapper.php
@@ -37,7 +37,7 @@ final class CallableTypeMapper implements TypeMapperInterface
     /**
      * @param CallableType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         $returnTypeNode = $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($type->getReturnType());
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
@@ -32,7 +32,7 @@ final class ClassStringTypeMapper implements TypeMapperInterface
     /**
      * @param ClassStringType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         $attributeAwareIdentifierTypeNode = new IdentifierTypeNode('class-string');
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ClosureTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ClosureTypeMapper.php
@@ -34,7 +34,7 @@ final class ClosureTypeMapper implements TypeMapperInterface
     /**
      * @param ClosureType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         $identifierTypeNode = new IdentifierTypeNode($type->getClassName());
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/FloatTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/FloatTypeMapper.php
@@ -32,7 +32,7 @@ final class FloatTypeMapper implements TypeMapperInterface
     /**
      * @param FloatType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('float');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/HasOffsetTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/HasOffsetTypeMapper.php
@@ -26,7 +26,7 @@ final class HasOffsetTypeMapper implements TypeMapperInterface
     /**
      * @param HasOffsetType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new ArrayTypeNode(new IdentifierTypeNode('mixed'));
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntegerTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntegerTypeMapper.php
@@ -32,7 +32,7 @@ final class IntegerTypeMapper implements TypeMapperInterface
     /**
      * @param IntegerType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('int');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -34,7 +34,7 @@ final class IntersectionTypeMapper implements TypeMapperInterface
     /**
      * @param IntersectionType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         $intersectionTypesNodes = [];
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IterableTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IterableTypeMapper.php
@@ -38,7 +38,7 @@ final class IterableTypeMapper implements TypeMapperInterface
     /**
      * @param IterableType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         $itemTypeNode = $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($type->getItemType());
         if ($itemTypeNode instanceof UnionTypeNode) {

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/MixedTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/MixedTypeMapper.php
@@ -24,7 +24,7 @@ final class MixedTypeMapper implements TypeMapperInterface
     /**
      * @param MixedType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/NeverTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/NeverTypeMapper.php
@@ -24,8 +24,11 @@ final class NeverTypeMapper implements TypeMapperInterface
     /**
      * @param NeverType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
+        if ($kind === 'return') {
+            return new IdentifierTypeNode('never');
+        }
         return new IdentifierTypeNode('mixed');
     }
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/NeverTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/NeverTypeMapper.php
@@ -10,6 +10,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
+use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;
 
 final class NeverTypeMapper implements TypeMapperInterface
 {
@@ -26,7 +27,7 @@ final class NeverTypeMapper implements TypeMapperInterface
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
-        if ($kind === 'return') {
+        if ($kind === TypeKind::KIND_RETURN) {
             return new IdentifierTypeNode('never');
         }
         return new IdentifierTypeNode('mixed');

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/NonEmptyArrayTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/NonEmptyArrayTypeMapper.php
@@ -26,7 +26,7 @@ final class NonEmptyArrayTypeMapper implements TypeMapperInterface
     /**
      * @param NonEmptyArrayType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new SpacingAwareArrayTypeNode(new IdentifierTypeNode('mixed'));
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
@@ -26,7 +26,7 @@ final class NullTypeMapper implements TypeMapperInterface
     /**
      * @param NullType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('null');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -38,7 +38,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
     /**
      * @param ObjectType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         if ($type instanceof ShortenedObjectType) {
             return new IdentifierTypeNode($type->getClassName());

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
@@ -38,7 +38,7 @@ final class ObjectWithoutClassTypeMapper implements TypeMapperInterface
     /**
      * @param ObjectWithoutClassType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         if ($type instanceof TemplateObjectWithoutClassType) {
             $attributeAwareIdentifierTypeNode = new IdentifierTypeNode($type->getName());

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ParentStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ParentStaticTypeMapper.php
@@ -25,7 +25,7 @@ final class ParentStaticTypeMapper implements TypeMapperInterface
     /**
      * @param ParentStaticType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('parent');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ResourceTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ResourceTypeMapper.php
@@ -24,7 +24,7 @@ final class ResourceTypeMapper implements TypeMapperInterface
     /**
      * @param ResourceType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('resource');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/SelfObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/SelfObjectTypeMapper.php
@@ -25,7 +25,7 @@ final class SelfObjectTypeMapper implements TypeMapperInterface
     /**
      * @param SelfObjectType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('self');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/StaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/StaticTypeMapper.php
@@ -36,7 +36,7 @@ final class StaticTypeMapper implements TypeMapperInterface
     /**
      * @param StaticType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new ThisTypeNode();
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/StrictMixedTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/StrictMixedTypeMapper.php
@@ -30,7 +30,7 @@ final class StrictMixedTypeMapper implements TypeMapperInterface
     /**
      * @param StrictMixedType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode(self::MIXED);
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/StringTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/StringTypeMapper.php
@@ -32,7 +32,7 @@ final class StringTypeMapper implements TypeMapperInterface
     /**
      * @param StringType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('string');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ThisTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ThisTypeMapper.php
@@ -25,7 +25,7 @@ final class ThisTypeMapper implements TypeMapperInterface
     /**
      * @param ThisType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new ThisTypeNode();
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/TypeWithClassNameTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/TypeWithClassNameTypeMapper.php
@@ -29,7 +29,7 @@ final class TypeWithClassNameTypeMapper implements TypeMapperInterface
     /**
      * @param TypeWithClassName $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode('string-class');
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -64,7 +64,7 @@ final class UnionTypeMapper implements TypeMapperInterface
     /**
      * @param UnionType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         $unionTypesNodes = [];
         $skipIterable = $this->shouldSkipIterable($type);

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
@@ -13,6 +13,7 @@ use PHPStan\Type\VoidType;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
+use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;
 
 final class VoidTypeMapper implements TypeMapperInterface
 {
@@ -51,7 +52,7 @@ final class VoidTypeMapper implements TypeMapperInterface
             return null;
         }
 
-        if (in_array($kind, ['param', 'property'], true)) {
+        if (in_array($kind, [TypeKind::KIND_PARAM, TypeKind::KIND_PROPERTY], true)) {
             return null;
         }
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
@@ -37,7 +37,7 @@ final class VoidTypeMapper implements TypeMapperInterface
     /**
      * @param VoidType $type
      */
-    public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
+    public function mapToPHPStanPhpDocTypeNode(Type $type, ?string $kind = null): TypeNode
     {
         return new IdentifierTypeNode(self::VOID);
     }

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -47,6 +47,8 @@ final class StaticTypeMapper
     }
 
     /**
+     * @param 'property'|'return'|null $kind
+     *
      * @return Name|NullableType|PhpParserUnionType|null
      */
     public function mapPHPStanTypeToPhpParserNode(Type $phpStanType, ?string $kind = null): ?Node

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -41,13 +41,16 @@ final class StaticTypeMapper
     ) {
     }
 
-    public function mapPHPStanTypeToPHPStanPhpDocTypeNode(Type $phpStanType): TypeNode
+    /**
+     * @param 'property'|'return'|null $kind
+     */
+    public function mapPHPStanTypeToPHPStanPhpDocTypeNode(Type $phpStanType, ?string $kind = null): TypeNode
     {
-        return $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($phpStanType);
+        return $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($phpStanType, $kind);
     }
 
     /**
-     * @param 'property'|'return'|null $kind
+     * @param 'property'|'param'|null $kind
      *
      * @return Name|NullableType|PhpParserUnionType|null
      */

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -23,6 +23,7 @@ use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
+use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;
 use Rector\StaticTypeMapper\PhpDoc\PhpDocTypeMapper;
@@ -42,7 +43,7 @@ final class StaticTypeMapper
     }
 
     /**
-     * @param 'property'|'return'|null $kind
+     * @param TypeKind::*|null $kind
      */
     public function mapPHPStanTypeToPHPStanPhpDocTypeNode(Type $phpStanType, ?string $kind = null): TypeNode
     {
@@ -50,7 +51,7 @@ final class StaticTypeMapper
     }
 
     /**
-     * @param 'property'|'param'|null $kind
+     * @param TypeKind::*|null $kind
      *
      * @return Name|NullableType|PhpParserUnionType|null
      */


### PR DESCRIPTION
which allows to differentiate the returned type based on the used location.

this is required to add a proper `@return never` handling as we are building it in https://github.com/rectorphp/rector-src/pull/296