### PR TITLE
[Scoper] Unprefix Helmich\TypoScriptParser\Parser\AST\Statement

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -108,6 +108,13 @@ return [
             'Symplify\SmartFileSystem\SmartFileInfo'
         ),
 
+        // unprefixed Statement
+        fn (string $filePath, string $prefix, string $content): string => Strings::replace(
+            $content,
+            '#' . $prefix . '\\\\Helmich\\\\TypoScriptParser\\\\Parser\\\\AST\\\\Statement#',
+            'Helmich\TypoScriptParser\Parser\AST\Statement'
+        ),
+
         // unprefixed ContainerConfigurator
         function (string $filePath, string $prefix, string $content): string {
             // keep vendor prefixed the prefixed file loading; not part of public API

--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -16,6 +16,8 @@ final class StaticEasyPrefixer
         'Symplify\SmartFileSystem\SmartFileInfo',
         // for ComposerJson because it is part of the public API. I.e. ComposerRectorInterface
         'Symplify\ComposerJsonManipulator\ValueObject\ComposerJson',
+        // for usage in Helmich\TypoScriptParser\Parser\Traverser\Visitor
+        'Helmich\TypoScriptParser\Parser\AST\Statement',
     ];
 
     /**


### PR DESCRIPTION
The patch https://github.com/rectorphp/rector-src/pull/646 cause adding : 

```php
RectorPrefix20210811\Helmich\TypoScriptParser\Parser\AST\Statement
```

in : 

- https://github.com/rectorphp/rector/blob/9d7620e51f19d58e2e038dd1da41b9fad2d26859/vendor/helmich/typo3-typoscript-parser/src/Parser/Traverser/Visitor.php#L24
- https://github.com/rectorphp/rector/blob/9d7620e51f19d58e2e038dd1da41b9fad2d26859/vendor/ssch/typo3-rector/src/FileProcessor/TypoScript/Rector/AbstractTypoScriptRector.php#L26

as parameter into `Visitor` and `AbstractTypoScriptRector` which it may cause it won't work on extended classes. This patch ensure:

- unprefixed Statement to use `Helmich\TypoScriptParser\Parser\AST\Statement` in the parameter.
- Add `Helmich\TypoScriptParser\Parser\AST\Statement` to scoper autoload so prefixed namespace of `RectorPrefix20210811 \Helmich\TypoScriptParser\Parser\AST\Statement` should detected as `Helmich\TypoScriptParser\Parser\AST\Statement`