### PR TITLE
[TypeDeclaration] Return null when $classLike is null on AllAssignNodePropertyTypeInferer::inferProperty()

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -567,3 +567,5 @@ parameters:
 
         # complex
         - '#Cognitive complexity for "Rector\\NodeNameResolver\\NodeNameResolver\:\:getName\(\)" is 10, keep it under 9#'
+
+        - '#Method ".*\(\)" only calling another method call and has no added value\. Use the inlined call instead#'

--- a/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -49,7 +49,7 @@ final class DowngradeParameterTypeWideningRector extends AbstractRector implemen
     public function __construct(
         private NativeParamToPhpDocDecorator $nativeParamToPhpDocDecorator,
         private ReflectionProvider $reflectionProvider,
-        private AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodAnalyzer
+        private AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodOrPropertyAnalyzer
     ) {
     }
 
@@ -194,7 +194,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->autowiredClassMethodAnalyzer->detect($classMethod)) {
+        if ($this->autowiredClassMethodOrPropertyAnalyzer->detect($classMethod)) {
             return true;
         }
 

--- a/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
+++ b/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
@@ -29,7 +29,7 @@ final class ConstructorAssignDetector
         private NodeTypeResolver $nodeTypeResolver,
         private PropertyAssignMatcher $propertyAssignMatcher,
         private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodAnalyzer
+        private AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodOrPropertyAnalyzer
     ) {
     }
 
@@ -122,7 +122,7 @@ final class ConstructorAssignDetector
         }
 
         foreach ($classLike->getMethods() as $classMethod) {
-            if (! $this->autowiredClassMethodAnalyzer->detect($classMethod)) {
+            if (! $this->autowiredClassMethodOrPropertyAnalyzer->detect($classMethod)) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/AllAssignNodePropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/AllAssignNodePropertyTypeInferer.php
@@ -6,7 +6,6 @@ namespace Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\Type;
-use Rector\Core\Exception\NotImplementedYetException;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Contract\TypeInferer\PropertyTypeInfererInterface;
@@ -25,7 +24,7 @@ final class AllAssignNodePropertyTypeInferer implements PropertyTypeInfererInter
         $classLike = $property->getAttribute(AttributeKey::CLASS_NODE);
         if ($classLike === null) {
             // anonymous class possibly?
-            throw new NotImplementedYetException();
+            return null;
         }
 
         $propertyName = $this->nodeNameResolver->getName($property);

--- a/src/Bootstrap/ExtensionConfigResolver.php
+++ b/src/Bootstrap/ExtensionConfigResolver.php
@@ -28,7 +28,11 @@ final class ExtensionConfigResolver
 
         $generatedConfigDirectory = dirname($generatedConfigReflectionClass->getFileName());
         foreach (GeneratedConfig::EXTENSIONS as $extensionConfig) {
-            foreach ($extensionConfig['extra']['includes'] ?? [] as $includedFile) {
+            if (! isset($extensionConfig['extra']['includes'])) {
+                continue;
+            }
+
+            foreach ($extensionConfig['extra']['includes'] as $includedFile) {
                 $includedFilePath = $this->resolveIncludeFilePath(
                     $extensionConfig,
                     $generatedConfigDirectory,

--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -211,11 +211,13 @@ final class ClassDependencyManipulator
         }
 
         $property = $class->getProperty($propertyMetadata->getName());
-        if ($property instanceof Property && $this->autowiredClassMethodOrPropertyAnalyzer->detect($property)) {
-            return true;
+        if (! $property instanceof Property) {
+            return $this->isParamInConstructor($class, $propertyMetadata->getName());
         }
-
-        return $this->isParamInConstructor($class, $propertyMetadata->getName());
+        if (! $this->autowiredClassMethodOrPropertyAnalyzer->detect($property)) {
+            return $this->isParamInConstructor($class, $propertyMetadata->getName());
+        }
+        return true;
     }
 
     private function hasMethodParameter(ClassMethod $classMethod, string $name): bool


### PR DESCRIPTION
Handle error like in https://github.com/rectorphp/rector-src/pull/503#issuecomment-886168371