### PR TITLE
[Php74] Do not remove non-empty-string docblock on TypedPropertyRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -290,6 +290,10 @@ final class PhpDocInfo
             $typeToRemove
         ): ?int {
             if ($node instanceof PhpDocTagNode && is_a($node->value, $typeToRemove, true)) {
+                if ($typeToRemove === VarTagValueNode::class && $node->name !== '@var') {
+                    return null;
+                }
+
                 $this->markAsChanged();
                 return PhpDocNodeTraverser::NODE_REMOVE;
             }

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_non_empty_string_docblock.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_non_empty_string_docblock.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 
-final class Foo
+final class DoNotRemoveNonEmptyStringDocblock
 {
     /**
      * @var string
@@ -16,7 +16,7 @@ final class Foo
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 
-final class Foo
+final class DoNotRemoveNonEmptyStringDocblock
 {
     /**
      * @psalm-var non-empty-string


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/1041 Fixes https://github.com/rectorphp/rector/issues/6763