### PR TITLE
Add failing test fixture for NullsafeOperatorRector

### DIFF
--- a/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/skip_ternary_no_direct_usage2.php.inc
+++ b/rules-tests/Php80/Rector/If_/NullsafeOperatorRector/Fixture/skip_ternary_no_direct_usage2.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\If_\NullsafeOperatorRector\Fixture;
+
+final class SkipTernaryNoDirectUsage2
+{
+    public function run()
+    {
+        return $someObject === null ? null : $this->parse($someObject);
+    }
+    
+    public function parse($someObject)
+    {
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for NullsafeOperatorRector

Based on https://getrector.org/demo/1ec1d0fc-200f-6fdc-9564-cdcd875b1603

Ref: https://github.com/rectorphp/rector/issues/6702