### PR TITLE
[CodeQuality][EarlyReturn] Handle SimplifyDeMorganBinaryRector + CompleteDynamicPropertiesRector + ChangeAndIfToEarlyReturnRector

### DIFF
--- a/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
+++ b/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
@@ -116,6 +116,10 @@ CODE_SAMPLE
             $propertiesToComplete
         );
 
+        if ($newProperties === []) {
+            return null;
+        }
+
         $node->stmts = array_merge($newProperties, $node->stmts);
 
         return $node;

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
+
+class ParentClass
+{
+    protected $d;
+}
+
+class Fixture extends ParentClass
+{
+    public function run($a, $b, $c)
+    {
+        if (($a === 'a' || $b === 'b') && $c) {
+            $this->d = 'd';
+        }
+    }
+}

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
@@ -16,3 +16,30 @@ class Fixture extends ParentClass
         }
     }
 }
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
+
+class ParentClass
+{
+    protected $d;
+}
+
+class Fixture extends ParentClass
+{
+    public function run($a, $b, $c)
+    {
+        if ($a !== 'a' && $b !== 'b') {
+            return;
+        }
+        if (!$c) {
+            return;
+        }
+        $this->d = 'd';
+    }
+}
+
+?>

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/IssueAndIfCompleteDeMorganTest.php
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/IssueAndIfCompleteDeMorganTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class IssueAndIfCompleteDeMorganTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/config/configured_rule.php
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ChangeAndIfToEarlyReturnRector::class);
+    $services->set(CompleteDynamicPropertiesRector::class);
+    $services->set(SimplifyDeMorganBinaryRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
class ParentClass
{
    protected $d;
}

class Fixture extends ParentClass
{
    public function run($a, $b, $c)
    {
        if (($a === 'a' || $b === 'b') && $c) {
            $this->d = 'd';
        }
    }
}
```

produce repetitive ifs and returns:

```diff
-        if (($a === 'a' || $b === 'b') && $c) {
-            $this->d = 'd';
+        if ($a === 'a') {
+            return;
         }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a === 'a') {
+            return;
+        }
+        if ($b === 'b') {
+            return;
+        }
+        if ($a !== 'a' && $b !== 'b') {
+            return;
+        }
+        return;
+        return;
+        return;
+        return;
+        return;
+        return;
+        return;
+        if (!$c) {
+            return;
+        }
+        $this->d = 'd';
```

Applied rules:

```php
Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
```