### PR TITLE
Enable auto-merge on weekly pull request

### DIFF
--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -49,10 +49,20 @@ jobs:
             -
                 name: Create pull-request
                 uses: peter-evans/create-pull-request@v3
+                id: cpr
                 with:
-                    token: ${{ secrets.GITHUB_TOKEN }}
+                    token: ${{ secrets.ACCESS_TOKEN }}
                     commit-message: "[automated] ${{ matrix.actions.name }}"
                     base: 'main'
                     branch: ${{ matrix.actions.branch }}
                     title: '[automated] ${{ matrix.actions.name }}'
                     delete-branch: true
+
+            -
+                name: Enable Pull Request Automerge
+                if: steps.cpr.outputs.pull-request-operation == 'created'
+                uses: peter-evans/enable-pull-request-automerge@v1
+                with:
+                    token: ${{ secrets.ACCESS_TOKEN }}
+                    pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+                    merge-method: squash


### PR DESCRIPTION
To make auto-merge like in getrector.org repo. It needs to use `secrets.ACCESS_TOKEN` in create pull request to make CI run and `id` to make auto-merge merge the pr from create pull request steps.