### PR TITLE
[Defluent] Skip interface on DefluentReturnMethodCallRector

### DIFF
--- a/rules-tests/Defluent/Rector/Return_/DefluentReturnMethodCallRector/Fixture/skip_interface.php.inc
+++ b/rules-tests/Defluent/Rector/Return_/DefluentReturnMethodCallRector/Fixture/skip_interface.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Defluent\Rector\Return_\DefluentReturnMethodCallRector\Fixture;
+
+use Rector\Tests\Defluent\Rector\Return_\DefluentReturnMethodCallRector\Source\MessageInterface;
+
+final class SkipInterface
+{
+    public function run(MessageInterface $message)
+    {
+        return $message->withStatus(500);
+    }
+}

--- a/rules-tests/Defluent/Rector/Return_/DefluentReturnMethodCallRector/Source/MessageInterface.php
+++ b/rules-tests/Defluent/Rector/Return_/DefluentReturnMethodCallRector/Source/MessageInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Defluent\Rector\Return_\DefluentReturnMethodCallRector\Source;
+
+interface MessageInterface
+{
+    public function withStatus($status): self;
+}

--- a/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -103,12 +103,6 @@ final class FluentChainMethodCallNodeAnalyzer
         return ! $this->isMethodCallCreatingNewInstance($methodCall);
     }
 
-    private function isInterface(ObjectType $type): bool
-    {
-        $classLike = $this->astResolver->resolveClassFromObjectType($type);
-        return $classLike instanceof Interface_;
-    }
-
     public function isLastChainMethodCall(MethodCall $methodCall): bool
     {
         // is chain method call
@@ -246,6 +240,12 @@ final class FluentChainMethodCallNodeAnalyzer
 
         $inferFunctionLike = $this->returnTypeInferer->inferFunctionLike($classMethod);
         return $inferFunctionLike instanceof ThisType;
+    }
+
+    private function isInterface(ObjectType $objectType): bool
+    {
+        $classLike = $this->astResolver->resolveClassFromObjectType($objectType);
+        return $classLike instanceof Interface_;
     }
 
     private function isMethodCallCreatingNewInstance(MethodCall $methodCall): bool

--- a/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\MutatingScope;
@@ -90,6 +91,11 @@ final class FluentChainMethodCallNodeAnalyzer
                 if ($calleeStaticType->isInstanceOf($knownFactoryFluentType)->yes()) {
                     return false;
                 }
+            }
+
+            $classLike = $this->astResolver->resolveClassFromObjectType($calleeStaticType);
+            if ($classLike instanceof Interface_) {
+                return false;
             }
         }
 
@@ -239,7 +245,7 @@ final class FluentChainMethodCallNodeAnalyzer
     {
         $classMethod = $this->astResolver->resolveClassMethodFromMethodCall($methodCall);
         if (! $classMethod instanceof ClassMethod) {
-            return true;
+            return false;
         }
 
         /** @var Return_[] $returns */

--- a/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -239,7 +239,7 @@ final class FluentChainMethodCallNodeAnalyzer
     {
         $classMethod = $this->astResolver->resolveClassMethodFromMethodCall($methodCall);
         if (! $classMethod instanceof ClassMethod) {
-            return false;
+            return true;
         }
 
         /** @var Return_[] $returns */

--- a/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -86,25 +86,27 @@ final class FluentChainMethodCallNodeAnalyzer
             return false;
         }
 
-        return $this->isNotInstantiatingNewInstance($calleeStaticType, $methodCall);
-    }
+        if (! $calleeStaticType instanceof ObjectType) {
+            return false;
+        }
 
-    private function isNotInstantiatingNewInstance(Type $calleeStaticType, MethodCall $methodCall): bool
-    {
-        if ($calleeStaticType instanceof ObjectType) {
-            foreach (self::KNOWN_FACTORY_FLUENT_TYPES as $knownFactoryFluentType) {
-                if ($calleeStaticType->isInstanceOf($knownFactoryFluentType)->yes()) {
-                    return false;
-                }
-            }
-
-            $classLike = $this->astResolver->resolveClassFromObjectType($calleeStaticType);
-            if ($classLike instanceof Interface_) {
+        foreach (self::KNOWN_FACTORY_FLUENT_TYPES as $knownFactoryFluentType) {
+            if ($calleeStaticType->isInstanceOf($knownFactoryFluentType)->yes()) {
                 return false;
             }
         }
 
+        if ($this->isInterface($calleeStaticType)) {
+            return false;
+        }
+
         return ! $this->isMethodCallCreatingNewInstance($methodCall);
+    }
+
+    private function isInterface(ObjectType $type): bool
+    {
+        $classLike = $this->astResolver->resolveClassFromObjectType($type);
+        return $classLike instanceof Interface_;
     }
 
     public function isLastChainMethodCall(MethodCall $methodCall): bool

--- a/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -86,6 +86,11 @@ final class FluentChainMethodCallNodeAnalyzer
             return false;
         }
 
+        return $this->isNotInstantiatingNewInstance($calleeStaticType, $methodCall);
+    }
+
+    private function isNotInstantiatingNewInstance(Type $calleeStaticType, MethodCall $methodCall): bool
+    {
         if ($calleeStaticType instanceof ObjectType) {
             foreach (self::KNOWN_FACTORY_FLUENT_TYPES as $knownFactoryFluentType) {
                 if ($calleeStaticType->isInstanceOf($knownFactoryFluentType)->yes()) {


### PR DESCRIPTION
When the type is interface, it is depends on the implementation for it is able to be defluent, eg: the implementation apply new self, or clone object first before return.