### PR TITLE
[CS] Cs Fix config Skip AssignmentInConditionSniff FoundInWhileCondition

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff;
 use PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
@@ -95,6 +96,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/packages-tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/StaticDoctrineAnnotationParserTest.php',
             '*TypeResolverTest.php',
         ],
+
+        AssignmentInConditionSniff::class . '.FoundInWhileCondition' => null,
     ]);
 
     $parameters->set(Option::LINE_ENDING, "\n");


### PR DESCRIPTION
Currently, the weekly cs fix github action got error:

```bash
------------------------------------------------------------------------
 packages/NodeNestingScope/FlowOfControlLocator.php:21
 ------------------------------------------------------------------------
 Variable assignment found within a condition. Did you mean to do a
comparison ?
 Reported by: "FoundInWhileCondition"
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 packages/NodeNestingScope/ParentFinder.php:37
 ------------------------------------------------------------------------
 Variable assignment found within a condition. Did you mean to do a
comparison ?
 Reported by: "FoundInWhileCondition"
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 rules/CodeQuality/Rector/Return_/SimplifyUselessVariableRector.php:111
 ------------------------------------------------------------------------
 Variable assignment found within a condition. Did you mean to do a
comparison ?
 Reported by: "FoundInWhileCondition"
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 rules/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector.php:188
 ------------------------------------------------------------------------
 Variable assignment found within a condition. Did you mean to do a
comparison ?
 Reported by: "FoundInWhileCondition"
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 rules/Php70/Rector/FuncCall/MultiDirnameRector.php:59
 ------------------------------------------------------------------------
 Variable assignment found within a condition. Did you mean to do a
comparison ?
 Reported by: "FoundInWhileCondition"
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 src/Application/FileProcessor.php:43
 ------------------------------------------------------------------------
 Variable assignment found within a condition. Did you mean to do a
comparison ?
 Reported by: "FoundInWhileCondition"
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 src/PhpParser/Node/BetterNodeFinder.php:66
 ------------------------------------------------------------------------
 Variable assignment found within a condition. Did you mean to do a
comparison ?
 Reported by: "FoundInWhileCondition"
 ------------------------------------------------------------------------
 [ERROR] Found 7 errors that need to be fixed manually.                         
```

which need to be skipped in the `ecs.php` config.