### PR TITLE
[DeadCode] Skip next ternary & coalesce assign on RemoveDoubleAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_next_coalesce_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_next_coalesce_assign.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleAssignRector\Fixture;
+
+class SkipNextCoalesceAssign
+{
+    public function run($check = null)
+    {
+        $exists = [];
+
+        $check ?? $exists = [rand(0,1)];
+
+        return $exists;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_next_ternary_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_next_ternary_assign.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleAssignRector\Fixture;
+
+class SkipNextTernaryAssign
+{
+    public function run($check)
+    {
+        $exists = [];
+
+        $check
+            ? []
+            : $exists = [rand(0,1)];
+
+        return $exists;
+    }
+}

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
@@ -104,8 +104,7 @@ CODE_SAMPLE
             return true;
         }
 
-        $parent = $this->betterNodeFinder->findParentType($assign, Ternary::class);
-        return $parent instanceof Ternary;
+        return (bool) $this->betterNodeFinder->findParentType($assign, Ternary::class);
     }
 
     private function isSelfReferencing(Assign $assign): bool

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\Assign;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Ternary;
@@ -13,6 +14,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
+use Rector\NodeNestingScope\ParentFinder;
 use Rector\NodeNestingScope\ScopeNestingComparator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -25,7 +27,8 @@ final class RemoveDoubleAssignRector extends AbstractRector
 {
     public function __construct(
         private ScopeNestingComparator $scopeNestingComparator,
-        private SideEffectNodeDetector $sideEffectNodeDetector
+        private SideEffectNodeDetector $sideEffectNodeDetector,
+        private ParentFinder $parentFinder
     ) {
     }
 
@@ -104,7 +107,7 @@ CODE_SAMPLE
             return true;
         }
 
-        return (bool) $this->betterNodeFinder->findParentType($assign, Ternary::class);
+        return (bool) $this->parentFinder->findByTypes($assign, [Ternary::class, Coalesce::class]);
     }
 
     private function isSelfReferencing(Assign $assign): bool

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Core\Rector\AbstractRector;
@@ -99,7 +100,12 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->scopeNestingComparator->areScopeNestingEqual($assign, $expression);
+        if (! $this->scopeNestingComparator->areScopeNestingEqual($assign, $expression)) {
+            return true;
+        }
+
+        $parent = $this->betterNodeFinder->findParentType($assign, Ternary::class);
+        return $parent instanceof Ternary;
     }
 
     private function isSelfReferencing(Assign $assign): bool


### PR DESCRIPTION
Given the following code:

```php
class SkipNextTernaryAssign
{
    public function run($check)
    {
        $exists = [];

        $check
            ? []
            : $exists = [rand(0,1)];

        return $exists;
    }
}
```

It currently produce:

```diff
-        $exists = [];
-
```

which can make error `Undefined variable $exists`, ref https://3v4l.org/ps5N3