### PR TITLE
[CodeQuality] Skip class __construct method on CallableThisArrayToAnonymousFunctionRector

### DIFF
--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -75,6 +75,11 @@ final class ArrayCallableMethodMatcher
 
         $className = $calleeType->getClassName();
         $methodName = $secondItemValue->value;
+
+        if ($methodName === MethodName::CONSTRUCT) {
+            return null;
+        }
+
         return new ArrayCallable($firstItemValue, $className, $methodName);
     }
 

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_other_class_construct.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_other_class_construct.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass3;
+
+final class OtherClassConstruct
+{
+    public function run()
+    {
+        return [OtherClass3::class, '__construct'];
+    }
+}
+
+?>


### PR DESCRIPTION
Given the following code:

```php
final class OtherClassConstruct
{
    public function run()
    {
        return [OtherClass3::class, '__construct'];
    }
}
```

It currently produce:

```diff
+        return function ($property) : void {
+            (new \Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass3())->__construct($property);
+        };
```

which make a double call `__construct`, first on `new`, then call `->__construct()`. It should be skipped.