### PR TITLE
[Testing] Use PHP_OS_FAMILY for isWindows() check

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -81,7 +81,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
 
     protected function isWindows(): bool
     {
-        return strncasecmp(PHP_OS, 'WIN', 3) === 0;
+        return PHP_OS_FAMILY === 'Windows';
     }
 
     protected function doTestFileInfo(SmartFileInfo $fixtureFileInfo, bool $allowMatches = true): void


### PR DESCRIPTION
There is `PHP_OS_FAMILY` that can be used to compare to `Windows` value ref https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family