### PR TITLE
[TypeDeclaration] Handle default value on TypedPropertyFromStrictConstructorRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_false_default_value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_false_default_value.php.inc
@@ -6,6 +6,27 @@ use stdClass;
 
 class HasFalseDefaultValue
 {
+    /**
+     * @var stdClass
+     */
+    private $stdClass = false;
+
+    public function __construct(stdClass $stdClass)
+    {
+        $this->stdClass = $stdClass;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use stdClass;
+
+class HasFalseDefaultValue
+{
     private \stdClass $stdClass;
 
     public function __construct(stdClass $stdClass)

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_false_default_value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_false_default_value.php.inc
@@ -6,10 +6,7 @@ use stdClass;
 
 class HasFalseDefaultValue
 {
-    /**
-     * @var stdClass
-     */
-    private $stdClass = false;
+    private \stdClass $stdClass;
 
     public function __construct(stdClass $stdClass)
     {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_false_default_value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_false_default_value.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use stdClass;
+
+class HasFalseDefaultValue
+{
+    /**
+     * @var stdClass
+     */
+    private $stdClass = false;
+
+    public function __construct(stdClass $stdClass)
+    {
+        $this->stdClass = $stdClass;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_null_default_value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_null_default_value.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use stdClass;
+
+class HasNullDefaultValue
+{
+    /**
+     * @var stdClass
+     */
+    private $stdClass = null;
+
+    public function __construct(stdClass $stdClass)
+    {
+        $this->stdClass = $stdClass;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_null_default_value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/has_null_default_value.php.inc
@@ -18,3 +18,21 @@ class HasNullDefaultValue
 }
 
 ?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use stdClass;
+
+class HasNullDefaultValue
+{
+    private \stdClass $stdClass;
+
+    public function __construct(stdClass $stdClass)
+    {
+        $this->stdClass = $stdClass;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/nullable_has_default_value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/nullable_has_default_value.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use stdClass;
+
+class NullableHasDefaultValue
+{
+    /**
+     * @var stdClass|null
+     */
+    private $stdClass = null;
+
+    public function __construct(?stdClass $stdClass)
+    {
+        $this->stdClass = $stdClass;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use stdClass;
+
+class NullableHasDefaultValue
+{
+    private ?\stdClass $stdClass;
+
+    public function __construct(?stdClass $stdClass)
+    {
+        $this->stdClass = $stdClass;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/variadic_constructor_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/variadic_constructor_param.php.inc
@@ -24,7 +24,7 @@ final class VariadicConstructorParam
     /**
      * @var DateTime[]
      */
-    private array $dates = [];
+    private array $dates;
 
     public function __construct(DateTime ...$dates) {
         $this->dates = $dates;

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -93,6 +93,7 @@ CODE_SAMPLE
         }
 
         $node->type = $propertyTypeNode;
+        $node->props[0]->default = null;
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $this->varTagRemover->removeVarTagIfUseless($phpDocInfo, $node);


### PR DESCRIPTION
Given the following code:

```php
use stdClass;

class HasNullDefaultValue
{
    /**
     * @var stdClass
     */
    private $stdClass = null;

    public function __construct(stdClass $stdClass)
    {
        $this->stdClass = $stdClass;
    }
}
```

It produce:

```diff
+    private \stdClass $stdClass = null;
```

which make Fatal error: "Fatal error: Default value for property of type stdClass may not be null. Use the nullable type ?stdClass to allow null" ref https://3v4l.org/aPY95