### PR TITLE
Add test case for auto import for docblock properties

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/rename_class_with_same_name_but_different_namespace_in_class_property.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/rename_class_with_same_name_but_different_namespace_in_class_property.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNames;
+
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\FirstNamespace\SomeServiceClass;
+
+class SomeClass2
+{
+    /**
+     * @var SomeServiceClass
+     */
+    private $someService;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNames;
+
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\SecondNamespace\SomeServiceClass;
+
+class SomeClass2
+{
+    /**
+     * @var SomeServiceClass
+     */
+    private $someService;
+}
+
+?>


### PR DESCRIPTION
When a class, which should be renamed, is only used in docblocks, the old class import is not removed properly. This test case shows what should happen

Based on: https://getrector.org/demo/1ec1d50f-cbdb-6e94-9cac-bbde4011c6aa
See also: https://github.com/rectorphp/rector/issues/6704