### PR TITLE
[CodingStyle] Handle too detailed pair class string array on VarConstantCommentRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
@@ -173,8 +173,9 @@ final class ArrayTypeMapper implements TypeMapperInterface
         TypeKind $typeKind,
         bool $withKey = false
     ): GenericTypeNode {
+        $itemType = $arrayType->getItemType();
         $itemTypeNode = $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode(
-            $arrayType->getItemType(),
+            $itemType,
             $typeKind
         );
         $identifierTypeNode = new IdentifierTypeNode('array');
@@ -190,8 +191,8 @@ final class ArrayTypeMapper implements TypeMapperInterface
                 $typeKind
             );
 
-            if ($itemTypeNode instanceof BracketsAwareUnionTypeNode && $arrayType->getItemType() instanceof UnionType && $this->genericClassStringTypeNormalizer->isAllGenericClassStringType($arrayType->getItemType())) {
-                if ($this->detailedTypeAnalyzer->isTooDetailed($arrayType->getItemType())) {
+            if ($itemTypeNode instanceof BracketsAwareUnionTypeNode && $itemType instanceof UnionType && $this->genericClassStringTypeNormalizer->isAllGenericClassStringType($itemType)) {
+                if ($this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
                     $genericTypes = [$keyTypeNode, $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode(
                         new ClassStringType(),
                         $typeKind

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
@@ -217,11 +217,15 @@ final class ArrayTypeMapper implements TypeMapperInterface
 
     private function isPairClassTooDetailed(Type $itemType): bool
     {
-        if ($itemType instanceof UnionType && $this->genericClassStringTypeNormalizer->isAllGenericClassStringType($itemType) && $this->detailedTypeAnalyzer->isTooDetailed($itemType)) {
-            return true;
+        if (! $itemType instanceof UnionType) {
+            return false;
         }
 
-        return false;
+        if (! $this->genericClassStringTypeNormalizer->isAllGenericClassStringType($itemType)) {
+            return false;
+        }
+
+        return $this->detailedTypeAnalyzer->isTooDetailed($itemType);
     }
 
     private function isIntegerKeyAndNonNestedArray(ArrayType $arrayType): bool
@@ -260,7 +264,7 @@ final class ArrayTypeMapper implements TypeMapperInterface
     private function createTypeNodeFromGenericClassStringType(
         GenericClassStringType $genericClassStringType,
         TypeKind $typeKind
-    ): TypeNode {
+    ): IdentifierTypeNode|GenericTypeNode {
         $genericType = $genericClassStringType->getGenericType();
         if ($genericType instanceof ObjectType && ! $this->reflectionProvider->hasClass($genericType->getClassName())) {
             return new IdentifierTypeNode($genericType->getClassName());

--- a/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array.php.inc
@@ -18,7 +18,7 @@ namespace Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fi
 class PairClassStringArray
 {
     /**
-     * @var array<class-string, class-string>
+     * @var array<string, class-string<\Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture\PairClassStringArray>>
      */
     private const CLASSES = [
         \stdClass::class => PairClassStringArray::class,

--- a/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array.php.inc
@@ -17,6 +17,9 @@ namespace Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fi
 
 class PairClassStringArray
 {
+    /**
+     * @var array<class-string, class-string>
+     */
     private const CLASSES = [
         \stdClass::class => PairClassStringArray::class,
     ];

--- a/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture;
+
+class PairClassStringArray
+{
+    private const CLASSES = [
+        \stdClass::class => PairClassStringArray::class,
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture;
+
+class PairClassStringArray
+{
+    private const CLASSES = [
+        \stdClass::class => PairClassStringArray::class,
+    ];
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array2.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array2.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture;
+
+class A { }
+class Aa { }
+class B { }
+class Bb { }
+class C { }
+class Cc { }
+class D { }
+class Dd { }
+
+class PairClassStringArray2
+{
+    private const CLASSES = [
+        A::class => Aa::class,
+        B::class => Bb::class,
+        C::class => Cc::class,
+        D::class => Dd::class,
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture;
+
+class A { }
+class Aa { }
+class B { }
+class Bb { }
+class C { }
+class Cc { }
+class D { }
+class Dd { }
+
+class PairClassStringArray2
+{
+    /**
+     * @var array<class-string, class-string>
+     */
+    private const CLASSES = [
+        A::class => Aa::class,
+        B::class => Bb::class,
+        C::class => Cc::class,
+        D::class => Dd::class,
+    ];
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array2.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array2.php.inc
@@ -39,7 +39,7 @@ class Dd { }
 class PairClassStringArray2
 {
     /**
-     * @var array<class-string, class-string>
+     * @var array<string, class-string>
      */
     private const CLASSES = [
         A::class => Aa::class,

--- a/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array_too_many.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/VarConstantCommentRector/Fixture/pair_class_string_array_too_many.php.inc
@@ -11,7 +11,7 @@ class Cc { }
 class D { }
 class Dd { }
 
-class PairClassStringArray2
+class PairClassStringArrayTooMany
 {
     private const CLASSES = [
         A::class => Aa::class,
@@ -36,7 +36,7 @@ class Cc { }
 class D { }
 class Dd { }
 
-class PairClassStringArray2
+class PairClassStringArrayTooMany
 {
     /**
      * @var array<string, class-string>

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -81,7 +81,7 @@ final class GenericClassStringTypeNormalizer
         return $arrayType;
     }
 
-    private function isAllGenericClassStringType(UnionType $unionType): bool
+    public function isAllGenericClassStringType(UnionType $unionType): bool
     {
         $types = $unionType->getTypes();
 


### PR DESCRIPTION
Given the following code with more than 3 classes in list, it got too detailed items, for example:

```php
class A { }
class Aa { }
class B { }
class Bb { }
class C { }
class Cc { }
class D { }
class Dd { }

class PairClassStringArray2
{
    private const CLASSES = [
        A::class => Aa::class,
        B::class => Bb::class,
        C::class => Cc::class,
        D::class => Dd::class,
    ];
}
```

It produce very long `@var`:

```diff
+ * @var array<string, class-string<\Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture\Aa>|class-string<\Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture\Bb>|class-string<\Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture\Cc>|class-string<\Rector\Tests\CodingStyle\Rector\ClassConst\VarConstantCommentRector\Fixture\Dd>>
```