### PR TITLE
[CodeQuality] Skip associative array on CallableThisArrayToAnonymousFunctionRector

### DIFF
--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -55,7 +55,7 @@ final class ArrayCallableMethodMatcher
             return null;
         }
 
-        $values = $this->valueResolver->getValue($array);
+        $this->valueResolver->getValue($array);
 
         if ($this->shouldSkipAssociativeArray($array)) {
             return null;

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -55,6 +55,13 @@ final class ArrayCallableMethodMatcher
             return null;
         }
 
+        $values = $this->valueResolver->getValue($array);
+        $keys   = array_keys($values);
+
+        if ($keys !== [0, 1] && $keys !== [1]) {
+            return null;
+        }
+
         // $this, self, static, FQN
         $firstItemValue = $array->items[0]->value;
 

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -56,9 +56,8 @@ final class ArrayCallableMethodMatcher
         }
 
         $values = $this->valueResolver->getValue($array);
-        $keys = array_keys($values);
 
-        if ($keys !== [0, 1] && $keys !== [1]) {
+        if ($this->shouldSkipAssociativeArray($array)) {
             return null;
         }
 
@@ -83,6 +82,14 @@ final class ArrayCallableMethodMatcher
         $className = $calleeType->getClassName();
         $methodName = $secondItemValue->value;
         return new ArrayCallable($firstItemValue, $className, $methodName);
+    }
+
+    private function shouldSkipAssociativeArray(Array_ $array): bool
+    {
+        $values = $this->valueResolver->getValue($array);
+        $keys = array_keys($values);
+
+        return $keys !== [0, 1] && $keys !== [1];
     }
 
     /**

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -55,8 +55,6 @@ final class ArrayCallableMethodMatcher
             return null;
         }
 
-        $this->valueResolver->getValue($array);
-
         if ($this->shouldSkipAssociativeArray($array)) {
             return null;
         }

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -56,7 +56,7 @@ final class ArrayCallableMethodMatcher
         }
 
         $values = $this->valueResolver->getValue($array);
-        $keys   = array_keys($values);
+        $keys = array_keys($values);
 
         if ($keys !== [0, 1] && $keys !== [1]) {
             return null;

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_associative_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_associative_array.php.inc
@@ -14,5 +14,3 @@ class SkipAssociativeArray
         return $first <=> $second;
     }
 }
-
-?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_associative_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_associative_array.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class SkipAssociativeArray
+{
+    public function run()
+    {
+        $data = ['extends' => $this, 'methods' => 'compareSize'];
+    }
+
+    protected function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
+++ b/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
@@ -112,9 +112,7 @@ CODE_SAMPLE
 
         $value = $this->valueResolver->getValue($node);
         if (is_array($value)) {
-            $isAssociativeArray = (bool) array_filter($value, function($k) {
-                return ! is_int($k);
-            }, ARRAY_FILTER_USE_KEY);
+            $isAssociativeArray = (bool) array_filter($value, fn ($k): bool => ! is_int($k), ARRAY_FILTER_USE_KEY);
 
             if ($isAssociativeArray) {
                 return null;

--- a/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
+++ b/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
@@ -110,15 +110,6 @@ CODE_SAMPLE
             return null;
         }
 
-        $value = $this->valueResolver->getValue($node);
-        if (is_array($value)) {
-            foreach (array_keys($value) as $singleValue) {
-                if (! is_int($singleValue)) {
-                    return null;
-                }
-            }
-        }
-
         return $this->anonymousFunctionFactory->createFromPhpMethodReflection(
             $phpMethodReflection,
             $arrayCallable->getCallerExpr()

--- a/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
+++ b/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
@@ -112,10 +112,10 @@ CODE_SAMPLE
 
         $value = $this->valueResolver->getValue($node);
         if (is_array($value)) {
-            $isAssociativeArray = (bool) array_filter($value, fn ($k): bool => ! is_int($k), ARRAY_FILTER_USE_KEY);
-
-            if ($isAssociativeArray) {
-                return null;
+            foreach (array_keys($value) as $singleValue) {
+                if (! is_int($singleValue)) {
+                    return null;
+                }
             }
         }
 

--- a/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
+++ b/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
@@ -110,6 +110,17 @@ CODE_SAMPLE
             return null;
         }
 
+        $value = $this->valueResolver->getValue($node);
+        if (is_array($value)) {
+            $isAssociativeArray = (bool) array_filter($value, function($k) {
+                return ! is_int($k);
+            }, ARRAY_FILTER_USE_KEY);
+
+            if ($isAssociativeArray) {
+                return null;
+            }
+        }
+
         return $this->anonymousFunctionFactory->createFromPhpMethodReflection(
             $phpMethodReflection,
             $arrayCallable->getCallerExpr()


### PR DESCRIPTION
Given the following code:

```php
class SkipAssociativeArray
{
    public function run()
    {
        $data = ['extends' => $this, 'methods' => 'compareSize'];
    }

    protected function compareSize(int $first, $second): bool
    {
        return $first <=> $second;
    }
}
```

It currently produce:

```diff
-        $data = ['extends' => $this, 'methods' => 'compareSize'];
+        $data = function (int $first, $second) : bool {
+            return $this->compareSize($first, $second);
+        };
```

which should be skipped, ref https://3v4l.org/ja8Qo