### PR TITLE
Add failing test fixture for RenamePropertyRector

### DIFF
--- a/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Fixture/child_class_with_old_property.php.inc
+++ b/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Fixture/child_class_with_old_property.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Source\ParentClassWithOldProperty;
+
+class ChildClassWithOldProperty extends ParentClassWithOldProperty
+{
+    public bool $oldProperty = true;
+
+    public function run(): bool
+    {
+        return $this->oldProperty;
+    }
+}
+
+class PropertyFetchFromChildClass
+{
+    public ChildClassWithOldProperty $classWithOldProperty;
+
+    public function run()
+    {
+        return $this->classWithOldProperty->oldProperty;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Source\ParentClassWithOldProperty;
+
+class ChildClassWithOldProperty extends ParentClassWithOldProperty
+{
+    public bool $newProperty = true;
+
+    public function run(): bool
+    {
+        return $this->newProperty;
+    }
+}
+
+class PropertyFetchFromChildClass
+{
+    public ChildClassWithOldProperty $classWithOldProperty;
+
+    public function run()
+    {
+        return $this->classWithOldProperty->newProperty;
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Source/ParentClassWithOldProperty.php
+++ b/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/Source/ParentClassWithOldProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Source;
+
+class ParentClassWithOldProperty
+{
+    public bool $oldProperty = false;
+
+    public function run(): bool
+    {
+        return $this->oldProperty;
+    }
+}

--- a/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/PropertyFetch/RenamePropertyRector/config/configured_rule.php
@@ -32,6 +32,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'oldProperty',
                     'newProperty'
                 ),
+                new RenameProperty(
+                    'Rector\Tests\Renaming\Rector\PropertyFetch\RenamePropertyRector\Source\ParentClassWithOldProperty',
+                    'oldProperty',
+                    'newProperty'
+                ),
             ]),
         ]]);
 };


### PR DESCRIPTION
When the child class overrides the property of the parent class, the `RenamePropertyRector` only renames the property fetch, the property in child class has not been renamed.
