### PR TITLE
[DX] make all configure() methods accept direct value object configuration

### DIFF
--- a/rules-tests/Transform/Rector/Class_/AddInterfaceByParentRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/Class_/AddInterfaceByParentRector/config/configured_rule.php
@@ -10,9 +10,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(AddInterfaceByParentRector::class)
-        ->call('configure', [[
-            AddInterfaceByParentRector::INTERFACE_BY_PARENT => [
-                SomeParent::class => SomeInterface::class,
-            ],
-        ]]);
+        ->configure([
+            SomeParent::class => SomeInterface::class,
+        ]);
 };

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
@@ -7,14 +7,9 @@ use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRect
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(AddReturnTypeDeclarationRector::class)
-        ->call('configure', [[
-            AddReturnTypeDeclarationRector::METHOD_RETURN_TYPES => ValueObjectInliner::inline([
-                new AddReturnTypeDeclaration(PHPUnitTestCase::class, 'tearDown', new VoidType()),
-            ]),
-        ]]);
+        ->configure([new AddReturnTypeDeclaration(PHPUnitTestCase::class, 'tearDown', new VoidType())]);
 };

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -134,7 +134,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $addedArguments = $configuration[self::ADDED_ARGUMENTS] ?? [];
+        $addedArguments = $configuration[self::ADDED_ARGUMENTS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($addedArguments, ArgumentAdder::class);
         $this->addedArguments = $addedArguments;
     }

--- a/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
@@ -104,7 +104,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $replacedArguments = $configuration[self::REPLACED_ARGUMENTS] ?? [];
+        $replacedArguments = $configuration[self::REPLACED_ARGUMENTS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($replacedArguments, ReplaceArgumentDefaultValue::class);
         $this->replacedArguments = $replacedArguments;
     }

--- a/rules/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector.php
+++ b/rules/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $replacedArguments = $configuration[self::REPLACED_ARGUMENTS] ?? [];
+        $replacedArguments = $configuration[self::REPLACED_ARGUMENTS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($replacedArguments, ReplaceFuncCallArgumentDefaultValue::class);
         $this->replacedArguments = $replacedArguments;
     }

--- a/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
+++ b/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
@@ -110,7 +110,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $functionArgumentSwaps = $configuration[self::FUNCTION_ARGUMENT_SWAPS] ?? [];
+        $functionArgumentSwaps = $configuration[self::FUNCTION_ARGUMENT_SWAPS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($functionArgumentSwaps, SwapFuncCallArguments::class);
         $this->functionArgumentSwaps = $functionArgumentSwaps;
     }

--- a/rules/Autodiscovery/Rector/Class_/MoveServicesBySuffixToDirectoryRector.php
+++ b/rules/Autodiscovery/Rector/Class_/MoveServicesBySuffixToDirectoryRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $groupNamesBySuffix = $configuration[self::GROUP_NAMES_BY_SUFFIX] ?? [];
+        $groupNamesBySuffix = $configuration[self::GROUP_NAMES_BY_SUFFIX] ?? ($configuration ?: []);
         Assert::allString($groupNamesBySuffix);
 
         $this->groupNamesBySuffix = $groupNamesBySuffix;

--- a/rules/Autodiscovery/Rector/Class_/MoveValueObjectsToValueObjectDirectoryRector.php
+++ b/rules/Autodiscovery/Rector/Class_/MoveValueObjectsToValueObjectDirectoryRector.php
@@ -154,8 +154,8 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->types = $configuration[self::TYPES] ?? [];
-        $this->suffixes = $configuration[self::SUFFIXES] ?? [];
+        $this->types = $configuration[self::TYPES] ?? ($configuration ?: []);
+        $this->suffixes = $configuration[self::SUFFIXES] ?? ($configuration ?: []);
         $this->enableValueObjectGuessing = $configuration[self::ENABLE_VALUE_OBJECT_GUESSING] ?? false;
     }
 

--- a/rules/Autodiscovery/Rector/Class_/MoveValueObjectsToValueObjectDirectoryRector.php
+++ b/rules/Autodiscovery/Rector/Class_/MoveValueObjectsToValueObjectDirectoryRector.php
@@ -15,6 +15,7 @@ use Rector\FileSystemRector\ValueObject\AddedFileWithNodes;
 use Rector\FileSystemRector\ValueObjectFactory\AddedFileWithNodesFactory;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * Inspiration @see https://github.com/rectorphp/rector/pull/1865/files#diff-0d18e660cdb626958662641b491623f8
@@ -50,7 +51,7 @@ final class MoveValueObjectsToValueObjectDirectoryRector extends AbstractRector 
     private bool $enableValueObjectGuessing = true;
 
     /**
-     * @var class-string[]
+     * @var string[]
      */
     private array $types = [];
 
@@ -154,9 +155,19 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->types = $configuration[self::TYPES] ?? ($configuration ?: []);
-        $this->suffixes = $configuration[self::SUFFIXES] ?? ($configuration ?: []);
-        $this->enableValueObjectGuessing = $configuration[self::ENABLE_VALUE_OBJECT_GUESSING] ?? false;
+        $types = $configuration[self::TYPES] ?? [];
+        Assert::isArray($types);
+        Assert::allString($types);
+        $this->types = $types;
+
+        $suffixes = $configuration[self::SUFFIXES] ?? [];
+        Assert::isArray($suffixes);
+        Assert::allString($suffixes);
+        $this->suffixes = $suffixes;
+
+        $enableValueObjectGuessing = $configuration[self::ENABLE_VALUE_OBJECT_GUESSING] ?? false;
+        Assert::boolean($enableValueObjectGuessing);
+        $this->enableValueObjectGuessing = $enableValueObjectGuessing;
     }
 
     private function isValueObjectMatch(Class_ $class): bool

--- a/rules/CodingStyle/Rector/ClassMethod/OrderAttributesRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/OrderAttributesRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $attributesOrder = $configuration[self::ATTRIBUTES_ORDER] ?? [];
+        $attributesOrder = $configuration[self::ATTRIBUTES_ORDER] ?? ($configuration ?: []);
         Assert::isArray($attributesOrder);
         Assert::allString($attributesOrder);
 

--- a/rules/CodingStyle/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
@@ -128,7 +128,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $methodsToYields = $configuration[self::METHODS_TO_YIELDS] ?? [];
+        $methodsToYields = $configuration[self::METHODS_TO_YIELDS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($methodsToYields, ReturnArrayClassMethodToYield::class);
         $this->methodsToYields = $methodsToYields;
     }

--- a/rules/CodingStyle/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
+++ b/rules/CodingStyle/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
@@ -106,7 +106,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $typeToPreference = $configuration[self::TYPE_TO_PREFERENCE] ?? [];
+        $typeToPreference = $configuration[self::TYPE_TO_PREFERENCE] ?? ($configuration ?: []);
         Assert::allIsAOf($typeToPreference, PreferenceSelfThis::class);
 
         $this->typeToPreference = $typeToPreference;

--- a/rules/CodingStyle/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
+++ b/rules/CodingStyle/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
@@ -102,7 +102,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, PreferenceSelfThis[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {

--- a/rules/Composer/Rector/AddPackageToRequireComposerRector.php
+++ b/rules/Composer/Rector/AddPackageToRequireComposerRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? [];
+        $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($packagesAndVersions, PackageAndVersion::class);
 
         $this->versionGuard->validate($packagesAndVersions);

--- a/rules/Composer/Rector/AddPackageToRequireDevComposerRector.php
+++ b/rules/Composer/Rector/AddPackageToRequireDevComposerRector.php
@@ -70,7 +70,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? [];
+        $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($packagesAndVersions, PackageAndVersion::class);
 
         $this->versionGuard->validate($packagesAndVersions);

--- a/rules/Composer/Rector/ChangePackageVersionComposerRector.php
+++ b/rules/Composer/Rector/ChangePackageVersionComposerRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? [];
+        $packagesAndVersions = $configuration[self::PACKAGES_AND_VERSIONS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($packagesAndVersions, PackageAndVersion::class);
 
         $this->versionGuard->validate($packagesAndVersions);

--- a/rules/Composer/Rector/RemovePackageComposerRector.php
+++ b/rules/Composer/Rector/RemovePackageComposerRector.php
@@ -59,6 +59,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->packageNames = $configuration[self::PACKAGE_NAMES] ?? [];
+        $this->packageNames = $configuration[self::PACKAGE_NAMES] ?? ($configuration ?: []);
     }
 }

--- a/rules/Composer/Rector/RemovePackageComposerRector.php
+++ b/rules/Composer/Rector/RemovePackageComposerRector.php
@@ -8,6 +8,7 @@ use Rector\Composer\Contract\Rector\ComposerRectorInterface;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Composer\Rector\RemovePackageComposerRector\RemovePackageComposerRectorTest
@@ -55,10 +56,15 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, string[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->packageNames = $configuration[self::PACKAGE_NAMES] ?? ($configuration ?: []);
+        $packagesNames = $configuration[self::PACKAGE_NAMES] ?? ($configuration ?: []);
+
+        Assert::isArray($packagesNames);
+        Assert::allString($packagesNames);
+
+        $this->packageNames = $packagesNames;
     }
 }

--- a/rules/Composer/Rector/RenamePackageComposerRector.php
+++ b/rules/Composer/Rector/RenamePackageComposerRector.php
@@ -80,7 +80,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $renamePackages = $configuration[self::RENAME_PACKAGES] ?? [];
+        $renamePackages = $configuration[self::RENAME_PACKAGES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($renamePackages, RenamePackage::class);
         $this->renamePackages = $renamePackages;
     }

--- a/rules/Composer/Rector/ReplacePackageAndVersionComposerRector.php
+++ b/rules/Composer/Rector/ReplacePackageAndVersionComposerRector.php
@@ -78,7 +78,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $replacePackagesAndVersions = $configuration[self::REPLACE_PACKAGES_AND_VERSIONS] ?? [];
+        $replacePackagesAndVersions = $configuration[self::REPLACE_PACKAGES_AND_VERSIONS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($replacePackagesAndVersions, ReplacePackageAndVersion::class);
 
         $this->versionGuard->validate($replacePackagesAndVersions);

--- a/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
+++ b/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
@@ -105,7 +105,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $annotationsToRemove = $configuration[self::ANNOTATIONS_TO_REMOVE] ?? [];
+        $annotationsToRemove = $configuration[self::ANNOTATIONS_TO_REMOVE] ?? ($configuration ?: []);
         Assert::allString($annotationsToRemove);
 
         $this->annotationsToRemove = $annotationsToRemove;

--- a/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
+++ b/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
@@ -16,6 +16,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\DependencyInjection\Rector\ClassMethod\AddMethodParentCallRector\AddMethodParentCallRectorTest
@@ -113,11 +114,16 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->methodByParentTypes = $configuration[self::METHODS_BY_PARENT_TYPES] ?? ($configuration ?: []);
+        $methodsByParentTypes = $configuration[self::METHODS_BY_PARENT_TYPES] ?? ($configuration ?: []);
+        Assert::allString(array_keys($methodsByParentTypes));
+        Assert::allString($methodsByParentTypes);
+
+        /** @var array<string, string> $methodsByParentTypes */
+        $this->methodByParentTypes = $methodsByParentTypes;
     }
 
     private function shouldSkipMethod(ClassMethod $classMethod, string $method): bool

--- a/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
+++ b/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
@@ -117,7 +117,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->methodByParentTypes = $configuration[self::METHODS_BY_PARENT_TYPES] ?? [];
+        $this->methodByParentTypes = $configuration[self::METHODS_BY_PARENT_TYPES] ?? ($configuration ?: []);
     }
 
     private function shouldSkipMethod(ClassMethod $classMethod, string $method): bool

--- a/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -143,12 +143,12 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $safeTypes = $configuration[self::SAFE_TYPES] ?? [];
+        $safeTypes = $configuration[self::SAFE_TYPES] ?? ($configuration ?: []);
         Assert::isArray($safeTypes);
         Assert::allString($safeTypes);
         $this->safeTypes = $safeTypes;
 
-        $safeTypesToMethods = $configuration[self::SAFE_TYPES_TO_METHODS] ?? [];
+        $safeTypesToMethods = $configuration[self::SAFE_TYPES_TO_METHODS] ?? ($configuration ?: []);
         Assert::isArray($safeTypesToMethods);
         foreach ($safeTypesToMethods as $key => $value) {
             Assert::string($key);

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $attributesToAnnotations = $configuration[self::ATTRIBUTE_TO_ANNOTATION] ?? [];
+        $attributesToAnnotations = $configuration[self::ATTRIBUTE_TO_ANNOTATION] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($attributesToAnnotations, DowngradeAttributeToAnnotation::class);
 
         $this->attributesToAnnotations = $attributesToAnnotations;

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
 
     private function shouldSkip(FuncCall|MethodCall|StaticCall $node): bool
     {
-        if (count($node->args) !== 1) {
+        if (count((array) $node->args) !== 1) {
             return true;
         }
 

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
 
     private function shouldSkip(FuncCall|MethodCall|StaticCall $node): bool
     {
-        if (count((array) $node->args) !== 1) {
+        if (count($node->args) !== 1) {
             return true;
         }
 

--- a/rules/Generics/Rector/ClassMethod/GenericClassMethodParamRector.php
+++ b/rules/Generics/Rector/ClassMethod/GenericClassMethodParamRector.php
@@ -127,7 +127,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $makeClassMethodGenerics = $configuration[self::GENERIC_CLASS_METHOD_PARAMS] ?? [];
+        $makeClassMethodGenerics = $configuration[self::GENERIC_CLASS_METHOD_PARAMS] ?? ($configuration ?: []);
         Assert::allIsAOf($makeClassMethodGenerics, GenericClassMethodParam::class);
 
         $this->genericClassMethodParams = $makeClassMethodGenerics;

--- a/rules/Generics/Rector/ClassMethod/GenericClassMethodParamRector.php
+++ b/rules/Generics/Rector/ClassMethod/GenericClassMethodParamRector.php
@@ -123,7 +123,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, GenericClassMethodParam[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $classesToSkip = $configuration[self::CLASSES_TO_SKIP] ?? [];
+        $classesToSkip = $configuration[self::CLASSES_TO_SKIP] ?? ($configuration ?: []);
         Assert::allString($classesToSkip);
 
         $this->classesToSkip = $classesToSkip;

--- a/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
+++ b/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
@@ -84,7 +84,7 @@ final class RemoveExtraParametersRector extends AbstractRector implements MinPhp
 
         $maximumAllowedParameterCount = $this->resolveMaximumAllowedParameterCount($functionLikeReflection);
 
-        $numberOfArguments = count($node->args);
+        $numberOfArguments = count((array) $node->args);
         if ($numberOfArguments <= $maximumAllowedParameterCount) {
             return null;
         }

--- a/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
+++ b/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
@@ -84,7 +84,7 @@ final class RemoveExtraParametersRector extends AbstractRector implements MinPhp
 
         $maximumAllowedParameterCount = $this->resolveMaximumAllowedParameterCount($functionLikeReflection);
 
-        $numberOfArguments = count((array) $node->args);
+        $numberOfArguments = count($node->args);
         if ($numberOfArguments <= $maximumAllowedParameterCount) {
             return null;
         }

--- a/rules/Php71/Rector/Name/ReservedObjectRector.php
+++ b/rules/Php71/Rector/Name/ReservedObjectRector.php
@@ -15,6 +15,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://wiki.php.net/rfc/object-typehint https://github.com/cebe/yii2/commit/9548a212ecf6e50fcdb0e5ba6daad88019cfc544
@@ -88,11 +89,17 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->reservedKeywordsToReplacements = $configuration[self::RESERVED_KEYWORDS_TO_REPLACEMENTS] ?? ($configuration ?: []);
+        $reservedKeywordsToReplacements = $configuration[self::RESERVED_KEYWORDS_TO_REPLACEMENTS] ?? ($configuration ?: []);
+
+        Assert::isArray($reservedKeywordsToReplacements);
+        Assert::allString(array_keys($reservedKeywordsToReplacements));
+        Assert::allString($reservedKeywordsToReplacements);
+
+        $this->reservedKeywordsToReplacements = $reservedKeywordsToReplacements;
     }
 
     private function processIdentifier(Identifier $identifier): Identifier

--- a/rules/Php71/Rector/Name/ReservedObjectRector.php
+++ b/rules/Php71/Rector/Name/ReservedObjectRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->reservedKeywordsToReplacements = $configuration[self::RESERVED_KEYWORDS_TO_REPLACEMENTS] ?? [];
+        $this->reservedKeywordsToReplacements = $configuration[self::RESERVED_KEYWORDS_TO_REPLACEMENTS] ?? ($configuration ?: []);
     }
 
     private function processIdentifier(Identifier $identifier): Identifier

--- a/rules/Php74/Rector/Function_/ReservedFnFunctionRector.php
+++ b/rules/Php74/Rector/Function_/ReservedFnFunctionRector.php
@@ -15,6 +15,7 @@ use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://github.com/php/php-src/pull/3941/files#diff-7e3a1a5df28a1cbd8c0fb6db68f243da
@@ -112,10 +113,16 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->reservedNamesToNewOnes = $configuration[self::RESERVED_NAMES_TO_NEW_ONES] ?? ($configuration ?: []);
+        $reservedNamesToNewOnes = $configuration[self::RESERVED_NAMES_TO_NEW_ONES] ?? ($configuration ?: []);
+
+        Assert::allString(array_keys($reservedNamesToNewOnes));
+        Assert::allString($reservedNamesToNewOnes);
+
+        /** @var array<string, string> $reservedNamesToNewOnes */
+        $this->reservedNamesToNewOnes = $reservedNamesToNewOnes;
     }
 }

--- a/rules/Php74/Rector/Function_/ReservedFnFunctionRector.php
+++ b/rules/Php74/Rector/Function_/ReservedFnFunctionRector.php
@@ -116,6 +116,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->reservedNamesToNewOnes = $configuration[self::RESERVED_NAMES_TO_NEW_ONES] ?? [];
+        $this->reservedNamesToNewOnes = $configuration[self::RESERVED_NAMES_TO_NEW_ONES] ?? ($configuration ?: []);
     }
 }

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -144,7 +144,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $annotationsToAttributes = $configuration[self::ANNOTATION_TO_ATTRIBUTE] ?? [];
+        $annotationsToAttributes = $configuration[self::ANNOTATION_TO_ATTRIBUTE] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($annotationsToAttributes, AnnotationToAttribute::class);
         $this->annotationsToAttributes = $annotationsToAttributes;
     }

--- a/rules/Privatization/Rector/MethodCall/ReplaceStringWithClassConstantRector.php
+++ b/rules/Privatization/Rector/MethodCall/ReplaceStringWithClassConstantRector.php
@@ -119,7 +119,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->replaceStringWithClassConstants = $configuration[self::REPLACE_STRING_WITH_CLASS_CONSTANT] ?? [];
+        $this->replaceStringWithClassConstants = $configuration[self::REPLACE_STRING_WITH_CLASS_CONSTANT] ?? ($configuration ?: []);
     }
 
     private function matchArg(

--- a/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
+++ b/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $removedArguments = $configuration[self::REMOVED_ARGUMENTS] ?? [];
+        $removedArguments = $configuration[self::REMOVED_ARGUMENTS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($removedArguments, ArgumentRemover::class);
         $this->removedArguments = $removedArguments;
     }

--- a/rules/Removing/Rector/Class_/RemoveInterfacesRector.php
+++ b/rules/Removing/Rector/Class_/RemoveInterfacesRector.php
@@ -80,6 +80,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->interfacesToRemove = $configuration[self::INTERFACES_TO_REMOVE] ?? [];
+        $this->interfacesToRemove = $configuration[self::INTERFACES_TO_REMOVE] ?? ($configuration ?: []);
     }
 }

--- a/rules/Removing/Rector/Class_/RemoveInterfacesRector.php
+++ b/rules/Removing/Rector/Class_/RemoveInterfacesRector.php
@@ -10,6 +10,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Removing\Rector\Class_\RemoveInterfacesRector\RemoveInterfacesRectorTest
@@ -22,7 +23,7 @@ final class RemoveInterfacesRector extends AbstractRector implements Configurabl
     public const INTERFACES_TO_REMOVE = 'interfaces_to_remove';
 
     /**
-     * @var class-string[]
+     * @var string[]
      */
     private array $interfacesToRemove = [];
 
@@ -76,10 +77,14 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, class-string[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->interfacesToRemove = $configuration[self::INTERFACES_TO_REMOVE] ?? ($configuration ?: []);
+        $interfacesToRemove = $configuration[self::INTERFACES_TO_REMOVE] ?? ($configuration ?: []);
+        Assert::allString($interfacesToRemove);
+
+        /** @var string[] $interfacesToRemove */
+        $this->interfacesToRemove = $interfacesToRemove;
     }
 }

--- a/rules/Removing/Rector/Class_/RemoveParentRector.php
+++ b/rules/Removing/Rector/Class_/RemoveParentRector.php
@@ -97,6 +97,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->parentClassesToRemove = $configuration[self::PARENT_TYPES_TO_REMOVE] ?? [];
+        $this->parentClassesToRemove = $configuration[self::PARENT_TYPES_TO_REMOVE] ?? ($configuration ?: []);
     }
 }

--- a/rules/Removing/Rector/Class_/RemoveParentRector.php
+++ b/rules/Removing/Rector/Class_/RemoveParentRector.php
@@ -13,6 +13,7 @@ use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Removing\Rector\Class_\RemoveParentRector\RemoveParentRectorTest
@@ -93,10 +94,15 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, class-string[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->parentClassesToRemove = $configuration[self::PARENT_TYPES_TO_REMOVE] ?? ($configuration ?: []);
+        $parentTypesToRemove = $configuration[self::PARENT_TYPES_TO_REMOVE] ?? ($configuration ?: []);
+
+        Assert::isArray($parentTypesToRemove);
+        Assert::allString($parentTypesToRemove);
+
+        $this->parentClassesToRemove = $parentTypesToRemove;
     }
 }

--- a/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
+++ b/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
@@ -94,6 +94,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->traitsToRemove = $configuration[self::TRAITS_TO_REMOVE] ?? [];
+        $this->traitsToRemove = $configuration[self::TRAITS_TO_REMOVE] ?? ($configuration ?: []);
     }
 }

--- a/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
+++ b/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
@@ -12,6 +12,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Removing\Rector\Class_\RemoveTraitUseRector\RemoveTraitUseRectorTest
@@ -90,10 +91,14 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, string[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->traitsToRemove = $configuration[self::TRAITS_TO_REMOVE] ?? ($configuration ?: []);
+        $traitsToRemove = $configuration[self::TRAITS_TO_REMOVE] ?? ($configuration ?: []);
+        Assert::allString($traitsToRemove);
+
+        /** @var string[] $traitsToRemove */
+        $this->traitsToRemove = $traitsToRemove;
     }
 }

--- a/rules/Removing/Rector/FuncCall/RemoveFuncCallArgRector.php
+++ b/rules/Removing/Rector/FuncCall/RemoveFuncCallArgRector.php
@@ -87,7 +87,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $removedFunctionArguments = $configuration[self::REMOVED_FUNCTION_ARGUMENTS] ?? [];
+        $removedFunctionArguments = $configuration[self::REMOVED_FUNCTION_ARGUMENTS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($removedFunctionArguments, RemoveFuncCallArg::class);
         $this->removedFunctionArguments = $removedFunctionArguments;
     }

--- a/rules/Removing/Rector/FuncCall/RemoveFuncCallRector.php
+++ b/rules/Removing/Rector/FuncCall/RemoveFuncCallRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $removeFuncCalls = $configuration[self::REMOVE_FUNC_CALLS] ?? [];
+        $removeFuncCalls = $configuration[self::REMOVE_FUNC_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($removeFuncCalls, RemoveFuncCall::class);
         $this->removeFuncCalls = $removeFuncCalls;
     }

--- a/rules/Renaming/Rector/ClassConstFetch/RenameClassConstFetchRector.php
+++ b/rules/Renaming/Rector/ClassConstFetch/RenameClassConstFetchRector.php
@@ -100,7 +100,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $renameClassConstFetches = $configuration[self::CLASS_CONSTANT_RENAME] ?? [];
+        $renameClassConstFetches = $configuration[self::CLASS_CONSTANT_RENAME] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($renameClassConstFetches, RenameClassConstFetchInterface::class);
 
         $this->renameClassConstFetches = $renameClassConstFetches;

--- a/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
+++ b/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
@@ -116,7 +116,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $renamedAnnotationsInTypes = $configuration[self::RENAMED_ANNOTATIONS_IN_TYPES] ?? [];
+        $renamedAnnotationsInTypes = $configuration[self::RENAMED_ANNOTATIONS_IN_TYPES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($renamedAnnotationsInTypes, RenameAnnotation::class);
         $this->renamedAnnotations = $renamedAnnotationsInTypes;
     }

--- a/rules/Renaming/Rector/ConstFetch/RenameConstantRector.php
+++ b/rules/Renaming/Rector/ConstFetch/RenameConstantRector.php
@@ -11,6 +11,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Renaming\Rector\ConstFetch\RenameConstantRector\RenameConstantRectorTest
@@ -87,10 +88,15 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->oldToNewConstants = $configuration[self::OLD_TO_NEW_CONSTANTS] ?? ($configuration ?: []);
+        $oldToNewConstants = $configuration[self::OLD_TO_NEW_CONSTANTS] ?? ($configuration ?: []);
+        Assert::allString(array_keys($oldToNewConstants));
+        Assert::allString($oldToNewConstants);
+
+        /** @var array<string, string> $oldToNewConstants */
+        $this->oldToNewConstants = $oldToNewConstants;
     }
 }

--- a/rules/Renaming/Rector/ConstFetch/RenameConstantRector.php
+++ b/rules/Renaming/Rector/ConstFetch/RenameConstantRector.php
@@ -91,6 +91,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->oldToNewConstants = $configuration[self::OLD_TO_NEW_CONSTANTS] ?? [];
+        $this->oldToNewConstants = $configuration[self::OLD_TO_NEW_CONSTANTS] ?? ($configuration ?: []);
     }
 }

--- a/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
+++ b/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
@@ -119,7 +119,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $namespacePrefixesWithExcludedClasses = $configuration[self::NAMESPACE_PREFIXES_WITH_EXCLUDED_CLASSES] ?? [];
+        $namespacePrefixesWithExcludedClasses = $configuration[self::NAMESPACE_PREFIXES_WITH_EXCLUDED_CLASSES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($namespacePrefixesWithExcludedClasses, PseudoNamespaceToNamespace::class);
 
         $this->pseudoNamespacesToNamespaces = $namespacePrefixesWithExcludedClasses;

--- a/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
@@ -122,7 +122,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $methodCallRenames = $configuration[self::METHOD_CALL_RENAMES] ?? [];
+        $methodCallRenames = $configuration[self::METHOD_CALL_RENAMES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($methodCallRenames, MethodCallRenameInterface::class);
 
         $this->methodCallRenames = $methodCallRenames;

--- a/rules/Renaming/Rector/Namespace_/RenameNamespaceRector.php
+++ b/rules/Renaming/Rector/Namespace_/RenameNamespaceRector.php
@@ -19,6 +19,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Renaming\ValueObject\RenamedNamespace;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Renaming\Rector\Namespace_\RenameNamespaceRector\RenameNamespaceRectorTest
@@ -120,11 +121,16 @@ final class RenameNamespaceRector extends AbstractRector implements Configurable
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->oldToNewNamespaces = $configuration[self::OLD_TO_NEW_NAMESPACES] ?? ($configuration ?: []);
+        $oldToNewNamespaces = $configuration[self::OLD_TO_NEW_NAMESPACES] ?? ($configuration ?: []);
+        Assert::allString(array_keys($oldToNewNamespaces));
+        Assert::allString($oldToNewNamespaces);
+
+        /** @var array<string, string> $oldToNewNamespaces */
+        $this->oldToNewNamespaces = $oldToNewNamespaces;
     }
 
     private function processFullyQualified(Name $name, RenamedNamespace $renamedNamespace): ?FullyQualified

--- a/rules/Renaming/Rector/Namespace_/RenameNamespaceRector.php
+++ b/rules/Renaming/Rector/Namespace_/RenameNamespaceRector.php
@@ -124,7 +124,7 @@ final class RenameNamespaceRector extends AbstractRector implements Configurable
      */
     public function configure(array $configuration): void
     {
-        $this->oldToNewNamespaces = $configuration[self::OLD_TO_NEW_NAMESPACES] ?? [];
+        $this->oldToNewNamespaces = $configuration[self::OLD_TO_NEW_NAMESPACES] ?? ($configuration ?: []);
     }
 
     private function processFullyQualified(Name $name, RenamedNamespace $renamedNamespace): ?FullyQualified

--- a/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
+++ b/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
@@ -75,7 +75,7 @@ final class RenamePropertyRector extends AbstractRector implements ConfigurableR
      */
     public function configure(array $configuration): void
     {
-        $renamedProperties = $configuration[self::RENAMED_PROPERTIES] ?? [];
+        $renamedProperties = $configuration[self::RENAMED_PROPERTIES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($renamedProperties, RenameProperty::class);
         $this->renamedProperties = $renamedProperties;
     }

--- a/rules/Renaming/Rector/String_/RenameStringRector.php
+++ b/rules/Renaming/Rector/String_/RenameStringRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $stringChanges = $configuration[self::STRING_CHANGES] ?? [];
+        $stringChanges = $configuration[self::STRING_CHANGES] ?? ($configuration ?: []);
         Assert::allString($stringChanges);
         Assert::allString(array_values($stringChanges));
 

--- a/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
+++ b/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
@@ -106,7 +106,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $useImportsToRestore = $configuration[self::USE_IMPORTS_TO_RESTORE] ?? [];
+        $useImportsToRestore = $configuration[self::USE_IMPORTS_TO_RESTORE] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($useImportsToRestore, CompleteImportForPartialAnnotation::class);
 
         $default = [

--- a/rules/Transform/Rector/Assign/DimFetchAssignToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/DimFetchAssignToMethodCallRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $dimFetchAssignToMethodCalls = $configuration[self::DIM_FETCH_ASSIGN_TO_METHOD_CALL] ?? [];
+        $dimFetchAssignToMethodCalls = $configuration[self::DIM_FETCH_ASSIGN_TO_METHOD_CALL] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($dimFetchAssignToMethodCalls, DimFetchAssignToMethodCall::class);
         $this->dimFetchAssignToMethodCalls = $dimFetchAssignToMethodCalls;
     }

--- a/rules/Transform/Rector/Assign/GetAndSetToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/GetAndSetToMethodCallRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $getAndSetToMethodCalls = $configuration[self::TYPE_TO_METHOD_CALLS] ?? [];
+        $getAndSetToMethodCalls = $configuration[self::TYPE_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsAOf($getAndSetToMethodCalls, GetAndSetToMethodCall::class);
 
         $this->getAndSetToMethodCalls = $getAndSetToMethodCalls;

--- a/rules/Transform/Rector/Assign/GetAndSetToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/GetAndSetToMethodCallRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, GetAndSetToMethodCall[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {

--- a/rules/Transform/Rector/Assign/PropertyAssignToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/PropertyAssignToMethodCallRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $propertyAssignsToMethodCalls = $configuration[self::PROPERTY_ASSIGNS_TO_METHODS_CALLS] ?? [];
+        $propertyAssignsToMethodCalls = $configuration[self::PROPERTY_ASSIGNS_TO_METHODS_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($propertyAssignsToMethodCalls, PropertyAssignToMethodCall::class);
         $this->propertyAssignsToMethodCalls = $propertyAssignsToMethodCalls;
     }

--- a/rules/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $propertiesToMethodCalls = $configuration[self::PROPERTIES_TO_METHOD_CALLS] ?? [];
+        $propertiesToMethodCalls = $configuration[self::PROPERTIES_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($propertiesToMethodCalls, PropertyFetchToMethodCall::class);
         $this->propertiesToMethodCalls = $propertiesToMethodCalls;
     }

--- a/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
+++ b/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
@@ -119,7 +119,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $attributeKeysToClassConstFetches = $configuration[self::ATTRIBUTE_KEYS_TO_CLASS_CONST_FETCHES] ?? [];
+        $attributeKeysToClassConstFetches = $configuration[self::ATTRIBUTE_KEYS_TO_CLASS_CONST_FETCHES] ?? ($configuration ?: []);
         Assert::allIsAOf($attributeKeysToClassConstFetches, AttributeKeyToClassConstFetch::class);
         $this->attributeKeysToClassConstFetches = $attributeKeysToClassConstFetches;
     }

--- a/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
+++ b/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
@@ -115,12 +115,13 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, AttributeKeyToClassConstFetch[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
         $attributeKeysToClassConstFetches = $configuration[self::ATTRIBUTE_KEYS_TO_CLASS_CONST_FETCHES] ?? ($configuration ?: []);
         Assert::allIsAOf($attributeKeysToClassConstFetches, AttributeKeyToClassConstFetch::class);
+
         $this->attributeKeysToClassConstFetches = $attributeKeysToClassConstFetches;
     }
 }

--- a/rules/Transform/Rector/ClassConstFetch/ClassConstFetchToValueRector.php
+++ b/rules/Transform/Rector/ClassConstFetch/ClassConstFetchToValueRector.php
@@ -80,7 +80,7 @@ final class ClassConstFetchToValueRector extends AbstractRector implements Confi
      */
     public function configure(array $configuration): void
     {
-        $classConstFetchesToValues = $configuration[self::CLASS_CONST_FETCHES_TO_VALUES] ?? [];
+        $classConstFetchesToValues = $configuration[self::CLASS_CONST_FETCHES_TO_VALUES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($classConstFetchesToValues, ClassConstFetchToValue::class);
 
         $this->classConstFetchesToValues = $classConstFetchesToValues;

--- a/rules/Transform/Rector/ClassMethod/SingleToManyMethodRector.php
+++ b/rules/Transform/Rector/ClassMethod/SingleToManyMethodRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $singleToManyMethods = $configuration[self::SINGLES_TO_MANY_METHODS] ?? [];
+        $singleToManyMethods = $configuration[self::SINGLES_TO_MANY_METHODS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($singleToManyMethods, SingleToManyMethod::class);
 
         $this->singleToManyMethods = $singleToManyMethods;

--- a/rules/Transform/Rector/ClassMethod/WrapReturnRector.php
+++ b/rules/Transform/Rector/ClassMethod/WrapReturnRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $typeMethodWraps = $configuration[self::TYPE_METHOD_WRAPS] ?? [];
+        $typeMethodWraps = $configuration[self::TYPE_METHOD_WRAPS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($typeMethodWraps, WrapReturn::class);
         $this->typeMethodWraps = $typeMethodWraps;
     }

--- a/rules/Transform/Rector/Class_/AddInterfaceByParentRector.php
+++ b/rules/Transform/Rector/Class_/AddInterfaceByParentRector.php
@@ -14,6 +14,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Transform\Rector\Class_\AddInterfaceByParentRector\AddInterfaceByParentRectorTest
@@ -101,10 +102,16 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->interfaceByParent = $configuration[self::INTERFACE_BY_PARENT] ?? ($configuration ?: []);
+        $interfaceByParent = $configuration[self::INTERFACE_BY_PARENT] ?? ($configuration ?: []);
+
+        Assert::isArray($interfaceByParent);
+        Assert::allString(array_keys($interfaceByParent));
+        Assert::allString($interfaceByParent);
+
+        $this->interfaceByParent = $interfaceByParent;
     }
 }

--- a/rules/Transform/Rector/Class_/AddInterfaceByParentRector.php
+++ b/rules/Transform/Rector/Class_/AddInterfaceByParentRector.php
@@ -105,6 +105,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->interfaceByParent = $configuration[self::INTERFACE_BY_PARENT] ?? [];
+        $this->interfaceByParent = $configuration[self::INTERFACE_BY_PARENT] ?? ($configuration ?: []);
     }
 }

--- a/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
+++ b/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
@@ -99,6 +99,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->interfaceByTrait = $configuration[self::INTERFACE_BY_TRAIT] ?? [];
+        $this->interfaceByTrait = $configuration[self::INTERFACE_BY_TRAIT] ?? ($configuration ?: []);
     }
 }

--- a/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
+++ b/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
@@ -14,6 +14,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Transform\Rector\Class_\AddInterfaceByTraitRector\AddInterfaceByTraitRectorTest
@@ -95,10 +96,17 @@ CODE_SAMPLE
     }
 
     /**
+     * @todo complex configuration, introduce value object!
      * @param array<string, array<string, string>> $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->interfaceByTrait = $configuration[self::INTERFACE_BY_TRAIT] ?? ($configuration ?: []);
+        $interfaceByTrait = $configuration[self::INTERFACE_BY_TRAIT] ?? ($configuration ?: []);
+
+        Assert::isArray($interfaceByTrait);
+        Assert::allString(array_keys($interfaceByTrait));
+        Assert::allString($interfaceByTrait);
+
+        $this->interfaceByTrait = $interfaceByTrait;
     }
 }

--- a/rules/Transform/Rector/Class_/MergeInterfacesRector.php
+++ b/rules/Transform/Rector/Class_/MergeInterfacesRector.php
@@ -11,6 +11,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * Covers cases like
@@ -94,7 +95,12 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->oldToNewInterfaces = $configuration[self::OLD_TO_NEW_INTERFACES] ?? ($configuration ?: []);
+        $oldToNewInterfaces = $configuration[self::OLD_TO_NEW_INTERFACES] ?? ($configuration ?: []);
+
+        Assert::allString(array_keys($oldToNewInterfaces));
+        Assert::allString($oldToNewInterfaces);
+
+        $this->oldToNewInterfaces = $oldToNewInterfaces;
     }
 
     private function makeImplementsUnique(Class_ $class): void

--- a/rules/Transform/Rector/Class_/MergeInterfacesRector.php
+++ b/rules/Transform/Rector/Class_/MergeInterfacesRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->oldToNewInterfaces = $configuration[self::OLD_TO_NEW_INTERFACES] ?? [];
+        $this->oldToNewInterfaces = $configuration[self::OLD_TO_NEW_INTERFACES] ?? ($configuration ?: []);
     }
 
     private function makeImplementsUnique(Class_ $class): void

--- a/rules/Transform/Rector/Class_/ParentClassToTraitsRector.php
+++ b/rules/Transform/Rector/Class_/ParentClassToTraitsRector.php
@@ -109,7 +109,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $parentClassToTraits = $configuration[self::PARENT_CLASS_TO_TRAITS] ?? [];
+        $parentClassToTraits = $configuration[self::PARENT_CLASS_TO_TRAITS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($parentClassToTraits, ParentClassToTraits::class);
         $this->parentClassToTraits = $parentClassToTraits;
     }

--- a/rules/Transform/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
+++ b/rules/Transform/Rector/FuncCall/ArgumentFuncCallToMethodCallRector.php
@@ -147,12 +147,12 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $functionToMethodCalls = $configuration[self::FUNCTIONS_TO_METHOD_CALLS] ?? [];
+        $functionToMethodCalls = $configuration[self::FUNCTIONS_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($functionToMethodCalls, ArgumentFuncCallToMethodCall::class);
 
         $this->argumentFuncCallToMethodCalls = $functionToMethodCalls;
 
-        $arrayFunctionsToMethodCalls = $configuration[self::ARRAY_FUNCTIONS_TO_METHOD_CALLS] ?? [];
+        $arrayFunctionsToMethodCalls = $configuration[self::ARRAY_FUNCTIONS_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($arrayFunctionsToMethodCalls, ArrayFuncCallToMethodCall::class);
 
         $this->arrayFunctionsToMethodCalls = $arrayFunctionsToMethodCalls;

--- a/rules/Transform/Rector/FuncCall/FuncCallToConstFetchRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToConstFetchRector.php
@@ -12,6 +12,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Transform\Rector\FuncCall\FuncCallToConstFetchRector\FunctionCallToConstantRectorTest
@@ -92,6 +93,11 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->functionsToConstants = $configuration[self::FUNCTIONS_TO_CONSTANTS] ?? ($configuration ?: []);
+        $functionsToConstants = $configuration[self::FUNCTIONS_TO_CONSTANTS] ?? ($configuration ?: []);
+        Assert::allString($functionsToConstants);
+        Assert::allString(array_keys($functionsToConstants));
+
+        /** @var array<string, string> $functionsToConstants */
+        $this->functionsToConstants = $functionsToConstants;
     }
 }

--- a/rules/Transform/Rector/FuncCall/FuncCallToConstFetchRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToConstFetchRector.php
@@ -92,6 +92,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->functionsToConstants = $configuration[self::FUNCTIONS_TO_CONSTANTS] ?? [];
+        $this->functionsToConstants = $configuration[self::FUNCTIONS_TO_CONSTANTS] ?? ($configuration ?: []);
     }
 }

--- a/rules/Transform/Rector/FuncCall/FuncCallToMethodCallRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToMethodCallRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $funcCallsToClassMethodCalls = $configuration[self::FUNC_CALL_TO_CLASS_METHOD_CALL] ?? [];
+        $funcCallsToClassMethodCalls = $configuration[self::FUNC_CALL_TO_CLASS_METHOD_CALL] ?? ($configuration ?: []);
         Assert::isArray($funcCallsToClassMethodCalls);
         Assert::allIsInstanceOf($funcCallsToClassMethodCalls, FuncCallToMethodCall::class);
 

--- a/rules/Transform/Rector/FuncCall/FuncCallToNewRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToNewRector.php
@@ -90,6 +90,6 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->functionToNew = $configuration[self::FUNCTIONS_TO_NEWS] ?? [];
+        $this->functionToNew = $configuration[self::FUNCTIONS_TO_NEWS] ?? ($configuration ?: []);
     }
 }

--- a/rules/Transform/Rector/FuncCall/FuncCallToStaticCallRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToStaticCallRector.php
@@ -76,7 +76,7 @@ final class FuncCallToStaticCallRector extends AbstractRector implements Configu
      */
     public function configure(array $configuration): void
     {
-        $funcCallsToStaticCalls = $configuration[self::FUNC_CALLS_TO_STATIC_CALLS] ?? [];
+        $funcCallsToStaticCalls = $configuration[self::FUNC_CALLS_TO_STATIC_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($funcCallsToStaticCalls, FuncCallToStaticCall::class);
         $this->funcCallsToStaticCalls = $funcCallsToStaticCalls;
     }

--- a/rules/Transform/Rector/Isset_/UnsetAndIssetToMethodCallRector.php
+++ b/rules/Transform/Rector/Isset_/UnsetAndIssetToMethodCallRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $issetUnsetToMethodCalls = $configuration[self::ISSET_UNSET_TO_METHOD_CALL] ?? [];
+        $issetUnsetToMethodCalls = $configuration[self::ISSET_UNSET_TO_METHOD_CALL] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($issetUnsetToMethodCalls, UnsetAndIssetToMethodCall::class);
 
         $this->issetUnsetToMethodCalls = $issetUnsetToMethodCalls;

--- a/rules/Transform/Rector/MethodCall/CallableInMethodCallToVariableRector.php
+++ b/rules/Transform/Rector/MethodCall/CallableInMethodCallToVariableRector.php
@@ -128,7 +128,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $callableInMethodCallToVariable = $configuration[self::CALLABLE_IN_METHOD_CALL_TO_VARIABLE] ?? [];
+        $callableInMethodCallToVariable = $configuration[self::CALLABLE_IN_METHOD_CALL_TO_VARIABLE] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($callableInMethodCallToVariable, CallableInMethodCallToVariable::class);
 
         $this->callableInMethodCallToVariable = $callableInMethodCallToVariable;

--- a/rules/Transform/Rector/MethodCall/MethodCallToAnotherMethodCallWithArgumentsRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToAnotherMethodCallWithArgumentsRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $methodCallRenamesWithAddedArguments = $configuration[self::METHOD_CALL_RENAMES_WITH_ADDED_ARGUMENTS] ?? [];
+        $methodCallRenamesWithAddedArguments = $configuration[self::METHOD_CALL_RENAMES_WITH_ADDED_ARGUMENTS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf(
             $methodCallRenamesWithAddedArguments,
             MethodCallToAnotherMethodCallWithArguments::class

--- a/rules/Transform/Rector/MethodCall/MethodCallToMethodCallRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToMethodCallRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $methodCallsToMethodsCalls = $configuration[self::METHOD_CALLS_TO_METHOD_CALLS] ?? [];
+        $methodCallsToMethodsCalls = $configuration[self::METHOD_CALLS_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsAOf($methodCallsToMethodsCalls, MethodCallToMethodCall::class);
         $this->methodCallsToMethodsCalls = $methodCallsToMethodsCalls;
     }

--- a/rules/Transform/Rector/MethodCall/MethodCallToMethodCallRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToMethodCallRector.php
@@ -138,12 +138,13 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, MethodCallToMethodCall[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
         $methodCallsToMethodsCalls = $configuration[self::METHOD_CALLS_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsAOf($methodCallsToMethodsCalls, MethodCallToMethodCall::class);
+
         $this->methodCallsToMethodsCalls = $methodCallsToMethodsCalls;
     }
 

--- a/rules/Transform/Rector/MethodCall/MethodCallToPropertyFetchRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToPropertyFetchRector.php
@@ -10,6 +10,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Transform\Rector\MethodCall\MethodCallToPropertyFetchRector\MethodCallToPropertyFetchRectorTest
@@ -85,10 +86,15 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->methodCallToPropertyFetchCollection = $configuration[self::METHOD_CALL_TO_PROPERTY_FETCHES] ?? [];
+        $methodCallToPropertyFetchCollection = $configuration[self::METHOD_CALL_TO_PROPERTY_FETCHES] ?? ($configuration ?: []);
+
+        Assert::allString($methodCallToPropertyFetchCollection);
+        Assert::allString(array_keys($methodCallToPropertyFetchCollection));
+
+        $this->methodCallToPropertyFetchCollection = $methodCallToPropertyFetchCollection;
     }
 }

--- a/rules/Transform/Rector/MethodCall/MethodCallToPropertyFetchRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToPropertyFetchRector.php
@@ -92,9 +92,10 @@ CODE_SAMPLE
     {
         $methodCallToPropertyFetchCollection = $configuration[self::METHOD_CALL_TO_PROPERTY_FETCHES] ?? ($configuration ?: []);
 
-        Assert::allString($methodCallToPropertyFetchCollection);
         Assert::allString(array_keys($methodCallToPropertyFetchCollection));
+        Assert::allString($methodCallToPropertyFetchCollection);
 
+        /** @var array<string, string> $methodCallToPropertyFetchCollection */
         $this->methodCallToPropertyFetchCollection = $methodCallToPropertyFetchCollection;
     }
 }

--- a/rules/Transform/Rector/MethodCall/MethodCallToStaticCallRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToStaticCallRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $methodCallsToStaticCalls = $configuration[self::METHOD_CALLS_TO_STATIC_CALLS] ?? [];
+        $methodCallsToStaticCalls = $configuration[self::METHOD_CALLS_TO_STATIC_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($methodCallsToStaticCalls, MethodCallToStaticCall::class);
         $this->methodCallsToStaticCalls = $methodCallsToStaticCalls;
     }

--- a/rules/Transform/Rector/MethodCall/ReplaceParentCallByPropertyCallRector.php
+++ b/rules/Transform/Rector/MethodCall/ReplaceParentCallByPropertyCallRector.php
@@ -98,7 +98,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $parentCallToProperties = $configuration[self::PARENT_CALLS_TO_PROPERTIES] ?? [];
+        $parentCallToProperties = $configuration[self::PARENT_CALLS_TO_PROPERTIES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($parentCallToProperties, ReplaceParentCallByPropertyCall::class);
 
         $this->parentCallToProperties = $parentCallToProperties;

--- a/rules/Transform/Rector/MethodCall/ServiceGetterToConstructorInjectionRector.php
+++ b/rules/Transform/Rector/MethodCall/ServiceGetterToConstructorInjectionRector.php
@@ -172,7 +172,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $methodCallToServices = $configuration[self::METHOD_CALL_TO_SERVICES] ?? [];
+        $methodCallToServices = $configuration[self::METHOD_CALL_TO_SERVICES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($methodCallToServices, ServiceGetterToConstructorInjection::class);
         $this->methodCallToServices = $methodCallToServices;
     }

--- a/rules/Transform/Rector/New_/NewArgToMethodCallRector.php
+++ b/rules/Transform/Rector/New_/NewArgToMethodCallRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $newArgsToMethodCalls = $configuration[self::NEW_ARGS_TO_METHOD_CALLS] ?? [];
+        $newArgsToMethodCalls = $configuration[self::NEW_ARGS_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($newArgsToMethodCalls, NewArgToMethodCall::class);
         $this->newArgsToMethodCalls = $newArgsToMethodCalls;
     }

--- a/rules/Transform/Rector/New_/NewToConstructorInjectionRector.php
+++ b/rules/Transform/Rector/New_/NewToConstructorInjectionRector.php
@@ -120,7 +120,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $typesToConstructorInjections = $configuration[self::TYPES_TO_CONSTRUCTOR_INJECTION] ?? [];
+        $typesToConstructorInjections = $configuration[self::TYPES_TO_CONSTRUCTOR_INJECTION] ?? ($configuration ?: []);
         foreach ($typesToConstructorInjections as $typeToConstructorInjection) {
             $this->constructorInjectionObjectTypes[] = new ObjectType($typeToConstructorInjection);
         }

--- a/rules/Transform/Rector/New_/NewToMethodCallRector.php
+++ b/rules/Transform/Rector/New_/NewToMethodCallRector.php
@@ -140,7 +140,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $newsToMethodCalls = $configuration[self::NEWS_TO_METHOD_CALLS] ?? [];
+        $newsToMethodCalls = $configuration[self::NEWS_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($newsToMethodCalls, NewToMethodCall::class);
         $this->newsToMethodCalls = $newsToMethodCalls;
     }

--- a/rules/Transform/Rector/New_/NewToStaticCallRector.php
+++ b/rules/Transform/Rector/New_/NewToStaticCallRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $typeToStaticCalls = $configuration[self::TYPE_TO_STATIC_CALLS] ?? [];
+        $typeToStaticCalls = $configuration[self::TYPE_TO_STATIC_CALLS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($typeToStaticCalls, NewToStaticCall::class);
         $this->typeToStaticCalls = $typeToStaticCalls;
     }

--- a/rules/Transform/Rector/StaticCall/StaticCallToFuncCallRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToFuncCallRector.php
@@ -81,7 +81,7 @@ final class StaticCallToFuncCallRector extends AbstractRector implements Configu
      */
     public function configure(array $configuration): void
     {
-        $staticCallsToFunctions = $configuration[self::STATIC_CALLS_TO_FUNCTIONS] ?? [];
+        $staticCallsToFunctions = $configuration[self::STATIC_CALLS_TO_FUNCTIONS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($staticCallsToFunctions, StaticCallToFuncCall::class);
         $this->staticCallsToFunctions = $staticCallsToFunctions;
     }

--- a/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
@@ -152,7 +152,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $staticCallsToMethodCalls = $configuration[self::STATIC_CALLS_TO_METHOD_CALLS] ?? [];
+        $staticCallsToMethodCalls = $configuration[self::STATIC_CALLS_TO_METHOD_CALLS] ?? ($configuration ?: []);
         Assert::isArray($staticCallsToMethodCalls);
         Assert::allIsInstanceOf($staticCallsToMethodCalls, StaticCallToMethodCall::class);
 

--- a/rules/Transform/Rector/StaticCall/StaticCallToNewRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToNewRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $staticCallsToNews = $configuration[self::STATIC_CALLS_TO_NEWS] ?? [];
+        $staticCallsToNews = $configuration[self::STATIC_CALLS_TO_NEWS] ?? ($configuration ?: []);
         Assert::allIsAOf($staticCallsToNews, StaticCallToNew::class);
 
         $this->staticCallsToNews = $staticCallsToNews;

--- a/rules/Transform/Rector/StaticCall/StaticCallToNewRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToNewRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, StaticCallToNew[]> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {

--- a/rules/Transform/Rector/String_/StringToClassConstantRector.php
+++ b/rules/Transform/Rector/String_/StringToClassConstantRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $stringToClassConstants = $configuration[self::STRINGS_TO_CLASS_CONSTANTS] ?? [];
+        $stringToClassConstants = $configuration[self::STRINGS_TO_CLASS_CONSTANTS] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($stringToClassConstants, StringToClassConstant::class);
         $this->stringsToClassConstants = $stringToClassConstants;
     }

--- a/rules/Transform/Rector/String_/ToStringToMethodCallRector.php
+++ b/rules/Transform/Rector/String_/ToStringToMethodCallRector.php
@@ -13,6 +13,7 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Transform\Rector\String_\ToStringToMethodCallRector\ToStringToMethodCallRectorTest
@@ -76,11 +77,17 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, array<string, string>> $configuration
+     * @param mixed[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $this->methodNamesByType = $configuration[self::METHOD_NAMES_BY_TYPE] ?? ($configuration ?: []);
+        $methodNamesByType = $configuration[self::METHOD_NAMES_BY_TYPE] ?? ($configuration ?: []);
+
+        Assert::allString(array_keys($methodNamesByType));
+        Assert::allString($methodNamesByType);
+
+        /** @var array<string, string> $methodNamesByType */
+        $this->methodNamesByType = $methodNamesByType;
     }
 
     private function processStringNode(String_ $string): ?Node

--- a/rules/Transform/Rector/String_/ToStringToMethodCallRector.php
+++ b/rules/Transform/Rector/String_/ToStringToMethodCallRector.php
@@ -80,7 +80,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $this->methodNamesByType = $configuration[self::METHOD_NAMES_BY_TYPE] ?? [];
+        $this->methodNamesByType = $configuration[self::METHOD_NAMES_BY_TYPE] ?? ($configuration ?: []);
     }
 
     private function processStringNode(String_ $string): ?Node

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
@@ -101,11 +101,11 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, AddReturnTypeDeclaration[]> $configuration
+     * @param array<string, AddReturnTypeDeclaration[]>|AddReturnTypeDeclaration[] $configuration
      */
     public function configure(array $configuration): void
     {
-        $methodReturnTypes = $configuration[self::METHOD_RETURN_TYPES] ?? [];
+        $methodReturnTypes = $configuration[self::METHOD_RETURN_TYPES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($methodReturnTypes, AddReturnTypeDeclaration::class);
 
         $this->methodReturnTypes = $methodReturnTypes;

--- a/rules/Visibility/Rector/ClassConst/ChangeConstantVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassConst/ChangeConstantVisibilityRector.php
@@ -110,7 +110,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $classConstantVisibilityChanges = $configuration[self::CLASS_CONSTANT_VISIBILITY_CHANGES] ?? [];
+        $classConstantVisibilityChanges = $configuration[self::CLASS_CONSTANT_VISIBILITY_CHANGES] ?? ($configuration ?: []);
         Assert::isArray($classConstantVisibilityChanges);
         Assert::allIsInstanceOf($classConstantVisibilityChanges, ChangeConstantVisibility::class);
 

--- a/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $methodVisibilities = $configuration[self::METHOD_VISIBILITIES] ?? [];
+        $methodVisibilities = $configuration[self::METHOD_VISIBILITIES] ?? ($configuration ?: []);
         Assert::allIsInstanceOf($methodVisibilities, ChangeMethodVisibility::class);
 
         $this->methodVisibilities = $methodVisibilities;


### PR DESCRIPTION
Follow up to https://github.com/rectorphp/rector-src/pull/1285 and https://github.com/rectorphp/rector-src/pull/1276

This enables much simpler configuration on classes using single value to input:

## Before

```php
    $services->set(AddReturnTypeDeclarationRector::class)
        ->call('configure', [[
            AddReturnTypeDeclarationRector::METHOD_RETURN_TYPES => ValueObjectInliner::inline([
                new AddReturnTypeDeclaration(PHPUnitTestCase::class, 'tearDown', new VoidType()),
            ]),
        ]]);
```

## Now

```php
    $services->set(AddReturnTypeDeclarationRector::class)
        ->configure([
            new AddReturnTypeDeclaration(PHPUnitTestCase::class, 'tearDown', new VoidType())
        ]);
```