### PR TITLE
Fix PHPStan notice

### DIFF
--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNodeAnalyzer.php
@@ -28,7 +28,7 @@ final class ExprUsedInNodeAnalyzer
             return true;
         }
 
-        if ($node instanceof FuncCall) {
+        if ($node instanceof FuncCall && $expr instanceof Variable) {
             return $this->compactFuncCallAnalyzer->isInCompact($node, $expr);
         }
 


### PR DESCRIPTION
Fix PHPStan notice:

```bash
  rules/DeadCode/NodeAnalyzer/ExprUsedInNodeAnalyzer.php:32
  - '#Parameter \#2 \$variable of method Rector\\Core\\NodeAnalyzer\\CompactFuncCallAnalyzer\:\:isInCompact\(\) expects PhpParser\\Node\\Expr\\Variable, PhpParser\\Node\\Expr given#'
```