### PR TITLE
Fix wrong docs for ArgumentRemoverRector

### DIFF
--- a/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
+++ b/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
@@ -48,7 +48,7 @@ $someObject->someMethod();
 CODE_SAMPLE
                     ,
                     [
-                        self::REMOVED_ARGUMENTS => [new ArgumentRemover('ExampleClass', 'someMethod', 0, 'true')],
+                        self::REMOVED_ARGUMENTS => [new ArgumentRemover('ExampleClass', 'someMethod', 0, [true])],
                     ]
                 ),
             ]


### PR DESCRIPTION
The value to remove has to be enclosed as array.
The value also has to match the type. The example has a boolean `true`.
The example rule now matches that to prevent confusion.

Resolves: https://github.com/rectorphp/rector/issues/6657