### PR TITLE
[Php70][Visibility] Avoid error  Argument #1 ($scope) must be of type PHPStan\Analyser\Scope, null given

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
@@ -61,15 +61,15 @@ final class UnionTypeNodePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor imp
         return $betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_CLOSE_PARENTHESES, $startAndEnd->getEnd());
     }
 
-    private function resolveStardAndEnd(UnionTypeNode $node): ?StartAndEnd
+    private function resolveStardAndEnd(UnionTypeNode $unionTypeNode): ?StartAndEnd
     {
-        $starAndEnd = $node->getAttribute(PhpDocAttributeKey::START_AND_END);
+        $starAndEnd = $unionTypeNode->getAttribute(PhpDocAttributeKey::START_AND_END);
         if ($starAndEnd instanceof StartAndEnd) {
             return $starAndEnd;
         }
 
         // unwrap with parent array type...
-        $parent = $node->getAttribute(PhpDocAttributeKey::PARENT);
+        $parent = $unionTypeNode->getAttribute(PhpDocAttributeKey::PARENT);
         if (! $parent instanceof Node) {
             return null;
         }

--- a/packages/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
@@ -61,7 +61,7 @@ final class UnionTypeNodePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor imp
         return $betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_CLOSE_PARENTHESES, $startAndEnd->getEnd());
     }
 
-    private function resolveStardAndEnd(Node $node): ?StartAndEnd
+    private function resolveStardAndEnd(UnionTypeNode $node): ?StartAndEnd
     {
         $starAndEnd = $node->getAttribute(PhpDocAttributeKey::START_AND_END);
         if ($starAndEnd instanceof StartAndEnd) {

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
@@ -158,7 +159,7 @@ CODE_SAMPLE
         }
 
         $scope = $staticCall->getAttribute(AttributeKey::SCOPE);
-        if (! $scope instanceof \PHPStan\Analyser\Scope) {
+        if (! $scope instanceof Scope) {
             return true;
         }
 

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -158,6 +158,9 @@ CODE_SAMPLE
         }
 
         $scope = $staticCall->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof \PHPStan\Analyser\Scope) {
+            return true;
+        }
 
         $parentClassName = $this->parentClassScopeResolver->resolveParentClassName($scope);
         return $className === $parentClassName;

--- a/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
     {
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         if (! $scope instanceof \PHPStan\Analyser\Scope) {
-            return true;
+            return null;
         }
 
         $parentClassName = $this->parentClassScopeResolver->resolveParentClassName($scope);

--- a/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
@@ -98,6 +98,9 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof \PHPStan\Analyser\Scope) {
+            return true;
+        }
 
         $parentClassName = $this->parentClassScopeResolver->resolveParentClassName($scope);
         if ($parentClassName === null) {

--- a/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
@@ -6,6 +6,7 @@ namespace Rector\Visibility\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\Visibility;
@@ -98,7 +99,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $scope = $node->getAttribute(AttributeKey::SCOPE);
-        if (! $scope instanceof \PHPStan\Analyser\Scope) {
+        if (! $scope instanceof Scope) {
             return null;
         }
 

--- a/src/Bootstrap/RectorConfigsResolver.php
+++ b/src/Bootstrap/RectorConfigsResolver.php
@@ -52,7 +52,9 @@ final class RectorConfigsResolver
             throw new FileNotFoundException($message);
         }
 
-        return realpath($configFile);
+        /** @var string $configFile */
+        $configFile = realpath($configFile);
+        return $configFile;
     }
 
     private function resolveFromInputWithFallback(ArgvInput $argvInput, string $fallbackFile): ?string

--- a/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -11,4 +11,3 @@ if (interface_exists('Symfony\Component\HttpKernel\Bundle\BundleInterface')) {
 interface BundleInterface
 {
 }
-

--- a/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -8,17 +8,7 @@ if (interface_exists('Symfony\Component\HttpKernel\Bundle\BundleInterface')) {
     return;
 }
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-
-interface BundleInterface extends ContainerAwareInterface
+interface BundleInterface
 {
-    public function boot();
-    public function shutdown();
-    public function build(ContainerBuilder $container);
-    public function getContainerExtension();
-    public function getName();
-    public function getNamespace();
-    public function getPath();
 }
 

--- a/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -8,67 +8,17 @@ if (interface_exists('Symfony\Component\HttpKernel\Bundle\BundleInterface')) {
     return;
 }
 
-/*
- * (c) Fabien Potencier <fabien@symfony.com>
- * @see https://github.com/symfony/http-kernel/blob/31b284c8cf1d8dc560023838472a310ac1bebfe5/LICENSE
- */
-
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
-/**
- * BundleInterface.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- */
 interface BundleInterface extends ContainerAwareInterface
 {
-    /**
-     * Boots the Bundle.
-     */
     public function boot();
-
-    /**
-     * Shutdowns the Bundle.
-     */
     public function shutdown();
-
-    /**
-     * Builds the bundle.
-     *
-     * It is only ever called once when the cache is empty.
-     */
     public function build(ContainerBuilder $container);
-
-    /**
-     * Returns the container extension that should be implicitly loaded.
-     *
-     * @return ExtensionInterface|null The default extension or null if there is none
-     */
     public function getContainerExtension();
-
-    /**
-     * Returns the bundle name (the class short name).
-     *
-     * @return string The Bundle name
-     */
     public function getName();
-
-    /**
-     * Gets the Bundle namespace.
-     *
-     * @return string The Bundle namespace
-     */
     public function getNamespace();
-
-    /**
-     * Gets the Bundle directory path.
-     *
-     * The path should always be returned as a Unix path (with /).
-     *
-     * @return string The Bundle absolute path
-     */
     public function getPath();
 }
 

--- a/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\HttpKernel\Bundle;
+
+if (interface_exists('Symfony\Component\HttpKernel\Bundle\BundleInterface')) {
+    return;
+}
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+/**
+ * BundleInterface.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface BundleInterface extends ContainerAwareInterface
+{
+    /**
+     * Boots the Bundle.
+     */
+    public function boot();
+
+    /**
+     * Shutdowns the Bundle.
+     */
+    public function shutdown();
+
+    /**
+     * Builds the bundle.
+     *
+     * It is only ever called once when the cache is empty.
+     */
+    public function build(ContainerBuilder $container);
+
+    /**
+     * Returns the container extension that should be implicitly loaded.
+     *
+     * @return ExtensionInterface|null The default extension or null if there is none
+     */
+    public function getContainerExtension();
+
+    /**
+     * Returns the bundle name (the class short name).
+     *
+     * @return string The Bundle name
+     */
+    public function getName();
+
+    /**
+     * Gets the Bundle namespace.
+     *
+     * @return string The Bundle namespace
+     */
+    public function getNamespace();
+
+    /**
+     * Gets the Bundle directory path.
+     *
+     * The path should always be returned as a Unix path (with /).
+     *
+     * @return string The Bundle absolute path
+     */
+    public function getPath();
+}
+

--- a/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/stubs/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -9,12 +9,8 @@ if (interface_exists('Symfony\Component\HttpKernel\Bundle\BundleInterface')) {
 }
 
 /*
- * This file is part of the Symfony package.
- *
  * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * @see https://github.com/symfony/http-kernel/blob/31b284c8cf1d8dc560023838472a310ac1bebfe5/LICENSE
  */
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;


### PR DESCRIPTION
 I tried to apply latest `"rector/rector": "dev-main"` for use PHPStan 1.0, and got error into CodeIgniter project to test compatibilty early https://github.com/codeigniter4/CodeIgniter4/pull/5269 and got error:

```bash
Error: ] Could not process "system/CodeIgniter.php" file, due to:               
         "Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver::resolvePa
         rentClassName(): Argument #1 ($scope) must be of type                  
         PHPStan\Analyser\Scope, null given, called in                          
         vendor/rector/rector/rules/Php70/Rector/StaticCall/StaticCallOnNonStati
         cToInstanceCallRector.php:152". On line: 10    
```

this patch fix it.