### PR TITLE
[DX] Add LevelSetList

### DIFF
--- a/config/set/level/up-to-php54.php
+++ b/config/set/level/up-to-php54.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_54);
+    $containerConfigurator->import(SetList::PHP_53);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_54);
+};

--- a/config/set/level/up-to-php55.php
+++ b/config/set/level/up-to-php55.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_55);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_54);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_55);
+};

--- a/config/set/level/up-to-php56.php
+++ b/config/set/level/up-to-php56.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_56);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_55);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_56);
+};

--- a/config/set/level/up-to-php70.php
+++ b/config/set/level/up-to-php70.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_70);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_56);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_70);
+};

--- a/config/set/level/up-to-php71.php
+++ b/config/set/level/up-to-php71.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_71);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_70);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_71);
+};

--- a/config/set/level/up-to-php72.php
+++ b/config/set/level/up-to-php72.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_72);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_71);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_72);
+};

--- a/config/set/level/up-to-php73.php
+++ b/config/set/level/up-to-php73.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_73);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_72);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_73);
+};

--- a/config/set/level/up-to-php74.php
+++ b/config/set/level/up-to-php74.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_74);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_73);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
+};

--- a/config/set/level/up-to-php80.php
+++ b/config/set/level/up-to-php80.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_80);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_74);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_80);
+};

--- a/config/set/level/up-to-php81.php
+++ b/config/set/level/up-to-php81.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::PHP_81);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_80);
+
+    // parameter must be defined after import, to override impored param version
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_81);
+};

--- a/packages/Set/ValueObject/LevelSetList.php
+++ b/packages/Set/ValueObject/LevelSetList.php
@@ -11,5 +11,50 @@ final class LevelSetList implements SetListInterface
     /**
      * @var string
      */
-    public const UP_TO_PHP80 = __DIR__ . '/../../../config/set/defluent.php';
+    public const UP_TO_PHP_81 = __DIR__ . '/../../../config/set/level/up-to-php81.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_80 = __DIR__ . '/../../../config/set/level/up-to-php80.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_74 = __DIR__ . '/../../../config/set/level/up-to-php74.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_73 = __DIR__ . '/../../../config/set/level/up-to-php73.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_72 = __DIR__ . '/../../../config/set/level/up-to-php72.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_71 = __DIR__ . '/../../../config/set/level/up-to-php71.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_70 = __DIR__ . '/../../../config/set/level/up-to-php70.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_56 = __DIR__ . '/../../../config/set/level/up-to-php56.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_55 = __DIR__ . '/../../../config/set/level/up-to-php55.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_54 = __DIR__ . '/../../../config/set/level/up-to-php54.php';
 }

--- a/rector.php
+++ b/rector.php
@@ -12,11 +12,15 @@ use Rector\Core\Configuration\Option;
 use Rector\Nette\Set\NetteSetList;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    // include the latest PHP version + all bellow in one config!
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_80);
+
     // include sets
     $containerConfigurator->import(SetList::CODING_STYLE);
     $containerConfigurator->import(SetList::CODING_STYLE_ADVANCED);
@@ -25,11 +29,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SetList::PRIVATIZATION);
     $containerConfigurator->import(SetList::NAMING);
     $containerConfigurator->import(SetList::TYPE_DECLARATION);
-    $containerConfigurator->import(SetList::PHP_71);
-    $containerConfigurator->import(SetList::PHP_72);
-    $containerConfigurator->import(SetList::PHP_73);
-    $containerConfigurator->import(SetList::PHP_74);
-    $containerConfigurator->import(SetList::PHP_80);
     $containerConfigurator->import(SetList::EARLY_RETURN);
     $containerConfigurator->import(SetList::TYPE_DECLARATION_STRICT);
     $containerConfigurator->import(NetteSetList::NETTE_UTILS_CODE_QUALITY);

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/config/phpdoc_void.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/config/phpdoc_void.php
@@ -8,7 +8,8 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AddVoidReturnTypeWhereNoReturnRector::class)->call('configure', [[
-        AddVoidReturnTypeWhereNoReturnRector::USE_PHPDOC => true,
-    ]]);
+    $services->set(AddVoidReturnTypeWhereNoReturnRector::class)
+        ->call('configure', [[
+            AddVoidReturnTypeWhereNoReturnRector::USE_PHPDOC => true,
+        ]]);
 };

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -135,9 +135,7 @@ CODE_SAMPLE
             return $if;
         }
 
-        $assign->expr = $ternary->if === null
-            ? $ternary->cond
-            : $ternary->if;
+        $assign->expr = $ternary->if ?? $ternary->cond;
 
         $this->nodesToAddCollector->addNodeAfterNode(new Expression($assign), $if);
         return $if;

--- a/src/DependencyInjection/RectorContainerFactory.php
+++ b/src/DependencyInjection/RectorContainerFactory.php
@@ -30,7 +30,7 @@ final class RectorContainerFactory
         // mt_rand is needed to invalidate container cache in case of class changes to be registered as services
         $isPHPUnitRun = StaticPHPUnitEnvironment::isPHPUnitRun();
         if (! $isPHPUnitRun) {
-            $environment .= mt_rand(0, 10000);
+            $environment .= random_int(0, 10000);
         }
 
         $phpStanStubLoader = new PHPStanStubLoader();


### PR DESCRIPTION
* Are you tired of registering all the PHP sets?
* Have you forget to register PHP 7.x and missed the features by accident?
* Do you want 1 configs to include-all-versions up to your current PHP?

We're adding solution just for you - new `LevelSetList New` class so you can level up your project in one line:

<br>

## `rector.php` Before :sleepy: 

```php
$containerConfigurator->import(SetList::PHP_52);
$containerConfigurator->import(SetList::PHP_53);
$containerConfigurator->import(SetList::PHP_54);
$containerConfigurator->import(SetList::PHP_55);
$containerConfigurator->import(SetList::PHP_56);
$containerConfigurator->import(SetList::PHP_70);
$containerConfigurator->import(SetList::PHP_71);
$containerConfigurator->import(SetList::PHP_72);
$containerConfigurator->import(SetList::PHP_73);
$containerConfigurator->import(SetList::PHP_74);
$containerConfigurator->import(SetList::PHP_80);
```

## `rector.php` Now :partying_face: 

```php
$containerConfigurator->import(LevelSetList::UP_TO_PHP80);
```

