### PR TITLE
Support compact() array syntax

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector/Fixture/skip_in_compact.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector/Fixture/skip_in_compact.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedAssignVariableRector\Fixture;
 
 class SkipInCompact
 {

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector/Fixture/skip_in_compact_array.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector/Fixture/skip_in_compact_array.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedAssignVariableRector\Fixture;
+
+class SkipInCompactArray
+{
+    public function run()
+    {
+        $value = 'foobar';
+        return compact(['value']);
+    }
+}

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_in_compact_array.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_in_compact_array.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class SkipInCompact
+{
+    public function run()
+    {
+        $value = 'foobar';
+        return compact(['value']);
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_in_compact_array.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_in_compact_array.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
 
-class SkipInCompact
+class SkipInCompactArray
 {
     public function run()
     {
@@ -10,5 +10,3 @@ class SkipInCompact
         return compact(['value']);
     }
 }
-
-?>

--- a/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
+++ b/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
@@ -29,11 +30,42 @@ final class CompactFuncCallAnalyzer
 
         $args = $funcCall->args;
         foreach ($args as $arg) {
+            if ($arg->value instanceof Array_) {
+                if ($this->isInArray($arg->value, $variableName)) {
+                    return true;
+                }
+
+                continue;
+            }
+
             if (! $arg->value instanceof String_) {
                 continue;
             }
 
             if ($arg->value->value === $variableName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isInArray(Array_ $array, string $variableName): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item->value instanceof Array_) {
+                if ($this->isInArray($item->value, $variableName)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (! $item->value instanceof String_) {
+                continue;
+            }
+
+            if ($item->value->value === $variableName) {
                 return true;
             }
         }

--- a/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
+++ b/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
@@ -28,44 +28,32 @@ final class CompactFuncCallAnalyzer
             return false;
         }
 
-        $args = $funcCall->args;
-        foreach ($args as $arg) {
-            if ($arg->value instanceof Array_) {
-                if ($this->isInArray($arg->value, $variableName)) {
-                    return true;
-                }
-
-                continue;
-            }
-
-            if (! $arg->value instanceof String_) {
-                continue;
-            }
-
-            if ($arg->value->value === $variableName) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->isInArgOrArrayItemNodes($funcCall->args, $variableName);
     }
 
-    private function isInArray(Array_ $array, string $variableName): bool
+    /**
+     * @param Array<\PhpParser\Node\Arg|\PhpParser\Node\Expr\ArrayItem|null> $nodes
+     */
+    private function isInArgOrArrayItemNodes(array $nodes, string $variableName): bool
     {
-        foreach ($array->items as $item) {
-            if ($item->value instanceof Array_) {
-                if ($this->isInArray($item->value, $variableName)) {
+        foreach ($nodes as $node) {
+            if ($node === null) {
+                continue;
+            }
+
+            if ($node->value instanceof Array_) {
+                if ($this->isInArgOrArrayItemNodes($node->value->items, $variableName)) {
                     return true;
                 }
 
                 continue;
             }
 
-            if (! $item->value instanceof String_) {
+            if (! $node->value instanceof String_) {
                 continue;
             }
 
-            if ($item->value->value === $variableName) {
+            if ($node->value->value === $variableName) {
                 return true;
             }
         }

--- a/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
+++ b/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
@@ -32,7 +32,7 @@ final class CompactFuncCallAnalyzer
     }
 
     /**
-     * @param Array<\PhpParser\Node\Arg|\PhpParser\Node\Expr\ArrayItem|null> $nodes
+     * @param array<int, \PhpParser\Node\Arg|\PhpParser\Node\Expr\ArrayItem|null> $nodes
      */
     private function isInArgOrArrayItemNodes(array $nodes, string $variableName): bool
     {


### PR DESCRIPTION
Continuing from #238, I have found that both `RemoveUnusedAssignVariableRector` and `RemoveUnusedVariableAssignRector` mistakenly remove variables that are referenced in `compact()` when using PHP's alternative array syntax.

In other words, currently Rector only supports `compact(string $var_name, string ...$var_names)` where as [PHP supports](https://www.php.net/manual/en/function.compact.php) `compact(array|string $var_name, array|string ...$var_names)` and will also recursively handle arrays within arrays. 

This PR addresses this issue and also fixes an incorrect test namespace from my previous PR.