### PR TITLE
[NodeCollector] Add ArrayCallableDynamicMethod value object

### DIFF
--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -19,6 +19,7 @@ use PHPStan\Type\TypeWithClassName;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\ValueObject\MethodName;
 use Rector\NodeCollector\ValueObject\ArrayCallable;
+use Rector\NodeCollector\ValueObject\ArrayCallableDynamicMethod;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -35,11 +36,12 @@ final class ArrayCallableMethodMatcher
 
     /**
      * Matches array like: "[$this, 'methodName']" → ['ClassName', 'methodName']
-     * Returns back value $array when unknown method of callable used, eg: [$this, $other]
+     *
+     * Returns ArrayCallableDynamicMethod object when unknown method of callable used, eg: [$this, $other]
      * @see https://github.com/rectorphp/rector-src/pull/908
      * @see https://github.com/rectorphp/rector-src/pull/909
      */
-    public function match(Array_ $array): null | Array_ | ArrayCallable
+    public function match(Array_ $array): null | ArrayCallableDynamicMethod | ArrayCallable
     {
         $arrayItems = $array->items;
         if (count($arrayItems) !== 2) {
@@ -66,15 +68,17 @@ final class ArrayCallableMethodMatcher
         }
 
         $values = $this->valueResolver->getValue($array);
+        $className = $calleeType->getClassName();
+        $secondItemValue = $items[1]->value;
+
         if ($values === []) {
-            return $array;
+            return new ArrayCallableDynamicMethod($firstItemValue, $className, $secondItemValue);
         }
 
         if ($this->shouldSkipAssociativeArray($values)) {
             return null;
         }
 
-        $secondItemValue = $items[1]->value;
         if (! $secondItemValue instanceof String_) {
             return null;
         }
@@ -83,9 +87,7 @@ final class ArrayCallableMethodMatcher
             return null;
         }
 
-        $className = $calleeType->getClassName();
         $methodName = $secondItemValue->value;
-
         if ($methodName === MethodName::CONSTRUCT) {
             return null;
         }

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -36,7 +36,6 @@ final class ArrayCallableMethodMatcher
 
     /**
      * Matches array like: "[$this, 'methodName']" → ['ClassName', 'methodName']
-     *
      * Returns ArrayCallableDynamicMethod object when unknown method of callable used, eg: [$this, $other]
      * @see https://github.com/rectorphp/rector-src/pull/908
      * @see https://github.com/rectorphp/rector-src/pull/909

--- a/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
+++ b/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
@@ -8,9 +8,6 @@ use PhpParser\Node\Expr;
 
 final class ArrayCallableDynamicMethod
 {
-    /**
-     * @param mixed $method
-     */
     public function __construct(
         private Expr $callerExpr,
         private string $class,

--- a/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
+++ b/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
@@ -14,7 +14,7 @@ final class ArrayCallableDynamicMethod
     public function __construct(
         private Expr $callerExpr,
         private string $class,
-        private $method
+        private Expr $method
     ) {
     }
 
@@ -24,7 +24,7 @@ final class ArrayCallableDynamicMethod
     }
 
     /**
-     * @return mixed
+     * @return Expr
      */
     public function getMethod()
     {

--- a/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
+++ b/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeCollector\ValueObject;
+
+use PhpParser\Node\Expr;
+
+final class ArrayCallableDynamicMethod
+{
+    /**
+     * @param mixed $method
+     */
+    public function __construct(
+        private Expr $callerExpr,
+        private string $class,
+        private $method
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    public function getCallerExpr(): Expr
+    {
+        return $this->callerExpr;
+    }
+}

--- a/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
+++ b/packages/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
@@ -20,10 +20,7 @@ final class ArrayCallableDynamicMethod
         return $this->class;
     }
 
-    /**
-     * @return Expr
-     */
-    public function getMethod()
+    public function getMethod(): Expr
     {
         return $this->method;
     }

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -18,6 +18,7 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\NodeCollector\NodeAnalyzer\ArrayCallableMethodMatcher;
 use Rector\NodeCollector\ValueObject\ArrayCallable;
+use Rector\NodeCollector\ValueObject\ArrayCallableDynamicMethod;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -118,7 +119,7 @@ final class IsClassMethodUsedAnalyzer
             }
 
             $arrayCallable = $this->arrayCallableMethodMatcher->match($array);
-            if ($arrayCallable instanceof Array_) {
+            if ($arrayCallable instanceof ArrayCallableDynamicMethod) {
                 return true;
             }
 
@@ -136,7 +137,7 @@ final class IsClassMethodUsedAnalyzer
         return false;
     }
 
-    private function shouldSkipArrayCallable(Class_ $class, null | Array_ | ArrayCallable $arrayCallable): bool
+    private function shouldSkipArrayCallable(Class_ $class, null | ArrayCallable $arrayCallable): bool
     {
         if (! $arrayCallable instanceof ArrayCallable) {
             return true;


### PR DESCRIPTION
Add `ArrayCallableDynamicMethod` value object to be used for array callable like `[$this, $other]` which method is dynamic, like in PRs:

- https://github.com/rectorphp/rector-src/pull/908
- https://github.com/rectorphp/rector-src/pull/909

Previusly, it handled by return back `Array_` object, this PR add the special value object to differentiate that it is a callable as well, but with dynamic method value.