### PR TITLE
fix(scoper): prefix vendor classes from PHPDoc, close #6614

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -122,6 +122,13 @@ return [
             'PHPUnit\Framework\Constraint\IsEqual'
         ),
 
+        // prefix vendor classes in phpdoc
+        fn (string $filePath, string $prefix, string $content): string => Strings::replace(
+            $content,
+            '#@(var|param) (\\\\(?!Rector)(?:[^ ]+))#',
+            '@$1 \\\\' . $prefix . '$2'
+        ),
+
         // unprefixed ContainerConfigurator
         function (string $filePath, string $prefix, string $content): string {
             // keep vendor prefixed the prefixed file loading; not part of public API


### PR DESCRIPTION
The fix is far to be perfect, but it still has the merit to replace:
```php
    /**
     * @var \Symplify\Astral\NodeTraverser\SimpleCallableNodeTraverser
     */
    private $foo;
    /**
     * @var \Symfony\Component\Console\Style\SymfonyStyle
     */
	private $bar;
    /**
     * @param \Symfony\Component\Console\Style\SymfonyStyle $a 
     */
     public function myMethod($a) {}
```
to
```php
    /**
     * @var \RectorPrefix20210823\Symplify\Astral\NodeTraverser\SimpleCallableNodeTraverser
     */
    private $foo;
    /**
     * @var \RectorPrefix20210823\Symfony\Component\Console\Style\SymfonyStyle
     */
	private $bar;
    /**
     * @param \RectorPrefix20210823\Symfony\Component\Console\Style\SymfonyStyle $a 
     */
     public function myMethod($a) {}
```

However, it does not work with unions types. 


Fixes https://github.com/rectorphp/rector/issues/6614