### PR TITLE
[DeadCode] Skip RecastingRemovalRector on has __set() and __get()

### DIFF
--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_with_set_get_magic.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_with_set_get_magic.php.inc
@@ -19,7 +19,7 @@ class AConfig
     }
 }
 
-class SkipWithMagicSet
+class SkipWithMagicSetGet
 {
     public function run(AConfig $config)
     {

--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_with_set_get_magic.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_with_set_get_magic.php.inc
@@ -19,7 +19,7 @@ class AConfig
     }
 }
 
-class SkipWithMagicSetGet
+class SkipWithSetGetMagic
 {
     public function run(AConfig $config)
     {

--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_with_set_magic.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_with_set_magic.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Rector;
+
+class AConfig
+{
+    private $data = [];
+
+    public function __get($name)
+    {
+        if (isset($this->data[$name])) {
+             return $this->data[$name];
+        }
+    }
+
+    public function __set($name, $value)
+    {
+        $this->data[$name] = (object) $value;
+    }
+}
+
+class SkipWithMagicSet
+{
+    public function run(AConfig $config)
+    {
+        $config->property = [];
+        var_dump([] === (array) $config->property);
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -126,6 +126,8 @@ CODE_SAMPLE
                 return true;
             }
 
+            // need to UnionType check due rectify cause removing (array) cast on $node->args
+            // on union $node type
             $varType = $this->nodeTypeResolver->resolve($expr->var);
             return ! $varType instanceof UnionType;
         }

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -25,6 +25,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -121,7 +122,8 @@ CODE_SAMPLE
         /** @var PropertyFetch|StaticPropertyFetch $expr */
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
-            return true;
+            $varType = $this->nodeTypeResolver->resolve($expr->var);
+            return ! $varType instanceof UnionType;
         }
 
         $nativeType = $phpPropertyReflection->getNativeType();

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -129,7 +129,6 @@ CODE_SAMPLE
             // need to UnionType check due rectify with RecastingRemovalRector + CountOnNullRector
             // cause add (array) cast on $node->args
             // on union $node types FuncCall|MethodCall|StaticCall
-            $varType = $this->nodeTypeResolver->resolve($expr->var);
             return ! $varType instanceof UnionType;
         }
 

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -122,9 +122,9 @@ CODE_SAMPLE
         /** @var PropertyFetch|StaticPropertyFetch $expr */
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
-            if ($expr instanceof StaticPropertyFetch) {
-                return true;
-            }
+            $varType = $expr instanceof StaticPropertyFetch
+                ? $this->nodeTypeResolver->resolve($expr->class)
+                : $this->nodeTypeResolver->resolve($expr->var);
 
             // need to UnionType check due rectify with RecastingRemovalRector + CountOnNullRector
             // cause add (array) cast on $node->args

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -126,7 +126,7 @@ CODE_SAMPLE
                 return true;
             }
 
-            // need to UnionType check due rectify cause removing (array) cast on $node->args
+            // need to UnionType check due rectify cause add (array) cast on $node->args
             // on union $node type
             $varType = $this->nodeTypeResolver->resolve($expr->var);
             return ! $varType instanceof UnionType;

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -122,6 +122,10 @@ CODE_SAMPLE
         /** @var PropertyFetch|StaticPropertyFetch $expr */
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
+            if ($expr instanceof StaticPropertyFetch) {
+                return true;
+            }
+
             $varType = $this->nodeTypeResolver->resolve($expr->var);
             return ! $varType instanceof UnionType;
         }

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -126,8 +126,9 @@ CODE_SAMPLE
                 return true;
             }
 
-            // need to UnionType check due rectify cause add (array) cast on $node->args
-            // on union $node type
+            // need to UnionType check due rectify with RecastingRemovalRector + CountOnNullRector
+            // cause add (array) cast on $node->args
+            // on union $node type on combined with
             $varType = $this->nodeTypeResolver->resolve($expr->var);
             return ! $varType instanceof UnionType;
         }

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -122,14 +122,14 @@ CODE_SAMPLE
         /** @var PropertyFetch|StaticPropertyFetch $expr */
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
-            $varType = $expr instanceof StaticPropertyFetch
+            $propertyType = $expr instanceof StaticPropertyFetch
                 ? $this->nodeTypeResolver->resolve($expr->class)
                 : $this->nodeTypeResolver->resolve($expr->var);
 
             // need to UnionType check due rectify with RecastingRemovalRector + CountOnNullRector
             // cause add (array) cast on $node->args
             // on union $node types FuncCall|MethodCall|StaticCall
-            return ! $varType instanceof UnionType;
+            return ! $propertyType instanceof UnionType;
         }
 
         $nativeType = $phpPropertyReflection->getNativeType();

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -128,7 +128,7 @@ CODE_SAMPLE
 
             // need to UnionType check due rectify with RecastingRemovalRector + CountOnNullRector
             // cause add (array) cast on $node->args
-            // on union $node type on combined with
+            // on union $node types FuncCall|MethodCall|StaticCall
             $varType = $this->nodeTypeResolver->resolve($expr->var);
             return ! $varType instanceof UnionType;
         }

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE
         /** @var PropertyFetch|StaticPropertyFetch $expr */
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
-            return false;
+            return true;
         }
 
         $nativeType = $phpPropertyReflection->getNativeType();


### PR DESCRIPTION
When property is not found on use casted `PropertyFetch`, it may be setted via `__set()` or `__get()`, which should be skipped.