### PR TITLE
Failing test case for SimplifyIfElseToTernaryRector and RemoveUnusedAssignVariableRector 

### DIFF
--- a/tests/Issues/Issue6655/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6655/Fixture/fixture.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+function getRes(): string
+{
+    if ('a' !== 'b') {
+        $res = "a";
+    } else {
+        $res = "b";
+    }
+
+    return $res;
+}
+?>
+-----
+<?php
+
+function getRes(): string
+{
+    $res = 'a' !== 'b' ? "a" : "b";
+
+    return $res;
+}
+?>

--- a/tests/Issues/Issue6655/SimplifyIfElseAndRemoveUnusedAssignVariableTest.php
+++ b/tests/Issues/Issue6655/SimplifyIfElseAndRemoveUnusedAssignVariableTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6420;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/6655
+ */
+final class SimplifyIfElseAndRemoveUnusedAssignVariableTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6655/config/configured_rule.php
+++ b/tests/Issues/Issue6655/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+use Rector\DeadCode\Rector\Assign\RemoveUnusedAssignVariableRector;
+use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimplifyIfElseToTernaryRector::class);
+    $services->set(RemoveUnusedAssignVariableRector::class);
+};


### PR DESCRIPTION
refs: https://github.com/rectorphp/rector/issues/6655
closes: https://github.com/rectorphp/rector/issues/6655


The main reason why this seems to occur is because of an incosistent "statement tree" (not sure what the proper term for this would be). Let me try to explain:

If SimplifyIfElseToTernaryRector changes something it will take an `PhpParser\Node\Stmt\If_` node and return a **new** `PhpParser\Node\Stmt\Expression` node. This works perfectly fine, however, the "parent statements" are not being updated properly.

So if I have a structure like so:

```php
function getRes(): string
{
    if ('a' !== 'b') {
        $res = "a";
    } else {
        $res = "b";
    }

    return $res;
}
```

and the SimplifyIfElseToTernaryRector returns the new ternary version, the statements of the function are not updated.

So the `PhpParser\Node\Stmt\If_` node that was replaced by an `PhpParser\Node\Stmt\Expression` node by the SimplifyIfElseToTernaryRector has a linked parent, this parent is the `PhpParser\Node\Stmt\Function_`. The `PhpParser\Node\Stmt\Function_`still has the statements [`PhpParser\Node\Stmt\If_` , `PhpParser\Node\Stmt\Return_`] while in reality it is now [`PhpParser\Node\Stmt\Expression`, `PhpParser\Node\Stmt\Return_`]. This results in the "statement tree" (for lack of better words) to be inconsistent, thus resulting in differing results between rectors if they're used in conjunction with each other.

Given that information, in the RemoveUnusedAssignVariableRector the NextVariableUsageNodeFinder tries to look up the method / function statements to look for usages, which are now stale references to things that don't exist anymore (namely the `PhpParser\Node\Stmt\If_` node) so it cannot skip the refactoring resulting in the behaviour that can be seen in the failing test case.

This is a rare condition though as usually nodes aren't entirely changed and/or two seperate rectors rarely need to touch the same type of statement constructs.

I'd hope someone with a deeper understanding of the rector core to take a look into this and potentially figure out if there's a decent solution for this.

I'd be happy to help implementing it if one was to point me in the right direction, however, currently I'm not sure where to go from here.
