### PR TITLE
[TypeDeclaration] Keep simple class on auto import for CompleteVarDocTypePropertyRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/AutoImportTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/AutoImportTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @requires PHP 8.0
+ */
+final class AutoImportTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureAutoImport');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/auto_import.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/FixtureAutoImport/keep_simple_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/FixtureAutoImport/keep_simple_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\FixtureAutoImport;
 
 use stdClass;
 

--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/FixtureAutoImport/keep_simple_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/FixtureAutoImport/keep_simple_class.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+use stdClass;
+
+final class KeepSimpleClass
+{
+    /**
+     * @var stdClass|null
+     */
+    public $obj;
+
+    public function run()
+    {
+        $this->obj = new stdClass();
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/config/auto_import.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/config/auto_import.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+
+    $services = $containerConfigurator->services();
+    $services->set(CompleteVarDocTypePropertyRector::class);
+};

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -11,7 +11,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
-use Rector\Core\Configuration\Option;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 final class GenericClassStringTypeNormalizer
@@ -24,8 +23,7 @@ final class GenericClassStringTypeNormalizer
 
     public function normalize(Type $type): Type
     {
-        $isAutoImport = $this->parameterProvider->provideBoolParameter(Option::AUTO_IMPORT_NAMES);
-        return TypeTraverser::map($type, function (Type $type, $callback) use ($isAutoImport): Type {
+        return TypeTraverser::map($type, function (Type $type, $callback): Type {
             if (! $type instanceof ConstantStringType) {
                 return $callback($type);
             }

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -5,16 +5,13 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\TypeAnalyzer;
 
 use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
-use PHPStan\Type\UnionType;
 use Rector\Core\Configuration\Option;
-use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 final class GenericClassStringTypeNormalizer
@@ -30,17 +27,7 @@ final class GenericClassStringTypeNormalizer
         $isAutoImport = $this->parameterProvider->provideBoolParameter(Option::AUTO_IMPORT_NAMES);
         return TypeTraverser::map($type, function (Type $type, $callback) use ($isAutoImport): Type {
             if (! $type instanceof ConstantStringType) {
-                $callbackType = $callback($type);
-                if ($callbackType instanceof ArrayType) {
-                    return $callbackType;
-                }
-
-                $typeWithFullyQualifiedObjectType = $this->verifyAutoImportedFullyQualifiedType($type, $isAutoImport);
-                if ($typeWithFullyQualifiedObjectType instanceof Type) {
-                    return $typeWithFullyQualifiedObjectType;
-                }
-
-                return $callbackType;
+                return $callback($type);
             }
 
             $value = $type->getValue();
@@ -68,45 +55,5 @@ final class GenericClassStringTypeNormalizer
             return new GenericClassStringType(new ObjectType($value));
         }
         return new StringType();
-    }
-
-    private function verifyAutoImportedFullyQualifiedType(Type $type, bool $isAutoImport): ?Type
-    {
-        if ($type instanceof UnionType) {
-            $unionTypes = $type->getTypes();
-            $types = [];
-            $hasFullyQualifiedObjectType = false;
-            foreach ($unionTypes as $unionType) {
-                if ($this->isAutoImportFullyQualifiedObjectType($unionType, $isAutoImport)) {
-                    /** @var FullyQualifiedObjectType $unionType */
-                    $types[] = new GenericClassStringType(new ObjectType($unionType->getClassName()));
-                    $hasFullyQualifiedObjectType = true;
-                    continue;
-                }
-
-                $types[] = $unionType;
-            }
-
-            if ($hasFullyQualifiedObjectType) {
-                return new UnionType($types);
-            }
-
-            return $type;
-        }
-
-        if ($this->isAutoImportFullyQualifiedObjectType($type, $isAutoImport)) {
-            /** @var FullyQualifiedObjectType $type */
-            return new GenericClassStringType(new ObjectType($type->getClassName()));
-        }
-
-        return null;
-    }
-
-    private function isAutoImportFullyQualifiedObjectType(Type $type, bool $isAutoImport): bool
-    {
-        return $isAutoImport && $type instanceof FullyQualifiedObjectType && ! str_contains(
-            $type->getClassName(),
-            '\\'
-        );
     }
 }


### PR DESCRIPTION
When auto import enabled, given the following code:

```php
use stdClass;

final class KeepSimpleClass
{
    /**
     * @var stdClass|null
     */
    public $obj;

    public function run()
    {
        $this->obj = new stdClass();
    }
}
```

It currently changed to:

```diff
     /**
-     * @var stdClass|null
+     * @var class-string<stdClass>|null
      */
     public $obj;
```

which invalid.