### PR TITLE
Add failing test fixture for IssetOnPropertyObjectToPropertyExistsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/demo_fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/demo_fixture.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+function x(stdClass $x) {
+    if (isset($x->property)) {
+    
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for IssetOnPropertyObjectToPropertyExistsRector

Based on https://getrector.org/demo/1ebfb9d9-19c4-69c0-9cf2-73fa0a756040

Test case for https://github.com/rectorphp/rector/issues/6630