### PR TITLE
Argument type declaration unnecessarily removed

### DIFF
--- a/tests/Issues/IssueDowngradeMixedType/DowngradeMixedTypeTest.php
+++ b/tests/Issues/IssueDowngradeMixedType/DowngradeMixedTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeMixedType;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeMixedTypeTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueDowngradeMixedType/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueDowngradeMixedType/Fixture/fixture.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeMixedType\Fixture;
+
+use Rector\Core\Tests\Issues\IssueDowngradeMixedType\Source\SomeClass;
+
+class AnotherClass
+{
+    private SomeClass $foo;
+
+    public function bar(SomeClass $baz)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeMixedType\Fixture;
+
+use Rector\Core\Tests\Issues\IssueDowngradeMixedType\Source\SomeClass;
+
+class AnotherClass
+{
+    /**
+     * @var SomeClass
+     */
+    private $foo;
+
+    public function bar(SomeClass $baz)
+    {
+    }
+}
+
+?>

--- a/tests/Issues/IssueDowngradeMixedType/Source/SomeClass.php
+++ b/tests/Issues/IssueDowngradeMixedType/Source/SomeClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeMixedType\Source;
+
+class SomeClass
+{
+}

--- a/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
+++ b/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector;
+use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeTypedPropertyRector::class);
+    $services->set(DowngradeMixedTypeDeclarationRector::class);
+};


### PR DESCRIPTION
Tests failing per my description in rectorphp/rector#6611.

Function argument should not be made into a mixed type.