### PR TITLE
Add failing testcase for `RemoveUnusedPrivateMethodRector`

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/keep_with_call_user_func.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/keep_with_call_user_func.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+final class KeepWithCallUserFunc
+{
+    public function go($unknown)
+    {
+        call_user_func([$this, $unknown]);
+    }
+
+    private function called()
+    {
+    }
+}


### PR DESCRIPTION
Not sure if this would be considered a bug. It's a stupid thing to do
but we have some code similar to this and this rule currently breaks it.