### PR TITLE
[Defluent] Skip New_ with not a Name on InArgFluentChainMethodCallToStandaloneMethodCallRector

### DIFF
--- a/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/new_in_arg_not_name.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/new_in_arg_not_name.php.inc
@@ -13,6 +13,18 @@ class NewInArgNotName
         );
     }
 
+    public function someFunction2()
+    {
+        $this->processFluentClass(
+            (new $this->getFluentClass())->someFunction()->otherFunction()
+        );
+    }
+
+    private function getFluentClass()
+    {
+        return ValueObject::A_CLASS;
+    }
+
     public function processFluentClass($arg)
     {
     }

--- a/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/new_in_arg_not_name.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/new_in_arg_not_name.php.inc
@@ -2,24 +2,18 @@
 
 namespace Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\Fixture;
 
-use Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\Source\FluentClass;
-
-class ValueObject
-{
-    public $class = FluentClass::class;
-}
+use Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\Source\ValueObject;
 
 class NewInArgNotName
 {
     public function someFunction(ValueObject $valueObject)
     {
         $this->processFluentClass(
-            (new $valueObject->class)->someFunction()->otherFunction(),
-            $valueObject->class
+            (new $valueObject->class)->someFunction()->otherFunction()
         );
     }
 
-    public function processFluentClass($arg, $arg2)
+    public function processFluentClass($arg)
     {
     }
 }

--- a/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/new_in_arg_not_name.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/new_in_arg_not_name.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\Fixture;
+
+use Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\Source\FluentClass;
+
+class ValueObject
+{
+    public $class = FluentClass::class;
+}
+
+class NewInArgNotName
+{
+    public function someFunction(ValueObject $valueObject)
+    {
+        $this->processFluentClass(
+            (new $valueObject->class)->someFunction()->otherFunction(),
+            $valueObject->class
+        );
+    }
+
+    public function processFluentClass($arg, $arg2)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/skip_new_in_arg_not_name.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Fixture/skip_new_in_arg_not_name.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToSt
 
 use Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\Source\ValueObject;
 
-class NewInArgNotName
+class SkipNewInArgNotName
 {
     public function someFunction(ValueObject $valueObject)
     {

--- a/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Source/ValueObject.php
+++ b/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Source/ValueObject.php
@@ -7,4 +7,6 @@ namespace Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToSt
 class ValueObject
 {
     public $class = FluentClass::class;
+
+    public const A_CLASS = FluentClass::class;
 }

--- a/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Source/ValueObject.php
+++ b/rules-tests/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector/Source/ValueObject.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\Source;
+
+class ValueObject
+{
+    public $class = FluentClass::class;
+}

--- a/rules/Naming/Naming/VariableNaming.php
+++ b/rules/Naming/Naming/VariableNaming.php
@@ -207,7 +207,7 @@ final class VariableNaming
     {
         $className = $this->nodeNameResolver->getName($new->class);
         if ($className === null) {
-            return '';
+            throw new NotImplementedYetException();
         }
 
         return $this->nodeNameResolver->getShortName($className);

--- a/rules/Naming/Naming/VariableNaming.php
+++ b/rules/Naming/Naming/VariableNaming.php
@@ -205,12 +205,8 @@ final class VariableNaming
 
     private function resolveFromNew(New_ $new): string
     {
-        if ($new->class instanceof Name) {
-            $className = $this->nodeNameResolver->getName($new->class);
-            return $this->nodeNameResolver->getShortName($className);
-        }
-
-        throw new NotImplementedYetException();
+        $className = $this->nodeNameResolver->getName($new->class);
+        return $this->nodeNameResolver->getShortName($className);
     }
 
     private function unwrapNode(Node $node): ?Node

--- a/rules/Naming/Naming/VariableNaming.php
+++ b/rules/Naming/Naming/VariableNaming.php
@@ -206,6 +206,10 @@ final class VariableNaming
     private function resolveFromNew(New_ $new): string
     {
         $className = $this->nodeNameResolver->getName($new->class);
+        if ($className === null) {
+            return '';
+        }
+
         return $this->nodeNameResolver->getShortName($className);
     }
 


### PR DESCRIPTION
Given the following code:

```php
        $this->processFluentClass(
            (new $valueObject->class)->someFunction()->otherFunction()
        );
```

Currently got error:

```bash
1) Rector\Tests\Defluent\Rector\MethodCall\InArgFluentChainMethodCallToStandaloneMethodCallRector\InArgFluentChainMethodCallToStandaloneMethodCallRectorTest::test with data set #8 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\NotImplementedYetException: 

/Users/samsonasik/www/rector-src/rules/Naming/Naming/VariableNaming.php:213
```