### PR TITLE
Add failing test fixture for ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/generic.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/generic.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+/**
+ * @template T
+ */
+final class Generic
+{
+	/**
+	 * @var T
+	 */
+	public mixed $value;
+
+	/**
+	 * @param T $value
+	 */
+	public function __construct(mixed $value) {
+		$this->value = $value;
+	}
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+/**
+ * @template T
+ */
+final class Generic
+{
+	/**
+	 * @param T $value
+	 */
+	public function __construct(public mixed $value) {
+	}
+}
+?>


### PR DESCRIPTION
# Failing Test for ClassPropertyAssignToConstructorPromotionRector

Based on https://getrector.org/demo/1ec04a84-bde1-6cb0-a397-d7c0f606a738