### PR TITLE
[VersionBonding] Correctly shows missed rectors  that will not run

### DIFF
--- a/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
+++ b/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
@@ -84,7 +84,7 @@ final class MissedRectorDueVersionChecker
     }
 
     /**
-     * @param MinPhpVersionInterface[] $minPhpVersions
+     * @param MinPhpVersionInterface[] $missedRectors
      */
     private function reportWarningMessage(int $minProjectPhpVersion, array $missedRectors): void
     {

--- a/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
+++ b/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
@@ -91,9 +91,10 @@ final class MissedRectorDueVersionChecker
         $phpVersion = new PhpVersion($minProjectPhpVersion);
 
         $warningMessage = sprintf(
-            'Your project requires min PHP version "%s".%sSome Rector rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase, use -vvv for detailed info.',
+            'Your project requires min PHP version "%s". %s%d Rector rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase, use -vvv for detailed info.',
             $phpVersion->getVersionString(),
             PHP_EOL . PHP_EOL,
+            count($missedRectors),
             PHP_EOL
         );
 

--- a/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
+++ b/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
@@ -93,8 +93,8 @@ final class MissedRectorDueVersionChecker
         $warningMessage = sprintf(
             'Your project requires min PHP version "%s".%sSome Rector rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase, use -vvv for detailed info.',
             $phpVersion->getVersionString(),
-            PHP_EOL,
-            PHP_EOL . PHP_EOL
+            PHP_EOL . PHP_EOL,
+            PHP_EOL
         );
 
         $this->symfonyStyle->warning($warningMessage);

--- a/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
+++ b/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
@@ -91,17 +91,12 @@ final class MissedRectorDueVersionChecker
         $phpVersion = new PhpVersion($minProjectPhpVersion);
 
         $warningMessage = sprintf(
-            'Your project requires min PHP version "%s".%s%sThe following Rector rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase: ',
+            'Your project requires min PHP version "%s".%sSome Rector rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase, use -vvv for detailed info.',
             $phpVersion->getVersionString(),
             PHP_EOL,
             PHP_EOL . PHP_EOL,
             PHP_EOL
         );
-
-        $warningMessage .= PHP_EOL;
-        foreach ($missedRectors as $missedRector) {
-            $warningMessage .= PHP_EOL . ' - ' . $missedRector::class;
-        }
 
         $this->symfonyStyle->warning($warningMessage);
     }

--- a/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
+++ b/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
@@ -94,8 +94,7 @@ final class MissedRectorDueVersionChecker
             'Your project requires min PHP version "%s".%sSome Rector rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase, use -vvv for detailed info.',
             $phpVersion->getVersionString(),
             PHP_EOL,
-            PHP_EOL . PHP_EOL,
-            PHP_EOL
+            PHP_EOL . PHP_EOL
         );
 
         $this->symfonyStyle->warning($warningMessage);

--- a/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
+++ b/packages/VersionBonding/Application/MissedRectorDueVersionChecker.php
@@ -86,18 +86,23 @@ final class MissedRectorDueVersionChecker
     /**
      * @param MinPhpVersionInterface[] $minPhpVersions
      */
-    private function reportWarningMessage(int $minProjectPhpVersion, array $minPhpVersions): void
+    private function reportWarningMessage(int $minProjectPhpVersion, array $missedRectors): void
     {
         $phpVersion = new PhpVersion($minProjectPhpVersion);
 
         $warningMessage = sprintf(
-            'Your project requires min PHP version "%s".%s%d%sSome Rectors rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase.',
+            'Your project requires min PHP version "%s".%s%sThe following Rector rules defined in your configuration require higher PHP version and will not run,%sto avoid breaking your codebase: ',
             $phpVersion->getVersionString(),
-            count($minPhpVersions),
             PHP_EOL,
             PHP_EOL . PHP_EOL,
             PHP_EOL
         );
+
+        $warningMessage .= PHP_EOL;
+        foreach ($missedRectors as $missedRector) {
+            $warningMessage .= PHP_EOL . ' - ' . $missedRector::class;
+        }
+
         $this->symfonyStyle->warning($warningMessage);
     }
 }


### PR DESCRIPTION
Previously shows invalid value on PR https://github.com/rectorphp/rector-src/pull/572

**Before**

![127821199-2db4e87a-08d0-4b30-8138-6a750f03b05f](https://user-images.githubusercontent.com/459648/127867886-40d6e427-a2e7-4987-b690-7134838d8f92.png)


**After**

![Screen Shot 2021-08-02 at 20 13 52](https://user-images.githubusercontent.com/459648/127867907-0c2387c5-24c5-4b7a-8010-94b0033fb7bc.png)
