### PR TITLE
[DeadCode][EarlyReturn] Handle RemoveUnusedPrivateMethodRector + RemoveAlwaysElseRector

### DIFF
--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -78,6 +78,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->nodesToAddCollector->isActive()) {
+            return null;
+        }
+
         $this->removeNode($node);
 
         return $node;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -122,7 +122,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
      */
     private $previousAppliedClass;
 
-    private NodesToAddCollector $nodesToAddCollector;
+    protected NodesToAddCollector $nodesToAddCollector;
 
     private CurrentFileProvider $currentFileProvider;
 

--- a/tests/Issues/Issue6670/Fixture/do_not_remove_used_class_method.php.inc
+++ b/tests/Issues/Issue6670/Fixture/do_not_remove_used_class_method.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
 
-final class Client
+final class DoNotRemoveUsedClassMethod
 {
     public function doSomething(): int
     {
@@ -24,7 +24,7 @@ final class Client
 
 namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
 
-final class Client
+final class DoNotRemoveUsedClassMethod
 {
     public function doSomething(): int
     {

--- a/tests/Issues/Issue6670/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6670/Fixture/fixture.php.inc
@@ -31,7 +31,6 @@ final class Client
         if (true === false) {
             return -1;
         }
-
         return $this->notUnused();
     }
 

--- a/tests/Issues/Issue6670/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6670/Fixture/fixture.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
+
+final class Client
+{
+    public function doSomething(): int
+    {
+        if (true === false) {
+            return -1;
+        } else {
+            return $this->notUnused();
+        }
+    }
+
+    private function notUnused(): int
+    {
+        // This is some code that is very important
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
+
+final class Client
+{
+    public function doSomething(): int
+    {
+        if (true === false) {
+            return -1;
+        }
+
+        return $this->notUnused();
+    }
+
+    private function notUnused(): int
+    {
+        // This is some code that is very important
+    }
+}
+?>

--- a/tests/Issues/Issue6670/RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest.php
+++ b/tests/Issues/Issue6670/RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6670;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/6670
+ */
+final class RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6670/config/configured_rule.php
+++ b/tests/Issues/Issue6670/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemoveUnusedPrivateMethodRector::class);
+    $services->set(RemoveAlwaysElseRector::class);
+};


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/801 Fixes https://github.com/rectorphp/rector/issues/6670

By check `NodesToAddCollector` isActive() check, it seems fix it.