### PR TITLE
[Downgrade PHP 7.2] Downgrade object type also in Closure

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/FunctionLike/DowngradeObjectTypeDeclarationRector/Fixture/anonymous_function.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FunctionLike/DowngradeObjectTypeDeclarationRector/Fixture/anonymous_function.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\FunctionLike\DowngradeObjectTypeDeclarationRector\Fixture;
+
+class AnonymousFunction
+{
+    public function return()
+    {
+        $callable = function (object $someObject) {
+            // ...
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\FunctionLike\DowngradeObjectTypeDeclarationRector\Fixture;
+
+class AnonymousFunction
+{
+    public function return()
+    {
+        $callable = function ($someObject) {
+            // ...
+        };
+    }
+}
+
+?>

--- a/rules/DowngradePhp72/Rector/FunctionLike/DowngradeObjectTypeDeclarationRector.php
+++ b/rules/DowngradePhp72/Rector/FunctionLike/DowngradeObjectTypeDeclarationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp72\Rector\FunctionLike;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -28,7 +29,7 @@ final class DowngradeObjectTypeDeclarationRector extends AbstractRector
      */
     public function getNodeTypes(): array
     {
-        return [Function_::class, ClassMethod::class];
+        return [Function_::class, ClassMethod::class, Closure::class];
     }
 
     /**


### PR DESCRIPTION
Added fix to downgrade `object` param type in closure:

```diff
-$callable = function (object $someObject) {
+$callable = function ($someObject) {
  // ...
};
```
