### PR TITLE
[Php71] Skip with If always array on CountOnNullRector

### DIFF
--- a/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_with_if_always_array.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_with_if_always_array.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\FuncCall\CountOnNullRector\Fixture;
+
+final class SkipWithIfAlwaysArray
+{
+    public function run($a, $b)
+    {
+        $data = [];
+        if (! $a) {
+            $data[] = $b;
+        }
+
+        $data[] = count($data) !== 0 ? 'a' : 'b';
+    }
+}

--- a/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/type_changed_on_if.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/type_changed_on_if.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\FuncCall\CountOnNullRector\Fixture;
+
+final class TypeChangedOnIf
+{
+    public function run($a, $b)
+    {
+        $data = [];
+        if (! $a) {
+            $data = new \stdClass;
+        }
+
+        $data[] = count($data) !== 0 ? 'a' : 'b';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php71\Rector\FuncCall\CountOnNullRector\Fixture;
+
+final class TypeChangedOnIf
+{
+    public function run($a, $b)
+    {
+        $data = [];
+        if (! $a) {
+            $data = new \stdClass;
+        }
+
+        $data[] = (is_array($data) || $data instanceof \Countable ? count($data) : 0) !== 0 ? 'a' : 'b';
+    }
+}
+
+?>

--- a/rules/Php71/Rector/FuncCall/CountOnNullRector.php
+++ b/rules/Php71/Rector/FuncCall/CountOnNullRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
 
         $countedType = $this->getType($countedNode);
 
-        if ($countedType instanceof UnionType && $this->isAlwaysArrayType($countedType)) {
+        if ($countedType instanceof UnionType && $this->isAlwaysIterableType($countedType)) {
             return null;
         }
 
@@ -139,7 +139,7 @@ CODE_SAMPLE
         return new Ternary($conditionNode, $node, new LNumber(0));
     }
 
-    private function isAlwaysArrayType(UnionType $unionType): bool
+    private function isAlwaysIterableType(UnionType $unionType): bool
     {
         $types = $unionType->getTypes();
 

--- a/rules/Php71/Rector/FuncCall/CountOnNullRector.php
+++ b/rules/Php71/Rector/FuncCall/CountOnNullRector.php
@@ -21,7 +21,6 @@ use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\UnionType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -145,7 +144,7 @@ CODE_SAMPLE
         $types = $unionType->getTypes();
 
         foreach ($types as $type) {
-            if (! $type instanceof ConstantArrayType) {
+            if ($type->isIterable()->no()) {
                 return false;
             }
         }

--- a/rules/Php71/Rector/FuncCall/CountOnNullRector.php
+++ b/rules/Php71/Rector/FuncCall/CountOnNullRector.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -111,7 +112,7 @@ CODE_SAMPLE
 
         $countedType = $this->getType($countedNode);
 
-        if ($countedType instanceof UnionType && $this->isAlwaysIterableType($countedType)) {
+        if ($this->isAlwaysIterableType($countedType)) {
             return null;
         }
 
@@ -139,9 +140,13 @@ CODE_SAMPLE
         return new Ternary($conditionNode, $node, new LNumber(0));
     }
 
-    private function isAlwaysIterableType(UnionType $unionType): bool
+    private function isAlwaysIterableType(Type $possibleUnionType): bool
     {
-        $types = $unionType->getTypes();
+        if (! $possibleUnionType instanceof UnionType) {
+            return false;
+        }
+
+        $types = $possibleUnionType->getTypes();
 
         foreach ($types as $type) {
             if ($type->isIterable()->no()) {


### PR DESCRIPTION
Given the following code:

```php
final class SkipWithIfAlwaysArray
{
    public function run($a, $b)
    {
        $data = [];
        if (! $a) {
            $data[] = $b;
        }

        $data[] = count($data) !== 0 ? 'a' : 'b';
    }
}
```

Currently produce:

```diff
+        $data[] = (is_array($data) || $data instanceof \Countable ? count($data) : 0) !== 0 ? 'a' : 'b';
```

which should be askipped as always array.