### PR TITLE
[Stubs] Fix Regression Scoped autoload introduced in 0.11.38

### DIFF
--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -44,16 +44,8 @@ final class PHPStanStubLoader
             }
 
             foreach (self::STUBS as $stub) {
-                $path = sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
-                $isExists = file_exists($path);
-
-                if (! $isExists) {
-                    // this is to handle phpstan's stubs got from phpstan-extracted instead of the .phar.
-                    $path = sprintf('%s/phpstan/phpstan-extracted/stubs/runtime/%s', $vendorPath, $stub);
-                    $isExists = file_exists($path);
-                }
-
-                if (! $isExists) {
+                $path = $this->getStubPath($vendorPath, $stub);
+                if ($path === null) {
                     continue 2;
                 }
 
@@ -65,5 +57,23 @@ final class PHPStanStubLoader
             // already loaded? stop loop
             break;
         }
+    }
+
+    private function getStubPath(string $vendorPath, string $stub): ?string
+    {
+        $path = sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
+        $isExists = file_exists($path);
+
+        if (! $isExists) {
+            // this is to handle phpstan's stubs got from phpstan-extracted instead of the .phar.
+            $path = sprintf('%s/phpstan/phpstan-extracted/stubs/runtime/%s', $vendorPath, $stub);
+            $isExists = file_exists($path);
+        }
+
+        if ($isExists) {
+            return $path;
+        }
+
+        return null;
     }
 }

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -44,9 +44,14 @@ final class PHPStanStubLoader
             }
 
             foreach (self::STUBS as $stub) {
-                // this is to handle phpstan's stubs got from phpstan-extracted instead of the .phar.
-                $path = sprintf('%s/phpstan/phpstan-extracted/stubs/runtime/%s', $vendorPath, $stub);
+                $path = sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
                 $isExists = file_exists($path);
+
+                if (! $isExists) {
+                    // this is to handle phpstan's stubs got from phpstan-extracted instead of the .phar.
+                    $path = sprintf('%s/phpstan/phpstan-extracted/stubs/runtime/%s', $vendorPath, $stub);
+                    $isExists = file_exists($path);
+                }
 
                 if (! $isExists) {
                     continue 2;

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -61,11 +61,12 @@ final class PHPStanStubLoader
 
     private function getStubPath(string $vendorPath, string $stub): ?string
     {
+        // @todo: need to be switched when phpstan-extracted used after scoped php 7.0 works
         $path = sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
         $isExists = file_exists($path);
 
         if (! $isExists) {
-            // this is to handle phpstan's stubs got from phpstan-extracted instead of the .phar.
+            // this is to handle phpstan's stubs got from phpstan-extracted instead of the .phar when exists after scoped php 7.0 applied
             $path = sprintf('%s/phpstan/phpstan-extracted/stubs/runtime/%s', $vendorPath, $stub);
             $isExists = file_exists($path);
         }


### PR DESCRIPTION
@TomasVotruba the error : 

```
Class 'ReflectionUnionType' not found
```

is introduced by https://github.com/rectorphp/rector-src/pull/475/files#diff-e554b0d428c1e970b85f6dedf089d2a50f66c1c28b81fbc094cdec4aa9e53ad9R47-R48 which it is looking at `phpstan-extracted` which not exists yet as it currently still looking at `phpstan` phar.

ref https://github.com/codeigniter4/CodeIgniter4/runs/3125228717#step:10:180 for example error.