### PR TITLE
[Privatization] Skip constant exists on RepeatedLiteralToClassConstantRector

### DIFF
--- a/rules-tests/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/skip_exists_different_value.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/skip_exists_different_value.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\RepeatedLiteralToClassConstantRector\Fixture;
+
+class SkipExistsDifferentValue
+{
+    private const REQUIRES = 'exists_different_value';
+
+    public function run($key, $items)
+    {
+        if ($key === 'requires') {
+            return $items['requires'];
+        }
+
+        return $items['requires'];
+    }
+}
+
+?>

--- a/rules-tests/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/use_exists_same_value.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/use_exists_same_value.php.inc
@@ -31,6 +31,7 @@ class UseExistsSameValue
      * @var string
      */
     private const REQUIRES = 'requires';
+
     public function run($key, $items)
     {
         if ($key === self::REQUIRES) {

--- a/rules-tests/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/use_exists_same_value.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/use_exists_same_value.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\RepeatedLiteralToClassConstantRector\Fixture;
+
+class UseExistsSameValue
+{
+    /**
+     * @var string
+     */
+    private const REQUIRES = 'requires';
+
+    public function run($key, $items)
+    {
+        if ($key === 'requires') {
+            return $items['requires'];
+        }
+
+        return $items['requires'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\RepeatedLiteralToClassConstantRector\Fixture;
+
+class UseExistsSameValue
+{
+    /**
+     * @var string
+     */
+    private const REQUIRES = 'requires';
+    public function run($key, $items)
+    {
+        if ($key === self::REQUIRES) {
+            return $items[self::REQUIRES];
+        }
+
+        return $items[self::REQUIRES];
+    }
+}
+
+?>

--- a/rules/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector.php
+++ b/rules/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\NodeManipulator\ClassInsertManipulator;
 use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -162,6 +163,11 @@ CODE_SAMPLE
             }
 
             if (! $this->valueResolver->isValues($node, $stringsToReplace)) {
+                return null;
+            }
+
+            $isInMethod = (bool) $this->betterNodeFinder->findParentType($node, ClassMethod::class);
+            if (! $isInMethod) {
                 return null;
             }
 


### PR DESCRIPTION
Given the following code:

1. has same constant, with same value, currently apply:

```diff
-    private const REQUIRES = 'requires';
+    private const REQUIRES = self::REQUIRES;
```

which make Fatal error:

```bash
Fatal error: Uncaught Error: Cannot declare self-referencing constant self::REQUIRES
```

2. has same constant  with different value, currently use it:

```diff
-        if ($key === 'requires') {
-            return $items['requires'];
+        if ($key === self::REQUIRES) {
+            return $items[self::REQUIRES];
         }
 
-        return $items['requires'];
+        return $items[self::REQUIRES];
```

which make code invalid as the value to compare is different.