### PR TITLE
[Docs] Using symplify/php-config-printer "9.5.x-dev as 9.4.22" for Enum handling docs generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symplify/composer-json-manipulator": "^9.4.14",
         "symplify/console-color-diff": "^9.4.14",
         "symplify/package-builder": "^9.4.14",
+        "symplify/php-config-printer": "9.5.x-dev as 9.4.22",
         "symplify/rule-doc-generator-contracts": "^9.4.14",
         "symplify/simple-php-doc-parser": "^9.4.14",
         "symplify/skipper": "^9.4.14",
@@ -141,5 +142,7 @@
     "config": {
         "sort-packages": true,
         "platform-check": false
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
@TomasVotruba this can be used to Fixes https://github.com/rectorphp/rector/issues/6584 which the patch still in `dev-main` https://github.com/symplify/php-config-printer/commit/7639e57ff92d0f8570082df44aa030560152f750 .

After new release `symplify/php-config-printer` exists, this can be reverted back.