### PR TITLE
Add failing test fixture for RemoveUnusedPrivatePropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/regression_property_removal.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/regression_property_removal.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+abstract class FooBar
+{
+    private string $foo;
+    private string $bar;
+
+    public function __construct(string $foo, string $bar) 
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    protected function calculateMac(): string
+    {
+        $foobar = $this->foo;
+        $foobar .= $this->bar;
+
+        return md5($foobar);
+    }
+}
+?>
+-----


### PR DESCRIPTION
# Failing Test for RemoveUnusedPrivatePropertyRector

Based on https://getrector.org/demo/1ec41588-8edc-6bcc-a01d-47e5845af8a7
See https://github.com/rectorphp/rector/issues/6794