### PR TITLE
[StaticTypeMapper] Refactor FullyQualifiedNodeMapper

### DIFF
--- a/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
+++ b/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
@@ -70,11 +70,11 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
         }
 
         $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
-        if ($parent instanceof Param && $parent->type instanceof NullableType && $parent->type->type === $node) {
-            return true;
+        if (! $parent instanceof Param) {
+            return false;
         }
 
-        return false;
+        return $parent->type->type === $node;
     }
 
     private function resolvePossibleAliasedObjectType(FullyQualified $fullyQualified): ?AliasedObjectType

--- a/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
+++ b/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
@@ -69,12 +69,12 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
             return false;
         }
 
-        $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parent instanceof Param) {
+        $parentOfParent = $parent->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parentOfParent instanceof Param) {
             return false;
         }
 
-        return $parent->type->type === $node;
+        return $parent->type === $node;
     }
 
     private function resolvePossibleAliasedObjectType(FullyQualified $fullyQualified): ?AliasedObjectType

--- a/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
+++ b/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
@@ -10,7 +10,6 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PHPStan\Type\Type;
 use Rector\CodingStyle\ClassNameImport\UsedImportsResolver;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -22,8 +21,7 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
 {
     public function __construct(
         private CurrentFileProvider $currentFileProvider,
-        private UsedImportsResolver $usedImportsResolver,
-        private BetterNodeFinder $betterNodeFinder
+        private UsedImportsResolver $usedImportsResolver
     ) {
     }
 
@@ -40,21 +38,15 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
      */
     public function mapToPHPStan(Node $node): Type
     {
-        $param = $this->betterNodeFinder->findParentType($node, Param::class);
-        if ($param instanceof Param) {
-            $possibleAliasedObjectType = null;
+        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
 
-            if ($param->type instanceof NullableType && $param->type->type === $node) {
-                $possibleAliasedObjectType = $this->resolvePossibleAliasedObjectType($node);
-            }
+        $possibleAliasedObjectType = null;
+        if ($this->isParamTyped($node, $parent)) {
+            $possibleAliasedObjectType = $this->resolvePossibleAliasedObjectType($node);
+        }
 
-            if ($param->type === $node) {
-                $possibleAliasedObjectType = $this->resolvePossibleAliasedObjectType($node);
-            }
-
-            if ($possibleAliasedObjectType instanceof AliasedObjectType) {
-                return $possibleAliasedObjectType;
-            }
+        if ($possibleAliasedObjectType instanceof AliasedObjectType) {
+            return $possibleAliasedObjectType;
         }
 
         $originalName = (string) $node->getAttribute(AttributeKey::ORIGINAL_NAME);
@@ -67,6 +59,22 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
         }
 
         return new FullyQualifiedObjectType($fullyQualifiedName);
+    }
+
+    private function isParamTyped(FullyQualified $node, ?Node $parent): bool
+    {
+        if ($parent instanceof Param && $parent->type === $node) {
+            return true;
+        }
+
+        if ($parent instanceof Node) {
+            $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
+            if ($parent instanceof Param && $parent->type instanceof NullableType && $parent->type->type === $node) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function resolvePossibleAliasedObjectType(FullyQualified $fullyQualified): ?AliasedObjectType

--- a/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
+++ b/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
@@ -40,13 +40,11 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
     {
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
 
-        $possibleAliasedObjectType = null;
         if ($this->isParamTyped($node, $parent)) {
             $possibleAliasedObjectType = $this->resolvePossibleAliasedObjectType($node);
-        }
-
-        if ($possibleAliasedObjectType instanceof AliasedObjectType) {
-            return $possibleAliasedObjectType;
+            if ($possibleAliasedObjectType instanceof AliasedObjectType) {
+                return $possibleAliasedObjectType;
+            }
         }
 
         $originalName = (string) $node->getAttribute(AttributeKey::ORIGINAL_NAME);

--- a/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
+++ b/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
@@ -65,11 +65,13 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
             return true;
         }
 
-        if ($parent instanceof Node) {
-            $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
-            if ($parent instanceof Param && $parent->type instanceof NullableType && $parent->type->type === $node) {
-                return true;
-            }
+        if (! $parent instanceof NullableType) {
+            return false;
+        }
+
+        $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
+        if ($parent instanceof Param && $parent->type instanceof NullableType && $parent->type->type === $node) {
+            return true;
         }
 
         return false;

--- a/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
+++ b/packages/StaticTypeMapper/PhpParser/FullyQualifiedNodeMapper.php
@@ -59,22 +59,22 @@ final class FullyQualifiedNodeMapper implements PhpParserNodeMapperInterface
         return new FullyQualifiedObjectType($fullyQualifiedName);
     }
 
-    private function isParamTyped(FullyQualified $node, ?Node $parent): bool
+    private function isParamTyped(FullyQualified $fullyQualified, ?Node $node): bool
     {
-        if ($parent instanceof Param && $parent->type === $node) {
+        if ($node instanceof Param && $node->type === $fullyQualified) {
             return true;
         }
 
-        if (! $parent instanceof NullableType) {
+        if (! $node instanceof NullableType) {
             return false;
         }
 
-        $parentOfParent = $parent->getAttribute(AttributeKey::PARENT_NODE);
+        $parentOfParent = $node->getAttribute(AttributeKey::PARENT_NODE);
         if (! $parentOfParent instanceof Param) {
             return false;
         }
 
-        return $parent->type === $node;
+        return $node->type === $fullyQualified;
     }
 
     private function resolvePossibleAliasedObjectType(FullyQualified $fullyQualified): ?AliasedObjectType


### PR DESCRIPTION
The scoped build somehow stopped after https://github.com/rectorphp/rector-src/commit/4b2877af19320a9b67b124bed02b107ff5c545a4 of PR https://github.com/rectorphp/rector-src/pull/1140.

I refactor `FullyQualifiedNodeMapper` to use direct parent node attribute to get nullable type.