### PR TITLE
Fix handling of curly braces for choice's callback

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocParser\ClassAnnotationMatcher;
+use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
 
 final class PhpDocClassRenamer
 {
@@ -43,16 +44,18 @@ final class PhpDocClassRenamer
         }
 
         $callback = $assertChoiceTagValueNode->getValueWithoutQuotes('callback');
-        if ($callback === null) {
+        if (! $callback instanceof CurlyListNode) {
             return;
         }
 
+        $callbackClass = $callback->getValueWithoutQuotes(0);
+
         foreach ($oldToNewClasses as $oldClass => $newClass) {
-            if ($callback[0] !== $oldClass) {
+            if ($callbackClass !== $oldClass) {
                 continue;
             }
 
-            $callback[0] = $newClass;
+            $callback->changeValue('0', $newClass);
 
             $assertChoiceTagValueNode->changeValue('callback', $callback);
             break;

--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
@@ -81,7 +81,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     public function changeValue(string $key, $value): void
     {
         // is quoted?
-        if (isset($this->values[$key])) {
+        if (isset($this->values[$key]) && is_string($this->values[$key])) {
             $isQuoted = (bool) Strings::match($this->values[$key], self::UNQUOTED_VALUE_REGEX);
             if ($isQuoted) {
                 $value = '"' . $value . '"';

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class Anything
+{
+    /**
+     * @Assert\Choice(callback={"Some\Random\Class_", "getChoices"})
+     */
+    private $attribute;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class Anything
+{
+    /**
+     * @Assert\Choice(callback={"Some\Other\Random\Class_", "getChoices"})
+     */
+    private $attribute;
+}
+
+?>

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class Anything
+final class CallbackWithCuryBraces
 {
     /**
      * @Assert\Choice(callback={"Some\Random\Class_", "getChoices"})

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
@@ -20,7 +20,7 @@ namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class Anything
+final class CallbackWithCuryBraces
 {
     /**
      * @Assert\Choice(callback={"Some\Other\Random\Class_", "getChoices"})

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class Anything
+final class SkipCallbackWithString
 {
     /**
      * @Assert\Choice(callback="getChoices")

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class Anything
+{
+    /**
+     * @Assert\Choice(callback="getChoices")
+     */
+    private $attribute;
+
+    public function getChoices(): array
+    {
+        return ['First Choice', 'Second Choice'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class Anything
+{
+    /**
+     * @Assert\Choice(callback="getChoices")
+     */
+    private $attribute;
+
+    public function getChoices(): array
+    {
+        return ['First Choice', 'Second Choice'];
+    }
+}
+
+?>

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
@@ -18,24 +18,3 @@ final class SkipCallbackWithString
 }
 
 ?>
------
-<?php
-
-namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
-
-use Symfony\Component\Validator\Constraints as Assert;
-
-final class Anything
-{
-    /**
-     * @Assert\Choice(callback="getChoices")
-     */
-    private $attribute;
-
-    public function getChoices(): array
-    {
-        return ['First Choice', 'Second Choice'];
-    }
-}
-
-?>

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/RenameClassInCallbackFromAssertAnnotationTest.php
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/RenameClassInCallbackFromAssertAnnotationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RenameClassInCallbackFromAssertAnnotation;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+class RenameClassInCallbackFromAssertAnnotationTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/config/configured_rule.php
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                'Some\\Random\\Class_' => 'Some\\Other\\Random\\Class_',
+            ],
+        ]]);
+};


### PR DESCRIPTION
Hi,

When trying to play around I encountered an issue with how the `callback` option of a `Choice` assert annotation was done.
So this is a proposal for a possible solution, don't hesitate if you have any suggestion!

The assertion `Choice` provided by Symfont accept an option `callback`
which can either be of type `string|array|Closure`.
In this case I think we are only interested by the `array` case since
it's the only one in which a class name can be provided.

The phpdoc parser will provide us with a node of type `CurlyListNode`
but it's currently treated like an array.
In addition the `AbstractValuesAwareNode::changeValue` method will
always check if the new value is quoted or not even when the value is
not actually a `string`.

Following I provide a version of the errors I had:
```
 [ERROR] Could not process
         "MySourceFile.php" file, due to:
         "Cannot use object of type Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode as
         array". On line: 47
```