### PR TITLE
Add failing test fixture for ExplicitMethodCallOverMagicGetSetRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/getter.php.inc
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/getter.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Fixture;
+
+final class DemoFile
+{
+    private ?string $foo = null;
+    
+    public function run() : string
+    {
+        $this->foo = 'test';
+        return $this->foo;
+    }
+    
+    public function getFoo() : ?string
+    {
+        return $this->foo;
+    }
+    
+    public function bar() : ?string
+    {
+        $this->foo = 'bar';
+    }
+    
+    public function __set($name, $value)
+    {
+        $this->$name = $value;
+    }
+    
+    public function __get($name) 
+    {
+        return $this->$name;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for ExplicitMethodCallOverMagicGetSetRector

Based on https://getrector.org/demo/1ec2c01b-1795-6f28-a527-19e29e633826