### PR TITLE
[CodeQuality] Skip CallableThisArrayToAnonymousFunctionRector in trait

### DIFF
--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -98,8 +98,11 @@ final class ArrayCallableMethodMatcher
     private function shouldSkipAssociativeArray(Array_ $array): bool
     {
         $values = $this->valueResolver->getValue($array);
-        $keys = array_keys($values);
+        if ($values === null) {
+            return false;
+        }
 
+        $keys = array_keys($values);
         return $keys !== [0, 1] && $keys !== [1];
     }
 

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -98,7 +98,7 @@ final class ArrayCallableMethodMatcher
     private function shouldSkipAssociativeArray(Array_ $array): bool
     {
         $values = $this->valueResolver->getValue($array);
-        if ($values === null) {
+        if (! is_array($values)) {
             return false;
         }
 

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_in_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_in_trait.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+Trait SkipInTrait
+{
+    public function run(array $values)
+    {
+        usort($values, [$this, 'compareSize']);
+
+        return $values;
+    }
+
+    private function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_in_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_in_trait.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
 
-Trait SkipInTrait
+trait SkipInTrait
 {
     public function run(array $values)
     {


### PR DESCRIPTION
On trait, currently produce error:

```diff
1) Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\CallableThisArrayToAnonymousFunctionRectorTest::test with data set #4 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
TypeError: array_keys(): Argument #1 ($array) must be of type array, null given
```

This PR patch it.