### PR TITLE
[EarlyReturn] Handle Repetitive If_ on use ReturnBinaryOrToEarlyReturnRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector/Fixture/multiple_binary_or_start_with_method_call.php.inc
+++ b/rules-tests/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector/Fixture/multiple_binary_or_start_with_method_call.php.inc
@@ -22,7 +22,13 @@ class MultipleBinaryOrStartWithMethodCall
 {
     public function run($a, $b)
     {
-        return $this->execute() || $a || $b;
+        if ($this->execute()) {
+            return true;
+        }
+        if ($a) {
+            return true;
+        }
+        return (bool) $b;
     }
 
     private function execute() {}

--- a/rules-tests/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector/Fixture/multiple_binary_or_start_with_method_call.php.inc
+++ b/rules-tests/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector/Fixture/multiple_binary_or_start_with_method_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\Return_\ReturnBinaryOrToEarlyReturnRector\Fixture;
+
+class MultipleBinaryOrStartWithMethodCall
+{
+    public function run($a, $b)
+    {
+        return $this->execute() || $a || $b;
+    }
+
+    private function execute() {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\Return_\ReturnBinaryOrToEarlyReturnRector\Fixture;
+
+class MultipleBinaryOrStartWithMethodCall
+{
+    public function run($a, $b)
+    {
+        return $this->execute() || $a || $b;
+    }
+
+    private function execute() {}
+}
+
+?>

--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
@@ -87,12 +87,12 @@ CODE_SAMPLE
             return null;
         }
 
+        if (! $this->callAnalyzer->doesIfHasObjectCall($ifs)) {
+            return null;
+        }
+
         $this->mirrorComments($ifs[0], $node);
         foreach ($ifs as $if) {
-            if (! $this->callAnalyzer->isObjectCall($if->cond)) {
-                return null;
-            }
-
             $this->addNodeBeforeNode($if, $node);
         }
 

--- a/src/NodeAnalyzer/CallAnalyzer.php
+++ b/src/NodeAnalyzer/CallAnalyzer.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\If_;
 
 final class CallAnalyzer
 {
@@ -33,6 +34,20 @@ final class CallAnalyzer
 
         foreach (self::OBJECT_CALL_TYPES as $objectCallType) {
             if (is_a($expr, $objectCallType, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param If_[] $ifs
+     */
+    public function doesIfHasObjectCall(array $ifs): bool
+    {
+        foreach ($ifs as $if) {
+            if ($this->isObjectCall($if->cond)) {
                 return true;
             }
         }


### PR DESCRIPTION
Given the following code:

```php
    public function run($a, $b)
    {
        return $this->execute() || $a || $b;
    }
```

Currently produce:

```diff
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
+        if ($this->execute()) {
+            return true;
+        }
         return $this->execute() || $a || $b;
```

which should be handled.