### PR TITLE
fix: ignore specified words while making it singularized

### DIFF
--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -105,7 +105,13 @@ final class InflectorSingularResolver
 
         $resolvedName = '';
         foreach ($camelCases as $camelCase) {
-            $resolvedName .= $this->inflector->singularize($camelCase['camelcase']);
+            $value = $this->inflector->singularize($camelCase['camelcase']);
+
+            if (in_array($camelCase['camelcase'], ['is', 'has'])) {
+                $value = $camelCase['camelcase'];
+            }
+
+            $resolvedName .= $value;
         }
 
         return $resolvedName;

--- a/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
+++ b/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
@@ -39,5 +39,6 @@ final class InflectorSingularResolverTest extends AbstractTestCase
         // news and plural
         yield ['staticCallsToNews', 'staticCallToNew'];
         yield ['newsToMethodCalls', 'newToMethodCall'];
+        yield ['hasFilters', 'hasFilter'];
     }
 }


### PR DESCRIPTION
Ref. https://github.com/rectorphp/rector/issues/6796

I don't know if it's the right way, but we should skip some specific keywords like `is`, `has`, etc. while inflecting it as a singular.