### PR TITLE
[NodeTypeResolver] Avoid error Uncaught TypeError: PHPStan\Type\Constant\ConstantIntegerType::__construct(): Argument #1 ($value) must be of type int, string given

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php
@@ -36,7 +36,7 @@ final class ScalarTypeResolver implements NodeTypeResolverInterface
         }
 
         if ($node instanceof String_) {
-            return new ConstantStringType($node->value);
+            return new ConstantStringType((string) $node->value);
         }
 
         if ($node instanceof LNumber) {

--- a/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php
@@ -32,7 +32,7 @@ final class ScalarTypeResolver implements NodeTypeResolverInterface
     public function resolve(Node $node): Type
     {
         if ($node instanceof DNumber) {
-            return new ConstantFloatType($node->value);
+            return new ConstantFloatType((float) $node->value);
         }
 
         if ($node instanceof String_) {
@@ -40,7 +40,7 @@ final class ScalarTypeResolver implements NodeTypeResolverInterface
         }
 
         if ($node instanceof LNumber) {
-            return new ConstantIntegerType($node->value);
+            return new ConstantIntegerType((int) $node->value);
         }
 
         if ($node instanceof MagicConst) {


### PR DESCRIPTION
Ensure cast value on passed value to `ConstantFloatType` and `ConstantIntegerType`, and `ConstantStringType` to avoid error like the following:

```bash
PHP Fatal error:  Uncaught TypeError: PHPStan\Type\Constant\ConstantIntegerType::__construct(): Argument #1 ($value) must be of type int, string given, called in /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php on line 41 and defined in phar:///Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/src/Type/Constant/ConstantIntegerType.php:24
Stack trace:
#0 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php(41): PHPStan\Type\Constant\ConstantIntegerType->__construct('1_048_576')
#1 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver.php(365): Rector\NodeTypeResolver\NodeTypeResolver\ScalarTypeResolver->resolve(Object(PhpParser\Node\Scalar\LNumber))
#2 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver.php(186): Rector\NodeTypeResolver\NodeTypeResolver->resolveByNodeTypeResolvers(Object(PhpParser\Node\Scalar\LNumber))
#3 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Rector/AbstractRector.php(324): Rector\NodeTypeResolver\NodeTypeResolver->getType(Object(PhpParser\Node\Scalar\LNumber))
#4 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php(95): Rector\Core\Rector\AbstractRector->getType(Object(PhpParser\Node\Scalar\LNumber))
#5 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php(79): Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector->isStringOrStaticNonNumbericString(Object(PhpParser\Node\Scalar\LNumber))
#6 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Rector/AbstractRector.php(249): Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector->refactor(Object(PhpParser\Node\Expr\BinaryOp\Smaller))
#7 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(113): Rector\Core\Rector\AbstractRector->enterNode(Object(PhpParser\Node\Expr\BinaryOp\Smaller))
#8 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\If_))
#9 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#10 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\ClassMethod))
#11 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#12 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Class_))
#13 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#14 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))
#15 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(85): PhpParser\NodeTraverser->traverseArray(Array)
#16 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/PhpParser/NodeTraverser/RectorNodeTraverser.php(52): PhpParser\NodeTraverser->traverse(Array)
#17 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor.php(49): Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser->traverse(Array)
#18 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(132): Rector\Core\Application\FileProcessor->refactor(Object(Rector\Core\ValueObject\Application\File))
#19 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(144): Rector\Core\Application\FileProcessor\PhpFileProcessor->Rector\Core\Application\FileProcessor\{closure}(Object(Rector\Core\ValueObject\Application\File))
#20 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(133): Rector\Core\Application\FileProcessor\PhpFileProcessor->tryCatchWrapper(Object(Rector\Core\ValueObject\Application\File), Object(Closure), Object(Rector\Core\Enum\ApplicationPhase))
#21 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(91): Rector\Core\Application\FileProcessor\PhpFileProcessor->refactorNodesWithRectors(Object(Rector\Core\ValueObject\Application\File))
#22 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/ApplicationFileProcessor.php(76): Rector\Core\Application\FileProcessor\PhpFileProcessor->process(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#23 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/ApplicationFileProcessor.php(57): Rector\Core\Application\ApplicationFileProcessor->processFiles(Array, Object(Rector\Core\ValueObject\Configuration))
#24 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Console/Command/ProcessCommand.php(152): Rector\Core\Application\ApplicationFileProcessor->run(Array, Object(Rector\Core\ValueObject\Configuration))
#25 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Command/Command.php(274): Rector\Core\Console\Command\ProcessCommand->execute(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#26 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(870): RectorPrefix20211109\Symfony\Component\Console\Command\Command->run(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#27 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(266): RectorPrefix20211109\Symfony\Component\Console\Application->doRunCommand(Object(Rector\Core\Console\Command\ProcessCommand), Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#28 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Console/ConsoleApplication.php(71): RectorPrefix20211109\Symfony\Component\Console\Application->doRun(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#29 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(162): Rector\Core\Console\ConsoleApplication->doRun(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#30 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/bin/rector.php(63): RectorPrefix20211109\Symfony\Component\Console\Application->run()
#31 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/bin/rector(5): require_once('/Users/samsonas...')
#32 {main}
  thrown in phar:///Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/src/Type/Constant/ConstantIntegerType.php on line 24

Fatal error: Uncaught TypeError: PHPStan\Type\Constant\ConstantIntegerType::__construct(): Argument #1 ($value) must be of type int, string given, called in /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php on line 41 and defined in phar:///Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/src/Type/Constant/ConstantIntegerType.php:24
Stack trace:
#0 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php(41): PHPStan\Type\Constant\ConstantIntegerType->__construct('1_048_576')
#1 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver.php(365): Rector\NodeTypeResolver\NodeTypeResolver\ScalarTypeResolver->resolve(Object(PhpParser\Node\Scalar\LNumber))
#2 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver.php(186): Rector\NodeTypeResolver\NodeTypeResolver->resolveByNodeTypeResolvers(Object(PhpParser\Node\Scalar\LNumber))
#3 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Rector/AbstractRector.php(324): Rector\NodeTypeResolver\NodeTypeResolver->getType(Object(PhpParser\Node\Scalar\LNumber))
#4 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php(95): Rector\Core\Rector\AbstractRector->getType(Object(PhpParser\Node\Scalar\LNumber))
#5 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php(79): Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector->isStringOrStaticNonNumbericString(Object(PhpParser\Node\Scalar\LNumber))
#6 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Rector/AbstractRector.php(249): Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector->refactor(Object(PhpParser\Node\Expr\BinaryOp\Smaller))
#7 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(113): Rector\Core\Rector\AbstractRector->enterNode(Object(PhpParser\Node\Expr\BinaryOp\Smaller))
#8 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\If_))
#9 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#10 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\ClassMethod))
#11 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#12 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Class_))
#13 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#14 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))
#15 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(85): PhpParser\NodeTraverser->traverseArray(Array)
#16 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/PhpParser/NodeTraverser/RectorNodeTraverser.php(52): PhpParser\NodeTraverser->traverse(Array)
#17 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor.php(49): Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser->traverse(Array)
#18 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(132): Rector\Core\Application\FileProcessor->refactor(Object(Rector\Core\ValueObject\Application\File))
#19 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(144): Rector\Core\Application\FileProcessor\PhpFileProcessor->Rector\Core\Application\FileProcessor\{closure}(Object(Rector\Core\ValueObject\Application\File))
#20 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(133): Rector\Core\Application\FileProcessor\PhpFileProcessor->tryCatchWrapper(Object(Rector\Core\ValueObject\Application\File), Object(Closure), Object(Rector\Core\Enum\ApplicationPhase))
#21 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(91): Rector\Core\Application\FileProcessor\PhpFileProcessor->refactorNodesWithRectors(Object(Rector\Core\ValueObject\Application\File))
#22 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/ApplicationFileProcessor.php(76): Rector\Core\Application\FileProcessor\PhpFileProcessor->process(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#23 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/ApplicationFileProcessor.php(57): Rector\Core\Application\ApplicationFileProcessor->processFiles(Array, Object(Rector\Core\ValueObject\Configuration))
#24 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Console/Command/ProcessCommand.php(152): Rector\Core\Application\ApplicationFileProcessor->run(Array, Object(Rector\Core\ValueObject\Configuration))
#25 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Command/Command.php(274): Rector\Core\Console\Command\ProcessCommand->execute(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#26 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(870): RectorPrefix20211109\Symfony\Component\Console\Command\Command->run(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#27 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(266): RectorPrefix20211109\Symfony\Component\Console\Application->doRunCommand(Object(Rector\Core\Console\Command\ProcessCommand), Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#28 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Console/ConsoleApplication.php(71): RectorPrefix20211109\Symfony\Component\Console\Application->doRun(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#29 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(162): Rector\Core\Console\ConsoleApplication->doRun(Object(RectorPrefix20211109\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211109\Symfony\Component\Console\Output\ConsoleOutput))
#30 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/bin/rector.php(63): RectorPrefix20211109\Symfony\Component\Console\Application->run()
#31 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/bin/rector(5): require_once('/Users/samsonas...')
#32 {main}
  thrown in phar:///Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/src/Type/Constant/ConstantIntegerType.php on line 24
```

I can't reproduce via unit test but casting seems fix it.