### PR TITLE
[TypeDeclaration] Fixes Return Type static in ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_return_static.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_return_static.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+final class SkipReturnStatic
+{
+    public function run()
+    {
+        return new static();
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/static_.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/static_.php.inc
@@ -11,6 +11,11 @@ class Static_
     {
         return $this;
     }
+
+    public function getStatic()
+    {
+        return new static();
+    }
 }
 
 ?>
@@ -27,6 +32,11 @@ class Static_
     public function getSelf(): static
     {
         return $this;
+    }
+
+    public function getStatic(): static
+    {
+        return new static();
     }
 }
 

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\UnionType as PhpParserUnionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractRector;
@@ -119,7 +120,24 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isNotSupportStaticType($inferedReturnType)) {
+            return null;
+        }
+
         return $this->processType($node, $inferedReturnType);
+    }
+
+    private function isNotSupportStaticType(Type $inferedReturnType): bool
+    {
+        if ($this->isAtLeastPhpVersion(PhpVersionFeature::STATIC_RETURN_TYPE)) {
+            return false;
+        }
+
+        if (! $inferedReturnType instanceof ThisType) {
+            return false;
+        }
+
+        return $inferedReturnType->getClassName() === 'static';
     }
 
     private function processType(ClassMethod | Function_ $node, Type $inferedType): ?Node

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -120,14 +120,14 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isNotSupportStaticType($inferedReturnType)) {
+        if ($this->isNotSupportedStaticType($inferedReturnType)) {
             return null;
         }
 
         return $this->processType($node, $inferedReturnType);
     }
 
-    private function isNotSupportStaticType(Type $inferedReturnType): bool
+    private function isNotSupportedStaticType(Type $inferedReturnType): bool
     {
         if ($this->isAtLeastPhpVersion(PhpVersionFeature::STATIC_RETURN_TYPE)) {
             return false;

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -6,7 +6,9 @@ namespace Rector\TypeDeclaration\TypeInferer;
 
 use PhpParser\Node\FunctionLike;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
 use Rector\TypeDeclaration\Sorter\TypeInfererSorter;
 use Rector\TypeDeclaration\TypeAnalyzer\GenericClassStringTypeNormalizer;
@@ -56,6 +58,10 @@ final class ReturnTypeInferer
             // in case of void, check return type of children methods
             if ($type instanceof MixedType) {
                 continue;
+            }
+
+            if ($type instanceof FullyQualifiedObjectType && $type->getClassName() === 'static') {
+                $type = new ThisType($type->getClassName());
             }
 
             // normalize ConstStringType to ClassStringType


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6541

- skip return static on use feature before static type ( php <= 7.4 )
- allow return static on php 8+ 