### PR TITLE
Failing Test for `RemoveUnusedNonEmptyArrayBeforeForeachRector`

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/nullable.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/nullable.php.inc
@@ -1,0 +1,23 @@
+<?php
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+function run(?array $values) {
+    if (!empty($values)) {
+        foreach ($values as $value) {
+            echo $value;
+        }
+    }
+}
+?>
+-----
+<?php
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+function run(?array $values) {
+    if (!empty($values)) {
+        foreach ($values as $value) {
+            echo $value;
+        }
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for RemoveUnusedNonEmptyArrayBeforeForeachRector

Based on https://getrector.org/demo/1ebd9159-bf12-6102-97bd-090aca3a1a9c

Could be modified to replace `empty` with `is_null` instead.