### PR TITLE
[CodingStyle] Skip RemoveUnusedAliasRector when same class in use statement exists, but not used

### DIFF
--- a/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/skip_same_class_in_use_statement_not_used.php.inc
+++ b/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/skip_same_class_in_use_statement_not_used.php.inc
@@ -5,15 +5,10 @@ namespace Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Fixture;
 use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\StandaloneClass;
 use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\DifferentNamespace\StandaloneClass as StandaloneClassDifferentNamespace;
 
-class SkipUsedByReturnMethodCall
+class SkipSameClassInUseStatementNotUsed
 {
-    private function getObj()
-    {
-        return new StandaloneClassDifferentNamespace();
-    }
-
     public function run()
     {
-        return $this->getObj();
+        return new StandaloneClassDifferentNamespace();
     }
 }

--- a/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/skip_used_by_return_method_call.php.inc
+++ b/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/skip_used_by_return_method_call.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\StandaloneClass;
+use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\DifferentNamespace\StandaloneClass as StandaloneClassDifferentNamespace;
+
+class SkipUsedByReturnMethodCall
+{
+    private function getObj()
+    {
+        if (rand(0, 1)) {
+            return new StandaloneClassDifferentNamespace();
+        }
+
+        return null;
+    }
+
+    public function run()
+    {
+        $obj = $this->getObj();
+
+        if (! $obj instanceof StandaloneClassDifferentNamespace) {
+            return null;
+        }
+
+        return $obj;
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/skip_used_by_return_method_call.php.inc
+++ b/rules-tests/CodingStyle/Rector/Use_/RemoveUnusedAliasRector/Fixture/skip_used_by_return_method_call.php.inc
@@ -9,21 +9,11 @@ class SkipUsedByReturnMethodCall
 {
     private function getObj()
     {
-        if (rand(0, 1)) {
-            return new StandaloneClassDifferentNamespace();
-        }
-
-        return null;
+        return new StandaloneClassDifferentNamespace();
     }
 
     public function run()
     {
-        $obj = $this->getObj();
-
-        if (! $obj instanceof StandaloneClassDifferentNamespace) {
-            return null;
-        }
-
-        return $obj;
+        return $this->getObj();
     }
 }

--- a/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
@@ -115,8 +115,10 @@ CODE_SAMPLE
             return true;
         }
 
-        /** @var Scope $scope */
         $scope = $foreach->expr->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return true;
+        }
 
         $type = $scope->getType($foreach->expr);
 

--- a/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
@@ -118,18 +118,16 @@ CODE_SAMPLE
         /** @var Scope $scope */
         $scope = $foreach->expr->getAttribute(AttributeKey::SCOPE);
 
-        if (! $scope instanceof Scope) {
-            return false;
-        }
-
         $type = $scope->getType($foreach->expr);
 
         if ($type instanceof ObjectType) {
-            return $type->isIterable()->yes();
+            return $type->isIterable()
+                ->yes();
         }
 
         if ($type instanceof ThisType) {
-            return $type->isIterable()->yes();
+            return $type->isIterable()
+                ->yes();
         }
 
         return false;

--- a/rules/CodingStyle/Rector/Use_/RemoveUnusedAliasRector.php
+++ b/rules/CodingStyle/Rector/Use_/RemoveUnusedAliasRector.php
@@ -210,18 +210,6 @@ CODE_SAMPLE
 
     private function refactorAliasName(Use_ $use, string $aliasName, string $lastName, UseUse $useUse): void
     {
-        // only alias name is used → use last name directly
-        $lowerAliasName = strtolower($aliasName);
-        if (! isset($this->resolvedNodeNames[$lowerAliasName])) {
-            return;
-        }
-
-        // keep to differentiate 2 aliases classes
-        $lowerLastName = strtolower($lastName);
-        if (count($this->useNamesAliasToName[$lowerLastName] ?? []) > 1) {
-            return;
-        }
-
         $parentUse = $use->getAttribute(AttributeKey::PARENT_NODE);
         if (! $parentUse instanceof Node) {
             return;
@@ -240,6 +228,7 @@ CODE_SAMPLE
             return;
         }
 
+        $lowerAliasName = strtolower($aliasName);
         $this->nameRenamer->renameNameNode($this->resolvedNodeNames[$lowerAliasName], $lastName);
         $useUse->alias = null;
     }


### PR DESCRIPTION
Given the folowing code:

```php
use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\StandaloneClass;
use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\DifferentNamespace\StandaloneClass as StandaloneClassDifferentNamespace;

class SkipSameClassInUseStatementNotUsed
{
    public function run()
    {
        return new StandaloneClassDifferentNamespace();
    }
}
```

When the same class defined in the use statement, it got result:

```diff
 use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\StandaloneClass;
-use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\DifferentNamespace\StandaloneClass as StandaloneClassDifferentNamespace;
+use Rector\Tests\CodingStyle\Rector\Use_\RemoveUnusedAliasRector\Source\DifferentNamespace\StandaloneClass;
 
 class SkipSameClassInUseStatementNotUsed
 {
     public function run()
     {
-        return new StandaloneClassDifferentNamespace();
+        return new StandaloneClass();
```

which make duplicating same class name in use statement.