### PR TITLE
Revert "fix(scoper): prefix vendor classes from PHPDoc

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -122,13 +122,6 @@ return [
             'PHPUnit\Framework\Constraint\IsEqual'
         ),
 
-        // prefix vendor classes in phpdoc
-        fn (string $filePath, string $prefix, string $content): string => Strings::replace(
-            $content,
-            '#@(var|param) (\\\\(?!Rector)(?:[^ ]+))#',
-            '@$1 \\\\' . $prefix . '$2'
-        ),
-
         // unprefixed ContainerConfigurator
         function (string $filePath, string $prefix, string $content): string {
             // keep vendor prefixed the prefixed file loading; not part of public API


### PR DESCRIPTION
Revert https://github.com/rectorphp/rector-src/pull/739 as has false positives, ref https://github.com/rectorphp/rector-src/pull/739#issuecomment-903349730

This reverts commit 877cbb2de8150b672a966d7a8907ed63769e1cdd.