### PR TITLE
[NodeTypeResolver] Check current file name is not equal with source file name for mixin class in source

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -149,8 +149,8 @@ final class PHPStanNodeScopeResolver
      */
     private function isMixinInSource(array $nodes, SmartFileInfo $smartFileInfo): bool
     {
-        $currentFileName = $smartFileInfo->getRealPath();
-        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($currentFileName): bool {
+        $realPath = $smartFileInfo->getRealPath();
+        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($realPath): bool {
             if (! $node instanceof FullyQualified) {
                 return false;
             }
@@ -183,7 +183,7 @@ final class PHPStanNodeScopeResolver
                 return false;
             }
 
-            if ($fileName === $currentFileName) {
+            if ($fileName === $realPath) {
                 return false;
             }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -132,7 +132,7 @@ final class PHPStanNodeScopeResolver
         // avoid crash on class with @mixin @see https://github.com/rectorphp/rector-src/pull/688
         if (! Strings::match($contents, self::MIXIN_REGEX)) {
             // avoid crash on class with @mixin in source @see https://github.com/rectorphp/rector-src/pull/689
-            if ($this->isMixinInSource($nodes)) {
+            if ($this->isMixinInSource($nodes, $smartFileInfo)) {
                 return $nodes;
             }
 
@@ -147,9 +147,10 @@ final class PHPStanNodeScopeResolver
     /**
      * @param Node[] $nodes
      */
-    private function isMixinInSource(array $nodes): bool
+    private function isMixinInSource(array $nodes, SmartFileInfo $smartFileInfo): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node): bool {
+        $currentFileName = $smartFileInfo->getRealPath();
+        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($currentFileName): bool {
             if (! $node instanceof FullyQualified) {
                 return false;
             }
@@ -179,6 +180,10 @@ final class PHPStanNodeScopeResolver
 
             $fileName = $classReflection->getFileName();
             if ($fileName === false) {
+                return false;
+            }
+
+            if ($fileName === $currentFileName) {
                 return false;
             }
 

--- a/rules/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector.php
+++ b/rules/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector.php
@@ -45,6 +45,11 @@ final class ManualJsonStringToJsonEncodeArrayRector extends AbstractRector
      */
     private const JSON_STRING_REGEX = '#{(.*?\:.*?)}#s';
 
+    /**
+     * @var string
+     */
+    private const JSON_DATA = 'jsonData';
+
     public function __construct(
         private ConcatJoiner $concatJoiner,
         private ConcatManipulator $concatManipulator,
@@ -109,7 +114,7 @@ CODE_SAMPLE
                 $jsonArray = $this->jsonArrayFactory->createFromJsonString($stringValue);
                 $jsonEncodeAssign = $this->createJsonEncodeAssign($node->var, $jsonArray);
 
-                $jsonDataVariable = new Variable('jsonData');
+                $jsonDataVariable = new Variable(self::JSON_DATA);
                 $jsonDataAssign = new Assign($jsonDataVariable, $jsonArray);
 
                 $this->addNodeBeforeNode($jsonDataAssign, $node);
@@ -234,7 +239,7 @@ CODE_SAMPLE
         $this->removeNodes($nodesToRemove);
 
         $jsonArray = $this->jsonArrayFactory->createFromJsonStringAndPlaceholders($stringValue, $placeholderNodes);
-        $jsonDataVariable = new Variable('jsonData');
+        $jsonDataVariable = new Variable(self::JSON_DATA);
         $jsonDataAssign = new Assign($jsonDataVariable, $jsonArray);
 
         $this->addNodeBeforeNode($jsonDataAssign, $assign);
@@ -305,7 +310,7 @@ CODE_SAMPLE
         }
 
         $jsonDataAssign = new Assign($assignExpr, $jsonArray);
-        $jsonDataVariable = new Variable('jsonData');
+        $jsonDataVariable = new Variable(self::JSON_DATA);
         $jsonDataAssign->expr = $this->nodeFactory->createFuncCall('json_encode', [$jsonDataVariable]);
 
         return $jsonDataAssign;


### PR DESCRIPTION
Same file name with current file name already checked in previous `Strings::match($contents, self::MIXIN_REGEX)` of current content file.