### PR TITLE
[Docker] Switch COMPOSER_ROOT_VERSION to dev-main

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,7 @@ version: "3.8"
 services:
   php:
     build: .
+    environment:
+        - COMPOSER_ROOT_VERSION=dev-main
     volumes:
       - .:/etc/rector


### PR DESCRIPTION
Fixes a problem that occurs during execution of the command from the [How to Contribute](https://github.com/rectorphp/rector-src/blob/main/CONTRIBUTING.md): `docker-compose run php composer install
`


`  Problem 1
    - Root composer.json requires rector/rector-generator ^0.4.1 -> satisfiable by rector/rector-generator[0.4.1].
    - rector/rector-generator 0.4.1 requires rector/rector-src dev-main -> satisfiable by rector/rector-src[dev-main, 0.11.x-dev (alias of dev-main)] from composer repo (https://repo.packagist.org) but rector/rector-src is the root package and cannot be modified. See https://getcomposer.org/dep-on-root for details and assistance.
`

The same fix is in the [GitHub workflow](https://github.com/rectorphp/rector-src/blob/main/.github/workflows/build_scoped_rector.yaml#L14)