### PR TITLE
[Naming] Use nullable alias on RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/use_nullable_aliased_on_promoted_property.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/use_nullable_aliased_on_promoted_property.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixt
 
 use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\EliteManager as AwesomeManager;
 
-class UseAliased
+class UseNullableAliased
 {
     public function __construct(private ?AwesomeManager $eventManager)
     {
@@ -19,7 +19,7 @@ namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixt
 
 use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\EliteManager as AwesomeManager;
 
-class UseAliased
+class UseNullableAliased
 {
     public function __construct(private ?AwesomeManager $awesomeManager)
     {

--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/use_nullable_aliased_on_promoted_property.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/FixturePhp80/use_nullable_aliased_on_promoted_property.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\EliteManager as AwesomeManager;
+
+class UseAliased
+{
+    public function __construct(private ?AwesomeManager $eventManager)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\EliteManager as AwesomeManager;
+
+class UseAliased
+{
+    public function __construct(private ?AwesomeManager $awesomeManager)
+    {
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -203,8 +204,8 @@ CODE_SAMPLE
                 return true;
             }
 
-            $conditional = $this->betterNodeFinder->findParentType($variable, Node\Expr\Ternary::class);
-            if ($conditional instanceof Node\Expr\Ternary) {
+            $conditional = $this->betterNodeFinder->findParentType($variable, Ternary::class);
+            if ($conditional instanceof Ternary) {
                 return true;
             }
         }


### PR DESCRIPTION
Given the following code:

```php
use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\EliteManager as AwesomeManager;

class UseNullableAliased
{
    public function __construct(private ?AwesomeManager $eventManager)
    {
    }
}
```

It produce:

```diff
+    public function __construct(private ?AwesomeManager $eliteManager)
```

which should be : 

```diff
+    public function __construct(private ?AwesomeManager $awesomeManager)
```

follow the aliased name.