### PR TITLE
Add failing test fixture for RemoveUselessParamTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class X {
+	/**
+	 * @param Closure(int): bool $filter
+	 */
+	static function filter(Closure $filter): array {
+	}
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
@@ -8,7 +8,7 @@ class X {
 	/**
 	 * @param \Closure(int): bool $filter
 	 */
-	static function filter(Closure $filter): array {
+	static function filter(\Closure $filter): array {
 	}
 }
 ?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\F
 
 class X {
 	/**
-	 * @param Closure(int): bool $filter
+	 * @param \Closure(int): bool $filter
 	 */
 	static function filter(Closure $filter): array {
 	}


### PR DESCRIPTION
# Failing Test for RemoveUselessParamTagRector

Based on https://getrector.org/demo/1ebfb5f9-a1f1-6412-b1e0-b75ba4616957

Test case for https://github.com/rectorphp/rector/issues/6628