### PR TITLE
[Core][CodingStyle][NodeManipulator] Improve Classes to use BetterNodeFinder instead of NodeFinder when BetterNodeFinder already injected

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -49,7 +49,6 @@ final class ShortNameResolver
     public function __construct(
         private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private NodeNameResolver $nodeNameResolver,
-        private NodeFinder $nodeFinder,
         private ReflectionProvider $reflectionProvider,
         private BetterNodeFinder $betterNodeFinder,
         private UseImportNameMatcher $useImportNameMatcher,
@@ -94,7 +93,7 @@ final class ShortNameResolver
         }
 
         /** @var ClassLike[] $classLikes */
-        $classLikes = $this->nodeFinder->findInstanceOf($namespace, ClassLike::class);
+        $classLikes = $this->betterNodeFinder->findInstanceOf($namespace, ClassLike::class);
 
         $shortClassLikeNames = [];
         foreach ($classLikes as $classLike) {
@@ -197,7 +196,7 @@ final class ShortNameResolver
      */
     private function resolveNativeClassReflection(array $stmts): ?ReflectionClass
     {
-        $firstClassLike = $this->nodeFinder->findFirstInstanceOf($stmts, ClassLike::class);
+        $firstClassLike = $this->betterNodeFinder->findFirstInstanceOf($stmts, ClassLike::class);
         if (! $firstClassLike instanceof ClassLike) {
             return null;
         }

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Namespace_;
-use PhpParser\NodeFinder;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Reflection\ReflectionProvider;

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -42,7 +42,6 @@ final class ClassMethodAssignManipulator
         private VariableManipulator $variableManipulator,
         private NodeComparator $nodeComparator,
         private ReflectionResolver $reflectionResolver,
-        private NodeFinder $nodeFinder,
         private ArrayDestructVariableFilter $arrayDestructVariableFilter
     ) {
     }
@@ -163,7 +162,7 @@ final class ClassMethodAssignManipulator
         $referencedVariables = [];
 
         /** @var Variable[] $variables */
-        $variables = $this->nodeFinder->findInstanceOf($classMethod, Variable::class);
+        $variables = $this->betterNodeFinder->findInstanceOf($classMethod, Variable::class);
 
         foreach ($variables as $variable) {
             if ($this->nodeNameResolver->isName($variable, 'this')) {

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
-use PhpParser\NodeFinder;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Type\Type;

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
-use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
@@ -61,7 +60,6 @@ final class AstResolver
     public function __construct(
         private SmartPhpParser $smartPhpParser,
         private SmartFileSystem $smartFileSystem,
-        private NodeFinder $nodeFinder,
         private NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private BetterNodeFinder $betterNodeFinder,
         private NodeNameResolver $nodeNameResolver,
@@ -115,7 +113,7 @@ final class AstResolver
             return null;
         }
 
-        $class = $this->nodeFinder->findFirstInstanceOf($nodes, Class_::class);
+        $class = $this->betterNodeFinder->findFirstInstanceOf($nodes, Class_::class);
         if (! $class instanceof Class_) {
             // avoids looking for a class in a file where is not present
             $this->classMethodsByClassAndMethod[$classReflection->getName()][$methodReflection->getName()] = null;
@@ -163,7 +161,7 @@ final class AstResolver
         }
 
         /** @var Function_[] $functions */
-        $functions = $this->nodeFinder->findInstanceOf($nodes, Function_::class);
+        $functions = $this->betterNodeFinder->findInstanceOf($nodes, Function_::class);
         foreach ($functions as $function) {
             if (! $this->nodeNameResolver->isName($function, $functionReflection->getName())) {
                 continue;

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\VersionBonding\PhpVersionedFilter;
 
@@ -22,7 +21,7 @@ final class RectorNodeTraverser extends NodeTraverser
      */
     public function __construct(
         private array $phpRectors,
-        private BetterNodeFinder $betterNodeFinder,
+        private NodeFinder $nodeFinder,
         private PhpVersionedFilter $phpVersionedFilter
     ) {
     }
@@ -35,7 +34,7 @@ final class RectorNodeTraverser extends NodeTraverser
     {
         $this->prepareNodeVisitors();
 
-        $hasNamespace = (bool) $this->betterNodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
+        $hasNamespace = (bool) $this->nodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
         if (! $hasNamespace && $nodes !== []) {
             $fileWithoutNamespace = new FileWithoutNamespace($nodes);
             return parent::traverse([$fileWithoutNamespace]);

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\VersionBonding\PhpVersionedFilter;
 
@@ -21,7 +22,7 @@ final class RectorNodeTraverser extends NodeTraverser
      */
     public function __construct(
         private array $phpRectors,
-        private NodeFinder $nodeFinder,
+        private BetterNodeFinder $betterNodeFinder,
         private PhpVersionedFilter $phpVersionedFilter
     ) {
     }
@@ -34,7 +35,7 @@ final class RectorNodeTraverser extends NodeTraverser
     {
         $this->prepareNodeVisitors();
 
-        $hasNamespace = (bool) $this->nodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
+        $hasNamespace = (bool) $this->betterNodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
         if (! $hasNamespace && $nodes !== []) {
             $fileWithoutNamespace = new FileWithoutNamespace($nodes);
             return parent::traverse([$fileWithoutNamespace]);


### PR DESCRIPTION
- remove `NodeFinder` dependency as already injected with `BetterNodeFinder` in `AstResolver`
- remove `NodeFinder` dependency as already injected with `BetterNodeFinder` in `ShortNameResolver`
- remove `NodeFinder` dependency as already injected with `BetterNodeFinder` in `ClassMethodAssignManipulator`
