### PR TITLE
[FileFormatter] Allow Yaml custom tags on YamlFileFormatter

### DIFF
--- a/packages-tests/FileFormatter/Formatter/YamlFileFormatter/Fixture/do_not_throw_error.yaml
+++ b/packages-tests/FileFormatter/Formatter/YamlFileFormatter/Fixture/do_not_throw_error.yaml
@@ -1,0 +1,9 @@
+services:
+  Vendor\Namespace\MyService:
+    arguments: [ !tagged_iterator { tag: 'namespace_mytag' } ]
+-----
+services:
+    Vendor\Namespace\MyService:
+        arguments:
+            - !tagged_iterator
+              tag: namespace_mytag

--- a/packages/FileFormatter/Formatter/YamlFileFormatter.php
+++ b/packages/FileFormatter/Formatter/YamlFileFormatter.php
@@ -25,7 +25,7 @@ final class YamlFileFormatter implements FileFormatterInterface
 
     public function format(File $file, EditorConfigConfiguration $editorConfigConfiguration): void
     {
-        $yaml = Yaml::parse($file->getFileContent());
+        $yaml = Yaml::parse($file->getFileContent(), Yaml::PARSE_CUSTOM_TAGS);
 
         $newFileContent = Yaml::dump($yaml, 99, $editorConfigConfiguration->getIndentSize());
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6737 avoid `ParseException`