### PR TITLE
[DeadCode] Skip InstanceOf class not a Name on RemoveDeadInstanceOfRector

### DIFF
--- a/packages/Caching/ValueObject/Storage/MemoryCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/MemoryCacheStorage.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Rector\Caching\ValueObject\Storage;
 
@@ -7,19 +9,24 @@ use Rector\Caching\ValueObject\CacheItem;
 /**
  * inspired by https://github.com/phpstan/phpstan-src/blob/560652088406d7461c2c4ad4897784e33f8ab312/src/Cache/MemoryCacheStorage.php
  */
-class MemoryCacheStorage implements CacheStorageInterface
+final class MemoryCacheStorage implements CacheStorageInterface
 {
-    /** @var array<string, CacheItem> */
+    /**
+     * @var array<string, CacheItem>
+     */
     private array $storage = [];
 
+    /**
+     * @return null|mixed
+     */
     public function load(string $key, string $variableKey)
     {
-        if (!isset($this->storage[$key])) {
+        if (! isset($this->storage[$key])) {
             return null;
         }
 
         $item = $this->storage[$key];
-        if (!$item->isVariableKeyValid($variableKey)) {
+        if (! $item->isVariableKeyValid($variableKey)) {
             return null;
         }
 
@@ -33,7 +40,7 @@ class MemoryCacheStorage implements CacheStorageInterface
 
     public function clean(string $key): void
     {
-        if (!isset($this->storage[$key])) {
+        if (! isset($this->storage[$key])) {
             return;
         }
 

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_not_name.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_not_name.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+class SkipNotName
+{
+    public function go()
+    {
+        if (rand(0, 1)) {
+            $className = new stdClass;
+        } else {
+            $className = new DateTime('now');
+        }
+
+        $obj = new stdClass;
+        if ($obj instanceof $className) {
+            echo 'it is an stdClass';
+        }
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Property;
@@ -107,6 +108,10 @@ CODE_SAMPLE
 
     private function processMayDeadInstanceOf(If_ $if, Instanceof_ $instanceof): ?If_
     {
+        if (! $instanceof->class instanceof Name) {
+            return null;
+        }
+
         $classType = $this->nodeTypeResolver->resolve($instanceof->class);
         $exprType = $this->nodeTypeResolver->resolve($instanceof->expr);
 


### PR DESCRIPTION
Instanceof `class` need to be a `Name` node instance to be able to checked to avoid dynamic check. Ref https://3v4l.org/vGZAt .

Non-`Name` node `class` (eg: Variable) for `InstanceOf_`'s class need to be skipped.