### PR TITLE
[Renaming] Handle var static docblock in union on RenameClassRector

### DIFF
--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
@@ -16,6 +16,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
+use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\NodeTypeResolver\PhpDoc\PhpDocNodeTraverser\RenamingPhpDocNodeVisitorFactory;
 use Rector\NodeTypeResolver\PhpDocNodeVisitor\ClassRenamePhpDocNodeVisitor;
 use Rector\NodeTypeResolver\ValueObject\OldToNewType;
@@ -92,6 +93,10 @@ final class DocBlockClassRenamer
 
     private function hasSpecialClassName(TypeNode $typeNode): bool
     {
+        if ($typeNode instanceof SpacingAwareArrayTypeNode) {
+            $typeNode = $typeNode->type;
+        }
+
         if (! $typeNode instanceof IdentifierTypeNode) {
             return false;
         }

--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
@@ -10,6 +10,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
@@ -95,6 +96,14 @@ final class DocBlockClassRenamer
     {
         if ($typeNode instanceof SpacingAwareArrayTypeNode) {
             $typeNode = $typeNode->type;
+        }
+
+        if ($typeNode instanceof GenericTypeNode) {
+            foreach ($typeNode->genericTypes as $type) {
+                if ($this->hasSpecialClassName($type)) {
+                    return true;
+                }
+            }
         }
 
         if (! $typeNode instanceof IdentifierTypeNode) {

--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
@@ -48,7 +48,7 @@ final class DocBlockClassRenamer
 
             // MethodTagValueNode doesn't has type property
             if ($tagValueNode instanceof MethodTagValueNode) {
-                continue;
+                return;
             }
 
             if (! is_string($tagName)) {

--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
@@ -4,20 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer;
 
-use PhpParser\Node\Name;
-use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\TypeNode;
-use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
-use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\NodeTypeResolver\PhpDoc\PhpDocNodeTraverser\RenamingPhpDocNodeVisitorFactory;
 use Rector\NodeTypeResolver\PhpDocNodeVisitor\ClassRenamePhpDocNodeVisitor;
 use Rector\NodeTypeResolver\ValueObject\OldToNewType;
@@ -39,78 +26,9 @@ final class DocBlockClassRenamer
             return;
         }
 
-        $phpDocNode = $phpDocInfo->getPhpDocNode();
-        $tags = $phpDocNode->getTags();
-
-        foreach ($tags as $tag) {
-            $tagValueNode = $tag->value;
-            $tagName = $phpDocInfo->resolveNameForPhpDocTagValueNode($tagValueNode);
-
-            // MethodTagValueNode doesn't has type property
-            if ($tagValueNode instanceof MethodTagValueNode) {
-                return;
-            }
-
-            if (! is_string($tagName)) {
-                continue;
-            }
-
-            /**
-             * @var ReturnTagValueNode|ParamTagValueNode|VarTagValueNode|PropertyTagValueNode $tagValueNode
-             */
-            if ($tagValueNode->type instanceof BracketsAwareUnionTypeNode && $this->hasSpecialClassNameInUnion(
-                $tagValueNode->type
-            )) {
-                return;
-            }
-
-            if ($tagValueNode->type instanceof NullableTypeNode && $this->hasSpecialClassName(
-                $tagValueNode->type->type
-            )) {
-                return;
-            }
-
-            if ($this->hasSpecialClassName($tagValueNode->type)) {
-                return;
-            }
-        }
-
         $phpDocNodeTraverser = $this->renamingPhpDocNodeVisitorFactory->create();
         $this->classRenamePhpDocNodeVisitor->setOldToNewTypes($oldToNewTypes);
 
         $phpDocNodeTraverser->traverse($phpDocInfo->getPhpDocNode());
-    }
-
-    private function hasSpecialClassNameInUnion(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
-    {
-        foreach ($bracketsAwareUnionTypeNode->types as $type) {
-            if ($this->hasSpecialClassName($type)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function hasSpecialClassName(TypeNode $typeNode): bool
-    {
-        if ($typeNode instanceof SpacingAwareArrayTypeNode) {
-            $typeNode = $typeNode->type;
-        }
-
-        if ($typeNode instanceof GenericTypeNode) {
-            foreach ($typeNode->genericTypes as $type) {
-                if ($this->hasSpecialClassName($type)) {
-                    return true;
-                }
-            }
-        }
-
-        if (! $typeNode instanceof IdentifierTypeNode) {
-            return false;
-        }
-
-        $name = new Name((string) $typeNode);
-        return $name->isSpecialClassName();
     }
 }

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -7,10 +7,10 @@ namespace Rector\StaticTypeMapper\PhpDocParser;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Analyser\NameScope;
-use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
@@ -19,7 +19,6 @@ use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
@@ -33,9 +32,9 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
     public function __construct(
         private ObjectTypeSpecifier $objectTypeSpecifier,
         private ScalarStringToTypeMapper $scalarStringToTypeMapper,
-        private ParentClassScopeResolver $parentClassScopeResolver,
         private BetterNodeFinder $betterNodeFinder,
-        private NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 
@@ -74,11 +73,11 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
         }
 
         if ($loweredName === ObjectReference::PARENT()->getValue()) {
-            return $this->mapParent($scope);
+            return $this->mapParent($node);
         }
 
         if ($loweredName === ObjectReference::STATIC()->getValue()) {
-            return $this->mapStatic($scope);
+            return $this->mapStatic($node);
         }
 
         if ($loweredName === 'iterable') {
@@ -108,9 +107,17 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
         return new SelfObjectType($className);
     }
 
-    private function mapParent(Scope $scope): ParentStaticType | MixedType
+    private function mapParent(Node $node): ParentStaticType | MixedType
     {
-        $parentClassReflection = $this->parentClassScopeResolver->resolveParentClassReflection($scope);
+        $className = $this->resolveValidClassName($node);
+        if (! is_string($className)) {
+            return new MixedType();
+        }
+
+        /** @var ClassReflection $classReflection */
+        $classReflection = $this->reflectionProvider->getClass($className);
+        $parentClassReflection = $classReflection->getParentClass();
+
         if (! $parentClassReflection instanceof ClassReflection) {
             return new MixedType();
         }
@@ -118,13 +125,34 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
         return new ParentStaticType($parentClassReflection);
     }
 
-    private function mapStatic(Scope $scope): MixedType | StaticType
+    private function mapStatic(Node $node): MixedType | StaticType
     {
-        $classReflection = $scope->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
+        $className = $this->resolveValidClassName($node);
+        if (! is_string($className)) {
             return new MixedType();
         }
 
+        /** @var ClassReflection $classReflection */
+        $classReflection = $this->reflectionProvider->getClass($className);
         return new StaticType($classReflection);
+    }
+
+    private function resolveValidClassName(Node $node): ?string
+    {
+        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
+        if (! $classLike instanceof ClassLike) {
+            return null;
+        }
+
+        $className = $this->nodeNameResolver->getName($classLike);
+        if (! is_string($className)) {
+            return null;
+        }
+
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        return $className;
     }
 }

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -134,7 +134,10 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
 
     private function resolveClassName(Node $node): ?string
     {
-        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
+        $classLike = $node instanceof ClassLike
+            ? $node
+            : $this->betterNodeFinder->findParentType($node, ClassLike::class);
+
         if (! $classLike instanceof ClassLike) {
             return null;
         }

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -90,13 +90,8 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
 
     private function mapSelf(Node $node): MixedType | SelfObjectType
     {
-        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
-        if (! $classLike instanceof ClassLike) {
-            return new MixedType();
-        }
-
         // @todo check FQN
-        $className = $this->nodeNameResolver->getName($classLike);
+        $className = $this->resolveClassName($node);
         if (! is_string($className)) {
             // self outside the class, e.g. in a function
             return new MixedType();
@@ -109,6 +104,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
     {
         $className = $this->resolveClassName($node);
         if (! is_string($className)) {
+            // parent outside the class, e.g. in a function
             return new MixedType();
         }
 
@@ -127,6 +123,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
     {
         $className = $this->resolveClassName($node);
         if (! is_string($className)) {
+            // static outside the class, e.g. in a function
             return new MixedType();
         }
 

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -107,7 +107,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
 
     private function mapParent(Node $node): ParentStaticType | MixedType
     {
-        $className = $this->resolveValidClassName($node);
+        $className = $this->resolveClassName($node);
         if (! is_string($className)) {
             return new MixedType();
         }
@@ -125,7 +125,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
 
     private function mapStatic(Node $node): MixedType | StaticType
     {
-        $className = $this->resolveValidClassName($node);
+        $className = $this->resolveClassName($node);
         if (! is_string($className)) {
             return new MixedType();
         }
@@ -135,7 +135,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
         return new StaticType($classReflection);
     }
 
-    private function resolveValidClassName(Node $node): ?string
+    private function resolveClassName(Node $node): ?string
     {
         $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
         if (! $classLike instanceof ClassLike) {

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -66,8 +66,6 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
             return new ClassStringType();
         }
 
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-
         if ($loweredName === ObjectReference::SELF()->getValue()) {
             return $this->mapSelf($node);
         }

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static.php.inc
@@ -39,7 +39,7 @@ class ArrayStatic extends \DateTime
     public function __construct(\DateTimeInterface $dateTime)
     {
         $this->dateTime = rand(0,1)
-            ? $dateTime
+            ? [$dateTime]
             : null;
     }
 }

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class ArrayStatic extends \DateTime
+{
+    /**
+     * @var static[]|null
+     */
+    private $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? [$dateTime]
+            : null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class ArrayStatic extends \DateTime
+{
+    /**
+     * @var static[]|null
+     */
+    private $dateTime;
+
+    public function __construct(\DateTimeInterface $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? $dateTime
+            : null;
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static2.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static2.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class ArrayStatic2 extends \DateTime
+{
+    /**
+     * @var static[]
+     */
+    private $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = [$dateTime];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class ArrayStatic2 extends \DateTime
+{
+    /**
+     * @var static[]
+     */
+    private $dateTime;
+
+    public function __construct(\DateTimeInterface $dateTime)
+    {
+        $this->dateTime = [$dateTime];
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static3.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static3.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class ArrayStatic3 extends \DateTime
+{
+    /**
+     * @var array<static>
+     */
+    private $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = [$dateTime];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class ArrayStatic2 extends \DateTime
+{
+    /**
+     * @var array<static>
+     */
+    private $dateTime;
+
+    public function __construct(\DateTimeInterface $dateTime)
+    {
+        $this->dateTime = [$dateTime];
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static3.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/array_static3.php.inc
@@ -27,7 +27,7 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
 use DateTime;
 use DateTimeInterface;
 
-class ArrayStatic2 extends \DateTime
+class ArrayStatic3 extends \DateTime
 {
     /**
      * @var array<static>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_nullable.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_nullable.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class VarStaticInNullable extends \DateTime
+{
+    /**
+     * @var static|null
+     */
+    private $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? $dateTime
+            : null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class VarStaticInNullable extends \DateTime
+{
+    /**
+     * @var static|null
+     */
+    private $dateTime;
+
+    public function __construct(\DateTimeInterface $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? $dateTime
+            : null;
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_nullable2.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_nullable2.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class VarStaticInNullable extends \DateTime
+{
+    /**
+     * @var static|null
+     */
+    private $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? $dateTime
+            : null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use DateTime;
+use DateTimeInterface;
+
+class VarStaticInNullable extends \DateTime
+{
+    /**
+     * @var static|null
+     */
+    private $dateTime;
+
+    public function __construct(\DateTimeInterface $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? $dateTime
+            : null;
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_nullable2.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_nullable2.php.inc
@@ -8,7 +8,7 @@ use DateTimeInterface;
 class VarStaticInNullable extends \DateTime
 {
     /**
-     * @var static|null
+     * @var ?static
      */
     private $dateTime;
 
@@ -32,7 +32,7 @@ use DateTimeInterface;
 class VarStaticInNullable extends \DateTime
 {
     /**
-     * @var static|null
+     * @var ?static
      */
     private $dateTime;
 

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_union.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_union.php.inc
@@ -2,12 +2,22 @@
 
 namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
 
+use DateTime;
+use DateTimeInterface;
+
 class VarStaticInUnion extends \DateTime
 {
     /**
-     * @var DateTime|static|null
+     * @var DateTimeInterface|static|null
      */
     private $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? $dateTime
+            : null;
+    }
 }
 
 ?>
@@ -16,12 +26,22 @@ class VarStaticInUnion extends \DateTime
 
 namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
 
+use DateTime;
+use DateTimeInterface;
+
 class VarStaticInUnion extends \DateTime
 {
     /**
      * @var DateTimeInterface|static|null
      */
     private $dateTime;
+
+    public function __construct(\DateTimeInterface $dateTime)
+    {
+        $this->dateTime = rand(0,1)
+            ? $dateTime
+            : null;
+    }
 }
 
 ?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_union.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/var_static_in_union.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+class VarStaticInUnion extends \DateTime
+{
+    /**
+     * @var DateTime|static|null
+     */
+    private $dateTime;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+class VarStaticInUnion extends \DateTime
+{
+    /**
+     * @var DateTimeInterface|static|null
+     */
+    private $dateTime;
+}
+
+?>


### PR DESCRIPTION
Given the following code:

```php
class VarStaticInUnion extends \DateTime
{
    /**
     * @var DateTime|static|null
     */
    private $dateTime;
}
```

It currently produce error:

```bash
There was 1 error:

1) Rector\Tests\Renaming\Rector\Name\RenameClassRector\RenameClassRectorTest::test with data set #17 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
TypeError: Rector\StaticTypeMapper\PhpDocParser\IdentifierTypeMapper::mapStatic(): Argument #1 ($scope) must be of type PHPStan\Analyser\Scope, null given, called in /Users/samsonasik/www/rector-src/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php on line 81
```