### PR TITLE
[DeadCode] Skip UnwrapFutureCompatibleIfPhpVersionRector on higher than current php provider

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector/Fixture/skip_higher_current.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector/Fixture/skip_higher_current.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector\Fixture;
+
+class SkipHigherCurrent
+{
+    public function run()
+    {
+        // $this->phpVersionProvider->provide() returns 10000 on test
+        if (version_compare(PHP_VERSION, '11.0', '<')) {
+            return 'a';
+        } else {
+            return 'b';
+        }
+    }
+}
+
+?>

--- a/rules/DeadCode/ConditionEvaluator.php
+++ b/rules/DeadCode/ConditionEvaluator.php
@@ -9,12 +9,17 @@ use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotEqual;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\Php\PhpVersionProvider;
 use Rector\DeadCode\Contract\ConditionInterface;
 use Rector\DeadCode\ValueObject\BinaryToVersionCompareCondition;
 use Rector\DeadCode\ValueObject\VersionCompareCondition;
 
 final class ConditionEvaluator
 {
+    public function __construct(private PhpVersionProvider $phpVersionProvider)
+    {
+    }
+
     /**
      * @return bool|int|null
      */
@@ -31,10 +36,14 @@ final class ConditionEvaluator
         return null;
     }
 
-    private function evaluateVersionCompareCondition(VersionCompareCondition $versionCompareCondition): bool | int
+    private function evaluateVersionCompareCondition(VersionCompareCondition $versionCompareCondition): bool | int | null
     {
         $compareSign = $versionCompareCondition->getCompareSign();
         if ($compareSign !== null) {
+            if ($compareSign === '<' && $this->phpVersionProvider->provide() < $versionCompareCondition->getSecondVersion()) {
+                return null;
+            }
+
             return version_compare(
                 (string) $versionCompareCondition->getFirstVersion(),
                 (string) $versionCompareCondition->getSecondVersion(),


### PR DESCRIPTION
This can happen when composer have the following requirement:

```php
    "require": {
        "php": "^7.3 || ^8.0",
```

and we have code:

```php
        if (version_compare(PHP_VERSION, '8.0', '<')) {
            return 'a';
        } else {
            return 'b';
        }
```

above code can run in php 7.3 or php 8.0, which both 'a' and 'b' can have result. Without this skip, it will result only:

```diff
-        if (version_compare(PHP_VERSION, '8.0', '<')) {
-            return 'a';
-        } else {
-            return 'b';
-        }
+        return 'a';
```

which invalid when we use php > 8.0
