### PR TITLE
[Php80] Handle UnionTypesRector with Auto Import

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/AutoImportTest.php
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/AutoImportTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AutoImportTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureAutoImport');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_auto_import.php';
+    }
+}

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/FixtureAutoImport/fixture.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/FixtureAutoImport/fixture.php.inc
@@ -29,10 +29,7 @@ use stdClass;
 
 class Fixture
 {
-    /**
-     * @return stdClass|array
-     */
-    public function get()
+    public function get(): stdClass|array
     {
         if (random_int(0, 1) !== 0) {
             return new stdClass();

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/FixtureAutoImport/fixture.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/FixtureAutoImport/fixture.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\FixtureAutoImport;
+
+use stdClass;
+
+class Fixture
+{
+    /**
+     * @return stdClass|array
+     */
+    public function get()
+    {
+        if (random_int(0, 1) !== 0) {
+            return new stdClass();
+        }
+
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\FixtureAutoImport;
+
+use stdClass;
+
+class Fixture
+{
+    /**
+     * @return stdClass|array
+     */
+    public function get()
+    {
+        if (random_int(0, 1) !== 0) {
+            return new stdClass();
+        }
+
+        return [];
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/config/configured_rule_auto_import.php
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/config/configured_rule_auto_import.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(UnionTypesRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersionFeature::UNION_TYPES);
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+};


### PR DESCRIPTION
It currently add `\` prefix like this:

```diff
-    public function get(): stdClass|array
+    public function get(): \stdClass|array
```

while `stdClass` already imported and with auto import option.