### PR TITLE
WIP: Rename method call if method exists

### DIFF
--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/rename_method_and_method_call.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/rename_method_and_method_call.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+final class CustomType
+{
+    public function notify(): int
+    {
+        return 5;
+    }
+}
+
+final class Caller
+{
+    public static function execute(): void
+    {
+        $demo = new CustomType();
+        $demo->notify();
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+final class CustomType
+{
+    public function __invoke(): int
+    {
+        return 5;
+    }
+}
+
+final class Caller
+{
+    public static function execute(): void
+    {
+        $demo = new CustomType();
+        $demo->__invoke();
+    }
+}
+?>

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/rename_method_call_when_class_method_exists.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/rename_method_call_when_class_method_exists.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\Foo;
+
+class RenameMethodCall
+{
+    private function call()
+    {
+        $foo = new Foo();
+        $foo->old();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\Foo;
+
+class RenameMethodCall
+{
+    private function call()
+    {
+        $foo = new Foo();
+        $foo->new();
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+class SkipRenameMethodCall
+{
+    public static function execute(): void
+    {
+        $demo = new SomeSubscriber();
+        $demo->old();
+    }
+}
+
+class SomeSubscriber implements SubscriberInterface
+{
+    public function old(): int
+    {
+        return 5;
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/CustomType.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/CustomType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+final class CustomType
+{
+    public function notify(): int
+    {
+        return 5;
+    }
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/Foo.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/Foo.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+final class Foo implements FooInterface
+{
+    public function old(): void
+    {
+    }
+
+    public function new(): void
+    {
+    }
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/FooInterface.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/FooInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+interface FooInterface
+{
+    public function old(): void;
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/SomeSubscriber.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/SomeSubscriber.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+class SomeSubscriber implements SubscriberInterface
+{
+    public function old(): int
+    {
+        return 5;
+    }
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/SubscriberInterface.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Source/SubscriberInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source;
+
+interface SubscriberInterface
+{
+    public function old(): int;
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -6,6 +6,9 @@ use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\MethodCallRenameWithArrayKey;
 use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\AbstractType;
+use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\CustomType;
+use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\Foo;
+use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\SomeSubscriber;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
@@ -17,12 +20,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new MethodCallRename(AbstractType::class, 'setDefaultOptions', 'configureOptions'),
                 new MethodCallRename('Nette\Utils\Html', 'add', 'addHtml'),
                 new MethodCallRename(
-                    'Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture\DemoFile',
+                    CustomType::class,
                     'notify',
                     '__invoke'
                 ),
                 new MethodCallRename(
-                    'Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture\SomeSubscriber',
+                    SomeSubscriber::class,
+                    'old',
+                    'new'
+                ),
+                new MethodCallRename(
+                    Foo::class,
                     'old',
                     'new'
                 ),


### PR DESCRIPTION
This is WIP PR. I added a test but didn't fix the implementation.


So I fixed problems [1-3](https://github.com/rectorphp/rector/issues/6691#issuecomment-951356409)
For case 3 I added fake classes _CustomType_ and _SomeSubscriber_, because the test ignore classes implemented in _php.inc_ files.