### PR TITLE
[DeadCode][TypeDeclaration] Handle Nullable Param on RemoveUnusedPrivateMethodParameterRector+RemoveUnreachableStatementRector+AddArrayParamDocTypeRector

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -48,6 +48,7 @@ use Rector\NodeTypeResolver\NodeTypeCorrector\GenericClassStringTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeCorrector\HasOffsetTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeResolver\IdentifierTypeResolver;
 use Rector\NodeTypeResolver\TypeAnalyzer\ArrayTypeAnalyzer;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\TypeDeclaration\PHPStan\Type\ObjectTypeSpecifier;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -142,6 +143,10 @@ final class NodeTypeResolver
     {
         if ($node instanceof NullableType) {
             $type = $this->getType($node->type);
+            if ($type instanceof ObjectType && ! $type instanceof FullyQualifiedObjectType) {
+                return new MixedType();
+            }
+
             if (! $type instanceof MixedType) {
                 return new UnionType([$type, new NullType()]);
             }

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PhpParser\Node\Scalar;
@@ -141,12 +142,12 @@ final class NodeTypeResolver
 
     public function getType(Node $node): Type
     {
+        if ($node instanceof Name && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
+            $node = new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME));
+        }
+
         if ($node instanceof NullableType) {
             $type = $this->getType($node->type);
-            if ($type instanceof ObjectType && ! $type instanceof FullyQualifiedObjectType) {
-                return new MixedType();
-            }
-
             if (! $type instanceof MixedType) {
                 return new UnionType([$type, new NullType()]);
             }

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -49,7 +49,6 @@ use Rector\NodeTypeResolver\NodeTypeCorrector\GenericClassStringTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeCorrector\HasOffsetTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeResolver\IdentifierTypeResolver;
 use Rector\NodeTypeResolver\TypeAnalyzer\ArrayTypeAnalyzer;
-use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\TypeDeclaration\PHPStan\Type\ObjectTypeSpecifier;
 use Symfony\Contracts\Service\Attribute\Required;

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -141,11 +141,11 @@ final class NodeTypeResolver
 
     public function getType(Node $node): Type
     {
-        if ($node instanceof Name && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
-            $node = new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME));
-        }
-
         if ($node instanceof NullableType) {
+            if ($node->type instanceof Name && $node->type->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
+                $node->type = new FullyQualified($node->type->getAttribute(AttributeKey::NAMESPACED_NAME));
+            }
+
             $type = $this->getType($node->type);
             if (! $type instanceof MixedType) {
                 return new UnionType([$type, new NullType()]);

--- a/tests/Issues/NullableParamNamespaced/Fixture/do_not_add_short_fqcn_class_name_docblock_nullable.php.inc
+++ b/tests/Issues/NullableParamNamespaced/Fixture/do_not_add_short_fqcn_class_name_docblock_nullable.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Core\Tests\Issues\NullableParamNamespaced\Fixture;
 
 use PhpParser\Node\Stmt\ClassLike;
 
-class Fixture
+class DoNotAddShortFQCNClassNameDocblockNullable
 {
     public function run(?ClassLike $classLike): bool
     {
@@ -29,7 +29,7 @@ namespace Rector\Core\Tests\Issues\NullableParamNamespaced\Fixture;
 
 use PhpParser\Node\Stmt\ClassLike;
 
-class Fixture
+class DoNotAddShortFQCNClassNameDocblockNullable
 {
     public function run(?ClassLike $classLike): bool
     {

--- a/tests/Issues/NullableParamNamespaced/Fixture/fixture.php.inc
+++ b/tests/Issues/NullableParamNamespaced/Fixture/fixture.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\NullableParamNamespaced\Fixture;
+
+use PhpParser\Node\Stmt\ClassLike;
+
+class Fixture
+{
+    public function run(?ClassLike $classLike): bool
+    {
+        if (! $classLike instanceof ClassLike) {
+            return false;
+        }
+
+        return $this->callPrivateMethod($classLike, true);
+    }
+
+    private function callPrivateMethod(ClassLike $classLike, bool $value)
+    {
+        return $classLike->getMethods() !== [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\NullableParamNamespaced\Fixture;
+
+use PhpParser\Node\Stmt\ClassLike;
+
+class Fixture
+{
+    public function run(?ClassLike $classLike): bool
+    {
+        if (! $classLike instanceof ClassLike) {
+            return false;
+        }
+
+        return $this->callPrivateMethod($classLike, true);
+    }
+
+    private function callPrivateMethod(ClassLike $classLike)
+    {
+        return $classLike->getMethods() !== [];
+    }
+}
+
+?>

--- a/tests/Issues/NullableParamNamespaced/NullableParamNamespacedTest.php
+++ b/tests/Issues/NullableParamNamespaced/NullableParamNamespacedTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\NullableParamNamespaced;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class NullableParamNamespacedTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/NullableParamNamespaced/config/configured_rule.php
+++ b/tests/Issues/NullableParamNamespaced/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
+use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddArrayParamDocTypeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(AddArrayParamDocTypeRector::class);
+    $services->set(RemoveUnusedPrivateMethodParameterRector::class);
+    $services->set(RemoveUnreachableStatementRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+};


### PR DESCRIPTION
Given the following code:

```php
use PhpParser\Node\Stmt\ClassLike;

class Fixture
{
    public function run(?ClassLike $classLike): bool
    {
        if (! $classLike instanceof ClassLike) {
            return false;
        }

        return $this->callPrivateMethod($classLike, true);
    }

    private function callPrivateMethod(ClassLike $classLike, bool $value)
    {
        return $classLike->getMethods() !== [];
    }
}
```

It produce addition docblock:

```diff
+    /**
+     * @param \ClassLike|null $classLike
+     */
```

while removing unused parameter in private method. The Param itself is invalid as there is no `\ClassLike` class, but `PhpParser\Node\Stmt\ClassLike` which imported in use statement.

Applied rules:

```php
Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
Rector\TypeDeclaration\Rector\ClassMethod\AddArrayParamDocTypeRector;
```