### PR TITLE
[Privatization][TypeDeclaration] Invalid return type on use RepeatedLiteralToClassConstantRector + ReturnTypeDeclarationRector

### DIFF
--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -26,7 +26,7 @@ final class GenericClassStringTypeNormalizer
 
     public function normalize(Type $type): Type
     {
-        $isAutoImport = $this->parameterProvider->provideParameter(Option::AUTO_IMPORT_NAMES);
+        $isAutoImport = $this->parameterProvider->provideBoolParameter(Option::AUTO_IMPORT_NAMES);
         return TypeTraverser::map($type, function (Type $type, $callback) use ($isAutoImport): Type {
             if (! $type instanceof ConstantStringType) {
                 $callbackType = $callback($type);

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\TypeAnalyzer;
 
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\ObjectType;
@@ -28,6 +29,11 @@ final class GenericClassStringTypeNormalizer
         $isAutoImport = $this->parameterProvider->provideParameter(Option::AUTO_IMPORT_NAMES);
         return TypeTraverser::map($type, function (Type $type, $callback) use ($isAutoImport): Type {
             if (! $type instanceof ConstantStringType) {
+                $callbackType = $callback($type);
+                if ($callbackType instanceof ArrayType) {
+                    return $callbackType;
+                }
+
                 $typeWithFullyQualifiedObjectType = $this->verifyAutoImportedFullyQualifiedType($type, $isAutoImport);
                 if ($typeWithFullyQualifiedObjectType instanceof Type) {
                     return $typeWithFullyQualifiedObjectType;
@@ -83,6 +89,9 @@ final class GenericClassStringTypeNormalizer
 
     private function isAutoImportFullyQualifiedObjectType(Type $type, bool $isAutoImport): bool
     {
-        return $isAutoImport && $type instanceof FullyQualifiedObjectType && ! str_contains($type->getClassName(), '\\');
+        return $isAutoImport && $type instanceof FullyQualifiedObjectType && ! str_contains(
+            $type->getClassName(),
+            '\\'
+        );
     }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -28,7 +28,7 @@ final class GenericClassStringTypeNormalizer
     public function normalize(Type $type): Type
     {
         $isAutoImport = $this->parameterProvider->provideParameter(Option::AUTO_IMPORT_NAMES);
-        return TypeTraverser::map($type, function (Type $type, $callback) use ($isAutoImport): ?Type {
+        return TypeTraverser::map($type, function (Type $type, $callback) use ($isAutoImport): Type {
             if (! $type instanceof ConstantStringType) {
                 if ($type instanceof UnionType) {
                     $returnTypes = $type->getTypes();
@@ -36,6 +36,7 @@ final class GenericClassStringTypeNormalizer
                     $hasFullyQualifiedObjectType = false;
                     foreach ($returnTypes as $returnType) {
                         if ($this->isAutoImportFullyQualifiedObjectType($returnType, $isAutoImport)) {
+                            /** @var FullyQualifiedObjectType $returnType */
                             $types[] = new GenericClassStringType(new ObjectType($returnType->getClassName()));
                             $hasFullyQualifiedObjectType = true;
                             continue;
@@ -52,6 +53,7 @@ final class GenericClassStringTypeNormalizer
                 }
 
                 if ($this->isAutoImportFullyQualifiedObjectType($type, $isAutoImport)) {
+                    /** @var FullyQualifiedObjectType $type */
                     return new GenericClassStringType(new ObjectType($type->getClassName()));
                 }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -39,7 +39,7 @@ final class GenericClassStringTypeNormalizer
                     return $typeWithFullyQualifiedObjectType;
                 }
 
-                return $callback($type);
+                return $callbackType;
             }
 
             // skip string that look like classe

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -83,6 +83,6 @@ final class GenericClassStringTypeNormalizer
 
     private function isAutoImportFullyQualifiedObjectType(Type $type, bool $isAutoImport): bool
     {
-        return $isAutoImport && $type instanceof FullyQualifiedObjectType;
+        return $isAutoImport && $type instanceof FullyQualifiedObjectType && ! str_contains($type->getClassName(), '\\');
     }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -63,7 +63,7 @@ final class GenericClassStringTypeNormalizer
             $hasFullyQualifiedObjectType = false;
             foreach ($unionTypes as $unionType) {
                 if ($this->isAutoImportFullyQualifiedObjectType($unionType, $isAutoImport)) {
-                    /** @var FullyQualifiedObjectType $returnType */
+                    /** @var FullyQualifiedObjectType $unionType */
                     $types[] = new GenericClassStringType(new ObjectType($unionType->getClassName()));
                     $hasFullyQualifiedObjectType = true;
                     continue;

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -58,18 +58,18 @@ final class GenericClassStringTypeNormalizer
     private function verifyAutoImportedFullyQualifiedType(Type $type, bool $isAutoImport): ?Type
     {
         if ($type instanceof UnionType) {
-            $returnTypes = $type->getTypes();
+            $unionTypes = $type->getTypes();
             $types = [];
             $hasFullyQualifiedObjectType = false;
-            foreach ($returnTypes as $returnType) {
-                if ($this->isAutoImportFullyQualifiedObjectType($returnType, $isAutoImport)) {
+            foreach ($unionTypes as $unionType) {
+                if ($this->isAutoImportFullyQualifiedObjectType($unionType, $isAutoImport)) {
                     /** @var FullyQualifiedObjectType $returnType */
-                    $types[] = new GenericClassStringType(new ObjectType($returnType->getClassName()));
+                    $types[] = new GenericClassStringType(new ObjectType($unionType->getClassName()));
                     $hasFullyQualifiedObjectType = true;
                     continue;
                 }
 
-                $types[] = $returnType;
+                $types[] = $unionType;
             }
 
             if ($hasFullyQualifiedObjectType) {

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\TypeInferer;
 
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
+use PhpParser\Node\UnionType as PhpParserUnionType;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -53,6 +55,14 @@ final class ReturnTypeInferer
 
         foreach ($this->returnTypeInferers as $returnTypeInferer) {
             if ($this->shouldSkipExcludedTypeInferer($returnTypeInferer, $excludedInferers)) {
+                continue;
+            }
+
+            if ($functionLike->returnType instanceof FullyQualified && ! str_contains($functionLike->returnType->toString(), '\\')) {
+                continue;
+            }
+
+            if ($functionLike->returnType instanceof PhpParserUnionType) {
                 continue;
             }
 

--- a/tests/Issues/IssueImportedReturn/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueImportedReturn/Fixture/fixture.php.inc
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
+
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging;
+
+final class Fixture
+{
+    public function run(): Logging
+    {
+        if ($this->config['config']) {
+
+        }
+
+        if (! $this->config['config']) {
+
+        }
+
+        if (! $this->config['config']) {
+
+        }
+
+        return new Logging();
+    }
+}
+
+?>
+-----
+<?php
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
+
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging;
+
+final class Fixture
+{
+    /**
+     * @var string
+     */
+    private const CONFIG = 'config';
+    public function run(): Logging
+    {
+        if ($this->config[self::CONFIG]) {
+
+        }
+
+        if (! $this->config[self::CONFIG]) {
+
+        }
+
+        if (! $this->config[self::CONFIG]) {
+
+        }
+
+        return new Logging();
+    }
+}
+
+?>

--- a/tests/Issues/IssueImportedReturn/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueImportedReturn/Fixture/fixture.php.inc
@@ -27,6 +27,7 @@ final class Fixture
 ?>
 -----
 <?php
+
 namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
 
 use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging;

--- a/tests/Issues/IssueImportedReturn/Fixture/namespaced.php.inc
+++ b/tests/Issues/IssueImportedReturn/Fixture/namespaced.php.inc
@@ -6,7 +6,7 @@ use Rector\Core\Tests\Issues\IssueImportedReturn\Source;
 
 final class Namespaced
 {
-    public function run(): Source\Logging
+    public function run(): Source\Logging|Source\Logging2
     {
         if ($this->config['config']) {
 
@@ -20,7 +20,11 @@ final class Namespaced
 
         }
 
-        return new Logging();
+        if (rand(0, 1)) {
+            return new Logging();
+        }
+
+        return new Logging2();
     }
 }
 
@@ -38,7 +42,7 @@ final class Namespaced
      * @var string
      */
     private const CONFIG = 'config';
-    public function run(): Source\Logging
+    public function run(): Source\Logging|Source\Logging2
     {
         if ($this->config[self::CONFIG]) {
 
@@ -52,7 +56,11 @@ final class Namespaced
 
         }
 
-        return new Logging();
+        if (rand(0, 1)) {
+            return new Logging();
+        }
+
+        return new Logging2();
     }
 }
 

--- a/tests/Issues/IssueImportedReturn/Fixture/namespaced.php.inc
+++ b/tests/Issues/IssueImportedReturn/Fixture/namespaced.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
+
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source;
+
+final class Namespaced
+{
+    public function run(): Source\Logging
+    {
+        if ($this->config['config']) {
+
+        }
+
+        if (! $this->config['config']) {
+
+        }
+
+        if (! $this->config['config']) {
+
+        }
+
+        return new Logging();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
+
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source;
+
+final class Namespaced
+{
+    /**
+     * @var string
+     */
+    private const CONFIG = 'config';
+    public function run(): Source\Logging
+    {
+        if ($this->config[self::CONFIG]) {
+
+        }
+
+        if (! $this->config[self::CONFIG]) {
+
+        }
+
+        if (! $this->config[self::CONFIG]) {
+
+        }
+
+        return new Logging();
+    }
+}
+
+?>

--- a/tests/Issues/IssueImportedReturn/Fixture/namespaced_union.php.inc
+++ b/tests/Issues/IssueImportedReturn/Fixture/namespaced_union.php.inc
@@ -4,9 +4,9 @@ namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
 
 use Rector\Core\Tests\Issues\IssueImportedReturn\Source;
 
-final class Namespaced
+final class NamespacedUnion
 {
-    public function run(): Source\Logging
+    public function run(): Source\Logging|Source\Logging2
     {
         if ($this->config['config']) {
 
@@ -20,7 +20,11 @@ final class Namespaced
 
         }
 
-        return new Logging();
+        if (rand(0, 1)) {
+            return new Logging();
+        }
+
+        return new Logging2();
     }
 }
 
@@ -32,13 +36,13 @@ namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
 
 use Rector\Core\Tests\Issues\IssueImportedReturn\Source;
 
-final class Namespaced
+final class NamespacedUnion
 {
     /**
      * @var string
      */
     private const CONFIG = 'config';
-    public function run(): Source\Logging
+    public function run(): Source\Logging|Source\Logging2
     {
         if ($this->config[self::CONFIG]) {
 
@@ -52,7 +56,11 @@ final class Namespaced
 
         }
 
-        return new Logging();
+        if (rand(0, 1)) {
+            return new Logging();
+        }
+
+        return new Logging2();
     }
 }
 

--- a/tests/Issues/IssueImportedReturn/Fixture/union_type.php.inc
+++ b/tests/Issues/IssueImportedReturn/Fixture/union_type.php.inc
@@ -1,0 +1,68 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
+
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging;
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging2;
+
+final class SomeUnionType
+{
+    public function run(): Logging|Logging2
+    {
+        if ($this->config['config']) {
+
+        }
+
+        if (! $this->config['config']) {
+
+        }
+
+        if (! $this->config['config']) {
+
+        }
+
+        if (rand(0, 1)) {
+            return new Logging();
+        }
+
+        return new Logging2();
+    }
+}
+
+?>
+-----
+<?php
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
+
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging;
+use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging2;
+
+final class SomeUnionType
+{
+    /**
+     * @var string
+     */
+    private const CONFIG = 'config';
+    public function run(): Logging|Logging2
+    {
+        if ($this->config[self::CONFIG]) {
+
+        }
+
+        if (! $this->config[self::CONFIG]) {
+
+        }
+
+        if (! $this->config[self::CONFIG]) {
+
+        }
+
+        if (rand(0, 1)) {
+            return new Logging();
+        }
+
+        return new Logging2();
+    }
+}
+
+?>

--- a/tests/Issues/IssueImportedReturn/Fixture/union_type.php.inc
+++ b/tests/Issues/IssueImportedReturn/Fixture/union_type.php.inc
@@ -32,6 +32,7 @@ final class SomeUnionType
 ?>
 -----
 <?php
+
 namespace Rector\Core\Tests\Issues\IssueImportedReturn\Fixture;
 
 use Rector\Core\Tests\Issues\IssueImportedReturn\Source\Logging;

--- a/tests/Issues/IssueImportedReturn/ImportedReturnTest.php
+++ b/tests/Issues/IssueImportedReturn/ImportedReturnTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueImportedReturn;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ImportedReturnTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueImportedReturn/Source/Logging.php
+++ b/tests/Issues/IssueImportedReturn/Source/Logging.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Source;
+
+class Logging
+{
+
+}

--- a/tests/Issues/IssueImportedReturn/Source/Logging2.php
+++ b/tests/Issues/IssueImportedReturn/Source/Logging2.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueImportedReturn\Source;
+
+class Logging2
+{
+
+}

--- a/tests/Issues/IssueImportedReturn/config/configured_rule.php
+++ b/tests/Issues/IssueImportedReturn/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Privatization\Rector\Class_\RepeatedLiteralToClassConstantRector;
+use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RepeatedLiteralToClassConstantRector::class);
+    $services->set(ReturnTypeDeclarationRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_80);
+};

--- a/tests/Issues/IssueImportedReturn/config/configured_rule.php
+++ b/tests/Issues/IssueImportedReturn/config/configured_rule.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
-use Rector\Core\ValueObject\PhpVersion;
 use Rector\Privatization\Rector\Class_\RepeatedLiteralToClassConstantRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -15,5 +14,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
-    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_80);
 };


### PR DESCRIPTION
With used of `RepeatedLiteralToClassConstantRector` and `ReturnTypeDeclarationRector`, it cause an invalid return type for the following use case:

```php
use A\B\C;

class X
{
     public function run(): C
     {
     }
}
```

Make : 

```diff
-     public function run(): C
+     public function run(): \C
```

which invalid.