### PR TITLE
Add failing test fixture for NullsafeOperatorRector with default value not being null

### DIFF
--- a/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/default_value.php.inc
+++ b/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/default_value.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\If_\NullsafeOperatorRector\Fixture;
+
+final class DefaultValue
+{
+    public function run()
+    {
+        if ($this->endWeekDate !== null) {
+            $param = $this->endWeekDate->format();
+        } else {
+            $param = "No data";
+        }
+        return $param;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\If_\NullsafeOperatorRector\Fixture;
+
+final class DefaultValue
+{
+    public function run()
+    {
+        $param = $this->endWeekDate?->format() ?? "No data";
+        return $param;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for NullsafeOperatorRector

Based on https://getrector.org/demo/1ebfc1be-1929-6f00-beb9-2735c352804c