### PR TITLE
[DeadCode] Skip RemoveDeadConstructorRector on empty constructor with class extends

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector/Fixture/skip_extends_with_no_stmt.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector/Fixture/skip_extends_with_no_stmt.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDeadConstructorRector\Fixture;
+
+class MyPdoStub extends MyPdo
+{
+    // empty on purpose for stub
+    public function __construct($username, $password)
+    {
+    }
+}
+
+class MyPdo
+{
+    public function __construct($username, $password)
+    {
+        db_connect($username, $password);
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
@@ -68,9 +69,18 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isNoStmtConstructorWithExtends($classLike)) {
+            return null;
+        }
+
         $this->removeNode($node);
 
         return null;
+    }
+
+    private function isNoStmtConstructorWithExtends(Class_ $class): bool
+    {
+        return $class->extends instanceof FullyQualified;
     }
 
     private function shouldSkipPropertyPromotion(ClassMethod $classMethod): bool

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
@@ -69,18 +69,13 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isNoStmtConstructorWithExtends($classLike)) {
+        if ($classLike->extends instanceof FullyQualified) {
             return null;
         }
 
         $this->removeNode($node);
 
         return null;
-    }
-
-    private function isNoStmtConstructorWithExtends(Class_ $class): bool
-    {
-        return $class->extends instanceof FullyQualified;
     }
 
     private function shouldSkipPropertyPromotion(ClassMethod $classMethod): bool


### PR DESCRIPTION
 Empty constuctor that the class has extends another class can be on purpose for stubbing usage, eg: on testing.