### PR TITLE
[Exclusion] Check Parent attribute is Node on ExclusionManager::isNodeSkippedByRector()

### DIFF
--- a/src/Exclusion/ExclusionManager.php
+++ b/src/Exclusion/ExclusionManager.php
@@ -37,6 +37,9 @@ final class ExclusionManager
     {
         if ($node instanceof PropertyProperty || $node instanceof Const_) {
             $node = $node->getAttribute(AttributeKey::PARENT_NODE);
+            if (! $node instanceof Node) {
+                return false;
+            }
         }
 
         if ($this->hasNoRectorPhpDocTagMatch($node, $phpRector)) {


### PR DESCRIPTION
The parent of node can be removed by other rules for multi rules running. To avoid error:

```bash
"Rector\Core\Exclusion\ExclusionManager::hasNoRectorPhpDocTagMatch(): Argument #1 ($node) must be of type      
         PhpParser\Node, null given
```

check parent attribute is null is needed.