### PR TITLE
[TypeDeclaration] Handle UnitEnum not exists check on ParamTypeByParentCallTypeRector

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -36,3 +36,16 @@ spl_autoload_register(function (string $class): void {
         }
     }
 });
+
+if (! interface_exists('UnitEnum')) {
+    /**
+     * @since 8.1
+     */
+    interface UnitEnum
+    {
+        /**
+         * @return static[]
+         */
+        public static function cases(): array;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector/Fixture/extends_exception.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector/Fixture/extends_exception.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+class SomeException extends \Exception
+{
+    protected $message = '';
+
+    public function __construct($message = '', $code = 0, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->message = $message;
+        $this->code = $code;
+    }
+}

--- a/stubs/Php/UnitEnum.php
+++ b/stubs/Php/UnitEnum.php
@@ -11,8 +11,6 @@ if (interface_exists('UnitEnum')) {
  */
 interface UnitEnum
 {
-    public string $name;
-
     /**
      * @return static[]
      */


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6682

@TomasVotruba this is the possible solution I found right now, by add check in the `bootstrap.php` for scoped rector/rector.