### PR TITLE
[Rectify] Manual twice run rector against rules directory

### DIFF
--- a/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
+++ b/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
@@ -117,10 +117,10 @@ CODE_SAMPLE
     /**
      * @return array<int, Node\Arg>
      */
-    private function resolveNewArguments(SwapFuncCallArguments $functionArgumentSwap, FuncCall $funcCall): array
+    private function resolveNewArguments(SwapFuncCallArguments $swapFuncCallArguments, FuncCall $funcCall): array
     {
         $newArguments = [];
-        foreach ($functionArgumentSwap->getOrder() as $oldPosition => $newPosition) {
+        foreach ($swapFuncCallArguments->getOrder() as $oldPosition => $newPosition) {
             if (! isset($funcCall->args[$oldPosition])) {
                 continue;
             }

--- a/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
@@ -128,7 +128,7 @@ CODE_SAMPLE
     {
         return (bool) $this->betterNodeFinder->findFirst(
             $foreach->stmts,
-            fn(Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $variable)
+            fn (Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $variable)
         );
     }
 

--- a/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
@@ -128,9 +128,7 @@ CODE_SAMPLE
     {
         return (bool) $this->betterNodeFinder->findFirst(
             $foreach->stmts,
-            function (Node $node) use ($variable): bool {
-                return $this->exprUsedInNodeAnalyzer->isUsed($node, $variable);
-            }
+            fn(Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $variable)
         );
     }
 

--- a/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
@@ -194,7 +194,6 @@ CODE_SAMPLE
 
         if ($reflectionMethod->isPrivate()) {
             $this->visibilityManipulator->makePrivate($classMethod);
-            return;
         }
     }
 

--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
@@ -18,8 +18,6 @@ final class ExprUsedInNextNodeAnalyzer
 
     public function isUsed(Expr $expr): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstNext($expr, function (Node $node) use ($expr): bool {
-            return $this->exprUsedInNodeAnalyzer->isUsed($node, $expr);
-        });
+        return (bool) $this->betterNodeFinder->findFirstNext($expr, fn(Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $expr));
     }
 }

--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
@@ -18,6 +18,9 @@ final class ExprUsedInNextNodeAnalyzer
 
     public function isUsed(Expr $expr): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstNext($expr, fn(Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $expr));
+        return (bool) $this->betterNodeFinder->findFirstNext(
+            $expr,
+            fn (Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $expr)
+        );
     }
 }

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
-use Rector\Core\NodeAnalyzer\CompactFuncCallAnalyzer;
 use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\PhpParser\Comparing\ConditionSearcher;
 use Rector\Core\Rector\AbstractRector;

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -34,7 +34,6 @@ final class RemoveUnusedVariableAssignRector extends AbstractRector
 {
     public function __construct(
         private ReservedKeywordAnalyzer $reservedKeywordAnalyzer,
-        private CompactFuncCallAnalyzer $compactFuncCallAnalyzer,
         private ConditionSearcher $conditionSearcher,
         private UsedVariableNameAnalyzer $usedVariableNameAnalyzer,
         private PureFunctionDetector $pureFunctionDetector,

--- a/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\Rector\ClassMethod;
 
-use Rector\NodeNestingScope\ContextAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeNestingScope\ContextAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -77,7 +77,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (!$lastNode instanceof Node) {
+        if (! $lastNode instanceof Node) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\Rector\ClassMethod;
 
+use Rector\NodeNestingScope\ContextAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -18,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveLastReturnRector extends AbstractRector
 {
     public function __construct(
-        private \Rector\NodeNestingScope\ContextAnalyzer $contextAnalyzer
+        private ContextAnalyzer $contextAnalyzer
     ) {
     }
 
@@ -56,7 +57,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<\PhpParser\Node>>
+     * @return array<class-string<Node>>
      */
     public function getNodeTypes(): array
     {
@@ -76,7 +77,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($lastNode === null) {
+        if (!$lastNode instanceof Node) {
             return null;
         }
 

--- a/rules/Naming/Matcher/ForeachMatcher.php
+++ b/rules/Naming/Matcher/ForeachMatcher.php
@@ -19,7 +19,6 @@ final class ForeachMatcher
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
         private CallMatcher $callMatcher,
-        private BetterNodeFinder $betterNodeFinder,
         private ParentFinder $parentFinder
     ) {
     }

--- a/rules/Naming/Matcher/ForeachMatcher.php
+++ b/rules/Naming/Matcher/ForeachMatcher.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Function_;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Naming\ValueObject\VariableAndCallForeach;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeNestingScope\ParentFinder;

--- a/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
+++ b/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Naming\ValueObject\VariableAndCallAssign;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeNestingScope\ParentFinder;

--- a/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
+++ b/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
@@ -20,7 +20,6 @@ final class VariableAndCallAssignMatcher
     public function __construct(
         private CallMatcher $callMatcher,
         private NodeNameResolver $nodeNameResolver,
-        private BetterNodeFinder $betterNodeFinder,
         private ParentFinder $parentFinder
     ) {
     }

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -115,7 +115,6 @@ final class EregToPcreTransformer
         $rr = 0;
         $l = strlen($content);
         while ($i < $l) {
-            // atom
             $char = $content[$i];
             if ($char === '(') {
                 $i = (int) $i;
@@ -169,14 +168,12 @@ final class EregToPcreTransformer
                 }
                 $r[$rr] .= $this->_ere2pcre_escape($content[$i]);
             } else {
-                // including ] and } which are allowed as a literal character
                 $r[$rr] .= $this->_ere2pcre_escape($char);
             }
             ++$i;
             if ($i >= $l) {
                 break;
             }
-            // piece after the atom (only ONE of them is possible)
             $char = $content[$i];
             if ($char === '*' || $char === '+' || $char === '?') {
                 $r[$rr] .= $char;

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -115,6 +115,7 @@ final class EregToPcreTransformer
         $rr = 0;
         $l = strlen($content);
         while ($i < $l) {
+            // atom
             $char = $content[$i];
             if ($char === '(') {
                 $i = (int) $i;
@@ -168,12 +169,14 @@ final class EregToPcreTransformer
                 }
                 $r[$rr] .= $this->_ere2pcre_escape($content[$i]);
             } else {
+                // including ] and } which are allowed as a literal character
                 $r[$rr] .= $this->_ere2pcre_escape($char);
             }
             ++$i;
             if ($i >= $l) {
                 break;
             }
+            // piece after the atom (only ONE of them is possible)
             $char = $content[$i];
             if ($char === '*' || $char === '+' || $char === '?') {
                 $r[$rr] .= $char;

--- a/rules/Php71/Rector/Assign/AssignArrayToStringRector.php
+++ b/rules/Php71/Rector/Assign/AssignArrayToStringRector.php
@@ -27,11 +27,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class AssignArrayToStringRector extends AbstractRector
 {
-    /**
-     * @var PropertyProperty[]
-     */
-    private array $emptyStringProperties = [];
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -64,7 +59,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $defaultExpr = $this->resolveDefaultValueExpr($node);
-        if ($defaultExpr === null) {
+        if (!$defaultExpr instanceof Expr) {
             return null;
         }
 
@@ -132,7 +127,7 @@ CODE_SAMPLE
         return $expr->value === '';
     }
 
-    private function resolveAssignedVar(Assign | Property $node): Property | Expr | Assign
+    private function resolveAssignedVar(Assign | Property $node): Expr|Property
     {
         if ($node instanceof Assign) {
             return $node->var;

--- a/rules/Php71/Rector/Assign/AssignArrayToStringRector.php
+++ b/rules/Php71/Rector/Assign/AssignArrayToStringRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Property;
-use PhpParser\Node\Stmt\PropertyProperty;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -59,7 +58,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $defaultExpr = $this->resolveDefaultValueExpr($node);
-        if (!$defaultExpr instanceof Expr) {
+        if (! $defaultExpr instanceof Expr) {
             return null;
         }
 
@@ -127,7 +126,7 @@ CODE_SAMPLE
         return $expr->value === '';
     }
 
-    private function resolveAssignedVar(Assign | Property $node): Expr|Property
+    private function resolveAssignedVar(Assign | Property $node): Expr | Property
     {
         if ($node instanceof Assign) {
             return $node->var;

--- a/rules/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
+++ b/rules/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
@@ -91,9 +91,7 @@ CODE_SAMPLE
      */
     private function isVariableUsedInStmts(array $nodes, Variable $variable): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($variable): bool {
-            return $this->exprUsedInNodeAnalyzer->isUsed($node, $variable);
-        });
+        return (bool) $this->betterNodeFinder->findFirst($nodes, fn(Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $variable));
     }
 
     private function isVariableUsedNext(Catch_ $catch, Variable $variable): bool

--- a/rules/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
+++ b/rules/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
@@ -91,7 +91,10 @@ CODE_SAMPLE
      */
     private function isVariableUsedInStmts(array $nodes, Variable $variable): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($nodes, fn(Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $variable));
+        return (bool) $this->betterNodeFinder->findFirst(
+            $nodes,
+            fn (Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $variable)
+        );
     }
 
     private function isVariableUsedNext(Catch_ $catch, Variable $variable): bool

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Return_;
-use PhpParser\Node\UnionType as PhpParserUnionType;
 use PHPStan\Type\MixedType;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -28,7 +28,7 @@ final class ReturnStrictTypeAnalyzer
 
     /**
      * @param Return_[] $returns
-     * @return array<Identifier|Name|NullableType|PhpParserUnionType>
+     * @return array<Identifier|Name|NullableType>
      */
     public function collectStrictReturnTypes(array $returns): array
     {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -98,7 +98,7 @@ CODE_SAMPLE
         }
 
         /** @var Return_[] $returns */
-        $returns = $this->betterNodeFinder->find((array) $node->stmts, function (Node $n) use ($node) {
+        $returns = $this->betterNodeFinder->find((array) $node->stmts, function (Node $n) use ($node): bool {
             $currentFunctionLike = $this->betterNodeFinder->findParentType($n, FunctionLike::class);
 
             if ($currentFunctionLike === $node) {

--- a/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/FunctionLikeDocParamTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/FunctionLikeDocParamTypeInferer.php
@@ -22,7 +22,6 @@ final class FunctionLikeDocParamTypeInferer implements ParamTypeInfererInterface
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
         private PhpDocInfoFactory $phpDocInfoFactory,
-        private BetterNodeFinder $betterNodeFinder,
         private ParentFinder $parentFinder
     ) {
     }

--- a/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/FunctionLikeDocParamTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/FunctionLikeDocParamTypeInferer.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeNestingScope\ParentFinder;
 use Rector\TypeDeclaration\Contract\TypeInferer\ParamTypeInfererInterface;

--- a/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
+++ b/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
@@ -32,7 +34,7 @@ final class CompactFuncCallAnalyzer
     }
 
     /**
-     * @param array<int, \PhpParser\Node\Arg|\PhpParser\Node\Expr\ArrayItem|null> $nodes
+     * @param array<int, Arg|ArrayItem|null> $nodes
      */
     private function isInArgOrArrayItemNodes(array $nodes, string $variableName): bool
     {


### PR DESCRIPTION
@TomasVotruba I don't know why, but it fix https://github.com/rectorphp/rector/issues/6573 . 

The error "RectorError::$fileInfo must not be accessed before initialization" no longer appear after run twice.