### PR TITLE
[Php71] Skip property with array doc filled by __construct on CountOnNullRector

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -51,6 +51,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
         if (file_exists(__DIR__ . '/../../../preload.php') && file_exists(__DIR__ . '/../../../vendor')) {
             require_once __DIR__ . '/../../../preload.php';
         }
+
         if (\file_exists(__DIR__ . '/../../../vendor/scoper-autoload.php')) {
             require_once __DIR__ . '/../../../vendor/scoper-autoload.php';
         }

--- a/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_param_array.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_param_array.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\FuncCall\CountOnNullRector\Fixture;
+
+final class SkipPropertyArray
+{
+    /** @var array */
+    private $property;
+
+    public function __construct(array $property)
+    {
+        $this->property = $property;
+    }
+
+    public function run(): int
+    {
+        return count($this->property);
+    }
+}

--- a/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_property_array_filled_by_construct.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_property_array_filled_by_construct.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php71\Rector\FuncCall\CountOnNullRector\Fixture;
 
-final class SkipPropertyArray
+final class SkipPropertyArrayFilledByConstruct
 {
     /** @var array */
     private $property;

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -127,7 +127,7 @@ final class PropertyFetchAnalyzer
         return $this->isLocalPropertyFetch($node->var);
     }
 
-    public function isFilledByConstructParam(Property $property): bool
+    public function isFilledByConstructParam(Property|PropertyFetch|StaticPropertyFetch $property): bool
     {
         $class = $this->betterNodeFinder->findParentType($property, Class_::class);
         if (! $class instanceof Class_) {
@@ -150,10 +150,17 @@ final class PropertyFetchAnalyzer
         }
 
         /** @var string $propertyName */
-        $propertyName = $this->nodeNameResolver->getName($property->props[0]->name);
-        $kindPropertyFetch = $property->isStatic()
-            ? StaticPropertyFetch::class
-            : PropertyFetch::class;
+        $propertyName = $property instanceof Property
+            ? $this->nodeNameResolver->getName($property->props[0]->name)
+            : $this->nodeNameResolver->getName($property);
+
+        if ($property instanceof Property) {
+            $kindPropertyFetch = $property->isStatic()
+                ? StaticPropertyFetch::class
+                : PropertyFetch::class;
+        } else {
+            $kindPropertyFetch = $property::class;
+        }
 
         return $this->isParamFilledStmts($params, $stmts, $propertyName, $kindPropertyFetch);
     }


### PR DESCRIPTION
Given the following code:

```php
final class SkipPropertyArrayFilledByConstruct
{
    /** @var array */
    private $property;

    public function __construct(array $property)
    {
        $this->property = $property;
    }

    public function run(): int
    {
        return count($this->property);
    }
}
```

It currently produce:

```diff
-        return count($this->property);
+        return count((array) $this->property);
```

which should be skipped.