### PR TITLE
Fix ArrayCallableMethodMatcher to accept only strings

### DIFF
--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -101,7 +101,8 @@ final class ArrayCallableMethodMatcher
             $classConstantReference = $classConstFetch->getAttribute(AttributeKey::CLASS_NAME);
         }
 
-        if ($classConstantReference === null) {
+        // non-class value
+        if (! is_string($classConstantReference)) {
             return new MixedType();
         }
 

--- a/rules-tests/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector/Fixture/skip_non_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector/Fixture/skip_non_callable.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\ArrayThisCallToThisMethodCallRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\ArrayThisCallToThisMethodCallRector\Source\SomeConstantInteger;
+
+final class SkipNonCallable
+{
+    public function run()
+    {
+        $this->process('tags', [
+            'usage' => SomeConstantInteger::VALUE,
+            'region' => 'tags',
+        ]);
+    }
+
+    public function process()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector/Source/SomeConstantInteger.php
+++ b/rules-tests/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector/Source/SomeConstantInteger.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\ArrayThisCallToThisMethodCallRector\Source;
+
+final class SomeConstantInteger
+{
+    const VALUE = 10000;
+}


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/6540