### PR TITLE
[Renaming] Handle error on RenameClassRector when method return static

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -27,7 +27,6 @@ use Rector\BetterPhpDocParser\PhpDocNodeVisitor\ChangedPhpDocNodeVisitor;
 use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 use Rector\ChangesReporting\Collector\RectorChangeCollector;
 use Rector\Core\Configuration\CurrentNodeProvider;
-use Rector\Core\Exception\NotImplementedYetException;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symplify\SimplePhpDocParser\PhpDocNodeTraverser;
 
@@ -476,15 +475,6 @@ final class PhpDocInfo
         return $this->node;
     }
 
-    private function getTypeOrMixed(?PhpDocTagValueNode $phpDocTagValueNode): MixedType | Type
-    {
-        if ($phpDocTagValueNode === null) {
-            return new MixedType();
-        }
-
-        return $this->staticTypeMapper->mapPHPStanPhpDocTypeToPHPStanType($phpDocTagValueNode, $this->node);
-    }
-
     public function resolveNameForPhpDocTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): ?string
     {
         foreach (self::TAGS_TYPES_TO_NAMES as $tagValueNodeType => $name) {
@@ -495,5 +485,14 @@ final class PhpDocInfo
         }
 
         return null;
+    }
+
+    private function getTypeOrMixed(?PhpDocTagValueNode $phpDocTagValueNode): MixedType | Type
+    {
+        if ($phpDocTagValueNode === null) {
+            return new MixedType();
+        }
+
+        return $this->staticTypeMapper->mapPHPStanPhpDocTypeToPHPStanType($phpDocTagValueNode, $this->node);
     }
 }

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -485,7 +485,7 @@ final class PhpDocInfo
         return $this->staticTypeMapper->mapPHPStanPhpDocTypeToPHPStanType($phpDocTagValueNode, $this->node);
     }
 
-    private function resolveNameForPhpDocTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): string
+    public function resolveNameForPhpDocTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): ?string
     {
         foreach (self::TAGS_TYPES_TO_NAMES as $tagValueNodeType => $name) {
             /** @var class-string<PhpDocTagNode> $tagValueNodeType */
@@ -494,6 +494,6 @@ final class PhpDocInfo
             }
         }
 
-        throw new NotImplementedYetException($phpDocTagValueNode::class);
+        return null;
     }
 }

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -338,6 +338,9 @@ final class PhpDocInfo
         }
 
         $name = $this->resolveNameForPhpDocTagValueNode($phpDocTagValueNode);
+        if (! is_string($name)) {
+            return;
+        }
 
         $phpDocTagNode = new PhpDocTagNode($name, $phpDocTagValueNode);
         $this->addPhpDocTagNode($phpDocTagNode);

--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
@@ -27,9 +27,6 @@ final class DocBlockClassRenamer
             return;
         }
 
-        $phpDocNodeTraverser = $this->renamingPhpDocNodeVisitorFactory->create();
-        $this->classRenamePhpDocNodeVisitor->setOldToNewTypes($oldToNewTypes);
-
         $phpDocNode = $phpDocInfo->getPhpDocNode();
         $tags = $phpDocNode->getTags();
 
@@ -49,6 +46,9 @@ final class DocBlockClassRenamer
                 }
             }
         }
+
+        $phpDocNodeTraverser = $this->renamingPhpDocNodeVisitorFactory->create();
+        $this->classRenamePhpDocNodeVisitor->setOldToNewTypes($oldToNewTypes);
 
         $phpDocNodeTraverser->traverse($phpDocInfo->getPhpDocNode());
     }

--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
@@ -9,8 +9,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\NodeTypeResolver\PhpDoc\PhpDocNodeTraverser\RenamingPhpDocNodeVisitorFactory;
 use Rector\NodeTypeResolver\PhpDocNodeVisitor\ClassRenamePhpDocNodeVisitor;
 use Rector\NodeTypeResolver\ValueObject\OldToNewType;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
 
 final class DocBlockClassRenamer
 {

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/return_static_doc_clone_this.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/return_static_doc_clone_this.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+class ReturnStaticDocCloneThis extends \DateTime
+{
+    /**
+     * @return static
+     */
+    public function run(\DateTime $dateTime)
+    {
+        $obj = clone $this;
+        return $obj;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+class ReturnStaticDocCloneThis extends \DateTime
+{
+    /**
+     * @return static
+     */
+    public function run(\DateTimeInterface $dateTime)
+    {
+        $obj = clone $this;
+        return $obj;
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba given the following class:

```php
class ReturnStaticDocCloneThis extends \DateTime
{
    /**
     * @return static
     */
    public function run(\DateTime $dateTime)
    {
        $obj = clone $this;
        return $obj;
    }
}
```

It cause error:

```bash
There was 1 error:

1) Rector\Tests\Renaming\Rector\Name\RenameClassRector\RenameClassRectorTest::test with data set #20 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
TypeError: Rector\StaticTypeMapper\PhpDocParser\IdentifierTypeMapper::mapStatic(): Argument #1 ($scope) must be of type PHPStan\Analyser\Scope, null given, called in /Users/samsonasik/www/rector-src/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php on line 81

/Users/samsonasik/www/rector-src/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php:121
/Users/samsonasik/www/rector-src/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php:81
```

like in https://github.com/rectorphp/rector-src/pull/1240