### PR TITLE
Add failing test fixture for RenameClassRector

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/baz.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/baz.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Foo\Bar;
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+final class Baz
+{
+    public function run()
+    {
+        return 5;
+    }
+}
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
@@ -45,6 +45,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 SecondInterface::class => ThirdInterface::class,
                 \Acme\Foo\DoNotUpdateExistingTargetNamespace::class => DoNotUpdateExistingTargetNamespace::class,
                 SomeNonFinalClass::class => SomeFinalClass::class,
+                'Foo\Bar' => 'Foo\Bar\BarInterface',
             ],
         ]]);
 };


### PR DESCRIPTION
# Failing Test for RenameClassRector

Based on https://getrector.org/demo/1ec2203d-825d-6c44-b859-d13560f1fff6

I was expecting namespace to stay the same even if the name is matching
as the rector's name is `RenameClassRector` and also config is using `RenameClassRector::OLD_TO_NEW_CLASSES`,
so no _namespace_ is mentioned and `RenameNamespace` should be separate step.