### PR TITLE
[DX] Add configure() method to service configuration to make configuration easy again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "symplify/phpstan-extensions": "^10.0",
         "symplify/phpstan-rules": "^10.0",
         "symplify/rule-doc-generator": "^10.0",
+        "symplify/vendor-patches": "^10.0",
         "timeweb/phpstan-enum": "dev-22-upgrade-phpstan-to-1.0"
     },
     "replace": {
@@ -142,6 +143,11 @@
         "release": "vendor/bin/monorepo-builder release patch --ansi"
     },
     "extra": {
+        "patches": {
+            "symfony/dependency-injection": [
+                "patches/symfony-dependency-injection-loader-configurator-servicesconfigurator-php.patch"
+            ]
+        },
         "branch-alias": {
             "dev-main": "0.12-dev"
         }

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "symplify/skipper": "^10.0",
         "symplify/smart-file-system": "^10.0",
         "symplify/symfony-php-config": "^10.0",
+        "symplify/vendor-patches": "^10.0",
         "tracy/tracy": "^2.8",
         "webmozart/assert": "^1.10"
     },
@@ -70,7 +71,6 @@
         "symplify/phpstan-extensions": "^10.0",
         "symplify/phpstan-rules": "^10.0",
         "symplify/rule-doc-generator": "^10.0",
-        "symplify/vendor-patches": "^10.0",
         "timeweb/phpstan-enum": "dev-22-upgrade-phpstan-to-1.0"
     },
     "replace": {

--- a/patches/symfony-dependency-injection-loader-configurator-servicesconfigurator-php.patch
+++ b/patches/symfony-dependency-injection-loader-configurator-servicesconfigurator-php.patch
@@ -1,0 +1,20 @@
+--- /dev/null
++++ ../Loader/Configurator/ServicesConfigurator.php
+@@ -70,7 +70,7 @@
+      * @param string|null $id    The service id, or null to create an anonymous service
+      * @param string|null $class The class of the service, or null when $id is also the class name
+      */
+-    final public function set(?string $id, string $class = null): ServiceConfigurator
++    final public function set(?string $id, string $class = null): \Rector\Core\DependencyInjection\Loader\Configurator\RectorServiceConfigurator
+     {
+         $defaults = $this->defaults;
+         $definition = new Definition();
+@@ -91,7 +91,7 @@
+         $definition->setBindings(unserialize(serialize($defaults->getBindings())));
+         $definition->setChanges([]);
+ 
+-        $configurator = new ServiceConfigurator($this->container, $this->instanceof, true, $this, $definition, $id, $defaults->getTags(), $this->path);
++        $configurator = new \Rector\Core\DependencyInjection\Loader\Configurator\RectorServiceConfigurator($this->container, $this->instanceof, true, $this, $definition, $id, $defaults->getTags(), $this->path);
+ 
+         return null !== $class ? $configurator->class($class) : $configurator;
+     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -514,3 +514,11 @@ parameters:
             paths:
                 - packages/StaticTypeMapper/PhpDocParser/IntersectionTypeMapper.php
                 - packages/StaticTypeMapper/PhpParser/IntersectionTypeNodeMapper.php
+
+        -
+            message: '#Use separate function calls with readable variable names#'
+            path: src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
+
+        -
+            message: '#\$service\-\>call\("configure", \[\[ \.\.\. \]\]\) must be followed by exact array#'
+            path: src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php

--- a/rector.php
+++ b/rector.php
@@ -15,7 +15,6 @@ use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     // include the latest PHP version + all bellow in one config!
@@ -38,18 +37,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // phpunit
     $services->set(PreferThisOrSelfMethodCallRector::class)
-        ->call('configure', [[
+        ->configure([
             PreferThisOrSelfMethodCallRector::TYPE_TO_PREFERENCE => [
-                TestCase::class => ValueObjectInliner::inline(PreferenceSelfThis::PREFER_THIS()),
+                TestCase::class => PreferenceSelfThis::PREFER_THIS(),
             ],
-        ]]);
+        ]);
 
     $services->set(ReturnArrayClassMethodToYieldRector::class)
-        ->call('configure', [[
-            ReturnArrayClassMethodToYieldRector::METHODS_TO_YIELDS => ValueObjectInliner::inline([
+        ->configure([
+            ReturnArrayClassMethodToYieldRector::METHODS_TO_YIELDS => [
                 new ReturnArrayClassMethodToYield('PHPUnit\Framework\TestCase', '*provide*'),
-            ]),
-        ]]);
+            ],
+        ]);
 
     $parameters = $containerConfigurator->parameters();
 

--- a/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
+++ b/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ServiceConfigurator;
+
+/**
+ * Same as Symfony service configurator, with extra "configure()" method for easier DX
+ */
+final class RectorServiceConfigurator extends ServiceConfigurator
+{
+
+}

--- a/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
+++ b/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
@@ -4,12 +4,51 @@ declare(strict_types=1);
 
 namespace Rector\Core\DependencyInjection\Loader\Configurator;
 
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServiceConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 /**
+ * @api
  * Same as Symfony service configurator, with extra "configure()" method for easier DX
  */
 final class RectorServiceConfigurator extends ServiceConfigurator
 {
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    public function configure(array $configuration): self
+    {
+        $this->ensureClassIsConfigurable($this->id);
 
+        // decorate with value object inliner so Symfony understands, see https://getrector.org/blog/2020/09/07/how-to-inline-value-object-in-symfony-php-config
+        array_walk_recursive($configuration, function (&$value) {
+            if (is_object($value)) {
+                $value = ValueObjectInliner::inline($value);
+            }
+
+            return $value;
+        });
+
+        $this->call('configure', [$configuration]);
+
+        return $this;
+    }
+
+    private function ensureClassIsConfigurable(?string $class): void
+    {
+        if ($class === null) {
+            throw new InvalidConfigurationException('The class is missing');
+        }
+
+        if (! is_a($class, ConfigurableRectorInterface::class, true)) {
+            $errorMessage = sprintf(
+                'The service "%s" is not configurable. Make it implement "%s" or remove "configure()" call.',
+                $class,
+                ConfigurableRectorInterface::class,
+            );
+            throw new InvalidConfigurationException($errorMessage);
+        }
+    }
 }

--- a/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
+++ b/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
@@ -16,7 +16,7 @@ use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 final class RectorServiceConfigurator extends ServiceConfigurator
 {
     /**
-     * @param array<string, mixed> $configuration
+     * @param array<string, string|bool|object|string[]|object[]> $configuration
      */
     public function configure(array $configuration): self
     {


### PR DESCRIPTION
We're using [Symfony PHP fluent configuration](https://github.com/symfony/symfony/issues/37186) to add autocomplete and ECS, PHPStan and Rector luxury to configs.

Yet it comes for a price, of complex configuration, mainly in case of value objects. Symfony container cannot work with value objects natively, [so extra inlining complexity has to be added](https://getrector.org/blog/2020/09/07/how-to-inline-value-object-in-symfony-php-config):

Also it's prone to errors:

```php
    ->call('configure', [[
    ->call('configure', [[[
    ->call('configure', [
    ->call('configure',
```

:red_circle: 

```php
        PreferThisOrSelfMethodCallRector::TYPE_TO_PREFERENCE => [
                TestCase::class => ValueObjectInliner::inline(PreferenceSelfThis::PREFER_THIS()),
         ],

        PreferThisOrSelfMethodCallRector::TYPE_TO_PREFERENCE => ValueObjectInliner::inline([
                TestCase::class => PreferenceSelfThis::PREFER_THIS(),
         ]),

        PreferThisOrSelfMethodCallRector::TYPE_TO_PREFERENCE => [
                TestCase::class => PreferenceSelfThis::PREFER_THIS(),
         ],


```

:red_circle: 

<br>

**This bothers the user with boring knowledge.** :-1: 

<br>

## New `->configure(...)` method :tada: 

Instead, this PR gets the simplicity back. Rector DI itself handles the value object wrapping by adding special `->configure()` method.

<br>

## Before :sneezing_face: 

```php
$services->set(SomeChangeRector::class)
    ->call('configure', [[
        SomeChangeRector::SOME_CONFIG => ValueObjectInliner::inline([
            new SomeChange('before', 'after');
        ]),
    ]]);
```

## Now  :+1: 

```php
$services->set(SomeChangeRector::class)
    ->configure([
        SomeChangeRector::SOME_CONFIG => [
            new SomeChange('before', 'after');
        ],
    ]);
```

<br>

```php
public function configure(array $configuration): self
{
	// ...
}
```

With `array` parameter type hint useful for PHPStorm and PHPStan as a bonus :heavy_check_mark: 