### PR TITLE
[TypeDeclaration] Skip child class method return parent class on ReturnTypeDeclarationRector

### DIFF
--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -70,7 +70,7 @@ final class ClassMethodReturnTypeOverrideGuard
         }
 
         if ($classMethod->returnType instanceof Node) {
-            return false;
+            return true;
         }
 
         if ($this->shouldSkipHasChildNoReturn($childrenClassReflections, $classMethod, $scope)) {

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/return_parent_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/return_parent_class.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+class ParentClass
+{
+    public function get(): ParentClass
+    {
+        return $this;
+    }
+}
+
+class ChildClass extends ParentClass
+{
+    public function get(): ParentClass
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
Given the following code:

```php
class ParentClass
{
    public function get(): ParentClass
    {
        return $this;
    }
}

class ChildClass extends ParentClass
{
    public function get(): ParentClass
    {
        return $this;
    }
}
```

It produce parent return static:

```diff
 class ParentClass
 {
-    public function get(): ParentClass
+    public function get(): static
```

which make it Fatal error: `Declaration of ChildClass::get(): ParentClass must be compatible with ParentClass::get(): static`, ref https://3v4l.org/NWkFi