### PR TITLE
[DeadCode] Skip clone and new self on RemoveUnusedPrivatePropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/sip_new_same_classname_usage.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/sip_new_same_classname_usage.php.inc
@@ -13,7 +13,7 @@ class SkipNewSameClassNameUsage
 
     public function run($var)
     {
-        $obj = new SkipCloneSelf($var);
+        $obj = new SkipNewSameClassNameUsage($var);
         echo $obj->var;
     }
 }

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/sip_new_same_classname_usage.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/sip_new_same_classname_usage.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
 
-class SkipCloneSelf
+class SkipNewSameClassNameUsage
 {
     private $var;
 
@@ -11,19 +11,7 @@ class SkipCloneSelf
         $this->var = $var;
     }
 
-    public function run()
-    {
-        $obj = clone $this;
-        echo $obj->var;
-    }
-
-    public function run2($var)
-    {
-        $obj = new self($var);
-        echo $obj->var;
-    }
-
-    public function run3($var)
+    public function run($var)
     {
         $obj = new SkipCloneSelf($var);
         echo $obj->var;

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_clone_self.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_clone_self.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+class SkipCloneSelf
+{
+    private $var;
+
+    public function __construct($var)
+    {
+        $this->var = $var;
+    }
+
+    public function run()
+    {
+        $obj = clone $this;
+        echo $obj->var;
+    }
+
+    public function run2($var)
+    {
+        $obj = new self($var);
+        echo $obj->var;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_clone_self.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_clone_self.php.inc
@@ -22,4 +22,10 @@ class SkipCloneSelf
         $obj = new self($var);
         echo $obj->var;
     }
+
+    public function run3($var)
+    {
+        $obj = new SkipCloneSelf($var);
+        echo $obj->var;
+    }
 }

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_clone_usage.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_clone_usage.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+class SkipCloneUsage
+{
+    private $var;
+
+    public function __construct($var)
+    {
+        $this->var = $var;
+    }
+
+    public function run()
+    {
+        $obj = clone $this;
+        echo $obj->var;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_new_self_usage.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_new_self_usage.php.inc
@@ -5,15 +5,18 @@ namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRecto
 class SkipNewSelfUsage
 {
     private $var;
+    private static $var2;
 
-    public function __construct($var)
+    public function __construct($var, $var2)
     {
         $this->var = $var;
+        self::$var2 = $var2;
     }
 
-    public function run($var)
+    public function run()
     {
-        $obj = new self($var);
+        $obj = new self('a', 'b');
         echo $obj->var;
+        echo $obj::$var2;
     }
 }

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_new_self_usage.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_new_self_usage.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+class SkipNewSelfUsage
+{
+    private $var;
+
+    public function __construct($var)
+    {
+        $this->var = $var;
+    }
+
+    public function run($var)
+    {
+        $obj = new self($var);
+        echo $obj->var;
+    }
+}

--- a/rules/Removing/NodeAnalyzer/ForbiddenPropertyRemovalAnalyzer.php
+++ b/rules/Removing/NodeAnalyzer/ForbiddenPropertyRemovalAnalyzer.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Removing\NodeAnalyzer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Clone_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Stmt\ClassLike;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
+use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
+use Rector\Core\PhpParser\Comparing\NodeComparator;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+
+final class ForbiddenPropertyRemovalAnalyzer
+{
+    public function __construct(
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeComparator $nodeComparator,
+        private NodeNameResolver $nodeNameResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer
+    ) {
+    }
+
+    public function isForbiddenInNewCurrentClassNameSelfClone(string $propertyName, ?ClassLike $classLike): bool
+    {
+        if (! $classLike instanceof ClassLike) {
+            return false;
+        }
+
+        $methods = $classLike->getMethods();
+        foreach ($methods as $method) {
+            $isInNewCurrentClassNameSelfClone = (bool) $this->betterNodeFinder->findFirst(
+                (array) $method->getStmts(),
+                function (Node $subNode) use ($classLike, $propertyName): bool {
+                    if ($subNode instanceof New_) {
+                        return $this->isPropertyNameUsedAfterNewOrClone($subNode, $classLike, $propertyName);
+                    }
+
+                    if ($subNode instanceof Clone_) {
+                        return $this->isPropertyNameUsedAfterNewOrClone($subNode, $classLike, $propertyName);
+                    }
+
+                    return false;
+                }
+            );
+
+            if ($isInNewCurrentClassNameSelfClone) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isPropertyNameUsedAfterNewOrClone(
+        New_|Clone_ $expr,
+        ClassLike $classLike,
+        string $propertyName
+    ): bool {
+        $parentAssign = $this->betterNodeFinder->findParentType($expr, Assign::class);
+        if (! $parentAssign instanceof Assign) {
+            return false;
+        }
+
+        $className = (string) $this->nodeNameResolver->getName($classLike);
+        $type = $expr instanceof New_
+            ? $this->nodeTypeResolver->getType($expr->class)
+            : $this->nodeTypeResolver->getType($expr->expr);
+
+        if ($expr instanceof Clone_ && $type instanceof ThisType) {
+            $type = $type->getStaticObjectType();
+        }
+
+        if ($type instanceof ObjectType) {
+            return $this->isFoundAfterCloneOrNew($type, $expr, $parentAssign, $className, $propertyName);
+        }
+
+        return false;
+    }
+
+    private function isFoundAfterCloneOrNew(
+        ObjectType $objectType,
+        Clone_|New_ $expr,
+        Assign $parentAssign,
+        string $className,
+        string $propertyName
+    ): bool {
+        if ($objectType->getClassName() !== $className) {
+            return false;
+        }
+
+        return (bool) $this->betterNodeFinder->findFirstNext($expr, function (Node $subNode) use (
+            $parentAssign,
+            $propertyName
+        ): bool {
+            if (! $this->propertyFetchAnalyzer->isPropertyFetch($subNode)) {
+                return false;
+            }
+
+            /** @var PropertyFetch|StaticPropertyFetch $subNode */
+            $propertyFetchName = (string) $this->nodeNameResolver->getName($subNode);
+            if ($subNode instanceof PropertyFetch) {
+                if (! $this->nodeComparator->areNodesEqual($subNode->var, $parentAssign->var)) {
+                    return false;
+                }
+
+                return $propertyFetchName === $propertyName;
+            }
+
+            if (! $this->nodeComparator->areNodesEqual($subNode->class, $parentAssign->var)) {
+                return false;
+            }
+
+            return $propertyFetchName === $propertyName;
+        });
+    }
+}

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -6,8 +6,6 @@ namespace Rector\Removing\NodeManipulator;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Clone_;
-use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Param;
@@ -15,9 +13,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\ThisType;
-use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
@@ -26,7 +21,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeRemoval\AssignRemover;
 use Rector\NodeRemoval\NodeRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\Removing\NodeAnalyzer\ForbiddenPropertyRemovalAnalyzer;
 
 final class ComplexNodeRemover
 {
@@ -37,8 +32,7 @@ final class ComplexNodeRemover
         private BetterNodeFinder $betterNodeFinder,
         private NodeRemover $nodeRemover,
         private NodeComparator $nodeComparator,
-        private NodeTypeResolver $nodeTypeResolver,
-        private PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private ForbiddenPropertyRemovalAnalyzer $forbiddenPropertyRemovalAnalyzer
     ) {
     }
 
@@ -86,100 +80,6 @@ final class ComplexNodeRemover
         }
     }
 
-    private function isPropertyNameInNewCurrentClassNameSelfClone(string $propertyName, ?ClassLike $classLike): bool
-    {
-        if (! $classLike instanceof ClassLike) {
-            return false;
-        }
-
-        $methods = $classLike->getMethods();
-        foreach ($methods as $method) {
-            $isInNewCurrentClassNameSelfClone = (bool) $this->betterNodeFinder->findFirst(
-                (array) $method->getStmts(),
-                function (Node $subNode) use ($classLike, $propertyName): bool {
-                    if ($subNode instanceof New_) {
-                        return $this->isPropertyNameUsedAfterNewOrClone($subNode, $classLike, $propertyName);
-                    }
-
-                    if ($subNode instanceof Clone_) {
-                        return $this->isPropertyNameUsedAfterNewOrClone($subNode, $classLike, $propertyName);
-                    }
-
-                    return false;
-                }
-            );
-
-            if ($isInNewCurrentClassNameSelfClone) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isFoundAfterCloneOrNew(
-        ObjectType $objectType,
-        Clone_|New_ $expr,
-        Assign $parentAssign,
-        string $className,
-        string $propertyName
-    ): bool {
-        if ($objectType->getClassName() !== $className) {
-            return false;
-        }
-
-        return (bool) $this->betterNodeFinder->findFirstNext($expr, function (Node $subNode) use (
-            $parentAssign,
-            $propertyName
-        ): bool {
-            if (! $this->propertyFetchAnalyzer->isPropertyFetch($subNode)) {
-                return false;
-            }
-
-            /** @var PropertyFetch|StaticPropertyFetch $subNode */
-            $propertyFetchName = (string) $this->nodeNameResolver->getName($subNode);
-            if ($subNode instanceof PropertyFetch) {
-                if (! $this->nodeComparator->areNodesEqual($subNode->var, $parentAssign->var)) {
-                    return false;
-                }
-
-                return $propertyFetchName === $propertyName;
-            }
-
-            if (! $this->nodeComparator->areNodesEqual($subNode->class, $parentAssign->var)) {
-                return false;
-            }
-
-            return $propertyFetchName === $propertyName;
-        });
-    }
-
-    private function isPropertyNameUsedAfterNewOrClone(
-        New_|Clone_ $expr,
-        ClassLike $classLike,
-        string $propertyName
-    ): bool {
-        $parentAssign = $this->betterNodeFinder->findParentType($expr, Assign::class);
-        if (! $parentAssign instanceof Assign) {
-            return false;
-        }
-
-        $className = (string) $this->nodeNameResolver->getName($classLike);
-        $type = $expr instanceof New_
-            ? $this->nodeTypeResolver->getType($expr->class)
-            : $this->nodeTypeResolver->getType($expr->expr);
-
-        if ($expr instanceof Clone_ && $type instanceof ThisType) {
-            $type = $type->getStaticObjectType();
-        }
-
-        if ($type instanceof ObjectType) {
-            return $this->isFoundAfterCloneOrNew($type, $expr, $parentAssign, $className, $propertyName);
-        }
-
-        return false;
-    }
-
     /**
      * @param string[] $classMethodNamesToSkip
      */
@@ -220,7 +120,10 @@ final class ComplexNodeRemover
         $classLike = $this->betterNodeFinder->findParentType($expr, ClassLike::class);
         $propertyName = (string) $this->nodeNameResolver->getName($expr);
 
-        if ($this->isPropertyNameInNewCurrentClassNameSelfClone($propertyName, $classLike)) {
+        if ($this->forbiddenPropertyRemovalAnalyzer->isForbiddenInNewCurrentClassNameSelfClone(
+            $propertyName,
+            $classLike
+        )) {
             return null;
         }
 

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -183,10 +183,6 @@ final class ComplexNodeRemover
             $type = $type->getStaticObjectType();
         }
 
-        if (! $expr instanceof Clone_) {
-            return $this->isFoundAfterCloneOrNew($type, $expr, $parentAssign, $className, $propertyName);
-        }
-
         if ($type instanceof ObjectType) {
             return $this->isFoundAfterCloneOrNew($type, $expr, $parentAssign, $className, $propertyName);
         }

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -124,16 +124,12 @@ final class ComplexNodeRemover
     }
 
     private function isFoundAfterCloneOrNew(
-        Type $type,
+        ObjectType $type,
         Clone_|New_ $expr,
         Assign $parentAssign,
         string $className,
         string $propertyName
     ): bool {
-        if (! $type instanceof ObjectType) {
-            return false;
-        }
-
         if ($type->getClassName() !== $className) {
             return false;
         }

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -331,14 +331,7 @@ final class ComplexNodeRemover
 
     private function isExpressionVariableNotAssign(Node $node): bool
     {
-        if ($node !== null) {
-            $expressionVariable = $node->getAttribute(AttributeKey::PARENT_NODE);
-
-            if (! $expressionVariable instanceof Assign) {
-                return true;
-            }
-        }
-
-        return false;
+        $expressionVariable = $node->getAttribute(AttributeKey::PARENT_NODE);
+        return ! $expressionVariable instanceof Assign;
     }
 }

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -30,7 +30,6 @@ use Rector\NodeRemoval\AssignRemover;
 use Rector\NodeRemoval\NodeRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
-use Rector\PostRector\Collector\NodesToRemoveCollector;
 
 final class ComplexNodeRemover
 {
@@ -40,7 +39,6 @@ final class ComplexNodeRemover
         private NodeNameResolver $nodeNameResolver,
         private BetterNodeFinder $betterNodeFinder,
         private NodeRemover $nodeRemover,
-        private NodesToRemoveCollector $nodesToRemoveCollector,
         private NodeComparator $nodeComparator,
         private CallAnalyzer $callAnalyzer,
         private NodeTypeResolver $nodeTypeResolver,
@@ -71,22 +69,10 @@ final class ComplexNodeRemover
             $assigns[] = $assign;
         }
 
-        $this->processRemovePropertyAssigns($property, $assigns);
+        $this->processRemovePropertyAssigns($assigns);
 
         if ($shouldKeepProperty) {
             return;
-        }
-
-        // remove __construct param
-
-        /** @var Property $property */
-        $this->nodeRemover->removeNode($property);
-
-        foreach ($property->props as $prop) {
-            if (! $this->nodesToRemoveCollector->isNodeRemoved($prop)) {
-                // if the property has at least one node left -> return
-                return;
-            }
         }
 
         $this->nodeRemover->removeNode($property);
@@ -95,7 +81,7 @@ final class ComplexNodeRemover
     /**
      * @param Assign[] $assigns
      */
-    private function processRemovePropertyAssigns(Property $property, array $assigns): void
+    private function processRemovePropertyAssigns(array $assigns): void
     {
         foreach ($assigns as $assign) {
             // remove assigns


### PR DESCRIPTION
Given the following code:

```php
class SkipCloneSelf
{
    private $var;

    public function __construct($var)
    {
        $this->var = $var;
    }

    public function run()
    {
        $obj = clone $this;
        echo $obj->var;
    }

    public function run2($var)
    {
        $obj = new self($var);
        echo $obj->var;
    }
}
```

It produce:

```diff
-    private $var;
-
-    public function __construct($var)
+    public function __construct()
     {
-        $this->var = $var;
     }
```

which should be skipped, ref https://3v4l.org/jjNe3