### PR TITLE
PropertyTypeResolver enum test coverage

### DIFF
--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/PropertyTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/PropertyTypeResolverTest.php
@@ -6,6 +6,7 @@ namespace Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyTypeResolver
 
 use Iterator;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
@@ -51,7 +52,7 @@ final class PropertyTypeResolverTest extends AbstractNodeTypeResolverTest
         $unionType = new UnionType([new ObjectType(SomeChild::class), new NullType()]);
         yield [__DIR__ . '/Source/ActionClass.php', 0, $unionType];
 
-        $unionType = new UnionType([new StringType(Enum::MODE_ADD), new StringType(Enum::MODE_EDIT), new StringType(Enum::MODE_CLONE)]);
+        $unionType = new UnionType([new ConstantStringType(Enum::MODE_ADD), new ConstantStringType(Enum::MODE_EDIT), new ConstantStringType(Enum::MODE_CLONE)]);
         yield [__DIR__ . '/Source/Enum.php', 0, $unionType];
     }
 

--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/PropertyTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/PropertyTypeResolverTest.php
@@ -8,11 +8,13 @@ use Iterator;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\AbstractNodeTypeResolverTest;
 use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyTypeResolver\Source\ClassThatExtendsHtml;
+use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyTypeResolver\Source\Enum;
 use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyTypeResolver\Source\Html;
 use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyTypeResolver\Source\SomeChild;
 
@@ -48,6 +50,9 @@ final class PropertyTypeResolverTest extends AbstractNodeTypeResolverTest
         // mimics failing test from DomainDrivenDesign set
         $unionType = new UnionType([new ObjectType(SomeChild::class), new NullType()]);
         yield [__DIR__ . '/Source/ActionClass.php', 0, $unionType];
+
+        $unionType = new UnionType([new StringType(Enum::MODE_ADD), new StringType(Enum::MODE_EDIT), new StringType(Enum::MODE_CLONE)]);
+        yield [__DIR__ . '/Source/Enum.php', 0, $unionType];
     }
 
     private function getStringFromType(Type $type): string

--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/Source/Enum.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyTypeResolver/Source/Enum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyTypeResolver\Source;
+
+class Enum
+{
+    const MODE_ADD = 'add';
+    const MODE_EDIT = 'edit';
+    const MODE_CLONE = 'clone';
+
+    /**
+     * @var self::*
+     */
+    public $mode;
+}


### PR DESCRIPTION
A property typed with a wildcard like `self::*` is turned into a `string` type, instead of a union of each supported constant-type, which would be more precise.

~~current: `self::*` phpdoc is mapped to `string`~~

expected
 `self::*` phpdoc should be mapped to the concrete values like `'add'|'edit'|'clone'`
