### PR TITLE
[CodingStyle] Restore ImportFullyQualifiedNamesRector import shortname docblock

### DIFF
--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/skip_same_namespaced_used_class.php.inc
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/skip_same_namespaced_used_class.php.inc
@@ -11,3 +11,20 @@ class SkipSameNamespacedUsedClass
     {
     }
 }
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\SharedShortName;
+class SkipSameNamespacedUsedClass
+{
+    /**
+     * @return SharedShortName
+     */
+    public function run(): SharedShortName
+    {
+    }
+}


### PR DESCRIPTION
The regression is happen at PR https://github.com/rectorphp/rector-src/pull/1144/files#diff-98c87bacfdbc114d15853cd78efcd4ecbda6d42d40c5cb9f26627de9fddfcbaa

The "skip_" prefix in the fixture purpose was to "skip" re-import.

This PR try to resolve it. 