### PR TITLE
[Cache] Avoid to remove non empty cache directories on cache clearing

### DIFF
--- a/packages-tests/Caching/ValueObject/Storage/FileCacheStorageTest.php
+++ b/packages-tests/Caching/ValueObject/Storage/FileCacheStorageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Caching\ValueObject\Storage;
+
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SmartFileSystem\SmartFileSystem;
+
+final class FileCacheStorageTest extends AbstractRectorTestCase
+{
+    private FileCacheStorage $fileCacheStorage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fileCacheStorage = new FileCacheStorage(__DIR__ . '/Source', $this->getService(SmartFileSystem::class));
+    }
+
+    public function testClean()
+    {
+        $this->fileCacheStorage->save('aaK1STfY', 'TEST', 'file cached');
+        $file1 = new SmartFileInfo(__DIR__ . '/Source/0e/76/0e76658526655756207688271159624026011393.php');
+        $this->fileCacheStorage->save('aaO8zKZF', 'TEST', 'file cached with the same two first caracters');
+        $file2 = new SmartFileInfo(__DIR__ . '/Source/0e/89/0e89257456677279068558073954252716165668.php');
+
+        $this->fileCacheStorage->clean('aaK1STfY');
+
+        $this->assertFileDoesNotExist($file1->getRealPath());
+        $this->assertDirectoryDoesNotExist(__DIR__ . '/Source/0e/76');
+
+        $this->assertFileExists($file2->getRealPath());
+        $this->assertDirectoryExists(__DIR__ . '/Source/0e/89');
+
+        $this->fileCacheStorage->clean('aaO8zKZF');
+
+        $this->assertFileDoesNotExist($file2->getRealPath());
+        $this->assertDirectoryDoesNotExist(__DIR__ . '/Source/0e/89');
+        $this->assertDirectoryDoesNotExist(__DIR__ . '/Source/0e');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config.php';
+    }
+}

--- a/packages-tests/Caching/ValueObject/Storage/config.php
+++ b/packages-tests/Caching/ValueObject/Storage/config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::CACHE_DIR, sys_get_temp_dir() . '/_rector_cached_files_test');
+    $parameters->set(Option::CACHE_CLASS, MemoryCacheStorage::class);
+};

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -78,16 +78,26 @@ final class FileCacheStorage implements CacheStorageInterface
     {
         $cacheFilePaths = $this->getCacheFilePaths($key);
 
-        $this->smartFileSystem->remove([
-            $cacheFilePaths->getFirstDirectory(),
-            $cacheFilePaths->getSecondDirectory(),
-            $cacheFilePaths->getFilePath(),
-        ]);
+        $this->smartFileSystem->remove($cacheFilePaths->getFilePath());
+
+        if ($this->isDirectoryEmpty($cacheFilePaths->getSecondDirectory())) {
+            $this->smartFileSystem->remove($cacheFilePaths->getSecondDirectory());
+        }
+        if ($this->isDirectoryEmpty($cacheFilePaths->getFirstDirectory())) {
+            $this->smartFileSystem->remove($cacheFilePaths->getFirstDirectory());
+        }
     }
 
     public function clear(): void
     {
         $this->smartFileSystem->remove($this->directory);
+    }
+
+    private function isDirectoryEmpty(string $directoryPath): bool
+    {
+        // FilesystemIterator will initially point to the first file in the folder - if there are no files in the folder, valid() will return false
+        $fileSystemIterator = new \FilesystemIterator($directoryPath);
+        return ! $fileSystemIterator->valid();
     }
 
     private function getCacheFilePaths(string $key): CacheFilePaths


### PR DESCRIPTION
Those deletions could remove already existant cached files notably the "configuration_hash" file

Fixes https://github.com/rectorphp/rector/issues/6731