### PR TITLE
Add failing test fixture for NullsafeOperatorRector

### DIFF
--- a/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/skip_ternary_no_direct_usage.php.inc
+++ b/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/skip_ternary_no_direct_usage.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\If_\NullsafeOperatorRector\Fixture;
+
+final class SkipTernaryNoDirectUsage
+{
+    public function run()
+    {
+        return $someObject === null ? null : \Carbon\Carbon::parse($someObject)->toDateTimeString();
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for NullsafeOperatorRector

Based on https://getrector.org/demo/1ec12269-441e-60aa-9263-91e21eea6a86

Ref: https://github.com/rectorphp/rector/issues/6685