### PR TITLE
[Scoper] Remove Doctrine\Inflector\Inflector from exclude class

### DIFF
--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -12,8 +12,6 @@ final class StaticEasyPrefixer
     public const EXCLUDED_CLASSES = [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
-        // this is not prefixed on few places by php-scoper by default, probably some bug
-        'Doctrine\Inflector\Inflector',
         // for SmartFileInfo
         'Symplify\SmartFileSystem\SmartFileInfo',
         // for ComposerJson because it is part of the public API. I.e. ComposerRectorInterface
@@ -24,6 +22,9 @@ final class StaticEasyPrefixer
      * @var string[]
      */
     private const EXCLUDED_NAMESPACES = [
+        // this is not prefixed on few places by php-scoper by default, probably some bug
+        'Doctrine\Inflector\*',
+
         // naturally
         'Rector\*',
         // we use this API a lot

--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -22,9 +22,6 @@ final class StaticEasyPrefixer
      * @var string[]
      */
     private const EXCLUDED_NAMESPACES = [
-        // this is not prefixed on few places by php-scoper by default, probably some bug
-        'Doctrine\Inflector\*',
-
         // naturally
         'Rector\*',
         // we use this API a lot


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6607

to avoid error: 

```
[ERROR] Could not process "app/Models/User.php" file, due to:                                                          
         "RectorPrefix20210802\Doctrine\Inflector\Inflector::__construct(): Argument #1 ($singularizer) must be of type 
         RectorPrefix20210802\Doctrine\Inflector\WordInflector, Doctrine\Inflector\CachedWordInflector given, called in 
         vendor/laravel/framework/src/Illuminate/Support/Pluralizer.php:140". On line: 28      
```