### PR TITLE
[Php80][CodingStyle] Handle ClassPropertyAssignToConstructorPromotionRector+NewlineAfterStatementRector

### DIFF
--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -111,6 +111,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if ($this->nodesToRemoveCollector->isActive()) {
+            return null;
+        }
+
         $node = $this->resolveCurrentStatement($node);
 
         if (! in_array($node::class, self::STMTS_TO_HAVE_NEXT_NEWLINE, true)) {
@@ -149,10 +153,6 @@ CODE_SAMPLE
             if ($rangeLine > 1) {
                 return null;
             }
-        }
-
-        if ($this->nodesToRemoveCollector->isActive()) {
-            return null;
         }
 
         $this->stmtsHashed[$hash] = true;

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -151,6 +151,10 @@ CODE_SAMPLE
             }
         }
 
+        if ($this->nodesToRemoveCollector->isActive()) {
+            return null;
+        }
+
         $this->stmtsHashed[$hash] = true;
         $this->nodesToAddCollector->addNodeAfterNode(new Nop(), $node);
 

--- a/tests/Issues/Issue6840/ClassPropertyPromotionAndNewLineAfterStatementRectorTest.php
+++ b/tests/Issues/Issue6840/ClassPropertyPromotionAndNewLineAfterStatementRectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6840;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/6840
+ */
+final class ClassPropertyPromotionAndNewLineAfterStatementRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6840/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6840/Fixture/fixture.php.inc
@@ -21,11 +21,10 @@ namespace Rector\Core\Tests\Issues\Issue6840\Fixture;
 
 class Fixture
 {
-    private array $imageSize;
+    protected array $imageSize;
 
-    public function __construct(
-        private string $imageId
-    ) {
+    public function __construct(protected $imageId)
+    {
         $this->imageSize = [];
     }
 }

--- a/tests/Issues/Issue6840/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6840/Fixture/fixture.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6840\Fixture;
+
+class Fixture
+{
+    protected string $imageId;
+    protected array $imageSize;
+
+    public function __construct($imageId)
+    {
+        $this->imageId = $imageId;
+        $this->imageSize = [];
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6840\Fixture;
+
+class Fixture
+{
+    private array $imageSize;
+
+    public function __construct(
+        private string $imageId
+    ) {
+        $this->imageSize = [];
+    }
+}
+?>

--- a/tests/Issues/Issue6840/config/configured_rule.php
+++ b/tests/Issues/Issue6840/config/configured_rule.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-
     $services = $containerConfigurator->services();
     $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
     $services->set(NewlineAfterStatementRector::class);

--- a/tests/Issues/Issue6840/config/configured_rule.php
+++ b/tests/Issues/Issue6840/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+
+    $services = $containerConfigurator->services();
+    $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
+    $services->set(NewlineAfterStatementRector::class);
+};


### PR DESCRIPTION
Handle stuck on used of 2 rules:

```php
Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
```

Closes https://github.com/rectorphp/rector-src/pull/1346 Fixes https://github.com/rectorphp/rector/issues/6840