### PR TITLE
Allow resolving names on dynamic property fetch

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver/VariableNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/VariableNameResolver.php
@@ -7,7 +7,6 @@ namespace Rector\NodeNameResolver\NodeNameResolver;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -31,11 +30,6 @@ final class VariableNameResolver implements NodeNameResolverInterface
 
         // skip $some->$dynamicMethodName()
         if ($parentNode instanceof MethodCall && $node === $parentNode->name) {
-            return null;
-        }
-
-        // skip $some->$dynamicPropertyName
-        if ($parentNode instanceof PropertyFetch && $node === $parentNode->name) {
             return null;
         }
 

--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/dynamic_property.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/dynamic_property.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\EliteManager;
+
+class DynamicProperty
+{
+    public function __construct(EliteManager $nonSense)
+    {
+        try {
+            $doesNotMatter = $this->$nonSense;
+        } catch (\Throwable $e) {}
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\EliteManager;
+
+class DynamicProperty
+{
+    public function __construct(EliteManager $eliteManager)
+    {
+        try {
+            $doesNotMatter = $this->$eliteManager;
+        } catch (\Throwable $e) {}
+    }
+}
+
+?>

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -103,6 +104,10 @@ final class LocalPropertyAnalyzer
         }
 
         if ($this->isPartOfClosureBind($propertyFetch)) {
+            return true;
+        }
+
+        if ($propertyFetch->name instanceof Variable) {
             return true;
         }
 

--- a/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -82,6 +83,11 @@ CODE_SAMPLE
 
         foreach ($node->vars as $issetVar) {
             if (! $issetVar instanceof PropertyFetch) {
+                continue;
+            }
+
+            // Ignore dynamically accessed properties ($o->$p)
+            if ($issetVar->name instanceof Variable) {
                 continue;
             }
 


### PR DESCRIPTION
Skipping name resolving for dynamic property fetches in low-level `VariableNameResolver` does not allow to write custom Rector rules that would like to rename such usages. So I've moved this condition to 2 explicit rules that depended on that (only 2 fixtures were causing errors in whole PHPUnit suite).

Fixes rectorphp/rector#6740