### PR TITLE
[DeadCode][CodeQualityStrict] Handle internal Rector prefixed class as non - side effect method / static call

### DIFF
--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -20,8 +20,8 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Encapsed;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\ObjectType;
-use Rector\NodeTypeResolver\NodeTypeResolver;
 use PHPStan\Type\TypeWithClassName;
+use Rector\NodeTypeResolver\NodeTypeResolver;
 
 final class SideEffectNodeDetector
 {
@@ -99,9 +99,6 @@ final class SideEffectNodeDetector
         return false;
     }
 
-    /**
-     * @param MethodCall|NullsafeMethodCall|StaticCall $expr
-     */
     private function isRectorPrefixed(MethodCall | NullsafeMethodCall | StaticCall $expr): bool
     {
         if ($expr instanceof MethodCall || $expr instanceof NullsafeMethodCall) {

--- a/rules/DowngradePhp70/Rector/Spaceship/DowngradeSpaceshipRector.php
+++ b/rules/DowngradePhp70/Rector/Spaceship/DowngradeSpaceshipRector.php
@@ -113,9 +113,8 @@ CODE_SAMPLE
             $stmt,
             fn (Node $node): bool => $node instanceof Variable && $this->nodeComparator->areNodesEqual($node, $variable)
         );
-
-        $count = 0;
         if ($isFoundPrevious) {
+            $count = 0;
             ++$count;
             $variableName .= (string) $count;
             return $this->getVariableAssign($stmt, $variableName);


### PR DESCRIPTION
It should can make `MoveVariableDeclarationNearReferenceRector` work on internal rector class's method call / static call allow jump between assign on next is method call / static call.