### PR TITLE
[CodingStyle] Default empty array [] on UnSpreadOperatorRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/handle_multiple_items_to_array.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/handle_multiple_items_to_array.php.inc
@@ -27,7 +27,7 @@ final class HandleMultipleItemsToArray
         $this->run('John', [1, 2, 3, 4, 5]);
     }
 
-    public function run(string $name, array $items)
+    public function run(string $name, array $items = [])
     {
     }
 }

--- a/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/not_pass_arg.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/not_pass_arg.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodingStyle\Rector\ClassMethod\UnSpreadOperatorRector\Fixture;
 
-final class Fixture
+final class NotPassArg
 {
     public function run(...$args)
     {
@@ -10,7 +10,7 @@ final class Fixture
 
     public function execute(array $data)
     {
-        $this->run(...$data);
+        $this->run();
     }
 }
 
@@ -20,7 +20,7 @@ final class Fixture
 
 namespace Rector\Tests\CodingStyle\Rector\ClassMethod\UnSpreadOperatorRector\Fixture;
 
-final class Fixture
+final class NotPassArg
 {
     public function run(array $args = [])
     {
@@ -28,7 +28,7 @@ final class Fixture
 
     public function execute(array $data)
     {
-        $this->run($data);
+        $this->run();
     }
 }
 

--- a/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/not_pass_arg.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/not_pass_arg.php.inc
@@ -8,7 +8,7 @@ final class NotPassArg
     {
     }
 
-    public function execute(array $data)
+    public function execute()
     {
         $this->run();
     }
@@ -26,7 +26,7 @@ final class NotPassArg
     {
     }
 
-    public function execute(array $data)
+    public function execute()
     {
         $this->run();
     }

--- a/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/typed_param_variadic.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/typed_param_variadic.php.inc
@@ -17,7 +17,7 @@ namespace Rector\Tests\CodingStyle\Rector\ClassMethod\UnSpreadOperatorRector\Fix
 
 final class TypedParamVariadic
 {
-    public function run(array $var)
+    public function run(array $var = [])
     {
     }
 }

--- a/rules/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector.php
@@ -94,6 +94,7 @@ CODE_SAMPLE
         foreach ($spreadParams as $spreadParam) {
             $spreadParam->variadic = false;
             $spreadParam->type = new Identifier('array');
+            $spreadParam->default = $this->nodeFactory->createArray([]);
         }
 
         return $classMethod;
@@ -135,7 +136,10 @@ CODE_SAMPLE
             return $methodCall;
         }
 
-        $methodCall->args[$firstSpreadParamPosition] = new Arg($this->nodeFactory->createArray($variadicArgs));
+        if ($variadicArgs !== []) {
+            $methodCall->args[$firstSpreadParamPosition] = new Arg($this->nodeFactory->createArray($variadicArgs));
+        }
+
         return $methodCall;
     }
 


### PR DESCRIPTION
On variadic, no argument means empty array, which is optional, while on `array` type hint without default value, it need to be passed. I think default empty array is needed to keep the method call working as previously used, if used by external source.

ref https://3v4l.org/S3sBS
