### PR TITLE
[PSR4] Fix PHPUnit run test error on FileWithoutNamespaceTest

### DIFF
--- a/rules-tests/PSR4/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/FileWithoutNamespaceTest.php
+++ b/rules-tests/PSR4/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/FileWithoutNamespaceTest.php
@@ -20,7 +20,7 @@ final class FileWithoutNamespaceTest extends AbstractRectorTestCase
     public function test(
         SmartFileInfo $originalFileInfo,
         array $expectedFilePathsWithContents,
-        bool $expectedOriginalFileWasRemoved
+        bool $expectedOriginalFileWasRemoved = true
     ): void {
         $this->doTestFileInfo($originalFileInfo);
 


### PR DESCRIPTION
It previously got error:

```bash
There was 1 error:

1) Rector\Tests\PSR4\Rector\Namespace_\MultipleClassFileToPsr4ClassesRector\FileWithoutNamespaceTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...), array(Rector\FileSystemRector\ValueObject\AddedFileWithContent Object (...), Rector\FileSystemRector\ValueObject\AddedFileWithContent Object (...)))
ArgumentCountError: Too few arguments to function Rector\Tests\PSR4\Rector\Namespace_\MultipleClassFileToPsr4ClassesRector\FileWithoutNamespaceTest::test(), 2 passed in /Users/samsonasik/www/rector-src/vendor/phpunit/phpunit/src/Framework/TestCase.php on line 1527 and exactly 3 expected

/Users/samsonasik/www/rector-src/rules-tests/PSR4/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/FileWithoutNamespaceTest.php:20
```

This patch fix it.