### PR TITLE
[Defluent] Skip NewFluentChainMethodCallToNonFluentRector on inside If_ cond

### DIFF
--- a/rules-tests/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector/Fixture/skip_inside_if_cond.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector/Fixture/skip_inside_if_cond.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\NewFluentChainMethodCallToNonFluentRector\Fixture;
+
+use Rector\Tests\Defluent\Rector\MethodCall\NewFluentChainMethodCallToNonFluentRector\Source\FluentInterfaceClass;
+
+class SkipInsideIfCond
+{
+    public function someFunction()
+    {
+        if ($instance = (new FluentInterfaceClass())->someFunction()->otherFunction()) {
+            return $instance;
+        }
+    }
+}
+
+?>

--- a/rules/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector.php
+++ b/rules/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Defluent\Matcher\AssignAndRootExprAndNodesToAddMatcher;
@@ -78,6 +79,11 @@ CODE_SAMPLE
         }
 
         if (! $parent instanceof Assign) {
+            return null;
+        }
+
+        $parentParent = $parent->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parentParent instanceof Expression) {
             return null;
         }
 


### PR DESCRIPTION
Given the following code:

```php
        if ($instance = (new FluentInterfaceClass())->someFunction()->otherFunction()) {
            return $instance;
        }
```

Currently got error:

```bash
1) Rector\Tests\Defluent\Rector\MethodCall\NewFluentChainMethodCallToNonFluentRector\NewFluentChainMethodCallToNonFluentRectorTest::test with data set #7 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Node "PhpParser\Node\Expr\Assign" on line 11 is child of "PhpParser\Node\Stmt\If_", so it cannot be removed as it would break PHP code. Change or remove the parent node instead.
```

This may happen in `do{}` and `while {}`'s cond, so better to skip it.