### PR TITLE
github-actions: declare timeout for job execution

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -16,6 +16,8 @@ env:
 jobs:
     build_scoped_rector:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
+
         steps:
             -
                 uses: actions/checkout@v2

--- a/.github/workflows/build_scoped_rector_php70.yaml
+++ b/.github/workflows/build_scoped_rector_php70.yaml
@@ -18,6 +18,8 @@ env:
 jobs:
     build_scoped_rector_php70:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
+
         steps:
             -
                 uses: actions/checkout@v2

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -38,6 +38,7 @@ jobs:
 
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/code_analysis_no_dev.yaml
+++ b/.github/workflows/code_analysis_no_dev.yaml
@@ -23,6 +23,7 @@ jobs:
 
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -15,6 +15,7 @@ env:
 jobs:
     packages_tests:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         strategy:
             fail-fast: false

--- a/.github/workflows/php_linter.yaml
+++ b/.github/workflows/php_linter.yaml
@@ -10,6 +10,7 @@ env:
 jobs:
     php_linter:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -29,6 +29,8 @@ jobs:
                     - rules
 
         runs-on: ubuntu-latest
+        timeout-minutes: 30
+
         steps:
             # workaround for missing secret in fork PRs - see https://github.com/actions/checkout/issues/298
             # see https://github.com/rectorphp/rector/commit/d395e1c28b8e6a56711dcc2e10490a82965850e4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,8 @@ env:
 jobs:
     tests:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
+
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -27,6 +27,7 @@ jobs:
 
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         steps:
             -


### PR DESCRIPTION
the default of 6h is way to long and produced a overlong queue in case of endless loop bugs.

as discussed in https://github.com/rectorphp/rector/issues/6574#issuecomment-881273800

closes https://github.com/rectorphp/rector/issues/6574