### PR TITLE
[Scoped] Remove phpstan/phpstan dependency on scoped rector

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -19,6 +19,8 @@
         }
     },
     "conflict": {
+        "phpstan/phpstan": "<1.1.2",
+        "phpstan/phpdoc-parser": "<1.2",
         "rector/rector-prefixed": "*",
         "rector/rector-phpunit": "*",
         "rector/rector-symfony": "*",

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -6,8 +6,7 @@
         "bin/rector"
     ],
     "require": {
-        "php": "^7.1|^8.0",
-        "phpstan/phpstan": "^1.1.1"
+        "php": "^7.1|^8.0"
     },
     "autoload": {
         "files": [
@@ -20,7 +19,6 @@
         }
     },
     "conflict": {
-        "phpstan/phpdoc-parser": "<1.2",
         "rector/rector-prefixed": "*",
         "rector/rector-phpunit": "*",
         "rector/rector-symfony": "*",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "nette/utils": "^3.2",
         "nikic/php-parser": "4.13.1",
         "phpstan/phpdoc-parser": "^1.2",
-        "phpstan/phpstan": "^1.1.1",
+        "phpstan/phpstan": "1.1.2",
         "phpstan/phpstan-phpunit": "^1.0",
         "rector/extension-installer": "^0.11.1",
         "rector/rector-cakephp": "^0.11.7",

--- a/rules/DowngradePhp55/Rector/Foreach_/DowngradeForeachListRector.php
+++ b/rules/DowngradePhp55/Rector/Foreach_/DowngradeForeachListRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp55\Rector\Foreach_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Expr\Variable;
@@ -16,7 +15,6 @@ use Rector\Naming\Naming\VariableNaming;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://wiki.php.net/rfc/foreachlist

--- a/rules/DowngradePhp55/Rector/Foreach_/DowngradeForeachListRector.php
+++ b/rules/DowngradePhp55/Rector/Foreach_/DowngradeForeachListRector.php
@@ -69,9 +69,9 @@ CODE_SAMPLE
         }
 
         $variable = $this->createVariable($node);
-        $exprAssign = new Expression(new Assign($node->valueVar, $variable));
+        $expression = new Expression(new Assign($node->valueVar, $variable));
         $node->valueVar = $variable;
-        $node->stmts = array_merge([$exprAssign], $node->stmts);
+        $node->stmts = array_merge([$expression], $node->stmts);
 
         return $node;
     }


### PR DESCRIPTION
@TomasVotruba since we use `phpstan/phpstan` in rector-src which still support php 7.1, I think we can remove it in the target scoped version. 

the phpstan/phpstan has `bootstrap.php` which on autoload files:

https://github.com/rectorphp/rector/blob/1dfe61b0be4033a1a32bf96fae7fce26dbeaeeed/vendor/phpstan/phpstan/composer.json#L24

Later, in rector bin, we load the `vendor/` autoload

https://github.com/rectorphp/rector/blob/1dfe61b0be4033a1a32bf96fae7fce26dbeaeeed/bin/rector.php#L77

before project autoload.

I tried `sh ./full_build.sh` in my local dev and it seems working ok:

![Screen Shot 2021-11-17 at 15 44 26](https://user-images.githubusercontent.com/459648/142167025-aab9ace2-933d-42b6-8090-a7afb40fcfb9.png)

what do you think?
