### PR TITLE
[EarlyReturn] Handle both ChangeAndIfToEarlyReturnRector and ChangeOrIfReturnToEarlyReturnRector

### DIFF
--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -235,6 +235,10 @@ CODE_SAMPLE
         }
 
         $parent = $if->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parent instanceof Node) {
+            return false;
+        }
+
         if ($parent instanceof If_) {
             return $this->isLastIfOrBeforeLastReturn($parent);
         }

--- a/tests/Issues/IssueEarlyReturnAndOr/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueEarlyReturnAndOr/Fixture/fixture.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndOr\Fixture;
+
+class ComplexAndOr
+{
+    public function run($a, $b, $c, $d)
+    {
+        if (($a && false === $b) || ! $c) {
+            return '';
+        }
+
+        return $d;
+    }
+}
+
+?>

--- a/tests/Issues/IssueEarlyReturnAndOr/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueEarlyReturnAndOr/Fixture/fixture.php.inc
@@ -17,3 +17,25 @@ class ComplexAndOr
 }
 
 ?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndOr\Fixture;
+
+class ComplexAndOr
+{
+    public function run($a, $b, $c, $d)
+    {
+        if ($a && false === $b) {
+            return '';
+        }
+        if (! $c) {
+            return '';
+        }
+        return $d;
+    }
+}
+
+?>

--- a/tests/Issues/IssueEarlyReturnAndOr/IssueEarlyReturnAndOrTest.php
+++ b/tests/Issues/IssueEarlyReturnAndOr/IssueEarlyReturnAndOrTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndOr;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class IssueEarlyReturnAndOrTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueEarlyReturnAndOr/config/configured_rule.php
+++ b/tests/Issues/IssueEarlyReturnAndOr/config/configured_rule.php
@@ -7,8 +7,6 @@ use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
-
     $services = $containerConfigurator->services();
     $services->set(ChangeOrIfReturnToEarlyReturnRector::class);
     $services->set(ChangeAndIfToEarlyReturnRector::class);

--- a/tests/Issues/IssueEarlyReturnAndOr/config/configured_rule.php
+++ b/tests/Issues/IssueEarlyReturnAndOr/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+
+    $services = $containerConfigurator->services();
+    $services->set(ChangeOrIfReturnToEarlyReturnRector::class);
+    $services->set(ChangeAndIfToEarlyReturnRector::class);
+};

--- a/tests/Issues/IssueEarlyReturnAndOr/config/configured_rule.php
+++ b/tests/Issues/IssueEarlyReturnAndOr/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
 use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
 
     $services = $containerConfigurator->services();
     $services->set(ChangeOrIfReturnToEarlyReturnRector::class);


### PR DESCRIPTION
Given the following code:

```php
class ComplexAndOr
{
    public function run($a, $b, $c, $d)
    {
        if (($a && false === $b) || ! $c) {
            return '';
        }

        return $d;
    }
}
```

with use both: `ChangeAndIfToEarlyReturnRector` and `ChangeOrIfReturnToEarlyReturnRector`, it currently got error:

```bash
1) Rector\Core\Tests\Issues\IssueEarlyReturnAndOr\IssueEarlyReturnAndOrTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
TypeError: Rector\NodeNestingScope\ContextAnalyzer::isHasAssignWithIndirectReturn(): Argument #1 ($node) must be of type PhpParser\Node, null given, called in /Users/samsonasik/www/rector-src/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php on line 242
```