### PR TITLE
[EarlyReturn] Refactor ChangeAndIfToEarlyReturnRector: return array of Nodes

### DIFF
--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -136,8 +136,7 @@ CODE_SAMPLE
         array $conditions,
         Return_ $ifNextReturnClone,
         array $afters
-    ): array
-    {
+    ): array {
         $ifs = $this->invertedIfFactory->createFromConditions($if, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $if);
 

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -85,9 +85,9 @@ CODE_SAMPLE
 
     /**
      * @param If_ $node
-     * @return Node|Node[]|null
+     * @return Node[]|null
      */
-    public function refactor(Node $node)
+    public function refactor(Node $node): ?array
     {
         if ($this->shouldSkip($node)) {
             return null;
@@ -129,14 +129,14 @@ CODE_SAMPLE
     /**
      * @param Expr[] $conditions
      * @param Node[] $afters
-     * @return If_|Node[]
+     * @return Node[]
      */
     private function processReplaceIfs(
         If_ $if,
         array $conditions,
         Return_ $ifNextReturnClone,
         array $afters
-    ): If_ | array
+    ): array
     {
         $ifs = $this->invertedIfFactory->createFromConditions($if, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $if);

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -98,6 +98,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($ifNextReturn instanceof Return_ && $ifNextReturn->expr instanceof BooleanAnd) {
+            return null;
+        }
+
         /** @var BooleanAnd $expr */
         $expr = $node->cond;
         $booleanAndConditions = $this->booleanAndAnalyzer->findBooleanAndConditions($expr);
@@ -106,10 +110,6 @@ CODE_SAMPLE
         if (! $ifNextReturn instanceof Return_) {
             $afters[] = $node->stmts[0];
             return $this->processReplaceIfs($node, $booleanAndConditions, new Return_(), $afters);
-        }
-
-        if ($ifNextReturn instanceof Return_ && $ifNextReturn->expr instanceof BooleanAnd) {
-            return null;
         }
 
         $this->removeNode($ifNextReturn);

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -140,8 +140,6 @@ CODE_SAMPLE
         $ifs = $this->invertedIfFactory->createFromConditions($if, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $if);
 
-        $this->removeNode($if);
-
         if (! $if->stmts[0] instanceof Return_ && $ifNextReturnClone->expr instanceof Expr && ! $this->contextAnalyzer->isInLoop(
             $if
         )) {

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -140,13 +140,20 @@ CODE_SAMPLE
         $ifs = $this->invertedIfFactory->createFromConditions($if, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $if);
 
-        if (! $if->stmts[0] instanceof Return_ && $ifNextReturnClone->expr instanceof Expr && ! $this->contextAnalyzer->isInLoop(
-            $if
-        )) {
-            return array_merge($ifs, $afters, [$ifNextReturnClone]);
+        $result = array_merge($ifs, $afters);
+        if ($if->stmts[0] instanceof Return_) {
+            return $result;
         }
 
-        return array_merge($ifs, $afters);
+        if (! $ifNextReturnClone->expr instanceof Expr) {
+            return $result;
+        }
+
+        if ($this->contextAnalyzer->isInLoop($if)) {
+            return $result;
+        }
+
+        return array_merge($result, [$ifNextReturnClone]);
     }
 
     private function shouldSkip(If_ $if): bool


### PR DESCRIPTION
- return array of Nodes instead of using `addNodesBeforeNode()`, `addNodeAfterNode()`
- remove unneeded removeNode() when next return array of nodes