### PR TITLE
[TypeDeclaration] Add mixed[] array back on complex class-string structure on CompleteVarDocTypePropertyRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/recursive_multiple_class_string_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/recursive_multiple_class_string_array.php.inc
@@ -41,7 +41,7 @@ class FactoryC {}
 final class RecursiveMultipleClassStringArray
 {
     /**
-     * @var array<string, array<class-string<\Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture\FactoryA>|class-string<\Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture\FactoryB>|class-string<\Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture\FactoryC>|class-string<\Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture\InvokableA>|class-string<\Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture\InvokableB>|class-string<\Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture\InvokableC>>>
+     * @var array<string, mixed[]>
      */
     public $services = [
         'invokables' => [

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclaration\TypeAnalyzer;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ClassStringType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
@@ -108,7 +107,7 @@ final class GenericClassStringTypeNormalizer
             $keyType = $unionType->getKeyType();
             $itemType = $unionType->getItemType();
 
-            if ($itemType instanceof ConstantArrayType) {
+            if ($itemType instanceof ArrayType) {
                 $arrayType = new ArrayType(new MixedType(), new MixedType());
                 return new ArrayType($keyType, $arrayType);
             }


### PR DESCRIPTION
This was set to `mixed[]` at https://github.com/rectorphp/rector-src/pull/520

The regression happen at https://github.com/rectorphp/rector-src/pull/1112/files#r739660546

This patch set it back to `mixed[]`