### PR TITLE
[DowngradePhp80/81] Refactor Downgrade Resource Return to Object to use BooleanOr check

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -5207,7 +5207,7 @@ change instanceof Object to is_resource
      public function run($obj)
      {
 -        $obj instanceof \CurlHandle;
-+        is_resource($obj);
++        is_resource($obj) || $obj instanceof \CurlHandle;
      }
  }
 ```
@@ -5447,7 +5447,7 @@ change instanceof Object to is_resource
      public function run($obj)
      {
 -        $obj instanceof \finfo;
-+        is_resource($obj);
++        is_resource($obj) || $obj instanceof \finfo;
      }
  }
 ```

--- a/rules-tests/DowngradePhp80/Rector/Instanceof_/DowngradePhp80ResourceReturnToObjectRector/Fixture/different_check.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Instanceof_/DowngradePhp80ResourceReturnToObjectRector/Fixture/different_check.php.inc
@@ -20,7 +20,7 @@ class DifferentCheck
 {
     public function run($obj)
     {
-        is_resource($obj) && rand(0, 1) === 1;
+        (is_resource($obj) || $obj instanceof \CurlHandle) && rand(0, 1) === 1;
     }
 }
 

--- a/rules-tests/DowngradePhp80/Rector/Instanceof_/DowngradePhp80ResourceReturnToObjectRector/Fixture/some_class.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Instanceof_/DowngradePhp80ResourceReturnToObjectRector/Fixture/some_class.php.inc
@@ -36,23 +36,23 @@ class SomeClass
 {
     public function run($obj)
     {
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
+        is_resource($obj) || $obj instanceof \CurlHandle;
+        is_resource($obj) || $obj instanceof \CurlMultiHandle;
+        is_resource($obj) || $obj instanceof \CurlShareHandle;
+        is_resource($obj) || $obj instanceof \Socket;
+        is_resource($obj) || $obj instanceof \GdImage;
+        is_resource($obj) || $obj instanceof \XMLWriter;
+        is_resource($obj) || $obj instanceof \XMLParser;
+        is_resource($obj) || $obj instanceof \EnchantBroker;
+        is_resource($obj) || $obj instanceof \EnchantDictionary;
+        is_resource($obj) || $obj instanceof \OpenSSLCertificate;
+        is_resource($obj) || $obj instanceof \OpenSSLCertificateSigningRequest;
+        is_resource($obj) || $obj instanceof \Shmop;
+        is_resource($obj) || $obj instanceof \SysvMessageQueue;
+        is_resource($obj) || $obj instanceof \SysvSemaphore;
+        is_resource($obj) || $obj instanceof \SysvSharedMemory;
+        is_resource($obj) || $obj instanceof \InflateContext;
+        is_resource($obj) || $obj instanceof \DeflateContext;
     }
 }
 

--- a/rules-tests/DowngradePhp81/Rector/Instanceof_/DowngradePhp81ResourceReturnToObjectRector/Fixture/some_class.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Instanceof_/DowngradePhp81ResourceReturnToObjectRector/Fixture/some_class.php.inc
@@ -28,15 +28,15 @@ class SomeClass
 {
     public function run($obj)
     {
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
-        is_resource($obj);
+        is_resource($obj) || $obj instanceof \finfo;
+        is_resource($obj) || $obj instanceof \FTP\Connection;
+        is_resource($obj) || $obj instanceof \IMAP\Connection;
+        is_resource($obj) || $obj instanceof \PSpell\Config;
+        is_resource($obj) || $obj instanceof \PSpell\Dictionary;
+        is_resource($obj) || $obj instanceof \LDAP\Result;
+        is_resource($obj) || $obj instanceof \LDAP\ResultEntry;
+        is_resource($obj) || $obj instanceof \PgSql\Result;
+        is_resource($obj) || $obj instanceof \PgSql\Lob;
     }
 }
 

--- a/rules-tests/DowngradePhp81/Rector/Instanceof_/DowngradePhp81ResourceReturnToObjectRector/Fixture/use_or_is_resource_different_expr.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Instanceof_/DowngradePhp81ResourceReturnToObjectRector/Fixture/use_or_is_resource_different_expr.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Instanceof_\DowngradePhp81ResourceReturnToObjectRector\Fixture;
+
+class UseOrIsResourceDifferentExpr
+{
+    public function run($obj, $expr)
+    {
+        $obj instanceof \finfo && is_resource($expr);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Instanceof_\DowngradePhp81ResourceReturnToObjectRector\Fixture;
+
+class UseOrIsResourceDifferentExpr
+{
+    public function run($obj, $expr)
+    {
+        (is_resource($obj) || $obj instanceof \finfo) && is_resource($expr);
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Instanceof_/DowngradePhp80ResourceReturnToObjectRector.php
+++ b/rules/DowngradePhp80/Rector/Instanceof_/DowngradePhp80ResourceReturnToObjectRector.php
@@ -85,7 +85,7 @@ class SomeClass
 {
     public function run($obj)
     {
-        is_resource($obj);
+        is_resource($obj) || $obj instanceof \CurlHandle;
     }
 }
 CODE_SAMPLE

--- a/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
+++ b/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp81\NodeManipulator;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Name;
@@ -26,7 +27,7 @@ final class ObjectToResourceReturn
     /**
      * @param string[] $collectionObjectToResource
      */
-    public function refactor(Instanceof_ $instanceof, array $collectionObjectToResource): ?FuncCall
+    public function refactor(Instanceof_ $instanceof, array $collectionObjectToResource): ?BooleanOr
     {
         if (! $instanceof->class instanceof FullyQualified) {
             return null;
@@ -43,7 +44,10 @@ final class ObjectToResourceReturn
                 continue;
             }
 
-            return $this->nodeFactory->createFuncCall('is_resource', [$instanceof->expr]);
+            return new BooleanOr(
+                $this->nodeFactory->createFuncCall('is_resource', [$instanceof->expr]),
+                $instanceof
+            );
         }
 
         return null;

--- a/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
+++ b/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
@@ -57,9 +57,6 @@ final class ObjectToResourceReturn
         return null;
     }
 
-    /**
-     * @param BinaryOp|null $binaryOp
-     */
     private function hasIsResourceCheck(Expr $expr, ?BinaryOp $binaryOp): bool
     {
         if ($binaryOp instanceof BinaryOp) {

--- a/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
+++ b/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp81\NodeManipulator;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
+use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -20,6 +23,7 @@ final class ObjectToResourceReturn
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,
         private NodeNameResolver $nodeNameResolver,
+        private NodeComparator $nodeComparator,
         private NodeFactory $nodeFactory
     ) {
     }
@@ -40,7 +44,7 @@ final class ObjectToResourceReturn
             }
 
             $binaryOp = $this->betterNodeFinder->findParentType($instanceof, BinaryOp::class);
-            if ($this->hasIsResourceCheck($binaryOp)) {
+            if ($this->hasIsResourceCheck($instanceof->expr, $binaryOp)) {
                 continue;
             }
 
@@ -53,12 +57,12 @@ final class ObjectToResourceReturn
         return null;
     }
 
-    private function hasIsResourceCheck(?BinaryOp $binaryOp): bool
+    private function hasIsResourceCheck(Expr $expr, ?BinaryOp $binaryOp): bool
     {
         if ($binaryOp instanceof BinaryOp) {
             return (bool) $this->betterNodeFinder->findFirst(
                 $binaryOp,
-                function (Node $subNode): bool {
+                function (Node $subNode) use ($expr): bool {
                     if (! $subNode instanceof FuncCall) {
                         return false;
                     }
@@ -67,7 +71,15 @@ final class ObjectToResourceReturn
                         return false;
                     }
 
-                    return $this->nodeNameResolver->isName($subNode->name, 'is_resource');
+                    if (! $this->nodeNameResolver->isName($subNode->name, 'is_resource')) {
+                        return false;
+                    }
+
+                    if (! isset($subNode->args[0]) || ! $subNode->args[0] instanceof Arg) {
+                        return false;
+                    }
+
+                    return $this->nodeComparator->areNodesEqual($subNode->args[0], $expr);
                 }
             );
         }

--- a/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
+++ b/rules/DowngradePhp81/NodeManipulator/ObjectToResourceReturn.php
@@ -57,6 +57,9 @@ final class ObjectToResourceReturn
         return null;
     }
 
+    /**
+     * @param BinaryOp|null $binaryOp
+     */
     private function hasIsResourceCheck(Expr $expr, ?BinaryOp $binaryOp): bool
     {
         if ($binaryOp instanceof BinaryOp) {
@@ -75,7 +78,11 @@ final class ObjectToResourceReturn
                         return false;
                     }
 
-                    if (! isset($subNode->args[0]) || ! $subNode->args[0] instanceof Arg) {
+                    if (! isset($subNode->args[0])) {
+                        return false;
+                    }
+
+                    if (! $subNode->args[0] instanceof Arg) {
                         return false;
                     }
 

--- a/rules/DowngradePhp81/Rector/Instanceof_/DowngradePhp81ResourceReturnToObjectRector.php
+++ b/rules/DowngradePhp81/Rector/Instanceof_/DowngradePhp81ResourceReturnToObjectRector.php
@@ -72,7 +72,7 @@ class SomeClass
 {
     public function run($obj)
     {
-        is_resource($obj);
+        is_resource($obj) || $obj instanceof \finfo;
     }
 }
 CODE_SAMPLE


### PR DESCRIPTION
Ensure to have the following behaviour :

```diff
-$obj instanceof \CurlHandle;
+is_resource($obj) || $obj instanceof \CurlHandle;
```

to keep code before and after downgraded  working when used in upper php version.