### PR TITLE
[CodeQuality] Handle both ExplicitBoolCompareRector + CountArrayToEmptyArrayComparisonRector usage

### DIFF
--- a/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
+++ b/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\If_;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
@@ -107,7 +108,7 @@ CODE_SAMPLE
         }
 
         $conditionStaticType = $this->getStaticType($conditionNode);
-        if ($conditionStaticType instanceof BooleanType) {
+        if ($conditionStaticType instanceof BooleanType || $conditionStaticType instanceof ConstantIntegerType) {
             return null;
         }
 

--- a/tests/Issues/Issue6561/CountArrayOnTruthyEmptyArrayCompareTest.php
+++ b/tests/Issues/Issue6561/CountArrayOnTruthyEmptyArrayCompareTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6561;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class CountArrayOnTruthyEmptyArrayCompareTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6561/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6561/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6561\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $array = [];
+
+        if (count($array)) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6561\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $array = [];
+
+        if ($array !== []) {
+        }
+    }
+}
+
+?>

--- a/tests/Issues/Issue6561/config/configured_rule.php
+++ b/tests/Issues/Issue6561/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
+use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ExplicitBoolCompareRector::class);
+    $services->set(CountArrayToEmptyArrayComparisonRector::class);
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6561