### PR TITLE
use symfony/console with fixed covariant types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "rector/rector-symfony": "^0.11.8",
         "sebastian/diff": "^4.0.4",
         "ssch/typo3-rector": "dev-main#e75102b",
-        "symfony/console": "^5.3",
+        "symfony/console": "5.3.x-dev",
         "symfony/dependency-injection": "^5.3",
         "symfony/finder": "^5.3",
         "symfony/http-kernel": "^5.3",


### PR DESCRIPTION
symfony/console classes have sometimes different param types than its parent interface

This causes fatal errors on donwgrade rule, because after moving from dynamic parsing to static reflection, Rector is trying to narrow node modification to current node only.

See failing CI on `rector/rector` (https://github.com/rectorphp/rector/runs/2985182881):
![image](https://user-images.githubusercontent.com/924196/124401063-7a490180-dd27-11eb-9aa4-6597cdb75dcf.png)

<br>

Coincidentaly, this was fixed in Symfony 5.4 just 2 days ago https://github.com/symfony/symfony/pull/41946
https://github.com/symfony/console/commit/d4c4ac30d2dc666fc72fc3c57fdc9df113e6b184#diff-565a2bb8afda62ae570ddc3b8b24efd584aaafc6c7b65e0071c5deddfd03a766, now backported to 5.3. Just in `dev-master` for time being.



This PR gives a new Symfony try