### PR TITLE
[Core] Fix PhpVersion value on php 8.1 and php 8.2

### DIFF
--- a/src/ValueObject/PhpVersion.php
+++ b/src/ValueObject/PhpVersion.php
@@ -78,13 +78,13 @@ final class PhpVersion extends Enum
      * @api
      * @var int
      */
-    public const PHP_81 = 81000;
+    public const PHP_81 = 80100;
 
     /**
      * @api
      * @var int
      */
-    public const PHP_82 = 82000;
+    public const PHP_82 = 80200;
 
     /**
      * @api


### PR DESCRIPTION
The value on constant in Phpversion class should be `80100` and `80200` for php 8.1 and 8.2 for consistency with previous version values, eg: php 7.4 with `70400`