### PR TITLE
[Defluent] Ensure parent is a node on NewFluentChainMethodCallToNonFluentRector before check $this->typeChecker->isInstanceOf()

### DIFF
--- a/rules/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector.php
+++ b/rules/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector.php
@@ -74,6 +74,12 @@ CODE_SAMPLE
     {
         // handled by another rule
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+
+        // may happen if another rule make parent null
+        if (! $parent instanceof Node) {
+            return null;
+        }
+
         if ($this->typeChecker->isInstanceOf($parent, [Return_::class, Arg::class])) {
             return null;
         }


### PR DESCRIPTION
The `$this->typeChecker->isInstanceOf()` is need the first parameter to be a node, while `$node->getAttribute(AttributeKey::PARENT_NODE)` may not be a node. 

For MethodCall, Parent node can be null if parent node is removed by another rector rule.