### PR TITLE
[EarlyReturn][Php73] Handle JsonThrowOnErrorRector + ChangeAndIfToEarlyReturnRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -510,6 +510,10 @@ parameters:
             message: '#Class cognitive complexity is 36, keep it under 30#'
 
         -
+            path: rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+            message: '#Class cognitive complexity is 31, keep it under 30#'
+
+        -
             message: '#Autowired/inject method name must respect "autowire/inject" \+ class name#'
             paths:
                 - packages/StaticTypeMapper/PhpDocParser/IntersectionTypeMapper.php

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -7,6 +7,7 @@ namespace Rector\EarlyReturn\Rector\If_;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;
@@ -126,6 +127,20 @@ CODE_SAMPLE
         return $this->processReplaceIfs($node, $booleanAndConditions, $ifNextReturnClone, $afters);
     }
 
+    /**
+     * @param Node[] $nodes
+     */
+    private function hasJsonEncodeOrJsonDecode(array $nodes): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $subNode): bool {
+            if (! $subNode instanceof FuncCall) {
+                return false;
+            }
+
+            return $this->nodeNameResolver->isNames($subNode, ['json_encode', 'json_decode']);
+        });
+    }
+
     private function isInLoopWithoutContinueOrBreak(If_ $if): bool
     {
         if (! $this->contextAnalyzer->isInLoop($if)) {
@@ -142,14 +157,19 @@ CODE_SAMPLE
     /**
      * @param Expr[] $conditions
      * @param Node[] $afters
-     * @return Node[]
+     * @return Node[]|null
      */
     private function processReplaceIfs(
         If_ $if,
         array $conditions,
         Return_ $ifNextReturnClone,
         array $afters
-    ): array {
+    ): ?array {
+        // handle for used along with JsonThrowOnErrorRector
+        if ($this->hasJsonEncodeOrJsonDecode($afters)) {
+            return null;
+        }
+
         $ifs = $this->invertedIfFactory->createFromConditions($if, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $if);
 

--- a/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
+++ b/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
+
+function f()
+{
+    if (true && true) {
+        json_decode($a);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
+
+function f()
+{
+    if (true && true) {
+        json_decode($a);
+    }
+}
+
+?>

--- a/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
+++ b/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
@@ -18,7 +18,7 @@ namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
 function f()
 {
     if (true && true) {
-        json_decode($a);
+        json_decode($a, null, 512, JSON_THROW_ON_ERROR);
     }
 }
 

--- a/tests/Issues/JsonThrowWithChangeAndIf/JsonThrowWithChangeAndIfTest.php
+++ b/tests/Issues/JsonThrowWithChangeAndIf/JsonThrowWithChangeAndIfTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class JsonThrowWithChangeAndIfTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/JsonThrowWithChangeAndIf/config/configured_rule.php
+++ b/tests/Issues/JsonThrowWithChangeAndIf/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(JsonThrowOnErrorRector::class);
+    $services->set(ChangeAndIfToEarlyReturnRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
function f()
{
    if (true && true) {
        json_decode($a);
    }
}
```

It produce error:

```bash
There was 1 failure:

1) Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\JsonThrowWithChangeAndIfTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
assert($itemStartPos >= 0 && $itemEndPos >= 0) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:865
```

applied rules:

```php
Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
```

Fixes https://github.com/rectorphp/rector/issues/6812