### PR TITLE
Add failing test fixture for ReturnNeverTypeRector

### DIFF
--- a/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
+++ b/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
@@ -47,6 +47,7 @@ final class ChangeResolvedClassInParticularContextForAnnotation
         if ($annotationToAttribute->getTag() !== $changeResolvedClassInParticularContextForAnnotationRule->getTag()) {
             return;
         }
+
         if (! ($docNodeValue instanceof CurlyListNode)) {
             return;
         }

--- a/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
+++ b/packages/BetterPhpDocParser/Annotation/ChangeResolvedClassInParticularContextForAnnotation.php
@@ -14,7 +14,7 @@ final class ChangeResolvedClassInParticularContextForAnnotation
     /**
      * @var ChangeResolvedClassInParticularContextForAnnotationRule[]
      */
-    private array $rules;
+    private array $rules = [];
 
     public function __construct()
     {
@@ -29,31 +29,42 @@ final class ChangeResolvedClassInParticularContextForAnnotation
 
     public function changeResolvedClassIfNeed(
         AnnotationToAttribute $annotationToAttribute,
-        DoctrineAnnotationTagValueNode $docNode
+        DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode
     ): void {
         foreach ($this->rules as $rule) {
-            $this->applyRule($docNode, $rule, $annotationToAttribute);
+            $this->applyRule($doctrineAnnotationTagValueNode, $rule, $annotationToAttribute);
         }
     }
 
     private function applyRule(
-        DoctrineAnnotationTagValueNode $docNode,
-        ChangeResolvedClassInParticularContextForAnnotationRule $rule,
+        DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
+        ChangeResolvedClassInParticularContextForAnnotationRule $changeResolvedClassInParticularContextForAnnotationRule,
         AnnotationToAttribute $annotationToAttribute
     ): void {
-        $docNodeValue = $docNode->getValue($rule->getValue());
-
-        if ($annotationToAttribute->getTag() !== $rule->getTag() || ! ($docNodeValue instanceof CurlyListNode)) {
+        $docNodeValue = $doctrineAnnotationTagValueNode->getValue(
+            $changeResolvedClassInParticularContextForAnnotationRule->getValue()
+        );
+        if ($annotationToAttribute->getTag() !== $changeResolvedClassInParticularContextForAnnotationRule->getTag()) {
+            return;
+        }
+        if (! ($docNodeValue instanceof CurlyListNode)) {
             return;
         }
 
         $toTraverse = [$docNodeValue->getValues(), $docNodeValue->getOriginalValues()];
 
-        foreach ($toTraverse as $tmp) {
-            if (! array_key_exists(0, $tmp) && ! ($tmp[0] instanceof DoctrineAnnotationTagValueNode)) {
+        foreach ($toTraverse as $singleToTraverse) {
+            if (! array_key_exists(
+                0,
+                $singleToTraverse
+            ) && ! ($singleToTraverse[0] instanceof DoctrineAnnotationTagValueNode)) {
                 continue;
             }
-            $tmp[0]->identifierTypeNode->setAttribute('resolved_class', $rule->getResolvedClass());
+
+            $singleToTraverse[0]->identifierTypeNode->setAttribute(
+                'resolved_class',
+                $changeResolvedClassInParticularContextForAnnotationRule->getResolvedClass()
+            );
         }
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_method_throwing.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_method_throwing.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+class XY
+{
+    private function myMethod($string)
+    {
+        $colParts = preg_split('/\s+/', $string, null, \PREG_SPLIT_NO_EMPTY);
+        $numParts = count($colParts);
+
+        if (3 == $numParts) {
+        } elseif (2 == $numParts) {
+        } elseif (1 == $numParts) {
+            if ('*' != $colParts[0]) {
+                $this->string($colParts[0]);
+            }
+        } else {
+            throw new Exception(sprintf('"%s" is not valid'));
+        }
+    }
+}


### PR DESCRIPTION
# Failing Test for ReturnNeverTypeRector

Based on https://getrector.org/demo/1ec40a23-2f0e-63dc-8378-89fab3f4e18e

another case where `@return never` is generated but is not correct.

actually this might be the same as https://github.com/rectorphp/rector-src/pull/1187