### PR TITLE
[DowngradePhp74] Skip php doc method on DowngradeContravariantArgumentTypeRector

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/phpdoc_method.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/phpdoc_method.php.inc
@@ -2,12 +2,7 @@
 
 namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector;
 
-/**
- * @method InterfaceWithPhpdocMethod someMethod(string|null $param)
- */
-interface InterfaceWithPhpdocMethod
-{
-}
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector\Source\InterfaceWithPhpdocMethod;
 
 class ContextImpl implements InterfaceWithPhpdocMethod
 {
@@ -23,12 +18,7 @@ class ContextImpl implements InterfaceWithPhpdocMethod
 
 namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector;
 
-/**
- * @method InterfaceWithPhpdocMethod someMethod(string|null $param)
- */
-interface InterfaceWithPhpdocMethod
-{
-}
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector\Source\InterfaceWithPhpdocMethod;
 
 class ContextImpl implements InterfaceWithPhpdocMethod
 {

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/phpdoc_method.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/phpdoc_method.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector;
+
+/**
+ * @method InterfaceWithPhpdocMethod someMethod(string|null $param)
+ */
+interface InterfaceWithPhpdocMethod
+{
+}
+
+class ContextImpl implements InterfaceWithPhpdocMethod
+{
+    public function someMethod(?string $param): self
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector;
+
+/**
+ * @method InterfaceWithPhpdocMethod someMethod(string|null $param)
+ */
+interface InterfaceWithPhpdocMethod
+{
+}
+
+class ContextImpl implements InterfaceWithPhpdocMethod
+{
+    public function someMethod(?string $param): self
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/skip_phpdoc_method.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/skip_phpdoc_method.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantA
 
 use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector\Source\InterfaceWithPhpdocMethod;
 
-class ContextImpl implements InterfaceWithPhpdocMethod
+class SkipPhpdocMethod implements InterfaceWithPhpdocMethod
 {
     public function someMethod(?string $param): self
     {
@@ -20,7 +20,7 @@ namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantA
 
 use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector\Source\InterfaceWithPhpdocMethod;
 
-class ContextImpl implements InterfaceWithPhpdocMethod
+class SkipPhpdocMethod implements InterfaceWithPhpdocMethod
 {
     public function someMethod(?string $param): self
     {

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/skip_phpdoc_method.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/skip_phpdoc_method.php.inc
@@ -13,19 +13,3 @@ class SkipPhpdocMethod implements InterfaceWithPhpdocMethod
 }
 
 ?>
------
-<?php
-
-namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector;
-
-use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector\Source\InterfaceWithPhpdocMethod;
-
-class SkipPhpdocMethod implements InterfaceWithPhpdocMethod
-{
-    public function someMethod(?string $param): self
-    {
-        return $this;
-    }
-}
-
-?>

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Source/InterfaceWithPhpdocMethod.php
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Source/InterfaceWithPhpdocMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector\Source;
+
+/**
+ * @method InterfaceWithPhpdocMethod someMethod(string|null $param)
+ */
+interface InterfaceWithPhpdocMethod
+{
+}

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
@@ -172,7 +172,7 @@ CODE_SAMPLE
         $parentClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
 
         foreach ($parentClassReflections as $parentClassReflection) {
-            $parentReflectionMethod = $this->resolveReflectionMethod($parentClassReflection, $methodName);
+            $parentReflectionMethod = $this->resolveParentReflectionMethod($parentClassReflection, $methodName);
 
             if (! $parentReflectionMethod instanceof ReflectionMethod) {
                 continue;
@@ -192,7 +192,10 @@ CODE_SAMPLE
         return null;
     }
 
-    private function resolveReflectionMethod(ClassReflection $classReflection, string $methodName): ?ReflectionMethod
+    private function resolveParentReflectionMethod(
+        ClassReflection $classReflection,
+        string $methodName
+    ): ?ReflectionMethod
     {
         if (! $classReflection->hasMethod($methodName)) {
             return null;

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
@@ -178,6 +178,10 @@ CODE_SAMPLE
 
             $nativeClassReflection = $parentClassReflection->getNativeReflection();
 
+            if (! $nativeClassReflection->hasMethod($methodName)) {
+                continue;
+            }
+
             // Find the param we're looking for
             $parentReflectionMethod = $nativeClassReflection->getMethod($methodName);
 

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
@@ -172,18 +172,11 @@ CODE_SAMPLE
         $parentClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
 
         foreach ($parentClassReflections as $parentClassReflection) {
-            if (! $parentClassReflection->hasMethod($methodName)) {
+            $parentReflectionMethod = $this->resolveReflectionMethod($parentClassReflection, $methodName);
+
+            if (! $parentReflectionMethod instanceof ReflectionMethod) {
                 continue;
             }
-
-            $nativeClassReflection = $parentClassReflection->getNativeReflection();
-
-            if (! $nativeClassReflection->hasMethod($methodName)) {
-                continue;
-            }
-
-            // Find the param we're looking for
-            $parentReflectionMethod = $nativeClassReflection->getMethod($methodName);
 
             $differentAncestorParamTypeName = $this->getDifferentParamTypeFromReflectionMethod(
                 $parentReflectionMethod,
@@ -197,6 +190,22 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function resolveReflectionMethod(ClassReflection $classReflection, string $methodName): ?ReflectionMethod
+    {
+        if (! $classReflection->hasMethod($methodName)) {
+            return null;
+        }
+
+        $reflectionClass = $classReflection->getNativeReflection();
+
+        if (! $reflectionClass->hasMethod($methodName)) {
+            return null;
+        }
+
+        // Find the param we're looking for
+        return $reflectionClass->getMethod($methodName);
     }
 
     private function getDifferentParamTypeFromReflectionMethod(


### PR DESCRIPTION
Close #718 Fixes https://github.com/rectorphp/rector/issues/6651