### PR TITLE
[PostRector][CodingStyle] Improve Auto import performance

### DIFF
--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -39,17 +39,15 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
     public function addUseImport(FullyQualifiedObjectType | AliasedObjectType $objectType): void
     {
         $file = $this->currentFileProvider->getFile();
-        $smartFileInfo = $file->getSmartFileInfo();
 
-        $this->useImportTypesInFilePath[$smartFileInfo->getRealPath()][] = $objectType;
+        $this->useImportTypesInFilePath[$file->getFilePath()][] = $objectType;
     }
 
     public function addFunctionUseImport(FullyQualifiedObjectType $fullyQualifiedObjectType): void
     {
         $file = $this->currentFileProvider->getFile();
-        $smartFileInfo = $file->getSmartFileInfo();
 
-        $this->functionUseImportTypesInFilePath[$smartFileInfo->getRealPath()][] = $fullyQualifiedObjectType;
+        $this->functionUseImportTypesInFilePath[$file->getFilePath()][] = $fullyQualifiedObjectType;
     }
 
     /**
@@ -57,9 +55,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
      */
     public function getUseImportTypesByNode(File $file, Node $node): array
     {
-        $fileInfo = $file->getSmartFileInfo();
-        $filePath = $fileInfo->getRealPath();
-
+        $filePath = $file->getFilePath();
         $objectTypes = $this->useImportTypesInFilePath[$filePath] ?? [];
 
         /** @var Use_[] $useNodes */
@@ -92,9 +88,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
 
     public function isShortImported(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType): bool
     {
-        $fileInfo = $file->getSmartFileInfo();
-        $filePath = $fileInfo->getRealPath();
-
+        $filePath = $file->getFilePath();
         $shortName = $fullyQualifiedObjectType->getShortName();
 
         if ($this->isShortClassImported($file, $shortName)) {
@@ -113,8 +107,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
 
     public function isImportShortable(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType): bool
     {
-        $fileInfo = $file->getSmartFileInfo();
-        $filePath = $fileInfo->getRealPath();
+        $filePath = $file->getFilePath();
 
         $fileUseImportTypes = $this->useImportTypesInFilePath[$filePath] ?? [];
 
@@ -152,8 +145,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
 
     private function isShortClassImported(File $file, string $shortName): bool
     {
-        $fileInfo = $file->getSmartFileInfo();
-        $realPath = $fileInfo->getRealPath();
+        $realPath = $file->getFilePath();
 
         $fileUseImports = $this->useImportTypesInFilePath[$realPath] ?? [];
 

--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -38,6 +38,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
 
     public function addUseImport(FullyQualifiedObjectType | AliasedObjectType $objectType): void
     {
+        /** @var File $file */
         $file = $this->currentFileProvider->getFile();
 
         $this->useImportTypesInFilePath[$file->getFilePath()][] = $objectType;
@@ -45,6 +46,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
 
     public function addFunctionUseImport(FullyQualifiedObjectType $fullyQualifiedObjectType): void
     {
+        /** @var File $file */
         $file = $this->currentFileProvider->getFile();
 
         $this->functionUseImportTypesInFilePath[$file->getFilePath()][] = $fullyQualifiedObjectType;

--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -89,12 +89,12 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
     public function isShortImported(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType): bool
     {
         $shortName = $fullyQualifiedObjectType->getShortName();
+        $filePath = $file->getFilePath();
 
-        if ($this->isShortClassImported($file, $shortName)) {
+        if ($this->isShortClassImported($filePath, $shortName)) {
             return true;
         }
 
-        $filePath = $file->getFilePath();
         $fileFunctionUseImportTypes = $this->functionUseImportTypesInFilePath[$filePath] ?? [];
 
         foreach ($fileFunctionUseImportTypes as $fileFunctionUseImportType) {
@@ -143,10 +143,9 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
         return $this->functionUseImportTypesInFilePath[$smartFileInfo->getRealPath()] ?? [];
     }
 
-    private function isShortClassImported(File $file, string $shortName): bool
+    private function isShortClassImported(string $filePath, string $shortName): bool
     {
-        $realPath = $file->getFilePath();
-        $fileUseImports = $this->useImportTypesInFilePath[$realPath] ?? [];
+        $fileUseImports = $this->useImportTypesInFilePath[$filePath] ?? [];
 
         foreach ($fileUseImports as $fileUseImport) {
             if ($fileUseImport->getShortName() === $shortName) {

--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -88,14 +88,15 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
 
     public function isShortImported(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType): bool
     {
-        $filePath = $file->getFilePath();
         $shortName = $fullyQualifiedObjectType->getShortName();
 
         if ($this->isShortClassImported($file, $shortName)) {
             return true;
         }
 
+        $filePath = $file->getFilePath();
         $fileFunctionUseImportTypes = $this->functionUseImportTypesInFilePath[$filePath] ?? [];
+
         foreach ($fileFunctionUseImportTypes as $fileFunctionUseImportType) {
             if ($fileFunctionUseImportType->getShortName() === $shortName) {
                 return true;
@@ -108,7 +109,6 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
     public function isImportShortable(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType): bool
     {
         $filePath = $file->getFilePath();
-
         $fileUseImportTypes = $this->useImportTypesInFilePath[$filePath] ?? [];
 
         foreach ($fileUseImportTypes as $fileUseImportType) {
@@ -146,7 +146,6 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
     private function isShortClassImported(File $file, string $shortName): bool
     {
         $realPath = $file->getFilePath();
-
         $fileUseImports = $this->useImportTypesInFilePath[$realPath] ?? [];
 
         foreach ($fileUseImports as $fileUseImport) {

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -41,24 +41,19 @@ final class NameImportingPostRector extends AbstractPostRector
         }
 
         $file = $this->currentFileProvider->getFile();
+        if (! $file instanceof File) {
+            return null;
+        }
+
+        if (! $this->shouldApply($file)) {
+            return null;
+        }
 
         if ($node instanceof Name) {
-            if (! $file instanceof File) {
-                return null;
-            }
-
-            if (! $this->shouldApply($file)) {
-                return null;
-            }
-
             return $this->processNodeName($node, $file);
         }
 
         if (! $this->parameterProvider->provideBoolParameter(Option::IMPORT_DOC_BLOCKS)) {
-            return null;
-        }
-
-        if ($file instanceof File && ! $this->shouldApply($file)) {
             return null;
         }
 

--- a/packages/StaticTypeMapper/ValueObject/Type/FullyQualifiedObjectType.php
+++ b/packages/StaticTypeMapper/ValueObject/Type/FullyQualifiedObjectType.php
@@ -26,11 +26,12 @@ final class FullyQualifiedObjectType extends ObjectType
 
     public function getShortName(): string
     {
-        if (! \str_contains($this->getClassName(), '\\')) {
-            return $this->getClassName();
+        $className = $this->getClassName();
+        if (! \str_contains($className, '\\')) {
+            return $className;
         }
 
-        return (string) Strings::after($this->getClassName(), '\\', -1);
+        return (string) Strings::after($className, '\\', -1);
     }
 
     public function getShortNameNode(): Name

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
@@ -29,13 +29,13 @@ final class AliasClassNameImportSkipVoter implements ClassNameImportSkipVoterInt
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
         $aliasedUses = $this->aliasUsesResolver->resolveFromNode($node);
-        $loweredShortNameFullyQualified = $fullyQualifiedObjectType->getShortNameLowered();
+        $shortNameLowered = $fullyQualifiedObjectType->getShortNameLowered();
 
         foreach ($aliasedUses as $aliasedUse) {
             $aliasedUseLowered = strtolower($aliasedUse);
 
             // its aliased, we cannot just rename it
-            if (\str_ends_with($aliasedUseLowered, '\\' . $loweredShortNameFullyQualified)) {
+            if (\str_ends_with($aliasedUseLowered, '\\' . $shortNameLowered)) {
                 return true;
             }
         }

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
@@ -29,12 +29,13 @@ final class AliasClassNameImportSkipVoter implements ClassNameImportSkipVoterInt
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
         $aliasedUses = $this->aliasUsesResolver->resolveFromNode($node);
+        $loweredShortNameFullyQualifiedObjectType = $fullyQualifiedObjectType->getShortNameLowered();
 
         foreach ($aliasedUses as $aliasedUse) {
             $aliasedUseLowered = strtolower($aliasedUse);
 
             // its aliased, we cannot just rename it
-            if (\str_ends_with($aliasedUseLowered, '\\' . $fullyQualifiedObjectType->getShortNameLowered())) {
+            if (\str_ends_with($aliasedUseLowered, '\\' . $loweredShortNameFullyQualifiedObjectType)) {
                 return true;
             }
         }

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
@@ -29,13 +29,13 @@ final class AliasClassNameImportSkipVoter implements ClassNameImportSkipVoterInt
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
         $aliasedUses = $this->aliasUsesResolver->resolveFromNode($node);
-        $loweredShortNameFullyQualifiedObjectType = $fullyQualifiedObjectType->getShortNameLowered();
+        $loweredShortNameFullyQualified = $fullyQualifiedObjectType->getShortNameLowered();
 
         foreach ($aliasedUses as $aliasedUse) {
             $aliasedUseLowered = strtolower($aliasedUse);
 
             // its aliased, we cannot just rename it
-            if (\str_ends_with($aliasedUseLowered, '\\' . $loweredShortNameFullyQualifiedObjectType)) {
+            if (\str_ends_with($aliasedUseLowered, '\\' . $loweredShortNameFullyQualified)) {
                 return true;
             }
         }

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -30,16 +30,16 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
     {
         // "new X" or "X::static()"
         $shortNamesToFullyQualifiedNames = $this->shortNameResolver->resolveFromFile($file);
-        $loweredShortNameFullyQualifiedObjectType = $fullyQualifiedObjectType->getShortNameLowered();
-        $loweredClassNameFullyQualifiedObjectType = $fullyQualifiedObjectType->getClassNameLowered();
+        $loweredShortNameFullyQualified = $fullyQualifiedObjectType->getShortNameLowered();
+        $loweredClassNameFullyQualified = $fullyQualifiedObjectType->getClassNameLowered();
 
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
             $shortNameLowered = strtolower($shortName);
-            if ($loweredShortNameFullyQualifiedObjectType !== $shortNameLowered) {
+            if ($loweredShortNameFullyQualified !== $shortNameLowered) {
                 continue;
             }
 
-            return $loweredClassNameFullyQualifiedObjectType !== strtolower($fullyQualifiedName);
+            return $loweredClassNameFullyQualified !== strtolower($fullyQualifiedName);
         }
 
         return false;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -31,7 +31,6 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
         // "new X" or "X::static()"
         $shortNamesToFullyQualifiedNames = $this->shortNameResolver->resolveFromFile($file);
         $loweredShortNameFullyQualified = $fullyQualifiedObjectType->getShortNameLowered();
-        $classNameLowered = $fullyQualifiedObjectType->getClassNameLowered();
 
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
             $shortNameLowered = strtolower($shortName);
@@ -39,7 +38,7 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
                 continue;
             }
 
-            return $classNameLowered !== strtolower($fullyQualifiedName);
+            return $fullyQualifiedObjectType->getClassNameLowered() !== strtolower($fullyQualifiedName);
         }
 
         return false;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -31,7 +31,7 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
         // "new X" or "X::static()"
         $shortNamesToFullyQualifiedNames = $this->shortNameResolver->resolveFromFile($file);
         $loweredShortNameFullyQualified = $fullyQualifiedObjectType->getShortNameLowered();
-        $loweredClassNameFullyQualified = $fullyQualifiedObjectType->getClassNameLowered();
+        $classNameLowered = $fullyQualifiedObjectType->getClassNameLowered();
 
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
             $shortNameLowered = strtolower($shortName);
@@ -39,7 +39,7 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
                 continue;
             }
 
-            return $loweredClassNameFullyQualified !== strtolower($fullyQualifiedName);
+            return $classNameLowered !== strtolower($fullyQualifiedName);
         }
 
         return false;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -30,13 +30,16 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
     {
         // "new X" or "X::static()"
         $shortNamesToFullyQualifiedNames = $this->shortNameResolver->resolveFromFile($file);
+        $loweredShortNameFullyQualifiedObjectType = $fullyQualifiedObjectType->getShortNameLowered();
+        $loweredClassNameFullyQualifiedObjectType = $fullyQualifiedObjectType->getClassNameLowered();
+
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
             $shortNameLowered = strtolower($shortName);
-            if ($fullyQualifiedObjectType->getShortNameLowered() !== $shortNameLowered) {
+            if ($loweredShortNameFullyQualifiedObjectType !== $shortNameLowered) {
                 continue;
             }
 
-            return $fullyQualifiedObjectType->getClassNameLowered() !== strtolower($fullyQualifiedName);
+            return $loweredClassNameFullyQualifiedObjectType !== strtolower($fullyQualifiedName);
         }
 
         return false;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
@@ -56,9 +56,11 @@ final class ClassNameImportSkipper
      */
     public function isAlreadyImported(Name $name, array $uses): bool
     {
+        $stringName = $name->toString();
+
         foreach ($uses as $use) {
             foreach ($use->uses as $useUse) {
-                if ($useUse->name->toString() === $name->toString()) {
+                if ($useUse->name->toString() === $stringName) {
                     return true;
                 }
             }
@@ -72,7 +74,9 @@ final class ClassNameImportSkipper
      */
     public function isFoundInUse(Name $name, array $uses): bool
     {
+        $stringName = $name->toString();
         $nameLastName = strtolower($name->getLast());
+
         foreach ($uses as $use) {
             foreach ($use->uses as $useUse) {
                 $useUseLastName = strtolower($useUse->name->getLast());
@@ -81,7 +85,7 @@ final class ClassNameImportSkipper
                     continue;
                 }
 
-                if ($this->isJustRenamedClass($name, $useUse)) {
+                if ($this->isJustRenamedClass($stringName, $useUse)) {
                     continue;
                 }
 
@@ -92,16 +96,18 @@ final class ClassNameImportSkipper
         return false;
     }
 
-    private function isJustRenamedClass(Name $name, UseUse $useUse): bool
+    private function isJustRenamedClass(string $stringName, UseUse $useUse): bool
     {
+        $useUseNameString = $useUse->name->toString();
+
         // is in renamed classes? skip it
         foreach ($this->renamedClassesDataCollector->getOldToNewClasses() as $oldClass => $newClass) {
             // is class being renamed in use imports?
-            if ($name->toString() !== $newClass) {
+            if ($stringName !== $newClass) {
                 continue;
             }
 
-            if ($useUse->name->toString() !== $oldClass) {
+            if ($useUseNameString !== $oldClass) {
                 continue;
             }
 

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -123,6 +123,8 @@ final class NameImporter
 
         $className = $fullyQualifiedObjectType->getClassName();
 
+        dump($className);
+
         // possibly aliased
         foreach ($this->aliasedUses as $aliasedUse) {
             if ($className === $aliasedUse) {

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -121,9 +121,11 @@ final class NameImporter
 
         $this->addUseImport($file, $name, $fullyQualifiedObjectType);
 
+        $className = $fullyQualifiedObjectType->getClassName();
+
         // possibly aliased
         foreach ($this->aliasedUses as $aliasedUse) {
-            if ($fullyQualifiedObjectType->getClassName() === $aliasedUse) {
+            if ($className === $aliasedUse) {
                 return null;
             }
         }

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -123,7 +123,9 @@ final class NameImporter
 
         $className = $fullyQualifiedObjectType->getClassName();
 
-        dump($className);
+        if (str_contains($className, '\\')) {
+            return null;
+        }
 
         // possibly aliased
         foreach ($this->aliasedUses as $aliasedUse) {

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -124,7 +124,7 @@ final class NameImporter
         $className = $fullyQualifiedObjectType->getClassName();
 
         if (str_contains($className, '\\')) {
-            return null;
+            return $fullyQualifiedObjectType->getShortNameNode();
         }
 
         // possibly aliased

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -126,6 +126,10 @@ final class NameImporter
 
         $this->addUseImport($file, $name, $fullyQualifiedObjectType);
 
+        if ($this->aliasedUses === []) {
+            return $fullyQualifiedObjectType->getShortNameNode();
+        }
+
         // possibly aliased
         foreach ($this->aliasedUses as $aliasedUse) {
             if ($className === $aliasedUse) {


### PR DESCRIPTION
- move method call to before loop when possible.
- reduce repetitive call getClassName
- move early check File and shouldApply
- class has backslash, no need to search in aliases, mark aliasedUses as empty
- get real path can be from File object

Close https://github.com/rectorphp/rector/issues/6768