### PR TITLE
[EarlyReturn] Skip same return expr on ChangeOrIfReturnToEarlyReturnRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector/Fixture/skip_same_return.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector/Fixture/skip_same_return.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector\Fixture;
+
+class SkipSameReturn
+{
+    public function run($a, $b)
+    {
+        if ($a || $b) {
+            return null;
+        }
+        return null;
+    }
+}
+
+?>

--- a/rules-tests/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector/Fixture/skip_same_return.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector/Fixture/skip_same_return.php.inc
@@ -4,9 +4,9 @@ namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRecto
 
 class SkipSameReturn
 {
-    public function run($a, $b)
+    public function run($a, $b, $c)
     {
-        if ($a || $b) {
+        if ($a && $b || $c) {
             return null;
         }
         return null;

--- a/rules/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector.php
@@ -90,14 +90,11 @@ CODE_SAMPLE
             }
         }
 
-        if (! $phpDocInfo->hasChanged()) {
-            return null;
+        if ($phpDocInfo->hasChanged()) {
+            $node->setAttribute(AttributeKey::HAS_PHP_DOC_INFO_JUST_CHANGED, true);
+            return $node;
         }
 
-        $node->setAttribute(AttributeKey::HAS_PHP_DOC_INFO_JUST_CHANGED, true);
-
-        // @see https://github.com/rectorphp/rector-src/pull/795
-        // avoid duplicated ifs and returns when combined with ChangeOrIfReturnToEarlyReturnRector, ChangeAndIfToEarlyReturnRector, and AddArrayReturnDocTypeRector
         return null;
     }
 

--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
@@ -91,21 +91,18 @@ CODE_SAMPLE
         }
 
         $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
-        if ($nextNode === null) {
-            return null;
-        }
-
-        if ($nextNode instanceof Return_ && $nextNode->expr === null) {
-            return null;
-        }
-
-        // avoid repetitive ifs combined with other rules
-        if ($this->nodeComparator->areNodesEqual($nextNode->expr, $node->stmts[0]->expr)) {
+        if ($this->shouldSkip($node, $nextNode)) {
             return null;
         }
 
         /** @var Return_ $return */
         $return = $node->stmts[0];
+
+        // avoid repetitive ifs combined with other rules
+        if ($this->nodeComparator->areNodesEqual($nextNode->expr, $return->expr)) {
+            return null;
+        }
+
         $ifs = $this->createMultipleIfs($node->cond, $return, []);
 
         foreach ($ifs as $key => $if) {
@@ -118,6 +115,15 @@ CODE_SAMPLE
 
         $this->removeNode($node);
         return $node;
+    }
+
+    private function shouldSkip(If_ $if, ?Node $nextNode): bool
+    {
+        if ($nextNode === null) {
+            return true;
+        }
+
+        return $nextNode instanceof Return_ && $nextNode->expr === null;
     }
 
     /**

--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
@@ -99,6 +99,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // avoid repetitive ifs combined with other rules
+        if ($this->nodeComparator->areNodesEqual($nextNode->expr, $node->stmts[0]->expr)) {
+            return null;
+        }
+
         /** @var Return_ $return */
         $return = $node->stmts[0];
         $ifs = $this->createMultipleIfs($node->cond, $return, []);

--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
         }
 
         $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
-        if ($this->shouldSkip($node, $nextNode)) {
+        if ($this->shouldSkip($nextNode)) {
             return null;
         }
 
@@ -99,7 +99,7 @@ CODE_SAMPLE
         $return = $node->stmts[0];
 
         // avoid repetitive ifs combined with other rules
-        if ($this->nodeComparator->areNodesEqual($nextNode->expr, $return->expr)) {
+        if ($nextNode instanceof Return_ && $this->nodeComparator->areNodesEqual($nextNode->expr, $return->expr)) {
             return null;
         }
 
@@ -117,7 +117,7 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function shouldSkip(If_ $if, ?Node $nextNode): bool
+    private function shouldSkip(?Node $nextNode): bool
     {
         if ($nextNode === null) {
             return true;


### PR DESCRIPTION
In rectify, previously, it will got:

![Screen Shot 2021-08-31 at 19 28 56](https://user-images.githubusercontent.com/459648/131502790-b426107d-c3ce-4023-9643-c3f37291a3ff.png)
