### PR TITLE
[Defluent] Skip mixin on FluentChainMethodCallToNormalMethodCallRector

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -47,9 +47,9 @@ final class PHPStanNodeScopeResolver
     /**
      * @var string
      *
-     * @see https://regex101.com/r/3DVXef/1
+     * @see https://regex101.com/r/3DVXef/2
      */
-    private const MIXIN_REGEX = '#\*\s+\@mixin\s+\w+#';
+    private const MIXIN_REGEX = '#\*\s+\@mixin\s+\\\\?\w+#';
 
     public function __construct(
         private ChangedFilesDetector $changedFilesDetector,

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -114,6 +114,8 @@ final class PHPStanNodeScopeResolver
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
         $printNodes = $this->betterStandardPrinter->print($nodes);
+
+        // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
         if (! Strings::match($printNodes, self::MIXIN_REGEX)) {
             $this->nodeScopeResolver->processNodes($nodes, $scope, $nodeCallback);
         }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -111,10 +111,10 @@ final class PHPStanNodeScopeResolver
 
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
-        $content = $smartFileInfo->getContents();
+        $contents = $smartFileInfo->getContents();
 
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
-        if (! Strings::match($content, self::MIXIN_REGEX)) {
+        if (! Strings::match($contents, self::MIXIN_REGEX)) {
             $this->nodeScopeResolver->processNodes($nodes, $scope, $nodeCallback);
         }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -24,7 +24,6 @@ use PHPStan\Reflection\ReflectionProvider;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Caching\FileSystem\DependencyResolver;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\StaticReflection\SourceLocator\ParentAttributeSourceLocator;
 use Rector\Core\StaticReflection\SourceLocator\RenamedClassesSourceLocator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -62,8 +61,7 @@ final class PHPStanNodeScopeResolver
         private TraitNodeScopeCollector $traitNodeScopeCollector,
         private PrivatesAccessor $privatesAccessor,
         private RenamedClassesSourceLocator $renamedClassesSourceLocator,
-        private ParentAttributeSourceLocator $parentAttributeSourceLocator,
-        private BetterStandardPrinter $betterStandardPrinter
+        private ParentAttributeSourceLocator $parentAttributeSourceLocator
     ) {
     }
 
@@ -113,10 +111,10 @@ final class PHPStanNodeScopeResolver
 
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
-        $printNodes = $this->betterStandardPrinter->print($nodes);
+        $content = $smartFileInfo->getContents();
 
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
-        if (! Strings::match($printNodes, self::MIXIN_REGEX)) {
+        if (! Strings::match($content, self::MIXIN_REGEX)) {
             $this->nodeScopeResolver->processNodes($nodes, $scope, $nodeCallback);
         }
 

--- a/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture;
+
+/**
+ * @mixin SkipMixin
+ */
+class SkipMixin
+{
+    public function someFunction()
+    {
+        $this->obj = $this;
+        $this->obj->run()->execute();
+    }
+
+    public function run()
+    {
+        return $this;
+    }
+
+    public function execute()
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin2.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture;
+
+/**
+ * @mixin \Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture
+ */
+class SkipMixin2
+{
+    public function someFunction()
+    {
+        $this->obj = $this;
+        $this->obj->run()->execute();
+    }
+
+    public function run()
+    {
+        return $this;
+    }
+
+    public function execute()
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin2.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin2.php.inc
@@ -3,7 +3,7 @@
 namespace Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture;
 
 /**
- * @mixin \Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture
+ * @mixin \Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture\SkipMixin2
  */
 class SkipMixin2
 {


### PR DESCRIPTION
Given the following code:

```php
/**
 * @mixin SkipMixin
 */
class SkipMixin
{
    public function someFunction()
    {
        $this->obj = $this;
        $this->obj->run()->execute();
    }

    public function run()
    {
        return $this;
    }

    public function execute()
    {
        return $this;
    }
}
```

It currently crash:

```bash
[1]    69072 segmentation fault  vendor/bin/phpunit 
```

Removing `@mixin` got normal output