### PR TITLE
[Scoped] Remove phpstan-extracted code check reference

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -30,25 +30,13 @@ $autoloadIncluder = new AutoloadIncluder();
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
 
 
-// load extracted PHPStan with its own preload.php
-$extractedPhpstanAutoload = __DIR__ . '/../vendor/phpstan/phpstan-extracted/vendor/autoload.php';
-if (file_exists($extractedPhpstanAutoload)) {
-    require_once $extractedPhpstanAutoload;
-}
-
 if (file_exists(__DIR__ . '/../preload.php') && is_dir(__DIR__ . '/../vendor')) {
     require_once __DIR__ . '/../preload.php';
 }
 
 require_once __DIR__ . '/../src/constants.php';
 
-// pre-set for PHP 5.6/7.0 downgraded version
-$autoloadIncluder->loadIfExistsAndNotLoadedYet(
-    __DIR__ . '/../vendor/phpstan/phpstan-extracted/vendor/phpstan-autoload.php'
-);
-
 $autoloadIncluder->loadIfExistsAndNotLoadedYet(__DIR__ . '/../vendor/scoper-autoload.php');
-
 $autoloadIncluder->autoloadProjectAutoloaderFile();
 $autoloadIncluder->autoloadFromCommandLine();
 
@@ -129,7 +117,6 @@ final class AutoloadIncluder
 
     public function loadIfExistsAndNotLoadedYet(string $filePath): void
     {
-        // the scoper-autoload.php is exists in phpstan-extracted/vendor/scoper-autoload.php, move the check in :
         if (! file_exists($filePath)) {
             return;
         }

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -61,15 +61,8 @@ final class PHPStanStubLoader
 
     private function getStubPath(string $vendorPath, string $stub): ?string
     {
-        // @todo: need to be switched when phpstan-extracted used after scoped php 7.0 works
         $path = sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
         $isExists = file_exists($path);
-
-        if (! $isExists) {
-            // this is to handle phpstan's stubs got from phpstan-extracted instead of the .phar when exists after scoped php 7.0 applied
-            $path = sprintf('%s/phpstan/phpstan-extracted/stubs/runtime/%s', $vendorPath, $stub);
-            $isExists = file_exists($path);
-        }
 
         if ($isExists) {
             return $path;

--- a/utils/compiler/src/Command/DowngradePathsCommand.php
+++ b/utils/compiler/src/Command/DowngradePathsCommand.php
@@ -50,28 +50,6 @@ final class DowngradePathsCommand extends Command
             'bin rector.php',
         ], $downgradePaths);
 
-        if (file_exists(getcwd() . '/vendor/phpstan/phpstan-extracted/vendor')) {
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/phpstan/phpdoc-parser/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/ondrejmirtes/better-reflection/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/nette/di/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/nette/php-generator/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/nette/utils/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/nette/schema/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/nette/finder/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/nette/robot-loader/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/nette/bootstrap/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/ondram/ci-detector/src';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/symfony/finder';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/symfony/console/Output/OutputInterface.php';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/symfony/console/Output/TrimmedBufferOutput.php';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/symfony/console/Logger/ConsoleLogger.php';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/symfony/console/Style/SymfonyStyle.php';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-extracted/vendor/symfony/console';
-            $downgradePaths[] = 'vendor/phpstan/phpstan-phpunit/src';
-        }
-
         // bash format
         $downgradePathsLine = implode(';', $downgradePaths);
         echo $downgradePathsLine . PHP_EOL;

--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -33,7 +33,7 @@ final class StaticEasyPrefixer
         'PhpParser\*',
         'Ssch\TYPO3Rector\*',
 
-        // phpstan needs to be here, as phpstan-extracted/vendor autoload is statically generated and namespaces cannot be changed
+        // phpstan needs to be here, as phpstan/vendor autoload is statically generated and namespaces cannot be changed
         'PHPStan\*',
 
         // this is public API of a Rector rule


### PR DESCRIPTION
We don't have phpstan's extracted yet, I think we can remove code check for it for now, and we can back to check it if the scoper will use extracted phpstan.