### PR TITLE
Another failing test case for DowngradeParameterTypeWideningRector.

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector/Fixture/anonymous_class_alternative.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector/Fixture/anonymous_class_alternative.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+interface SomeInterface
+{
+    public function hello(string $world = 'world');
+}
+
+class SomeClass
+{
+    public function doSomething(): void
+    {
+        $class = new class (function () {
+            return $this->doSomethingElse();
+        }) implements SomeInterface {
+            public function hello(string $world = 'world') {
+                printf('Hi %s', $world);
+            }
+        };
+    }
+
+    public function doSomethingElse(): void
+    {
+        print('Hello again');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+interface SomeInterface
+{
+    /**
+     * @param string $world
+     */
+    public function hello($world = 'world');
+}
+
+class SomeClass
+{
+    public function doSomething(): void
+    {
+        $class = new class (function () {
+            return $this->doSomethingElse();
+        }) implements SomeInterface {
+            /**
+             * @param string $world
+             */
+            public function hello($world = 'world') {
+                printf('Hi %s', $world);
+            }
+        };
+    }
+
+    public function doSomethingElse(): void
+    {
+        print('Hello again');
+    }
+}
+
+?>


### PR DESCRIPTION
Sorry guys, one more DowngradeParameterTypeWideningRector issue, reproducible with this test case. This time the demo appears to be successful with the change, while it is failing locally. 

Demo: https://getrector.org/demo/1ec0a872-5237-62ca-8e29-034b5bf01dbf

Local (c42b1969ce3d7d22a0f57beca1e0373e0730c84f):

```
1) Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\DowngradeParameterTypeWideningRectorTest::test with data set #16 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules-tests/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector/Fixture/anonymous_class_alternative.php.inc
Failed asserting that string matches format description.
```

```diff
         $class = new class (function () {
             return $this->doSomethingElse();
         }) implements SomeInterface {
-            /**
-             * @param string $world
-             */
-            public function hello($world = 'world') {
+            public function hello(string $world = 'world') {
                 printf('Hi %s', $world);
             }
         };
```

PS: this code probably doesn't make much sense, however it was adapted from real code generated by an external library. Specifically https://github.com/olvlvl/symfony-dependency-injection-proxy, which generates code for the compiled container to lazy load dependencies from the Symfony dependency container.