### PR TITLE
[DeadCode] Refactor PureFunctionDetector: ensure NativeFunctionReflection for pure function check

### DIFF
--- a/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -296,11 +296,6 @@ CODE_SAMPLE
                 return false;
             }
 
-            $funcName = $this->getName($n);
-            if ($funcName === null) {
-                return false;
-            }
-
             return ! $this->pureFunctionDetector->detect($n);
         });
     }

--- a/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -26,7 +26,6 @@ use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\While_;
-use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
@@ -300,16 +299,6 @@ CODE_SAMPLE
             $funcName = $this->getName($n);
             if ($funcName === null) {
                 return false;
-            }
-
-            $functionName = new Name($funcName);
-            if (! $this->reflectionProvider->hasFunction($functionName, null)) {
-                return true;
-            }
-
-            $function = $this->reflectionProvider->getFunction($functionName, null);
-            if (! $function instanceof NativeFunctionReflection) {
-                return true;
             }
 
             return ! $this->pureFunctionDetector->detect($n);

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -6,9 +6,9 @@ namespace Rector\DeadCode\SideEffect;
 
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
-use Rector\NodeNameResolver\NodeNameResolver;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\NodeNameResolver\NodeNameResolver;
 
 final class PureFunctionDetector
 {
@@ -120,13 +120,17 @@ final class PureFunctionDetector
     public function detect(FuncCall $funcCall): bool
     {
         $funcCallName = $this->nodeNameResolver->getName($funcCall);
-        $hasFunction  = $this->reflectionProvider->hasFunction(new Name($funcCallName), null);
+        if ($funcCallName === null) {
+            return false;
+        }
 
+        $funcCallName = new Name($funcCallName);
+        $hasFunction = $this->reflectionProvider->hasFunction($funcCallName, null);
         if (! $hasFunction) {
             return false;
         }
 
-        $function = $this->reflectionProvider->getFunction(new Name($funcCallName), null);
+        $function = $this->reflectionProvider->getFunction($funcCallName, null);
         if (! $function instanceof NativeFunctionReflection) {
             return false;
         }

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Name;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class PureFunctionDetector
 {
@@ -124,13 +125,15 @@ final class PureFunctionDetector
             return false;
         }
 
+        $scope = $funcCall->getAttribute(AttributeKey::SCOPE);
         $name = new Name($funcCallName);
-        $hasFunction = $this->reflectionProvider->hasFunction($name, null);
+
+        $hasFunction = $this->reflectionProvider->hasFunction($name, $scope);
         if (! $hasFunction) {
             return false;
         }
 
-        $function = $this->reflectionProvider->getFunction($name, null);
+        $function = $this->reflectionProvider->getFunction($name, $scope);
         if (! $function instanceof NativeFunctionReflection) {
             return false;
         }

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -124,13 +124,13 @@ final class PureFunctionDetector
             return false;
         }
 
-        $funcCallName = new Name($funcCallName);
-        $hasFunction = $this->reflectionProvider->hasFunction($funcCallName, null);
+        $name = new Name($funcCallName);
+        $hasFunction = $this->reflectionProvider->hasFunction($name, null);
         if (! $hasFunction) {
             return false;
         }
 
-        $function = $this->reflectionProvider->getFunction($funcCallName, null);
+        $function = $this->reflectionProvider->getFunction($name, null);
         if (! $function instanceof NativeFunctionReflection) {
             return false;
         }


### PR DESCRIPTION
- function not found: impure
- function found but non-native: impure

This reduce `MoveVariableDeclarationNearReferenceRector` rector rule logic and possibly used by other rules.