### PR TITLE
NarrowUnionTypeDocRector should skip literal strings

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
+++ b/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\PHPStanStaticTypeMapper\TypeAnalyzer;
 
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
@@ -102,7 +103,7 @@ final class UnionTypeAnalyzer
         }
 
         foreach ($types as $type) {
-            if ($type instanceof StringType) {
+            if ($type instanceof StringType && !$type instanceof ConstantStringType) {
                 continue;
             }
             if ($type instanceof FloatType) {

--- a/rules-tests/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector/Fixture/skip_constant_union.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector/Fixture/skip_constant_union.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\NarrowUnionTypeDocRector\Fixture;
+
+class SkipConstantUnion
+{
+    public const A = 'a';
+    public const B = 'b';
+    public const C = 'c';
+    public const D = 'd';
+
+    /**
+     * @param self::* $value
+     */
+    public function run(string $value): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector/Fixture/skip_literal_union.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector/Fixture/skip_literal_union.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\NarrowUnionTypeDocRector\Fixture;
+
+class SkipLiteralUnion
+{
+    /**
+     * @param 'a'|'b'|'c'|'d' $value
+     */
+    public function run(string $value): void
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
The definition of scalar is too loose, in `UnionTypeAnalyzer`. It should not include literal constant strings.