### PR TITLE
[TypeDeclaration] Handle too detailed array item class-string on AddArrayReturnDocTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array_item.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array_item.php.inc
@@ -42,7 +42,7 @@ class DFactory {}
 class ClassStringArrayItem
 {
     /**
-     * @return array<string, array<class-string, class-string>>
+     * @return array<string, mixed>
      */
     public function getData()
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array_item.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array_item.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+class A {}
+class B {}
+class C {}
+class CFactory {}
+class D {}
+class DFactory {}
+
+class ClassStringArrayItem
+{
+    public function getData()
+    {
+        return [
+            'invokables' => [
+                A::class => A::class,
+                B::class => B::class,
+            ],
+            'factories'  => [
+                C::class => CFactory::class,
+                D::class => DFactory::class,
+            ],
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+class A {}
+class B {}
+class C {}
+class CFactory {}
+class D {}
+class DFactory {}
+
+class ClassStringArrayItem
+{
+    /**
+     * @return array<string, array<class-string, class-string>>
+     */
+    public function getData()
+    {
+        return [
+            'invokables' => [
+                A::class => A::class,
+                B::class => B::class,
+            ],
+            'factories'  => [
+                C::class => CFactory::class,
+                D::class => DFactory::class,
+            ],
+        ];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array_item2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/class_string_array_item2.php.inc
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+class A {}
+class B {}
+class C {}
+class CFactory {}
+class D {}
+class DFactory {}
+
+class ClassStringArrayItem2
+{
+    public function getData()
+    {
+        return [
+            A::class,
+            B::class,
+            C::class,
+            CFactory::class,
+            D::class,
+            DFactory::class,
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+class A {}
+class B {}
+class C {}
+class CFactory {}
+class D {}
+class DFactory {}
+
+class ClassStringArrayItem2
+{
+    /**
+     * @return array<int, class-string>
+     */
+    public function getData()
+    {
+        return [
+            A::class,
+            B::class,
+            C::class,
+            CFactory::class,
+            D::class,
+            DFactory::class,
+        ];
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -67,12 +67,15 @@ final class GenericClassStringTypeNormalizer
         if ($itemType instanceof UnionType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
             return new ArrayType($keyType, new ClassStringType());
         }
+
         if (! $itemType instanceof UnionType) {
             return $arrayType;
         }
+
         if ($this->isAllGenericClassStringType($itemType)) {
             return $arrayType;
         }
+
         return new ArrayType($keyType, new MixedType());
     }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -59,20 +59,21 @@ final class GenericClassStringTypeNormalizer
         return $type;
     }
 
-    private function resolveArrayTypeWithUnionKeyType(ArrayType $arrayType): Type
+    private function resolveArrayTypeWithUnionKeyType(ArrayType $arrayType): ArrayType
     {
-        $keyType  = $arrayType->getKeyType();
+        $keyType = $arrayType->getKeyType();
         $itemType = $arrayType->getItemType();
 
         if ($itemType instanceof UnionType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
             return new ArrayType($keyType, new ClassStringType());
         }
-
-        if ($itemType instanceof UnionType && ! $this->isAllGenericClassStringType($itemType)) {
-            return new ArrayType($keyType, new MixedType());
+        if (! $itemType instanceof UnionType) {
+            return $arrayType;
         }
-
-        return $arrayType;
+        if ($this->isAllGenericClassStringType($itemType)) {
+            return $arrayType;
+        }
+        return new ArrayType($keyType, new MixedType());
     }
 
     private function isAllGenericClassStringType(UnionType $unionType): bool

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -63,9 +63,8 @@ final class GenericClassStringTypeNormalizer
     {
         $keyType = $arrayType->getKeyType();
         $itemType = $arrayType->getItemType();
-        $isAllGenericClassStringType = $this->isAllGenericClassStringType($itemType);
 
-        if ($itemType instanceof UnionType && $isAllGenericClassStringType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
+        if ($itemType instanceof UnionType && $this->isAllGenericClassStringType($itemType) && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
             return new ArrayType($keyType, new ClassStringType());
         }
 
@@ -73,7 +72,7 @@ final class GenericClassStringTypeNormalizer
             return $arrayType;
         }
 
-        if ($isAllGenericClassStringType) {
+        if ($this->isAllGenericClassStringType($itemType)) {
             return $arrayType;
         }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -53,19 +53,26 @@ final class GenericClassStringTypeNormalizer
         }
 
         if ($type instanceof ArrayType && $type->getKeyType() instanceof UnionType) {
-            $keyType  = $type->getKeyType();
-            $itemType = $type->getItemType();
-
-            if ($itemType instanceof UnionType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
-                return new ArrayType($keyType, new ClassStringType());
-            }
-
-            if ($itemType instanceof UnionType && ! $this->isAllGenericClassStringType($itemType)) {
-                return new ArrayType($keyType, new MixedType());
-            }
+            return $this->resolveArrayTypeWithUnionKeyType($type);
         }
 
         return $type;
+    }
+
+    private function resolveArrayTypeWithUnionKeyType(ArrayType $arrayType): Type
+    {
+        $keyType  = $arrayType->getKeyType();
+        $itemType = $arrayType->getItemType();
+
+        if ($itemType instanceof UnionType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
+            return new ArrayType($keyType, new ClassStringType());
+        }
+
+        if ($itemType instanceof UnionType && ! $this->isAllGenericClassStringType($itemType)) {
+            return new ArrayType($keyType, new MixedType());
+        }
+
+        return $arrayType;
     }
 
     private function isAllGenericClassStringType(UnionType $unionType): bool

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -69,15 +69,16 @@ final class GenericClassStringTypeNormalizer
 
         $keyType = $arrayType->getKeyType();
         $isAllGenericClassStringType = $this->isAllGenericClassStringType($itemType);
-        if ($isAllGenericClassStringType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
+
+        if (! $isAllGenericClassStringType) {
+            return new ArrayType($keyType, new MixedType());
+        }
+
+        if ($this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
             return new ArrayType($keyType, new ClassStringType());
         }
 
-        if ($isAllGenericClassStringType) {
-            return $arrayType;
-        }
-
-        return new ArrayType($keyType, new MixedType());
+        return $arrayType;
     }
 
     private function isAllGenericClassStringType(UnionType $unionType): bool

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -61,18 +61,19 @@ final class GenericClassStringTypeNormalizer
 
     private function resolveArrayTypeWithUnionKeyType(ArrayType $arrayType): ArrayType
     {
-        $keyType = $arrayType->getKeyType();
         $itemType = $arrayType->getItemType();
-
-        if ($itemType instanceof UnionType && $this->isAllGenericClassStringType($itemType) && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
-            return new ArrayType($keyType, new ClassStringType());
-        }
 
         if (! $itemType instanceof UnionType) {
             return $arrayType;
         }
 
-        if ($this->isAllGenericClassStringType($itemType)) {
+        $keyType = $arrayType->getKeyType();
+        $isAllGenericClassStringType = $this->isAllGenericClassStringType($itemType);
+        if ($isAllGenericClassStringType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
+            return new ArrayType($keyType, new ClassStringType());
+        }
+
+        if ($isAllGenericClassStringType) {
             return $arrayType;
         }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -63,8 +63,9 @@ final class GenericClassStringTypeNormalizer
     {
         $keyType = $arrayType->getKeyType();
         $itemType = $arrayType->getItemType();
+        $isAllGenericClassStringType = $this->isAllGenericClassStringType($itemType);
 
-        if ($itemType instanceof UnionType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
+        if ($itemType instanceof UnionType && $isAllGenericClassStringType && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
             return new ArrayType($keyType, new ClassStringType());
         }
 
@@ -72,7 +73,7 @@ final class GenericClassStringTypeNormalizer
             return $arrayType;
         }
 
-        if ($this->isAllGenericClassStringType($itemType)) {
+        if ($isAllGenericClassStringType) {
             return $arrayType;
         }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -51,7 +51,12 @@ final class GenericClassStringTypeNormalizer
         }
 
         if ($type instanceof ArrayType && $type->getKeyType() instanceof UnionType) {
-            return new ArrayType($type->getKeyType(), new MixedType());
+            $keyType  = $type->getKeyType();
+            $itemType = $type->getItemType() instanceof UnionType
+                ? new MixedType()
+                : $type->getItemType();
+
+            return new ArrayType($keyType, $itemType);
         }
 
         return $type;

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -52,14 +52,29 @@ final class GenericClassStringTypeNormalizer
 
         if ($type instanceof ArrayType && $type->getKeyType() instanceof UnionType) {
             $keyType  = $type->getKeyType();
-            $itemType = $type->getItemType() instanceof UnionType
+            $itemType = $type->getItemType();
+
+            $itemType = $itemType instanceof UnionType && ! $this->isAllGenericClassStringType($itemType)
                 ? new MixedType()
-                : $type->getItemType();
+                : new ClassStringType();
 
             return new ArrayType($keyType, $itemType);
         }
 
         return $type;
+    }
+
+    private function isAllGenericClassStringType(UnionType $unionType): bool
+    {
+        $types = $unionType->getTypes();
+
+        foreach ($types as $type) {
+            if (! $type instanceof GenericClassStringType) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function resolveClassStringInUnionType(UnionType $type): UnionType | ArrayType

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -50,6 +50,10 @@ final class GenericClassStringTypeNormalizer
             return $this->resolveClassStringInUnionType($type);
         }
 
+        if ($type instanceof ArrayType && $type->getKeyType() instanceof UnionType) {
+            return new ArrayType($type->getKeyType(), new MixedType());
+        }
+
         return $type;
     }
 


### PR DESCRIPTION
Given the following code:

```php
class ClassStringArrayItem
{
    public function getData()
    {
        return [
            'invokables' => [
                A::class => A::class,
                B::class => B::class,
            ],
            'factories'  => [
                C::class => CFactory::class,
                D::class => DFactory::class,
            ],
        ];
    }
}
```

It currently produce long:

```diff
+     * @return array<string, class-string<\Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture\A>|class-string<\Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture\B>>[]|array<string, class-string<\Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture\CFactory>|class-string<\Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture\DFactory>>[]
```

which should be `@return array<string, mixed>` is enough.