### PR TITLE
PreferThisOrSelfMethodCallRector should only convert static methods

### DIFF
--- a/rules-tests/CodingStyle/Rector/MethodCall/PreferThisOrSelfMethodCallRector/Fixture/skip_createMock.php.inc
+++ b/rules-tests/CodingStyle/Rector/MethodCall/PreferThisOrSelfMethodCallRector/Fixture/skip_createMock.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\MethodCall\PreferThisOrSelfMethodCallRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\MethodCall\PreferThisOrSelfMethodCallRector\Source\AbstractTestCase;
+
+class ToSelf extends AbstractTestCase
+{
+    public function run()
+    {
+        $this->createMock(\Foo::class);
+    }
+}
+
+?>


### PR DESCRIPTION
Not quite sure how to fix this one, but `PreferThisOrSelfMethodCallRector` should only convert actual static methods to `self`. `createMock()` is an instance method and should always use `$this`. Same goes for `getMockBuilder`. This behavior is handled properly in php-cs-fixer's `php_unit_test_case_static_method_calls` so I think Rector should do the same for consistency.