### PR TITLE
Allowing future versions of phpstan

### DIFF
--- a/build/target-repository/.github/workflows/along_other_packages.yaml
+++ b/build/target-repository/.github/workflows/along_other_packages.yaml
@@ -26,7 +26,7 @@ jobs:
 
                     -
                         name: 'Along PHPStan'
-                        install: composer require phpstan/phpstan:^0.12.96 --dev --ansi
+                        install: composer require phpstan/phpstan:^0.12.97 --dev --ansi
 
         name: "PHP ${{ matrix.php_version }}"
 

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "phpstan/phpstan": "0.12.96"
+        "phpstan/phpstan": "0.12.97"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "nette/utils": "^3.2",
         "nikic/php-parser": "4.12.0",
         "phpstan/phpdoc-parser": "^0.5.5",
-        "phpstan/phpstan": "0.12.96",
+        "phpstan/phpstan": "^0.12.96",
         "phpstan/phpstan-phpunit": "^0.12.22",
         "rector/extension-installer": "^0.11.0",
         "rector/rector-cakephp": "^0.11.3",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "nette/utils": "^3.2",
         "nikic/php-parser": "4.12.0",
         "phpstan/phpdoc-parser": "^0.5.5",
-        "phpstan/phpstan": "0.12.97"
+        "phpstan/phpstan": "0.12.97",
         "phpstan/phpstan-phpunit": "^0.12.22",
         "rector/extension-installer": "^0.11.0",
         "rector/rector-cakephp": "^0.11.3",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "nette/utils": "^3.2",
         "nikic/php-parser": "4.12.0",
         "phpstan/phpdoc-parser": "^0.5.5",
-        "phpstan/phpstan": "^0.12.96",
+        "phpstan/phpstan": "0.12.97"
         "phpstan/phpstan-phpunit": "^0.12.22",
         "rector/extension-installer": "^0.11.0",
         "rector/rector-cakephp": "^0.11.3",


### PR DESCRIPTION
phpstan 0.12.97 was just released today https://github.com/phpstan/phpstan/releases
So right now, rector cannot be installed :-(