### PR TITLE
[Core] Remove unneded check $this->autowiredClassMethodOrPropertyAnalyzer->detect($property) after negation if return early on ClassDependencyManipulator

### DIFF
--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -229,7 +229,7 @@ final class ClassDependencyManipulator
         }
 
         // is inject/autowired property?
-        return $property instanceof Property && $this->autowiredClassMethodOrPropertyAnalyzer->detect($property);
+        return $property instanceof Property;
     }
 
     private function hasMethodParameter(ClassMethod $classMethod, string $name): bool


### PR DESCRIPTION
It is detected by phpstan with temporary includes:

```bash
- vendor/phpstan/phpstan/conf/bleedingEdge.neon
```

there are 36 errors show, this is one them:

```
Note: Using configuration file /Users/samsonasik/www/rector-src/phpstan.neon.
 1432/1432 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------------------------------------------------------------------------------------------------------------------
  packages/Caching/FileSystem/DependencyResolver.php:36
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Dependency\\DependencyResolver\:\:resolveDependencies\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/Caching/ValueObject/Storage/FileCacheStorage.php:66
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\File\\FileWriter\:\:write\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/NodeTypeResolver/PHPStan/TypeHasher.php:73
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Type\\UnionTypeHelper\:\:sortTypes\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php:125
 ------------------------------------------------------------------------------------------------------------------
  - '#If condition is always false#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/NodeTypeResolver/Reflection/BetterReflection/RectorBetterReflectionSourceLocatorFactory.php:22
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\BetterReflection\\BetterReflectionSourceLocatorFactory\:\:create\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php:67
 ------------------------------------------------------------------------------------------------------------------
  - '#Creating new PHPStan\\Reflection\\BetterReflection\\SourceLocator\\OptimizedSingleFileSourceLocator is not covered by backward compatibility promise\. The class might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php:71
 ------------------------------------------------------------------------------------------------------------------
  - '#Creating new PHPStan\\Reflection\\BetterReflection\\SourceLocator\\OptimizedDirectorySourceLocator is not covered by backward compatibility promise\. The class might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/ReadWrite/Guard/VariableToConstantGuard.php:76
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Native\\NativeFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/ReadWrite/NodeAnalyzer/ReadWritePropertyAnalyzer.php:94
 ------------------------------------------------------------------------------------------------------------------
  - '#Negated boolean expression is always false#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/VersionBonding/Application/MissedRectorDueVersionChecker.php:78
 ------------------------------------------------------------------------------------------------------------------
  - '#Creating new PHPStan\\Php\\PhpVersion is not covered by backward compatibility promise\. The class might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  packages/VersionBonding/Application/MissedRectorDueVersionChecker.php:91
 ------------------------------------------------------------------------------------------------------------------
  - '#Creating new PHPStan\\Php\\PhpVersion is not covered by backward compatibility promise\. The class might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/CodeQuality/Rector/Assign/CombinedAssignRector.php:62
 ------------------------------------------------------------------------------------------------------------------
  - '#Method Rector\\CodeQuality\\Rector\\Assign\\CombinedAssignRector\:\:refactor\(\) should return PhpParser\\Node\|null but returns object#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/CodeQuality/Rector/Identical/SimplifyConditionsRector.php:118
 ------------------------------------------------------------------------------------------------------------------
  - '#Method Rector\\CodeQuality\\Rector\\Identical\\SimplifyConditionsRector\:\:createInversedBooleanOp\(\) should return PhpParser\\Node\\Expr\\BinaryOp\|null but returns object#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/CodeQuality/Rector/Return_/SimplifyUselessVariableRector.php:99
 ------------------------------------------------------------------------------------------------------------------
  - '#Property PhpParser\\Node\\Stmt\\Return_\:\:\$expr \(PhpParser\\Node\\Expr\|null\) does not accept object#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php:91
 ------------------------------------------------------------------------------------------------------------------
  - '#Method Rector\\CodeQuality\\Rector\\Ternary\\UnnecessaryTernaryExpressionRector\:\:refactor\(\) should return PhpParser\\Node\|null but returns object#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/CodingStyle/Reflection/VendorLocationDetector.php:42
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getFileName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/Defluent/Skipper/FluentMethodCallSkipper.php:25
 ------------------------------------------------------------------------------------------------------------------
  - '#PHPDoc tag @var for constant Rector\\Defluent\\Skipper\\FluentMethodCallSkipper\:\:ALLOWED_FLUENT_TYPES with type array<class\-string\> is not subtype of value array\('Symfony\\\\Component…', 'Symfony\\\\Component…', 'Doctrine\\\\ORM…', 'Nette\\\\Utils\\\\Finder', 'Nette\\\\Forms…', 'Nette\\\\DI…', 'Nette\\\\DI…', 'Nette\\\\DI…', \.\.\.\)#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php:177
 ------------------------------------------------------------------------------------------------------------------
  - '#Parameter \#1 \$callback of function array_map expects callable\(PhpParser\\Node\\Expr\\ArrayItem\|null\)\: mixed, Closure\(PhpParser\\Node\\Expr\\ArrayItem\)\: PhpParser\\Node\\Arg given#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php:97
 ------------------------------------------------------------------------------------------------------------------
  - '#Creating new PHPStan\\Reflection\\Php\\PhpParameterReflection is not covered by backward compatibility promise\. The class might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php:37
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Native\\NativeFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/DowngradePhp80/Reflection/DefaultParameterValueResolver.php:81
 ------------------------------------------------------------------------------------------------------------------
  - '#Elseif condition is always true#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  rules/Php70/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector.php:159
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Analyser\\MutatingScope\:\:assignExpression\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/Bootstrap/ExtensionConfigResolver.php:31
 ------------------------------------------------------------------------------------------------------------------
  - '#Offset 'includes' on array\('includes' \=\> array\('config/config\.php'\)\) on left side of \?\? always exists and is not nullable#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/NodeManipulator/BinaryOpManipulator.php:76
 ------------------------------------------------------------------------------------------------------------------
  - '#Method Rector\\Core\\NodeManipulator\\BinaryOpManipulator\:\:inverseBinaryOp\(\) should return PhpParser\\Node\\Expr\\BinaryOp\|null but returns object#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/NodeManipulator/BinaryOpManipulator.php:95
 ------------------------------------------------------------------------------------------------------------------
  - '#Method Rector\\Core\\NodeManipulator\\BinaryOpManipulator\:\:invertCondition\(\) should return PhpParser\\Node\\Expr\\BinaryOp\|null but returns object#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/NodeManipulator/BinaryOpManipulator.php:103
 ------------------------------------------------------------------------------------------------------------------
  - '#Method Rector\\Core\\NodeManipulator\\BinaryOpManipulator\:\:inverseNode\(\) should return PhpParser\\Node but returns object#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/NodeManipulator/ClassDependencyManipulator.php:232
 ------------------------------------------------------------------------------------------------------------------
  - '#Right side of && is always true#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PHPStan/Reflection/TypeToCallReflectionResolver/ClosureTypeToCallReflectionResolver.php:26
 ------------------------------------------------------------------------------------------------------------------
  - '#Creating new PHPStan\\Reflection\\Native\\NativeFunctionReflection is not covered by backward compatibility promise\. The class might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/AstResolver.php:152
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/AstResolver.php:153
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/AstResolver.php:156
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getFileName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/AstResolver.php:164
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/AstResolver.php:176
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/AstResolver.php:181
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/AstResolver.php:187
 ------------------------------------------------------------------------------------------------------------------
  - '#Calling PHPStan\\Reflection\\Php\\PhpFunctionReflection\:\:getName\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 ------------------------------------------------------------------------------------------------------------------

 ------------------------------------------------------------------------------------------------------------------
  src/PhpParser/Node/AssignAndBinaryMap.php:68
 ------------------------------------------------------------------------------------------------------------------
  - '#PHPDoc tag @var for constant Rector\\Core\\PhpParser\\Node\\AssignAndBinaryMap\:\:ASSIGN_OP_TO_BINARY_OP_CLASSES with type array<class\-string<PhpParser\\Node\\Expr\\AssignOp\>, class\-string<PhpParser\\Node\\Expr\\AssignOp\>\> is incompatible with value array\('PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\BitwiseOr' \=\> 'PhpParser\\\\Node\\\\Expr…', 'PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\BitwiseAnd' \=\> 'PhpParser\\\\Node\\\\Expr…', 'PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\BitwiseXor' \=\> 'PhpParser\\\\Node\\\\Expr…', 'PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Plus' \=\> 'PhpParser\\\\Node\\\\Expr…', 'PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Div' \=\> 'PhpParser\\\\Node\\\\Expr…', 'PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Mul' \=\> 'PhpParser\\\\Node\\\\Expr…', 'PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Minus' \=\> 'PhpParser\\\\Node\\\\Expr…', 'PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Concat' \=\> 'PhpParser\\\\Node\\\\Expr…', \.\.\.\)#'
 ------------------------------------------------------------------------------------------------------------------


                                                                                                                        
 [ERROR] Found 36 errors                                                                                                
                                                                                                                        

Script vendor/bin/phpstan analyse --ansi --error-format symplify handling the phpstan event returned with error code 1
```