### PR TITLE
Add failing test fixture for ReturnNeverTypeRector

### DIFF
--- a/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
+++ b/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
@@ -47,6 +47,7 @@ final class ChangeResolvedClassInParticularContextForAnnotation
         if ($annotationToAttribute->getTag() !== $changeResolvedClassInParticularContextForAnnotationRule->getTag()) {
             return;
         }
+
         if (! ($docNodeValue instanceof CurlyListNode)) {
             return;
         }

--- a/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
+++ b/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
@@ -14,7 +14,7 @@ final class ChangeResolvedClassInParticularContextForAnnotation
     /**
      * @var ChangeResolvedClassInParticularContextForAnnotationRule[]
      */
-    private array $rules;
+    private array $rules = [];
 
     public function __construct()
     {
@@ -29,31 +29,42 @@ final class ChangeResolvedClassInParticularContextForAnnotation
 
     public function changeResolvedClassIfNeed(
         AnnotationToAttribute $annotationToAttribute,
-        DoctrineAnnotationTagValueNode $docNode
+        DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode
     ): void {
         foreach ($this->rules as $rule) {
-            $this->applyRule($docNode, $rule, $annotationToAttribute);
+            $this->applyRule($doctrineAnnotationTagValueNode, $rule, $annotationToAttribute);
         }
     }
 
     private function applyRule(
-        DoctrineAnnotationTagValueNode $docNode,
-        ChangeResolvedClassInParticularContextForAnnotationRule $rule,
+        DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
+        ChangeResolvedClassInParticularContextForAnnotationRule $changeResolvedClassInParticularContextForAnnotationRule,
         AnnotationToAttribute $annotationToAttribute
     ): void {
-        $docNodeValue = $docNode->getValue($rule->getValue());
-
-        if ($annotationToAttribute->getTag() !== $rule->getTag() || ! ($docNodeValue instanceof CurlyListNode)) {
+        $docNodeValue = $doctrineAnnotationTagValueNode->getValue(
+            $changeResolvedClassInParticularContextForAnnotationRule->getValue()
+        );
+        if ($annotationToAttribute->getTag() !== $changeResolvedClassInParticularContextForAnnotationRule->getTag()) {
+            return;
+        }
+        if (! ($docNodeValue instanceof CurlyListNode)) {
             return;
         }
 
         $toTraverse = [$docNodeValue->getValues(), $docNodeValue->getOriginalValues()];
 
-        foreach ($toTraverse as $tmp) {
-            if (! array_key_exists(0, $tmp) && ! ($tmp[0] instanceof DoctrineAnnotationTagValueNode)) {
+        foreach ($toTraverse as $singleToTraverse) {
+            if (! array_key_exists(
+                0,
+                $singleToTraverse
+            ) && ! ($singleToTraverse[0] instanceof DoctrineAnnotationTagValueNode)) {
                 continue;
             }
-            $tmp[0]->identifierTypeNode->setAttribute('resolved_class', $rule->getResolvedClass());
+
+            $singleToTraverse[0]->identifierTypeNode->setAttribute(
+                'resolved_class',
+                $changeResolvedClassInParticularContextForAnnotationRule->getResolvedClass()
+            );
         }
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_conditional_throw.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_conditional_throw.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+function imagesavetofile($gdImage, $filename, $quality)
+{
+    $ext = pathinfo($filename, \PATHINFO_EXTENSION);
+    if (!$ext) {
+        throw new Exception('Unable to determine file extension for '.$filename);
+    }
+
+    switch (strtolower($ext)) {
+        case 'jpeg':
+        case 'jpg':
+                imagejpeg($gdImage, $filename, $quality);
+                break;
+
+        case 'png':
+                imagepng($gdImage, $filename, $pngQuality);
+
+                break;
+
+        case 'gif':
+                imagegif($gdImage, $filename);
+                break;
+
+        default:
+            throw new Exception('Unsupported file extension '.$ext);
+    }
+}


### PR DESCRIPTION
# Failing Test for ReturnNeverTypeRector

Based on https://getrector.org/demo/1ec40a17-139b-61c4-9cad-bd2ce88d948c

rector should not infer a `@return never` because the function does not always throw, but just in certain cases