### PR TITLE
[DeadCode] Fix non-null type check on RemoveUnusedNonEmptyArrayBeforeForeachRector

### DIFF
--- a/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
+++ b/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
@@ -62,13 +62,7 @@ final class UselessIfCondBeforeForeachDetector
             return true;
         }
 
-        return $this->isNullableParam($previousParam);
-    }
-
-    public function isNullableParam(Param $param): bool
-    {
-        $type = $this->nodeTypeResolver->resolve($param->var);
-        return $type instanceof NullableType;
+        return ! $previousParam->type instanceof NullableType;
     }
 
     /**


### PR DESCRIPTION
Previously, the : 

```php
$this->nodeTypeResolver->resolve($param->var)
```

will returns `MixedType` on the following code:

```php
function run(?array $values) {
```

so the code is always negated, which is always not a NullableType, even invalid check as `NodeTypeResolver` must be checked against `PHPStan` type, while we compare against Node's NullableType.

There is no need to update the tests as it previously always negated.