### PR TITLE
don't clear the ChangedFilesDetector in ChangedFilesDetectorTest

### DIFF
--- a/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -20,11 +20,6 @@ final class ChangedFilesDetectorTest extends AbstractRectorTestCase
         $this->changedFilesDetector = $this->getService(ChangedFilesDetector::class);
     }
 
-    protected function tearDown(): void
-    {
-        $this->changedFilesDetector->clear();
-    }
-
     public function testHasFileChanged(): void
     {
         $smartFileInfo = new SmartFileInfo(__DIR__ . '/Source/file.php');

--- a/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Rector\Tests\Caching\Detector;
 
 use Iterator;
+use Rector\Caching\Cache;
+use Rector\Caching\Config\FileHashComputer;
 use Rector\Caching\Detector\ChangedFilesDetector;
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class ChangedFilesDetectorTest extends AbstractRectorTestCase
 {
@@ -17,7 +21,21 @@ final class ChangedFilesDetectorTest extends AbstractRectorTestCase
     {
         parent::setUp();
 
-        $this->changedFilesDetector = $this->getService(ChangedFilesDetector::class);
+        $smartFileSystem = $this->getService(SmartFileSystem::class);
+
+        $cacheDir = sys_get_temp_dir() . '/rector_changed_files_detector_test';
+        $fileCacheStorage = new FileCacheStorage(
+            $cacheDir,
+            $smartFileSystem
+        );
+        $cache = new Cache($fileCacheStorage);
+
+        // use a local object, instead of this registered service,
+        // so this unit test does not clear global ChangedFilesDetector caches
+        $this->changedFilesDetector = new ChangedFilesDetector(
+            new FileHashComputer(),
+            $cache
+        );
     }
 
     protected function tearDown(): void

--- a/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -20,6 +20,11 @@ final class ChangedFilesDetectorTest extends AbstractRectorTestCase
         $this->changedFilesDetector = $this->getService(ChangedFilesDetector::class);
     }
 
+    protected function tearDown(): void
+    {
+        $this->changedFilesDetector->clear();
+    }
+
     public function testHasFileChanged(): void
     {
         $smartFileInfo = new SmartFileInfo(__DIR__ . '/Source/file.php');


### PR DESCRIPTION
looking at the blackfire profiles I got the impression that the `ChangedFilesDetectorTest` clears a global cache of the testsuite, and therefore negatively affects the overall test-run performance:

![grafik](https://user-images.githubusercontent.com/120441/126792644-358dc251-cb26-4d74-be87-56cf6e665e33.png)

in other words: the `clear` call removes from caches, then those required/affected by the unit test.
those needs to be re-build after the `ChangedFilesDetectorTest` completed.

after removing the explicit `clear` call the testsuite runtime improved from 7 to 6 seconds (~18% improvement).

I guess the `clear` call is not necessary, right?