### PR TITLE
Move test and dataProvider to parent

### DIFF
--- a/packages/Testing/Contract/RectorTestInterface.php
+++ b/packages/Testing/Contract/RectorTestInterface.php
@@ -7,4 +7,6 @@ namespace Rector\Testing\Contract;
 interface RectorTestInterface
 {
     public function provideConfigFilePath(): string;
+
+    public function provideFixtureDirectory(): string;
 }

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -42,6 +42,22 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
 
     private ApplicationFileProcessor $applicationFileProcessor;
 
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory($this->provideFixtureDirectory());
+    }
+
     protected function setUp(): void
     {
         // speed up

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/ArgumentAdderRectorTest.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/ArgumentAdderRectorTest.php
@@ -4,26 +4,13 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 
-use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ArgumentAdderRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
-    public function test(SmartFileInfo $fileInfo): void
+    public function provideFixtureDirectory(): string
     {
-        $this->doTestFileInfo($fileInfo);
-    }
-
-    /**
-     * @return Iterator<SmartFileInfo>
-     */
-    public function provideData(): Iterator
-    {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return __DIR__ . '/Fixture';
     }
 
     public function provideConfigFilePath(): string


### PR DESCRIPTION
This is just an example of https://github.com/rectorphp/rector/issues/6736

I think this saves a lot of copy-pasting for (local project) rule developers and also makes it more clear what is expected (so a better DX).