### PR TITLE
[Core] Avoid "Backtrack limit was exhausted" error on BetterStandardPrinter

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -59,10 +59,10 @@ final class BetterStandardPrinter extends Standard
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
 
     /**
-     * @see https://regex101.com/r/qZiqGo/7
+     * @see https://regex101.com/r/qZiqGo/8
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^((public|private|protected)\s+)?function .*?\(.*?\)) : #';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^((public|private|protected)\s+)?function .*?\(.*?\) : )#';
 
     /**
      * Use space by default

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -59,10 +59,10 @@ final class BetterStandardPrinter extends Standard
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
 
     /**
-     * @see https://regex101.com/r/qZiqGo/11
+     * @see https://regex101.com/r/qZiqGo/12
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^(((static)\s+)?((public|private|protected)\s+)?((static)\s+)?)?function .*\(.*\)) : #';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^.*?function .*\(.*\)) : ';
 
     /**
      * Use space by default

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -59,10 +59,10 @@ final class BetterStandardPrinter extends Standard
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
 
     /**
-     * @see https://regex101.com/r/qZiqGo/4
+     * @see https://regex101.com/r/qZiqGo/7
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(function .*?\(.*?\)) : #';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^((public|private|protected)\s+)?function .*?\(.*?\)) : #';
 
     /**
      * Use space by default

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -62,7 +62,7 @@ final class BetterStandardPrinter extends Standard
      * @see https://regex101.com/r/qZiqGo/8
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^((public|private|protected)\s+)?function .*?\(.*?\) : )#';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^((public|private|protected)\s+)?function .*?\(.*?\)) : #mU';
 
     /**
      * Use space by default

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -59,10 +59,10 @@ final class BetterStandardPrinter extends Standard
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
 
     /**
-     * @see https://regex101.com/r/qZiqGo/12
+     * @see https://regex101.com/r/qZiqGo/13
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^.*?function .*\(.*\)) : ';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^.*function .*\(.*\)) : ';
 
     /**
      * Use space by default

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -59,10 +59,10 @@ final class BetterStandardPrinter extends Standard
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
 
     /**
-     * @see https://regex101.com/r/qZiqGo/10
+     * @see https://regex101.com/r/qZiqGo/11
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^(((static)\s+)?(public|private|protected)\s+((static)\s+)?)?function .*\(.*\)) : #';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^(((static)\s+)?((public|private|protected)\s+)?((static)\s+)?)?function .*\(.*\)) : #';
 
     /**
      * Use space by default

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -62,7 +62,7 @@ final class BetterStandardPrinter extends Standard
      * @see https://regex101.com/r/qZiqGo/13
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^.*function .*\(.*\)) : ';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^.*function .*\(.*\)) : #';
 
     /**
      * Use space by default

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -59,10 +59,10 @@ final class BetterStandardPrinter extends Standard
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
 
     /**
-     * @see https://regex101.com/r/qZiqGo/8
+     * @see https://regex101.com/r/qZiqGo/10
      * @var string
      */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^((public|private|protected)\s+)?function .*?\(.*?\)) : #mU';
+    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^(((static)\s+)?(public|private|protected)\s+((static)\s+)?)?function .*\(.*\)) : #';
 
     /**
      * Use space by default


### PR DESCRIPTION
The regex error can happen on very large Doctrine migration insert:

```bash
    public function up(Schema $schema): void
    {
    
            $this->addSql("# ************************************************************
            
INSERT INTO `tableName` (`id`, `name`)
VALUES
    	(1, 'test 1'),
    	// ....

");
    }    	
    	
```
