### PR TITLE
[CodingStyle] Handle VarConstantCommentRector + NewlineAfterStatementRector

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfo/PhpDocInfoTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfo/PhpDocInfoTest.php
@@ -63,7 +63,7 @@ final class PhpDocInfoTest extends AbstractTestCase
         $this->assertStringEqualsFile(__DIR__ . '/Source/expected-replaced-tag.txt', $printedPhpDocInfo);
     }
 
-    public function testDoNotAddSpaseWhenAddEmptyString()
+    public function testDoNotAddSpaseWhenAddEmptyString(): void
     {
         $this->phpDocInfo->addPhpDocTagNode(new PhpDocTextNode(''));
         $this->phpDocInfo->addPhpDocTagNode(new PhpDocTextNode('Some text'));

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -142,9 +142,10 @@ CODE_SAMPLE
                 return null;
             }
 
-            // re-draw original node
-            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            $endLine = $node->getEndLine();
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($nextNode);
+            if ($phpDocInfo->hasChanged()) {
+                return null;
+            }
 
             $line = $comments[0]->getLine();
             $rangeLine = $line - $endLine;

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -142,6 +142,10 @@ CODE_SAMPLE
                 return null;
             }
 
+            // re-draw original node
+            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $endLine = $node->getEndLine();
+
             $line = $comments[0]->getLine();
             $rangeLine = $line - $endLine;
 

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -134,11 +134,8 @@ CODE_SAMPLE
 
         if ($rangeLine > 1) {
             $comments = $nextNode->getAttribute(AttributeKey::COMMENTS);
-            if ($comments === null) {
-                return null;
-            }
 
-            if (! isset($comments[0])) {
+            if ($this->hasNoComment($comments)) {
                 return null;
             }
 
@@ -159,6 +156,15 @@ CODE_SAMPLE
         $this->nodesToAddCollector->addNodeAfterNode(new Nop(), $node);
 
         return $node;
+    }
+
+    private function hasNoComment(?array $comments): bool
+    {
+        if ($comments === null) {
+            return true;
+        }
+
+        return ! isset($comments[0]);
     }
 
     private function shouldSkip(Node $nextNode): bool

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\CodingStyle\Rector\Stmt;
 
+use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Catch_;
@@ -158,6 +159,9 @@ CODE_SAMPLE
         return $node;
     }
 
+    /**
+     * @param null|Doc[] $comments
+     */
     private function hasNoComment(?array $comments): bool
     {
         if ($comments === null) {

--- a/tests/Issues/IssueVarConstantNewline/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueVarConstantNewline/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueVarConstantNewline\Fixture;
+
+class Fixture
+{
+    public const A = 'a';
+
+    public const B = 'b';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueVarConstantNewline\Fixture;
+
+class Fixture
+{
+    /**
+     * @var string
+     */
+    public const A = 'a';
+
+    /**
+     * @var string
+     */
+    public const B = 'b';
+}
+
+?>

--- a/tests/Issues/IssueVarConstantNewline/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueVarConstantNewline/Fixture/fixture.php.inc
@@ -7,6 +7,12 @@ class Fixture
     public const A = 'a';
 
     public const B = 'b';
+    /**
+     * @var string
+     */
+    public const C = 'c';
+    public const D = 'd';
+    public const E = 'e';
 }
 
 ?>
@@ -26,6 +32,21 @@ class Fixture
      * @var string
      */
     public const B = 'b';
+
+    /**
+     * @var string
+     */
+    public const C = 'c';
+
+    /**
+     * @var string
+     */
+    public const D = 'd';
+
+    /**
+     * @var string
+     */
+    public const E = 'e';
 }
 
 ?>

--- a/tests/Issues/IssueVarConstantNewline/IssueVarConstantNewlineTest.php
+++ b/tests/Issues/IssueVarConstantNewline/IssueVarConstantNewlineTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueVarConstantNewline;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class IssueVarConstantNewlineTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueVarConstantNewline/config/configured_rule.php
+++ b/tests/Issues/IssueVarConstantNewline/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\ClassConst\VarConstantCommentRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(VarConstantCommentRector::class);
+    $services->set(NewlineAfterStatementRector::class);
+};


### PR DESCRIPTION
Given the following code:


```php
class Fixture
{
    public const A = 'a';

    public const B = 'b';
}
```

It produce double line:

```diff
     public const A = 'a';
 
+
     /**
      * @var string
```

applied rules:

```php
Rector\CodingStyle\Rector\ClassConst\VarConstantCommentRector;
Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
```

which as already new line, the new line should not be added.