### PR TITLE
[DeadCode][Naming] Handle null start token on use RemoveOverriddenValuesRector & RenameVariableToMatchNewTypeRector

### DIFF
--- a/rules/DeadCode/NodeCollector/NodeByTypeAndPositionCollector.php
+++ b/rules/DeadCode/NodeCollector/NodeByTypeAndPositionCollector.php
@@ -36,6 +36,10 @@ final class NodeByTypeAndPositionCollector
             /** @var int $startTokenPos */
             $startTokenPos = $assignedVariable->getAttribute(AttributeKey::START_TOKEN_POSITION);
 
+            if ($startTokenPos === null) {
+                continue;
+            }
+
             // not in different scope, than previous one - e.g. if/while/else...
             // get nesting level to $classMethodNode
             /** @var Assign $assign */

--- a/rules/DeadCode/NodeCollector/NodeByTypeAndPositionCollector.php
+++ b/rules/DeadCode/NodeCollector/NodeByTypeAndPositionCollector.php
@@ -33,7 +33,6 @@ final class NodeByTypeAndPositionCollector
         $nodesByTypeAndPosition = [];
 
         foreach ($assignedVariables as $assignedVariable) {
-            /** @var int $startTokenPos */
             $startTokenPos = $assignedVariable->getAttribute(AttributeKey::START_TOKEN_POSITION);
 
             if ($startTokenPos === null) {

--- a/tests/Issues/Issue6557/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6557/Fixture/fixture.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6557\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        return function () {
+            $demo = new SomeClass();
+            $demo->doSomething();
+            return;
+        };
+    }
+}
+
+final class SomeClass
+{
+    public function doSomething(): void
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6557\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        return function () {
+            $someClass = new SomeClass();
+            $someClass->doSomething();
+            return;
+        };
+    }
+}
+
+final class SomeClass
+{
+    public function doSomething(): void
+    {
+
+    }
+}
+
+?>

--- a/tests/Issues/Issue6557/NullStartTokenTest.php
+++ b/tests/Issues/Issue6557/NullStartTokenTest.php
@@ -8,7 +8,7 @@ use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-final class RemoveOverriddenValuesRectorTest extends AbstractRectorTestCase
+final class NullStartTokenTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()

--- a/tests/Issues/Issue6557/RemoveOverriddenValuesRectorTest.php
+++ b/tests/Issues/Issue6557/RemoveOverriddenValuesRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6557;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveOverriddenValuesRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6557/config/configured_rule.php
+++ b/tests/Issues/Issue6557/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DeadCode\Rector\FunctionLike\RemoveOverriddenValuesRector;
+use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemoveOverriddenValuesRector::class);
+    $services->set(RenameVariableToMatchNewTypeRector::class);
+};


### PR DESCRIPTION
Closes #396 Fixes https://github.com/rectorphp/rector/issues/6557