### PR TITLE
Add failing test fixture for ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/y.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/y.php.inc
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Y {}
+class Z {}
+
+final class X
+{
+	public Y $y;
+
+	/**
+	 * @var Z[]
+	 *
+	 * @Assert\Valid()
+	 * @Assert\NotBlank()
+	 */
+	public array $z = [];
+
+	/**
+	 * @param Z[] $z
+	 */
+	public function __construct(Y $y, array $z = [])
+	{
+		$this->y = $y;
+		$this->z = $z;
+	}
+}
+?>
+-----
+<?php
+
+// Not sure what's correct. I don't know if promoted properties can have a docblock with annotations. But it certainly shouldn't just delete my annotations.

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/y.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/y.php.inc
@@ -30,6 +30,27 @@ final class X
 }
 ?>
 -----
-<?php
+<?php declare(strict_types = 1);
 
-// Not sure what's correct. I don't know if promoted properties can have a docblock with annotations. But it certainly shouldn't just delete my annotations.
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Y {}
+class Z {}
+
+final class X
+{
+	public function __construct(
+		public Y $y,
+		/**
+		 * @var Z[]
+		 *
+		 * @Assert\Valid()
+		 * @Assert\NotBlank()
+		 */
+		public array $z = []
+	) {
+	}
+}
+?>


### PR DESCRIPTION
# Failing Test for ClassPropertyAssignToConstructorPromotionRector

Based on https://getrector.org/demo/1ec03dbd-591c-689e-b45c-6563b6259c57

Disregard the demo, it doesn't reflect the current behavior of dev-main rector. I'm showing the behavior of latest dev rector below instead. It's correct that the property is promoted but my Doctrine annotations shouldn't be deleted.

Note: I can't use attributes yet because sometimes I'm using nested annotations with `Assert\All(...)` in these cases.

![Screenshot from 2021-08-23 08-37-39](https://user-images.githubusercontent.com/539462/130401776-bacb3086-7634-49a2-93f5-66607691d2b1.png)
