### PR TITLE
[DowngradePhp74] Skip DowngradeCovariantReturnTypeRector on child return parent

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -53,8 +53,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 PhpDocNodeVisitorInterface::class,
                 Node::class,
                 NodeNameResolverInterface::class,
-                // symfony
-                \Symfony\Component\String\AbstractString::class,
                 // phpstan
                 SourceLocator::class,
                 \PHPStan\PhpDocParser\Ast\Node::class,

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/skip_return_parent.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/skip_return_parent.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Fixture;
+
+abstract class AParent
+{
+    public function run(): self
+    {
+        return $this;
+    }
+}
+
+class AChildClass extends AParent
+{
+    public function run(): parent
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
@TomasVotruba this is the failing test case that probably related with removed `return parent`, the test case is different use case, while it currently the failing test case return:

from 

```bash
    public function run(): parent
    {
```

to:

```diff
+    /**
+     * @return parent
+     */
+    public function run(): \Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Fixture\AParent
```

which while different probably different usecase, it should be skipped.