### PR TITLE
[DowngradePhp71] Using exact same type on PhpDocFromTypeDeclarationDecorator::isMatchingType()

### DIFF
--- a/rules/DowngradePhp71/TypeDeclaration/PhpDocFromTypeDeclarationDecorator.php
+++ b/rules/DowngradePhp71/TypeDeclaration/PhpDocFromTypeDeclarationDecorator.php
@@ -127,12 +127,6 @@ final class PhpDocFromTypeDeclarationDecorator
      */
     private function isMatchingType(Type $type, array $requiredTypes): bool
     {
-        foreach ($requiredTypes as $requiredType) {
-            if ($type::class === $requiredType) {
-                return true;
-            }
-        }
-
-        return false;
+        return in_array($type::class, $requiredTypes, true);
     }
 }


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/770