### PR TITLE
Namespaces should use a case sensitive comparison

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -71,7 +71,7 @@ final class NodeNameResolver
         return false;
     }
 
-    public function isNameExactly(Node $node, string $name): bool
+    public function isCaseSensitiveName(Node $node, string $name): bool
     {
         if ($name === '') {
             return false;

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -52,7 +52,7 @@ final class NodeNameResolver
     /**
      * @param Node|Node[] $node
      */
-    public function isName(Node | array $node, string $name): bool
+    public function isName(Node | array $node, string $name, bool $strict = false): bool
     {
         if ($node instanceof MethodCall) {
             return false;
@@ -63,7 +63,7 @@ final class NodeNameResolver
         $nodes = is_array($node) ? $node : [$node];
 
         foreach ($nodes as $node) {
-            if ($this->isSingleName($node, $name)) {
+            if ($this->isSingleName($node, $name, $strict)) {
                 return true;
             }
         }
@@ -195,7 +195,7 @@ final class NodeNameResolver
         return $this->callAnalyzer->isObjectCall($node);
     }
 
-    private function isSingleName(Node $node, string $name): bool
+    private function isSingleName(Node $node, string $name, bool $strict = false): bool
     {
         if ($node instanceof MethodCall) {
             // method call cannot have a name, only the variable or method name
@@ -226,6 +226,8 @@ final class NodeNameResolver
             return $name === $resolvedName;
         }
 
-        return strtolower($resolvedName) === strtolower($name);
+        return $strict === true
+            ? $resolvedName === $name
+            : strtolower($resolvedName) === strtolower($name);
     }
 }

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -52,7 +52,7 @@ final class NodeNameResolver
     /**
      * @param Node|Node[] $node
      */
-    public function isName(Node | array $node, string $name, bool $strict = false): bool
+    public function isName(Node | array $node, string $name): bool
     {
         if ($node instanceof MethodCall) {
             return false;
@@ -63,12 +63,33 @@ final class NodeNameResolver
         $nodes = is_array($node) ? $node : [$node];
 
         foreach ($nodes as $node) {
-            if ($this->isSingleName($node, $name, $strict)) {
+            if ($this->isSingleName($node, $name)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    public function isNameExactly(Node $node, string $name): bool
+    {
+        if ($name === '') {
+            return false;
+        }
+
+        if ($node instanceof MethodCall) {
+            return false;
+        }
+        if ($node instanceof StaticCall) {
+            return false;
+        }
+
+        $resolvedName = $this->getName($node);
+        if ($resolvedName === null) {
+            return false;
+        }
+
+        return $name === $resolvedName;
     }
 
     public function getName(Node | string $node): ?string
@@ -195,7 +216,7 @@ final class NodeNameResolver
         return $this->callAnalyzer->isObjectCall($node);
     }
 
-    private function isSingleName(Node $node, string $name, bool $strict = false): bool
+    private function isSingleName(Node $node, string $name): bool
     {
         if ($node instanceof MethodCall) {
             // method call cannot have a name, only the variable or method name
@@ -226,8 +247,6 @@ final class NodeNameResolver
             return $name === $resolvedName;
         }
 
-        return $strict === true
-            ? $resolvedName === $name
-            : strtolower($resolvedName) === strtolower($name);
+        return strtolower($resolvedName) === strtolower($name);
     }
 }

--- a/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/case_insensitive.php.inc
+++ b/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/case_insensitive.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TestS\PSR4\RecTor\fileWithoutNamespace\NorMAliZeNamespaceByPSR4ComposerAutoloadRector\fixture;
+
+class Foo
+{
+
+}
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector\Fixture;
+
+class Foo
+{
+
+}
+?>

--- a/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
+++ b/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
         }
 
         // is namespace and already correctly named?
-        if ($node instanceof Namespace_ && $this->isName($node, $expectedNamespace, true)) {
+        if ($node instanceof Namespace_ && $this->isNameExactly($node, $expectedNamespace)) {
             return null;
         }
 

--- a/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
+++ b/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
         }
 
         // is namespace and already correctly named?
-        if ($node instanceof Namespace_ && $this->nodeNameResolver->isNameExactly($node, $expectedNamespace)) {
+        if ($node instanceof Namespace_ && $this->nodeNameResolver->isCaseSensitiveName($node, $expectedNamespace)) {
             return null;
         }
 

--- a/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
+++ b/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
         }
 
         // is namespace and already correctly named?
-        if ($node instanceof Namespace_ && $this->isName($node, $expectedNamespace)) {
+        if ($node instanceof Namespace_ && $this->isName($node, $expectedNamespace, true)) {
             return null;
         }
 

--- a/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
+++ b/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
         }
 
         // is namespace and already correctly named?
-        if ($node instanceof Namespace_ && $this->isNameExactly($node, $expectedNamespace)) {
+        if ($node instanceof Namespace_ && $this->nodeNameResolver->isNameExactly($node, $expectedNamespace)) {
             return null;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -305,11 +305,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         return $this->nodeNameResolver->isName($node, $name);
     }
 
-    protected function isNameExactly(Node $node, string $name): bool
-    {
-        return $this->nodeNameResolver->isNameExactly($node, $name);
-    }
-
     /**
      * @param string[] $names
      */

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -300,9 +300,9 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         return $this->nodesToReturn[$objectHash] ?? $node;
     }
 
-    protected function isName(Node $node, string $name): bool
+    protected function isName(Node $node, string $name, bool $strict = false): bool
     {
-        return $this->nodeNameResolver->isName($node, $name);
+        return $this->nodeNameResolver->isName($node, $name, $strict);
     }
 
     /**

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -300,9 +300,14 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         return $this->nodesToReturn[$objectHash] ?? $node;
     }
 
-    protected function isName(Node $node, string $name, bool $strict = false): bool
+    protected function isName(Node $node, string $name): bool
     {
-        return $this->nodeNameResolver->isName($node, $name, $strict);
+        return $this->nodeNameResolver->isName($node, $name);
+    }
+
+    protected function isNameExactly(Node $node, string $name): bool
+    {
+        return $this->nodeNameResolver->isNameExactly($node, $name);
     }
 
     /**


### PR DESCRIPTION
When using `NormalizeNamespaceByPSR4ComposerAutoloadRector`, a namespace is not corrected if it differs only by case.

I wrote a test and made an attempt at a fix. Not sure if you'd prefer this being configured, but I added a strict parameter to AbstractRector::isName() and NodeNameResolver::isName() to allow for strict comparisons.