### PR TITLE
Create test for invalid null type declaration on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/null_type_declaration.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/null_type_declaration.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+final class Demo
+{
+    public function run(): void
+    {
+        $this->doSomething(null);
+    }
+
+    private function doSomething($a): void
+    {
+    }
+}
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+final class Demo
+{
+    public function run(): void
+    {
+        $this->doSomething(null);
+    }
+
+    private function doSomething($a): void
+    {
+    }
+}
+?>


### PR DESCRIPTION
If only `null` is ever passed to an argument, the type declaration is set as `null` when running `AddMethodCallBasedStrictParamTypeRector`. However, `null` is not a valid type declaration.