### PR TITLE
[TypeDeclaration] Handle PHPStan\Type\Accessory\HasMethodType on PropertyTypeDeclarationRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -10,6 +10,7 @@ use PhpParser\Node\UnionType;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\Accessory\HasMethodType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
@@ -37,6 +38,10 @@ final class PHPStanStaticTypeMapper
 
         if ($type instanceof AccessoryNumericStringType) {
             return new IdentifierTypeNode('string');
+        }
+
+        if ($type instanceof HasMethodType) {
+            return new IdentifierTypeNode('object');
         }
 
         throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);

--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/has_method_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/has_method_type.php.inc
@@ -17,3 +17,26 @@ class HasMethodType
 }
 
 ?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
+
+class HasMethodType
+{
+    /**
+     * @var class-string|object|null
+     */
+    public $obj;
+
+    public function loader($obj)
+    {
+        if (! method_exists($obj, 'findFile')) {
+            return;
+        }
+
+        return $this->obj = $obj;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/has_method_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/PropertyTypeDeclarationRector/Fixture/has_method_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\Fixture;
+
+class HasMethodType
+{
+    public $obj;
+
+    public function loader($obj)
+    {
+        if (! method_exists($obj, 'findFile')) {
+            return;
+        }
+
+        return $this->obj = $obj;
+    }
+}
+
+?>


### PR DESCRIPTION
Given the following code:

```php
class HasMethodType
{
    public $obj;

    public function loader($obj)
    {
        if (! method_exists($obj, 'findFile')) {
            return;
        }

        return $this->obj = $obj;
    }
}
```

It currently produce error:

```bash
There was 1 error:

1) Rector\Tests\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector\PropertyTypeDeclarationRectorTest::test with data set #24 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\NotImplementedYetException: Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper::mapToPHPStanPhpDocTypeNode for PHPStan\Type\Accessory\HasMethodType
```