### PR TITLE
[DeadCode] Skip RemoveUnreachableStatementRector on use of $this->markTestIncomplete()

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_marked_incomplete_test_file.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_marked_incomplete_test_file.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipMarkedIncompleteTestFile extends TestCase
+{
+    public function testMultipleArguments(): void
+    {
+        $this->markTestIncomplete('need to be completed');
+
+        $db = db_connect();
+        $db->run();
+    }
+}

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -161,7 +161,7 @@ CODE_SAMPLE
                 return false;
             }
 
-            return $this->isName($node->name, 'markTestSkipped');
+            return $this->isNames($node->name, ['markTestSkipped', 'markTestIncomplete']);
         });
     }
 


### PR DESCRIPTION
Skip with `markTestIncomplete()` for test usage so the test for can be continued later.