### PR TITLE
feat: str starts with hardcoded

### DIFF
--- a/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/hardcoded.php.inc
+++ b/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/hardcoded.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class HardCoded
+{
+    public function run()
+    {
+        $isMatch = substr($haystack, 0, 3) === 'foo';
+
+        $isMatch = 'foo' === substr($haystack, 0, 3);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class HardCoded
+{
+    public function run()
+    {
+        $isMatch = str_starts_with($haystack, 'foo');
+
+        $isMatch = str_starts_with($haystack, 'foo');
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/hardcoded_not_identical.php.inc
+++ b/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/hardcoded_not_identical.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class HardCodedNotIdentical
+{
+    public function run()
+    {
+        $isMatch = substr($haystack, 0, 3) !== 'foo';
+
+        $isMatch = 'foo' !== substr($haystack, 0, 3);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class HardCodedNotIdentical
+{
+    public function run()
+    {
+        $isMatch = !str_starts_with($haystack, 'foo');
+
+        $isMatch = !str_starts_with($haystack, 'foo');
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/skip_strncmp_hardcoded_invalid_length.php.inc
+++ b/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/skip_strncmp_hardcoded_invalid_length.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class SkipStrncmpHardCodedInvalidLength
+{
+    public function run()
+    {
+        $isMatch = strncmp($haystack, 'invalid_length', 1) === 0;
+
+        $isMatch = 0 === strncmp($haystack, 'invalid_length', 1);
+    }
+}

--- a/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/strncmp_hardcoded.php.inc
+++ b/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/strncmp_hardcoded.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class StrncmpHardCoded
+{
+    public function run()
+    {
+        $isMatch = strncmp($haystack, 'hardcoded', 9) === 0;
+
+        $isMatch = 0 === strncmp($haystack, 'hardcoded', 9);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class StrncmpHardCoded
+{
+    public function run()
+    {
+        $isMatch = str_starts_with($haystack, 'hardcoded');
+
+        $isMatch = str_starts_with($haystack, 'hardcoded');
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/strpos_hardcoded.php.inc
+++ b/rules-tests/Php80/Rector/Identical/StrStartsWithRector/Fixture/strpos_hardcoded.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class StrposHardCoded
+{
+    public function run()
+    {
+        $isMatch = strpos($haystack, 'hardcoded') === 0;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Identical\StrStartsWithRector\Fixture;
+
+class StrposHardCoded
+{
+    public function run()
+    {
+        $isMatch = str_starts_with($haystack, 'hardcoded');
+    }
+}
+
+?>

--- a/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrncmpMatchAndRefactor.php
+++ b/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrncmpMatchAndRefactor.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Php80\Contract\StrStartWithMatchAndRefactorInterface;
@@ -58,26 +60,48 @@ final class StrncmpMatchAndRefactor implements StrStartWithMatchAndRefactorInter
 
     public function refactorStrStartsWith(StrStartsWith $strStartsWith): ?Node
     {
+        if (!$this->isNeedleExprWithStrlen($strStartsWith) && !$this->isHardcodedStringWithLNumberLength($strStartsWith)) {
+            return null;
+        }
+
+        return $this->strStartsWithFuncCallFactory->createStrStartsWith($strStartsWith);
+    }
+
+    private function isNeedleExprWithStrlen(StrStartsWith $strStartsWith): bool
+    {
         $strncmpFuncCall = $strStartsWith->getFuncCall();
         $needleExpr = $strStartsWith->getNeedleExpr();
 
         $secondArgumentValue = $strncmpFuncCall->args[2]->value;
         if (! $secondArgumentValue instanceof FuncCall) {
-            return null;
+            return false;
         }
 
         if (! $this->nodeNameResolver->isName($secondArgumentValue, 'strlen')) {
-            return null;
+            return false;
         }
 
         /** @var FuncCall $strlenFuncCall */
         $strlenFuncCall = $strncmpFuncCall->args[2]->value;
         $strlenArgumentValue = $strlenFuncCall->args[0]->value;
 
-        if (! $this->nodeComparator->areNodesEqual($needleExpr, $strlenArgumentValue)) {
-            return null;
+        return $this->nodeComparator->areNodesEqual($needleExpr, $strlenArgumentValue);
+    }
+
+    private function isHardcodedStringWithLNumberLength(StrStartsWith $strStartsWith): bool
+    {
+        $strncmpFuncCall = $strStartsWith->getFuncCall();
+
+        $hardcodedStringNeedle = $strncmpFuncCall->args[1]->value;
+        if (! $hardcodedStringNeedle instanceof String_) {
+            return false;
         }
 
-        return $this->strStartsWithFuncCallFactory->createStrStartsWith($strStartsWith);
+        $lNumberLength = $strncmpFuncCall->args[2]->value;
+        if (! $lNumberLength instanceof LNumber) {
+            return false;
+        }
+
+        return $lNumberLength->value === strlen($hardcodedStringNeedle->value);
     }
 }

--- a/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/SubstrMatchAndRefactor.php
+++ b/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/SubstrMatchAndRefactor.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -54,18 +56,27 @@ final class SubstrMatchAndRefactor implements StrStartWithMatchAndRefactorInterf
 
     public function refactorStrStartsWith(StrStartsWith $strStartsWith): ?Node
     {
+        if (!$this->isStrlenWithNeedleExpr($strStartsWith) && !$this->isHardcodedStringWithLNumberLength($strStartsWith)) {
+            return null;
+        }
+
+        return $this->strStartsWithFuncCallFactory->createStrStartsWith($strStartsWith);
+    }
+
+    private function isStrlenWithNeedleExpr(StrStartsWith $strStartsWith): bool
+    {
         $substrFuncCall = $strStartsWith->getFuncCall();
         if (! $this->valueResolver->isValue($substrFuncCall->args[1]->value, 0)) {
-            return null;
+            return false;
         }
 
         $secondFuncCallArgValue = $substrFuncCall->args[2]->value;
         if (! $secondFuncCallArgValue instanceof FuncCall) {
-            return null;
+            return false;
         }
 
         if (! $this->nodeNameResolver->isName($secondFuncCallArgValue, 'strlen')) {
-            return null;
+            return false;
         }
 
         /** @var FuncCall $strlenFuncCall */
@@ -73,10 +84,26 @@ final class SubstrMatchAndRefactor implements StrStartWithMatchAndRefactorInterf
         $needleExpr = $strlenFuncCall->args[0]->value;
 
         $comparedNeedleExpr = $strStartsWith->getNeedleExpr();
-        if (! $this->nodeComparator->areNodesEqual($needleExpr, $comparedNeedleExpr)) {
-            return null;
+        return $this->nodeComparator->areNodesEqual($needleExpr, $comparedNeedleExpr);
+    }
+
+    private function isHardcodedStringWithLNumberLength(StrStartsWith $strStartsWith): bool
+    {
+        $substrFuncCall = $strStartsWith->getFuncCall();
+        if (! $this->valueResolver->isValue($substrFuncCall->args[1]->value, 0)) {
+            return false;
         }
 
-        return $this->strStartsWithFuncCallFactory->createStrStartsWith($strStartsWith);
+        $hardcodedStringNeedle = $strStartsWith->getNeedleExpr();
+        if (! $hardcodedStringNeedle instanceof String_) {
+            return false;
+        }
+
+        $lNumberLength = $substrFuncCall->args[2]->value;
+        if (! $lNumberLength instanceof LNumber) {
+            return false;
+        }
+
+        return $lNumberLength->value === strlen($hardcodedStringNeedle->value);
     }
 }


### PR DESCRIPTION
## related issue and PR

https://github.com/rectorphp/rector-src/pull/399
https://github.com/rectorphp/rector/issues/6549

This PR adds a feature to convert `substr, substr_copmare, strpos` with hardcoded strings to `str_starts_with`.
I found this useful because I could find these kind of usage in several repositories I am using.
ex. git grep in symfony/symfony

<details>

```php
git grep -E '=== substr\(\$[^,]*, 0, [0-9]+\)'
src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php:            if ('security.context_listener' === substr($serviceId, 0, 25)) {
src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php:            if ('\'nonce-' === substr($directive, 0, 7)) {
src/Symfony/Component/Asset/Package.php:        return str_contains($url, '://') || '//' === substr($url, 0, 2);
src/Symfony/Component/Asset/UrlPackage.php:            if ('https://' === substr($url, 0, 8) || '//' === substr($url, 0, 2)) {
src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php:            if ('\\' === substr($class, 0, 1)) {
src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php:            if ('\\' === substr($class, 0, 1)) {
src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php:            if ('\\' === substr($class, 0, 1)) {
src/Symfony/Component/Finder/Gitignore.php:            if ('!' === substr($line, 0, 1)) {
src/Symfony/Component/HttpFoundation/IpUtils.php:        if ('[' === substr($ip, 0, 1) && ']' === substr($ip, -1, 1)) {
src/Symfony/Component/HttpFoundation/UrlHelper.php:        if (str_contains($path, '://') || '//' === substr($path, 0, 2)) {
src/Symfony/Component/HttpFoundation/UrlHelper.php:        if (str_contains($path, '://') || '//' === substr($path, 0, 2)) {
src/Symfony/Component/Routing/RouteCollectionBuilder.php:                if ('_unnamed_route_' === substr($name, 0, 15)) {
src/Symfony/Component/Translation/Loader/PoFileLoader.php:            } elseif ('#,' === substr($line, 0, 2)) {
src/Symfony/Component/Translation/Loader/PoFileLoader.php:            } elseif ('msgid "' === substr($line, 0, 7)) {
```

</details>

This is the same feature I added to `str_ends_with` rector rule before (sorry for being very late).