### PR TITLE
[CodeQuality][EarlyReturn][TypeDeclaration] Handle ChangeOrIfReturnToEarlyReturnRector + ChangeAndIfToEarlyReturnRector + AddArrayReturnDocTypeRector + NarrowUnionTypeDocRector

### DIFF
--- a/rules/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector.php
@@ -90,11 +90,14 @@ CODE_SAMPLE
             }
         }
 
-        if ($phpDocInfo->hasChanged()) {
-            $node->setAttribute(AttributeKey::HAS_PHP_DOC_INFO_JUST_CHANGED, true);
-            return $node;
+        if (! $phpDocInfo->hasChanged()) {
+            return null;
         }
 
+        $node->setAttribute(AttributeKey::HAS_PHP_DOC_INFO_JUST_CHANGED, true);
+
+        // @see https://github.com/rectorphp/rector-src/pull/795
+        // avoid duplicated ifs and returns when combined with ChangeOrIfReturnToEarlyReturnRector, ChangeAndIfToEarlyReturnRector, and AddArrayReturnDocTypeRector
         return null;
     }
 

--- a/tests/Issues/IssueEarlyReturnAndOrNarrow/Fixture/and_next_or.php.inc
+++ b/tests/Issues/IssueEarlyReturnAndOrNarrow/Fixture/and_next_or.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndOrNarrow\Fixture;
+
+class AndNextOrReturnVoid
+{
+    public function run($a, $b, $c, $d)
+    {
+        if ($a && $b  || $c) {
+            return null;
+        }
+
+        return;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndOrNarrow\Fixture;
+
+class AndNextOrReturnVoid
+{
+    public function run($a, $b, $c, $d)
+    {
+        if ($a && $b) {
+            return null;
+        }
+        if ($c) {
+            return null;
+        }
+        return;
+    }
+}
+
+?>

--- a/tests/Issues/IssueEarlyReturnAndOrNarrow/Fixture/and_next_or.php.inc
+++ b/tests/Issues/IssueEarlyReturnAndOrNarrow/Fixture/and_next_or.php.inc
@@ -26,6 +26,9 @@ namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndOrNarrow\Fixture;
 
 class AndNextOrReturnVoid
 {
+    /**
+     * @return null|void
+     */
     public function run($a, $b, $c, $d)
     {
         if ($a && $b) {

--- a/tests/Issues/IssueEarlyReturnAndOrNarrow/IssueEarlyReturnAndOrNarrowTest.php
+++ b/tests/Issues/IssueEarlyReturnAndOrNarrow/IssueEarlyReturnAndOrNarrowTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndOrNarrow;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class IssueEarlyReturnAndOrNarrowTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueEarlyReturnAndOrNarrow/config/configured_rule.php
+++ b/tests/Issues/IssueEarlyReturnAndOrNarrow/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\ClassMethod\NarrowUnionTypeDocRector;
+use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ChangeOrIfReturnToEarlyReturnRector::class);
+    $services->set(ChangeAndIfToEarlyReturnRector::class);
+    $services->set(AddArrayReturnDocTypeRector::class);
+    $services->set(NarrowUnionTypeDocRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
class AndNextOrReturnVoid
{
    public function run($a, $b, $c, $d)
    {
        if ($a && $b  || $c) {
            return null;
        }

        return;
    }
}
```

It currently produce duplicated ifs and returns:

```diff
    public function run($a, $b, $c, $d)
     {
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
+        if (!$a) {
+            return;
+        }
+        if (!$b) {
+            return;
+        }
         if ($a && $b) {
             return null;
         }
+        return null;
+        return null;
+        return null;
+        return null;
+        return null;
+        return null;
+        return null;
+        return null;
         if ($c) {
```

Rules used:

```
Rector\CodeQuality\Rector\ClassMethod\NarrowUnionTypeDocRector;
Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector;
```