### PR TITLE
[Php74] Do not remove Array union doc not loaded class on TypedPropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/array_union_doc_loaded_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/array_union_doc_loaded_class.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ArrayUnionDocLoadedClass
+{
+    /** @var string[]|\stdClass[] */
+    private $unionValue;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ArrayUnionDocLoadedClass
+{
+    /** @var string[]|\stdClass[] */
+    private array $unionValue;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/array_union_doc_loaded_class2.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/array_union_doc_loaded_class2.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ArrayUnionDocLoadedClass2
+{
+    /** @var string[][]|\stdClass[][] */
+    private $unionValue;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ArrayUnionDocLoadedClass2
+{
+    /** @var string[][]|\stdClass[][] */
+    private array $unionValue;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class DoNotRemoveArrayUnionDocNotLoadedClass
+{
+    /** @var string[]|\NotLoadedClass[] */
+    private $unionValue;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class DoNotRemoveArrayUnionDocNotLoadedClass
+{
+    /** @var string[]|\NotLoadedClass[] */
+    private array $unionValue;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class.php.inc
@@ -6,9 +6,6 @@ final class DoNotRemoveArrayUnionDocNotLoadedClass
 {
     /** @var string[]|\NotLoadedClass[] */
     private $unionValue;
-
-    /** @var string[][]|\NotLoadedClass[][] */
-    private $unionValue2;
 }
 
 ?>
@@ -21,9 +18,6 @@ final class DoNotRemoveArrayUnionDocNotLoadedClass
 {
     /** @var string[]|\NotLoadedClass[] */
     private array $unionValue;
-
-    /** @var string[][]|\NotLoadedClass[][] */
-    private array $unionValue2;
 }
 
 ?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class.php.inc
@@ -6,6 +6,9 @@ final class DoNotRemoveArrayUnionDocNotLoadedClass
 {
     /** @var string[]|\NotLoadedClass[] */
     private $unionValue;
+
+    /** @var string[][]|\NotLoadedClass[][] */
+    private $unionValue2;
 }
 
 ?>
@@ -18,6 +21,9 @@ final class DoNotRemoveArrayUnionDocNotLoadedClass
 {
     /** @var string[]|\NotLoadedClass[] */
     private array $unionValue;
+
+    /** @var string[][]|\NotLoadedClass[][] */
+    private array $unionValue2;
 }
 
 ?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class2.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_array_union_doc_not_loaded_class2.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class DoNotRemoveArrayUnionDocNotLoadedClass2
+{
+    /** @var string[][]|\NotLoadedClass[][] */
+    private $unionValue2;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class DoNotRemoveArrayUnionDocNotLoadedClass2
+{
+    /** @var string[][]|\NotLoadedClass[][] */
+    private array $unionValue2;
+}
+
+?>

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -21,7 +21,6 @@ use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\DeadCode\PhpDoc\DeadVarTagValueNodeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
 use Rector\StaticTypeMapper\StaticTypeMapper;
-use Symplify\PackageBuilder\Reflection\ClassLikeExistenceChecker;
 
 final class VarTagRemover
 {
@@ -29,7 +28,6 @@ final class VarTagRemover
         private DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
         private StaticTypeMapper $staticTypeMapper,
         private PhpDocInfoFactory $phpDocInfoFactory,
-        private ClassLikeExistenceChecker $classLikeExistenceChecker,
         private DeadVarTagValueNodeAnalyzer $deadVarTagValueNodeAnalyzer
     ) {
     }
@@ -103,10 +101,7 @@ final class VarTagRemover
         return $varTagValueNode->type instanceof ArrayTypeNode;
     }
 
-    private function isArrayOfClass(
-        Node $node,
-        SpacingAwareArrayTypeNode $spacingAwareArrayTypeNode
-    ): bool {
+    private function isArrayOfClass(Node $node, SpacingAwareArrayTypeNode $spacingAwareArrayTypeNode): bool {
         $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
             $spacingAwareArrayTypeNode,
             $node

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -85,7 +85,7 @@ final class VarTagRemover
     {
         if ($varTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
             foreach ($varTagValueNode->type->types as $type) {
-                if ($type instanceof SpacingAwareArrayTypeNode && $this->isArrayOfExistingClassNode($node, $type)) {
+                if ($type instanceof SpacingAwareArrayTypeNode && $this->isArrayOfClass($node, $type)) {
                     return true;
                 }
             }
@@ -103,7 +103,7 @@ final class VarTagRemover
         return $varTagValueNode->type instanceof ArrayTypeNode;
     }
 
-    private function isArrayOfExistingClassNode(
+    private function isArrayOfClass(
         Node $node,
         SpacingAwareArrayTypeNode $spacingAwareArrayTypeNode
     ): bool {
@@ -117,12 +117,6 @@ final class VarTagRemover
         }
 
         $itemType = $staticType->getItemType();
-        if (! $itemType instanceof ObjectType) {
-            return false;
-        }
-
-        $className = $itemType->getClassName();
-
-        return $this->classLikeExistenceChecker->doesClassLikeExist($className);
+        return $itemType instanceof ObjectType;
     }
 }

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -102,6 +102,10 @@ final class VarTagRemover
     }
 
     private function isArrayOfClass(Node $node, SpacingAwareArrayTypeNode $spacingAwareArrayTypeNode): bool {
+        if ($spacingAwareArrayTypeNode->type instanceof SpacingAwareArrayTypeNode) {
+            return $this->isArrayOfClass($node, $spacingAwareArrayTypeNode->type);
+        }
+
         $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
             $spacingAwareArrayTypeNode,
             $node


### PR DESCRIPTION
Given the following code:

```php
final class DoNotRemoveArrayUnionDocNotLoadedClass
{
    /** @var string[]|\NotLoadedClass[] */
    private $unionValue;
}
```

It produce:

```diff
-    /** @var string[]|\NotLoadedClass[] */
+    private array $unionValue;
```

which the `@var` removed, which should not. 

For loaded class, it is working ok, it only happen when union type on not loaded class.