### PR TITLE
Add failing test fixture for `TypedPropertyRector`

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/non-empty-string-docblock.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/non-empty-string-docblock.php.inc
@@ -16,7 +16,11 @@ final class Foo
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 
-// what is expected code?
-// should remain the same? delete part bellow ----- (included)
-
+final class Foo
+{
+    /**
+     * @psalm-var non-empty-string
+     */
+    private string $name;
+}
 ?>


### PR DESCRIPTION
# Failing Test for TypedPropertyRector

Based on https://getrector.org/demo/1ec33193-437e-6bf0-901d-7d3b37cdd15e

Relates to https://github.com/rectorphp/rector/issues/6763