### PR TITLE
[DX] Remove extra check for Stmt/Node

### DIFF
--- a/rules/CodingStyle/Rector/ClassMethod/FuncGetArgsToVariadicParamRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/FuncGetArgsToVariadicParamRector.php
@@ -94,7 +94,8 @@ CODE_SAMPLE
     }
 
     private function applyVariadicParams(
-        ClassMethod | Function_ | Closure $node, string $variableName
+        ClassMethod | Function_ | Closure $node,
+        string $variableName
     ): ClassMethod | Function_ | Closure | null {
         $param = $this->createVariadicParam($variableName);
         $variableParam = $param->var;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -275,11 +275,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             }
         }
 
-        // if Stmt ("$value;") was replaced by Expr ("$value"), add Expression (the ending ";") to prevent breaking the code
-        if ($originalNode instanceof Stmt && $node instanceof Expr) {
-            $node = new Expression($node);
-        }
-
         return $node;
     }
 


### PR DESCRIPTION
Automated node wrapping can cause unwanted bugs and hides implementation behind magic.
This shoud make using nodes easier and more explicit.	
