### PR TITLE
Failing scenario for ChangeSwitchToMatchRector

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/default_outside_switch.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/default_outside_switch.php.inc
@@ -30,10 +30,11 @@ final class DefaultOutsideSwitch
 {
     public function run($input)
     {
+        $value = 0;
         $value = match ($input) {
             100 => 1000,
             200 => 2000,
-            default => 0,
+            default => $value,
         };
 
         return $value;

--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/default_outside_switch.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/default_outside_switch.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+final class DefaultOutsideSwitch
+{
+    public function run($input)
+    {
+        $value = 0;
+        switch ($input) {
+            case 100:
+                $value = 1000;
+                break;
+            case 200:
+                $value = 2000;
+                break;
+        }
+
+        return $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+final class DefaultOutsideSwitch
+{
+    public function run($input)
+    {
+        $value = match ($input) {
+            100 => 1000,
+            200 => 2000,
+            default => 0,
+        };
+
+        return $value;
+    }
+}
+
+?>


### PR DESCRIPTION
Hi there wonderful team!

I've run into a scenario where `ChangeSwitchToMatchRector` breaks the code.

This PR currently only adds a failing test to demonstrate the issue as I haven't (yet) been able to work out the solution.

Essentially the simplest scenario is:

```php
public function run ($input)
{
    $value = 0;
    switch ($input) {
        case 100:
            $value = 1000;
            break;
        case 200:
            $value = 2000;
            break;
    }

    return $value;
}
```

The broken result is currently:

```php
public function run($input)
{
    $value = match ($input) {
        100 => 1000,
        200 => 2000,
        default => $value,
    };
}
```

Which removes the return, and breaks the default of `0`.

I would expect the default to be `0` and for `$value` to still be returned.

Any guidance would be very appreciated!