### PR TITLE
[CodingStyle] Add NewlineAfterStatementRector

### DIFF
--- a/config/set/coding-style.php
+++ b/config/set/coding-style.php
@@ -25,6 +25,7 @@ use Rector\CodingStyle\Rector\MethodCall\UseMessageVariableForSprintfInSymfonySt
 use Rector\CodingStyle\Rector\Plus\UseIncrementAssignRector;
 use Rector\CodingStyle\Rector\PostInc\PostIncDecToPreIncDecRector;
 use Rector\CodingStyle\Rector\Property\AddFalseDefaultToBoolPropertyRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\CodingStyle\Rector\String_\SplitStringClassConstantToClassConstFetchRector;
 use Rector\CodingStyle\Rector\String_\SymplifyQuoteEscapeRector;
 use Rector\CodingStyle\Rector\Switch_\BinarySwitchToIfElseRector;
@@ -76,4 +77,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RemoveDoubleUnderscoreInMethodNameRector::class);
     $services->set(PostIncDecToPreIncDecRector::class);
     $services->set(UnSpreadOperatorRector::class);
+    $services->set(NewlineAfterStatementRector::class);
 };

--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/PlainValueParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/PlainValueParser.php
@@ -135,12 +135,15 @@ final class PlainValueParser
         if (strtolower($currentTokenValue) === 'true') {
             return new ConstExprTrueNode();
         }
+
         if (! is_numeric($currentTokenValue)) {
             return null;
         }
+
         if ((string) (int) $currentTokenValue !== $currentTokenValue) {
             return null;
         }
+
         return new ConstExprIntegerNode($currentTokenValue);
     }
 }

--- a/packages/BetterPhpDocParser/ValueObject/Type/SpacingAwareCallableTypeNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/Type/SpacingAwareCallableTypeNode.php
@@ -55,12 +55,15 @@ final class SpacingAwareCallableTypeNode extends CallableTypeNode implements Str
         if ($parameterTypeString !== '') {
             return '(' . $parameterTypeString . ')';
         }
+
         if ($returnTypeAsString === 'mixed') {
             return $parameterTypeString;
         }
+
         if ($returnTypeAsString === '') {
             return $parameterTypeString;
         }
+
         return '()';
     }
 
@@ -69,9 +72,11 @@ final class SpacingAwareCallableTypeNode extends CallableTypeNode implements Str
         if ($returnTypeAsString !== 'mixed') {
             return ':' . $returnTypeAsString;
         }
+
         if ($parameterTypeString !== '') {
             return ':' . $returnTypeAsString;
         }
+
         return '';
     }
 }

--- a/packages/ChangesReporting/Collector/AffectedFilesCollector.php
+++ b/packages/ChangesReporting/Collector/AffectedFilesCollector.php
@@ -24,6 +24,7 @@ final class AffectedFilesCollector
         if ($this->affectedFiles !== []) {
             return current($this->affectedFiles);
         }
+
         return null;
     }
 

--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -105,9 +105,11 @@ final class FamilyRelationsAnalyzer
             if ($ancestor->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;
             }
+
             if ($nodes === null) {
                 continue;
             }
+
             if (! $this->isPropertyWritten($nodes, $propertyName, $kindPropertyFetch)) {
                 continue;
             }

--- a/packages/FileFormatter/Formatter/XmlFileFormatter.php
+++ b/packages/FileFormatter/Formatter/XmlFileFormatter.php
@@ -126,9 +126,11 @@ final class XmlFileFormatter implements FileFormatterInterface
         if ($this->isOpeningTag($part)) {
             ++$this->depth;
         }
+
         if ($this->isClosingCdataTag($part)) {
             $this->preserveWhitespace = false;
         }
+
         if ($this->isOpeningCdataTag($part)) {
             $this->preserveWhitespace = true;
         }

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -57,9 +57,11 @@ final class NodeNameResolver
         if ($node instanceof MethodCall) {
             return false;
         }
+
         if ($node instanceof StaticCall) {
             return false;
         }
+
         $nodes = is_array($node) ? $node : [$node];
 
         foreach ($nodes as $node) {
@@ -80,6 +82,7 @@ final class NodeNameResolver
         if ($node instanceof MethodCall) {
             return false;
         }
+
         if ($node instanceof StaticCall) {
             return false;
         }

--- a/packages/NodeNameResolver/NodeNameResolver/ClassConstFetchNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/ClassConstFetchNameResolver.php
@@ -38,6 +38,7 @@ final class ClassConstFetchNameResolver implements NodeNameResolverInterface
         if ($class === null) {
             return null;
         }
+
         if ($name === null) {
             return null;
         }

--- a/packages/NodeNestingScope/ScopeNestingComparator.php
+++ b/packages/NodeNestingScope/ScopeNestingComparator.php
@@ -61,12 +61,15 @@ final class ScopeNestingComparator
         if ($this->isInBothIfElseBranch($foundParent, $expr)) {
             return false;
         }
+
         if (! $foundParent instanceof Else_) {
             return ! $foundParent instanceof FunctionLike;
         }
+
         if (! $this->nodeComparator->areNodesEqual($expr, $this->doubleIfBranchExprs)) {
             return ! $foundParent instanceof FunctionLike;
         }
+
         return false;
     }
 

--- a/packages/NodeRemoval/BreakingRemovalGuard.php
+++ b/packages/NodeRemoval/BreakingRemovalGuard.php
@@ -44,12 +44,15 @@ final class BreakingRemovalGuard
         if ($parent instanceof BooleanNot) {
             $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
         }
+
         if ($parent instanceof Assign) {
             return false;
         }
+
         if ($this->isIfCondition($node)) {
             return false;
         }
+
         return ! $this->isWhileCondition($node);
     }
 

--- a/packages/NodeTypeResolver/NodeTypeCorrector/PregMatchTypeCorrector.php
+++ b/packages/NodeTypeResolver/NodeTypeCorrector/PregMatchTypeCorrector.php
@@ -87,6 +87,7 @@ final class PregMatchTypeCorrector
             if (! $node instanceof Variable) {
                 return false;
             }
+
             return $node->name === $variable->name;
         });
     }

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -498,6 +498,7 @@ final class NodeTypeResolver
         if (! $this->isObjectTypeOfObjectType($renamedObjectType, $requiredObjectType)) {
             return $this->isObjectTypeOfObjectType($resolvedObjectType, $requiredObjectType);
         }
+
         return true;
     }
 }

--- a/packages/NodeTypeResolver/NodeTypeResolver/VariableTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/VariableTypeResolver.php
@@ -115,6 +115,7 @@ final class VariableTypeResolver implements NodeTypeResolverInterface
 
             return $parentNodeScope;
         }
+
         return null;
     }
 }

--- a/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -72,12 +72,15 @@ final class ArrayTypeAnalyzer
             if ($intersectionNodeType instanceof ArrayType) {
                 continue;
             }
+
             if ($intersectionNodeType instanceof HasOffsetType) {
                 continue;
             }
+
             if ($intersectionNodeType instanceof NonEmptyArrayType) {
                 continue;
             }
+
             return false;
         }
 
@@ -98,6 +101,7 @@ final class ArrayTypeAnalyzer
         if ($classLike instanceof Interface_) {
             return false;
         }
+
         if ($classLike === null) {
             return false;
         }
@@ -119,9 +123,11 @@ final class ArrayTypeAnalyzer
         } else {
             $propertyOwnerStaticType = $this->nodeTypeResolver->resolve($node->class);
         }
+
         if ($propertyOwnerStaticType instanceof ThisType) {
             return false;
         }
+
         return $propertyOwnerStaticType instanceof TypeWithClassName;
     }
 }

--- a/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -102,12 +102,15 @@ final class TypeComparator
         if ($firstType instanceof AliasedObjectType && $secondType instanceof ObjectType && $firstType->getFullyQualifiedClass() === $secondType->getClassName()) {
             return true;
         }
+
         if (! $secondType instanceof AliasedObjectType) {
             return false;
         }
+
         if (! $firstType instanceof ObjectType) {
             return false;
         }
+
         return $secondType->getFullyQualifiedClass() === $firstType->getClassName();
     }
 
@@ -119,6 +122,7 @@ final class TypeComparator
         if (! $firstType instanceof ArrayType) {
             return false;
         }
+
         if (! $secondType instanceof ArrayType) {
             return false;
         }

--- a/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
+++ b/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
@@ -106,15 +106,19 @@ final class UnionTypeAnalyzer
             if ($type instanceof StringType && ! $type instanceof ConstantStringType) {
                 continue;
             }
+
             if ($type instanceof FloatType) {
                 continue;
             }
+
             if ($type instanceof IntegerType) {
                 continue;
             }
+
             if ($type instanceof BooleanType) {
                 continue;
             }
+
             return false;
         }
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -142,9 +142,11 @@ final class UnionTypeMapper implements TypeMapperInterface
         if (! $unionTypeAnalysis instanceof UnionTypeAnalysis) {
             return false;
         }
+
         if (! $unionTypeAnalysis->hasIterable()) {
             return false;
         }
+
         return $unionTypeAnalysis->hasArray();
     }
 

--- a/packages/PostRector/Rector/NodeRemovingPostRector.php
+++ b/packages/PostRector/Rector/NodeRemovingPostRector.php
@@ -124,6 +124,7 @@ CODE_SAMPLE
         if (! $mainMethodCall->var instanceof MethodCall) {
             return false;
         }
+
         if ($toBeRemovedMethodCall !== $mainMethodCall->var) {
             return false;
         }

--- a/packages/PostRector/Rector/PropertyAddingPostRector.php
+++ b/packages/PostRector/Rector/PropertyAddingPostRector.php
@@ -38,9 +38,11 @@ final class PropertyAddingPostRector extends AbstractPostRector
         if (! $node instanceof Class_) {
             return null;
         }
+
         if ($this->classAnalyzer->isAnonymousClass($node)) {
             return null;
         }
+
         $this->addConstants($node);
         $this->addProperties($node);
         $this->addPropertiesWithoutConstructor($node);

--- a/packages/Testing/PHPUnit/Behavior/MultipleFilesChangedTrait.php
+++ b/packages/Testing/PHPUnit/Behavior/MultipleFilesChangedTrait.php
@@ -32,6 +32,7 @@ trait MultipleFilesChangedTrait
         if (trim($expectedContent)) {
             $fixtureContent .= $separator . $expectedContent;
         }
+
         FileSystem::write($fixturePath, $fixtureContent);
         $newFileInfo = new SmartFileInfo($fixturePath);
         $this->doTestFileInfo($newFileInfo, $allowMatches);
@@ -55,6 +56,7 @@ trait MultipleFilesChangedTrait
             if ($path === null) {
                 throw new ShouldNotHappenException('Path for additional change must be set');
             }
+
             $fullPath = $this->getFixtureTempDirectory() . '/' . $path;
 
             $input = isset($additionalFileChange[1]) ? trim($additionalFileChange[1]) : null;
@@ -65,6 +67,7 @@ trait MultipleFilesChangedTrait
 
             $expectedFileChanges[$fullPath] = isset($additionalFileChange[2]) ? trim($additionalFileChange[2]) : '';
         }
+
         return $expectedFileChanges;
     }
 

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
@@ -6,6 +6,18 @@ class NoNewLine
 {
     private $property;
     private $property2;
+    public function run(array $data)
+    {
+        if (rand(0, 1)) {
+
+        }
+        echo 'test';
+
+        foreach ($data as $key => $value) {
+            # code...
+        }
+        return true;
+    }
 }
 
 ?>
@@ -19,6 +31,21 @@ class NoNewLine
     private $property;
 
     private $property2;
+
+    public function run(array $data)
+    {
+        if (rand(0, 1)) {
+
+        }
+
+        echo 'test';
+
+        foreach ($data as $key => $value) {
+            # code...
+        }
+
+        return true;
+    }
 }
 
 ?>

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
@@ -4,12 +4,8 @@ namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixtu
 
 class NoNewLine
 {
-    public function run()
-    {
-    }
-    public function run2()
-    {
-    }
+    private $property;
+    private $property2;
 }
 
 ?>
@@ -20,13 +16,9 @@ namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixtu
 
 class NoNewLine
 {
-    public function run()
-    {
-    }
+    private $property;
 
-    public function run2()
-    {
-    }
+    private $property2;
 }
 
 ?>

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixture;
+
+class NoNewLine
+{
+    public function run()
+    {
+    }
+    public function run2()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixture;
+
+class NoNewLine
+{
+    public function run()
+    {
+    }
+
+    public function run2()
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line.php.inc
@@ -6,6 +6,8 @@ class NoNewLine
 {
     private $property;
     private $property2;
+    private const VIEW = 'view';
+    private const ADD = 'add';
     public function run(array $data)
     {
         if (rand(0, 1)) {
@@ -31,6 +33,10 @@ class NoNewLine
     private $property;
 
     private $property2;
+
+    private const VIEW = 'view';
+
+    private const ADD = 'add';
 
     public function run(array $data)
     {

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line_function.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/no_new_line_function.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixture;
+
+function run()
+{
+}
+function run2()
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixture;
+
+function run()
+{
+}
+
+function run2()
+{
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/skip_already_has_newline.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/skip_already_has_newline.php.inc
@@ -4,22 +4,9 @@ namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixtu
 
 class SkipAlreadyHasNewline
 {
-    public function run()
-    {
-        if (rand(0,1)) {
-        }
+    private $property;
 
-        if (rand(0,1)) {
-        }
-    }
-
-    public function run2(array $data)
-    {
-        foreach ($data as $key => $value) {
-        }
-
-        return true;
-    }
+    private $property2;
 }
 
 ?>

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/skip_already_has_newline.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/skip_already_has_newline.php.inc
@@ -7,6 +7,21 @@ class SkipAlreadyHasNewline
     private $property;
 
     private $property2;
+
+    public function run(array $data)
+    {
+        if (rand(0, 1)) {
+
+        }
+
+        echo 'test';
+
+        foreach ($data as $key => $value) {
+            # code...
+        }
+
+        return true;
+    }
 }
 
 ?>

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/skip_already_has_newline.php.inc
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/Fixture/skip_already_has_newline.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\Fixture;
+
+class SkipAlreadyHasNewline
+{
+    public function run()
+    {
+        if (rand(0,1)) {
+        }
+
+        if (rand(0,1)) {
+        }
+    }
+
+    public function run2(array $data)
+    {
+        foreach ($data as $key => $value) {
+        }
+
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/NewlineAfterStatementRectorTest.php
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/NewlineAfterStatementRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class NewlineAfterStatementRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/config/configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/Stmt/NewlineAfterStatementRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(NewlineAfterStatementRector::class);
+};

--- a/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
+++ b/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
@@ -124,9 +124,11 @@ CODE_SAMPLE
             if (! isset($funcCall->args[$oldPosition])) {
                 continue;
             }
+
             if (! isset($funcCall->args[$newPosition])) {
                 continue;
             }
+
             $newArguments[$newPosition] = $funcCall->args[$oldPosition];
         }
 

--- a/rules/CodeQuality/NodeAnalyzer/ForAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/ForAnalyzer.php
@@ -105,6 +105,7 @@ final class ForAnalyzer
                 if (! $parent instanceof Unset_) {
                     return false;
                 }
+
                 return $node instanceof ArrayDimFetch;
             }
         );
@@ -145,6 +146,7 @@ final class ForAnalyzer
             if (! $node instanceof Variable) {
                 return false;
             }
+
             return $this->nodeNameResolver->isName($node, $iteratedVariableSingle);
         });
     }

--- a/rules/CodeQuality/NodeManipulator/ClassMethodParameterTypeManipulator.php
+++ b/rules/CodeQuality/NodeManipulator/ClassMethodParameterTypeManipulator.php
@@ -90,6 +90,7 @@ final class ClassMethodParameterTypeManipulator
                 $phpDocType = new UnionType([$phpDocType, new NullType()]);
             }
         }
+
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         $this->phpDocTypeChanger->changeParamType($phpDocInfo, $phpDocType, $param, $paramName);
     }
@@ -130,6 +131,7 @@ final class ClassMethodParameterTypeManipulator
         if ($paramName === null) {
             return;
         }
+
         if ($this->shouldSkipMethodCallRefactor($paramName, $methodCall, $methodsReturningClassInstance)) {
             return;
         }

--- a/rules/CodeQuality/NodeManipulator/ClassMethodReturnTypeManipulator.php
+++ b/rules/CodeQuality/NodeManipulator/ClassMethodReturnTypeManipulator.php
@@ -41,6 +41,7 @@ final class ClassMethodReturnTypeManipulator
             $isNullable = true;
             $returnType = $returnType->type;
         }
+
         if (! $this->nodeTypeResolver->isObjectType($returnType, $objectType)) {
             return;
         }
@@ -57,10 +58,12 @@ final class ClassMethodReturnTypeManipulator
             } else {
                 $phpDocType = new UnionType([$phpDocType, new NullType()]);
             }
+
             if (! $replaceIntoType instanceof NullableType) {
                 $replaceIntoType = new NullableType($replaceIntoType);
             }
         }
+
         $classMethod->returnType = $replaceIntoType;
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);

--- a/rules/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector.php
+++ b/rules/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector.php
@@ -93,6 +93,7 @@ CODE_SAMPLE
         if ($this->isAssignedToNetteMagicOnProperty($node)) {
             return null;
         }
+
         if ($this->isInsideProperty($node)) {
             return null;
         }

--- a/rules/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector.php
+++ b/rules/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector.php
@@ -56,6 +56,7 @@ final class SimplifyEmptyArrayCheckRector extends AbstractRector
                 if (! $node instanceof FuncCall) {
                     return false;
                 }
+
                 return $this->isName($node, 'is_array');
             },
             Empty_::class

--- a/rules/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector.php
@@ -120,6 +120,7 @@ CODE_SAMPLE
             $isNullable = true;
             $type = $type->type;
         }
+
         if (! $this->isObjectType($type, new ObjectType(self::DATE_TIME))) {
             return null;
         }
@@ -133,6 +134,7 @@ CODE_SAMPLE
         if ($isNullable) {
             $property->type = new NullableType($property->type);
         }
+
         return $property;
     }
 
@@ -179,6 +181,7 @@ CODE_SAMPLE
         if (! $classMethod->returnType instanceof Node) {
             return;
         }
+
         $this->classMethodReturnTypeManipulator->refactorFunctionReturnType(
             $classMethod,
             $fromObjectType,

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -72,9 +72,11 @@ CODE_SAMPLE
         if ($leftStaticType instanceof ObjectType) {
             return null;
         }
+
         if ($leftStaticType instanceof MixedType) {
             return null;
         }
+
         if ($rightStaticType instanceof MixedType) {
             return null;
         }

--- a/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
+++ b/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
@@ -79,9 +79,11 @@ CODE_SAMPLE
         if ($node->expr instanceof BooleanAnd) {
             return $this->processExplicitIf($node);
         }
+
         if ($node->expr instanceof BooleanOr) {
             return $this->processExplicitIf($node);
         }
+
         return null;
     }
 

--- a/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
+++ b/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
@@ -105,6 +105,7 @@ CODE_SAMPLE
         if ($countInCond === null) {
             return null;
         }
+
         if ($variableName === null) {
             return null;
         }

--- a/rules/CodeQuality/Rector/Foreach_/ForeachToInArrayRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/ForeachToInArrayRector.php
@@ -144,6 +144,7 @@ CODE_SAMPLE
         if (! $nextNode instanceof Node) {
             return true;
         }
+
         if (! $nextNode instanceof Return_) {
             return true;
         }
@@ -172,6 +173,7 @@ CODE_SAMPLE
         if ($ifCondition instanceof Identical) {
             return false;
         }
+
         return ! $ifCondition instanceof Equal;
     }
 

--- a/rules/CodeQuality/Rector/Foreach_/SimplifyForeachToCoalescingRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/SimplifyForeachToCoalescingRector.php
@@ -148,6 +148,7 @@ CODE_SAMPLE
         } else {
             return null;
         }
+
         $nextNode = $foreach->getAttribute(AttributeKey::NEXT_NODE);
 
         // is next node Return?

--- a/rules/CodeQuality/Rector/FuncCall/AddPregQuoteDelimiterRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/AddPregQuoteDelimiterRector.php
@@ -115,6 +115,7 @@ CODE_SAMPLE
             $upperMostConcat = $parent;
             $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
         }
+
         return $upperMostConcat;
     }
 }

--- a/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
@@ -93,9 +93,11 @@ CODE_SAMPLE
         if (! $firstValueStaticType instanceof ConstantArrayType) {
             return null;
         }
+
         if ($firstValueStaticType->getItemType() instanceof MixedType) {
             return null;
         }
+
         return $this->refactorAssignArray($firstValue, $node);
     }
 

--- a/rules/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector.php
+++ b/rules/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector.php
@@ -101,6 +101,7 @@ CODE_SAMPLE
         if ($node->stmts === null) {
             return null;
         }
+
         if ($node->stmts === []) {
             return null;
         }

--- a/rules/CodeQuality/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
+++ b/rules/CodeQuality/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
@@ -159,6 +159,7 @@ CODE_SAMPLE
         if ($types[0] === $types[1]) {
             return true;
         }
+
         if ($types[0] instanceof NullType) {
             return false;
         }

--- a/rules/CodeQuality/Rector/Identical/SimplifyBoolIdenticalTrueRector.php
+++ b/rules/CodeQuality/Rector/Identical/SimplifyBoolIdenticalTrueRector.php
@@ -70,12 +70,15 @@ CODE_SAMPLE
         ) && ! $this->valueResolver->isTrueOrFalse($node->left)) {
             return $this->processBoolTypeToNotBool($node, $node->left, $node->right);
         }
+
         if (! $this->nodeTypeResolver->isStaticType($node->right, BooleanType::class)) {
             return null;
         }
+
         if ($this->valueResolver->isTrueOrFalse($node->right)) {
             return null;
         }
+
         return $this->processBoolTypeToNotBool($node, $node->right, $node->left);
     }
 

--- a/rules/CodeQuality/Rector/Identical/SimplifyConditionsRector.php
+++ b/rules/CodeQuality/Rector/Identical/SimplifyConditionsRector.php
@@ -104,6 +104,7 @@ final class SimplifyConditionsRector extends AbstractRector
         if ($binaryOp->left instanceof BinaryOp) {
             return true;
         }
+
         return $binaryOp->right instanceof BinaryOp;
     }
 

--- a/rules/CodeQuality/Rector/If_/ConsecutiveNullCompareReturnsToNullCoalesceQueueRector.php
+++ b/rules/CodeQuality/Rector/If_/ConsecutiveNullCompareReturnsToNullCoalesceQueueRector.php
@@ -98,6 +98,7 @@ CODE_SAMPLE
                     $currentNode = $currentNode->getAttribute(AttributeKey::NEXT_NODE);
                     continue;
                 }
+
                 return null;
             }
 
@@ -105,6 +106,7 @@ CODE_SAMPLE
                 $this->nodesToRemove[] = $currentNode;
                 break;
             }
+
             return null;
         }
 
@@ -112,6 +114,7 @@ CODE_SAMPLE
         if (count($this->coalescingNodes) < 2) {
             return null;
         }
+
         $this->removeNodes($this->nodesToRemove);
 
         return $this->createReturnCoalesceNode($this->coalescingNodes);

--- a/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -86,6 +86,7 @@ CODE_SAMPLE
         if (! $ifAssignVar instanceof Expr) {
             return null;
         }
+
         if (! $elseAssignVar instanceof Expr) {
             return null;
         }
@@ -99,6 +100,7 @@ CODE_SAMPLE
         if (! $ternaryIf instanceof Expr) {
             return null;
         }
+
         if (! $ternaryElse instanceof Expr) {
             return null;
         }

--- a/rules/CodeQuality/Rector/If_/SimplifyIfNotNullReturnRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfNotNullReturnRector.php
@@ -68,6 +68,7 @@ CODE_SAMPLE
             if (! $nextNode instanceof Return_) {
                 return null;
             }
+
             if ($nextNode->expr === null) {
                 return null;
             }

--- a/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
@@ -121,6 +121,7 @@ CODE_SAMPLE
         if (! $nextNode instanceof Return_) {
             return true;
         }
+
         if ($nextNode->expr === null) {
             return true;
         }

--- a/rules/CodeQuality/Rector/LogicalAnd/AndAssignsToSeparateLinesRector.php
+++ b/rules/CodeQuality/Rector/LogicalAnd/AndAssignsToSeparateLinesRector.php
@@ -65,9 +65,11 @@ CODE_SAMPLE
         if (! $node->left instanceof Assign) {
             return null;
         }
+
         if (! $node->right instanceof Assign) {
             return null;
         }
+
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
         if (! $parentNode instanceof Expression) {
             return null;

--- a/rules/CodeQuality/Rector/Return_/SimplifyUselessVariableRector.php
+++ b/rules/CodeQuality/Rector/Return_/SimplifyUselessVariableRector.php
@@ -134,6 +134,7 @@ CODE_SAMPLE
         if (! $previousExpression instanceof Node) {
             return true;
         }
+
         if (! $previousExpression instanceof Expression) {
             return true;
         }
@@ -179,9 +180,11 @@ CODE_SAMPLE
         if (! $prePreviousExpression instanceof Expression) {
             return false;
         }
+
         if (! $prePreviousExpression->expr instanceof AssignOp) {
             return false;
         }
+
         return $this->nodeComparator->areNodesEqual($prePreviousExpression->expr->var, $previousNode->var);
     }
 }

--- a/rules/CodeQuality/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
+++ b/rules/CodeQuality/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
@@ -101,6 +101,7 @@ CODE_SAMPLE
         if (! $this->nodeComparator->areNodesEqual($arrayDimFetch->var, $valuesExpr)) {
             return false;
         }
+
         return $this->nodeComparator->areNodesEqual($arrayDimFetch->dim, $keyExpr);
     }
 }

--- a/rules/CodeQuality/Rector/Ternary/SimplifyDuplicatedTernaryRector.php
+++ b/rules/CodeQuality/Rector/Ternary/SimplifyDuplicatedTernaryRector.php
@@ -68,9 +68,11 @@ CODE_SAMPLE
         if ($node->if === null) {
             return null;
         }
+
         if (! $this->valueResolver->isTrue($node->if)) {
             return null;
         }
+
         if (! $this->valueResolver->isFalse($node->else)) {
             return null;
         }

--- a/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
+++ b/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
@@ -67,9 +67,11 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
         if (! $condition instanceof BinaryOp) {
             return $this->processNonBinaryCondition($ifExpression, $elseExpression, $condition);
         }
+
         if ($this->valueResolver->isNull($ifExpression)) {
             return null;
         }
+
         if ($this->valueResolver->isNull($elseExpression)) {
             return null;
         }
@@ -94,12 +96,15 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
         if ($this->valueResolver->isTrue($ifExpression) && $this->valueResolver->isFalse($elseExpression)) {
             return $this->processTrueIfExpressionWithFalseElseExpression($condition);
         }
+
         if (! $this->valueResolver->isFalse($ifExpression)) {
             return null;
         }
+
         if (! $this->valueResolver->isTrue($elseExpression)) {
             return null;
         }
+
         return $this->processFalseIfExpressionWithTrueElseExpression($condition);
     }
 

--- a/rules/CodingStyle/NodeAnalyzer/ImplodeAnalyzer.php
+++ b/rules/CodingStyle/NodeAnalyzer/ImplodeAnalyzer.php
@@ -37,6 +37,7 @@ final class ImplodeAnalyzer
         if (! $firstArgumentValue instanceof String_) {
             return true;
         }
+
         return $firstArgumentValue->value === '","';
     }
 }

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -163,9 +163,11 @@ CODE_SAMPLE
             if (! $parent instanceof Node) {
                 return;
             }
+
             if ($parent instanceof FunctionLike) {
                 return;
             }
+
             $nextNode = $parent->getAttribute(AttributeKey::NEXT_NODE);
             $this->replaceNextUsageVariable($parent, $nextNode, $oldVariableName, $newVariableName);
 

--- a/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
@@ -132,9 +132,11 @@ CODE_SAMPLE
         if ($reflectionMethod->isProtected() && $classMethod->isProtected()) {
             return true;
         }
+
         if (! $reflectionMethod->isPrivate()) {
             return false;
         }
+
         return $classMethod->isPrivate();
     }
 

--- a/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
@@ -92,6 +92,7 @@ CODE_SAMPLE
                 // insert newline before stmt
                 $newStmts[] = new Nop();
             }
+
             $newStmts[] = $stmt;
 
             $this->previousPreviousStmtVariableName = $this->previousStmtVariableName;

--- a/rules/CodingStyle/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
+++ b/rules/CodingStyle/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
@@ -161,6 +161,7 @@ CODE_SAMPLE
             if (! $node instanceof BooleanAnd) {
                 return null;
             }
+
             if (! $this->isLocalPropertyOfNamesNotIdenticalToNull($node->left, $propertyNames)) {
                 return null;
             }

--- a/rules/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
@@ -115,6 +115,7 @@ CODE_SAMPLE
         if ($left === null) {
             return null;
         }
+
         if ($right === null) {
             return null;
         }
@@ -131,6 +132,7 @@ CODE_SAMPLE
         if (! $expr instanceof ConstFetch) {
             return false;
         }
+
         return $expr->name->toString() === 'PHP_VERSION';
     }
 

--- a/rules/CodingStyle/Rector/PostInc/PostIncDecToPreIncDecRector.php
+++ b/rules/CodingStyle/Rector/PostInc/PostIncDecToPreIncDecRector.php
@@ -76,15 +76,19 @@ CODE_SAMPLE
         if ($parentNode instanceof ArrayDimFetch && $this->nodeComparator->areNodesEqual($parentNode->dim, $node)) {
             return $this->processPreArray($node, $parentNode);
         }
+
         if (! $parentNode instanceof For_) {
             return null;
         }
+
         if (count($parentNode->loop) !== 1) {
             return null;
         }
+
         if (! $this->nodeComparator->areNodesEqual($parentNode->loop[0], $node)) {
             return null;
         }
+
         return $this->processPreFor($node, $parentNode);
     }
 
@@ -93,6 +97,7 @@ CODE_SAMPLE
         if (! $node instanceof Node) {
             return false;
         }
+
         return $node instanceof Expression;
     }
 

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -6,10 +6,12 @@ namespace Rector\CodingStyle\Rector\Stmt;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Property;
@@ -29,12 +31,14 @@ final class NewlineAfterStatementRector extends AbstractRector
      */
     private const STMTS_TO_HAVE_NEXT_NEWLINE = [
         ClassMethod::class,
+        Function_::class,
         Property::class,
         If_::class,
         Foreach_::class,
         Do_::class,
         While_::class,
         For_::class,
+        ClassConst::class,
     ];
 
     /**

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -5,19 +5,15 @@ declare(strict_types=1);
 namespace Rector\CodingStyle\Rector\Stmt;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Do_;
-use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\For_;
-use PhpParser\Node\Stmt\Nop;
-use PhpParser\Node\Stmt\While_;
 use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Property;
-use PhpParser\Node\Stmt\PropertyProperty;
-use PhpParser\NodeTraverser;
+use PhpParser\Node\Stmt\While_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -29,12 +25,13 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class NewlineAfterStatementRector extends AbstractRector
 {
     private const STMTS_TO_HAVE_NEXT_NEWLINE = [
-        //ClassMethod::class,
+        ClassMethod::class,
         Property::class,
-        //Do_::class,
-        //While_::class,
-        //For_::class,
-        //Foreach_::class,
+        If_::class,
+        Foreach_::class,
+        Do_::class,
+        While_::class,
+        For_::class,
     ];
 
     private array $stmtsHashed = [];
@@ -87,44 +84,30 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parent instanceof Node) {
+        if (! in_array($node::class, self::STMTS_TO_HAVE_NEXT_NEWLINE, true)) {
             return null;
         }
 
-        $print = $this->betterStandardPrinter->prettyPrint([$parent]);
-        $this->traverseNodesWithCallable($parent, function (Node $subNode) use ($node, $print, $parent): void {
-            if (! in_array($node::class, self::STMTS_TO_HAVE_NEXT_NEWLINE, true)) {
-                return;
-            }
+        $hash = spl_object_hash($node);
+        if (isset($this->stmtsHashed[$hash])) {
+            return null;
+        }
 
-            if ($subNode !== $node) {
-                return;
-            }
+        $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
+        if (! $nextNode instanceof Node) {
+            return null;
+        }
 
-            $hash = spl_object_hash($node);
-            if (isset($this->stmtsHashed[$hash])) {
-                return;
-            }
+        $currentLineEnd = $node->getEndLine();
+        $nextLineStart  = $nextNode->getLine();
+        $rangeLine   = $nextLineStart - $currentLineEnd;
 
-            $nextNode = $subNode->getAttribute(AttributeKey::NEXT_NODE);
-            if ($nextNode instanceof Nop) {
-                return;
-            }
+        if ($rangeLine > 1) {
+            return null;
+        }
 
-            if (! $nextNode instanceof Node) {
-                return;
-            }
-
-            $parent = $subNode->getAttribute(AttributeKey::PARENT_NODE);
-            $newPrint = $this->betterStandardPrinter->prettyPrint([$parent]);
-            if ($newPrint !== $print) {
-                return;
-            }
-
-            $this->stmtsHashed[$hash] = true;
-            $this->addNodeAfterNode(new Nop(), $subNode);
-        });
+        $this->stmtsHashed[$hash] = true;
+        $this->addNodeAfterNode(new Nop(), $node);
 
         return $node;
     }

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -34,6 +34,9 @@ final class NewlineAfterStatementRector extends AbstractRector
         For_::class,
     ];
 
+    /**
+     * @var array<string, true>
+     */
     private array $stmtsHashed = [];
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\Stmt;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\Node\Stmt\While_;
+use PhpParser\Node\Stmt\Foreach_;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodingStyle\Rector\Stmt\NewlineAfterStatementRector\NewlineAfterStatementRectorTest
+ */
+final class NewlineAfterStatementRector extends AbstractRector
+{
+    private const STMTS_TO_HAVE_NEXT_NEWLINE = [
+        ClassMethod::class,
+        If_::class,
+        Do_::class,
+        While_::class,
+        For_::class,
+        Foreach_::class,
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add new line after statements to tidify code',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function test()
+    {
+    }
+    public function test2()
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function test()
+    {
+    }
+
+    public function test2()
+    {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Stmt::class];
+    }
+
+    /**
+     * @param Stmt $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! in_array($node::class, self::STMTS_TO_HAVE_NEXT_NEWLINE, true)) {
+            return null;
+        }
+
+        $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
+        if ($nextNode instanceof Nop) {
+            return null;
+        }
+
+        if (! $nextNode instanceof Nop) {
+            return null;
+        }
+
+        $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        if ($currentStatement instanceof Nop) {
+            return null;
+        }
+
+        $this->addNodeAfterNode(new Nop(), $node);
+        return $node;
+    }
+}

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodingStyle\Rector\Stmt;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -14,6 +15,9 @@ use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\While_;
 use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\NodeTraverser;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -25,13 +29,15 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class NewlineAfterStatementRector extends AbstractRector
 {
     private const STMTS_TO_HAVE_NEXT_NEWLINE = [
-        ClassMethod::class,
-        If_::class,
-        Do_::class,
-        While_::class,
-        For_::class,
-        Foreach_::class,
+        //ClassMethod::class,
+        Property::class,
+        //Do_::class,
+        //While_::class,
+        //For_::class,
+        //Foreach_::class,
     ];
+
+    private array $stmtsHashed = [];
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -81,25 +87,45 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! in_array($node::class, self::STMTS_TO_HAVE_NEXT_NEWLINE, true)) {
+        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parent instanceof Node) {
             return null;
         }
 
-        $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
-        if ($nextNode instanceof Nop) {
-            return null;
-        }
+        $print = $this->betterStandardPrinter->prettyPrint([$parent]);
+        $this->traverseNodesWithCallable($parent, function (Node $subNode) use ($node, $print, $parent): void {
+            if (! in_array($node::class, self::STMTS_TO_HAVE_NEXT_NEWLINE, true)) {
+                return;
+            }
 
-        if (! $nextNode instanceof Nop) {
-            return null;
-        }
+            if ($subNode !== $node) {
+                return;
+            }
 
-        $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        if ($currentStatement instanceof Nop) {
-            return null;
-        }
+            $hash = spl_object_hash($node);
+            if (isset($this->stmtsHashed[$hash])) {
+                return;
+            }
 
-        $this->addNodeAfterNode(new Nop(), $node);
+            $nextNode = $subNode->getAttribute(AttributeKey::NEXT_NODE);
+            if ($nextNode instanceof Nop) {
+                return;
+            }
+
+            if (! $nextNode instanceof Node) {
+                return;
+            }
+
+            $parent = $subNode->getAttribute(AttributeKey::PARENT_NODE);
+            $newPrint = $this->betterStandardPrinter->prettyPrint([$parent]);
+            if ($newPrint !== $print) {
+                return;
+            }
+
+            $this->stmtsHashed[$hash] = true;
+            $this->addNodeAfterNode(new Nop(), $subNode);
+        });
+
         return $node;
     }
 }

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -24,6 +24,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class NewlineAfterStatementRector extends AbstractRector
 {
+    /**
+     * @var array<class-string<Node>>
+     */
     private const STMTS_TO_HAVE_NEXT_NEWLINE = [
         ClassMethod::class,
         Property::class,
@@ -101,9 +104,9 @@ CODE_SAMPLE
             return null;
         }
 
-        $currentLineEnd = $node->getEndLine();
-        $nextLineStart  = $nextNode->getLine();
-        $rangeLine   = $nextLineStart - $currentLineEnd;
+        $endLine = $node->getEndLine();
+        $line = $nextNode->getLine();
+        $rangeLine = $line - $endLine;
 
         if ($rangeLine > 1) {
             return null;

--- a/rules/CodingStyle/Rector/String_/UseClassKeywordForClassNameResolutionRector.php
+++ b/rules/CodingStyle/Rector/String_/UseClassKeywordForClassNameResolutionRector.php
@@ -127,6 +127,7 @@ CODE_SAMPLE
                 $exprsToConcat[] = new String_($part);
             }
         }
+
         return $exprsToConcat;
     }
 }

--- a/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
+++ b/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
@@ -60,6 +60,7 @@ CODE_SAMPLE
         if (! $nodeIf instanceof Assign) {
             return null;
         }
+
         if (! $nodeElse instanceof Assign) {
             return null;
         }
@@ -69,6 +70,7 @@ CODE_SAMPLE
         if (! $nodeIfVar instanceof Variable) {
             return null;
         }
+
         if (! $nodeElseVar instanceof Variable) {
             return null;
         }

--- a/rules/Composer/Rector/RenamePackageComposerRector.php
+++ b/rules/Composer/Rector/RenamePackageComposerRector.php
@@ -37,6 +37,7 @@ final class RenamePackageComposerRector implements ComposerRectorInterface
                     $version
                 );
             }
+
             if ($composerJson->hasRequiredDevPackage($renamePackage->getOldPackageName())) {
                 $version = $composerJson->getRequireDev()[$renamePackage->getOldPackageName()];
                 $composerJson->replacePackage(

--- a/rules/DeadCode/NodeAnalyzer/InstanceOfUniqueKeyResolver.php
+++ b/rules/DeadCode/NodeAnalyzer/InstanceOfUniqueKeyResolver.php
@@ -20,6 +20,7 @@ final class InstanceOfUniqueKeyResolver
         if (! $instanceof->expr instanceof Variable) {
             return null;
         }
+
         $variableName = $this->nodeNameResolver->getName($instanceof->expr);
         if ($variableName === null) {
             return null;

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -164,6 +164,7 @@ final class IsClassMethodUsedAnalyzer
             if (! $method instanceof ClassMethod) {
                 continue;
             }
+
             return true;
         }
 

--- a/rules/DeadCode/NodeFinder/VariableUseFinder.php
+++ b/rules/DeadCode/NodeFinder/VariableUseFinder.php
@@ -37,6 +37,7 @@ final class VariableUseFinder
             if ($parentNode instanceof Assign && ($parentNode->var instanceof Variable && $parentNode->var === $node)) {
                 return false;
             }
+
             $nodeNameResolverGetName = $this->nodeNameResolver->getName($node);
 
             // simple variable only

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -47,12 +47,15 @@ final class DeadParamTagValueNodeAnalyzer
         ], true)) {
             return false;
         }
+
         if (! $paramTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
             return $paramTagValueNode->description === '';
         }
+
         if (! $this->hasGenericType($paramTagValueNode->type)) {
             return $paramTagValueNode->description === '';
         }
+
         return false;
     }
 

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedAssignVariableRector.php
@@ -126,6 +126,7 @@ CODE_SAMPLE
         if (! $parentIf instanceof If_) {
             return (bool) $this->nextVariableUsageNodeFinder->find($assign);
         }
+
         if (! $parentIf->else instanceof Else_) {
             return (bool) $this->nextVariableUsageNodeFinder->find($assign);
         }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
@@ -83,9 +83,11 @@ CODE_SAMPLE
         if (! $this->isName($classMethod, MethodName::CONSTRUCT)) {
             return true;
         }
+
         if ($classMethod->stmts === null) {
             return true;
         }
+
         if ($classMethod->stmts !== []) {
             return true;
         }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
@@ -106,6 +106,7 @@ CODE_SAMPLE
         if (! $classLike instanceof Class_) {
             return true;
         }
+
         return $classLike->extends === null;
     }
 

--- a/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
+++ b/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
@@ -150,6 +150,7 @@ CODE_SAMPLE
         if ($expr instanceof Scalar) {
             return false;
         }
+
         return ! $this->valueResolver->isTrueOrFalse($expr);
     }
 }

--- a/rules/DeadCode/Rector/FunctionLike/RemoveDeadReturnRector.php
+++ b/rules/DeadCode/Rector/FunctionLike/RemoveDeadReturnRector.php
@@ -74,6 +74,7 @@ CODE_SAMPLE
         if ($node->stmts === []) {
             return null;
         }
+
         if ($node->stmts === null) {
             return null;
         }

--- a/rules/DeadCode/Rector/FunctionLike/RemoveOverriddenValuesRector.php
+++ b/rules/DeadCode/Rector/FunctionLike/RemoveOverriddenValuesRector.php
@@ -178,6 +178,7 @@ CODE_SAMPLE
                 if ($comments !== null) {
                     continue;
                 }
+
                 $nodesIsName = $nodes->isName($assignedVariableName);
 
                 if (! $nodesIsName) {

--- a/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
@@ -169,12 +169,15 @@ CODE_SAMPLE
         if (! $class instanceof Class_) {
             return false;
         }
+
         if (! $typeWithClassName instanceof ThisType) {
             return false;
         }
+
         if ($class->isFinal()) {
             return false;
         }
+
         return ! $classMethod->isPrivate();
     }
 

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -128,9 +128,11 @@ CODE_SAMPLE
         if (! $node instanceof Nop) {
             return ! $this->typeChecker->isInstanceOf($node, self::NODES_TO_MATCH);
         }
+
         if (count($node->getComments()) <= 1) {
             return ! $this->typeChecker->isInstanceOf($node, self::NODES_TO_MATCH);
         }
+
         return true;
     }
 

--- a/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
+++ b/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
@@ -110,6 +110,7 @@ CODE_SAMPLE
             if (! $this->valueResolver->isValue($node->expr, 1)) {
                 return null;
             }
+
             if ($this->nodeTypeResolver->isNumberType($node->var)) {
                 return $node->var;
             }
@@ -128,9 +129,11 @@ CODE_SAMPLE
         if ($node instanceof Mul) {
             return $this->processBinaryMulAndDiv($node);
         }
+
         if ($node instanceof Div) {
             return $this->processBinaryMulAndDiv($node);
         }
+
         return null;
     }
 
@@ -143,6 +146,7 @@ CODE_SAMPLE
             if ($binaryOp instanceof Minus) {
                 return new UnaryMinus($binaryOp->right);
             }
+
             return $binaryOp->right;
         }
 

--- a/rules/DeadCode/Rector/PropertyProperty/RemoveNullPropertyInitializationRector.php
+++ b/rules/DeadCode/Rector/PropertyProperty/RemoveNullPropertyInitializationRector.php
@@ -77,6 +77,7 @@ CODE_SAMPLE
         if (strtolower((string) $defaultValueNode->name) !== 'null') {
             return null;
         }
+
         $nodeNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
 
         if ($nodeNode instanceof NullableType) {

--- a/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
+++ b/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
@@ -62,9 +62,11 @@ final class UselessIfCondBeforeForeachDetector
         if (! $previousParam instanceof Param) {
             return true;
         }
+
         if ($this->paramAnalyzer->isNullable($previousParam)) {
             return false;
         }
+
         return ! $this->paramAnalyzer->hasDefaultNull($previousParam);
     }
 

--- a/rules/DowngradePhp70/Rector/String_/DowngradeGeneratedScalarTypesRector.php
+++ b/rules/DowngradePhp70/Rector/String_/DowngradeGeneratedScalarTypesRector.php
@@ -166,6 +166,7 @@ CODE_SAMPLE
         foreach ($this->phpRectors as $phpRector) {
             $nodeTraverser->addVisitor($phpRector);
         }
+
         return $nodeTraverser;
     }
 }

--- a/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
+++ b/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
@@ -54,12 +54,15 @@ CODE_SAMPLE
         if ($parentNode instanceof Assign && $this->nodeComparator->areNodesEqual($node, $parentNode->var)) {
             return $this->processToList($node);
         }
+
         if (! $parentNode instanceof Foreach_) {
             return null;
         }
+
         if (! $this->nodeComparator->areNodesEqual($node, $parentNode->valueVar)) {
             return null;
         }
+
         return $this->processToList($node);
     }
 

--- a/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
+++ b/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
@@ -78,6 +78,7 @@ CODE_SAMPLE
         if (! $parentOfNextNode instanceof ArrayDimFetch) {
             return null;
         }
+
         if (! $this->nodeComparator->areNodesEqual($parentOfNextNode->dim, $nextNode)) {
             return null;
         }

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -143,9 +143,11 @@ CODE_SAMPLE
             if (! $singleClassConst->value instanceof ConstFetch) {
                 continue;
             }
+
             if (! $this->isName($singleClassConst->value, self::FLAG)) {
                 continue;
             }
+
             $classConst->consts[$key]->value = new LNumber(512);
             return $classConst;
         }

--- a/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
+++ b/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
@@ -131,9 +131,11 @@ CODE_SAMPLE
             $this->removeNode($parentNode);
             return null;
         }
+
         if ($rightSideRemovableParamsCount > 0) {
             array_splice($node->items, $nodeItemsCount - $rightSideRemovableParamsCount);
         }
+
         return $node;
     }
 
@@ -144,12 +146,15 @@ CODE_SAMPLE
         if (! $parentNode instanceof Assign) {
             return false;
         }
+
         if ($parentNode->var !== $node) {
             return false;
         }
+
         if (! $parentNode->expr instanceof Variable) {
             return false;
         }
+
         return $this->hasAnyItemByRef($node->items);
     }
 
@@ -184,6 +189,7 @@ CODE_SAMPLE
             // Item not by reference. Reach the end
             return $count;
         }
+
         return $count;
     }
 
@@ -203,6 +209,7 @@ CODE_SAMPLE
             if (! $listItem instanceof ArrayItem) {
                 continue;
             }
+
             if ($listItem->value instanceof Variable && ! $listItem->byRef) {
                 continue;
             }
@@ -237,6 +244,7 @@ CODE_SAMPLE
                 )
             );
         }
+
         return $newNodes;
     }
 
@@ -272,9 +280,11 @@ CODE_SAMPLE
         if ($arrayItem->key instanceof String_) {
             return $arrayItem->key->value;
         }
+
         if ($arrayItem->key instanceof LNumber) {
             return $arrayItem->key->value;
         }
+
         return $position;
     }
 
@@ -293,6 +303,7 @@ CODE_SAMPLE
             $nestedArrayIndexDim = BuilderHelpers::normalizeValue($nestedArrayIndex);
             $nestedExprVariable = new ArrayDimFetch($nestedExprVariable, $nestedArrayIndexDim);
         }
+
         $dim = BuilderHelpers::normalizeValue($arrayIndex);
         $arrayDimFetch = new ArrayDimFetch($nestedExprVariable, $dim);
         return new AssignRef($assignVariable, $arrayDimFetch);
@@ -339,9 +350,11 @@ CODE_SAMPLE
             // $condition === self::ANY
             return $this->hasAnyItemByRef($nestedList->items);
         }
+
         if (! $arrayItem->value instanceof Variable) {
             return false;
         }
+
         return $arrayItem->byRef;
     }
 }

--- a/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
+++ b/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
@@ -97,6 +97,7 @@ CODE_SAMPLE
         if (! $this->shouldRefactor($node)) {
             return null;
         }
+
         return $this->refactorNode($node);
     }
 
@@ -141,6 +142,7 @@ CODE_SAMPLE
                     // If it is a not variable, transform it to a variable
                     $item->value = $this->createVariableFromNonVariable($array, $item, $position);
                 }
+
                 if ($accumulatedItems !== []) {
                     // If previous items were in the new array, add them first
                     $newItems[] = $this->createArrayItem($accumulatedItems);
@@ -159,6 +161,7 @@ CODE_SAMPLE
         if ($accumulatedItems !== []) {
             $newItems[] = $this->createArrayItem($accumulatedItems);
         }
+
         return $newItems;
     }
 
@@ -175,6 +178,7 @@ CODE_SAMPLE
                 $item->unpack = false;
                 return $this->createArgFromSpreadArrayItem($nodeScope, $item);
             }
+
             return new Arg($item);
         }, $items));
     }

--- a/rules/DowngradePhp74/Rector/Identical/DowngradeFreadFwriteFalsyToNegationRector.php
+++ b/rules/DowngradePhp74/Rector/Identical/DowngradeFreadFwriteFalsyToNegationRector.php
@@ -73,12 +73,15 @@ CODE_SAMPLE
         if ($identical->left instanceof FuncCall && $this->isNames($identical->left, self::FUNC_FREAD_FWRITE)) {
             return $identical->right;
         }
+
         if (! $identical->right instanceof FuncCall) {
             return null;
         }
+
         if (! $this->isNames($identical->right, self::FUNC_FREAD_FWRITE)) {
             return null;
         }
+
         return $identical->left;
     }
 

--- a/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -86,6 +86,7 @@ CODE_SAMPLE
         if ($node instanceof DNumber && ! \str_contains($node->value, '.')) {
             $node->value .= '.0';
         }
+
         return $node;
     }
 
@@ -95,6 +96,7 @@ CODE_SAMPLE
         if ($node instanceof LNumber) {
             return $node->getAttribute(AttributeKey::KIND) === LNumber::KIND_DEC;
         }
+
         return true;
     }
 }

--- a/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
@@ -86,6 +86,7 @@ final class NamedToUnnamedArgs
             if (in_array($i, $keys, true)) {
                 continue;
             }
+
             if ($i > $highestParameterPosition) {
                 continue;
             }

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -134,6 +134,7 @@ CODE_SAMPLE
                 $switchCases[] = new Case_($matchArm->conds[0] ?? null, $stmts);
             }
         }
+
         return $switchCases;
     }
 

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
@@ -78,6 +78,7 @@ CODE_SAMPLE
         if ($node instanceof BooleanNot) {
             return new Identical($funcCall, $this->nodeFactory->createFalse());
         }
+
         return new NotIdentical($funcCall, $this->nodeFactory->createFalse());
     }
 
@@ -90,9 +91,11 @@ CODE_SAMPLE
         if (! $expr instanceof FuncCall) {
             return null;
         }
+
         if (! $this->isName($expr, 'str_contains')) {
             return null;
         }
+
         return $expr;
     }
 }

--- a/rules/EarlyReturn/NodeTransformer/ConditionInverter.php
+++ b/rules/EarlyReturn/NodeTransformer/ConditionInverter.php
@@ -25,9 +25,11 @@ final class ConditionInverter
             if (! $inversedCondition instanceof BinaryOp) {
                 return new BooleanNot($expr);
             }
+
             if ($inversedCondition instanceof BooleanAnd) {
                 return new BooleanNot($expr);
             }
+
             return $inversedCondition;
         }
 

--- a/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
+++ b/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
@@ -106,6 +106,7 @@ CODE_SAMPLE
             if (! $parent instanceof Assign) {
                 return false;
             }
+
             return $this->nodeComparator->areNodesEqual($node, $assignVariable);
         });
 

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -159,9 +159,11 @@ CODE_SAMPLE
         if (! $this->ifManipulator->isIfWithOnlyOneStmt($if)) {
             return true;
         }
+
         if (! $if->cond instanceof BooleanAnd) {
             return true;
         }
+
         if (! $this->ifManipulator->isIfWithoutElseAndElseIfs($if)) {
             return true;
         }

--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
@@ -117,6 +117,7 @@ CODE_SAMPLE
 
             $expr = $expr->right;
         }
+
         return $ifs + [$this->createIf($expr, $return)];
     }
 

--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
@@ -113,6 +113,7 @@ CODE_SAMPLE
 
             $expr = $expr->right;
         }
+
         return $ifNegations + [
             $this->ifManipulator->createIfNegation($expr, new Return_($this->nodeFactory->createFalse())),
         ];

--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
@@ -120,9 +120,11 @@ CODE_SAMPLE
             if ($expr instanceof BooleanAnd) {
                 return [];
             }
+
             if (! $expr instanceof BooleanOr) {
                 continue;
             }
+
             return [];
         }
 

--- a/rules/MysqlToMysqli/Rector/Assign/MysqlAssignToMysqliRector.php
+++ b/rules/MysqlToMysqli/Rector/Assign/MysqlAssignToMysqliRector.php
@@ -142,11 +142,9 @@ CODE_SAMPLE
 
     private function processMysqlFetchField(Assign $assign, FuncCall $funcCall): Assign
     {
-        if (isset($funcCall->args[1])) {
-            $funcCall->name = new Name('mysqli_fetch_field_direct');
-        } else {
-            $funcCall->name = new Name('mysqli_fetch_field');
-        }
+        $funcCall->name = isset($funcCall->args[1]) ? new Name('mysqli_fetch_field_direct') : new Name(
+            'mysqli_fetch_field'
+        );
 
         return $assign;
     }
@@ -180,6 +178,7 @@ CODE_SAMPLE
                 if ($parentNode instanceof PropertyFetch) {
                     continue;
                 }
+
                 if ($parentNode instanceof StaticPropertyFetch) {
                     continue;
                 }

--- a/rules/MysqlToMysqli/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
+++ b/rules/MysqlToMysqli/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
@@ -170,6 +170,7 @@ CODE_SAMPLE
         if ($this->isUnionTypeWithResourceSubType($staticType, $resourceType)) {
             return true;
         }
+
         if (! $expr instanceof Variable) {
             return false;
         }

--- a/rules/Naming/Naming/PropertyNaming.php
+++ b/rules/Naming/Naming/PropertyNaming.php
@@ -241,9 +241,11 @@ final class PropertyNaming
         if (! \str_starts_with($shortClassName, 'I')) {
             return false;
         }
+
         if (! ctype_upper($shortClassName[1])) {
             return false;
         }
+
         return ctype_lower($shortClassName[2]);
     }
 

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -108,6 +108,7 @@ CODE_SAMPLE
         if ($expectedName === null) {
             return null;
         }
+
         if ($this->isName($node->var, $expectedName)) {
             return null;
         }

--- a/rules/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
+++ b/rules/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
@@ -81,6 +81,7 @@ CODE_SAMPLE
             if ($expectedName === null) {
                 continue;
             }
+
             if ($this->isName($variable, $expectedName)) {
                 continue;
             }

--- a/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
+++ b/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
@@ -100,6 +100,7 @@ CODE_SAMPLE
         if ($singularValueVarName === $exprName) {
             return null;
         }
+
         if ($singularValueVarName === $valueVarName) {
             return null;
         }
@@ -135,6 +136,7 @@ CODE_SAMPLE
             if (! $this->isName($node, $valueVarName)) {
                 return null;
             }
+
             return new Variable($singularValueVarName);
         });
 

--- a/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchMethodCallReturnTypeRector.php
@@ -89,6 +89,7 @@ CODE_SAMPLE
         if ($expectedName === null) {
             return null;
         }
+
         if ($this->isName($variableAndCallForeach->getVariable(), $expectedName)) {
             return null;
         }

--- a/rules/Php52/Rector/Switch_/ContinueToBreakInSwitchRector.php
+++ b/rules/Php52/Rector/Switch_/ContinueToBreakInSwitchRector.php
@@ -107,12 +107,15 @@ CODE_SAMPLE
         if (! $staticType instanceof ConstantType) {
             return $continue;
         }
+
         if (! $staticType instanceof ConstantIntegerType) {
             return $continue;
         }
+
         if ($staticType->getValue() > 1) {
             return $continue;
         }
+
         return new Break_();
     }
 }

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -92,6 +92,7 @@ final class EregToPcreTransformer
         } elseif (isset($this->cache[$content])) {
             return $this->cache[$content];
         }
+
         [$r, $i] = $this->_ere2pcre($content, 0);
         if ($i !== strlen($content)) {
             throw new InvalidEregException('unescaped metacharacter ")"');
@@ -127,9 +128,11 @@ final class EregToPcreTransformer
                     $cls .= '^';
                     ++$i;
                 }
+
                 if ($i >= $l) {
                     throw new InvalidEregException('"[" does not have a matching "]"');
                 }
+
                 $start = true;
 
                 $i = (int) $i;
@@ -138,6 +141,7 @@ final class EregToPcreTransformer
                 if ($i >= $l) {
                     throw new InvalidEregException('"[" does not have a matching "]"');
                 }
+
                 $r[$rr] .= '[' . $cls . ']';
             } elseif ($char === ')') {
                 break;
@@ -159,6 +163,7 @@ final class EregToPcreTransformer
                 if ($r[$rr] === '') {
                     throw new InvalidEregException('empty branch');
                 }
+
                 $r[] = '';
                 ++$rr;
                 ++$i;
@@ -167,11 +172,13 @@ final class EregToPcreTransformer
                 if (++$i >= $l) {
                     throw new InvalidEregException('an invalid escape sequence at the end');
                 }
+
                 $r[$rr] .= $this->_ere2pcre_escape($content[$i]);
             } else {
                 // including ] and } which are allowed as a literal character
                 $r[$rr] .= $this->_ere2pcre_escape($char);
             }
+
             ++$i;
             if ($i >= $l) {
                 break;
@@ -210,6 +217,7 @@ final class EregToPcreTransformer
             if ($ii >= $l || $content[$ii] !== ')') {
                 throw new InvalidEregException('"(" does not have a matching ")"');
             }
+
             $r[$rr] .= '(' . $t . ')';
             $i = $ii;
         }
@@ -232,6 +240,7 @@ final class EregToPcreTransformer
                 if ($a === '-' && ! $start && ! ($i < $l && $s[$i] === ']')) {
                     throw new InvalidEregException('"-" is invalid for the start character in the brackets');
                 }
+
                 if ($i < $l && $s[$i] === '-') {
                     $b = $s[++$i];
                     ++$i;
@@ -242,11 +251,13 @@ final class EregToPcreTransformer
                         $errorMessage = sprintf('an invalid character range %d-%d"', (int) $a, (int) $b);
                         throw new InvalidEregException($errorMessage);
                     }
+
                     $cls .= $this->_ere2pcre_escape($a) . '-' . $this->_ere2pcre_escape($b);
                 } else {
                     $cls .= $this->_ere2pcre_escape($a);
                 }
             }
+
             $start = false;
         } while ($i < $l && $s[$i] !== ']');
 
@@ -318,6 +329,7 @@ final class EregToPcreTransformer
         if (! isset(self::CHARACTER_CLASS_MAP[$ccls])) {
             throw new InvalidEregException('an invalid or unsupported character class [' . $ccls . ']');
         }
+
         $cls .= self::CHARACTER_CLASS_MAP[$ccls];
         $i = $ii + 1;
 

--- a/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
+++ b/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
@@ -175,6 +175,7 @@ CODE_SAMPLE
         if (! $scope instanceof Scope) {
             return null;
         }
+
         $classReflection = $scope->getClassReflection();
 
         if (! $classReflection instanceof ClassReflection) {

--- a/rules/Php70/Rector/FuncCall/EregToPregMatchRector.php
+++ b/rules/Php70/Rector/FuncCall/EregToPregMatchRector.php
@@ -163,6 +163,7 @@ final class EregToPregMatchRector extends AbstractRector
         if (\str_contains($functionName, 'eregi')) {
             return true;
         }
+
         return \str_contains($functionName, 'spliti');
     }
 }

--- a/rules/Php70/Rector/If_/IfToSpaceshipRector.php
+++ b/rules/Php70/Rector/If_/IfToSpaceshipRector.php
@@ -115,6 +115,7 @@ CODE_SAMPLE
         if ($this->firstValue === null) {
             return null;
         }
+
         if ($this->secondValue === null) {
             return null;
         }
@@ -180,9 +181,11 @@ CODE_SAMPLE
         )) {
             return true;
         }
+
         if (! $this->nodeComparator->areNodesEqual($binaryOp->right, $firstValue)) {
             return false;
         }
+
         return $this->nodeComparator->areNodesEqual($binaryOp->left, $secondValue);
     }
 

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -103,6 +103,7 @@ CODE_SAMPLE
         if ($methodName === null) {
             return null;
         }
+
         if ($className === null) {
             return null;
         }

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -60,9 +60,11 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             // not a match
             return null;
         }
+
         if ($checkedNode === null) {
             return null;
         }
+
         if (! $fallbackNode instanceof Expr) {
             return null;
         }
@@ -72,6 +74,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
         if ($this->isNullMatch($ternaryCompareNode->left, $ternaryCompareNode->right, $checkedNode)) {
             return new Coalesce($checkedNode, $fallbackNode);
         }
+
         if ($this->isNullMatch($ternaryCompareNode->right, $ternaryCompareNode->left, $checkedNode)) {
             return new Coalesce($checkedNode, $fallbackNode);
         }
@@ -96,6 +99,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
         if (! isset($issetNode->vars[0])) {
             return null;
         }
+
         if (count($issetNode->vars) > 1) {
             return null;
         }

--- a/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
+++ b/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
@@ -74,9 +74,11 @@ CODE_SAMPLE
         if ($node instanceof Concat) {
             return null;
         }
+
         if ($node instanceof Coalesce) {
             return null;
         }
+
         if ($this->isStringOrStaticNonNumbericString($node->left) && $this->nodeTypeResolver->isNumberType(
             $node->right
         )) {

--- a/rules/Php71/Rector/List_/ListToArrayDestructRector.php
+++ b/rules/Php71/Rector/List_/ListToArrayDestructRector.php
@@ -74,12 +74,15 @@ CODE_SAMPLE
         if ($parentNode instanceof Assign && $parentNode->var === $node) {
             return new Array_($node->items);
         }
+
         if (! $parentNode instanceof Foreach_) {
             return null;
         }
+
         if ($parentNode->valueVar !== $node) {
             return null;
         }
+
         return new Array_($node->items);
     }
 

--- a/rules/Php72/Rector/Assign/ListEachRector.php
+++ b/rules/Php72/Rector/Assign/ListEachRector.php
@@ -135,6 +135,7 @@ CODE_SAMPLE
         if ($listNode->items[0] !== null) {
             return false;
         }
+
         return $listNode->items[1] === null;
     }
 }

--- a/rules/Php72/Rector/Assign/ReplaceEachAssignmentWithKeyCurrentRector.php
+++ b/rules/Php72/Rector/Assign/ReplaceEachAssignmentWithKeyCurrentRector.php
@@ -97,6 +97,7 @@ CODE_SAMPLE
         if (! $parentNode instanceof Assign) {
             return false;
         }
+
         return $parentNode->var instanceof List_;
     }
 

--- a/rules/Php72/Rector/FuncCall/GetClassOnNullRector.php
+++ b/rules/Php72/Rector/FuncCall/GetClassOnNullRector.php
@@ -148,9 +148,11 @@ CODE_SAMPLE
         ) && ! $this->valueResolver->isNull($ternary->cond->right)) {
             return true;
         }
+
         if (! $this->nodeComparator->areNodesEqual($ternary->cond->right, $funcCall->args[0]->value)) {
             return false;
         }
+
         return ! $this->valueResolver->isNull($ternary->cond->left);
     }
 
@@ -169,9 +171,11 @@ CODE_SAMPLE
         ) && $this->valueResolver->isNull($ternary->cond->right)) {
             return true;
         }
+
         if (! $this->nodeComparator->areNodesEqual($ternary->cond->right, $funcCall->args[0]->value)) {
             return false;
         }
+
         return $this->valueResolver->isNull($ternary->cond->left);
     }
 }

--- a/rules/Php72/Rector/Unset_/UnsetCastRector.php
+++ b/rules/Php72/Rector/Unset_/UnsetCastRector.php
@@ -61,6 +61,7 @@ CODE_SAMPLE
 
             return null;
         }
+
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         if ($parentNode instanceof Expression) {

--- a/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
+++ b/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
@@ -150,9 +150,11 @@ CODE_SAMPLE
             if (! is_string($token)) {
                 continue;
             }
+
             if (! str_contains($token, '_')) {
                 continue;
             }
+
             return true;
         }
 

--- a/rules/Php74/Rector/MethodCall/ChangeReflectionTypeToStringToGetNameRector.php
+++ b/rules/Php74/Rector/MethodCall/ChangeReflectionTypeToStringToGetNameRector.php
@@ -100,9 +100,11 @@ CODE_SAMPLE
         if ($node->expr instanceof MethodCall) {
             return $this->refactorIfHasReturnTypeWasCalled($node->expr);
         }
+
         if (! $node->expr instanceof Variable) {
             return null;
         }
+
         if (! $this->isObjectType($node->expr, new ObjectType('ReflectionType'))) {
             return null;
         }
@@ -125,9 +127,11 @@ CODE_SAMPLE
             if (! $type instanceof ObjectType) {
                 continue;
             }
+
             if ($type->getClassName() !== 'ReflectionType') {
                 continue;
             }
+
             return true;
         }
 
@@ -180,9 +184,11 @@ CODE_SAMPLE
             if (! $variableName) {
                 return;
             }
+
             if (! $methodName) {
                 return;
             }
+
             $this->callsByVariable[$variableName][] = $methodName;
         }
     }

--- a/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrncmpMatchAndRefactor.php
+++ b/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrncmpMatchAndRefactor.php
@@ -44,12 +44,15 @@ final class StrncmpMatchAndRefactor implements StrStartWithMatchAndRefactorInter
         )) {
             return $this->strStartsWithFactory->createFromFuncCall($binaryOp->left, $isPositive);
         }
+
         if (! $binaryOp->right instanceof FuncCall) {
             return null;
         }
+
         if (! $this->nodeNameResolver->isName($binaryOp->right, self::FUNCTION_NAME)) {
             return null;
         }
+
         return $this->strStartsWithFactory->createFromFuncCall($binaryOp->right, $isPositive);
     }
 

--- a/rules/Php80/NodeAnalyzer/MatchSwitchAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/MatchSwitchAnalyzer.php
@@ -87,6 +87,7 @@ final class MatchSwitchAnalyzer
             if ($matchArm->conds === null) {
                 return true;
             }
+
             if ($matchArm->conds === []) {
                 return true;
             }

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -263,12 +263,15 @@ final class TokenManipulator
         if ($identical->left instanceof ArrayDimFetch && $identical->right instanceof ConstFetch) {
             return new ArrayDimFetchAndConstFetch($identical->left, $identical->right);
         }
+
         if (! $identical->right instanceof ArrayDimFetch) {
             return null;
         }
+
         if (! $identical->left instanceof ConstFetch) {
             return null;
         }
+
         return new ArrayDimFetchAndConstFetch($identical->right, $identical->left);
     }
 

--- a/rules/Php80/Rector/ClassMethod/FinalPrivateToPrivateVisibilityRector.php
+++ b/rules/Php80/Rector/ClassMethod/FinalPrivateToPrivateVisibilityRector.php
@@ -67,6 +67,7 @@ CODE_SAMPLE
         if (! $classMethod->isFinal()) {
             return true;
         }
+
         return ! $classMethod->isPrivate();
     }
 }

--- a/rules/Php80/Rector/ClassMethod/SetStateToStaticRector.php
+++ b/rules/Php80/Rector/ClassMethod/SetStateToStaticRector.php
@@ -68,6 +68,7 @@ CODE_SAMPLE
         if (! $this->isName($classMethod, MethodName::SET_STATE)) {
             return true;
         }
+
         return $classMethod->isStatic();
     }
 }

--- a/rules/Php80/Rector/Identical/StrEndsWithRector.php
+++ b/rules/Php80/Rector/Identical/StrEndsWithRector.php
@@ -169,6 +169,7 @@ CODE_SAMPLE
         if (! $substrOffset->expr instanceof FuncCall) {
             return false;
         }
+
         $funcCall = $substrOffset->expr;
 
         if (! $this->nodeNameResolver->isName($funcCall, 'strlen')) {
@@ -187,6 +188,7 @@ CODE_SAMPLE
         if (! $substrOffset->expr instanceof LNumber) {
             return false;
         }
+
         $lNumber = $substrOffset->expr;
 
         if (! $needle instanceof String_) {

--- a/rules/Php80/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/Php80/Rector/If_/NullsafeOperatorRector.php
@@ -228,6 +228,7 @@ CODE_SAMPLE
         if ($this->shouldProcessAssignInCurrentNode($assign, $nextNode)) {
             return $this->processAssignInCurrentNode($assign, $prevExpression, $nextNode, $isStartIf);
         }
+
         return $this->processAssignMayInNextNode($nextNode);
     }
 
@@ -236,12 +237,15 @@ CODE_SAMPLE
         if (! property_exists($assign->expr, self::NAME)) {
             return false;
         }
+
         if (! property_exists($nextNode, 'expr')) {
             return false;
         }
+
         if (! property_exists($nextNode->expr, self::NAME)) {
             return false;
         }
+
         return ! $this->valueResolver->isNull($nextNode->expr);
     }
 
@@ -302,9 +306,11 @@ CODE_SAMPLE
         if (! $nextNode instanceof Expression) {
             return null;
         }
+
         if (! $nextNode->expr instanceof Assign) {
             return null;
         }
+
         $mayNextIf = $nextNode->getAttribute(AttributeKey::NEXT_NODE);
         if (! $mayNextIf instanceof If_) {
             return null;
@@ -423,6 +429,7 @@ CODE_SAMPLE
         if (! $this->canTernaryReturnNull($ternary)) {
             return true;
         }
+
         if ($ternary->cond instanceof Identical) {
             return ! $this->hasNullComparison($ternary->cond);
         }

--- a/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
+++ b/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
@@ -55,9 +55,11 @@ CODE_SAMPLE
         if ($node->isPrivate()) {
             return null;
         }
+
         if ($node->isProtected()) {
             return null;
         }
+
         if ($node->isFinal()) {
             return null;
         }

--- a/rules/Privatization/NodeAnalyzer/PropertyFetchByMethodAnalyzer.php
+++ b/rules/Privatization/NodeAnalyzer/PropertyFetchByMethodAnalyzer.php
@@ -96,6 +96,7 @@ final class PropertyFetchByMethodAnalyzer
         if (! $this->nodeNameResolver->isName($classMethod, MethodName::CONSTRUCT)) {
             return false;
         }
+
         return $this->isPropertyChanging($classMethod, $propertyName);
     }
 

--- a/rules/Privatization/Rector/ClassMethod/ChangeGlobalVariablesToPropertiesRector.php
+++ b/rules/Privatization/Rector/ClassMethod/ChangeGlobalVariablesToPropertiesRector.php
@@ -171,12 +171,15 @@ CODE_SAMPLE
                 if (! $node instanceof Assign) {
                     return false;
                 }
+
                 if ($node->var instanceof Variable) {
                     return $this->nodeNameResolver->isName($node->var, $globalVariableName);
                 }
+
                 if ($node->var instanceof PropertyFetch) {
                     return $this->nodeNameResolver->isName($node->var, $globalVariableName);
                 }
+
                 return false;
             });
 

--- a/rules/Renaming/NodeManipulator/SwitchManipulator.php
+++ b/rules/Renaming/NodeManipulator/SwitchManipulator.php
@@ -20,10 +20,12 @@ final class SwitchManipulator
             if (! $node instanceof Break_) {
                 continue;
             }
+
             if (! $node->num instanceof LNumber || $node->num->value === 1) {
                 unset($stmts[$key]);
                 continue;
             }
+
             $node->num = $node->num->value === 2 ? null : new LNumber($node->num->value - 1);
         }
 

--- a/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
+++ b/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
@@ -132,9 +132,11 @@ CODE_SAMPLE
             if (! $this->isName($useUse->name, $completeImportForPartialAnnotation->getUse())) {
                 continue;
             }
+
             if ((string) $useUse->alias !== $completeImportForPartialAnnotation->getAlias()) {
                 continue;
             }
+
             return $namespace;
         }
 

--- a/rules/Transform/Rector/Assign/DimFetchAssignToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/DimFetchAssignToMethodCallRector.php
@@ -136,8 +136,10 @@ CODE_SAMPLE
             if (! $this->isObjectType($assign->expr, $dimFetchAssignToMethodCall->getItemObjectType())) {
                 continue;
             }
+
             return $dimFetchAssignToMethodCall;
         }
+
         return null;
     }
 }

--- a/rules/Transform/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
+++ b/rules/Transform/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
@@ -276,12 +276,15 @@ CODE_SAMPLE
         )) {
             return new MethodCall($propertyFetch, $arrayFuncCallToMethodCall->getArrayMethod(), $funcCall->args);
         }
+
         if ($arrayFuncCallToMethodCall->getNonArrayMethod() === '') {
             return null;
         }
+
         if ($this->arrayTypeAnalyzer->isArrayType($funcCall->args[0]->value)) {
             return null;
         }
+
         return new MethodCall($propertyFetch, $arrayFuncCallToMethodCall->getNonArrayMethod(), $funcCall->args);
     }
 }

--- a/rules/Transform/Rector/FuncCall/FuncCallToConstFetchRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToConstFetchRector.php
@@ -79,6 +79,7 @@ CODE_SAMPLE
         if (! $functionName) {
             return null;
         }
+
         if (! array_key_exists($functionName, $this->functionsToConstants)) {
             return null;
         }

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -103,12 +103,15 @@ final class CallTypesResolver
             $unionedType = $this->narrowParentObjectTreeToSingleObjectChildType($unionedType);
             $staticTypeByArgumentPosition[$position] = $unionedType;
         }
+
         if (count($staticTypeByArgumentPosition) !== 1) {
             return $staticTypeByArgumentPosition;
         }
+
         if (! $staticTypeByArgumentPosition[0] instanceof NullType) {
             return $staticTypeByArgumentPosition;
         }
+
         return [new MixedType()];
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -196,12 +196,15 @@ CODE_SAMPLE
         if ($node->returnType !== null) {
             return true;
         }
+
         if (! $node instanceof ClassMethod) {
             return $this->isUnionPossibleReturnsVoid($node);
         }
+
         if (! $node->isMagic()) {
             return $this->isUnionPossibleReturnsVoid($node);
         }
+
         return true;
     }
 

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -81,6 +81,7 @@ CODE_SAMPLE
         if (! $varType instanceof Type) {
             return null;
         }
+
         if ($varType instanceof  MixedType) {
             return null;
         }

--- a/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
+++ b/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
@@ -149,9 +149,11 @@ final class ReturnTypeAlreadyAddedChecker
         if ($type instanceof IterableType) {
             return true;
         }
+
         if (! $type instanceof ObjectType) {
             return false;
         }
+
         return $type->getClassName() === Iterator::class;
     }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -88,9 +88,11 @@ final class GenericClassStringTypeNormalizer
         if ($classReflection->isBuiltIn()) {
             return new GenericClassStringType(new ObjectType($value));
         }
+
         if (str_contains($value, '\\')) {
             return new GenericClassStringType(new ObjectType($value));
         }
+
         return new StringType();
     }
 }

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -96,6 +96,7 @@ final class AssignToPropertyTypeInferer
             if ($isAssignedInConstructor) {
                 return false;
             }
+
             return ! $hasPropertyDefaultValue;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/GetterNodeParamTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/GetterNodeParamTypeInferer.php
@@ -62,9 +62,11 @@ final class GetterNodeParamTypeInferer implements ParamTypeInfererInterface
             if (! $node instanceof Return_) {
                 return null;
             }
+
             if ($node->expr === null) {
                 return null;
             }
+
             $isMatch = $this->propertyFetchAnalyzer->isLocalPropertyOfNames($node->expr, $propertyNames);
             if (! $isMatch) {
                 return null;

--- a/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
@@ -195,6 +195,7 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
                 if ($position !== $parameterPosition) {
                     continue;
                 }
+
                 if (! $singleDataProvidedSetItem instanceof ArrayItem) {
                     continue;
                 }

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInferer.php
@@ -133,6 +133,7 @@ final class ReturnedNodesReturnTypeInferer implements ReturnTypeInfererInterface
         if (! $classLike instanceof Class_) {
             return false;
         }
+
         return $classLike->isAbstract();
     }
 

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/SetterNodeReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/SetterNodeReturnTypeInferer.php
@@ -41,6 +41,7 @@ final class SetterNodeReturnTypeInferer implements ReturnTypeInfererInterface
             if (! $inferredPropertyType instanceof Type) {
                 continue;
             }
+
             $types[] = $inferredPropertyType;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/YieldNodesReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/YieldNodesReturnTypeInferer.php
@@ -53,6 +53,7 @@ final class YieldNodesReturnTypeInferer implements ReturnTypeInfererInterface
             if ($resolvedType instanceof MixedType) {
                 continue;
             }
+
             $types[] = $resolvedType;
         }
 

--- a/src/Bootstrap/ExtensionConfigResolver.php
+++ b/src/Bootstrap/ExtensionConfigResolver.php
@@ -69,9 +69,11 @@ final class ExtensionConfigResolver
         if (! file_exists($includedFilePath)) {
             return null;
         }
+
         if (! is_readable($includedFilePath)) {
             return null;
         }
+
         return $includedFilePath;
     }
 }

--- a/src/Differ/DefaultDiffer.php
+++ b/src/Differ/DefaultDiffer.php
@@ -25,6 +25,7 @@ final class DefaultDiffer
         if ($old === $new) {
             return '';
         }
+
         return $this->differ->diff($old, $new);
     }
 }

--- a/src/NodeAnalyzer/ConstFetchAnalyzer.php
+++ b/src/NodeAnalyzer/ConstFetchAnalyzer.php
@@ -18,6 +18,7 @@ final class ConstFetchAnalyzer
         if ($this->isTrue($node)) {
             return true;
         }
+
         return $this->isFalse($node);
     }
 

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -188,12 +188,15 @@ final class PropertyFetchAnalyzer
                 if (! $node instanceof Assign) {
                     return false;
                 }
+
                 if ($kindPropertyFetch !== $node->var::class) {
                     return false;
                 }
+
                 if (! $this->nodeNameResolver->isName($node->var, $propertyName)) {
                     return false;
                 }
+
                 return $this->nodeComparator->areNodesEqual($node->expr, $paramVariable);
             });
 

--- a/src/NodeFactory/ClassWithPublicPropertiesFactory.php
+++ b/src/NodeFactory/ClassWithPublicPropertiesFactory.php
@@ -37,6 +37,7 @@ final class ClassWithPublicPropertiesFactory
         if ($namespace !== '') {
             $namespaceBuilder = new NamespaceBuilder($namespace);
         }
+
         $classBuilder = new ClassBuilder($className);
         if ($parent !== null && $parent !== '') {
             $classBuilder->extend($this->fixFullyQualifiedName($parent));
@@ -52,6 +53,7 @@ final class ClassWithPublicPropertiesFactory
             if ($nullable) {
                 $propertyType = new NullableType($propertyType);
             }
+
             $propertyBuilder = new PropertyBuilder($propertyName);
             $propertyBuilder->setType($propertyType);
             $classBuilder->addStmt($propertyBuilder);

--- a/src/NodeManipulator/ArrayManipulator.php
+++ b/src/NodeManipulator/ArrayManipulator.php
@@ -94,6 +94,7 @@ final class ArrayManipulator
         if (! $arrayItem->key instanceof String_) {
             return false;
         }
+
         return $arrayItem->key->value === $name;
     }
 }

--- a/src/NodeManipulator/BinaryOpManipulator.php
+++ b/src/NodeManipulator/BinaryOpManipulator.php
@@ -42,12 +42,15 @@ final class BinaryOpManipulator
         if ($firstCondition($binaryOp->left, $binaryOp->right) && $secondCondition($binaryOp->right, $binaryOp->left)) {
             return new TwoNodeMatch($binaryOp->left, $binaryOp->right);
         }
+
         if (! $firstCondition($binaryOp->right, $binaryOp->left)) {
             return null;
         }
+
         if (! $secondCondition($binaryOp->left, $binaryOp->right)) {
             return null;
         }
+
         return new TwoNodeMatch($binaryOp->right, $binaryOp->left);
     }
 

--- a/src/NodeManipulator/ClassInsertManipulator.php
+++ b/src/NodeManipulator/ClassInsertManipulator.php
@@ -34,6 +34,7 @@ final class ClassInsertManipulator
         if ($this->isSuccessToInsertBeforeFirstMethod($class, $stmt)) {
             return;
         }
+
         if ($this->isSuccessToInsertAfterLastProperty($class, $stmt)) {
             return;
         }

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -239,6 +239,7 @@ final class ClassMethodAssignManipulator
         if ($this->isFuncCallWithReferencedArgument($node, $variable)) {
             return true;
         }
+
         return $this->isConstructorWithReference($node, $argumentPosition);
     }
 
@@ -310,6 +311,7 @@ final class ClassMethodAssignManipulator
                 if ($parameterPosition !== $argumentPosition) {
                     continue;
                 }
+
                 return $parameterReflection->passedByReference()
                     ->yes();
             }

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -68,12 +68,15 @@ final class ClassMethodManipulator
         if (! $classLike instanceof Class_) {
             return false;
         }
+
         if ($classMethod->isPrivate()) {
             return true;
         }
+
         if ($classLike->isFinal()) {
             return false;
         }
+
         return $classMethod->isProtected();
     }
 

--- a/src/NodeManipulator/FunctionLikeManipulator.php
+++ b/src/NodeManipulator/FunctionLikeManipulator.php
@@ -38,9 +38,11 @@ final class FunctionLikeManipulator
             if (! $node instanceof Return_) {
                 return null;
             }
+
             if ($node->expr === null) {
                 return null;
             }
+
             if (! $this->propertyFetchAnalyzer->isLocalPropertyFetch($node->expr)) {
                 return null;
             }

--- a/src/NodeManipulator/IfManipulator.php
+++ b/src/NodeManipulator/IfManipulator.php
@@ -191,6 +191,7 @@ final class IfManipulator
         if (! $this->nodeComparator->areNodesEqual($lastIfStmt->var, $lastElseStmt->var)) {
             return false;
         }
+
         return $this->nodeComparator->areNodesEqual($desiredExpr, $lastElseStmt->var);
     }
 
@@ -209,6 +210,7 @@ final class IfManipulator
         if (! $if->cond instanceof FuncCall) {
             return false;
         }
+
         return $this->nodeNameResolver->isName($if->cond, $functionName);
     }
 
@@ -239,6 +241,7 @@ final class IfManipulator
         if (! $this->isIfWithoutElseAndElseIfs($currentIf)) {
             return [];
         }
+
         $betterNodeFinderFindInstanceOf = $this->betterNodeFinder->findInstanceOf($currentIf->stmts, Return_::class);
 
         if ($betterNodeFinderFindInstanceOf !== []) {
@@ -297,9 +300,11 @@ final class IfManipulator
         if (! $node instanceof MethodCall && ! $node instanceof PropertyFetch) {
             return false;
         }
+
         if (! $if->cond instanceof NotIdentical) {
             return false;
         }
+
         return ! $this->nodeComparator->areNodesEqual($this->getIfCondVar($if), $node->var);
     }
 
@@ -346,6 +351,7 @@ final class IfManipulator
         if (! $this->nodeComparator->areNodesEqual($notIdentical->right, $return->expr)) {
             return null;
         }
+
         if ($this->valueResolver->isNull($notIdentical->left)) {
             return $notIdentical->right;
         }
@@ -358,9 +364,11 @@ final class IfManipulator
         if ($this->nodeComparator->areNodesEqual($notIdentical->left, $notIdentical->right)) {
             return false;
         }
+
         if ($this->valueResolver->isNull($notIdentical->right)) {
             return true;
         }
+
         return $this->valueResolver->isNull($notIdentical->left);
     }
 

--- a/src/PHPStan/Reflection/TypeToCallReflectionResolver/ConstantArrayTypeToCallReflectionResolver.php
+++ b/src/PHPStan/Reflection/TypeToCallReflectionResolver/ConstantArrayTypeToCallReflectionResolver.php
@@ -40,9 +40,11 @@ final class ConstantArrayTypeToCallReflectionResolver implements TypeToCallRefle
         if (! $constantArrayTypeAndMethod instanceof ConstantArrayTypeAndMethod) {
             return null;
         }
+
         if ($constantArrayTypeAndMethod->isUnknown()) {
             return null;
         }
+
         if (! $constantArrayTypeAndMethod->getCertainty()->yes()) {
             return null;
         }

--- a/src/PhpParser/NodeFinder/PropertyFetchFinder.php
+++ b/src/PhpParser/NodeFinder/PropertyFetchFinder.php
@@ -115,9 +115,11 @@ final class PropertyFetchFinder
             if ($node instanceof PropertyFetch) {
                 return $this->nodeNameResolver->isName($node, $propertyName);
             }
+
             if ($node instanceof StaticPropertyFetch) {
                 return $this->nodeNameResolver->isName($node, $propertyName);
             }
+
             return false;
         });
 

--- a/src/ValueObject/Bootstrap/BootstrapConfigs.php
+++ b/src/ValueObject/Bootstrap/BootstrapConfigs.php
@@ -31,6 +31,7 @@ final class BootstrapConfigs
         if ($this->mainConfigFileInfo !== null) {
             $configFileInfos[] = $this->mainConfigFileInfo;
         }
+
         return array_merge($configFileInfos, $this->setConfigFileInfos);
     }
 }


### PR DESCRIPTION
Sometime, when running rector, rector remove the line between statements, this new rector rule  `NewlineAfterStatementRector` ensure that there is a 1 line after statement if no new line for registered stmts: 

```
        ClassMethod::class,
        Function_::class,
        Property::class,
        If_::class,
        Foreach_::class,
        Do_::class,
        While_::class,
        For_::class,
        ClassConst::class,
```

I registered the rule to config set, for direct go to review, can direct check to https://github.com/rectorphp/rector-src/pull/787/files#diff-073196adc4979d1e1a3d5688fe95bb533bc4fdef1e86535001fa6fd15cc71fd9