### PR TITLE
[Php81] Fix NewInInitializerRector code sample

### DIFF
--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -41,8 +41,10 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
+    private Logger $logger;
+
     public function __construct(
-        private Logger $logger = new NullLogger,
+        Logger $logger = new NullLogger,
     ) {
     }
 }


### PR DESCRIPTION
@TomasVotruba based on the test fixture : 

https://github.com/rectorphp/rector-src/blob/b201787edc0cc033d0108505c600c7b2ecc889a3/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/some_class.php.inc#L26

it doesn't add property promotion with `private` modifier. Or it should be added but not applied ?