### PR TITLE
[Downgrade PHP 8.0] Fix DowngradeNullsafeToTernaryOperatorRector for trait

### DIFF
--- a/config/set/downgrade-php80.php
+++ b/config/set/downgrade-php80.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
-
 use Rector\DowngradePhp80\Rector\Catch_\DowngradeNonCapturingCatchesRector;
 use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
 use Rector\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector;
@@ -39,6 +38,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]]);
 
     $services->set(DowngradeNamedArgumentRector::class);
+
     $services->set(DowngradeAttributeToAnnotationRector::class)
         ->call('configure', [[
             DowngradeAttributeToAnnotationRector::ATTRIBUTE_TO_ANNOTATION => ValueObjectInliner::inline([

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\NullsafeMethodCall\DowngradeNullsafeToTernaryOperatorRector\Fixture;
+
+use PhpParser\Node\Expr\ArrayItem;
+
+final class GetNullable
+{
+    public function run($value)
+    {
+        return $this->extractArrayItemByKey($value)?->value;
+    }
+
+    protected function extractArrayItemByKey($value): ?ArrayItem
+    {
+        return null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\NullsafeMethodCall\DowngradeNullsafeToTernaryOperatorRector\Fixture;
+
+use PhpParser\Node\Expr\ArrayItem;
+
+final class GetNullable
+{
+    public function run($value)
+    {
+        return ($extractArrayItemByKey = $this->extractArrayItemByKey($value)) ? $extractArrayItemByKey->value : null;
+    }
+
+    protected function extractArrayItemByKey($value): ?ArrayItem
+    {
+        return null;
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable_in_trait.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable_in_trait.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\NullsafeMethodCall\DowngradeNullsafeToTernaryOperatorRector\Fixture;
+
+use PhpParser\Node\Expr\ArrayItem;
+
+trait GetNullableInTrait
+{
+    public function run($value)
+    {
+        return $this->extractArrayItemByKey($value)?->value;
+    }
+
+    protected function extractArrayItemByKey($value): ?ArrayItem
+    {
+        return null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\NullsafeMethodCall\DowngradeNullsafeToTernaryOperatorRector\Fixture;
+
+use PhpParser\Node\Expr\ArrayItem;
+
+trait GetNullableInTrait
+{
+    public function run($value)
+    {
+        return ($extractArrayItemByKey = $this->extractArrayItemByKey($value)) ? $extractArrayItemByKey->value : null;
+    }
+
+    protected function extractArrayItemByKey($value): ?ArrayItem
+    {
+        return null;
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
+++ b/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
@@ -58,9 +58,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): Ternary
     {
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+
         $tempVarName = $this->variableNaming->resolveFromNodeWithScopeCountAndFallbackName(
             $node->var,
-            $node->getAttribute(AttributeKey::SCOPE),
+            $scope,
             '_'
         );
 

--- a/rules/Naming/Naming/VariableNaming.php
+++ b/rules/Naming/Naming/VariableNaming.php
@@ -63,7 +63,7 @@ final class VariableNaming
 
     public function resolveFromNodeWithScopeCountAndFallbackName(
         Expr $expr,
-        Scope $scope,
+        ?Scope $scope,
         string $fallbackName
     ): string {
         $name = $this->resolveFromNode($expr);


### PR DESCRIPTION
- add test case for missed downgrade nullsafe
- fix for trait
