### PR TITLE
[TypeDeclaration] Handle object|static return on ReturnTypeDeclarationRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -195,6 +195,7 @@ final class UnionTypeMapper implements TypeMapperInterface
         foreach ($unionType->types as $type) {
             if ($this->nodeNameResolver->isName($type, 'object')) {
                 $hasObject = true;
+                continue;
             }
 
             if ($this->nodeNameResolver->isName($type, 'static')) {

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -187,12 +187,12 @@ final class UnionTypeMapper implements TypeMapperInterface
         return null;
     }
 
-    private function hasObjectAndStaticType(PhpParserUnionType $unionType): bool
+    private function hasObjectAndStaticType(PhpParserUnionType $phpParserUnionType): bool
     {
         $hasObject = false;
         $hasStatic = false;
 
-        foreach ($unionType->types as $type) {
+        foreach ($phpParserUnionType->types as $type) {
             if ($this->nodeNameResolver->isName($type, 'object')) {
                 $hasObject = true;
                 continue;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -189,21 +189,8 @@ final class UnionTypeMapper implements TypeMapperInterface
 
     private function hasObjectAndStaticType(PhpParserUnionType $phpParserUnionType): bool
     {
-        $hasObject = false;
-        $hasStatic = false;
-
-        foreach ($phpParserUnionType->types as $type) {
-            if ($this->nodeNameResolver->isName($type, 'object')) {
-                $hasObject = true;
-                continue;
-            }
-
-            if ($this->nodeNameResolver->isName($type, 'static')) {
-                $hasStatic = true;
-            }
-        }
-
-        return $hasObject && $hasStatic;
+        $typeNames = $this->nodeNameResolver->getNames($phpParserUnionType->types);
+        return ! (bool) array_diff(['object', 'static'], $typeNames);
     }
 
     /**

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -190,7 +190,7 @@ final class UnionTypeMapper implements TypeMapperInterface
     private function hasObjectAndStaticType(PhpParserUnionType $phpParserUnionType): bool
     {
         $typeNames = $this->nodeNameResolver->getNames($phpParserUnionType->types);
-        return ! (bool) array_diff(['object', 'static'], $typeNames);
+        return array_diff(['object', 'static'], $typeNames) === [];
     }
 
     /**

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -190,7 +190,9 @@ final class UnionTypeMapper implements TypeMapperInterface
     private function hasObjectAndStaticType(PhpParserUnionType $phpParserUnionType): bool
     {
         $typeNames = $this->nodeNameResolver->getNames($phpParserUnionType->types);
-        return array_diff(['object', 'static'], $typeNames) === [];
+        $diff = array_diff(['object', 'static'], $typeNames);
+
+        return $diff === [];
     }
 
     /**

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_static_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_static_object.php.inc
@@ -19,6 +19,3 @@ class SkipStaticObject
         return $this;
     }
 }
-
-
-?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_static_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_static_object.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
 
-class StaticObject
+class SkipStaticObject
 {
     /**
      * @var object

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/static_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/static_object.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+class StaticObject
+{
+    /**
+     * @var object
+     */
+    protected $obj;
+
+    public function get($obj = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->obj;
+        }
+
+        $this->obj = $obj;
+        return $this;
+    }
+}
+
+
+?>


### PR DESCRIPTION
Given the following code:

```php
class StaticObject
{
    /**
     * @var object
     */
    protected $obj;

    public function get($obj = null)
    {
        if (func_num_args() === 0) {
            return $this->obj;
        }

        $this->obj = $obj;
        return $this;
    }
}
```

It produce `object|static` return type:

```diff
+    public function get($obj = null): object|static
```

which make Fatal error, ref https://3v4l.org/eeHbf