### PR TITLE
[DeadCode][CodeQualityStrict] Add SideEffectNodeDetector::detectCallExpr()

### DIFF
--- a/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -264,9 +264,10 @@ CODE_SAMPLE
 
     private function hasCall(Node $node): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($node, function (Node $n): bool {
-            return $this->sideEffectNodeDetector->detectCallExpr($n);
-        });
+        return (bool) $this->betterNodeFinder->findFirst(
+            $node,
+            fn (Node $n): bool => $this->sideEffectNodeDetector->detectCallExpr($n)
+        );
     }
 
     private function getCountFound(Node $node, Variable $variable): int

--- a/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -8,13 +8,9 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
@@ -27,9 +23,8 @@ use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\While_;
 use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
-use Rector\DeadCode\SideEffect\PureFunctionDetector;
+use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
 use Rector\NodeNestingScope\NodeFinder\ScopeAwareNodeFinder;
 use Rector\NodeNestingScope\ParentFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -43,7 +38,7 @@ final class MoveVariableDeclarationNearReferenceRector extends AbstractRector
 {
     public function __construct(
         private ScopeAwareNodeFinder $scopeAwareNodeFinder,
-        private PureFunctionDetector $pureFunctionDetector,
+        private SideEffectNodeDetector $sideEffectNodeDetector,
         private ReflectionProvider $reflectionProvider,
         private ParentFinder $parentFinder
     ) {
@@ -267,36 +262,10 @@ CODE_SAMPLE
         return false;
     }
 
-    private function isClassCallerThrowable(StaticCall $staticCall): bool
-    {
-        $class = $staticCall->class;
-        if (! $class instanceof Name) {
-            return false;
-        }
-
-        $throwableType = new ObjectType('Throwable');
-        $type = new ObjectType($class->toString());
-
-        return $throwableType->isSuperTypeOf($type)
-            ->yes();
-    }
-
     private function hasCall(Node $node): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($node, function (Node $n): bool {
-            if ($n instanceof StaticCall && ! $this->isClassCallerThrowable($n)) {
-                return true;
-            }
-
-            if ($n instanceof MethodCall) {
-                return true;
-            }
-
-            if (! $n instanceof FuncCall) {
-                return false;
-            }
-
-            return ! $this->pureFunctionDetector->detect($n);
+            return $this->sideEffectNodeDetector->detectCallExpr($n);
         });
     }
 

--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\SideEffect;
 
+use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Encapsed;
 use PHPStan\Type\ConstantType;
+use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
 final class SideEffectNodeDetector
@@ -22,6 +28,15 @@ final class SideEffectNodeDetector
      * @var array<class-string<Expr>>
      */
     private const SIDE_EFFECT_NODE_TYPES = [Encapsed::class, New_::class, Concat::class, PropertyFetch::class];
+
+    /**
+     * @var array<class-string<Expr>>
+     */
+    private const CALL_EXPR_SIDE_EFFECT_NODE_TYPES = [
+        MethodCall::class,
+        NullsafeMethodCall::class,
+        StaticCall::class,
+    ];
 
     public function __construct(
         private NodeTypeResolver $nodeTypeResolver,
@@ -57,6 +72,43 @@ final class SideEffectNodeDetector
         }
 
         return true;
+    }
+
+    public function detectCallExpr(Node $node): bool
+    {
+        if (! $node instanceof Expr) {
+            return false;
+        }
+
+        $exprClass = $node::class;
+
+        if ($node instanceof StaticCall && $this->isClassCallerThrowable($node)) {
+            return false;
+        }
+
+        if (in_array($exprClass, self::CALL_EXPR_SIDE_EFFECT_NODE_TYPES, true)) {
+            return true;
+        }
+
+        if ($node instanceof FuncCall) {
+            return ! $this->pureFunctionDetector->detect($node);
+        }
+
+        return false;
+    }
+
+    private function isClassCallerThrowable(StaticCall $staticCall): bool
+    {
+        $class = $staticCall->class;
+        if (! $class instanceof Name) {
+            return false;
+        }
+
+        $throwableType = new ObjectType('Throwable');
+        $type = new ObjectType($class->toString());
+
+        return $throwableType->isSuperTypeOf($type)
+            ->yes();
     }
 
     private function resolveVariable(Expr $expr): ?Variable

--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -80,12 +80,11 @@ final class SideEffectNodeDetector
             return false;
         }
 
-        $exprClass = $node::class;
-
         if ($node instanceof StaticCall && $this->isClassCallerThrowable($node)) {
             return false;
         }
 
+        $exprClass = $node::class;
         if (in_array($exprClass, self::CALL_EXPR_SIDE_EFFECT_NODE_TYPES, true)) {
             return true;
         }

--- a/rules/DowngradePhp70/Rector/Coalesce/DowngradeNullCoalesceRector.php
+++ b/rules/DowngradePhp70/Rector/Coalesce/DowngradeNullCoalesceRector.php
@@ -21,8 +21,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeNullCoalesceRector extends AbstractRector
 {
-    public function __construct(private CoalesceAnalyzer $coalesceAnalyzer)
-    {
+    public function __construct(
+        private CoalesceAnalyzer $coalesceAnalyzer
+    ) {
     }
 
     /**


### PR DESCRIPTION
It can reduce code at `MoveVariableDeclarationNearReferenceRector`, and possibly can be used in other rules for check dead code removal.