### PR TITLE
[CodingStyle] Handle Non-string specifier for EncapsedStringsToSprintfRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/int_type.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/int_type.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\Fixture;
+
+final class IntType
+{
+    public function run(array $array, string $item)
+    {
+        $value = count($array);
+        return "We have {$count} {$item}";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\Fixture;
+
+final class IntType
+{
+    public function run(array $array, string $item)
+    {
+        $value = count($array);
+        return sprintf('We have %d %s', $count, $item);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/int_type.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/int_type.php.inc
@@ -7,7 +7,7 @@ final class IntType
     public function run(array $array, string $item)
     {
         $value = count($array);
-        return "We have {$count} {$item}";
+        return "We have {$value} {$item}";
     }
 }
 
@@ -22,7 +22,7 @@ final class IntType
     public function run(array $array, string $item)
     {
         $value = count($array);
-        return sprintf('We have %d %s', $count, $item);
+        return sprintf('We have %d %s', $value, $item);
     }
 }
 

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/int_type.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/int_type.php.inc
@@ -9,6 +9,17 @@ final class IntType
         $value = count($array);
         return "We have {$value} {$item}";
     }
+
+    public function run2(string $item)
+    {
+        $value = 1;
+        return "We have {$value} {$item}";
+    }
+
+    public function run3(int $value = 1, string $item)
+    {
+        return "We have {$value} {$item}";
+    }
 }
 
 ?>
@@ -22,6 +33,17 @@ final class IntType
     public function run(array $array, string $item)
     {
         $value = count($array);
+        return sprintf('We have %d %s', $value, $item);
+    }
+
+    public function run2(string $item)
+    {
+        $value = 1;
+        return sprintf('We have %d %s', $value, $item);
+    }
+
+    public function run3(int $value = 1, string $item)
+    {
         return sprintf('We have %d %s', $value, $item);
     }
 }

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/numberz.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/numberz.php.inc
@@ -20,7 +20,7 @@ final class Numberz
 {
     public function run(string $format, int $value, float $money)
     {
-        return sprintf('Format %s from %s to %s', $format, $value, $money);
+        return sprintf('Format %s from %d to %s', $format, $value, $money);
     }
 }
 


### PR DESCRIPTION
Given the following code:

```php
    public function run(array $array, string $item)
    {
        $value = count($array);
        return "We have {$value} {$item}";
    }
```

Currently produce:

```php
return sprintf('We have %s %s', $value, $item);
```

which should be: 

```php
return sprintf('We have %d %s', $value, $item);
```