### PR TITLE
[EarlyReturn] Do not move up variable up next foreach on ChangeAndIfToEarlyReturnRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/do_not_move_variable_up_foreach.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/do_not_move_variable_up_foreach.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+class DoNotMoveVariableUpForeach
+{
+    public function run(array $data, $a, $b)
+    {
+        foreach ($data as $value) {
+            if ($a && $b) {
+                unset($value);
+            }
+        }
+
+        $targets = [];
+        return $targets;
+    }
+}
+
+?>

--- a/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/do_not_move_variable_up_foreach.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/do_not_move_variable_up_foreach.php.inc
@@ -18,3 +18,28 @@ class DoNotMoveVariableUpForeach
 }
 
 ?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+class DoNotMoveVariableUpForeach
+{
+    public function run(array $data, $a, $b)
+    {
+        foreach ($data as $value) {
+            if (!$a) {
+                continue;
+            }
+            if (!$b) {
+                continue;
+            }
+            unset($value);
+        }
+
+        $targets = [];
+        return $targets;
+    }
+}
+
+?>

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -147,7 +147,7 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        if (! $node->stmts[0] instanceof Return_ && $ifNextReturnClone->expr instanceof Expr) {
+        if (! $node->stmts[0] instanceof Return_ && $ifNextReturnClone->expr instanceof Expr && ! $this->contextAnalyzer->isInLoop($node)) {
             return [$node, $ifNextReturnClone];
         }
 

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -147,7 +147,9 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        if (! $node->stmts[0] instanceof Return_ && $ifNextReturnClone->expr instanceof Expr && ! $this->contextAnalyzer->isInLoop($node)) {
+        if (! $node->stmts[0] instanceof Return_ && $ifNextReturnClone->expr instanceof Expr && ! $this->contextAnalyzer->isInLoop(
+            $node
+        )) {
             return [$node, $ifNextReturnClone];
         }
 


### PR DESCRIPTION
Given the following code:

```php
class DoNotMoveVariableUpForeach
{
    public function run(array $data, $a, $b)
    {
        foreach ($data as $value) {
            if ($a && $b) {
                unset($value);
            }
        }

        $targets = [];
        return $targets;
    }
}
```

produce moved up variable next foreach to inside foreach:

```diff
         foreach ($data as $value) {
-            if ($a && $b) {
-                unset($value);
+            if (!$a) {
+                continue;
             }
+            if (!$b) {
+                continue;
+            }
+            unset($value);
+            return $targets;
         }
```

that make Warning error:

```
Warning: Undefined variable $targets
```

ref https://3v4l.org/ManEo