### PR TITLE
[CodingStyle] Handle null item on ManualJsonStringToJsonEncodeArrayRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector/Fixture/null_item.php.inc
+++ b/rules-tests/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector/Fixture/null_item.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Assign\ManualJsonStringToJsonEncodeArrayRector\Fixture;
+
+final class NullItem
+{
+    public function run()
+    {
+        $json = '{"a":null}';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Assign\ManualJsonStringToJsonEncodeArrayRector\Fixture;
+
+final class NullItem
+{
+    public function run()
+    {
+        $jsonData = ['a' => null];
+        $json = \Nette\Utils\Json::encode($jsonData);
+    }
+}
+
+?>

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -575,10 +575,6 @@ final class NodeFactory
     private function createArrayItem($item, string | int | null $key = null): ArrayItem
     {
         $arrayItem = null;
-        if ($item === null) {
-            $item = $this->createNull();
-            $arrayItem = new ArrayItem($item);
-        }
 
         if ($item instanceof Variable
             || $item instanceof MethodCall
@@ -599,7 +595,7 @@ final class NodeFactory
             $arrayItem = new ArrayItem($this->createArray($item));
         }
 
-        if ($item instanceof ClassConstFetch) {
+        if ($item === null || $item instanceof ClassConstFetch) {
             $itemValue = BuilderHelpers::normalizeValue($item);
             $arrayItem = new ArrayItem($itemValue);
         }

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -575,6 +575,10 @@ final class NodeFactory
     private function createArrayItem($item, string | int | null $key = null): ArrayItem
     {
         $arrayItem = null;
+        if ($item === null) {
+            $item = $this->createNull();
+            $arrayItem = new ArrayItem($item);
+        }
 
         if ($item instanceof Variable
             || $item instanceof MethodCall


### PR DESCRIPTION
Given the following code:

```php
$json = '{"a":null}';
```

It got error:

```bash
1) Rector\Tests\CodingStyle\Rector\Assign\ManualJsonStringToJsonEncodeArrayRector\ManualJsonStringToJsonEncodeArrayRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\NotImplementedYetException: Not implemented yet. Go to "Rector\Core\PhpParser\Node\NodeFactory::createArrayItem()" and add check for "" node.
```

This patch fix it .