### PR TITLE
Failing test case for RemoveUnusedPrivateMethodRector and RemoveAlwaysElseRector

### DIFF
--- a/tests/Issues/Issue6670/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6670/Fixture/fixture.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
+
+final class Client
+{
+    public function doSomething(): int
+    {
+        if (true === false) {
+            return -1;
+        } else {
+            return $this->notUnused();
+        }
+    }
+
+    private function notUnused(): int
+    {
+        // This is some code that is very important
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
+
+final class Client
+{
+    public function doSomething(): int
+    {
+        if (true === false) {
+            return -1;
+        }
+
+        return $this->notUnused();
+    }
+
+    private function notUnused(): int
+    {
+        // This is some code that is very important
+    }
+}
+?>

--- a/tests/Issues/Issue6670/RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest.php
+++ b/tests/Issues/Issue6670/RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6670;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/6670
+ */
+final class RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6670/config/configured_rule.php
+++ b/tests/Issues/Issue6670/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemoveUnusedPrivateMethodRector::class);
+    $services->set(RemoveAlwaysElseRector::class);
+};


### PR DESCRIPTION
refs: https://github.com/rectorphp/rector/issues/6670
closes: https://github.com/rectorphp/rector/issues/6670


Might be related to the same "error" (inconsistent statement tree) described in https://github.com/rectorphp/rector-src/pull/788