### PR TITLE
[Php56] Skip has previous require on AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_has_previous_require.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_has_previous_require.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class SkipHasPreviousRequire
+{
+    public function run()
+    {
+        require __DIR__ . '/connection.php';
+        $conn->execute();
+    }
+}


### PR DESCRIPTION
Given the following code:

```php
        require __DIR__ . '/connection.php';
        $conn->execute();
```

It currently add : 

```diff
+        $conn = null;
```

which can be skipped, as require can include variable already.