### PR TITLE
[DeadCode] Skip RemoveDeadInstanceOfRector on check variable from not typed param

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+/**
+ * @param DateTime|stdClass $value
+ */
+function reasssignOnNotTyped($value)
+{
+    $value = rand(0, 1)
+        ? new stdClass
+        : new DateTime('now');
+
+    if ($value instanceof stdClass) {
+        return 'a';
+    }
+
+    if ($value instanceof DateTime) {
+        return 'b';
+    }
+
+    return 'c';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+/**
+ * @param DateTime|stdClass $value
+ */
+function reasssignOnNotTyped($value)
+{
+    $value = rand(0, 1)
+        ? new stdClass
+        : new DateTime('now');
+
+    if ($value instanceof stdClass) {
+        return 'a';
+    }
+
+    return 'b';
+
+    return 'c';
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed_param.php.inc
@@ -8,7 +8,7 @@ use stdClass;
 /**
  * @param DateTime|stdClass $value
  */
-function reasssignOnNotTyped($value)
+function reasssignOnNotTypedParam($value)
 {
     $value = rand(0, 1)
         ? new stdClass

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed_param.php.inc
@@ -37,7 +37,7 @@ use stdClass;
 /**
  * @param DateTime|stdClass $value
  */
-function reasssignOnNotTyped($value)
+function reasssignOnNotTypedParam($value)
 {
     $value = rand(0, 1)
         ? new stdClass

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_union_not_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_union_not_typed_param.php.inc
@@ -8,7 +8,7 @@ use stdClass;
 /**
  * @param DateTime|stdClass $value
  */
-function run($value)
+function skipUnionNotTypedParam($value)
 {
     if ($value instanceof stdClass) {
         return 'a';

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_union_not_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_union_not_typed_param.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+/**
+ * @param DateTime|stdClass $value
+ */
+function run($value)
+{
+    if ($value instanceof stdClass) {
+        return 'a';
+    }
+
+    if ($value instanceof DateTime) {
+        return 'b';
+    }
+
+    return 'c';
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/union_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/union_typed_param.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+function run2(DateTime|stdClass $value)
+{
+    if ($value instanceof stdClass) {
+        return 'a';
+    }
+
+    if ($value instanceof DateTime) {
+        return 'b';
+    }
+
+    return 'c';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+function run2(DateTime|stdClass $value)
+{
+    if ($value instanceof stdClass) {
+        return 'a';
+    }
+
+    return 'b';
+
+    return 'c';
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/union_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/union_typed_param.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
 use DateTime;
 use stdClass;
 
-function run2(DateTime|stdClass $value)
+function unionTypedParam(DateTime|stdClass $value)
 {
     if ($value instanceof stdClass) {
         return 'a';
@@ -27,7 +27,7 @@ namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
 use DateTime;
 use stdClass;
 
-function run2(DateTime|stdClass $value)
+function unionTypedParam(DateTime|stdClass $value)
 {
     if ($value instanceof stdClass) {
         return 'a';

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -158,7 +158,9 @@ CODE_SAMPLE
         }
 
         $variable = $instanceof->expr;
-        $isReassign = (bool) $this->betterNodeFinder->findFirstPreviousOfNode($instanceof, function (Node $subNode) use ($variable): bool {
+        $isReassign = (bool) $this->betterNodeFinder->findFirstPreviousOfNode($instanceof, function (Node $subNode) use (
+            $variable
+        ): bool {
             if (! $subNode instanceof Assign) {
                 return false;
             }
@@ -175,9 +177,11 @@ CODE_SAMPLE
             if (! $param->var instanceof Variable) {
                 continue;
             }
+
             if (! $this->nodeComparator->areNodesEqual($param->var, $instanceof->expr)) {
                 continue;
             }
+
             return $param->type === null;
         }
 

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -153,20 +153,11 @@ CODE_SAMPLE
             return false;
         }
 
-        if (! $instanceof->expr instanceof Variable) {
-            return false;
-        }
-
         $variable = $instanceof->expr;
-        $isReassign = (bool) $this->betterNodeFinder->findFirstPreviousOfNode($instanceof, function (Node $subNode) use (
-            $variable
-        ): bool {
-            if (! $subNode instanceof Assign) {
-                return false;
-            }
-
-            return $this->nodeComparator->areNodesEqual($subNode->var, $variable);
-        });
+        $isReassign = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+            $instanceof,
+            fn (Node $subNode): bool => $subNode instanceof Assign && $this->nodeComparator->areNodesEqual($subNode->var, $variable)
+        );
 
         if ($isReassign) {
             return false;
@@ -174,15 +165,9 @@ CODE_SAMPLE
 
         $params = $functionLike->getParams();
         foreach ($params as $param) {
-            if (! $param->var instanceof Variable) {
-                continue;
+            if ($this->nodeComparator->areNodesEqual($param->var, $instanceof->expr)) {
+                return $param->type === null;
             }
-
-            if (! $this->nodeComparator->areNodesEqual($param->var, $instanceof->expr)) {
-                continue;
-            }
-
-            return $param->type === null;
         }
 
         return false;

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\If_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\PropertyFetch;
@@ -153,6 +154,19 @@ CODE_SAMPLE
         }
 
         if (! $instanceof->expr instanceof Variable) {
+            return false;
+        }
+
+        $variable = $instanceof->expr;
+        $isReassign = (bool) $this->betterNodeFinder->findFirstPreviousOfNode($instanceof, function (Node $subNode) use ($variable): bool {
+            if (! $subNode instanceof Assign) {
+                return false;
+            }
+
+            return $this->nodeComparator->areNodesEqual($subNode->var, $variable);
+        });
+
+        if ($isReassign) {
             return false;
         }
 

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -158,9 +158,13 @@ CODE_SAMPLE
 
         $params = $functionLike->getParams();
         foreach ($params as $param) {
-            if ($param->var instanceof Variable && $this->nodeComparator->areNodesEqual($param->var, $instanceof->expr)) {
-                return $param->type === null;
+            if (! $param->var instanceof Variable) {
+                continue;
             }
+            if (! $this->nodeComparator->areNodesEqual($param->var, $instanceof->expr)) {
+                continue;
+            }
+            return $param->type === null;
         }
 
         return false;


### PR DESCRIPTION
Given the following code:

```php
/**
 * @param DateTime|stdClass $value
 */
function run($value)
{
    if ($value instanceof stdClass) {
        return 'a';
    }

    if ($value instanceof DateTime) {
        return 'b';
    }

    return 'c';
}
```

it produce:

```diff
-    if ($value instanceof DateTime) {
-        return 'b';
-    }
+    return 'b';
```

which non-typed param can pass non-defined in `@param` type types. This PR patch it.