### PR TITLE
[Privatization][Php71] Handle CountOnNullRector + ChangeReadOnlyVariableWithDefaultValueToConstantRector usage on exactly array

### DIFF
--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\MixedType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\NodeManipulator\ClassInsertManipulator;
 use Rector\Core\Rector\AbstractRector;
@@ -220,7 +221,7 @@ CODE_SAMPLE
     {
         $constructor = $param->getAttribute(AttributeKey::METHOD_NODE);
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($constructor);
-        if ($phpDocInfo === null) {
+        if (! $phpDocInfo instanceof PhpDocInfo) {
             return;
         }
 

--- a/rules/Php71/Rector/FuncCall/CountOnNullRector.php
+++ b/rules/Php71/Rector/FuncCall/CountOnNullRector.php
@@ -82,10 +82,6 @@ CODE_SAMPLE
         }
 
         $countedNode = $node->args[0]->value;
-        if ($countedNode instanceof ClassConstFetch) {
-            return null;
-        }
-
         if ($this->countableTypeAnalyzer->isCountableType($countedNode)) {
             return null;
         }
@@ -134,6 +130,10 @@ CODE_SAMPLE
     private function shouldSkip(FuncCall $funcCall): bool
     {
         if (! $this->isName($funcCall, 'count')) {
+            return true;
+        }
+
+        if ($funcCall->args[0]->value instanceof ClassConstFetch) {
             return true;
         }
 

--- a/rules/Php71/Rector/FuncCall/CountOnNullRector.php
+++ b/rules/Php71/Rector/FuncCall/CountOnNullRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\Cast\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\Ternary;
@@ -81,6 +82,10 @@ CODE_SAMPLE
         }
 
         $countedNode = $node->args[0]->value;
+        if ($countedNode instanceof ClassConstFetch) {
+            return null;
+        }
+
         if ($this->countableTypeAnalyzer->isCountableType($countedNode)) {
             return null;
         }

--- a/tests/Issues/CountOnNullExactlyArray/CountOnNullExactlyArrayTest.php
+++ b/tests/Issues/CountOnNullExactlyArray/CountOnNullExactlyArrayTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\CountOnNullExactlyArray;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class CountOnNullExactlyArrayTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/CountOnNullExactlyArray/Fixture/fixture.php.inc
+++ b/tests/Issues/CountOnNullExactlyArray/Fixture/fixture.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\CountOnNullExactlyArray\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $array = [];
+        if (count($array) > 0) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\CountOnNullExactlyArray\Fixture;
+
+final class Fixture
+{
+    /**
+     * @var mixed[]
+     */
+    private const ARRAY = [];
+    public function run()
+    {
+        if (count(self::ARRAY) > 0) {
+        }
+    }
+}
+
+?>

--- a/tests/Issues/CountOnNullExactlyArray/config/configured_rule.php
+++ b/tests/Issues/CountOnNullExactlyArray/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Php71\Rector\FuncCall\CountOnNullRector;
+use Rector\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ChangeReadOnlyVariableWithDefaultValueToConstantRector::class);
+    $services->set(CountOnNullRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
    public function run()
    {
        $array = [];
        if (count($array) > 0) {
        }
    }
```

Got the following result:

```diff
+    private const ARRAY = [];
     public function run()
     {
-        if (count(self::ARRAY) > 0) {
+        if ((is_countable(self::ARRAY) ? count(self::ARRAY) : 0) > 0) {
         }
```

which invalid as it is exactly an array for applied rules:

```php
use Rector\Php71\Rector\FuncCall\CountOnNullRector;
use Rector\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector;
```