### PR TITLE
fix getArgs() missing in phpstan scoped version in rector-src packages

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -498,3 +498,8 @@ parameters:
 
         # false positive - class_exists check is right above it
         - '#Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string<Rector\\RectorInstaller\\GeneratedConfig\>\|Rector\\RectorInstaller\\GeneratedConfig, string given#'
+
+        # waits for phpstan upgrade to php-parser 4.13
+        - '#Access to an undefined property PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder\:\:\$value#'
+        - '#(.*?), array<PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder\> given#'
+        - '#(.*?) but returns array<int, PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder\>#'

--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -100,7 +100,7 @@ final class ArgumentDefaultValueReplacer
         ) && $argValue === $replaceArgumentDefaultValue->getValueBefore()) {
             $expr->args[$position] = $this->normalizeValueToArgument($replaceArgumentDefaultValue->getValueAfter());
         } elseif (is_array($replaceArgumentDefaultValue->getValueBefore())) {
-            $newArgs = $this->processArrayReplacement($expr->getArgs(), $replaceArgumentDefaultValue);
+            $newArgs = $this->processArrayReplacement($expr->args, $replaceArgumentDefaultValue);
 
             if ($newArgs) {
                 $expr->args = $newArgs;

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -71,7 +71,7 @@ final class DowngradePregUnmatchedAsNullConstantRector extends AbstractRector
             return null;
         }
 
-        $args = $node->getArgs();
+        $args = $node->args;
         if (! isset($args[3])) {
             return null;
         }

--- a/rules/DowngradePhp80/Rector/ClassMethod/DowngradeTrailingCommasInParamUseRector.php
+++ b/rules/DowngradePhp80/Rector/ClassMethod/DowngradeTrailingCommasInParamUseRector.php
@@ -117,7 +117,7 @@ CODE_SAMPLE
 
     private function processArgs(FuncCall | MethodCall | StaticCall | New_ $node): ?Node
     {
-        $args = $node->getArgs();
+        $args = $node->args;
         if ($args === []) {
             return null;
         }

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrEndsWithRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrEndsWithRector.php
@@ -64,7 +64,7 @@ final class DowngradeStrEndsWithRector extends AbstractRector
 
     private function createSubstrCompareFuncCall(FuncCall $funcCall): FuncCall
     {
-        $args = $funcCall->getArgs();
+        $args = $funcCall->args;
 
         $strlenFuncCall = $this->createStrlenFuncCall($args[1]->value);
         $args[] = new Arg(new UnaryMinus($strlenFuncCall));

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeNamedArgumentRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeNamedArgumentRector.php
@@ -81,7 +81,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $args = $node->getArgs();
+        $args = $node->args;
         if ($this->shouldSkip($args)) {
             return null;
         }

--- a/rules/MysqlToMysqli/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
+++ b/rules/MysqlToMysqli/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
@@ -131,10 +131,9 @@ CODE_SAMPLE
                 continue;
             }
 
-            $args = $node->getArgs();
+            $args = $node->args;
             if (
-                $args === []
-                || ! $this->isProbablyMysql($args[0]->value)
+                $args === [] || ! $this->isProbablyMysql($args[0]->value)
             ) {
                 $connectionVariable = $this->findConnectionVariable($node);
 
@@ -144,7 +143,7 @@ CODE_SAMPLE
                     return null;
                 }
 
-                $node->args = array_merge([new Arg($connectionVariable)], $node->getArgs());
+                $node->args = array_merge([new Arg($connectionVariable)], $node->args);
             }
 
             $node->name = new Name($newFunction);

--- a/rules/Php70/Rector/FuncCall/CallUserMethodRector.php
+++ b/rules/Php70/Rector/FuncCall/CallUserMethodRector.php
@@ -65,7 +65,7 @@ final class CallUserMethodRector extends AbstractRector implements MinPhpVersion
         $newName = self::OLD_TO_NEW_FUNCTIONS[$this->getName($node)];
         $node->name = new Name($newName);
 
-        $oldArgs = $node->getArgs();
+        $oldArgs = $node->args;
 
         unset($node->args[1]);
 

--- a/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
@@ -82,7 +82,7 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
             return null;
         }
 
-        $args = $funcCall->getArgs();
+        $args = $funcCall->args;
         if (count($args) >= 3) {
             return null;
         }

--- a/rules/Php73/Rector/FuncCall/SetCookieRector.php
+++ b/rules/Php73/Rector/FuncCall/SetCookieRector.php
@@ -122,7 +122,7 @@ CODE_SAMPLE
     {
         $items = [];
 
-        $args = $funcCall->getArgs();
+        $args = $funcCall->args;
 
         $newArgs = [];
         $newArgs[] = $args[0];

--- a/rules/Php73/Rector/FuncCall/SetCookieRector.php
+++ b/rules/Php73/Rector/FuncCall/SetCookieRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\VariadicPlaceholder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -116,7 +117,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return Arg[]
+     * @return Arg[]|VariadicPlaceholder[]
      */
     private function composeNewArgs(FuncCall $funcCall): array
     {

--- a/rules/Php80/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
+++ b/rules/Php80/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
@@ -144,12 +144,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $expectedArgOrParamOrder = $this->resolveExpectedArgParamOrderIfDifferent($methodReflection, $new->getArgs());
+        $expectedArgOrParamOrder = $this->resolveExpectedArgParamOrderIfDifferent($methodReflection, $new->args);
         if ($expectedArgOrParamOrder === null) {
             return null;
         }
 
-        $new->args = $this->argumentSorter->sortArgsByExpectedParamOrder($new->getArgs(), $expectedArgOrParamOrder);
+        $new->args = $this->argumentSorter->sortArgsByExpectedParamOrder($new->args, $expectedArgOrParamOrder);
         $new->setAttribute(self::ALREADY_SORTED, true);
 
         return $new;
@@ -164,14 +164,14 @@ CODE_SAMPLE
 
         $expectedArgOrParamOrder = $this->resolveExpectedArgParamOrderIfDifferent(
             $methodReflection,
-            $methodCall->getArgs()
+            $methodCall->args
         );
         if ($expectedArgOrParamOrder === null) {
             return null;
         }
 
         $newArgs = $this->argumentSorter->sortArgsByExpectedParamOrder(
-            $methodCall->getArgs(),
+            $methodCall->args,
             $expectedArgOrParamOrder
         );
 

--- a/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecMocksToPHPUnitMocksRector.php
+++ b/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecMocksToPHPUnitMocksRector.php
@@ -223,7 +223,7 @@ final class PhpSpecMocksToPHPUnitMocksRector extends AbstractPhpSpecToPHPUnitRec
 
     private function createIsTypeOrIsInstanceOf(StaticCall $staticCall): MethodCall
     {
-        $args = $staticCall->getArgs();
+        $args = $staticCall->args;
         $type = $this->valueResolver->getValue($args[0]->value);
 
         $name = $this->typeAnalyzer->isPhpReservedType($type) ? 'isType' : 'isInstanceOf';

--- a/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
+++ b/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
@@ -147,7 +147,7 @@ final class PhpSpecPromisesToPHPUnitAssertRector extends AbstractPhpSpecToPHPUni
 
         $this->processMatchersKeys($node);
 
-        $args = $node->getArgs();
+        $args = $node->args;
         foreach (self::NEW_METHOD_TO_OLD_METHODS as $newMethod => $oldMethods) {
             if (! $this->isNames($node->name, $oldMethods)) {
                 continue;


### PR DESCRIPTION
Fixes case when phpstan uses old parser (4.13.x-dev before tagging), while we use never one (4.13), where `getArgs()` is. This happens only on missing `preload.php` when we use `rector-src` to test joined dev packages. This would not affect the `rector/rector` users.

See https://github.com/rectorphp/phpstan-rules/runs/3756325213