### PR TITLE
[DowngradePhp71] Using exact same type on PhpDocFromTypeDeclarationDecorator

### DIFF
--- a/rules/DowngradePhp71/TypeDeclaration/PhpDocFromTypeDeclarationDecorator.php
+++ b/rules/DowngradePhp71/TypeDeclaration/PhpDocFromTypeDeclarationDecorator.php
@@ -71,7 +71,7 @@ final class PhpDocFromTypeDeclarationDecorator
             return;
         }
 
-        if (! $this->isTypeMatchOrSubType($param->type, $requireType)) {
+        if (! $this->isTypeMatch($param->type, $requireType)) {
             return;
         }
 
@@ -90,7 +90,7 @@ final class PhpDocFromTypeDeclarationDecorator
             return false;
         }
 
-        if (! $this->isTypeMatchOrSubType($functionLike->returnType, $requireType)) {
+        if (! $this->isTypeMatch($functionLike->returnType, $requireType)) {
             return false;
         }
 
@@ -98,7 +98,7 @@ final class PhpDocFromTypeDeclarationDecorator
         return true;
     }
 
-    private function isTypeMatchOrSubType(Node $typeNode, Type $requireType): bool
+    private function isTypeMatch(Node $typeNode, Type $requireType): bool
     {
         $returnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($typeNode);
 
@@ -106,7 +106,8 @@ final class PhpDocFromTypeDeclarationDecorator
         if ($returnType instanceof UnionType) {
             $returnType = $this->typeUnwrapper->unwrapNullableType($returnType);
         }
-        return is_a($returnType, $requireType::class, true);
+
+        return $returnType::class === $requireType::class;
     }
 
     private function moveParamTypeToParamDoc(

--- a/rules/DowngradePhp80/Rector/ClassMethod/DowngradeStaticTypeDeclarationRector.php
+++ b/rules/DowngradePhp80/Rector/ClassMethod/DowngradeStaticTypeDeclarationRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\ClassMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -73,10 +72,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($node->returnType instanceof Name && $this->nodeNameResolver->isNames($node->returnType, ['self', 'parent'])) {
-            return null;
-        }
-
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         if ($scope === null) {
             $className = $node->getAttribute(AttributeKey::CLASS_NAME);

--- a/rules/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector.php
+++ b/rules/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector.php
@@ -6,7 +6,6 @@ namespace Rector\DowngradePhp80\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\MixedType;
@@ -70,10 +69,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($node->returnType instanceof Name && $this->nodeNameResolver->isName($node->returnType, 'parent')) {
-            return null;
-        }
-
         $mixedType = new MixedType();
 
         foreach ($node->getParams() as $param) {


### PR DESCRIPTION
The `PhpDocFromTypeDeclarationDecorator ` used in some rules, this same type actual check is to avoid error like in https://github.com/rectorphp/rector-src/pull/765#issuecomment-906302880 