### PR TITLE
[DeadCode] Skip RemoveParentCallWithoutParentRector on inside assign

### DIFF
--- a/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_with_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_with_assign.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Fixture;
+
+class SkipWithAssign
+{
+    public function run()
+    {
+        $result = parent::run();
+
+        return $result;
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
 use Rector\Core\Rector\AbstractRector;
@@ -102,6 +103,11 @@ CODE_SAMPLE
 
         $calledMethodName = $this->getName($node->name);
         if ($this->classMethodManipulator->hasParentMethodOrInterfaceMethod($classMethod, $calledMethodName)) {
+            return null;
+        }
+
+        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parent instanceof Expression) {
             return null;
         }
 


### PR DESCRIPTION
To avoid error : 

```bash
  Node "PhpParser\Node\Expr\StaticCall" on line 662 is child of "PhpParser\Node\Expr\Assign", so it cannot be removed as it would break PHP code. Change or remove the parent node instead.  
```