### PR TITLE
Partial imports not recognized

### DIFF
--- a/tests/Issues/IssuePartialImports/Fixture/fixture.php.inc
+++ b/tests/Issues/IssuePartialImports/Fixture/fixture.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssuePartialImports\Fixture;
+
+use Rector\Core\Tests\Issues\IssuePartialImports\Source;
+
+final class AnotherClass
+{
+    public function run(Source\SomeClass $foo)
+    {
+    }
+}
+
+?>

--- a/tests/Issues/IssuePartialImports/PartialImportsTest.php
+++ b/tests/Issues/IssuePartialImports/PartialImportsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssuePartialImports;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class PartialImportsTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssuePartialImports/Source/SomeClass.php
+++ b/tests/Issues/IssuePartialImports/Source/SomeClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssuePartialImports\Source;
+
+final class SomeClass
+{
+}

--- a/tests/Issues/IssuePartialImports/config/configured_rule.php
+++ b/tests/Issues/IssuePartialImports/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+};


### PR DESCRIPTION
If I import a parent namespace like:

``` php
use Some\Namespace;
```

Then refer to it in code like:

``` php
$a = new Namespace\Foo();
```

If auto_import_names is enabled, it imports `Some\Namespace\Foo` but also leaves `Some\Namespace`.

IMO it should just leave `Some\Namespace`, or at least have it configurable. It doesn't matter to me, but the current behavior seems obviously incorrect.

See included test.

Probably related to #631 / #634.