### PR TITLE
Add failing test fixture for ReturnTypeFromReturnNewRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/demo_file.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/demo_file.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        return new self();
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+final class DemoFile
+{
+    public function run(): self
+    {
+        return new self();
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for ReturnTypeFromReturnNewRector

Based on https://getrector.org/demo/1ebef269-093c-6afe-9c29-afdc8959befb

refs https://github.com/rectorphp/rector/issues/6595