### PR TITLE
[AnnotationToAttributeRector] Skip unwrap symfony nested validators

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/skip_unwrap_symfony_nested_validators.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/skip_unwrap_symfony_nested_validators.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class SkipUnwrapSymfonyNestedValidators
+{
+    /**
+     * @var array
+     * @Assert\All(
+     *     constraints={
+     *         @GenericAnnotation("firstConstraint"),
+     *         @GenericAnnotation("secondConstraint")
+     *     }
+     * )
+     */
+    public $all;
+
+    /**
+     * @Assert\Sequentially({
+     *     @GenericAnnotation("stepOne"),
+     *     @GenericAnnotation("stepTwo")
+     *   }
+     * )
+     */
+    public $sequentially;
+
+    /**
+     * @Assert\AtLeastOneOf({
+     *     @GenericAnnotation("thisOne"),
+     *     @GenericAnnotation("orThisOne")
+     * })
+     */
+    public $atLeastOneOf;
+
+    /**
+     * @var array
+     *
+     * @Assert\Collection(
+     *     fields = {
+     *         "email" = @GenericAnnotation("email"),
+     *         "password" = @GenericAnnotation("password"),
+     *     }
+     * )
+     */
+    public $collection;
+}
+?>

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -41,6 +41,17 @@ final class AnnotationToAttributeRector extends AbstractRector implements Config
     public const ANNOTATION_TO_ATTRIBUTE = 'annotation_to_attribute';
 
     /**
+     * List of annotations that should not be unwrapped
+     * @var class-string[]
+     */
+    private const SKIP_UNWRAP_ANNOTATIONS = [
+        'Symfony\Component\Validator\Constraints\All',
+        'Symfony\Component\Validator\Constraints\AtLeastOneOf',
+        'Symfony\Component\Validator\Constraints\Collection',
+        'Symfony\Component\Validator\Constraints\Sequentially',
+    ];
+
+    /**
      * @var AnnotationToAttribute[]
      */
     private array $annotationsToAttributes = [];
@@ -190,6 +201,9 @@ CODE_SAMPLE
         PhpDocInfo $phpDocInfo,
         ClassMethod | Function_ | Closure | ArrowFunction | Property | Class_ $node
     ): void {
+        if ($this->shouldSkip($phpDocInfo)) {
+            return;
+        }
         $doctrineTagAndAnnotationToAttributes = [];
 
         $phpDocNodeTraverser = new PhpDocNodeTraverser();
@@ -232,5 +246,10 @@ CODE_SAMPLE
                 $doctrineTagAndAnnotationToAttribute->getAnnotationToAttribute()
             );
         }
+    }
+
+    private function shouldSkip(PhpDocInfo $phpDocInfo): bool
+    {
+        return $phpDocInfo->hasByAnnotationClasses(self::SKIP_UNWRAP_ANNOTATIONS);
     }
 }


### PR DESCRIPTION
After release 0.11.32  AnnotationToAttributeRector tries to unwrap nested annotations, but it has no sense for some symfony validators. This pr provides test and possible solution. @TomasVotruba @samsonasik what do you think? 