### PR TITLE
[TypedPropertyRector] Refactor skip Type hint DummyTraitClass on TypedPropertyRector

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/packages/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -14,12 +14,12 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
 use Rector\NodeTypeResolver\PHPStan\TypeHasher;
 use Rector\StaticTypeMapper\TypeFactory\UnionTypeFactory;
-use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
 final class TypeFactory
 {
@@ -101,7 +101,7 @@ final class TypeFactory
      */
     private function resolveNonConstantArrayType(Type $type, array $unwrappedTypes): array
     {
-        if ($type instanceof FullyQualifiedObjectType && $type->getClassName() === 'Rector\Core\Stubs\DummyTraitClass') {
+        if ($type instanceof ObjectType && $type->getClassName() === 'Rector\Core\Stubs\DummyTraitClass') {
             return $unwrappedTypes;
         }
 

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_type_hint_dummy_trait_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_type_hint_dummy_trait_class.php.inc
@@ -6,14 +6,14 @@ trait MaterializedPathEntity
 {
     /** @var self */
     protected $parent;
-    
+
     public function setParent(self $parent = null) : static
     {
         $this->parent = $parent;
 
         return $this;
     }
-    
+
     public function getParent() : static
     {
         return $this->parent;
@@ -23,42 +23,9 @@ trait MaterializedPathEntity
 final class DemoFile
 {
     use MaterializedPathEntity;
-    
+
     public function run()
     {
         return $this->getParent();
     }
 }
-?>
------
-<?php
-
-namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
-
-trait MaterializedPathEntity
-{
-    protected ?\Rector\Core\Stubs\DummyTraitClass $parent = null;
-    
-    public function setParent(self $parent = null) : static
-    {
-        $this->parent = $parent;
-
-        return $this;
-    }
-    
-    public function getParent() : static
-    {
-        return $this->parent;
-    }
-}
-
-final class DemoFile
-{
-    use MaterializedPathEntity;
-    
-    public function run()
-    {
-        return $this->getParent();
-    }
-}
-?>


### PR DESCRIPTION
The issue was fixed at https://github.com/rectorphp/rector-src/pull/965

The regression is introduced at https://github.com/rectorphp/rector-src/pull/1087/files#r737998198 which re-add `DummyTraitClass` type hint in the trait property which should not.

Changing from `FullyQualifiedObjectType` to `ObjectType` resolve it.