### PR TITLE
[Renaming] Fully Qualified import doc same name renaming class error

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/rename_class_with_same_name_but_different_namespace_in_var_doc4.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/rename_class_with_same_name_but_different_namespace_in_var_doc4.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportN
 
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\FirstNamespace\SomeServiceClass;
 
-class SomeClass5
+class RenameClassWithSameNameButDifferentNamespaceInVarDoc4
 {
     public function run()
     {
@@ -23,7 +23,7 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportN
 
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\SecondNamespace\SomeServiceClass;
 
-class SomeClass5
+class RenameClassWithSameNameButDifferentNamespaceInVarDoc4
 {
     public function run()
     {


### PR DESCRIPTION
The test somehow error right now tested in local:

```bash
1) Rector\Tests\Renaming\Rector\Name\RenameClassRector\AutoImportNamesTest::test with data set #1 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/rename_class_with_same_name_but_different_namespace_in_var_doc4.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNames;
 
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\SecondNamespace\SomeServiceClass;
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\FirstNamespace\SomeServiceClass;
 
 class RenameClassWithSameNameButDifferentNamespaceInVarDoc4
```

On the following code:

```php
use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\FirstNamespace\SomeServiceClass;

class RenameClassWithSameNameButDifferentNamespaceInVarDoc4
{
    public function run()
    {
        /**
         * @var \Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\FirstNamespace\SomeServiceClass $someService
         */
        $someService2 = get_service2();
    }
}
```