### PR TITLE
[Core] Refactor RectorError ValueObject with inject with SmartFileInfo

### DIFF
--- a/packages/ChangesReporting/ValueObjectFactory/ErrorFactory.php
+++ b/packages/ChangesReporting/ValueObjectFactory/ErrorFactory.php
@@ -7,6 +7,7 @@ namespace Rector\ChangesReporting\ValueObjectFactory;
 use PHPStan\AnalysedCodeException;
 use Rector\Core\Error\ExceptionCorrector;
 use Rector\Core\ValueObject\Application\RectorError;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ErrorFactory
 {
@@ -15,9 +16,9 @@ final class ErrorFactory
     ) {
     }
 
-    public function createAutoloadError(AnalysedCodeException $analysedCodeException): RectorError
+    public function createAutoloadError(AnalysedCodeException $analysedCodeException, SmartFileInfo $smartFileInfo): RectorError
     {
         $message = $this->exceptionCorrector->getAutoloadExceptionMessageAndAddLocation($analysedCodeException);
-        return new RectorError($message);
+        return new RectorError($message, $smartFileInfo);
     }
 }

--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -125,14 +125,14 @@ final class PhpFileProcessor implements FileProcessorInterface
             }
 
             $this->notParsedFiles[] = $file;
-            $error = $this->errorFactory->createAutoloadError($analysedCodeException);
+            $error = $this->errorFactory->createAutoloadError($analysedCodeException, $file->getSmartFileInfo());
             $file->addRectorError($error);
         } catch (Throwable $throwable) {
             if ($this->symfonyStyle->isVerbose() || StaticPHPUnitEnvironment::isPHPUnitRun()) {
                 throw $throwable;
             }
 
-            $rectorError = new RectorError($throwable->getMessage(), $throwable->getLine());
+            $rectorError = new RectorError($throwable->getMessage(), $file->getSmartFileInfo(), $throwable->getLine());
             $file->addRectorError($rectorError);
         }
     }

--- a/src/ValueObject/Application/RectorError.php
+++ b/src/ValueObject/Application/RectorError.php
@@ -8,10 +8,9 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class RectorError
 {
-    private SmartFileInfo $fileInfo;
-
     public function __construct(
         private string $message,
+        private SmartFileInfo $smartFileInfo,
         private ?int $line = null,
         private ?string $rectorClass = null
     ) {

--- a/src/ValueObject/Application/RectorError.php
+++ b/src/ValueObject/Application/RectorError.php
@@ -10,7 +10,7 @@ final class RectorError
 {
     public function __construct(
         private string $message,
-        private SmartFileInfo $smartFileInfo,
+        private SmartFileInfo $fileInfo,
         private ?int $line = null,
         private ?string $rectorClass = null
     ) {


### PR DESCRIPTION
To avoid error : "Typed property Rector\Core\ValueObject\Application\RectorError::$fileInfo must not be accessed before initialization" like in https://github.com/rectorphp/rector/issues/6573