### PR TITLE
[DeadCode] Skip RemoveUselessParamTagRector on typed closure

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_typed_closure.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_typed_closure.php.inc
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
 
-class X {
+class SkipTypedClosure {
 	/**
 	 * @param \Closure(int): bool $filter
 	 */

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class X {
+	/**
+	 * @param Closure(int): bool $filter
+	 */
+	static function filter(Closure $filter): array {
+	}
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
@@ -8,7 +8,7 @@ class X {
 	/**
 	 * @param \Closure(int): bool $filter
 	 */
-	static function filter(Closure $filter): array {
+	static function filter(\Closure $filter): array {
 	}
 }
 ?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/x.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\F
 
 class X {
 	/**
-	 * @param Closure(int): bool $filter
+	 * @param \Closure(int): bool $filter
 	 */
 	static function filter(Closure $filter): array {
 	}

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -8,6 +8,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareCallableTypeNode;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 
@@ -39,6 +40,10 @@ final class DeadParamTagValueNodeAnalyzer
         }
 
         if ($paramTagValueNode->type instanceof GenericTypeNode) {
+            return false;
+        }
+
+        if ($paramTagValueNode->type instanceof SpacingAwareCallableTypeNode) {
             return false;
         }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/658 Fixes https://github.com/rectorphp/rector/issues/6628