### PR TITLE
[Defluent][Rector-Symfony] Handle TypeError on AddFlashRector

### DIFF
--- a/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/rules/Defluent/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -25,6 +25,7 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 
 /**
@@ -178,6 +179,16 @@ final class FluentChainMethodCallNodeAnalyzer
     public function isTypeAndChainCalls(Node $node, Type $type, array $methods): bool
     {
         if (! $node instanceof MethodCall) {
+            return false;
+        }
+
+        $rootMethodCall = $this->resolveRootMethodCall($node);
+        if (! $rootMethodCall instanceof MethodCall) {
+            return false;
+        }
+
+        $rootMethodCallVarType = $this->nodeTypeResolver->getType($rootMethodCall->var);
+        if (! $rootMethodCallVarType instanceof FullyQualifiedObjectType) {
             return false;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6755 when root method call var is MixedType as from : 

```php
$session = $this->get('session');
```

which need to be skipped.