### PR TITLE
[Core] Fix PHPStan realpath() notice on RectorConfigsResolver

### DIFF
--- a/src/Bootstrap/RectorConfigsResolver.php
+++ b/src/Bootstrap/RectorConfigsResolver.php
@@ -52,7 +52,9 @@ final class RectorConfigsResolver
             throw new FileNotFoundException($message);
         }
 
-        return realpath($configFile);
+        /** @var string $configFile */
+        $configFile = realpath($configFile);
+        return $configFile;
     }
 
     private function resolveFromInputWithFallback(ArgvInput $argvInput, string $fallbackFile): ?string


### PR DESCRIPTION
Fix PHPStan error notice:

```bash
 ------------------------------------------------------------------------
  src/Bootstrap/RectorConfigsResolver.php:55
 ------------------------------------------------------------------------
  - '#Method Rector\\Core\\Bootstrap\\RectorConfigsResolver\:\:resolveFromInput\(\) should return string\|null but returns string\|false#'
 ------------------------------------------------------------------------
```

Previously, it has condition `file_exists`, so it path must be return string.