### PR TITLE
[PhpSpecToPHPUnit] Restore PhpSpecToPHPUnitRector behaviour on namespaced name usage

### DIFF
--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/custom_matcher.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/custom_matcher.php.inc
@@ -64,7 +64,7 @@ use PhpSpec\ObjectBehavior;
 class RatesTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\Rates $rates;
-    private \PHPUnit\Framework\MockObject\MockObject|Provider $provider;
+    private \PHPUnit\Framework\MockObject\MockObject|\spec\Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\Provider $provider;
     protected function setUp()
     {
         $this->provider = $this->createMock(Provider::class);

--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/custom_matcher.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/custom_matcher.php.inc
@@ -64,7 +64,7 @@ use PhpSpec\ObjectBehavior;
 class RatesTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\Rates $rates;
-    private \PHPUnit\Framework\MockObject\MockObject|\Provider $provider;
+    private \PHPUnit\Framework\MockObject\MockObject|Provider $provider;
     protected function setUp()
     {
         $this->provider = $this->createMock(Provider::class);

--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/issue_3931.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/issue_3931.php.inc
@@ -67,7 +67,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class PageLinksGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\PageLinksGenerator $pageLinksGenerator;
-    private \PHPUnit\Framework\MockObject\MockObject|\Symfony\Bundle\FrameworkBundle\Routing $router;
+    private \PHPUnit\Framework\MockObject\MockObject|\Symfony\Bundle\FrameworkBundle\Routing\Router $router;
     public function testInitializable()
     {
         $this->assertInstanceOf(PageLinksGenerator::class, $this->pageLinksGenerator);

--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/issue_3931.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/issue_3931.php.inc
@@ -67,7 +67,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class PageLinksGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\PageLinksGenerator $pageLinksGenerator;
-    private \PHPUnit\Framework\MockObject\MockObject|\Router $router;
+    private \PHPUnit\Framework\MockObject\MockObject|\Symfony\Bundle\FrameworkBundle\Routing $router;
     public function testInitializable()
     {
         $this->assertInstanceOf(PageLinksGenerator::class, $this->pageLinksGenerator);

--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/let_create_edge.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/let_create_edge.php.inc
@@ -33,7 +33,7 @@ use PhpSpec\ObjectBehavior;
 class CurrencyTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\Currency $currency;
-    private \CurrencyData|\PHPUnit\Framework\MockObject\MockObject $data;
+    private CurrencyData|\PHPUnit\Framework\MockObject\MockObject $data;
     protected function setUp()
     {
         $this->data = $this->createMock(CurrencyData::class);

--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/let_create_edge.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/let_create_edge.php.inc
@@ -33,7 +33,7 @@ use PhpSpec\ObjectBehavior;
 class CurrencyTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\Currency $currency;
-    private CurrencyData|\PHPUnit\Framework\MockObject\MockObject $data;
+    private \PHPUnit\Framework\MockObject\MockObject|\spec\Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\CurrencyData $data;
     protected function setUp()
     {
         $this->data = $this->createMock(CurrencyData::class);

--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/mock_properties.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/mock_properties.php.inc
@@ -31,7 +31,7 @@ use Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Source\
 class MockPropertiesTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\MockProperties $mockProperties;
-    private \OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory;
+    private OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory;
     protected function setUp()
     {
         $this->factory = $this->createMock(OrderFactory::class);

--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/mock_properties.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/mock_properties.php.inc
@@ -31,7 +31,7 @@ use Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Source\
 class MockPropertiesTest extends \PHPUnit\Framework\TestCase
 {
     private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\MockProperties $mockProperties;
-    private OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory;
+    private \PHPUnit\Framework\MockObject\MockObject|\Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Source\OrderFactory $factory;
     protected function setUp()
     {
         $this->factory = $this->createMock(OrderFactory::class);

--- a/rules/PhpSpecToPHPUnit/PhpSpecMockCollector.php
+++ b/rules/PhpSpecToPHPUnit/PhpSpecMockCollector.php
@@ -113,7 +113,7 @@ final class PhpSpecMockCollector
             throw new ShouldNotHappenException();
         }
 
-        $paramType = (string) ($param->type->getAttribute(AttributeKey::ORIGINAL_NAME) ?: $param->type);
+        $paramType = (string) ($param->type ?? $param->type->getAttribute(AttributeKey::ORIGINAL_NAME));
         $this->mocksWithsTypes[$class][$variable] = $paramType;
     }
 }


### PR DESCRIPTION
The regression from PR https://github.com/rectorphp/rector-src/pull/1144/files#r744037285

This PR try to resolve it.