### PR TITLE
[Defluent] Skip mixin in source on FluentChainMethodCallToNormalMethodCallRector

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -116,12 +116,13 @@ final class PHPStanNodeScopeResolver
 
         $contents = $smartFileInfo->getContents();
 
+        // avoid crash on class with @mixin in source @see https://github.com/rectorphp/rector-src/pull/689
+        if ($this->isMixinInSource($nodes)) {
+            return $nodes;
+        }
+
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
         if (! Strings::match($contents, self::MIXIN_REGEX)) {
-            if ($this->isMixinInSource($nodes)) {
-                return $nodes;
-            }
-
             $this->nodeScopeResolver->processNodes($nodes, $scope, $nodeCallback);
         }
 
@@ -129,6 +130,9 @@ final class PHPStanNodeScopeResolver
         return $nodes;
     }
 
+    /**
+     * @param Node[] $nodes
+     */
     private function isMixinInSource(array $nodes): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node): bool {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -114,12 +114,12 @@ final class PHPStanNodeScopeResolver
 
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
-        $contents = $smartFileInfo->getContents();
-
         // avoid crash on class with @mixin in source @see https://github.com/rectorphp/rector-src/pull/689
         if ($this->isMixinInSource($nodes)) {
             return $nodes;
         }
+
+        $contents = $smartFileInfo->getContents();
 
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
         if (! Strings::match($contents, self::MIXIN_REGEX)) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -154,7 +154,7 @@ final class PHPStanNodeScopeResolver
             }
 
             $classReflection = $this->reflectionProvider->getClass($className);
-            if (! $classReflection->isClass()) {
+            if (! $classReflection->isClass() || $classReflection->isBuiltIn()) {
                 return false;
             }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -152,7 +152,9 @@ final class PHPStanNodeScopeResolver
             }
 
             $className = $node->toString();
+
             // fix error in parallel test
+            // use function_exists on purpose as using reflectionProvider broke the test in parallel
             if (function_exists($className)) {
                 return false;
             }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -115,7 +115,7 @@ final class PHPStanNodeScopeResolver
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
         // avoid crash on class with @mixin in source @see https://github.com/rectorphp/rector-src/pull/689
-        if ($this->isMixinInSource($nodes)) {
+        if ($this->isMixinInSource($nodes, $scope)) {
             return $nodes;
         }
 
@@ -134,15 +134,15 @@ final class PHPStanNodeScopeResolver
     /**
      * @param Node[] $nodes
      */
-    private function isMixinInSource(array $nodes): bool
+    private function isMixinInSource(array $nodes, Scope $scope): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node): bool {
+        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($scope): bool {
             if (! $node instanceof FullyQualified) {
                 return false;
             }
 
             $className = $node->toString();
-            $hasFunction = $this->reflectionProvider->hasFunction($node, null);
+            $hasFunction = $this->reflectionProvider->hasFunction($node, $scope);
 
             if ($hasFunction) {
                 return false;

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -151,12 +151,12 @@ final class PHPStanNodeScopeResolver
                 return false;
             }
 
-            $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-            if (! $currentStatement instanceof Node) {
+            $className = $node->toString();
+            // fix error in parallel test
+            if (function_exists($className)) {
                 return false;
             }
 
-            $className = $node->toString();
             $hasClass = $this->reflectionProvider->hasClass($className);
 
             if (! $hasClass) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
+use Closure;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
@@ -114,6 +115,15 @@ final class PHPStanNodeScopeResolver
 
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
+        return $this->processNodesWithMixinHandling($smartFileInfo, $nodes, $scope, $nodeCallback);
+    }
+
+    /**
+     * @param Stmt[] $nodes
+     * @return Stmt[]
+     */
+    private function processNodesWithMixinHandling(SmartFileInfo $smartFileInfo, array $nodes, MutatingScope $scope, callable $nodeCallback): array
+    {
         $contents = $smartFileInfo->getContents();
 
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -143,7 +143,7 @@ final class PHPStanNodeScopeResolver
 
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
             if (! $nextNode instanceof Node) {
-                return false;
+             //   return false;
             }
 
             $className = $node->toString();

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -118,7 +118,7 @@ final class PHPStanNodeScopeResolver
 
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
         if (! Strings::match($contents, self::MIXIN_REGEX)) {
-            if ($this->isMixinAsSource($nodes)) {
+            if ($this->isMixinInSource($nodes)) {
                 return $nodes;
             }
 
@@ -129,7 +129,7 @@ final class PHPStanNodeScopeResolver
         return $nodes;
     }
 
-    private function isMixinAsSource(array $nodes): bool
+    private function isMixinInSource(array $nodes): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node): bool {
             if (! $node instanceof FullyQualified) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -148,8 +148,8 @@ final class PHPStanNodeScopeResolver
                 return false;
             }
 
-            $class    = $this->reflectionProvider->getClass($className);
-            $fileName = $class->getFileName();
+            $classReflection = $this->reflectionProvider->getClass($className);
+            $fileName = $classReflection->getFileName();
 
             if ($fileName === false) {
                 return false;

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -114,15 +114,15 @@ final class PHPStanNodeScopeResolver
 
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
-        // avoid crash on class with @mixin in source @see https://github.com/rectorphp/rector-src/pull/689
-        if ($this->isMixinInSource($nodes, $scope)) {
-            return $nodes;
-        }
-
         $contents = $smartFileInfo->getContents();
 
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
         if (! Strings::match($contents, self::MIXIN_REGEX)) {
+            // avoid crash on class with @mixin in source @see https://github.com/rectorphp/rector-src/pull/689
+            if ($this->isMixinInSource($nodes)) {
+                return $nodes;
+            }
+
             $this->nodeScopeResolver->processNodes($nodes, $scope, $nodeCallback);
         }
 
@@ -134,9 +134,9 @@ final class PHPStanNodeScopeResolver
     /**
      * @param Node[] $nodes
      */
-    private function isMixinInSource(array $nodes, MutatingScope $scope): bool
+    private function isMixinInSource(array $nodes): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($scope): bool {
+        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node): bool {
             if (! $node instanceof FullyQualified) {
                 return false;
             }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -134,7 +134,7 @@ final class PHPStanNodeScopeResolver
     /**
      * @param Node[] $nodes
      */
-    private function isMixinInSource(array $nodes, Scope $scope): bool
+    private function isMixinInSource(array $nodes, MutatingScope $scope): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($scope): bool {
             if (! $node instanceof FullyQualified) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
-use Closure;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
@@ -122,7 +121,12 @@ final class PHPStanNodeScopeResolver
      * @param Stmt[] $nodes
      * @return Stmt[]
      */
-    private function processNodesWithMixinHandling(SmartFileInfo $smartFileInfo, array $nodes, MutatingScope $scope, callable $nodeCallback): array
+    private function processNodesWithMixinHandling(
+        SmartFileInfo $smartFileInfo,
+        array $nodes,
+        MutatingScope $mutatingScope,
+        callable $nodeCallback
+    ): array
     {
         $contents = $smartFileInfo->getContents();
 
@@ -133,10 +137,10 @@ final class PHPStanNodeScopeResolver
                 return $nodes;
             }
 
-            $this->nodeScopeResolver->processNodes($nodes, $scope, $nodeCallback);
+            $this->nodeScopeResolver->processNodes($nodes, $mutatingScope, $nodeCallback);
         }
 
-        $this->resolveAndSaveDependentFiles($nodes, $scope, $smartFileInfo);
+        $this->resolveAndSaveDependentFiles($nodes, $mutatingScope, $smartFileInfo);
 
         return $nodes;
     }
@@ -166,7 +170,11 @@ final class PHPStanNodeScopeResolver
             }
 
             $classReflection = $this->reflectionProvider->getClass($className);
-            if (! $classReflection->isClass() || $classReflection->isBuiltIn()) {
+            if (! $classReflection->isClass()) {
+                return false;
+            }
+
+            if ($classReflection->isBuiltIn()) {
                 return false;
             }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -141,13 +141,12 @@ final class PHPStanNodeScopeResolver
                 return false;
             }
 
-            $className = $node->toString();
-            $hasFunction = $this->reflectionProvider->hasFunction($node, $scope);
-
-            if ($hasFunction) {
+            $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
+            if (! $nextNode instanceof Node) {
                 return false;
             }
 
+            $className = $node->toString();
             $hasClass = $this->reflectionProvider->hasClass($className);
 
             if (! $hasClass) {
@@ -155,8 +154,11 @@ final class PHPStanNodeScopeResolver
             }
 
             $classReflection = $this->reflectionProvider->getClass($className);
-            $fileName = $classReflection->getFileName();
+            if (! $classReflection->isClass()) {
+                return false;
+            }
 
+            $fileName = $classReflection->getFileName();
             if ($fileName === false) {
                 return false;
             }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -127,6 +127,7 @@ final class PHPStanNodeScopeResolver
         }
 
         $this->resolveAndSaveDependentFiles($nodes, $scope, $smartFileInfo);
+
         return $nodes;
     }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -142,6 +142,12 @@ final class PHPStanNodeScopeResolver
             }
 
             $className = $node->toString();
+            $hasFunction = $this->reflectionProvider->hasFunction($node, null);
+
+            if ($hasFunction) {
+                return false;
+            }
+
             $hasClass = $this->reflectionProvider->hasClass($className);
 
             if (! $hasClass) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -141,9 +141,9 @@ final class PHPStanNodeScopeResolver
                 return false;
             }
 
-            $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
-            if (! $nextNode instanceof Node) {
-             //   return false;
+            $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
+            if (! $currentStatement instanceof Node) {
+                return false;
             }
 
             $className = $node->toString();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -390,6 +390,7 @@ parameters:
             paths:
                  - src/functions/node_helper.php
                  - packages/ReadWrite/Guard/VariableToConstantGuard.php
+                 - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
 
         # upgrade to PHP 7.4 wip
         - '#This property type might be inlined to PHP\. Do you have confidence it is correct\? Put it here#'

--- a/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin_as_source.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin_as_source.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Fixture;
+
+use Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Source\MixinClass;
+
+class SkipMixinAsSource
+{
+    public function someFunction()
+    {
+        $queryBuilder = new MixinClass();
+        $queryBuilder->addQuery()
+                        ->select();
+    }
+}

--- a/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin_in_source.php.inc
+++ b/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Fixture/skip_mixin_in_source.php.inc
@@ -4,12 +4,18 @@ namespace Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalM
 
 use Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Source\MixinClass;
 
-class SkipMixinAsSource
+class SkipMixinInSource
 {
     public function someFunction()
     {
         $queryBuilder = new MixinClass();
         $queryBuilder->addQuery()
+                        ->select();
+    }
+
+    public function someFunction2(MixinClass $mixinClass)
+    {
+        $mixinClass->addQuery()
                         ->select();
     }
 }

--- a/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Source/MixinClass.php
+++ b/rules-tests/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector/Source/MixinClass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Defluent\Rector\MethodCall\FluentChainMethodCallToNormalMethodCallRector\Source;
+
+/**
+ * @mixin MixinClass
+ */
+final class MixinClass
+{
+    public function addQuery(): self
+    {
+        return $this;
+    }
+
+    public function select(): self
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/688 , the `@mixin` can make crash when the class used as source to be called.

```bash
.............[1]    4044 segmentation fault  vendor/bin/phpunit 
```