### PR TITLE
Add failing test fixture for NullsafeOperatorRector

### DIFF
--- a/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/demo_file.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\If_\NullsafeOperatorRector\Fixture;
+
+abstract class DemoFile
+{
+    public ?string $value;
+    
+    public function run(): ?string
+    {
+        return $this->value !== null ? $this->doSomething($this->value) : null;
+    }
+    
+    abstract public function doSomething(string $value);
+}
+?>


### PR DESCRIPTION
# Failing Test for NullsafeOperatorRector

Based on https://getrector.org/demo/1ec16b73-2144-6540-ba0e-07a271231275