### PR TITLE
[CodingStyle] Do not escape expression on ConsistentPregDelimiterRector with double quote

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_end_anchor.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_end_anchor.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class DoNotEscapeEndAnchor
+{
+    public function run($value)
+    {
+        preg_match("/^value$/", $value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class DoNotEscapeEndAnchor
+{
+    public function run($value)
+    {
+        preg_match("#^value$#", $value);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_end_anchor.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_end_anchor.php.inc
@@ -7,7 +7,7 @@ class DoNotEscapeEndAnchor
     public function run($value)
     {
         preg_match("/^value$/", $value);
-        preg_match("/^value$/u", $value);
+        preg_match("/^[-. '\p{L}]+$/u", $value);
     }
 }
 
@@ -22,7 +22,7 @@ class DoNotEscapeEndAnchor
     public function run($value)
     {
         preg_match("#^value$#", $value);
-        preg_match("#^value$#u", $value);
+        preg_match("#^[-. '\p{L}]+$#u", $value);
     }
 }
 

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_end_anchor.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_end_anchor.php.inc
@@ -7,6 +7,7 @@ class DoNotEscapeEndAnchor
     public function run($value)
     {
         preg_match("/^value$/", $value);
+        preg_match("/^value$/u", $value);
     }
 }
 
@@ -21,6 +22,7 @@ class DoNotEscapeEndAnchor
     public function run($value)
     {
         preg_match("#^value$#", $value);
+        preg_match("#^value$#u", $value);
     }
 }
 

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_expression_and_anchor.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/do_not_escape_expression_and_anchor.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
 
-class DoNotEscapeEndAnchor
+class DoNotEscapedExpressionAndAnchor
 {
     public function run($value)
     {
@@ -17,7 +17,7 @@ class DoNotEscapeEndAnchor
 
 namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
 
-class DoNotEscapeEndAnchor
+class DoNotEscapedExpressionAndAnchor
 {
     public function run($value)
     {

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/escaped_dollar_char.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/escaped_dollar_char.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class EscapedDollarChar
+{
+    public function run($value)
+    {
+        preg_match("#^value\\$#", $value, $match);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class EscapedDollarChar
+{
+    public function run($value)
+    {
+        preg_match("#^value\\$#", $value, $match);
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -38,9 +38,9 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Conf
 
     /**
      * @var string
-     * @see https://regex101.com/r/EyXsV6/5
+     * @see https://regex101.com/r/EyXsV6/6
      */
-    private const END_ANCHOR_DOUBLE_QUOTED_REGEX = '#^"(?<delimiter>.{1}).{1,}[^\\\\]\\\\\$\k<delimiter>[imsxeADSUXJu]*"$#';
+    private const DOUBLE_QUOTED_REGEX = '#^"(?<delimiter>.{1}).{1,}\k<delimiter>[imsxeADSUXJu]*"$#';
 
     /**
      * All with pattern as 1st argument
@@ -178,7 +178,7 @@ CODE_SAMPLE
         $string = $arg->value;
         $string->value = Strings::replace($string->value, self::INNER_REGEX, function (array $match) use (&$string): string {
             $printedString = $this->betterStandardPrinter->print($string);
-            if (Strings::match($printedString, self::END_ANCHOR_DOUBLE_QUOTED_REGEX)) {
+            if (Strings::match($printedString, self::DOUBLE_QUOTED_REGEX)) {
                 $string->setAttribute(AttributeKey::IS_REGULAR_PATTERN, true);
             }
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -38,9 +38,9 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Conf
 
     /**
      * @var string
-     * @see https://regex101.com/r/EyXsV6/4/
+     * @see https://regex101.com/r/EyXsV6/5
      */
-    private const END_ANCHOR_DOUBLE_QUOTED_REGEX = '#^"(?<delimiter>.{1}).{1,}[^\\\\]\\\\\$\k<delimiter>"$#';
+    private const END_ANCHOR_DOUBLE_QUOTED_REGEX = '#^"(?<delimiter>.{1}).{1,}[^\\\\]\\\\\$\k<delimiter>[imsxeADSUXJu]*"$#';
 
     /**
      * All with pattern as 1st argument

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -38,7 +38,7 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Conf
 
     /**
      * @var string
-     * @see https://regex101.com/r/EyXsV6/2/
+     * @see https://regex101.com/r/EyXsV6/3/
      */
     private const END_ANCHOR_DOUBLE_QUOTED_REGEX = '#^".{1,}[^\\\\]\\\\(?=\$).{2}"#';
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -176,13 +176,12 @@ CODE_SAMPLE
 
         /** @var String_ $string */
         $string = $arg->value;
+        $string->value = Strings::replace($string->value, self::INNER_REGEX, function (array $match) use (&$string): string {
+            $printedString = $this->betterStandardPrinter->print($string);
+            if (Strings::match($printedString, self::END_ANCHOR_DOUBLE_QUOTED_REGEX)) {
+                $string->setAttribute(AttributeKey::IS_REGULAR_PATTERN, true);
+            }
 
-        $printedString = $this->betterStandardPrinter->print($string);
-        if (Strings::match($printedString, self::END_ANCHOR_DOUBLE_QUOTED_REGEX)) {
-            $string->setAttribute(AttributeKey::IS_REGULAR_PATTERN, true);
-        }
-
-        $string->value = Strings::replace($string->value, self::INNER_REGEX, function (array $match): string {
             $innerPattern = $match['content'];
             $positionDelimiter = strpos($innerPattern, $this->delimiter);
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -38,9 +38,9 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Conf
 
     /**
      * @var string
-     * @see https://regex101.com/r/EyXsV6/3/
+     * @see https://regex101.com/r/EyXsV6/4/
      */
-    private const END_ANCHOR_DOUBLE_QUOTED_REGEX = '#^".{1,}[^\\\\]\\\\(?=\$).{2}"#';
+    private const END_ANCHOR_DOUBLE_QUOTED_REGEX = '#^"(?<delimiter>.{1}).{1,}[^\\\\]\\\\\$\k<delimiter>"$#';
 
     /**
      * All with pattern as 1st argument

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -34,6 +35,12 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Conf
      * For modifiers see https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
      */
     private const INNER_REGEX = '#(?<content>.*?)(?<close>[imsxeADSUXJu]*)$#s';
+
+    /**
+     * @var string
+     * @see https://regex101.com/r/EyXsV6/2/
+     */
+    private const END_ANCHOR_DOUBLE_QUOTED_REGEX = '#^".{1,}[^\\\\]\\\\(?=\$).{2}"#';
 
     /**
      * All with pattern as 1st argument
@@ -169,9 +176,13 @@ CODE_SAMPLE
 
         /** @var String_ $string */
         $string = $arg->value;
-        $value = $string->value;
 
-        $string->value = Strings::replace($value, self::INNER_REGEX, function (array $match): string {
+        $printedString = $this->betterStandardPrinter->print($string);
+        if (Strings::match($printedString, self::END_ANCHOR_DOUBLE_QUOTED_REGEX)) {
+            $string->setAttribute(AttributeKey::IS_REGULAR_PATTERN, true);
+        }
+
+        $string->value = Strings::replace($string->value, self::INNER_REGEX, function (array $match): string {
             $innerPattern = $match['content'];
             $positionDelimiter = strpos($innerPattern, $this->delimiter);
 


### PR DESCRIPTION
If `$` is an end anchor, it should not be escaped. Given the following code:

```php
preg_match("/^value$/", $value);
```

it currently produce:

```diff
+ preg_match("#^value\$#", $value);
```

which should be fine to be:

```diff
+ preg_match("#^value$#", $value);
```