### PR TITLE
[PHPStan][Scoped] Remove phpstan <=0.12.99 from conflict config

### DIFF
--- a/build/target-repository/.github/workflows/along_other_packages.yaml
+++ b/build/target-repository/.github/workflows/along_other_packages.yaml
@@ -26,7 +26,7 @@ jobs:
 
                     -
                         name: 'Along PHPStan'
-                        install: composer require phpstan/phpstan:^1.0 --dev --ansi
+                        install: composer require phpstan/phpstan:^1.1.1 --dev --ansi
 
         name: "PHP ${{ matrix.php_version }}"
 

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "phpstan/phpstan": "^1.0"
+        "phpstan/phpstan": "^1.1.1"
     },
     "autoload": {
         "files": [
@@ -21,7 +21,6 @@
     },
     "conflict": {
         "phpstan/phpdoc-parser": "<=0.5.3",
-        "phpstan/phpstan": "<=0.12.99",
         "rector/rector-prefixed": "*",
         "rector/rector-phpunit": "*",
         "rector/rector-symfony": "*",


### PR DESCRIPTION
- update phpstan req to ^1.1.1 like in root composer.json
- remove phpstan <=0.12.99 from conflict config as it already covered by requirement of phpstan ^1+ tagged stable.