### PR TITLE
[DeadCode] Skip Empty Class Method for __construct with class extends, and class with __invoke

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_construct_class_extends.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_construct_class_extends.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Source\MyPdo;
+
+/**
+ * Construct empty with extends can be used for stub in test
+ */
+class SkipConstructClassExtends extends MyPdo
+{
+    public function __construct()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_invoke.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_invoke.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+/**
+ * Invokable class can be used for stub in test
+ */
+class SkipInvoke
+{
+    public function __invoke()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Source/MyPdo.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Source/MyPdo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Source;
+
+class MyPdo
+{
+    public function __construct()
+    {
+        db_connnect();
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
 use Rector\DeadCode\NodeManipulator\ControllerClassMethodManipulator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -124,6 +126,15 @@ CODE_SAMPLE
             return true;
         }
 
-        return $this->controllerClassMethodManipulator->isControllerClassMethodWithBehaviorAnnotation($classMethod);
+        if ($this->controllerClassMethodManipulator->isControllerClassMethodWithBehaviorAnnotation($classMethod)) {
+            return true;
+        }
+
+        if ($this->nodeNameResolver->isName($classMethod, MethodName::CONSTRUCT)) {
+            $class = $classMethod->getAttribute(AttributeKey::CLASS_NODE);
+            return $class instanceof Class_ && $class->extends instanceof FullyQualified;
+        }
+
+        return $this->nodeNameResolver->isName($classMethod, MethodName::INVOKE);
     }
 }

--- a/src/ValueObject/MethodName.php
+++ b/src/ValueObject/MethodName.php
@@ -54,4 +54,9 @@ final class MethodName
      * @var string
      */
     public const TO_STRING = '__toString';
+
+    /**
+     * @var string
+     */
+    public const INVOKE = '__invoke';
 }


### PR DESCRIPTION
- Empty class method with extends class can be used for stub like in https://github.com/rectorphp/rector-src/pull/611
- Class with empty __invoke can be used for stub in test