### PR TITLE
[Downgrade PHP 8.1] Add DowngradeReadonlyPropertyRector

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.1']
+                php: ['8.0']
                 path:
                     - tests
                     - rules-tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0']
+                php: ['8.1']
                 path:
                     - tests
                     - rules-tests

--- a/config/phpstan/parser.neon
+++ b/config/phpstan/parser.neon
@@ -1,3 +1,6 @@
+parameters:
+    phpVersion: 80100
+
 services:
     defaultAnalysisParser:
         factory: @cachedRectorParser

--- a/config/set/downgrade-php81.php
+++ b/config/set/downgrade-php81.php
@@ -7,6 +7,7 @@ use Rector\Core\ValueObject\PhpVersion;
 use Rector\DowngradePhp81\Rector\ClassConst\DowngradeFinalizePublicClassConstantRector;
 use Rector\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector;
 use Rector\DowngradePhp81\Rector\Instanceof_\DowngradePhp81ResourceReturnToObjectRector;
+use Rector\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -17,4 +18,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeFinalizePublicClassConstantRector::class);
     $services->set(DowngradeNeverTypeDeclarationRector::class);
     $services->set(DowngradePhp81ResourceReturnToObjectRector::class);
+    $services->set(DowngradeReadonlyPropertyRector::class);
 };

--- a/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/DowngradeReadonlyPropertyRectorTest.php
+++ b/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/DowngradeReadonlyPropertyRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeReadonlyPropertyRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/class_property.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/class_property.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    public readonly string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @readonly
+     */
+    public string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/class_property_docblock.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/class_property_docblock.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * Property comment.
+     */
+    public readonly string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * Property comment.
+     * @readonly
+     */
+    public string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/class_property_docblock_tag.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/class_property_docblock_tag.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * Property comment.
+     * @readonly
+     */
+    public readonly string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * Property comment.
+     * @readonly
+     */
+    public string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/promoted_property.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/Fixture/promoted_property.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    public function __construct(
+        public readonly string $foo = 'foo'
+    )
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\Fixture;
+
+class SomeClass
+{
+    public function __construct(
+        public string $foo = 'foo'
+    )
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeReadonlyPropertyRector::class);
+};

--- a/rules/DowngradePhp55/Rector/Foreach_/DowngradeForeachListRector.php
+++ b/rules/DowngradePhp55/Rector/Foreach_/DowngradeForeachListRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp55\Rector\Foreach_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Expr\Variable;
@@ -16,7 +15,6 @@ use Rector\Naming\Naming\VariableNaming;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://wiki.php.net/rfc/foreachlist

--- a/rules/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector.php
+++ b/rules/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp81\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/readonly_properties_v2
+ *
+ * @see \Rector\Tests\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector\DowngradeReadonlyPropertyRectorTest
+ */
+final class DowngradeReadonlyPropertyRector extends AbstractRector
+{
+    /**
+     * @var string
+     */
+    private const TAGNAME = 'readonly';
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Property::class, Param::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove "readonly" property type, add a "@readonly" tag instead',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public readonly string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /**
+     * @readonly
+     */
+    public string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param Property|Param $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->visibilityManipulator->isReadonly($node)) {
+            return null;
+        }
+
+        if ($node instanceof Property) {
+            $this->addPhpDocTag($node);
+        }
+
+        $this->visibilityManipulator->removeReadonly($node);
+
+        return $node;
+    }
+
+    private function addPhpDocTag(Property $property): void
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+
+        if ($phpDocInfo->hasByName(self::TAGNAME)) {
+            return;
+        }
+
+        $phpDocInfo->addPhpDocTagNode(new PhpDocTagNode('@' . self::TAGNAME, new GenericTagValueNode('')));
+    }
+}

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -6,7 +6,6 @@ namespace Rector\Php81\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\Rector\AbstractRector;
@@ -111,7 +110,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->visibilityManipulator->hasVisibility($param, Class_::MODIFIER_READONLY)) {
+        if ($this->visibilityManipulator->isReadonly($param)) {
             return null;
         }
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -116,7 +116,17 @@ final class VisibilityManipulator
 
     public function makeReadonly(Property | Param $node): void
     {
-        $this->addVisibilityFlag($node, Class_::MODIFIER_READONLY);
+        $this->addVisibilityFlag($node, Visibility::READONLY);
+    }
+
+    public function isReadonly(Property | Param $node): bool
+    {
+        return $this->hasVisibility($node, Visibility::READONLY);
+    }
+
+    public function removeReadonly(Property | Param $node): void
+    {
+        $this->removeVisibilityFlag($node, Visibility::READONLY);
     }
 
     private function addVisibilityFlag(
@@ -124,6 +134,13 @@ final class VisibilityManipulator
         int $visibility
     ): void {
         $node->flags |= $visibility;
+    }
+
+    private function removeVisibilityFlag(
+        Class_ | ClassMethod | Property | ClassConst | Param $node,
+        int $visibility
+    ): void {
+        $node->flags &= ~$visibility;
     }
 
     private function replaceVisibilityFlag(ClassMethod | Property | ClassConst $node, int $visibility): void

--- a/src/ValueObject/Visibility.php
+++ b/src/ValueObject/Visibility.php
@@ -37,4 +37,9 @@ final class Visibility
      * @var int
      */
     public const FINAL = Class_::MODIFIER_FINAL;
+
+    /**
+     * @var int
+     */
+    public const READONLY = Class_::MODIFIER_READONLY;
 }


### PR DESCRIPTION
I had to run the tests with PHP 8.1 to avoid a syntax error: https://phpstan.org/r/2a115211-9002-4800-9999-261b2f7d36a7