### PR TITLE
[Scoped] Fix missing trigger_deprecatoin() in explicit preload

### DIFF
--- a/build/build-preload.php
+++ b/build/build-preload.php
@@ -95,6 +95,8 @@ PHP;
         // append ContainerConfiguration to avoid accidental load of prefixed one from another tool
         $fileInfos[] = new SplFileInfo(__DIR__ . '/../vendor/symfony/dependency-injection/Loader/Configurator/AbstractConfigurator.php');
         $fileInfos[] = new SplFileInfo(__DIR__ . '/../vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php');
+        // attempt to fix https://github.com/rectorphp/rector-src/pull/1199
+        $fileInfos[] = new SplFileInfo(__DIR__ . '/../vendor/symfony/contracts/Deprecation/function.php');
 
         // 2. put first-class usages first
         usort($fileInfos, function (SplFileInfo $firstFileInfo, SplFileInfo $secondFileInfo) {

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/console": "^5.3",
         "symfony/contracts": "^2.4",
         "symfony/dependency-injection": "^5.3",
+        "symfony/deprecation-contracts": "^2.4",
         "symfony/finder": "^5.3",
         "symfony/process": "^5.3",
         "symfony/yaml": "^5.3",

--- a/preload.php
+++ b/preload.php
@@ -253,3 +253,4 @@ require_once __DIR__ . '/vendor/symplify/symfony-php-config/src/Reflection/Argum
 require_once __DIR__ . '/vendor/symplify/symfony-php-config/src/ValueObjectInliner.php';
 require_once __DIR__ . '/vendor/symfony/dependency-injection/Loader/Configurator/AbstractConfigurator.php';
 require_once __DIR__ . '/vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php';
+require_once __DIR__ . '/vendor/symfony/contracts/Deprecation/function.php';

--- a/scoper.php
+++ b/scoper.php
@@ -12,8 +12,6 @@ use Rector\Core\Application\VersionResolver;
 require_once __DIR__ . '/vendor/autoload.php';
 // [BEWARE] this path is relative to the root and location of this file
 $filePathsToRemoveNamespace = [
-    // @see https://github.com/rectorphp/rector/issues/2852#issuecomment-586315588
-    'vendor/symfony/contracts/Deprecation/function.php',
     // it would make polyfill function work only with namespace = brokes
     'vendor/symfony/polyfill-ctype/bootstrap.php',
     'vendor/symfony/polyfill-ctype/bootstrap80.php',


### PR DESCRIPTION
Attempt to fix missing trigger_deprecation() from Symfony package, that was just renamed.

See https://github.com/rectorphp/rector-src/pull/1199