### PR TITLE
[TypeDeclaration] Skip ParamTypeDeclarationRector on NullType

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/skip_null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/skip_null.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector\Fixture;
+
+class SkipNull
+{
+    /**
+     * @param null $value
+     */
+    public function someFunction($value)
+    {
+    }
+}

--- a/rules/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Interface_;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DeadCode\PhpDoc\TagRemover\ParamTagRemover;
@@ -144,6 +145,10 @@ CODE_SAMPLE
 
         $inferedType = $this->paramTypeInferer->inferParam($param);
         if ($inferedType instanceof MixedType) {
+            return;
+        }
+
+        if ($inferedType instanceof NullType) {
             return;
         }
 


### PR DESCRIPTION
'null' cannot be used as standalone types