### PR TITLE
[Scoped] Wait 3 minutes before checkout rectorphp/rector-src on create a tag

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -19,7 +19,7 @@ jobs:
         timeout-minutes: 30
 
         steps:
-            # sometime, when 2 or more consecutive PRs merged, the checkout rectorphp/rector is overlapped
+            # sometime, when 2 or more consecutive PRs merged, the checkout rectorphp/rector-src is overlapped
             # and reverting other commit change
             # this should not happen on create a tag, so wait first
             -

--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -19,6 +19,14 @@ jobs:
         timeout-minutes: 30
 
         steps:
+            # sometime, when 2 or more consecutive PRs merged, the checkout rectorphp/rector is overlapped
+            # and reverting other commit change
+            # this should not happen on create a tag, so wait first
+            -
+                name: "Wait 3 minutes before checkout rectorphp/rector on create a tag"
+                if: "startsWith(github.ref, 'refs/tags/')"
+                run: sleep 180
+
             -
                 uses: actions/checkout@v2
                 with:
@@ -65,14 +73,6 @@ jobs:
                     cp -R templates rector-prefixed-downgraded/
                     cp CONTRIBUTING.md rector-prefixed-downgraded/
                     cp preload.php rector-prefixed-downgraded/
-
-            # sometime, when 2 or more consecutive PRs merged, the checkout rectorphp/rector is overlapped
-            # and reverting other commit change
-            # this should not happen on create a tag, so wait first
-            -
-                name: "Wait 3 minutes before checkout rectorphp/rector on create a tag"
-                if: "startsWith(github.ref, 'refs/tags/')"
-                run: sleep 180
 
             # 6. clone remote repository, so we can push it
             -

--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -23,7 +23,7 @@ jobs:
             # and reverting other commit change
             # this should not happen on create a tag, so wait first
             -
-                name: "Wait 3 minutes before checkout rectorphp/rector on create a tag"
+                name: "Wait 3 minutes before checkout rectorphp/rector-src on create a tag"
                 if: "startsWith(github.ref, 'refs/tags/')"
                 run: sleep 180
 

--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -66,6 +66,14 @@ jobs:
                     cp CONTRIBUTING.md rector-prefixed-downgraded/
                     cp preload.php rector-prefixed-downgraded/
 
+            # sometime, when 2 or more consecutive PRs merged, the checkout rectorphp/rector is overlapped
+            # and reverting other commit change
+            # this should not happen on create a tag, so wait first
+            -
+                name: "Wait 3 minutes before checkout rectorphp/rector on create a tag"
+                if: "startsWith(github.ref, 'refs/tags/')"
+                run: sleep 180
+
             # 6. clone remote repository, so we can push it
             -
                 uses: "actions/checkout@v2"


### PR DESCRIPTION
Sometime, when 2 or more consecutive PRs merged in very near time, the checkout rectorphp/rector-src is overlapped and reverting other commit change so need to manually trigger build scoped. 

ref https://github.com/rectorphp/rector/commit/0dad1bbb20e92668772df4f6de517f4a7cf00079 for sample use case.

This should not happen on create a tag, so wait first to ensure it checking out latest rector-src.