### PR TITLE
[Scoped] Fix downgrade AsciiSlugger

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -107,7 +107,6 @@ final class DowngradeRectorConfig
         // loaded with "require-dev" so it'd throw an error
 
         // use relative paths, so files are excluded on nested directory too
-        'vendor/symfony/string/Slugger/AsciiSlugger.php',
         'vendor/symfony/cache/*',
         // no event-dispatcher used
         'vendor/symfony/console/Event/*',

--- a/rules/DowngradePhp80/Rector/New_/DowngradeArbitraryExpressionsSupportRector.php
+++ b/rules/DowngradePhp80/Rector/New_/DowngradeArbitraryExpressionsSupportRector.php
@@ -130,11 +130,13 @@ CODE_SAMPLE
             $token = $oldTokens[$previousTokenPos] ?? null;
             --$previousTokenPos;
 
-            if (isset($token[0]) && in_array($token[0], [\T_COMMENT, \T_WHITESPACE], true)) {
-                continue;
+            if (! isset($token[0])) {
+                return $token === '(';
             }
 
-            return $token === '(';
+            if (! in_array($token[0], [\T_COMMENT, \T_WHITESPACE], true)) {
+                return $token === '(';
+            }
         }
 
         return false;


### PR DESCRIPTION
Current scoped got error:

```bash
     23| {
    24|     private const LOCALE_TO_TRANSLITERATOR_ID = ['am' => 'Amharic-Latin', 'ar' => 'Arabic-Latin', 'az' => 'Azerbaijani-Latin', 'be' => 'Belarusian-Latin', 'bg' => 'Bulgarian-Latin', 'bn' => 'Bengali-Latin', 'de' => 'de-ASCII', 'el' => 'Greek-Latin', 'fa' => 'Persian-Latin', 'he' => 'Hebrew-Latin', 'hy' => 'Armenian-Latin', 'ka' => 'Georgian-Latin', 'kk' => 'Kazakh-Latin', 'ky' => 'Kirghiz-Latin', 'ko' => 'Korean-Latin', 'mk' => 'Macedonian-Latin', 'mn' => 'Mongolian-Latin', 'or' => 'Oriya-Latin', 'ps' => 'Pashto-Latin', 'ru' => 'Russian-Latin', 'sr' => 'Serbian-Latin', 'sr_Cyrl' => 'Serbian-Latin', 'th' => 'Thai-Latin', 'tk' => 'Turkmen-Latin', 'uk' => 'Ukrainian-Latin', 'uz' => 'Uzbek-Latin', 'zh' => 'Han-Latin'];
  > 25|     private ?string $defaultLocale;
    26|     private \Closure|array $symbolsMap = ['en' => ['@' => 'at', '&' => 'and']];
    27|     /**
Unexpected '?', expecting function (T_FUNCTION) or const (T_CONST) in rector-prefixed-downgraded/vendor/symfony/string/Slugger/AsciiSlugger.php on line 25
```

This PR try to resolve it.