### PR TITLE
DateTimeImmutable - Add failing test fixture for SimplifyUselessVariableRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Return_/SimplifyUselessVariableRector/Fixture/kepp_property_used_with_date_time_immutable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Return_/SimplifyUselessVariableRector/Fixture/kepp_property_used_with_date_time_immutable.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Return_\SimplifyUselessVariableRector\Fixture;
+
+final class KeppPropertyUsedWithDateTimeImmutable
+{
+    public function run()
+    {
+        $dateTime = new DateTimeImmutable();
+        $dateTime = $dateTime->setTime(14, 0, 0);
+
+        return $dateTime;
+    }
+}


### PR DESCRIPTION
Add failing test fixture for SimplifyUselessVariableRector in combination with DateTimeImmutable object

Rector should not remove a local variable, otherwise, time is not set in the returned object.
Issue https://github.com/rectorphp/rector/issues/6769

Based on https://getrector.org/demo/1ec35a54-0df0-69b8-ab06-f7704eb531f0