### PR TITLE
[Scoped] Update phpstan/phpdoc-parser conflict conflict to < 1.2

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "conflict": {
-        "phpstan/phpdoc-parser": "<=0.5.3",
+        "phpstan/phpdoc-parser": "<1.2",
         "rector/rector-prefixed": "*",
         "rector/rector-phpunit": "*",
         "rector/rector-symfony": "*",


### PR DESCRIPTION
Current root composer.json now require `"phpstan/phpdoc-parser": "^1.2"`, 

https://github.com/rectorphp/rector-src/blob/fed8756bacf4220a777936c2456e326379ccfa77/composer.json#L22

so in the scoped, it needs to be updated to `"phpstan/phpdoc-parser": "<1.2",`
