### PR TITLE
[NodeCollector] Ensure pass Scope instance to 2nd arg on ClassReflection->getMethod() in ArrayCallableMethodMatcher

### DIFF
--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
@@ -148,8 +149,12 @@ final class ArrayCallableMethodMatcher
             return new MixedType();
         }
 
-        $classReflection = $this->reflectionProvider->getClass($classConstantReference);
         $scope = $classConstFetch->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return new MixedType();
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($classConstantReference);
         $hasConstruct = $classReflection->hasMethod(MethodName::CONSTRUCT);
 
         if ($hasConstruct) {

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -157,14 +157,16 @@ final class ArrayCallableMethodMatcher
         $classReflection = $this->reflectionProvider->getClass($classConstantReference);
         $hasConstruct = $classReflection->hasMethod(MethodName::CONSTRUCT);
 
-        if ($hasConstruct) {
-            $methodReflection = $classReflection->getMethod(MethodName::CONSTRUCT, $scope);
-            $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+        if (! $hasConstruct) {
+            return new ObjectType($classConstantReference, null, $classReflection);
+        }
 
-            foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
-                if ($parameterReflection->getDefaultValue() === null) {
-                    return new MixedType();
-                }
+        $methodReflection = $classReflection->getMethod(MethodName::CONSTRUCT, $scope);
+        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+
+        foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
+            if ($parameterReflection->getDefaultValue() === null) {
+                return new MixedType();
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6718