### PR TITLE
[Autodiscovery] Using AstResolver->resolveClassFromName() on ValueObjectClassAnalyzer

### DIFF
--- a/rules/Autodiscovery/Analyzer/ValueObjectClassAnalyzer.php
+++ b/rules/Autodiscovery/Analyzer/ValueObjectClassAnalyzer.php
@@ -9,8 +9,8 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
+use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\ValueObject\MethodName;
-use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
@@ -25,7 +25,7 @@ final class ValueObjectClassAnalyzer
         private NodeNameResolver $nodeNameResolver,
         private NodeTypeResolver $nodeTypeResolver,
         private PhpDocInfoFactory $phpDocInfoFactory,
-        private NodeRepository $nodeRepository,
+        private AstResolver $astResolver,
         private ClassAnalyzer $classAnalyzer
     ) {
     }
@@ -58,7 +58,7 @@ final class ValueObjectClassAnalyzer
 
             // awesome!
             // is it services or value object?
-            $paramTypeClass = $this->nodeRepository->findClass($paramType->getClassName());
+            $paramTypeClass = $this->astResolver->resolveClassFromName($paramType->getClassName());
             if (! $paramTypeClass instanceof Class_) {
                 // not sure :/
                 continue;


### PR DESCRIPTION
Replace the `NodeRepository-> findClass()` with `AstResolver->resolveClassFromName()`