### PR TITLE
Bump branch-alias from 0.10 to 0.11

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -16,7 +16,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.10-dev"
+            "dev-main": "0.11-dev"
         }
     },
     "conflict": {


### PR DESCRIPTION
Keep the branch-alias of `rector/rector` the same as `rector/rector-src`