### PR TITLE
[TypeDeclaration] Avoid error Rector\Core\Rector\AbstractRector::isObjectType() must implement interface PhpParser\Node, null given on AddParamTypeDeclarationRector

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
         }
 
         /** @var ClassLike $classLike */
-        $classLike = $this->betterNodeFinder->findParentType($node, Class_::class);
+        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
 
         foreach ($this->parameterTypehints as $parameterTypehint) {
             if (! $this->isObjectType($classLike, $parameterTypehint->getObjectType())) {


### PR DESCRIPTION
Avoid error like:

```bash
Error: ] Could not process "system/Cookie/CloneableCookieInterface.php" file,   
         due to:                                                                
         "Argument 1 passed to Rector\Core\Rector\AbstractRector::isObjectType()
         must implement interface PhpParser\Node, null given, called in         
         vendor/rector/rector/rules/TypeDeclaration/Rector/ClassMethod/AddParamT
         ypeDeclarationRector.php:83". On line: 315        
```

ref https://github.com/codeigniter4/CodeIgniter4/pull/5320#issuecomment-968409012

Closes https://github.com/rectorphp/rector-src/pull/1218 , The non `ClassLike` already handled in `shouldSkip()` method.