### PR TITLE
[Defluent] Skip Fluent in If_ cond on FluentChainMethodCallToNormalMethodCallRector

### DIFF
--- a/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_fluent_in_if_cond.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_fluent_in_if_cond.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture;
+
+use Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Source\FluentInterfaceClass;
+
+final class SkipFluentInIfCond
+{
+    public function run()
+    {
+        $obj = new FluentInterfaceClass();
+
+        if ($obj->someFunction()->otherFunction()) {
+
+        }
+    }
+}

--- a/rules/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector.php
+++ b/rules/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Defluent\Matcher\AssignAndRootExprAndNodesToAddMatcher;
@@ -74,6 +75,11 @@ CODE_SAMPLE
         }
 
         if ($this->methodCallSkipAnalyzer->shouldSkipMethodCallIncludingNew($node)) {
+            return null;
+        }
+
+        $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        if (! $currentStatement instanceof Expression && ! $currentStatement instanceof Return_) {
             return null;
         }
 


### PR DESCRIPTION
Given the following code:

```php
        if ($obj->someFunction()->otherFunction()) {

        }
```

Produce error:

```bash
1) Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\FluentChainMethodCallToNormalMethodCallRectorTest::test with data set #3 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Node "PhpParser\Node\Expr\MethodCall" on line 13 is child of "PhpParser\Node\Stmt\If_", so it cannot be removed as it would break PHP code. Change or remove the parent node instead.
```