### PR TITLE
[TypeDeclaration] Skip indirect get array value on PHPUnit dataProvider get on ParamTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/skip_indirect_array_value_phpuint_data_provider.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/skip_indirect_array_value_phpuint_data_provider.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SkipInDirectArrayValuePHPUnitDataProvider extends TestCase
+{
+    protected function getData()
+    {
+        return [
+            ['a', 'b', 'c'],
+        ];
+    }
+
+    public function dataProvider()
+    {
+        $data = $this->getData();
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function test($a, $b, $c)
+    {
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
@@ -112,7 +112,7 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
         $firstReturnedExpr = $returns[0]->expr;
 
         if (! $firstReturnedExpr instanceof Array_) {
-            throw new ShouldNotHappenException();
+            return new MixedType();
         }
 
         $paramOnPositionTypes = $this->resolveParamOnPositionTypes($firstReturnedExpr, $parameterPosition);


### PR DESCRIPTION
Given the following code:

```php
class SkipInDirectArrayValuePHPUnitDataProvider extends TestCase
{
    protected function getData()
    {
        return [
            ['a', 'b', 'c'],
        ];
    }

    public function dataProvider()
    {
        $data = $this->getData();

        return $data;
    }

    /**
     * @dataProvider dataProvider
     */
    public function test($a, $b, $c)
    {
    }
}
```

with dataProvider got from another method call, currently got error:

```bash
1) Rector\Tests\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector\ParamTypeDeclarationRectorTest::test with data set #14 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Look at "Rector\TypeDeclaration\TypeInferer\ParamTypeInferer\PHPUnitDataProviderParamTypeInferer::resolveReturnStaticArrayTypeByParameterPosition()" on line 115
```