### PR TITLE
[PostRector] Using NodesToAddCollector in Rector rules

### DIFF
--- a/rules/CodeQuality/Rector/Assign/SplitListAssignToSeparateLineRector.php
+++ b/rules/CodeQuality/Rector/Assign/SplitListAssignToSeparateLineRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
         $rightArray = $node->expr;
 
         $standaloneAssigns = $this->createStandaloneAssigns($leftArray, $rightArray);
-        $this->addNodesAfterNode($standaloneAssigns, $node);
+        $this->nodesToAddCollector->addNodesAfterNode($standaloneAssigns, $node);
 
         $this->removeNode($node);
 

--- a/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
+++ b/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
         }
 
         $countAssign = new Assign(new Variable($variableName), $countInCond);
-        $this->addNodeBeforeNode($countAssign, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($countAssign, $node);
 
         return $node;
     }

--- a/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
                 $this->mirrorComments($assignExpression, $node);
             }
 
-            $this->addNodeAfterNode($assignExpression, $node);
+            $this->nodesToAddCollector->addNodeAfterNode($assignExpression, $node);
 
             ++$position;
         }

--- a/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
         $preAssign = new Assign($assignVariable, $array);
 
         $currentStatement = $funcCall->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        $this->addNodeBeforeNode($preAssign, $currentStatement);
+        $this->nodesToAddCollector->addNodeBeforeNode($preAssign, $currentStatement);
 
         return $expr;
     }

--- a/rules/CodeQuality/Rector/LogicalAnd/AndAssignsToSeparateLinesRector.php
+++ b/rules/CodeQuality/Rector/LogicalAnd/AndAssignsToSeparateLinesRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->addNodeAfterNode($node->right, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($node->right, $node);
 
         return $node->left;
     }

--- a/rules/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector.php
+++ b/rules/CodingStyle/Rector/Assign/ManualJsonStringToJsonEncodeArrayRector.php
@@ -117,7 +117,7 @@ CODE_SAMPLE
                 $jsonDataVariable = new Variable(self::JSON_DATA);
                 $jsonDataAssign = new Assign($jsonDataVariable, $jsonArray);
 
-                $this->addNodeBeforeNode($jsonDataAssign, $node);
+                $this->nodesToAddCollector->addNodeBeforeNode($jsonDataAssign, $node);
 
                 return $jsonEncodeAssign;
             }
@@ -242,7 +242,7 @@ CODE_SAMPLE
         $jsonDataVariable = new Variable(self::JSON_DATA);
         $jsonDataAssign = new Assign($jsonDataVariable, $jsonArray);
 
-        $this->addNodeBeforeNode($jsonDataAssign, $assign);
+        $this->nodesToAddCollector->addNodeBeforeNode($jsonDataAssign, $assign);
 
         return $this->createJsonEncodeAssign($assign->var, $jsonArray);
     }

--- a/rules/CodingStyle/Rector/Assign/SplitDoubleAssignRector.php
+++ b/rules/CodingStyle/Rector/Assign/SplitDoubleAssignRector.php
@@ -78,12 +78,12 @@ CODE_SAMPLE
         $newAssign = new Assign($node->var, $node->expr->expr);
 
         if (! $this->isExprCallOrNew($node->expr->expr)) {
-            $this->addNodeAfterNode($node->expr, $node);
+            $this->nodesToAddCollector->addNodeAfterNode($node->expr, $node);
             return $newAssign;
         }
 
         $varAssign = new Assign($node->expr->var, $node->var);
-        $this->addNodeBeforeNode(new Expression($newAssign), $node);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($newAssign), $node);
 
         return $varAssign;
     }

--- a/rules/CodingStyle/Rector/MethodCall/UseMessageVariableForSprintfInSymfonyStyleRector.php
+++ b/rules/CodingStyle/Rector/MethodCall/UseMessageVariableForSprintfInSymfonyStyleRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
 
         $messageVariable = new Variable('message');
         $assign = new Assign($messageVariable, $argValue);
-        $this->addNodeBeforeNode($assign, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($assign, $node);
 
         $node->args[0]->value = $messageVariable;
 

--- a/rules/CodingStyle/Rector/PostInc/PostIncDecToPreIncDecRector.php
+++ b/rules/CodingStyle/Rector/PostInc/PostIncDecToPreIncDecRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
         }
 
         $arrayDimFetch->dim = $node->var;
-        $this->addNodeAfterNode($this->processPrePost($node), $arrayDimFetch);
+        $this->nodesToAddCollector->addNodeAfterNode($this->processPrePost($node), $arrayDimFetch);
 
         return $arrayDimFetch->dim;
     }

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -137,7 +137,7 @@ CODE_SAMPLE
         }
 
         $this->stmtsHashed[$hash] = true;
-        $this->addNodeAfterNode(new Nop(), $node);
+        $this->nodesToAddCollector->addNodeAfterNode(new Nop(), $node);
 
         return $node;
     }

--- a/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
+++ b/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
@@ -196,7 +196,7 @@ CODE_SAMPLE
         }
 
         if ($this->phpVersionConstraint >= $value->value) {
-            $this->addNodesBeforeNode($if->stmts, $if);
+            $this->nodesToAddCollector->addNodesBeforeNode($if->stmts, $if);
             $this->removeNode($if);
         }
 
@@ -214,7 +214,7 @@ CODE_SAMPLE
         }
 
         if ($this->phpVersionConstraint >= $value->value) {
-            $this->addNodesBeforeNode($if->stmts, $if);
+            $this->nodesToAddCollector->addNodesBeforeNode($if->stmts, $if);
             $this->removeNode($if);
         }
 
@@ -259,7 +259,7 @@ CODE_SAMPLE
         }
 
         if ($this->phpVersionConstraint >= $value->value) {
-            $this->addNodesBeforeNode($if->stmts, $if);
+            $this->nodesToAddCollector->addNodesBeforeNode($if->stmts, $if);
             $this->removeNode($if);
         }
 

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -133,7 +133,7 @@ CODE_SAMPLE
         }
 
         if ($if->cond === $instanceof) {
-            $this->addNodesBeforeNode($if->stmts, $if);
+            $this->nodesToAddCollector->addNodesBeforeNode($if->stmts, $if);
         }
 
         $this->removeNode($if);

--- a/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
+++ b/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
@@ -70,7 +70,7 @@ CODE_SAMPLE
         }
 
         foreach ($node->stmts as $stmt) {
-            $this->addNodeBeforeNode($stmt, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($stmt, $node);
         }
 
         $this->removeNode($node);

--- a/rules/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector.php
+++ b/rules/Defluent/Rector/MethodCall/FluentChainMethodCallToNormalMethodCallRector.php
@@ -106,7 +106,7 @@ CODE_SAMPLE
         }
 
         $this->removeCurrentNode($node);
-        $this->addNodesAfterNode($nodesToAdd, $node);
+        $this->nodesToAddCollector->addNodesAfterNode($nodesToAdd, $node);
 
         return null;
     }

--- a/rules/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector.php
+++ b/rules/Defluent/Rector/MethodCall/InArgFluentChainMethodCallToStandaloneMethodCallRector.php
@@ -129,7 +129,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->addNodesBeforeNode($assignAndRootExprAndNodesToAdd->getNodesToAdd(), $node);
+        $this->nodesToAddCollector->addNodesBeforeNode($assignAndRootExprAndNodesToAdd->getNodesToAdd(), $node);
         return $assignAndRootExprAndNodesToAdd->getRootCallerExpr();
     }
 
@@ -144,7 +144,7 @@ CODE_SAMPLE
         $newVariable = $this->variableFromNewFactory->create($new);
         $nodesToAdd[] = $this->fluentMethodCallAsArgFactory->createFluentAsArg($methodCall, $newVariable);
 
-        $this->addNodesBeforeNode($nodesToAdd, $methodCall);
+        $this->nodesToAddCollector->addNodesBeforeNode($nodesToAdd, $methodCall);
         $this->removeParentParent($methodCall);
     }
 

--- a/rules/Defluent/Rector/MethodCall/MethodCallOnSetterMethodCallToStandaloneAssignRector.php
+++ b/rules/Defluent/Rector/MethodCall/MethodCallOnSetterMethodCallToStandaloneAssignRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
         }
 
         $newStmts = $this->nonFluentChainMethodCallFactory->createFromNewAndRootMethodCall($new, $node);
-        $this->addNodesBeforeNode($newStmts, $node);
+        $this->nodesToAddCollector->addNodesBeforeNode($newStmts, $node);
 
         // change new arg to root variable
         $newVariable = $this->variableFromNewFactory->create($new);

--- a/rules/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector.php
+++ b/rules/Defluent/Rector/MethodCall/NewFluentChainMethodCallToNonFluentRector.php
@@ -113,7 +113,7 @@ CODE_SAMPLE
         }
 
         $this->fluentNodeRemover->removeCurrentNode($node);
-        $this->addNodesAfterNode($assignAndRootExprAndNodesToAdd->getNodesToAdd(), $node);
+        $this->nodesToAddCollector->addNodesAfterNode($assignAndRootExprAndNodesToAdd->getNodesToAdd(), $node);
 
         return null;
     }

--- a/rules/Defluent/Rector/Return_/ReturnFluentChainMethodCallToNormalMethodCallRector.php
+++ b/rules/Defluent/Rector/Return_/ReturnFluentChainMethodCallToNormalMethodCallRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
         }
 
         $this->fluentNodeRemover->removeCurrentNode($node);
-        $this->addNodesAfterNode($nodesToAdd, $node);
+        $this->nodesToAddCollector->addNodesAfterNode($nodesToAdd, $node);
 
         return null;
     }

--- a/rules/Defluent/Rector/Return_/ReturnNewFluentChainMethodCallToNonFluentRector.php
+++ b/rules/Defluent/Rector/Return_/ReturnNewFluentChainMethodCallToNonFluentRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
         }
 
         $this->fluentNodeRemover->removeCurrentNode($node);
-        $this->addNodesAfterNode($nodesToAdd, $node);
+        $this->nodesToAddCollector->addNodesAfterNode($nodesToAdd, $node);
 
         return $node;
     }

--- a/rules/DowngradePhp70/Rector/FuncCall/DowngradeSessionStartArrayOptionsRector.php
+++ b/rules/DowngradePhp70/Rector/FuncCall/DowngradeSessionStartArrayOptionsRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE
             $funcName = new Name('ini_set');
             $iniSet = new FuncCall($funcName, [new Arg($sessionKey), new Arg($option->value)]);
 
-            $this->addNodeBeforeNode(new Expression($iniSet), $currentStatement);
+            $this->nodesToAddCollector->addNodeBeforeNode(new Expression($iniSet), $currentStatement);
         }
 
         unset($node->args[0]);

--- a/rules/DowngradePhp70/Rector/Spaceship/DowngradeSpaceshipRector.php
+++ b/rules/DowngradePhp70/Rector/Spaceship/DowngradeSpaceshipRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
         $variableAssignName = $this->variableNaming->createCountedValueName('battleShipcompare', $scope);
         $variableAssign = new Variable($variableAssignName);
         $assignExpression = $this->getAssignExpression($anonymousFunction, $variableAssign);
-        $this->addNodeBeforeNode($assignExpression, $currentStatement);
+        $this->nodesToAddCollector->addNodeBeforeNode($assignExpression, $currentStatement);
 
         return new FuncCall($variableAssign, [new Arg($node->left), new Arg($node->right)]);
     }

--- a/rules/DowngradePhp71/Rector/List_/DowngradeKeysInListRector.php
+++ b/rules/DowngradePhp71/Rector/List_/DowngradeKeysInListRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
 
         if ($parent instanceof Assign) {
             $this->mirrorComments($assignExpressions[0], $parentExpression);
-            $this->addNodesBeforeNode($assignExpressions, $node);
+            $this->nodesToAddCollector->addNodesBeforeNode($assignExpressions, $node);
             $this->removeNode($parentExpression);
 
             return $node;
@@ -117,7 +117,7 @@ CODE_SAMPLE
             if ($stmts === []) {
                 $parent->stmts = $assignExpressions;
             } else {
-                $this->addNodesBeforeNode($assignExpressions, $parent->stmts[0]);
+                $this->nodesToAddCollector->addNodesBeforeNode($assignExpressions, $parent->stmts[0]);
             }
 
             return $parent->valueVar;

--- a/rules/DowngradePhp71/Rector/StaticCall/DowngradeClosureFromCallableRector.php
+++ b/rules/DowngradePhp71/Rector/StaticCall/DowngradeClosureFromCallableRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
         );
 
         $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        $this->addNodeBeforeNode($assignment, $currentStatement);
+        $this->nodesToAddCollector->addNodeBeforeNode($assignment, $currentStatement);
 
         $closure = new Closure;
         $closure->uses[] = new ClosureUse($tempVariable);

--- a/rules/DowngradePhp71/Rector/StaticCall/DowngradeClosureFromCallableRector.php
+++ b/rules/DowngradePhp71/Rector/StaticCall/DowngradeClosureFromCallableRector.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Stmt\Return_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\Naming\VariableNaming;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\PostRector\Collector\NodesToAddCollector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -78,28 +77,17 @@ CODE_SAMPLE
 
         $tempVariable = new Variable($tempVariableName);
 
-        $assignment = new Expression(
-            new Assign(
-                $tempVariable,
-                $node->args[0]->value
-            )
-        );
+        $expression = new Expression(new Assign($tempVariable, $node->args[0]->value));
 
         $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        $this->nodesToAddCollector->addNodeBeforeNode($assignment, $currentStatement);
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $currentStatement);
 
-        $closure = new Closure;
+        $closure = new Closure();
         $closure->uses[] = new ClosureUse($tempVariable);
 
         $innerFuncCall = new FuncCall(
             $tempVariable,
-            [
-                new Arg(
-                    $this->nodeFactory->createFuncCall('func_get_args'),
-                    false,
-                    true
-                )
-            ]
+            [new Arg($this->nodeFactory->createFuncCall('func_get_args'), false, true)]
         );
 
         $closure->stmts[] = new Return_($innerFuncCall);

--- a/rules/DowngradePhp71/Rector/TryCatch/DowngradePipeToMultiCatchExceptionRector.php
+++ b/rules/DowngradePhp71/Rector/TryCatch/DowngradePipeToMultiCatchExceptionRector.php
@@ -70,7 +70,7 @@ CODE_SAMPLE
                     continue;
                 }
 
-                $this->addNodeAfterNode(new Catch_([$catchType], $catch->var, $catch->stmts), $node->catches[$key]);
+                $this->nodesToAddCollector->addNodeAfterNode(new Catch_([$catchType], $catch->var, $catch->stmts), $node->catches[$key]);
             }
         }
 

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -275,7 +275,7 @@ CODE_SAMPLE
     {
         $parent = $funcCall->getAttribute(AttributeKey::PARENT_NODE);
         if ($parent instanceof Expression) {
-            $this->addNodeAfterNode($replaceEmptystringToNull, $funcCall);
+            $this->nodesToAddCollector->addNodeAfterNode($replaceEmptystringToNull, $funcCall);
             return $funcCall;
         }
 
@@ -316,12 +316,12 @@ CODE_SAMPLE
                 ? $cond->right
                 : $cond->left;
             if ($this->valueResolver->isFalse($valueCompare)) {
-                $this->addNodeAfterNode($replaceEmptystringToNull, $if);
+                $this->nodesToAddCollector->addNodeAfterNode($replaceEmptystringToNull, $if);
             }
         }
 
         if ($cond instanceof BooleanNot) {
-            $this->addNodeAfterNode($replaceEmptystringToNull, $if);
+            $this->nodesToAddCollector->addNodeAfterNode($replaceEmptystringToNull, $if);
         }
 
         return $funcCall;
@@ -331,7 +331,7 @@ CODE_SAMPLE
     {
         if ($if->stmts !== []) {
             $firstStmt = $if->stmts[0];
-            $this->addNodeBeforeNode($funcCall, $firstStmt);
+            $this->nodesToAddCollector->addNodeBeforeNode($funcCall, $firstStmt);
         } else {
             $if->stmts[0] = new Expression($funcCall);
         }

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
         $function = $this->createClosure();
         $assign = new Assign(new Variable('streamIsatty'), $function);
 
-        $this->addNodeBeforeNode($assign, $node);
+        $this->nodesToAddCollector->addNodeBeforeNode($assign, $node);
 
         return new FuncCall(new Variable('streamIsatty'), $node->args);
     }

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -76,7 +76,7 @@ CODE_SAMPLE
         $array = $funcCall->args[0]->value;
 
         $resetFuncCall = $this->nodeFactory->createFuncCall('reset', [$array]);
-        $this->addNodeBeforeNode($resetFuncCall, $funcCall);
+        $this->nodesToAddCollector->addNodeBeforeNode($resetFuncCall, $funcCall);
 
         $funcCall->name = new Name('key');
 
@@ -87,7 +87,7 @@ CODE_SAMPLE
     {
         $array = $funcCall->args[0]->value;
         $resetFuncCall = $this->nodeFactory->createFuncCall('end', [$array]);
-        $this->addNodeBeforeNode($resetFuncCall, $funcCall);
+        $this->nodesToAddCollector->addNodeBeforeNode($resetFuncCall, $funcCall);
 
         $funcCall->name = new Name('key');
 

--- a/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
+++ b/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
@@ -109,7 +109,7 @@ CODE_SAMPLE
 
         // Add new nodes to do the assignment by reference
         $newNodes = $this->createAssignRefArrayFromListReferences($node->items, $exprVariable, []);
-        $this->addNodesAfterNode($newNodes, $node);
+        $this->nodesToAddCollector->addNodesAfterNode($newNodes, $node);
 
         // Remove the stale params right-most-side
         return $this->removeStaleParams($node, $rightSideRemovableParamsCount);

--- a/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
+++ b/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
@@ -208,7 +208,7 @@ CODE_SAMPLE
         );
         // Assign the value to the variable, and replace the element with the variable
         $newVariable = new Variable($variableName);
-        $this->addNodeBeforeNode(new Assign($newVariable, $arrayItem->value), $array);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Assign($newVariable, $arrayItem->value), $array);
         return $newVariable;
     }
 

--- a/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
+++ b/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
@@ -119,7 +119,7 @@ CODE_SAMPLE
             );
             // Assign the value to the variable
             $newVariable = new Variable($variableName);
-            $this->addNodeBeforeNode(new Assign($newVariable, $allowableTagsParam), $node);
+            $this->nodesToAddCollector->addNodeBeforeNode(new Assign($newVariable, $allowableTagsParam), $node);
 
             // Apply refactor on the variable
             $newExpr = $this->createIsArrayTernaryFromExpression($newVariable);

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -139,7 +139,7 @@ CODE_SAMPLE
             ? $ternary->cond
             : $ternary->if;
 
-        $this->addNodeAfterNode(new Expression($assign), $if);
+        $this->nodesToAddCollector->addNodeAfterNode(new Expression($assign), $if);
         return $if;
     }
 
@@ -160,7 +160,7 @@ CODE_SAMPLE
         }
 
         $assign->expr = $coalesce->left;
-        $this->addNodeAfterNode(new Expression($assign), $if);
+        $this->nodesToAddCollector->addNodeAfterNode(new Expression($assign), $if);
         return $if;
     }
 

--- a/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
+++ b/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
@@ -141,7 +141,7 @@ CODE_SAMPLE
         Foreach_ $foreach
     ): Foreach_ {
         $this->removeNode($expression);
-        $this->addNodeBeforeNode(new Return_($assign->expr), $breaks[0]);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Return_($assign->expr), $breaks[0]);
         $this->removeNode($breaks[0]);
 
         $return->expr = $assignPreviousVariable->expr;

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -104,7 +104,7 @@ CODE_SAMPLE
         $booleanAndConditions = $this->booleanAndAnalyzer->findBooleanAndConditions($expr);
 
         if (! $ifNextReturn instanceof Return_) {
-            $this->addNodeAfterNode($node->stmts[0], $node);
+            $this->nodesToAddCollector->addNodeAfterNode($node->stmts[0], $node);
             return $this->processReplaceIfs($node, $booleanAndConditions, new Return_());
         }
 
@@ -114,7 +114,7 @@ CODE_SAMPLE
 
         $this->removeNode($ifNextReturn);
         $ifNextReturn = $node->stmts[0];
-        $this->addNodeAfterNode($ifNextReturn, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($ifNextReturn, $node);
 
         $ifNextReturnClone = $ifNextReturn instanceof Return_
             ? clone $ifNextReturn
@@ -128,7 +128,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->addNodeAfterNode(new Return_(), $node);
+        $this->nodesToAddCollector->addNodeAfterNode(new Return_(), $node);
         return $this->processReplaceIfs($node, $booleanAndConditions, $ifNextReturnClone);
     }
 
@@ -142,7 +142,7 @@ CODE_SAMPLE
         $this->mirrorComments($ifs[0], $node);
 
         foreach ($ifs as $if) {
-            $this->addNodeBeforeNode($if, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($if, $node);
         }
 
         $this->removeNode($node);

--- a/rules/EarlyReturn/Rector/If_/ChangeNestedIfsToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeNestedIfsToEarlyReturnRector.php
@@ -110,7 +110,7 @@ CODE_SAMPLE
         foreach ($nestedIfsWithOnlyReturn as $key => $nestedIfWithOnlyReturn) {
             // last item → the return node
             if ($nestedIfsWithOnlyReturnCount === $key + 1) {
-                $this->addNodeAfterNode($nestedIfWithOnlyReturn, $if);
+                $this->nodesToAddCollector->addNodeAfterNode($nestedIfWithOnlyReturn, $if);
             } else {
                 $this->addStandaloneIfsWithReturn($nestedIfWithOnlyReturn, $if, $nextReturn);
             }
@@ -127,17 +127,17 @@ CODE_SAMPLE
         if ($invertedCondition instanceof BooleanNot && $invertedCondition->expr instanceof BooleanAnd) {
             $booleanNotPartIf = new If_(new BooleanNot($invertedCondition->expr->left));
             $booleanNotPartIf->stmts = [clone $return];
-            $this->addNodeAfterNode($booleanNotPartIf, $if);
+            $this->nodesToAddCollector->addNodeAfterNode($booleanNotPartIf, $if);
 
             $booleanNotPartIf = new If_(new BooleanNot($invertedCondition->expr->right));
             $booleanNotPartIf->stmts = [clone $return];
-            $this->addNodeAfterNode($booleanNotPartIf, $if);
+            $this->nodesToAddCollector->addNodeAfterNode($booleanNotPartIf, $if);
             return;
         }
 
         $nestedIfWithOnlyReturn->cond = $invertedCondition;
         $nestedIfWithOnlyReturn->stmts = [clone $return];
 
-        $this->addNodeAfterNode($nestedIfWithOnlyReturn, $if);
+        $this->nodesToAddCollector->addNodeAfterNode($nestedIfWithOnlyReturn, $if);
     }
 }

--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfContinueToMultiContinueRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfContinueToMultiContinueRector.php
@@ -104,7 +104,7 @@ CODE_SAMPLE
                 $this->mirrorComments($if, $node);
             }
 
-            $this->addNodeBeforeNode($if, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($if, $node);
         }
 
         $this->removeNode($node);

--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
                 $this->mirrorComments($if, $node);
             }
 
-            $this->addNodeBeforeNode($if, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($if, $node);
         }
 
         $this->removeNode($node);

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -87,7 +87,7 @@ CODE_SAMPLE
             $if = new If_($node->cond);
             $if->stmts = $node->stmts;
 
-            $this->addNodeBeforeNode($if, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($if, $node);
             $this->mirrorComments($if, $node);
 
             /** @var ElseIf_ $firstElseIf */
@@ -103,7 +103,7 @@ CODE_SAMPLE
 
             if ($originalNode->else instanceof Else_) {
                 $node->else = null;
-                $this->addNodeAfterNode($originalNode->else, $node);
+                $this->nodesToAddCollector->addNodeAfterNode($originalNode->else, $node);
             }
 
             return $node;

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -98,7 +98,7 @@ CODE_SAMPLE
 
             $statements = $this->getStatementsElseIfs($node);
             if ($statements !== []) {
-                $this->addNodesAfterNode($statements, $node);
+                $this->nodesToAddCollector->addNodesAfterNode($statements, $node);
             }
 
             if ($originalNode->else instanceof Else_) {
@@ -110,7 +110,7 @@ CODE_SAMPLE
         }
 
         if ($node->else !== null) {
-            $this->addNodesAfterNode($node->else->stmts, $node);
+            $this->nodesToAddCollector->addNodesAfterNode($node->else->stmts, $node);
             $node->else = null;
             return $node;
         }

--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
@@ -85,14 +85,14 @@ CODE_SAMPLE
 
         $this->mirrorComments($ifNegations[0], $node);
         foreach ($ifNegations as $ifNegation) {
-            $this->addNodeBeforeNode($ifNegation, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($ifNegation, $node);
         }
 
         /** @var BooleanAnd $booleanAnd */
         $booleanAnd = $node->expr;
 
         $lastReturnExpr = $this->assignAndBinaryMap->getTruthyExpr($booleanAnd->right);
-        $this->addNodeBeforeNode(new Return_($lastReturnExpr), $node);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Return_($lastReturnExpr), $node);
         $this->removeNode($node);
 
         return $node;

--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
@@ -93,11 +93,11 @@ CODE_SAMPLE
 
         $this->mirrorComments($ifs[0], $node);
         foreach ($ifs as $if) {
-            $this->addNodeBeforeNode($if, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($if, $node);
         }
 
         $lastReturnExpr = $this->assignAndBinaryMap->getTruthyExpr($booleanOr->right);
-        $this->addNodeBeforeNode(new Return_($lastReturnExpr), $node);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Return_($lastReturnExpr), $node);
         $this->removeNode($node);
 
         return $node;

--- a/rules/MysqlToMysqli/Rector/Assign/MysqlAssignToMysqliRector.php
+++ b/rules/MysqlToMysqli/Rector/Assign/MysqlAssignToMysqliRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
         $newFuncCall = new FuncCall(new Name('mysql_fetch_array'), [$funcCall->args[0]]);
         $newAssignNode = new Assign($assign->var, new ArrayDimFetch($newFuncCall, new LNumber(0)));
 
-        $this->addNodeAfterNode($newAssignNode, $assign);
+        $this->nodesToAddCollector->addNodeAfterNode($newAssignNode, $assign);
 
         return $funcCall;
     }
@@ -120,10 +120,10 @@ CODE_SAMPLE
         $mysqlFetchRowFuncCall = new FuncCall(new Name('mysqli_fetch_row'), [$funcCall->args[0]]);
         $fetchVariable = new Variable('fetch');
         $newAssignNode = new Assign($fetchVariable, $mysqlFetchRowFuncCall);
-        $this->addNodeAfterNode($newAssignNode, $assign);
+        $this->nodesToAddCollector->addNodeAfterNode($newAssignNode, $assign);
 
         $newAssignNode = new Assign($assign->var, new ArrayDimFetch($fetchVariable, new LNumber(0)));
-        $this->addNodeAfterNode($newAssignNode, $assign);
+        $this->nodesToAddCollector->addNodeAfterNode($newAssignNode, $assign);
 
         return $funcCall;
     }
@@ -133,7 +133,7 @@ CODE_SAMPLE
         $funcCall->name = new Name('mysqli_select_db');
 
         $newAssignNode = new Assign($assign->var, new FuncCall(new Name('mysqli_query'), [$funcCall->args[1]]));
-        $this->addNodeAfterNode($newAssignNode, $assign);
+        $this->nodesToAddCollector->addNodeAfterNode($newAssignNode, $assign);
 
         unset($funcCall->args[1]);
 
@@ -162,10 +162,10 @@ CODE_SAMPLE
         $mysqlFetchArrayFuncCall = new FuncCall(new Name('mysqli_fetch_array'), [$funcCall->args[0]]);
         $fetchVariable = new Variable('fetch');
         $newAssignNode = new Assign($fetchVariable, $mysqlFetchArrayFuncCall);
-        $this->addNodeAfterNode($newAssignNode, $assign);
+        $this->nodesToAddCollector->addNodeAfterNode($newAssignNode, $assign);
 
         $newAssignNode = new Assign($assign->var, new ArrayDimFetch($fetchVariable, $fetchField ?? new LNumber(0)));
-        $this->addNodeAfterNode($newAssignNode, $assign);
+        $this->nodesToAddCollector->addNodeAfterNode($newAssignNode, $assign);
 
         return $funcCall;
     }

--- a/rules/Php70/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector.php
+++ b/rules/Php70/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector.php
@@ -86,7 +86,7 @@ final class NonVariableToVariableOnFunctionCallRector extends AbstractRector
             $current = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
 
             $currentStatement = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-            $this->addNodeBeforeNode(
+            $this->nodesToAddCollector->addNodeBeforeNode(
                 $replacements->getAssign(),
                 $current instanceof Return_ ? $current : $currentStatement
             );

--- a/rules/Php72/Rector/Assign/ListEachRector.php
+++ b/rules/Php72/Rector/Assign/ListEachRector.php
@@ -81,7 +81,7 @@ CODE_SAMPLE
         // only value: list(, $value) = each($values);
         if ($listNode->items[1] && $listNode->items[0] === null) {
             $nextFuncCall = $this->nodeFactory->createFuncCall('next', $eachFuncCall->args);
-            $this->addNodeAfterNode($nextFuncCall, $node);
+            $this->nodesToAddCollector->addNodeAfterNode($nextFuncCall, $node);
 
             $currentFuncCall = $this->nodeFactory->createFuncCall('current', $eachFuncCall->args);
 
@@ -98,10 +98,10 @@ CODE_SAMPLE
         }
 
         $assign = new Assign($secondArrayItem->value, $currentFuncCall);
-        $this->addNodeAfterNode($assign, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($assign, $node);
 
         $nextFuncCall = $this->nodeFactory->createFuncCall('next', $eachFuncCall->args);
-        $this->addNodeAfterNode($nextFuncCall, $node);
+        $this->nodesToAddCollector->addNodeAfterNode($nextFuncCall, $node);
 
         $keyFuncCall = $this->nodeFactory->createFuncCall('key', $eachFuncCall->args);
 

--- a/rules/Php72/Rector/Assign/ReplaceEachAssignmentWithKeyCurrentRector.php
+++ b/rules/Php72/Rector/Assign/ReplaceEachAssignmentWithKeyCurrentRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
         $assignVariable = $node->var;
 
         $newNodes = $this->createNewNodes($assignVariable, $eachedVariable);
-        $this->addNodesAfterNode($newNodes, $node);
+        $this->nodesToAddCollector->addNodesAfterNode($newNodes, $node);
         $this->removeNode($node);
 
         return null;

--- a/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
+++ b/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
@@ -258,7 +258,7 @@ final class PhpSpecPromisesToPHPUnitAssertRector extends AbstractPhpSpecToPHPUni
             $methodCall->args = [];
             $funcCall->args[] = new Arg($methodCall);
 
-            $this->addNodesAfterNode([$assign, $funcCall], $methodCall);
+            $this->nodesToAddCollector->addNodesAfterNode([$assign, $funcCall], $methodCall);
 
             $this->removeNode($methodCall);
 

--- a/rules/Transform/Rector/MethodCall/CallableInMethodCallToVariableRector.php
+++ b/rules/Transform/Rector/MethodCall/CallableInMethodCallToVariableRector.php
@@ -109,7 +109,7 @@ CODE_SAMPLE
             $unwrappedNodes = $this->unwrapClosureFactory->createAssign($resultVariable, $arg);
 
             $arg->value = $resultVariable;
-            $this->addNodesBeforeNode($unwrappedNodes, $node);
+            $this->nodesToAddCollector->addNodesBeforeNode($unwrappedNodes, $node);
 
             return $node;
         }


### PR DESCRIPTION
Direct `addNode(s)AfterNode()` and `addNode(s)BeforeNode()` are deprecated, use `NodesToAddCollector` instead in rector rules.