### PR TITLE
[Php80] Handle Remove Doc Array Typed Param on UnionTypesRector

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/_remove_doc_array_typed2.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/_remove_doc_array_typed2.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+final class RemoveDocArrayTyped2
+{
+    /**
+     * @param bool|float|int|string|array<mixed> $value
+     */
+    public function normalizeNodeValue($value)
+    {
+        return $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+final class RemoveDocArrayTyped2
+{
+    public function normalizeNodeValue(bool|float|int|string|array $value)
+    {
+        return $value;
+    }
+}
+
+?>

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -8,6 +8,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareCallableTypeNode;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -61,6 +62,10 @@ final class DeadParamTagValueNodeAnalyzer
 
         foreach ($types as $type) {
             if ($type instanceof GenericTypeNode) {
+                if ($type->type instanceof IdentifierTypeNode && $type->type->name === 'array') {
+                    continue;
+                }
+
                 return true;
             }
         }


### PR DESCRIPTION
Like removal `@return` at https://github.com/rectorphp/rector-src/runs/3338083534#step:5:73