### PR TITLE
Fix match static method name in annotation

### DIFF
--- a/packages/NodeCollector/StaticAnalyzer.php
+++ b/packages/NodeCollector/StaticAnalyzer.php
@@ -43,6 +43,7 @@ final class StaticAnalyzer
             return false;
         }
 
+        // @see https://regex101.com/r/7Zkej2/1
         return (bool) Strings::match(
             $resolvedPhpDocBlock->getPhpDocString(),
             '#@method\s*static\s*((([\w\|\\\\]+)|\$this)*+(\[\])*)*\s+\b' . $methodName . '\b#'

--- a/packages/NodeCollector/StaticAnalyzer.php
+++ b/packages/NodeCollector/StaticAnalyzer.php
@@ -45,7 +45,7 @@ final class StaticAnalyzer
 
         return (bool) Strings::match(
             $resolvedPhpDocBlock->getPhpDocString(),
-            '#@method\s*static\s*(.*?)\b' . $methodName . '\b#'
+            '#@method\s*static\s*((([\w\|\\\\]+)|\$this)*+(\[\])*)*\s+\b' . $methodName . '\b#'
         );
     }
 }

--- a/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/skip_string_not_method_name_in_annotation.php.inc
+++ b/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/skip_string_not_method_name_in_annotation.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture;
+
+/**
+ * @method static static create($parameters) some description with parameters
+ */
+trait SkipStringNotMethodNameInAnnotation
+{
+    public function run()
+    {
+        $this->parameters();
+    }
+
+    public function parameters(): void
+    {
+    }
+}

--- a/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/static_method_in_annotation.php.inc
+++ b/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/static_method_in_annotation.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCal
 
 /**
  * @method static static staticReturnStatic()
- * @method static static|StaticMethodInAnnotation|string[] staticReturnMixed()
+ * @method static static|StaticMethodInAnnotation|string[]|$this staticReturnMixed()
  * @method static withoutReturnType()
  * @method static withoutParameters
  * @method StaticMethodInAnnotation|static returnStatic
@@ -29,7 +29,7 @@ namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCal
 
 /**
  * @method static static staticReturnStatic()
- * @method static static|StaticMethodInAnnotation|string[] staticReturnMixed()
+ * @method static static|StaticMethodInAnnotation|string[]|$this staticReturnMixed()
  * @method static withoutReturnType()
  * @method static withoutParameters
  * @method StaticMethodInAnnotation|static returnStatic

--- a/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/static_method_in_annotation.php.inc
+++ b/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/static_method_in_annotation.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture;
+
+/**
+ * @method static static staticReturnStatic()
+ * @method static static|\Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|string[] staticReturnMixed()
+ * @method static withoutReturnType()
+ * @method static withoutParameters
+ * @method \Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|static returnStatic
+ */
+trait StaticMethodInAnnotation
+{
+    public function run()
+    {
+        $this->staticReturnStatic();
+        $this->staticReturnMixed();
+        $this->withoutReturnType();
+        $this->withoutParameters();
+        $this->returnStatic();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture;
+
+/**
+ * @method static static staticReturnStatic()
+ * @method static static|\Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|string[] staticReturnMixed()
+ * @method static withoutReturnType()
+ * @method static withoutParameters
+ * @method \Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|static returnStatic
+ */
+trait StaticMethodInAnnotation
+{
+    public function run()
+    {
+        static::staticReturnStatic();
+        static::staticReturnMixed();
+        static::withoutReturnType();
+        static::withoutParameters();
+        $this->returnStatic();
+    }
+}
+
+?>

--- a/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/static_method_in_annotation.php.inc
+++ b/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/static_method_in_annotation.php.inc
@@ -4,10 +4,10 @@ namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCal
 
 /**
  * @method static static staticReturnStatic()
- * @method static static|\Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|string[] staticReturnMixed()
+ * @method static static|StaticMethodInAnnotation|string[] staticReturnMixed()
  * @method static withoutReturnType()
  * @method static withoutParameters
- * @method \Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|static returnStatic
+ * @method StaticMethodInAnnotation|static returnStatic
  */
 trait StaticMethodInAnnotation
 {
@@ -29,10 +29,10 @@ namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCal
 
 /**
  * @method static static staticReturnStatic()
- * @method static static|\Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|string[] staticReturnMixed()
+ * @method static static|StaticMethodInAnnotation|string[] staticReturnMixed()
  * @method static withoutReturnType()
  * @method static withoutParameters
- * @method \Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture\StaticMethodInAnnotation|static returnStatic
+ * @method StaticMethodInAnnotation|static returnStatic
  */
 trait StaticMethodInAnnotation
 {


### PR DESCRIPTION
# Failing Test for ThisCallOnStaticMethodToStaticCallRector

Based on https://getrector.org/demo/1ebe6192-f226-655c-8137-c979d4975a08

Fixes: rectorphp/rector#6578

`skip_string_not_method_name_in_annotation.php.inc` is the failing test fixture and `static_method_in_annotation.php.inc` is added to ensure that the previous code can run correctly.