### PR TITLE
[TypeDeclaration] Handle class-string[] on class string array

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+use stdClass;
+use DateTime;
+
+class ClassStringArray
+{
+    public function getData()
+    {
+        return [
+            stdClass::class,
+            DateTime::class,
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+use stdClass;
+use DateTime;
+
+class ClassStringArray
+{
+    /**
+     * @return class-string[]
+     */
+    public function getData()
+    {
+        return [
+            stdClass::class,
+            DateTime::class,
+        ];
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -46,11 +46,28 @@ final class GenericClassStringTypeNormalizer
             return $this->resolveStringType($value);
         });
 
+        if ($type instanceof ArrayType && $type->getItemType() instanceof UnionType && $this->hasClassStringOnly($type->getItemType())) {
+            return new ArrayType(new MixedType(), new ClassStringType());
+        }
+
         if ($type instanceof UnionType) {
             return $this->resolveClassStringInUnionType($type);
         }
 
         return $type;
+    }
+
+    private function hasClassStringOnly(UnionType $type): bool
+    {
+        $unionTypes = $type->getTypes();
+
+        foreach ($unionTypes as $unionType) {
+            if (! $unionType instanceof GenericClassStringType) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function resolveClassStringInUnionType(UnionType $type): UnionType | ArrayType


### PR DESCRIPTION
Given the following code:

```php
class ClassStringArray
{
    public function getData()
    {
        return [
            stdClass::class,
            DateTime::class,
        ];
    }
}
```

It currently produce:

```diff
+     * @return class-string<\DateTime>[]|class-string<\stdClass>[]
```

which I think it sholud only:

```diff
+     * @return class-string[]
```