### PR TITLE
[Doc] Autoload Troubleshooting

### DIFF
--- a/build/target-repository/docs/static_reflection_and_autoload.md
+++ b/build/target-repository/docs/static_reflection_and_autoload.md
@@ -64,3 +64,14 @@ composer dump-autoload -o
 ```
 
 before run the rector.
+
+If the false positive still happen, you can skip the rule applied as last resort to do:
+
+```php
+    $parameters->set(Option::SKIP, [
+        \Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector::class => [
+            // classes that has children, and not detected even with composer dump-autoload -o
+            __DIR__ . '/src/HasChildClass.php',
+        ],
+    ]);
+```

--- a/build/target-repository/docs/static_reflection_and_autoload.md
+++ b/build/target-repository/docs/static_reflection_and_autoload.md
@@ -52,3 +52,13 @@ Listed files will be executed like:
 ```php
 include $filePath;
 ```
+
+## Troubleshooting
+
+Sometime, when we run Rector to class that detect children class, like `\Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector`, we may experience that parent class changed to final while it has children class, it because of the `FamilyRelationsAnalyzer` cannot get all classes on scanning it. To avoid this issue, you may dump all classes via composer:
+
+```bash
+composer dump-autoload -o
+```
+
+before run the rector.

--- a/build/target-repository/docs/static_reflection_and_autoload.md
+++ b/build/target-repository/docs/static_reflection_and_autoload.md
@@ -55,7 +55,9 @@ include $filePath;
 
 ## Troubleshooting
 
-Sometime, when we run Rector to class that detect children class, like `\Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector`, we may experience that parent class changed to final while it has children class, it because of the `FamilyRelationsAnalyzer` cannot get all classes on scanning it. To avoid this issue, you may dump all classes via composer:
+Sometime, when we run Rector to class that detect children class, like `\Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector`, we may experience that parent class changed to final while it has children class, it because of the `PHPStan\Reflection\ReflectionProvider` cannot get all classes on scanning it on usage via `FamilyRelationsAnalyzer` service.
+
+To avoid this issue, you may dump all classes via composer:
 
 ```bash
 composer dump-autoload -o


### PR DESCRIPTION
Add documentation for troubleshooting when sometime, rector doesn't detect all children classes via `PHPStan\Reflection\ReflectionProvider` that called via `FamilyRelationsAnalyzer ` service even both parent and child in same directory, and rector run on that directory.

 The solution is to run `composer dump-autoload -o`