### PR TITLE
StaticTypeMapper: added failling enum test

### DIFF
--- a/packages-tests/NodeTypeResolver/Source/Enum.php
+++ b/packages-tests/NodeTypeResolver/Source/Enum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeTypeResolver\Source;
+
+class Enum
+{
+    const MODE_ADD = 'add';
+    const MODE_EDIT = 'edit';
+    const MODE_CLONE = 'clone';
+
+    /**
+     * @var self::*
+     */
+    public $mode;
+}

--- a/packages-tests/NodeTypeResolver/Source/Enum.php
+++ b/packages-tests/NodeTypeResolver/Source/Enum.php
@@ -9,9 +9,4 @@ class Enum
     const MODE_ADD = 'add';
     const MODE_EDIT = 'edit';
     const MODE_CLONE = 'clone';
-
-    /**
-     * @var self::*
-     */
-    public $mode;
 }

--- a/packages-tests/NodeTypeResolver/StaticTypeMapper/StaticTypeMapperTest.php
+++ b/packages-tests/NodeTypeResolver/StaticTypeMapper/StaticTypeMapperTest.php
@@ -88,10 +88,10 @@ final class StaticTypeMapperTest extends AbstractTestCase
 
     public function testStringUnion(): void
     {
-        $mixedType = new UnionType([new ConstantStringType(Enum::MODE_ADD), new ConstantStringType(Enum::MODE_EDIT), new ConstantStringType(Enum::MODE_CLONE)]);
+        $stringUnion = new UnionType([new ConstantStringType(Enum::MODE_ADD), new ConstantStringType(Enum::MODE_EDIT), new ConstantStringType(Enum::MODE_CLONE)]);
 
         $phpStanDocTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode(
-            $mixedType,
+            $stringUnion,
             TypeKind::PROPERTY()
         );
         $this->assertInstanceOf(BracketsAwareUnionTypeNode::class, $phpStanDocTypeNode);

--- a/packages-tests/NodeTypeResolver/StaticTypeMapper/StaticTypeMapperTest.php
+++ b/packages-tests/NodeTypeResolver/StaticTypeMapper/StaticTypeMapperTest.php
@@ -13,12 +13,16 @@ use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\ClassStringType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\UnionType;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\Testing\PHPUnit\AbstractTestCase;
+use Rector\Tests\NodeTypeResolver\Source\Enum;
 
 final class StaticTypeMapperTest extends AbstractTestCase
 {
@@ -80,6 +84,18 @@ final class StaticTypeMapperTest extends AbstractTestCase
             TypeKind::ANY()
         );
         $this->assertInstanceOf(IdentifierTypeNode::class, $phpStanDocTypeNode);
+    }
+
+    public function testStringUnion(): void
+    {
+        $mixedType = new UnionType([new ConstantStringType(Enum::MODE_ADD), new ConstantStringType(Enum::MODE_EDIT), new ConstantStringType(Enum::MODE_CLONE)]);
+
+        $phpStanDocTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode(
+            $mixedType,
+            TypeKind::PROPERTY()
+        );
+        $this->assertInstanceOf(BracketsAwareUnionTypeNode::class, $phpStanDocTypeNode);
+        $this->assertSame("'add'|'edit'|'clone'", $phpStanDocTypeNode->__toString());
     }
 
     /**


### PR DESCRIPTION
A property typed with a wildcard like `self::*` is turned into a `string` type, instead of a union of each supported constant-type, which would be more precise.

current: `self::*` phpdoc is mapped to `string`

expected
 `self::*` phpdoc should be mapped to the concrete values like `'add'|'edit'|'clone'`
