### PR TITLE
[DeadCode] Skip non-typed property for RecastingRemovalRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_non_typed_property.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_non_typed_property.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Rector;
+
+class SkipNonTypedProperty
+{
+    /** @var int */
+    public $property = 1;
+
+    public function run()
+    {
+        $value = (int) $this->property;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_non_typed_property.php2.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_non_typed_property.php2.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Rector;
+
+class Config
+{
+    /** @var int */
+    public $property = 1;
+}
+
+class SkipNonTypedProperty2
+{
+    public function run(Config $config)
+    {
+        $value = (int) $config->property;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/typed_property.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/typed_property.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Rector;
+
+class TypedProperty
+{
+    public int $property = 1;
+
+    public function run()
+    {
+        $value = (int) $this->property;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Rector;
+
+class TypedProperty
+{
+    public int $property = 1;
+
+    public function run()
+    {
+        $value = $this->property;
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -13,6 +13,8 @@ use PhpParser\Node\Expr\Cast\Double;
 use PhpParser\Node\Expr\Cast\Int_;
 use PhpParser\Node\Expr\Cast\Object_;
 use PhpParser\Node\Expr\Cast\String_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
@@ -115,6 +117,7 @@ CODE_SAMPLE
             return false;
         }
 
+        /** @var PropertyFetch|StaticPropertyFetch $expr */
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
             return false;


### PR DESCRIPTION
- Allow typed property
- Skip non-typed property