### PR TITLE
[Transform] Handle Multi Assign on NewToConstructorInjectionRector

### DIFF
--- a/rules-tests/Transform/Rector/New_/NewToConstructorInjectionRector/Fixture/multi_assign.php.inc
+++ b/rules-tests/Transform/Rector/New_/NewToConstructorInjectionRector/Fixture/multi_assign.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\New_\NewToConstructorInjectionRector\Fixture;
+
+use Rector\Tests\Transform\Rector\New_\NewToConstructorInjectionRector\Source\DummyValidator;
+
+class MultiAssign
+{
+    public function run()
+    {
+        $dummyValidator = $temp =  new DummyValidator();
+        $dummyValidator->validate(100000);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\New_\NewToConstructorInjectionRector\Fixture;
+
+use Rector\Tests\Transform\Rector\New_\NewToConstructorInjectionRector\Source\DummyValidator;
+
+class MultiAssign
+{
+    public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToConstructorInjectionRector\Source\DummyValidator $dummyValidator)
+    {
+    }
+    public function run()
+    {
+        $this->dummyValidator->validate(100000);
+    }
+}
+
+?>

--- a/rules/Transform/Rector/New_/NewToConstructorInjectionRector.php
+++ b/rules/Transform/Rector/New_/NewToConstructorInjectionRector.php
@@ -15,6 +15,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\Naming\PropertyNaming;
 use Rector\Naming\ValueObject\ExpectedName;
+use Rector\NodeRemoval\AssignRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Collector\PropertyToAddCollector;
 use Rector\PostRector\ValueObject\PropertyMetadata;
@@ -40,7 +41,8 @@ final class NewToConstructorInjectionRector extends AbstractRector implements Co
     public function __construct(
         private PropertyFetchFactory $propertyFetchFactory,
         private PropertyNaming $propertyNaming,
-        private PropertyToAddCollector $propertyToAddCollector
+        private PropertyToAddCollector $propertyToAddCollector,
+        private AssignRemover $assignRemover
     ) {
     }
 
@@ -158,7 +160,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $this->removeNode($assign);
+            $this->assignRemover->removeAssignNode($assign);
         }
     }
 


### PR DESCRIPTION
Given the following code:

```php
$dummyValidator = $temp =  new DummyValidator();
```

It currently got error:

```bash
1) Rector\Tests\Transform\Rector\New_\NewToConstructorInjectionRector\NewToConstructorInjectionRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Node "PhpParser\Node\Expr\Assign" on line 11 is child of "PhpParser\Node\Expr\Assign", so it cannot be removed as it would break PHP code. Change or remove the parent node instead.
```

Using `AssignRemover` service fix it.