### PR TITLE
Add failing test fixture for RenameNamespaceRector

### DIFF
--- a/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/baz.php.inc
+++ b/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/baz.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Foo {
+	interface Bar
+	{
+    	public function run();
+    }
+}
+
+namespace Foo\Bar {
+  final class Baz implements \Foo\Bar
+	{
+    	public function run()
+	    {
+    	    return 5;
+	    }
+	}
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Namespace_\RenameNamespaceRector\Fixture;
+
+namespace Foo {
+
+	interface Bar
+	{
+    	public function run();
+    }
+}
+
+namespace Foo\Tmp {
+  final class Baz implements \Foo\Bar
+	{
+    	public function run()
+	    {
+    	    return 5;
+	    }
+	}
+}
+?>

--- a/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/config/configured_rule.php
@@ -14,6 +14,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'OldNamespaceWith\OldSplitNamespace' => 'NewNamespaceWith\NewSplitNamespace',
                 'Old\Long\AnyNamespace' => 'Short\AnyNamespace',
                 'PHPUnit_Framework_' => 'PHPUnit\Framework\\',
+                'Foo\Bar' => 'Foo\Tmp',
             ],
         ]]);
 };


### PR DESCRIPTION
# Failing Test for RenameNamespaceRector

Based on https://getrector.org/demo/1ec22097-6a9c-6394-83be-bba4dcc87f31

I have classes \Foo\Bar and \Foo\Bar\Baz (Baz class in Foo\Bar namespace).
The class/interface \Foo\Bar should not be renamed to \Foo\Tmp class.