### PR TITLE
[Privatization] Skip change variable from Param on ChangeReadOnlyVariableWithDefaultValueToConstantRector

### DIFF
--- a/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/from_param.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/from_param.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector\Fixture;
+
+class FromParam
+{
+    public function run($a)
+    {
+        if ($a === 0) {
+            $a = '0';
+        }
+
+        if ($a === 'a') {
+            return 0;
+        }
+
+        if ($a === 'z') {
+            return 10000;
+        }
+
+        return 0;
+    }
+}
+
+?>

--- a/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_from_param.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_from_param.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector\Fixture;
 
-class FromParam
+class SkipFromParam
 {
     public function run($a)
     {

--- a/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
@@ -184,8 +184,6 @@ CODE_SAMPLE
     private function refactorClassMethod(ClassMethod $classMethod, Class_ $class, array $readOnlyVariableAssigns): void
     {
         foreach ($readOnlyVariableAssigns as $readOnlyVariableAssign) {
-            $this->removeNode($readOnlyVariableAssign);
-
             /** @var Variable|ClassConstFetch $variable */
             $variable = $readOnlyVariableAssign->var;
             // already overridden
@@ -193,15 +191,22 @@ CODE_SAMPLE
                 continue;
             }
 
-            $classConst = $this->createPrivateClassConst($variable, $readOnlyVariableAssign->expr);
-
-            // replace $variable usage in the code with constant
-            $this->propertyToAddCollector->addConstantToClass($class, $classConst);
-
             $variableName = $this->getName($variable);
             if ($variableName === null) {
                 throw new ShouldNotHappenException();
             }
+
+            foreach ($classMethod->getParams() as $param) {
+                if ($this->nodeNameResolver->isName($param->var, $variableName)) {
+                    return;
+                }
+            }
+
+            $this->removeNode($readOnlyVariableAssign);
+            $classConst = $this->createPrivateClassConst($variable, $readOnlyVariableAssign->expr);
+
+            // replace $variable usage in the code with constant
+            $this->propertyToAddCollector->addConstantToClass($class, $classConst);
 
             $this->replaceVariableWithClassConstFetch($classMethod, $variableName, $classConst);
         }

--- a/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
@@ -198,7 +198,7 @@ CODE_SAMPLE
 
             foreach ($classMethod->getParams() as $param) {
                 if ($this->nodeNameResolver->isName($param->var, $variableName)) {
-                    return;
+                    continue 2;
                 }
             }
 


### PR DESCRIPTION
Given the following code:

```php
class FromParam
{
    public function run($a)
    {
        if ($a === 0) {
            $a = '0';
        }

        if ($a === 'a') {
            return 0;
        }

        if ($a === 'z') {
            return 10000;
        }

        return 0;
    }
}
```

It produce changed param:

```diff
+    public function run(self::A)
     {
```

which make it Parse Error: "Parse error: syntax error, unexpected token "::", expecting variable" ref https://3v4l.org/g9dvq