### PR TITLE
[PostRector] Improve UseNodesToAddCollector

### DIFF
--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -103,7 +103,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
 
         $fileFunctionUseImportTypes = $this->functionUseImportTypesInFilePath[$filePath] ?? [];
         foreach ($fileFunctionUseImportTypes as $fileFunctionUseImportType) {
-            if ($fileFunctionUseImportType->getShortName() === $fullyQualifiedObjectType->getShortName()) {
+            if ($fileFunctionUseImportType->getShortName() === $shortName) {
                 return true;
             }
         }

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
@@ -29,8 +29,11 @@ final class ClassLikeNameClassNameImportSkipVoter implements ClassNameImportSkip
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
         $classLikeNames = $this->shortNameResolver->resolveShortClassLikeNamesForNode($node);
-        $shortNameLowered = $fullyQualifiedObjectType->getShortNameLowered();
+        if ($classLikeNames === []) {
+            return false;
+        }
 
+        $shortNameLowered = $fullyQualifiedObjectType->getShortNameLowered();
         foreach ($classLikeNames as $classLikeName) {
             if (strtolower($classLikeName) === $shortNameLowered) {
                 return true;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
@@ -29,9 +29,10 @@ final class ClassLikeNameClassNameImportSkipVoter implements ClassNameImportSkip
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
         $classLikeNames = $this->shortNameResolver->resolveShortClassLikeNamesForNode($node);
+        $shortName = $fullyQualifiedObjectType->getShortNameLowered();
 
         foreach ($classLikeNames as $classLikeName) {
-            if (strtolower($classLikeName) === $fullyQualifiedObjectType->getShortNameLowered()) {
+            if (strtolower($classLikeName) === $shortName) {
                 return true;
             }
         }

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
@@ -29,10 +29,10 @@ final class ClassLikeNameClassNameImportSkipVoter implements ClassNameImportSkip
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
         $classLikeNames = $this->shortNameResolver->resolveShortClassLikeNamesForNode($node);
-        $shortName = $fullyQualifiedObjectType->getShortNameLowered();
+        $shortNameLowered = $fullyQualifiedObjectType->getShortNameLowered();
 
         foreach ($classLikeNames as $classLikeName) {
-            if (strtolower($classLikeName) === $shortName) {
+            if (strtolower($classLikeName) === $shortNameLowered) {
                 return true;
             }
         }


### PR DESCRIPTION
- use existing `$shortName` instead of re-call `$fullyQualifiedObjectType->getShortName()` in the loop.
- move $fullyQualifiedObjectType->getShortNameLowered() to outside loop on ClassLikeNameClassNameImportSkipVoter
- early compare to [] before check ->getShortNameLowered()