### PR TITLE
Create test for RemoveUnusedAliasRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/parent_alias.php.inc
+++ b/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/parent_alias.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\DifferentNamespace as Foo;
+
+class Demo
+{
+    public function run()
+    {
+        $foo = new Foo\StandaloneClass();
+    }
+}
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\DifferentNamespace as Foo;
+
+class Demo
+{
+    public function run()
+    {
+        $foo = new Foo\StandaloneClass();
+    }
+}
+?>


### PR DESCRIPTION
Creating a test for RemoveUnusedAliasRector. If I alias a namespace, then try to use a class within that alias, it is detected as an unused alias.