### PR TITLE
Sync FileCacheStorage with changes from phpstan-src

### DIFF
--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -97,8 +97,8 @@ final class FileCacheStorage
     private function getCacheFilePaths(string $key): CacheFilePaths
     {
         $keyHash = sha1($key);
-        $firstDirectory = sprintf('%s/%s', $this->directory, Strings::substring($keyHash, 0, 2));
-        $secondDirectory = sprintf('%s/%s', $firstDirectory, Strings::substring($keyHash, 2, 2));
+        $firstDirectory = sprintf('%s/%s', $this->directory, substr($keyHash, 0, 2));
+        $secondDirectory = sprintf('%s/%s', $firstDirectory, substr($keyHash, 2, 2));
         $filePath = sprintf('%s/%s.php', $secondDirectory, $keyHash);
 
         return new CacheFilePaths($firstDirectory, $secondDirectory, $filePath);

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Rector\Caching\ValueObject\Storage;
 
 use Nette\Utils\Random;
-use Nette\Utils\Strings;
-use Rector\Caching\ValueObject\CacheFilePaths;
-use Rector\Caching\ValueObject\CacheItem;
-use Symplify\EasyCodingStandard\Caching\Exception\CachingException;
-use Symplify\SmartFileSystem\SmartFileSystem;
+use PHPStan\Cache\CacheItem;
+use PHPStan\File\FileWriter;
+use PHPStan\ShouldNotHappenException;
 
 /**
  * Inspired by
@@ -23,66 +21,83 @@ final class FileCacheStorage
     ) {
     }
 
+    private function makeDir(string $directory) : void
+    {
+        if (\is_dir($directory)) {
+            return;
+        }
+        $result = @\mkdir($directory, 0777);
+        if ($result === \false) {
+            \clearstatcache();
+            if (\is_dir($directory)) {
+                return;
+            }
+            $error = \error_get_last();
+            throw new \InvalidArgumentException(\sprintf('Failed to create directory "%s" (%s).', $this->directory, $error !== null ? $error['message'] : 'unknown cause'));
+        }
+    }
+
     /**
+     * @param string $key
+     * @param string $variableKey
      * @return mixed|null
      */
     public function load(string $key, string $variableKey)
     {
-        $cacheFilePaths = $this->getCacheFilePaths($key);
-
-        $filePath = $cacheFilePaths->getFilePath();
-        if (! is_file($filePath)) {
-            return null;
-        }
-
-        $cacheItem = require $filePath;
-        if (! $cacheItem instanceof CacheItem) {
-            return null;
-        }
-
-        if (! $cacheItem->isVariableKeyValid($variableKey)) {
-            return null;
-        }
-
-        return $cacheItem->getData();
+        return (function (string $key, string $variableKey) {
+            [, , $filePath] = $this->getFilePaths($key);
+            if (!\is_file($filePath)) {
+                return null;
+            }
+            $cacheItem = (require $filePath);
+            if (!$cacheItem instanceof CacheItem) {
+                return null;
+            }
+            if (!$cacheItem->isVariableKeyValid($variableKey)) {
+                return null;
+            }
+            return $cacheItem->getData();
+        })($key, $variableKey);
     }
 
     /**
+     * @param string $key
+     * @param string $variableKey
      * @param mixed $data
+     * @return void
      */
-    public function save(string $key, string $variableKey, $data): void
+    public function save(string $key, string $variableKey, $data) : void
     {
-        $cacheFilePaths = $this->getCacheFilePaths($key);
-
-        $this->smartFileSystem->mkdir($cacheFilePaths->getFirstDirectory());
-        $this->smartFileSystem->mkdir($cacheFilePaths->getSecondDirectory());
-
-        $errorBefore = error_get_last();
-        $exported = @var_export(new CacheItem($variableKey, $data), true);
-        $errorAfter = error_get_last();
-
+        [$firstDirectory, $secondDirectory, $path] = $this->getFilePaths($key);
+        $this->makeDir($this->directory);
+        $this->makeDir($firstDirectory);
+        $this->makeDir($secondDirectory);
+        $tmpPath = \sprintf('%s/%s.tmp', $this->directory, Random::generate());
+        $errorBefore = \error_get_last();
+        $exported = @\var_export(new CacheItem($variableKey, $data), \true);
+        $errorAfter = \error_get_last();
         if ($errorAfter !== null && $errorBefore !== $errorAfter) {
-            $errorMessage = sprintf(
-                'Error occurred while saving item "%s" ("%s") to cache: "%s"',
-                $key,
-                $variableKey,
-                $errorAfter['message']
-            );
-            throw new CachingException($errorMessage);
+            throw new ShouldNotHappenException(\sprintf('Error occurred while saving item %s (%s) to cache: %s', $key, $variableKey, $errorAfter['message']));
         }
-
-        $variableFileContent = sprintf("<?php declare(strict_types = 1);\n\nreturn %s;", $exported);
-        $this->smartFileSystem->dumpFile($cacheFilePaths->getFilePath(), $variableFileContent);
+        FileWriter::write($tmpPath, \sprintf("<?php declare(strict_types = 1);\n\nreturn %s;", $exported));
+        $renameSuccess = @\rename($tmpPath, $path);
+        if ($renameSuccess) {
+            return;
+        }
+        @\unlink($tmpPath);
+        if (\DIRECTORY_SEPARATOR === '/' || !\file_exists($path)) {
+            throw new \InvalidArgumentException(\sprintf('Could not write data to cache file %s.', $path));
+        }
     }
 
     public function clean(string $cacheKey): void
     {
-        $cacheFilePaths = $this->getCacheFilePaths($cacheKey);
+        [$firstDirectory, $secondDirectory, $path] = $this->getFilePaths($cacheKey);
 
         $this->smartFileSystem->remove([
-            $cacheFilePaths->getFirstDirectory(),
-            $cacheFilePaths->getSecondDirectory(),
-            $cacheFilePaths->getFilePath(),
+            $firstDirectory,
+            $secondDirectory,
+            $path
         ]);
     }
 
@@ -91,13 +106,16 @@ final class FileCacheStorage
         $this->smartFileSystem->remove($this->directory);
     }
 
-    private function getCacheFilePaths(string $key): CacheFilePaths
+    /**
+     * @param string $key
+     * @return array{string, string, string}
+     */
+    private function getFilePaths(string $key) : array
     {
-        $keyHash = sha1($key);
-        $firstDirectory = sprintf('%s/%s', $this->directory, Strings::substring($keyHash, 0, 2));
-        $secondDirectory = sprintf('%s/%s', $firstDirectory, Strings::substring($keyHash, 2, 2));
-        $filePath = sprintf('%s/%s.php', $secondDirectory, $keyHash);
-
-        return new CacheFilePaths($firstDirectory, $secondDirectory, $filePath);
+        $keyHash = \sha1($key);
+        $firstDirectory = \sprintf('%s/%s', $this->directory, \substr($keyHash, 0, 2));
+        $secondDirectory = \sprintf('%s/%s', $firstDirectory, \substr($keyHash, 2, 2));
+        $filePath = \sprintf('%s/%s.php', $secondDirectory, $keyHash);
+        return [$firstDirectory, $secondDirectory, $filePath];
     }
 }

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -8,6 +8,7 @@ use Nette\Utils\Random;
 use PHPStan\Cache\CacheItem;
 use PHPStan\File\FileWriter;
 use PHPStan\ShouldNotHappenException;
+use Symplify\SmartFileSystem\SmartFileSystem;
 
 /**
  * Inspired by https://github.com/phpstan/phpstan-src/blob/1e7ceae933f07e5a250b61ed94799e6c2ea8daa2/src/Cache/FileCacheStorage.php

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -7,8 +7,8 @@ namespace Rector\Caching\ValueObject\Storage;
 use Nette\Utils\Random;
 use Rector\Caching\ValueObject\CacheItem;
 use PHPStan\File\FileWriter;
-use PHPStan\ShouldNotHappenException;
 use Symplify\SmartFileSystem\SmartFileSystem;
+use Symplify\EasyCodingStandard\Caching\Exception\CachingException;
 
 /**
  * Inspired by https://github.com/phpstan/phpstan-src/blob/1e7ceae933f07e5a250b61ed94799e6c2ea8daa2/src/Cache/FileCacheStorage.php
@@ -33,7 +33,7 @@ final class FileCacheStorage
                 return;
             }
             $error = \error_get_last();
-            throw new \InvalidArgumentException(\sprintf('Failed to create directory "%s" (%s).', $this->directory, $error !== null ? $error['message'] : 'unknown cause'));
+            throw new CachingException(\sprintf('Failed to create directory "%s" (%s).', $this->directory, $error !== null ? $error['message'] : 'unknown cause'));
         }
     }
 
@@ -77,7 +77,7 @@ final class FileCacheStorage
         $exported = @\var_export(new CacheItem($variableKey, $data), \true);
         $errorAfter = \error_get_last();
         if ($errorAfter !== null && $errorBefore !== $errorAfter) {
-            throw new ShouldNotHappenException(\sprintf('Error occurred while saving item %s (%s) to cache: %s', $key, $variableKey, $errorAfter['message']));
+            throw new CachingException(\sprintf('Error occurred while saving item %s (%s) to cache: %s', $key, $variableKey, $errorAfter['message']));
         }
         FileWriter::write($tmpPath, \sprintf("<?php declare(strict_types = 1);\n\nreturn %s;", $exported));
         $renameSuccess = @\rename($tmpPath, $path);
@@ -86,7 +86,7 @@ final class FileCacheStorage
         }
         @\unlink($tmpPath);
         if (\DIRECTORY_SEPARATOR === '/' || !\file_exists($path)) {
-            throw new \InvalidArgumentException(\sprintf('Could not write data to cache file %s.', $path));
+            throw new CachingException(\sprintf('Could not write data to cache file %s.', $path));
         }
     }
 

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -66,6 +66,7 @@ final class FileCacheStorage
         if ($errorAfter !== null && $errorBefore !== $errorAfter) {
             throw new CachingException(\sprintf('Error occurred while saving item %s (%s) to cache: %s', $key, $variableKey, $errorAfter['message']));
         }
+        // for performance reasons we don't use SmartFileSystem
         FileWriter::write($tmpPath, \sprintf("<?php declare(strict_types = 1);\n\nreturn %s;", $exported));
         $renameSuccess = @\rename($tmpPath, $path);
         if ($renameSuccess) {

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Caching\ValueObject\Storage;
 
 use Nette\Utils\Random;
+use Rector\Caching\ValueObject\CacheFilePaths;
 use Rector\Caching\ValueObject\CacheItem;
 use PHPStan\File\FileWriter;
 use Symplify\SmartFileSystem\SmartFileSystem;

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -10,8 +10,7 @@ use PHPStan\File\FileWriter;
 use PHPStan\ShouldNotHappenException;
 
 /**
- * Inspired by
- * https://github.com/phpstan/phpstan-src/commit/4df7342f3a0aaef4bcd85456dd20ca88d38dd90d#diff-6dc14f6222bf150e6840ca44a7126653052a1cedc6a149b4e5c1e1a2c80eacdc
+ * Inspired by https://github.com/phpstan/phpstan-src/blob/1e7ceae933f07e5a250b61ed94799e6c2ea8daa2/src/Cache/FileCacheStorage.php
  */
 final class FileCacheStorage
 {

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -62,7 +62,7 @@ final class FileCacheStorage
 
         $tmpPath = \sprintf('%s/%s.tmp', $this->directory, Random::generate());
         $errorBefore = \error_get_last();
-        $exported = @\var_export(new CacheItem($variableKey, $data), \true);
+        $exported = @\var_export(new CacheItem($variableKey, $data), true);
         $errorAfter = \error_get_last();
         if ($errorAfter !== null && $errorBefore !== $errorAfter) {
             throw new CachingException(\sprintf('Error occurred while saving item %s (%s) to cache: %s', $key, $variableKey, $errorAfter['message']));

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\Caching\ValueObject\Storage;
 
 use Nette\Utils\Random;
-use PHPStan\Cache\CacheItem;
+use Rector\Caching\ValueObject\CacheItem;
 use PHPStan\File\FileWriter;
 use PHPStan\ShouldNotHappenException;
 use Symplify\SmartFileSystem\SmartFileSystem;

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -21,22 +21,6 @@ final class FileCacheStorage
     ) {
     }
 
-    private function makeDir(string $directory) : void
-    {
-        if (\is_dir($directory)) {
-            return;
-        }
-        $result = @\mkdir($directory, 0777);
-        if ($result === \false) {
-            \clearstatcache();
-            if (\is_dir($directory)) {
-                return;
-            }
-            $error = \error_get_last();
-            throw new CachingException(\sprintf('Failed to create directory "%s" (%s).', $this->directory, $error !== null ? $error['message'] : 'unknown cause'));
-        }
-    }
-
     /**
      * @param string $key
      * @param string $variableKey
@@ -69,9 +53,10 @@ final class FileCacheStorage
     public function save(string $key, string $variableKey, $data) : void
     {
         [$firstDirectory, $secondDirectory, $path] = $this->getFilePaths($key);
-        $this->makeDir($this->directory);
-        $this->makeDir($firstDirectory);
-        $this->makeDir($secondDirectory);
+
+        $this->smartFileSystem->mkdir($this->directory);
+        $this->smartFileSystem->mkdir($firstDirectory);
+        $this->smartFileSystem->mkdir($secondDirectory);
         $tmpPath = \sprintf('%s/%s.tmp', $this->directory, Random::generate());
         $errorBefore = \error_get_last();
         $exported = @\var_export(new CacheItem($variableKey, $data), \true);

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -57,7 +57,6 @@ final class FileCacheStorage
         $this->smartFileSystem->mkdir($cacheFilePaths->getFirstDirectory());
         $this->smartFileSystem->mkdir($cacheFilePaths->getSecondDirectory());
 
-        $tmpPath = sprintf('%s/%s.tmp', $this->directory, Random::generate());
         $errorBefore = error_get_last();
         $exported = @var_export(new CacheItem($variableKey, $data), true);
         $errorAfter = error_get_last();
@@ -73,10 +72,7 @@ final class FileCacheStorage
         }
 
         $variableFileContent = sprintf("<?php declare(strict_types = 1);\n\nreturn %s;", $exported);
-        $this->smartFileSystem->dumpFile($tmpPath, $variableFileContent);
-
-        $this->smartFileSystem->rename($tmpPath, $cacheFilePaths->getFilePath(), true);
-        $this->smartFileSystem->remove($tmpPath);
+        $this->smartFileSystem->dumpFile($cacheFilePaths->getFilePath(), $variableFileContent);
     }
 
     public function clean(string $cacheKey): void

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -533,18 +533,18 @@ parameters:
         -
             message: '#Use explicit names over dynamic ones#'
             paths:
-                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php
+                - packages/Caching/ValueObject/Storage/FileCacheStorage.php
 
         # native filesystem calls, required for performance reasons
         -
             message: '#"@\\unlink\(\$tmpPath\)" is forbidden to use#'
             paths:
-                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php
+                - packages/Caching/ValueObject/Storage/FileCacheStorage.php
         -
             message: '#"@\\rename\(\$tmpPath, \$path\)" is forbidden to use#'
             paths:
-                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php
+                - packages/Caching/ValueObject/Storage/FileCacheStorage.php
         -
             message: '#"%s" in sprintf\(\) format must be quoted#'
             paths:
-                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php
+                - packages/Caching/ValueObject/Storage/FileCacheStorage.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -459,8 +459,6 @@ parameters:
             message: '#Access to an undefined property PHPStan\\PhpDocParser\\Ast\\PhpDoc\\PhpDocChildNode\:\:\$value#'
             path: packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php #348
 
-        - '#"@var_export\(new \\Rector\\Caching\\ValueObject\\CacheItem\(\$variableKey, \$data\), true\)" is forbidden to use#'
-
         -
             message: '#Class with base "StaticTypeMapper" name is already used in "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\StaticTypeMapper", "Rector\\StaticTypeMapper\\StaticTypeMapper"\. Use unique name to make classes easy to recognize#'
             path: packages/StaticTypeMapper/StaticTypeMapper.php #31
@@ -546,5 +544,9 @@ parameters:
                 - packages/Caching/ValueObject/Storage/FileCacheStorage.php
         -
             message: '#"%s" in sprintf\(\) format must be quoted#'
+            paths:
+                - packages/Caching/ValueObject/Storage/FileCacheStorage.php
+        -
+            message: '#"@\\var_export\(new \\Rector\\Caching\\ValueObject\\CacheItem\(\$variableKey, \$data\), true\)" is forbidden to use#'
             paths:
                 - packages/Caching/ValueObject/Storage/FileCacheStorage.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -528,3 +528,23 @@ parameters:
         - '#Method "refactorParamType\(\)" returns bool type, so the name should start with is/has/was#'
         - '#Method "decorateReturnWithSpecificType\(\)" returns bool type, so the name should start with is/has/was#'
         - '#Method "resolveObjectType\(\)" returns bool type, so the name should start with is/has/was#'
+
+        # resolve later
+        -
+            message: '#Use explicit names over dynamic ones#'
+            paths:
+                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php
+
+        # native filesystem calls, required for performance reasons
+        -
+            message: '#"@\\unlink\(\$tmpPath\)" is forbidden to use#'
+            paths:
+                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php
+        -
+            message: '#"@\\rename\(\$tmpPath, \$path\)" is forbidden to use#'
+            paths:
+                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php
+        -
+            message: '#"%s" in sprintf\(\) format must be quoted#'
+            paths:
+                - path: packages/Caching/ValueObject/Storage/FileCacheStorage.php


### PR DESCRIPTION
as can be seen in https://github.com/rectorphp/rector-src/pull/461#issuecomment-885617373 the FileCacheStorage is a major bottleneck while running tests on windows - I guess the same is true on other OSes.

This PR removes unnecessary temp-file handling, because `smartFileSystem->dumpFile` is already a atomic operation which does magic temp-path file handling behind the scenes. therefore we don't need to do the same things on the rector side.