### PR TITLE
[Renaming] Do not change to property exists on RenamePropertyRector

### DIFF
--- a/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Fixture/do_not_change_to_property_exists.php.inc
+++ b/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Fixture/do_not_change_to_property_exists.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Fixture;
+
+class DoNotChangeToPropertyExists
+{
+    public $oldProperty;
+    public $newProperty;
+
+    public function onlyChangePropertyFetch()
+    {
+        return $this->oldProperty;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Fixture;
+
+class DoNotChangeToPropertyExists
+{
+    public $oldProperty;
+    public $newProperty;
+
+    public function onlyChangePropertyFetch()
+    {
+        return $this->newProperty;
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Fixture/skip_not_configured_class.php.inc
+++ b/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Fixture/skip_not_configured_class.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Fixture;
+
+class SkipNotConfiguredClass
+{
+    public $oldProperty;
+
+    public function run()
+    {
+        return $this->oldProperty;
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/config/configured_rule.php
@@ -27,7 +27,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'oldProperty',
                     'newProperty'
                 ),
-
+                new RenameProperty(
+                    'Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Fixture\DoNotChangeToPropertyExists',
+                    'oldProperty',
+                    'newProperty'
+                ),
             ]),
         ]]);
 };

--- a/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
+++ b/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
@@ -91,7 +91,8 @@ final class RenamePropertyRector extends AbstractRector implements ConfigurableR
     private function renameProperty(ClassLike $classLike, RenameProperty $renameProperty): void
     {
         $classLikeName = $this->nodeNameResolver->getName($classLike);
-        $className     = $renameProperty->getObjectType()->getClassName();
+        $renamePropertyObjectType = $renameProperty->getObjectType();
+        $className = $renamePropertyObjectType->getClassName();
 
         if ($classLikeName !== $className) {
             return;

--- a/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
+++ b/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
@@ -90,12 +90,25 @@ final class RenamePropertyRector extends AbstractRector implements ConfigurableR
 
     private function renameProperty(ClassLike $classLike, RenameProperty $renameProperty): void
     {
+        $classLikeName = $this->nodeNameResolver->getName($classLike);
+        $className     = $renameProperty->getObjectType()->getClassName();
+
+        if ($classLikeName !== $className) {
+            return;
+        }
+
         $property = $classLike->getProperty($renameProperty->getOldProperty());
         if (! $property instanceof Property) {
             return;
         }
 
-        $property->props[0]->name = new VarLikeIdentifier($renameProperty->getNewProperty());
+        $newProperty = $renameProperty->getNewProperty();
+        $targetNewProperty = $classLike->getProperty($newProperty);
+        if ($targetNewProperty instanceof Property) {
+            return;
+        }
+
+        $property->props[0]->name = new VarLikeIdentifier($newProperty);
     }
 
     private function processFromPropertyFetch(PropertyFetch $propertyFetch): ?PropertyFetch


### PR DESCRIPTION
PR https://github.com/rectorphp/rector-src/pull/825 introduce bug:

- not check classname equal with config
- change property when target new property exists, which will cause Fatal error.

This PR patch it.