### PR TITLE
Add failing test fixture for NullsafeOperatorRector

### DIFF
--- a/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/demo_file.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\If_\NullsafeOperatorRector\Fixture;
+
+abstract class DemoFile
+{
+	public function addCover(Date $date, Money $amount): void
+	{
+		/** @var Money|null $currentAmount */
+		$currentAmount = $this->covers->get($date, null);
+
+		if ($currentAmount !== null) {
+			$amount = $currentAmount->add($amount);
+		}
+
+		$this->covers->put($date, $amount);
+	}
+}
+?>


### PR DESCRIPTION
# Failing Test for NullsafeOperatorRector

Based on https://getrector.org/demo/1ec16f8d-87c9-6fd6-b943-fd404ff74fb8

This is certainly incorrect. In the original code `$amount` is always not null. With the change by rector it can become null.