### PR TITLE
[DX] add link to first line of diff

### DIFF
--- a/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -72,6 +72,13 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
         $i = 0;
         foreach ($fileDiffs as $fileDiff) {
             $relativeFilePath = $fileDiff->getRelativeFilePath();
+
+            // append line number for faster file jump in diff
+            $firstLineNumber = $fileDiff->getFirstLineNumber();
+            if ($firstLineNumber !== null) {
+                $relativeFilePath .= ':' . $firstLineNumber;
+            }
+
             $message = sprintf('<options=bold>%d) %s</>', ++$i, $relativeFilePath);
 
             $this->outputStyle->writeln($message);

--- a/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
+++ b/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
@@ -103,7 +103,7 @@ final class UnionTypeAnalyzer
         }
 
         foreach ($types as $type) {
-            if ($type instanceof StringType && !$type instanceof ConstantStringType) {
+            if ($type instanceof StringType && ! $type instanceof ConstantStringType) {
                 continue;
             }
             if ($type instanceof FloatType) {

--- a/rules/DowngradePhp72/NodeAnalyzer/BuiltInMethodAnalyzer.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/BuiltInMethodAnalyzer.php
@@ -11,8 +11,10 @@ use Rector\NodeNameResolver\NodeNameResolver;
 
 final class BuiltInMethodAnalyzer
 {
-    public function __construct(private NodeNameResolver $nodeNameResolver, private ClassChildAnalyzer $classChildAnalyzer)
-    {
+    public function __construct(
+        private NodeNameResolver $nodeNameResolver,
+        private ClassChildAnalyzer $classChildAnalyzer
+    ) {
     }
 
     public function isImplementsBuiltInInterface(ClassReflection $classReflection, ClassMethod $classMethod): bool

--- a/src/ValueObject/Reporting/FileDiff.php
+++ b/src/ValueObject/Reporting/FileDiff.php
@@ -4,12 +4,24 @@ declare(strict_types=1);
 
 namespace Rector\Core\ValueObject\Reporting;
 
+use Nette\Utils\Strings;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class FileDiff
 {
+    /**
+     * @var string
+     * @se https://regex101.com/r/AUPIX4/1
+     */
+    private const FIRST_LINE_REGEX = '#@@(.*?)(?<' . self::FIRST_LINE_KEY . '>\d+)(.*?)@@#';
+
+    /**
+     * @var string
+     */
+    private const FIRST_LINE_KEY = 'first_line';
+
     /**
      * @param RectorWithLineChange[] $rectorWithLineChanges
      */
@@ -60,6 +72,18 @@ final class FileDiff
         }
 
         return $this->sortClasses($rectorClasses);
+    }
+
+    public function getFirstLineNumber(): ?int
+    {
+        $match = Strings::match($this->diff, self::FIRST_LINE_REGEX);
+
+        // probably some error in diff
+        if (! isset($match[self::FIRST_LINE_KEY])) {
+            return null;
+        }
+
+        return (int) $match[self::FIRST_LINE_KEY] - 1;
     }
 
     /**


### PR DESCRIPTION
Diff file links now jump to start of the file. Which is kind of useless if you want to resolve the issue manually.

Let's change that to useful links with line jumps :) 

![Peek 2021-08-26 13-50](https://user-images.githubusercontent.com/924196/130958401-5507031e-fde2-4c79-be64-c13d06bcf1d1.gif)
