### PR TITLE
AddDefaultValueForUndefinedVariableRector adds variable definition to embedded HTML

### DIFF
--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/with_embedded_html.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/with_embedded_html.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+final class Foo
+{
+    public function run(): void
+    {
+        ?>
+        <p>Let's insert stuff here.</p>
+        <?php
+        if (random_int(1, 10) === 5) {
+            $a = true;
+        }
+
+        if (isset($a)) {
+            doStuff();
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+final class Foo
+{
+    public function run(): void
+    {
+        $a = null;
+        ?>
+        <p>Let's insert stuff here.</p>
+        <?php
+        if (random_int(1, 10) === 5) {
+            $a = true;
+        }
+
+        if (isset($a)) {
+            doStuff();
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
This is a failing test that shows that `AddDefaultValueForUndefinedVariableRector` adds variable definition to embedded HTML. This is obviously a problem and won't actually define the variable.