### PR TITLE
[CodeQuality][EarlyReturn] Handle ExplicitBoolCompareRector + ChangeOrIfReturnToEarlyRector

### DIFF
--- a/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
+++ b/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
@@ -28,7 +28,9 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\TypeAnalyzer\ArrayTypeAnalyzer;
 use Rector\NodeTypeResolver\TypeAnalyzer\StringTypeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -116,6 +118,11 @@ CODE_SAMPLE
 
         $newConditionNode = $this->resolveNewConditionNode($conditionNode, $isNegated);
         if (! $newConditionNode instanceof BinaryOp) {
+            return null;
+        }
+
+        $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
+        if ($conditionStaticType instanceof StringType && $newConditionNode instanceof BooleanOr && ! $nextNode instanceof Node) {
             return null;
         }
 

--- a/tests/Issues/IssueOrIfExplicitBoolCompare/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueOrIfExplicitBoolCompare/Fixture/fixture.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueOrIfExplicitBoolCompare\Fixture;
+
+class Fixture
+{
+    /**
+     * @param string $a
+     */
+    public function run($a = '"', $b)
+    {
+        if (! $a || ! $b) {
+            return;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueOrIfExplicitBoolCompare\Fixture;
+
+class Fixture
+{
+    /**
+     * @param string $a
+     */
+    public function run($a = '"', $b)
+    {
+        if (! $a) {
+            return;
+        }
+        if (! $b) {
+            return;
+        }
+    }
+}
+
+?>

--- a/tests/Issues/IssueOrIfExplicitBoolCompare/IssueOrIfExplicitBoolCompareTest.php
+++ b/tests/Issues/IssueOrIfExplicitBoolCompare/IssueOrIfExplicitBoolCompareTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueOrIfExplicitBoolCompare;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class IssueOrIfExplicitBoolCompareTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueOrIfExplicitBoolCompare/config/configured_rule.php
+++ b/tests/Issues/IssueOrIfExplicitBoolCompare/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ExplicitBoolCompareRector::class);
+    $services->set(ChangeOrIfReturnToEarlyReturnRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
class Fixture
{
    /**
     * @param string $a
     */
    public function run($a = '"', $b)
    {
        if (! $a || ! $b) {
            return;
        }
    }
}
```

It currently produce repetitive if:

```diff
-        if (! $a) {
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if ($a === '' || $a === '0') {
             return;
         }
```

with the following rules:

```php
Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
```