### PR TITLE
Add failing test fixture for RenameClassRector for Generic template of class

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
@@ -10,6 +10,7 @@ use MyNamespace\MyClass
 interface MyServiceInterface
 {
 }
+
 ?>
 -----
 <?php
@@ -24,3 +25,5 @@ use MyNewNamespace\MyNewClass;
 interface MyServiceInterface
 {
 }
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
@@ -2,10 +2,10 @@
 
 namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
 
-use App\Model\OldClass;
+use MyNamespace\MyClass
 
 /**
- * @template T of OldClass
+ * @template T of MyClass
  */
 interface MyServiceInterface
 {
@@ -16,10 +16,10 @@ interface MyServiceInterface
 
 namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
 
-use App\Model\OldClass;
+use MyNewNamespace\MyNewClass;
 
 /**
- * @template T of NewClass
+ * @template T of MyNewClass
  */
 interface MyServiceInterface
 {

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use App\Model\OldClass;
+
+/**
+ * @template T of OldClass
+ */
+interface MyServiceInterface
+{
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use App\Model\OldClass;
+
+/**
+ * @template T of NewClass
+ */
+interface MyServiceInterface
+{
+}

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/rename_generic_template_of_fixture.php.inc
@@ -9,6 +9,10 @@ use MyNamespace\MyClass
  */
 interface MyServiceInterface
 {
+    /**
+     * @return T
+     */
+    public function get(): MyClass;
 }
 
 ?>
@@ -24,6 +28,10 @@ use MyNewNamespace\MyNewClass;
  */
 interface MyServiceInterface
 {
+    /**
+     * @return T
+     */
+    public function get(): MyNewClass;
 }
 
 ?>


### PR DESCRIPTION
# Failing Test for RenameClassRector

Based on https://getrector.org/demo/1ec4e145-1672-628e-a7a2-e3aa19da6373

https://github.com/rectorphp/rector/issues/6835