### PR TITLE
[Php70] Avoid error Undefined property: PhpParser\Node\Stmt\Class_::$namespacedName on ThisCallOnStaticMethodToStaticCallRector

### DIFF
--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -149,7 +149,7 @@ final class ArrayCallableMethodMatcher
                 return new MixedType();
             }
 
-            $classConstantReference = $classLike->namespacedName->toString();
+            $classConstantReference = (string) $this->nodeNameResolver->getName($classLike);
         }
 
         // non-class value

--- a/packages/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
@@ -17,6 +17,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -28,6 +29,7 @@ final class NameTypeResolver implements NodeTypeResolverInterface
     public function __construct(
         private ReflectionProvider $reflectionProvider,
         private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -64,7 +66,7 @@ final class NameTypeResolver implements NodeTypeResolverInterface
             return new MixedType();
         }
 
-        $className = $class->namespacedName->toString();
+        $className = $this->nodeNameResolver->getName($class);
         if (! is_string($className)) {
             return new MixedType();
         }
@@ -105,7 +107,7 @@ final class NameTypeResolver implements NodeTypeResolverInterface
                 return $name->toString();
             }
 
-            return $classLike->namespacedName->toString();
+            return (string) $this->nodeNameResolver->getName($classLike);
         }
 
         /** @var Name|null $resolvedNameNode */

--- a/packages/NodeTypeResolver/PHPStan/CollisionGuard/MixinGuard.php
+++ b/packages/NodeTypeResolver/PHPStan/CollisionGuard/MixinGuard.php
@@ -36,7 +36,9 @@ final class MixinGuard
                 return false;
             }
 
-            $className = $node instanceof FullyQualified ? $node->toString() : (string) $this->nodeNameResolver->getName($node);
+            $className = $node instanceof FullyQualified ? $node->toString() : (string) $this->nodeNameResolver->getName(
+                $node
+            );
 
             return $this->isCircularMixin($className);
         });

--- a/packages/NodeTypeResolver/PHPStan/CollisionGuard/MixinGuard.php
+++ b/packages/NodeTypeResolver/PHPStan/CollisionGuard/MixinGuard.php
@@ -11,12 +11,14 @@ use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\NodeNameResolver\NodeNameResolver;
 
 final class MixinGuard
 {
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,
         private ReflectionProvider $reflectionProvider,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -34,7 +36,7 @@ final class MixinGuard
                 return false;
             }
 
-            $className = $node instanceof FullyQualified ? $node->toString() : $node->namespacedName->toString();
+            $className = $node instanceof FullyQualified ? $node->toString() : (string) $this->nodeNameResolver->getName($node);
 
             return $this->isCircularMixin($className);
         });

--- a/packages/PostRector/NodeAnalyzer/NetteInjectDetector.php
+++ b/packages/PostRector/NodeAnalyzer/NetteInjectDetector.php
@@ -46,7 +46,7 @@ final class NetteInjectDetector
 
     private function hasParentClassConstructor(Class_ $class): bool
     {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
         if (! $this->reflectionProvider->hasClass($className)) {
             return false;
         }

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -20,6 +20,7 @@ use PHPStan\Type\Type;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 use Rector\StaticTypeMapper\Mapper\ScalarStringToTypeMapper;
@@ -33,7 +34,8 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
         private ObjectTypeSpecifier $objectTypeSpecifier,
         private ScalarStringToTypeMapper $scalarStringToTypeMapper,
         private ParentClassScopeResolver $parentClassScopeResolver,
-        private BetterNodeFinder $betterNodeFinder
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -97,7 +99,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
         }
 
         // @todo check FQN
-        $className = $classLike->namespacedName->toString();
+        $className = $this->nodeNameResolver->getName($classLike);
         if (! is_string($className)) {
             // self outside the class, e.g. in a function
             return new MixedType();

--- a/packages/StaticTypeMapper/PhpParser/NameNodeMapper.php
+++ b/packages/StaticTypeMapper/PhpParser/NameNodeMapper.php
@@ -23,6 +23,7 @@ use PHPStan\Type\Type;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ParentObjectWithoutClassType;
@@ -33,7 +34,8 @@ final class NameNodeMapper implements PhpParserNodeMapperInterface
     public function __construct(
         private RenamedClassesDataCollector $renamedClassesDataCollector,
         private ReflectionProvider $reflectionProvider,
-        private BetterNodeFinder $betterNodeFinder
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -83,7 +85,7 @@ final class NameNodeMapper implements PhpParserNodeMapperInterface
             return new MixedType();
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
         $classReflection = $this->reflectionProvider->getClass($className);
 
         if ($reference === ObjectReference::STATIC()->getValue()) {

--- a/rules/Autodiscovery/Analyzer/ValueObjectClassAnalyzer.php
+++ b/rules/Autodiscovery/Analyzer/ValueObjectClassAnalyzer.php
@@ -11,6 +11,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\ValueObject\MethodName;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
 final class ValueObjectClassAnalyzer
@@ -24,7 +25,8 @@ final class ValueObjectClassAnalyzer
         private NodeTypeResolver $nodeTypeResolver,
         private PhpDocInfoFactory $phpDocInfoFactory,
         private AstResolver $astResolver,
-        private ClassAnalyzer $classAnalyzer
+        private ClassAnalyzer $classAnalyzer,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -35,7 +37,7 @@ final class ValueObjectClassAnalyzer
         }
 
         /** @var string $className */
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         if (isset($this->valueObjectStatusByClassName[$className])) {
             return $this->valueObjectStatusByClassName[$className];

--- a/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
+++ b/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
@@ -131,7 +131,7 @@ CODE_SAMPLE
             return true;
         }
 
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
         if (! $this->reflectionProvider->hasClass($className)) {
             return true;
         }

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -200,7 +200,7 @@ final class ShortNameResolver
             return null;
         }
 
-        $className = $firstClassLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($firstClassLike);
         if (! $this->reflectionProvider->hasClass($className)) {
             return null;
         }

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\UseUse;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
@@ -17,7 +18,8 @@ final class UsedImportsResolver
 {
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,
-        private UseImportsTraverser $useImportsTraverser
+        private UseImportsTraverser $useImportsTraverser,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -52,7 +54,7 @@ final class UsedImportsResolver
         // add class itself
         // is not anonymous class
         if ($class !== null && property_exists($class, 'namespacedName')) {
-            $className = $class->namespacedName->toString();
+            $className = (string) $this->nodeNameResolver->getName($class);
             $usedImports[] = new FullyQualifiedObjectType($className);
         }
 

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -64,7 +64,7 @@ final class IsClassMethodUsedAnalyzer
 
     private function isClassMethodUsedInLocalStaticCall(Class_ $class, string $classMethodName): bool
     {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         /** @var StaticCall[] $staticCalls */
         $staticCalls = $this->betterNodeFinder->findInstanceOf($class, StaticCall::class);
@@ -73,7 +73,7 @@ final class IsClassMethodUsedAnalyzer
 
     private function isClassMethodCalledInLocalMethodCall(Class_ $class, string $classMethodName): bool
     {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         /** @var MethodCall[] $methodCalls */
         $methodCalls = $this->betterNodeFinder->findInstanceOf($class, MethodCall::class);

--- a/rules/DependencyInjection/NodeAnalyzer/ControllerClassMethodAnalyzer.php
+++ b/rules/DependencyInjection/NodeAnalyzer/ControllerClassMethodAnalyzer.php
@@ -8,11 +8,13 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\NodeNameResolver\NodeNameResolver;
 
 final class ControllerClassMethodAnalyzer
 {
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -23,7 +25,7 @@ final class ControllerClassMethodAnalyzer
             return false;
         }
 
-        $className = $class->namespacedName->toString();
+        $className = $this->nodeNameResolver->getName($class);
         if (! is_string($className)) {
             return false;
         }

--- a/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
+++ b/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
 
         foreach ($this->methodByParentTypes as $type => $method) {
             if (! $this->isObjectType($classLike, new ObjectType($type))) {

--- a/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
@@ -30,7 +30,7 @@ final class PropertyRenameFactory
             return null;
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
 
         return new PropertyRename(
             $property,

--- a/rules/PSR4/FileInfoAnalyzer/FileInfoDeletionAnalyzer.php
+++ b/rules/PSR4/FileInfoAnalyzer/FileInfoDeletionAnalyzer.php
@@ -8,6 +8,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node\Stmt\ClassLike;
 use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\Core\ValueObject\Application\File;
+use Rector\NodeNameResolver\NodeNameResolver;
 
 final class FileInfoDeletionAnalyzer
 {
@@ -18,13 +19,14 @@ final class FileInfoDeletionAnalyzer
     private const TESTING_PREFIX_REGEX = '#input_(.*?)_#';
 
     public function __construct(
-        private ClassNaming $classNaming
+        private ClassNaming $classNaming,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
     public function isClassLikeAndFileInfoMatch(File $file, ClassLike $classLike): bool
     {
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
         $smartFileInfo = $file->getSmartFileInfo();
 
         $baseFileName = $this->clearNameFromTestingPrefix($smartFileInfo->getBasenameWithoutSuffix());

--- a/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $className = $this->nodeNameResolver->getName($classLike);
+        $className = (string) $this->nodeNameResolver->getName($classLike);
 
         $isStaticMethod = $this->staticAnalyzer->isStaticMethod($methodName, $className);
         if (! $isStaticMethod) {

--- a/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = $this->nodeNameResolver->getName($classLike);
 
         $isStaticMethod = $this->staticAnalyzer->isStaticMethod($methodName, $className);
         if (! $isStaticMethod) {

--- a/rules/PhpSpecToPHPUnit/Naming/PhpSpecRenaming.php
+++ b/rules/PhpSpecToPHPUnit/Naming/PhpSpecRenaming.php
@@ -106,14 +106,14 @@ final class PhpSpecRenaming
     public function resolveTestedClass(Node $node): string
     {
         if ($node instanceof ClassLike) {
-            $className = $node->namespacedName->toString();
+            $className = (string) $this->nodeNameResolver->getName($node);
         } else {
             $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
             if (! $classLike instanceof ClassLike) {
                 throw new ShouldNotHappenException();
             }
 
-            $className = $classLike->namespacedName->toString();
+            $className = (string) $this->nodeNameResolver->getName($classLike);
         }
 
         $newClassName = StaticRectorStrings::removePrefixes($className, ['spec\\']);

--- a/rules/PhpSpecToPHPUnit/PhpSpecMockCollector.php
+++ b/rules/PhpSpecToPHPUnit/PhpSpecMockCollector.php
@@ -44,7 +44,7 @@ final class PhpSpecMockCollector
      */
     public function resolveClassMocksFromParam(Class_ $class): array
     {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         if (isset($this->mocks[$className]) && $this->mocks[$className] !== []) {
             return $this->mocks[$className];
@@ -75,14 +75,14 @@ final class PhpSpecMockCollector
     public function isVariableMockInProperty(Class_ $class, Variable $variable): bool
     {
         $variableName = $this->nodeNameResolver->getName($variable);
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         return in_array($variableName, $this->propertyMocksByClass[$className] ?? [], true);
     }
 
     public function getTypeForClassAndVariable(Class_ $class, string $variable): string
     {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         if (! isset($this->mocksWithsTypes[$className][$variable])) {
             throw new ShouldNotHappenException();
@@ -100,7 +100,7 @@ final class PhpSpecMockCollector
     {
         $variable = $this->nodeNameResolver->getName($param->var);
 
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         $classMethod = $this->betterNodeFinder->findParentType($param, ClassMethod::class);
         if (! $classMethod instanceof ClassMethod) {

--- a/rules/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
+++ b/rules/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
@@ -157,7 +157,7 @@ CODE_SAMPLE
             return false;
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
 
         $objectType = new ObjectType($className);
         $callerType = $this->nodeTypeResolver->getType($staticCall->class);

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -205,7 +205,7 @@ final class ClassRenamer
             return null;
         }
 
-        $currentName = $classLike->namespacedName->toString();
+        $currentName = (string) $this->nodeNameResolver->getName($classLike);
         $newClassFullyQualified = $oldToNewClasses[$currentName];
 
         if ($this->reflectionProvider->hasClass($newClassFullyQualified)) {
@@ -233,7 +233,7 @@ final class ClassRenamer
         // rename interfaces
         $this->renameClassImplements($classLike, $oldToNewClasses);
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
 
         $newName = $oldToNewClasses[$className] ?? null;
         if (! $newName) {

--- a/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
+++ b/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
@@ -91,7 +91,7 @@ final class RenamePropertyRector extends AbstractRector implements ConfigurableR
 
     private function renameProperty(ClassLike $classLike, RenameProperty $renameProperty): void
     {
-        $classLikeName = $classLike->namespacedName->toString();
+        $classLikeName = (string) $this->nodeNameResolver->getName($classLike);
         $renamePropertyObjectType = $renameProperty->getObjectType();
         $className = $renamePropertyObjectType->getClassName();
 

--- a/rules/Transform/NodeAnalyzer/SingletonClassMethodAnalyzer.php
+++ b/rules/Transform/NodeAnalyzer/SingletonClassMethodAnalyzer.php
@@ -18,6 +18,7 @@ use PHPStan\Type\ObjectType;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
 final class SingletonClassMethodAnalyzer
@@ -27,6 +28,7 @@ final class SingletonClassMethodAnalyzer
         private ValueResolver $valueResolver,
         private NodeComparator $nodeComparator,
         private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -81,7 +83,7 @@ final class SingletonClassMethodAnalyzer
             return null;
         }
 
-        $className = $class->namespacedName->toString();
+        $className = $this->nodeNameResolver->getName($class);
         if (! is_string($className)) {
             return null;
         }

--- a/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
+++ b/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
@@ -45,7 +45,7 @@ final class TypeProvidingExprFromClassResolver
         ClassMethod | Function_ $functionLike,
         ObjectType $objectType
     ): ?Expr {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         // A. match a method
         $classReflection = $this->reflectionProvider->getClass($className);

--- a/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
+++ b/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
@@ -91,7 +91,7 @@ final class ReturnTypeAlreadyAddedChecker
             return false;
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
 
         $nodeContent = $this->nodeComparator->printWithoutComments($returnNode);
         $nodeContentWithoutPreslash = ltrim($nodeContent, '\\');

--- a/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/KnownArrayParamTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/KnownArrayParamTypeInferer.php
@@ -31,7 +31,7 @@ final class KnownArrayParamTypeInferer implements ParamTypeInfererInterface
             return new MixedType();
         }
 
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
         if (! $this->reflectionProvider->hasClass($className)) {
             return new MixedType();
         }

--- a/src/NodeAnalyzer/PropertyPresenceChecker.php
+++ b/src/NodeAnalyzer/PropertyPresenceChecker.php
@@ -40,7 +40,7 @@ final class PropertyPresenceChecker
 
     public function getClassContextProperty(Class_ $class, PropertyMetadata $propertyMetadata): Property | Param | null
     {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
         if (! $this->reflectionProvider->hasClass($className)) {
             return null;
         }

--- a/src/NodeManipulator/Dependency/DependencyClassMethodDecorator.php
+++ b/src/NodeManipulator/Dependency/DependencyClassMethodDecorator.php
@@ -15,6 +15,7 @@ use Rector\Core\NodeAnalyzer\PromotedPropertyParamCleaner;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\ValueObject\MethodName;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Symplify\Astral\NodeTraverser\SimpleCallableNodeTraverser;
 
 final class DependencyClassMethodDecorator
@@ -24,7 +25,8 @@ final class DependencyClassMethodDecorator
         private PromotedPropertyParamCleaner $promotedPropertyParamCleaner,
         private ReflectionProvider $reflectionProvider,
         private AstResolver $astResolver,
-        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -36,7 +38,7 @@ final class DependencyClassMethodDecorator
         ClassMethod $classMethod,
         Scope $scope
     ): void {
-        $className = $class->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($class);
         if (! $this->reflectionProvider->hasClass($className)) {
             return;
         }

--- a/src/NodeManipulator/VariableManipulator.php
+++ b/src/NodeManipulator/VariableManipulator.php
@@ -93,7 +93,7 @@ final class VariableManipulator
             return false;
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
         if (! \str_ends_with($className, 'Test')) {
             return false;
         }

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -77,7 +77,7 @@ final class ValueResolver
                 // @todo scope is needed
                 $classLike = $this->betterNodeFinder->findParentType($expr, ClassLike::class);
                 if ($classLike instanceof ClassLike) {
-                    return $classLike->namespacedName->toString();
+                    return $this->nodeNameResolver->getName($classLike);
                 }
             }
 
@@ -280,7 +280,7 @@ final class ValueResolver
                 throw new ShouldNotHappenException();
             }
 
-            $class = $classLike->namespacedName->toString();
+            $class = (string) $this->nodeNameResolver->getName($classLike);
         }
 
         if ($constant === 'class') {

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -77,7 +77,7 @@ final class ValueResolver
                 // @todo scope is needed
                 $classLike = $this->betterNodeFinder->findParentType($expr, ClassLike::class);
                 if ($classLike instanceof ClassLike) {
-                    return $this->nodeNameResolver->getName($classLike);
+                    return (string) $this->nodeNameResolver->getName($classLike);
                 }
             }
 

--- a/src/PhpParser/NodeFinder/LocalMethodCallFinder.php
+++ b/src/PhpParser/NodeFinder/LocalMethodCallFinder.php
@@ -31,7 +31,7 @@ final class LocalMethodCallFinder
             return [];
         }
 
-        $className = $class->namespacedName->toString();
+        $className = $this->nodeNameResolver->getName($class);
         if (! is_string($className)) {
             return [];
         }

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -49,7 +49,7 @@ final class ReflectionResolver
             );
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = (string) $this->nodeNameResolver->getName($classLike);
         return $this->reflectionProvider->getClass($className);
     }
 
@@ -137,7 +137,7 @@ final class ReflectionResolver
             return null;
         }
 
-        $className = $classLike->namespacedName->toString();
+        $className = $this->nodeNameResolver->getName($classLike);
         if (! is_string($className)) {
             return null;
         }


### PR DESCRIPTION
I tried rector 0.12.0 on CodeIgniter project and got error:

```bash
 541/674 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░]  80%PHP Warning:  Undefined property: PhpParser\Node\Stmt\Class_::$namespacedName in /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php on line 104

Warning: Undefined property: PhpParser\Node\Stmt\Class_::$namespacedName in /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php on line 104
```

This PR updated to use `NodeNameResolver->getName()` to get the class name.