### PR TITLE
[DowngradePhp74] Handle iterable on DowngradeArraySpreadRector

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector/Fixture/with_iterable_pseudotype_array.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector/Fixture/with_iterable_pseudotype_array.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\Array_\DowngradeArraySpreadRector\Fixture;
+
+class WithIterablePseudotypeArray
+{
+    public function run()
+    {
+        $result = $this->getData([]);
+        $result = [...$result];
+    }
+
+    private function getData(iterable $iterable): iterable
+    {
+        return [...$iterable];
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\Array_\DowngradeArraySpreadRector\Fixture;
+
+class WithIterablePseudotypeArray
+{
+    public function run()
+    {
+        $result = $this->getData([]);
+        $result = array_merge(is_array($result) ? $result : iterator_to_array($result));
+    }
+
+    private function getData(iterable $iterable): iterable
+    {
+        return array_merge(is_array($iterable) ? $iterable : iterator_to_array($iterable));
+    }
+}
+?>

--- a/rules-tests/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector/Fixture/with_iterable_pseudotype_function_item.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector/Fixture/with_iterable_pseudotype_function_item.php.inc
@@ -35,7 +35,7 @@ class WithIterablePseudotypeFunctionItemClass
     public function run()
     {
         $item2Unpacked = $this->getIterable();
-        $fruits = array_merge(['banana', 'orange'], iterator_to_array($item2Unpacked), ['watermelon']);
+        $fruits = array_merge(['banana', 'orange'], is_array($item2Unpacked) ? $item2Unpacked : iterator_to_array($item2Unpacked), ['watermelon']);
     }
 }
 

--- a/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
+++ b/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
@@ -257,13 +257,13 @@ CODE_SAMPLE
     }
 
     /**
-     * Iterables: either objects declaring the interface Traversable,
-     * or the pseudo-type iterable
+     * Iterables: objects declaring the interface Traversable,
+     * For "iterable" type, it can be array
      */
     private function isIterableType(Type $type): bool
     {
         if ($type instanceof IterableType) {
-            return true;
+            return false;
         }
 
         $traversableObjectType = new ObjectType('Traversable');


### PR DESCRIPTION
Closes #371 Fixes https://github.com/rectorphp/rector/issues/6544 

The solution I found for now is mark typed "iterable" as non Iterable type, as it can be array as well.