### PR TITLE
DowngradeStaticTypeDeclarationRector removes self return type

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/ClassMethod/DowngradeStaticTypeDeclarationRector/Fixture/self.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/ClassMethod/DowngradeStaticTypeDeclarationRector/Fixture/self.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp80\Rector\ClassMethod\DowngradeStaticTypeDeclarationRector\Fixture;
+
+final class Foo
+{
+    public function run(): self
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
DowngradeStaticTypeDeclarationRector removes `self` from the return type of methods even though this is valid in PHP 7.4. It should only remove `static`.