### PR TITLE
[Renaming] add ValueObjectInliner::inline to ConfiguredCodeSamples

### DIFF
--- a/rules/Renaming/Rector/ClassConstFetch/RenameClassConstFetchRector.php
+++ b/rules/Renaming/Rector/ClassConstFetch/RenameClassConstFetchRector.php
@@ -15,6 +15,7 @@ use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 use Webmozart\Assert\Assert;
 
 /**
@@ -35,10 +36,10 @@ final class RenameClassConstFetchRector extends AbstractRector implements Config
     public function getRuleDefinition(): RuleDefinition
     {
         $configuration = [
-            self::CLASS_CONSTANT_RENAME => [
+            self::CLASS_CONSTANT_RENAME => ValueObjectInliner::inline([
                 new RenameClassConstFetch('SomeClass', 'OLD_CONSTANT', 'NEW_CONSTANT'),
                 new RenameClassAndConstFetch('SomeClass', 'OTHER_OLD_CONSTANT', 'DifferentClass', 'NEW_CONSTANT'),
-            ],
+            ]),
         ];
 
         return new RuleDefinition(

--- a/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
+++ b/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
@@ -15,6 +15,7 @@ use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockTagReplacer;
 use Rector\Renaming\ValueObject\RenameAnnotation;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 use Webmozart\Assert\Assert;
 
 /**
@@ -68,9 +69,9 @@ class SomeTest extends PHPUnit\Framework\TestCase
 CODE_SAMPLE
                     ,
                     [
-                        self::RENAMED_ANNOTATIONS_IN_TYPES => [
+                        self::RENAMED_ANNOTATIONS_IN_TYPES => ValueObjectInliner::inline([
                             new RenameAnnotation('PHPUnit\Framework\TestCase', 'test', 'scenario'),
-                        ],
+                        ]),
                     ]
                 ),
             ]

--- a/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
+++ b/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
@@ -22,6 +22,7 @@ use Rector\NodeTypeResolver\PhpDoc\PhpDocTypeRenamer;
 use Rector\Renaming\ValueObject\PseudoNamespaceToNamespace;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 use Webmozart\Assert\Assert;
 
 /**
@@ -69,9 +70,9 @@ $someClassToKeep = new Some_Class_To_Keep;
 CODE_SAMPLE
                 ,
                 [
-                    self::NAMESPACE_PREFIXES_WITH_EXCLUDED_CLASSES => [
+                    self::NAMESPACE_PREFIXES_WITH_EXCLUDED_CLASSES => ValueObjectInliner::inline([
                         new PseudoNamespaceToNamespace('Some_', ['Some_Class_To_Keep']),
-                    ],
+                    ]),
                 ]
             ),
         ]);

--- a/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
@@ -22,6 +22,7 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\MethodCallRenameWithArrayKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 use Webmozart\Assert\Assert;
 
 /**
@@ -60,9 +61,9 @@ $someObject->newMethod();
 CODE_SAMPLE
                 ,
                 [
-                    self::METHOD_CALL_RENAMES => [
+                    self::METHOD_CALL_RENAMES => ValueObjectInliner::inline([
                         new MethodCallRename('SomeExampleClass', 'oldMethod', 'newMethod'),
-                    ],
+                    ]),
                 ]
             ),
         ]);

--- a/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
+++ b/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
@@ -17,6 +17,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Renaming\ValueObject\RenameProperty;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 use Webmozart\Assert\Assert;
 
 /**
@@ -41,9 +42,9 @@ final class RenamePropertyRector extends AbstractRector implements ConfigurableR
                 '$someObject->someOldProperty;',
                 '$someObject->someNewProperty;',
                 [
-                    self::RENAMED_PROPERTIES => [
+                    self::RENAMED_PROPERTIES => ValueObjectInliner::inline([
                         new RenameProperty('SomeClass', 'someOldProperty', 'someNewProperty'),
-                    ],
+                    ]),
                 ]
             ),
         ]);

--- a/rules/Renaming/Rector/StaticCall/RenameStaticMethodRector.php
+++ b/rules/Renaming/Rector/StaticCall/RenameStaticMethodRector.php
@@ -13,6 +13,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Renaming\ValueObject\RenameStaticMethod;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 use Webmozart\Assert\Assert;
 
 /**
@@ -38,15 +39,15 @@ final class RenameStaticMethodRector extends AbstractRector implements Configura
     public function getRuleDefinition(): RuleDefinition
     {
         $renameClassConfiguration = [
-            self::OLD_TO_NEW_METHODS_BY_CLASSES => [
+            self::OLD_TO_NEW_METHODS_BY_CLASSES => ValueObjectInliner::inline([
                 new RenameStaticMethod(self::SOME_CLASS, 'oldMethod', 'AnotherExampleClass', 'newStaticMethod'),
-            ],
+            ]),
         ];
 
         $renameMethodConfiguration = [
-            self::OLD_TO_NEW_METHODS_BY_CLASSES => [
+            self::OLD_TO_NEW_METHODS_BY_CLASSES => ValueObjectInliner::inline([
                 new RenameStaticMethod(self::SOME_CLASS, 'oldMethod', self::SOME_CLASS, 'newStaticMethod'),
-            ],
+            ]),
         ];
 
         return new RuleDefinition('Turns method names to new ones.', [


### PR DESCRIPTION
This PR adds `ValueObjectInliner::inline` to  `ConfiguredCodeSamples` of Renaming rectors, because the generated document is invalid, and took me a lot of time to investigate when I first encountered.