### PR TITLE
[Php71] Skip AssignArrayToStringRector on empty string array dim fetch value

### DIFF
--- a/rules-tests/Php71/Rector/Assign/AssignArrayToStringRector/Fixture/empty_string_array_dim_fetch_value.php.inc
+++ b/rules-tests/Php71/Rector/Assign/AssignArrayToStringRector/Fixture/empty_string_array_dim_fetch_value.php.inc
@@ -6,7 +6,9 @@ final class EmptyStringArrayDimFetchValue
 {
     public function run()
     {
+        // a
         $r = [];
+        // b
         $r[] = '';
     }
 }

--- a/rules-tests/Php71/Rector/Assign/AssignArrayToStringRector/Fixture/empty_string_array_dim_fetch_value.php.inc
+++ b/rules-tests/Php71/Rector/Assign/AssignArrayToStringRector/Fixture/empty_string_array_dim_fetch_value.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\Assign\AssignArrayToStringRector\Fixture;
+
+final class EmptyStringArrayDimFetchValue
+{
+    public function run()
+    {
+        $r = [];
+        $r[] = '';
+    }
+}
+
+?>

--- a/rules-tests/Php71/Rector/Assign/AssignArrayToStringRector/Fixture/skip_empty_string_array_dim_fetch_value.php.inc
+++ b/rules-tests/Php71/Rector/Assign/AssignArrayToStringRector/Fixture/skip_empty_string_array_dim_fetch_value.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php71\Rector\Assign\AssignArrayToStringRector\Fixture;
 
-final class EmptyStringArrayDimFetchValue
+final class SkipEmptyStringArrayDimFetchValue
 {
     public function run()
     {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -382,7 +382,7 @@ final class BetterNodeFinder
         } elseif ($expr instanceof StaticPropertyFetch || $expr instanceof PropertyFetch) {
             $exprName = $this->nodeNameResolver->getName($expr->name);
         } else {
-            throw new NotImplementedYetException();
+            return [];
         }
 
         if ($exprName === null) {


### PR DESCRIPTION
It currently got error:

```bash
There was 1 error:

1) Rector\Tests\Php71\Rector\Assign\AssignArrayToStringRector\AssignArrayToStringRectorTest::test with data set #9 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\NotImplementedYetException: 

/Users/samsonasik/www/rector-src/src/PhpParser/Node/BetterNodeFinder.php:385
/Users/samsonasik/www/rector-src/rules/Php71/Rector/Assign/AssignArrayToStringRector.php:81
```

It Fixes rectorphp/rector#6573
