### PR TITLE
Failing test case for DowngradeParameterTypeWideningRector.

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector/Fixture/anonymous_return_abstract_interface.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector/Fixture/anonymous_return_abstract_interface.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+interface SomeInterface
+{
+    public function test(\SplFileInfo $file);
+}
+
+abstract class SomeAbstractClass implements SomeInterface
+{
+    public function test2(\SplFileInfo $file, string $world = 'world') {
+        printf('Hello %s', $world);
+    }
+}
+
+return new class extends SomeAbstractClass {
+    public function test(\SplFileInfo $file) {
+        $this->test2($file);
+    }
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+interface SomeInterface
+{
+    /**
+     * @param \SplFileInfo $file
+     */
+    public function test($file);
+}
+
+abstract class SomeAbstractClass implements SomeInterface
+{
+    /**
+     * @param \SplFileInfo $file
+     * @param string $world
+     */
+    public function test2($file, $world = 'world') {
+        printf('Hello %s', $world);
+    }
+}
+
+return new class extends SomeAbstractClass {
+    /**
+     * @param \SplFileInfo $file
+     */
+    public function test($file) {
+        $this->test2($file);
+    }
+};
+
+?>


### PR DESCRIPTION
Just found another DowngradeParameterTypeWideningRector issue which I was able to reproduce with this test case. Using the demo on getrector.org to open an issue with an example unfortunately didn't succeed since Rector (as expected) was not able to fix it and didn't show any changes.

Running the test locally resulted in:

```
1) Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\DowngradeParameterTypeWideningRectorTest::test with data set #2 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
TypeError: Rector\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector::shouldSkip(): Argument #2 ($classMethod) must be of type PhpParser\Node\Stmt\ClassMethod, null given, called in /workdir/rector-src/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php on line 141
```

While trying to debug it myself I got another interesting error while dumping the value of `$node` for this specific case within the rule, just before it failed:

```
1) Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\DowngradeParameterTypeWideningRectorTest::test with data set #8 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Error: Internal error: Failed to retrieve the reflection object
```

Hope all is clear.