### PR TITLE
Add Symfony's bootstrap80 files to the list for namespace removal

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -17,9 +17,13 @@ $filePathsToRemoveNamespace = [
     'vendor/symfony/deprecation-contracts/function.php',
     // it would make polyfill function work only with namespace = brokes
     'vendor/symfony/polyfill-ctype/bootstrap.php',
+    'vendor/symfony/polyfill-ctype/bootstrap80.php',
     'vendor/symfony/polyfill-intl-normalizer/bootstrap.php',
+    'vendor/symfony/polyfill-intl-normalizer/bootstrap80.php',
     'vendor/symfony/polyfill-intl-grapheme/bootstrap.php',
+    'vendor/symfony/polyfill-intl-grapheme/bootstrap80.php',
     'vendor/symfony/polyfill-mbstring/bootstrap.php',
+    'vendor/symfony/polyfill-mbstring/bootstrap80.php',
     'vendor/symfony/polyfill-php80/bootstrap.php',
     'vendor/symfony/polyfill-php74/bootstrap.php',
     'vendor/symfony/polyfill-php73/bootstrap.php',


### PR DESCRIPTION
This change proposes to add the bootstrap files for php:^8.0 into the file list to remove namespaces from. This comes in the sequence of the investigation done triggered by an error on the command `vendor/bin/rector init` when executed in my php 8.0 installation.