### PR TITLE
Add failing testcase for unnecessary reformat

### DIFF
--- a/tests/PhpParser/Printer/CommentPreserving/Fixture/view_not_reformatted.php.inc
+++ b/tests/PhpParser/Printer/CommentPreserving/Fixture/view_not_reformatted.php.inc
@@ -1,0 +1,5 @@
+<? if (count($xs)): ?>
+    <? foreach ($xs as $x): ?>
+        <? /* Some comment */ ?>
+    <? endforeach; ?>
+<? endif; ?>


### PR DESCRIPTION
Not sure what's going on here but it seems to be caused by the comment.
We're hitting this in a number of our files, seems to be the closing statement gets un-indented in the block containing a comment.
Test is probably in an inappropriate place.