### PR TITLE
[DowngradePhp72] Improve DowngradeParameterTypeWideningRector

### DIFF
--- a/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -241,13 +241,14 @@ CODE_SAMPLE
 
     private function isSafeType(ClassReflection $classReflection, ClassMethod $classMethod): bool
     {
+        $classReflectionName = $classReflection->getName();
         foreach ($this->safeTypes as $safeType) {
             if ($classReflection->isSubclassOf($safeType)) {
                 return true;
             }
 
             // skip self too
-            if ($classReflection->getName() === $safeType) {
+            if ($classReflectionName === $safeType) {
                 return true;
             }
         }
@@ -262,7 +263,7 @@ CODE_SAMPLE
             }
 
             // skip self too
-            if ($classReflection->getName() === $safeType) {
+            if ($classReflectionName === $safeType) {
                 return true;
             }
         }

--- a/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -218,11 +218,6 @@ CODE_SAMPLE
             return;
         }
 
-        // It already has no type => nothing to do - check original param, as it could have been removed by this rule
-        if ($param->type === null) {
-            return;
-        }
-
         // Add the current type in the PHPDoc
         $this->nativeParamToPhpDocDecorator->decorate($classMethod, $param);
         $param->type = null;

--- a/rules/TypeDeclaration/NodeAnalyzer/AutowiredClassMethodOrPropertyAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/AutowiredClassMethodOrPropertyAnalyzer.php
@@ -8,14 +8,14 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Symfony\Contracts\Service\Attribute\Required;
 
 final class AutowiredClassMethodOrPropertyAnalyzer
 {
     public function __construct(
         private PhpDocInfoFactory $phpDocInfoFactory,
-        private NodeNameResolver $nodeNameResolver
+        private PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -26,17 +26,6 @@ final class AutowiredClassMethodOrPropertyAnalyzer
             return true;
         }
 
-        foreach ($node->attrGroups as $attrGroup) {
-            foreach ($attrGroup->attrs as $attribute) {
-                if ($this->nodeNameResolver->isNames(
-                    $attribute->name,
-                    [Required::class, 'Nette\DI\Attributes\Inject']
-                )) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return $this->phpAttributeAnalyzer->hasPhpAttributes($node, [Required::class, 'Nette\DI\Attributes\Inject']);
     }
 }


### PR DESCRIPTION
- move `$classReflection->getName()` outside loop when posisible
- use `PhpAttributeAnalyzer` service to check attributes names 
- check for no params, private, or magic early
- clean up unneded $param->type === null check as already checked in hasParamAlreadyNonTyped()