### PR TITLE
[CodingStyle] Skip indirect version number on VersionCompareFuncCallToConstantRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector/Fixture/skip_indirect_string_number.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector/Fixture/skip_indirect_string_number.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\VersionCompareFuncCallToConstantRector\Fixture;
+
+class SkipIndirectStringNumber
+{
+    private const MIN_PHP_VERSION = '7.3';
+
+    public function run()
+    {
+        version_compare(PHP_VERSION, self::MIN_PHP_VERSION, '<');
+        version_compare(self::MIN_PHP_VERSION, PHP_VERSION, '<');
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
@@ -18,7 +18,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Util\PhpVersionFactory;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -114,6 +113,10 @@ CODE_SAMPLE
         $left = $this->getNewNodeForArg($node->args[0]->value);
         $right = $this->getNewNodeForArg($node->args[1]->value);
 
+        if ($left === null || $right === null) {
+            return null;
+        }
+
         /** @var String_ $operator */
         $operator = $node->args[2]->value;
         $comparisonClass = self::OPERATOR_TO_COMPARISON[$operator->value];
@@ -129,7 +132,7 @@ CODE_SAMPLE
         return $expr->name->toString() === 'PHP_VERSION';
     }
 
-    private function getNewNodeForArg(Expr $expr): ConstFetch | LNumber
+    private function getNewNodeForArg(Expr $expr): ConstFetch | LNumber | null
     {
         if ($this->isPhpVersionConstant($expr)) {
             return new ConstFetch(new Name('PHP_VERSION_ID'));
@@ -138,10 +141,10 @@ CODE_SAMPLE
         return $this->getVersionNumberFormVersionString($expr);
     }
 
-    private function getVersionNumberFormVersionString(Expr $expr): LNumber
+    private function getVersionNumberFormVersionString(Expr $expr): ?LNumber
     {
         if (! $expr instanceof String_) {
-            throw new ShouldNotHappenException();
+            return null;
         }
 
         $value = $this->phpVersionFactory->createIntVersion($expr->value);

--- a/rules/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
@@ -112,8 +112,10 @@ CODE_SAMPLE
 
         $left = $this->getNewNodeForArg($node->args[0]->value);
         $right = $this->getNewNodeForArg($node->args[1]->value);
-
-        if ($left === null || $right === null) {
+        if ($left === null) {
+            return null;
+        }
+        if ($right === null) {
             return null;
         }
 


### PR DESCRIPTION
This for compare with eg: class contant.