### PR TITLE
[TypeDeclaration] Skip has return to return void on ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/no_return_to_return_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/no_return_to_return_void.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector\Fixture;
+
+class NoReturnToReturnVoid
+{
+   public function run(array $name = [])
+   {
+        call_user_func_array(function () use ($name) {
+
+        }, []);
+   }
+
+   public function run2(array $name = [])
+   {
+        call_user_func_array(function () use ($name) {
+            return;
+        }, []);
+   }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector\Fixture;
+
+class NoReturnToReturnVoid
+{
+   public function run(array $name = [])
+   {
+        call_user_func_array(function () use ($name): void {
+
+        }, []);
+   }
+
+   public function run2(array $name = [])
+   {
+        call_user_func_array(function () use ($name): void {
+            return;
+        }, []);
+   }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/skip_has_return_to_return_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/skip_has_return_to_return_void.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector\Fixture;
 
-class SkipReturnVoid
+class SkipHasReturnToReturnVoid
 {
    public function run(array $name = [])
    {

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/skip_return_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/skip_return_void.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+class SkipReturnVoid
+{
+   public function run(array $name = [])
+   {
+        call_user_func_array(function () use ($name) {
+            return $this->execute();
+        }, []);
+   }
+
+   public function execute(): void
+   {
+   }
+}

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -141,7 +141,6 @@ final class ReturnTypeInferer
 
     private function resolveTypeWithVoidHandling(FunctionLike $functionLike, Type $resolvedType): Type
     {
-        // normalize ConstStringType to ClassStringType
         if ($resolvedType instanceof VoidType) {
             $hasReturnValue = (bool) $this->betterNodeFinder->findFirst(
                 (array) $functionLike->getStmts(),

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\TypeInferer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\UnionType as PhpParserUnionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
+use PHPStan\Type\VoidType;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Php\PhpVersionProvider;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
@@ -39,7 +43,8 @@ final class ReturnTypeInferer
         TypeInfererSorter $typeInfererSorter,
         private GenericClassStringTypeNormalizer $genericClassStringTypeNormalizer,
         private PhpVersionProvider $phpVersionProvider,
-        private ParameterProvider $parameterProvider
+        private ParameterProvider $parameterProvider,
+        private BetterNodeFinder $betterNodeFinder
     ) {
         $this->returnTypeInferers = $typeInfererSorter->sort($returnTypeInferers);
     }
@@ -86,8 +91,7 @@ final class ReturnTypeInferer
                 continue;
             }
 
-            // normalize ConstStringType to ClassStringType
-            return $this->genericClassStringTypeNormalizer->normalize($type);
+            return $this->resolveTypeWithVoidHandling($functionLike, $type);
         }
 
         return new MixedType();
@@ -131,6 +135,30 @@ final class ReturnTypeInferer
         }
 
         return new UnionType($types);
+    }
+
+    private function resolveTypeWithVoidHandling(FunctionLike $functionLike, Type $type): Type
+    {
+        // normalize ConstStringType to ClassStringType
+        $resolvedType = $this->genericClassStringTypeNormalizer->normalize($type);
+        if ($resolvedType instanceof VoidType) {
+            $hasReturnValue = (bool) $this->betterNodeFinder->findFirst(
+                (array) $functionLike->getStmts(),
+                function (Node $subNode): bool {
+                    if (! $subNode instanceof Return_) {
+                        return false;
+                    }
+
+                    return $subNode->expr instanceof Expr;
+                }
+            );
+
+            if ($hasReturnValue) {
+                return new MixedType();
+            }
+        }
+
+        return $resolvedType;
     }
 
     private function isAutoImportWithFullyQualifiedReturn(bool $isAutoImport, FunctionLike $functionLike): bool

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -91,7 +91,9 @@ final class ReturnTypeInferer
                 continue;
             }
 
-            return $this->resolveTypeWithVoidHandling($functionLike, $type);
+            // normalize ConstStringType to ClassStringType
+            $resolvedType = $this->genericClassStringTypeNormalizer->normalize($type);
+            return $this->resolveTypeWithVoidHandling($functionLike, $resolvedType);
         }
 
         return new MixedType();
@@ -137,10 +139,9 @@ final class ReturnTypeInferer
         return new UnionType($types);
     }
 
-    private function resolveTypeWithVoidHandling(FunctionLike $functionLike, Type $type): Type
+    private function resolveTypeWithVoidHandling(FunctionLike $functionLike, Type $resolvedType): Type
     {
         // normalize ConstStringType to ClassStringType
-        $resolvedType = $this->genericClassStringTypeNormalizer->normalize($type);
         if ($resolvedType instanceof VoidType) {
             $hasReturnValue = (bool) $this->betterNodeFinder->findFirst(
                 (array) $functionLike->getStmts(),


### PR DESCRIPTION
Given the following code:

```php
class SkipReturnVoid
{
   public function run(array $name = [])
   {
        call_user_func_array(function () use ($name) {
            return $this->execute();
        }, []);
   }

   public function execute(): void
   {
   }
}
```

It currently produce:

```diff
+        call_user_func_array(function () use ($name): void {
```

which make fatal error, ref `A void function must not return a value`, ref https://3v4l.org/cUVjT