### PR TITLE
[DeadCode] Add support remove unused in between private method parameter for RemoveUnusedPrivateMethodParameterRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/in_between_parameter.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/in_between_parameter.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
 
-final class SkipInBetweenParameter
+final class InBetweenParameter
 {
     private $value;
     private $value3;
@@ -12,4 +12,34 @@ final class SkipInBetweenParameter
         $this->value = $value;
         $this->value3 = $value3;
     }
+
+    public function execute()
+    {
+        $this->run('a', 'b', 'c');
+    }
 }
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
+
+final class InBetweenParameter
+{
+    private $value;
+    private $value3;
+
+    private function run($value, $value3)
+    {
+        $this->value = $value;
+        $this->value3 = $value3;
+    }
+
+    public function execute()
+    {
+        $this->run('a', 'c');
+    }
+}
+
+?>

--- a/rules/Autodiscovery/Rector/Class_/MoveServicesBySuffixToDirectoryRector.php
+++ b/rules/Autodiscovery/Rector/Class_/MoveServicesBySuffixToDirectoryRector.php
@@ -110,7 +110,8 @@ CODE_SAMPLE
      *
      * @param string[] $groupNamesBySuffix
      */
-    private function processGroupNamesBySuffix(SmartFileInfo $smartFileInfo, array $groupNamesBySuffix): void {
+    private function processGroupNamesBySuffix(SmartFileInfo $smartFileInfo, array $groupNamesBySuffix): void
+    {
         foreach ($groupNamesBySuffix as $groupNames) {
             // has class suffix
             $suffixPattern = '\w+' . $groupNames . '(Test)?\.php$';

--- a/rules/Autodiscovery/Rector/Class_/MoveServicesBySuffixToDirectoryRector.php
+++ b/rules/Autodiscovery/Rector/Class_/MoveServicesBySuffixToDirectoryRector.php
@@ -85,7 +85,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $this->processGroupNamesBySuffix($this->file->getSmartFileInfo(), $this->file, $this->groupNamesBySuffix);
+        $this->processGroupNamesBySuffix($this->file->getSmartFileInfo(), $this->groupNamesBySuffix);
 
         return null;
     }
@@ -110,11 +110,7 @@ CODE_SAMPLE
      *
      * @param string[] $groupNamesBySuffix
      */
-    private function processGroupNamesBySuffix(
-        SmartFileInfo $smartFileInfo,
-        File $file,
-        array $groupNamesBySuffix
-    ): void {
+    private function processGroupNamesBySuffix(SmartFileInfo $smartFileInfo, array $groupNamesBySuffix): void {
         foreach ($groupNamesBySuffix as $groupNames) {
             // has class suffix
             $suffixPattern = '\w+' . $groupNames . '(Test)?\.php$';

--- a/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
+++ b/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
@@ -7,13 +7,11 @@ namespace Rector\DeadCode\NodeCollector;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
-use Rector\NodeNameResolver\NodeNameResolver;
 
 final class UnusedParameterResolver
 {
     public function __construct(
-        private ClassMethodManipulator $classMethodManipulator,
-        private NodeNameResolver $nodeNameResolver
+        private ClassMethodManipulator $classMethodManipulator
     ) {
     }
 

--- a/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
+++ b/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
@@ -7,7 +7,6 @@ namespace Rector\DeadCode\NodeCollector;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
-use Rector\Core\ValueObject\MethodName;
 use Rector\NodeNameResolver\NodeNameResolver;
 
 final class UnusedParameterResolver
@@ -33,11 +32,6 @@ final class UnusedParameterResolver
             }
 
             if ($this->classMethodManipulator->isParameterUsedInClassMethod($param, $classMethod)) {
-                // reset to keep order of removed arguments, if not construtctor - probably autowired
-                if (! $this->nodeNameResolver->isName($classMethod, MethodName::CONSTRUCT)) {
-                    $unusedParameters = [];
-                }
-
                 continue;
             }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
@@ -124,11 +124,8 @@ CODE_SAMPLE
     {
         $args = $methodCall->getArgs();
         foreach (array_keys($args) as $key) {
-            foreach ($keysArg as $keyArg) {
-                if ($key === $keyArg) {
-                    unset($args[$key]);
-                    continue 2;
-                }
+            if (in_array($key, $keysArg, true)) {
+                unset($args[$key]);
             }
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
@@ -108,9 +108,12 @@ CODE_SAMPLE
         $keysArg = array_keys($unusedParameters);
 
         foreach ($methods as $method) {
-
             /** @var MethodCall[] $callers */
             $callers = $this->resolveCallers($method, $methodName);
+            if ($callers === []) {
+                continue;
+            }
+
             foreach ($callers as $caller) {
                 $this->cleanupArgs($caller, $keysArg);
             }

--- a/rules/Php71/Rector/TryCatch/MultiExceptionCatchRector.php
+++ b/rules/Php71/Rector/TryCatch/MultiExceptionCatchRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $collectedTypes = $this->collectTypesFromCatchedByIds($node, $catchKeys);
+            $collectedTypes = $this->collectTypesFromCatchedByIds($catchKeys);
 
             /** @var Catch_ $firstCatch */
             $firstCatch = array_shift($catchKeys);
@@ -112,7 +112,7 @@ CODE_SAMPLE
      * @param Catch_[] $catches
      * @return Name[]
      */
-    private function collectTypesFromCatchedByIds(TryCatch $tryCatch, array $catches): array
+    private function collectTypesFromCatchedByIds(array $catches): array
     {
         $collectedTypes = [];
 

--- a/tests/Issues/NullableParamNamespaced/Fixture/do_not_add_short_fqcn_class_name_docblock_nullable.php.inc
+++ b/tests/Issues/NullableParamNamespaced/Fixture/do_not_add_short_fqcn_class_name_docblock_nullable.php.inc
@@ -37,7 +37,7 @@ class DoNotAddShortFQCNClassNameDocblockNullable
             return false;
         }
 
-        return $this->callPrivateMethod($classLike, true);
+        return $this->callPrivateMethod($classLike);
     }
 
     private function callPrivateMethod(ClassLike $classLike)


### PR DESCRIPTION
remove both of:

1. param in method 
2. arg in caller as well

Fixes https://github.com/rectorphp/rector/issues/6834