### PR TITLE
Add failing test fixture for RemoveUselessParamTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
 use Ds\Vector;
 
 /**
@@ -7,8 +9,6 @@ use Ds\Vector;
  *
  * @implements IteratorAggregate<int, TValue>
  */
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
-
 final class ImmutableVector implements Countable, IteratorAggregate
 {
 	/**

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
@@ -3,6 +3,7 @@
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
 
 use Ds\Vector;
+use IteratorAggregate;
 
 /**
  * @template TValue

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
@@ -10,7 +10,7 @@ use IteratorAggregate;
  *
  * @implements IteratorAggregate<int, TValue>
  */
-final class ImmutableVector implements Countable, IteratorAggregate
+final class ImmutableVector implements IteratorAggregate
 {
 	/**
 	 * @var Vector<TValue>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+use Ds\Vector;
+
+/**
+ * @template TValue
+ *
+ * @implements IteratorAggregate<int, TValue>
+ */
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+final class ImmutableVector implements Countable, IteratorAggregate
+{
+	/**
+	 * @var Vector<TValue>
+	 */
+	private Vector $vector;
+
+	/**
+	 * @param iterable<TValue>|null $values
+	 */
+	public function __construct(?iterable $values = null)
+	{
+		$this->vector = new Vector($values ?? []);
+	}
+}
+?>
+


### PR DESCRIPTION
# Failing Test for RemoveUselessParamTagRector

Based on https://getrector.org/demo/1ebfe5ca-06c8-6aac-9ff9-15322cba3b32

EDIT: By the way if you check my second commit you'll see that getrector.org kinda messed up when adding the namespace. Might be worth fixing too.