### PR TITLE
[Core] Refactor init command to use LevelSetList::UP_TO_PHP_XY set list

### DIFF
--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Console\Command;
 
+use Nette\Utils\Strings;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Contract\Template\TemplateResolverInterface;
 use Rector\Core\Exception\Template\TemplateTypeNotFoundException;
@@ -63,7 +64,7 @@ final class InitCommand extends Command
             $this->smartFileSystem->copy($rectorTemplateFilePath, $rectorRootFilePath);
 
             $fullPHPVersion = (string) $this->phpVersionProvider->provide();
-            $phpVersion = substr($fullPHPVersion, 0, 1) . substr($fullPHPVersion, 2, 1);
+            $phpVersion = Strings::substring($fullPHPVersion, 0, 1) . Strings::substring($fullPHPVersion, 2, 1);
 
             $fileContent = $this->smartFileSystem->readFile($rectorRootFilePath);
             $fileContent = str_replace(

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -7,6 +7,7 @@ namespace Rector\Core\Console\Command;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Contract\Template\TemplateResolverInterface;
 use Rector\Core\Exception\Template\TemplateTypeNotFoundException;
+use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Template\DefaultResolver;
 use Stringable;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +27,8 @@ final class InitCommand extends Command
         private FileSystemGuard $fileSystemGuard,
         private SmartFileSystem $smartFileSystem,
         private SymfonyStyle $symfonyStyle,
-        private array $templateResolvers
+        private array $templateResolvers,
+        private PhpVersionProvider $phpVersionProvider
     ) {
         parent::__construct();
     }
@@ -59,6 +61,16 @@ final class InitCommand extends Command
             $this->symfonyStyle->warning('Config file "rector.php" already exists');
         } else {
             $this->smartFileSystem->copy($rectorTemplateFilePath, $rectorRootFilePath);
+
+            $phpVersion  = (int) $this->phpVersionProvider->provide();
+            $fileContent = $this->smartFileSystem->readFile($rectorRootFilePath);
+            $fileContent = str_replace(
+                'LevelSetList::UP_TO_PHP_XY',
+                sprintf('LevelSetList::UP_TO_PHP_%d', $phpVersion),
+                $fileContent
+            );
+            $this->smartFileSystem->dumpFile($rectorRootFilePath, $fileContent);
+
             $this->symfonyStyle->success('"rector.php" config file was added');
         }
 

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -62,7 +62,9 @@ final class InitCommand extends Command
         } else {
             $this->smartFileSystem->copy($rectorTemplateFilePath, $rectorRootFilePath);
 
-            $phpVersion  = substr((string) $this->phpVersionProvider->provide(), 0, 2);
+            $fullPHPVersion = (string) $this->phpVersionProvider->provide();
+            $phpVersion  = substr($fullPHPVersion, 0, 1) . substr($fullPHPVersion, 2, 1);
+
             $fileContent = $this->smartFileSystem->readFile($rectorRootFilePath);
             $fileContent = str_replace(
                 'LevelSetList::UP_TO_PHP_XY',

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -62,7 +62,7 @@ final class InitCommand extends Command
         } else {
             $this->smartFileSystem->copy($rectorTemplateFilePath, $rectorRootFilePath);
 
-            $phpVersion  = (int) $this->phpVersionProvider->provide();
+            $phpVersion  = substr((string) $this->phpVersionProvider->provide(), 0, 2);
             $fileContent = $this->smartFileSystem->readFile($rectorRootFilePath);
             $fileContent = str_replace(
                 'LevelSetList::UP_TO_PHP_XY',

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -63,7 +63,7 @@ final class InitCommand extends Command
             $this->smartFileSystem->copy($rectorTemplateFilePath, $rectorRootFilePath);
 
             $fullPHPVersion = (string) $this->phpVersionProvider->provide();
-            $phpVersion  = substr($fullPHPVersion, 0, 1) . substr($fullPHPVersion, 2, 1);
+            $phpVersion = substr($fullPHPVersion, 0, 1) . substr($fullPHPVersion, 2, 1);
 
             $fileContent = $this->smartFileSystem->readFile($rectorRootFilePath);
             $fileContent = str_replace(

--- a/templates/rector.php.dist
+++ b/templates/rector.php.dist
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
 use Rector\Php74\Rector\Property\TypedPropertyRector;
-use Rector\Set\ValueObject\SetList;
+use Rector\Set\ValueObject\LevelSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -15,7 +15,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     ]);
 
     // Define what rule sets will be applied
-    $containerConfigurator->import(SetList::DEAD_CODE);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_XY);
 
     // get services (needed for register a single rule)
     // $services = $containerConfigurator->services();


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6839

It requires PR https://github.com/rectorphp/rector-src/pull/1327 to be merged first as value for php 81 and php 82 currently 81000 and 82000 instead of `80100` and `80200`