### PR TITLE
[DeadCode] Skip used in If_ cond, reassign in Else_ on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_if_cond_reassign_in_else.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_if_cond_reassign_in_else.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class SkipUsedInIfCondReassignInElse
+{
+    public function run()
+    {
+        $value = 'a value';
+
+        if ($value) {
+            $value = true;
+        }  else {
+            $value = false;
+        }
+    }
+}

--- a/src/PhpParser/Comparing/ConditionSearcher.php
+++ b/src/PhpParser/Comparing/ConditionSearcher.php
@@ -41,6 +41,16 @@ final class ConditionSearcher
                 return false;
             }
         }
+
+        $isInCond = (bool) $this->betterNodeFinder->findFirst(
+            $if->cond,
+            fn (Node $subNode): bool => $this->nodeComparator->areNodesEqual($varNode, $subNode)
+        );
+
+        if ($isInCond) {
+            return false;
+        }
+
         return $this->hasVariableRedeclaration($varNode, $elseNode->stmts);
     }
 


### PR DESCRIPTION
Given the following code:

```php
        $value = 'a value';

        if ($value) {
            $value = true;
        }  else {
            $value = false;
        }
```

It currently remove the initialization:

```diff
-        $value = 'a value';
```

which make error : "Undefined variable $value"