### PR TITLE
[Core] Remove template-extends check as well on FileProcessor

### DIFF
--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -4,29 +4,19 @@ declare(strict_types=1);
 
 namespace Rector\Core\Application;
 
-use Nette\Utils\Strings;
-use PhpParser\Node;
 use Rector\ChangesReporting\Collector\AffectedFilesCollector;
 use Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser;
 use Rector\Core\PhpParser\Parser\RectorParser;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 
 final class FileProcessor
 {
-    /**
-     * @var string
-     * @see https://regex101.com/r/ozPuC9/1
-     */
-    public const TEMPLATE_EXTENDS_REGEX = '#(\*|\/\/)\s+\@template-extends\s+\\\\?\w+#';
-
     public function __construct(
         private AffectedFilesCollector $affectedFilesCollector,
         private NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private RectorParser $rectorParser,
-        private RectorNodeTraverser $rectorNodeTraverser,
-        private BetterStandardPrinter $betterStandardPrinter
+        private RectorNodeTraverser $rectorNodeTraverser
     ) {
     }
 
@@ -38,17 +28,6 @@ final class FileProcessor
 
         $oldStmts = $stmtsAndTokens->getStmts();
         $oldTokens = $stmtsAndTokens->getTokens();
-
-        /**
-         * Tweak PHPStan internal issue for has @template-extends that cause endless loop in the process
-         *
-         * @see https://github.com/phpstan/phpstan/issues/3865
-         * @see https://github.com/rectorphp/rector/issues/6758
-         */
-        if ($this->isTemplateExtendsInSource($oldStmts)) {
-            $file->hydrateStmtsAndTokens($oldStmts, $oldStmts, $oldTokens);
-            return;
-        }
 
         // @todo may need tweak to refresh PHPStan types to avoid issue like in https://github.com/rectorphp/rector/issues/6561
         $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $oldStmts);
@@ -64,14 +43,5 @@ final class FileProcessor
         while ($otherTouchedFile = $this->affectedFilesCollector->getNext()) {
             $this->refactor($otherTouchedFile);
         }
-    }
-
-    /**
-     * @param Node[] $nodes
-     */
-    private function isTemplateExtendsInSource(array $nodes): bool
-    {
-        $print = $this->betterStandardPrinter->print($nodes);
-        return (bool) Strings::match($print, self::TEMPLATE_EXTENDS_REGEX);
     }
 }


### PR DESCRIPTION
@TomasVotruba this is continue of https://github.com/rectorphp/rector-src/pull/1096 to remove template-extends check on FileProcessor as well.