### PR TITLE
[Scoped] Fix scoping symfony Deprecation contract function

### DIFF
--- a/rules/DowngradePhp55/Rector/ClassConstFetch/DowngradeClassConstantToStringRector.php
+++ b/rules/DowngradePhp55/Rector/ClassConstFetch/DowngradeClassConstantToStringRector.php
@@ -72,12 +72,15 @@ CODE_SAMPLE
         if (! $node->name instanceof Identifier) {
             return null;
         }
+
         if (strtolower($node->name->name) !== 'class') {
             return null;
         }
+
         if (! $node->class instanceof Name) {
             return null;
         }
+
         $className = $node->class->toString();
 
         $func = match (strtolower($className)) {

--- a/rules/DowngradePhp55/Rector/ClassConstFetch/DowngradeClassConstantToStringRector.php
+++ b/rules/DowngradePhp55/Rector/ClassConstFetch/DowngradeClassConstantToStringRector.php
@@ -18,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see Rector\Tests\DowngradePhp55\Rector\ClassConstFetch\DowngradeClassConstantToStringRector\DowngradeClassConstantToStringRectorTest
  */
-class DowngradeClassConstantToStringRector extends AbstractRector
+final class DowngradeClassConstantToStringRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -69,14 +69,15 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (
-            ! $node->name instanceof Identifier
-            || strtolower($node->name->name) !== 'class'
-            || ! $node->class instanceof Name
-        ) {
+        if (! $node->name instanceof Identifier) {
             return null;
         }
-
+        if (strtolower($node->name->name) !== 'class') {
+            return null;
+        }
+        if (! $node->class instanceof Name) {
+            return null;
+        }
         $className = $node->class->toString();
 
         $func = match (strtolower($className)) {

--- a/scoper.php
+++ b/scoper.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 // [BEWARE] this path is relative to the root and location of this file
 $filePathsToRemoveNamespace = [
     // @see https://github.com/rectorphp/rector/issues/2852#issuecomment-586315588
-    'vendor/symfony/deprecation-contracts/function.php',
+    'vendor/symfony/contracts/Deprecation/function.php',
     // it would make polyfill function work only with namespace = brokes
     'vendor/symfony/polyfill-ctype/bootstrap.php',
     'vendor/symfony/polyfill-ctype/bootstrap80.php',


### PR DESCRIPTION
@TomasVotruba this should resolve https://github.com/rectorphp/rector/issues/6797

The path of Deprecation function is now moved to `vendor/symfony/contracts/Deprecation` instead of old `vendor/symfony/deprecation-contracts`