### PR TITLE
[EarlyReturn] Move comment in If_ stmt for ChangeAndIfToEarlyReturnRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/move_comment_in_if_stmt.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/move_comment_in_if_stmt.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+class MoveCommentInIfStmt
+{
+    public function canDrive(Car $car)
+    {
+        if ($car->hasWheels && $car->hasFuel) {
+            // a comment
+            return true;
+        }
+
+        return false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+class MoveCommentInIfStmt
+{
+    public function canDrive(Car $car)
+    {
+        if (!$car->hasWheels) {
+            return false;
+        }
+        if (!$car->hasFuel) {
+            return false;
+        }
+        // a comment
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/move_comment_in_if_stmt2.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/move_comment_in_if_stmt2.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+class MoveCommentInIfStmt2
+{
+    public function canDrive(Car $car)
+    {
+        if ($car->hasWheels && $car->hasFuel) {
+            // a comment
+            return true;
+        }
+
+        // another comment
+        return false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+class MoveCommentInIfStmt2
+{
+    public function canDrive(Car $car)
+    {
+        if (!$car->hasWheels) {
+            // another comment
+            return false;
+        }
+        if (!$car->hasFuel) {
+            // another comment
+            return false;
+        }
+        // a comment
+        return true;
+    }
+}
+
+?>

--- a/rules/EarlyReturn/NodeFactory/InvertedIfFactory.php
+++ b/rules/EarlyReturn/NodeFactory/InvertedIfFactory.php
@@ -30,9 +30,14 @@ final class InvertedIfFactory
     public function createFromConditions(If_ $if, array $conditions, Return_ $return): array
     {
         $ifs = [];
-        $stmt = $this->contextAnalyzer->isInLoop($if) && ! $this->getIfNextReturn($if)
+        $ifNextReturn = $this->getIfNextReturn($if);
+        $stmt = $this->contextAnalyzer->isInLoop($if) && ! $ifNextReturn
             ? [new Continue_()]
             : [$return];
+
+        if ($ifNextReturn instanceof Return_) {
+            $stmt[0]->setAttribute(AttributeKey::COMMENTS, $ifNextReturn->getAttribute(AttributeKey::COMMENTS));
+        }
 
         $getNextReturnExpr = $this->getNextReturnExpr($if);
         if ($getNextReturnExpr instanceof Return_) {

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -138,6 +138,10 @@ CODE_SAMPLE
      */
     private function processReplaceIfs(If_ $node, array $conditions, Return_ $ifNextReturnClone): If_ | array
     {
+        if (isset($conditions[0])) {
+            $this->mirrorComments($ifNextReturnClone, $conditions[0]);
+        }
+
         $ifs = $this->invertedIfFactory->createFromConditions($node, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $node);
 

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -138,10 +138,6 @@ CODE_SAMPLE
      */
     private function processReplaceIfs(If_ $node, array $conditions, Return_ $ifNextReturnClone): If_ | array
     {
-        if (isset($conditions[0])) {
-            $this->mirrorComments($ifNextReturnClone, $conditions[0]);
-        }
-
         $ifs = $this->invertedIfFactory->createFromConditions($node, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $node);
 


### PR DESCRIPTION
Given the following code:

```php
    public function canDrive(Car $car)
    {
        if ($car->hasWheels && $car->hasFuel) {
            // a comment
            return true;
        }

        return false;
    }
```

It currently got : 

```diff
     public function canDrive(Car $car)
     {
         if (!$car->hasWheels) {
+            // a comment
             return false;
         }
         if (!$car->hasFuel) {
+            // a comment
             return false;
         }
         // a comment
        return true;
```

which the "// a comment" should be moved out to only have one above return true.