### PR TITLE
Add failing test fixture for ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_nullable_callable_without_typehint.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_nullable_callable_without_typehint.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class SkipNullableCallableWithoutTypehint
+{
+    /** @var callable|null */
+    public $cb;
+
+    public function __construct($cb = null)
+    {
+        $this->cb = $cb;
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_union_typed_with_callable_type.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_union_typed_with_callable_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class SkipUnionTypedWithCallableType
+{
+    /** @var callable|array */
+    public $cb;
+
+    public function __construct(callable|array $cb = null)
+    {
+        $this->cb = $cb;
+    }
+}


### PR DESCRIPTION
The `ClassPropertyAssignToConstructorPromotionRector` skipped the callable attributes, but did not skip the union types contains the callable type.