### PR TITLE
[CodeQuality][EarlyReturn] Handle SimplifyDeMorganBinaryRector + DateTimeToDateTimeInterfaceRector + ChangeAndIfToEarlyReturnRector

### DIFF
--- a/rules/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector.php
@@ -96,8 +96,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         if ($node instanceof ClassMethod) {
-            $this->refactorClassMethod($node);
-            return $node;
+            return $this->refactorClassMethod($node);
         }
 
         return $this->refactorProperty($node);
@@ -161,10 +160,10 @@ CODE_SAMPLE
         return $node instanceof NullableType;
     }
 
-    private function refactorClassMethod(ClassMethod $classMethod): void
+    private function refactorClassMethod(ClassMethod $classMethod): ?ClassMethod
     {
         if ($this->shouldSkipExactlyReturnDateTime($classMethod)) {
-            return;
+            return null;
         }
 
         $fromObjectType = new ObjectType(self::DATE_TIME);
@@ -179,7 +178,7 @@ CODE_SAMPLE
             self::METHODS_RETURNING_CLASS_INSTANCE_MAP
         );
         if (! $classMethod->returnType instanceof Node) {
-            return;
+            return null;
         }
 
         $this->classMethodReturnTypeManipulator->refactorFunctionReturnType(
@@ -188,6 +187,7 @@ CODE_SAMPLE
             $fullyQualified,
             $unionType
         );
+        return $classMethod;
     }
 
     private function shouldSkipExactlyReturnDateTime(ClassMethod $classMethod): bool

--- a/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/Fixture/fixture.php.inc
@@ -15,3 +15,25 @@ class Fixture
 }
 
 ?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueChangeAndIfAndDateTimeAndDeMorgan\Fixture;
+
+class Fixture
+{
+    public function run($a, $b, $c)
+    {
+        if ($a !== 'a' && $b !== 'b') {
+            return;
+        }
+        if (!$c) {
+            return;
+        }
+        $d = 'd';
+    }
+}
+
+?>

--- a/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/Fixture/fixture.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueChangeAndIfAndDateTimeAndDeMorgan\Fixture;
+
+class Fixture
+{
+    public function run($a, $b, $c)
+    {
+        if (($a === 'a' || $b === 'b') && $c) {
+            $d = 'd';
+        }
+    }
+}
+
+?>

--- a/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/IssueChangeAndIfAndDateTimeAndDeMorganTest.php
+++ b/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/IssueChangeAndIfAndDateTimeAndDeMorganTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueChangeAndIfAndDateTimeAndDeMorgan;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class IssueChangeAndIfAndDateTimeAndDeMorganTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/config/configured_rule.php
+++ b/tests/Issues/IssueChangeAndIfAndDateTimeAndDeMorgan/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
+use Rector\CodeQuality\Rector\ClassMethod\DateTimeToDateTimeInterfaceRector;
+use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(SimplifyDeMorganBinaryRector::class);
+    $services->set(ChangeAndIfToEarlyReturnRector::class);
+    $services->set(DateTimeToDateTimeInterfaceRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
class Fixture
{
    public function run($a, $b, $c)
    {
        if (($a === 'a' || $b === 'b') && $c) {
            $d = 'd';
        }
    }
}
```

It currently repetitive ifs and returns:

```diff
-        if (($a === 'a' || $b === 'b') && $c) {
-            $d = 'd';
+        if ($a === 'a') {
+            return;
         }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a !== 'a' && $b !== 'b') {
+            return;
+        }
+        return;
+        return;
+        return;
+        return;
+        return;
+        return;
+        return;
+        if (!$c) {
+            return;
+        }
+        $d = 'd';
     }
```

Applied rules:

```php
Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
Rector\CodeQuality\Rector\ClassMethod\DateTimeToDateTimeInterfaceRector;
Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
```