### PR TITLE
VisibilityManipulator adjustment

### DIFF
--- a/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
+++ b/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Rector\Tests\Privatization\NodeManipulator;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\CodingStyle\ClassNameImport\ShortNameResolver;
+use Rector\Core\ValueObject\Visibility;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Rector\Testing\PHPUnit\AbstractTestCase;
+use Rector\Testing\TestingParser\TestingParser;
+
+final class VisibilityManipulatorTest extends AbstractTestCase
+{
+    private VisibilityManipulator $visibilityManipulator;
+
+    protected function setUp(): void
+    {
+        $this->boot();
+        $this->visibilityManipulator = $this->getService(VisibilityManipulator::class);
+    }
+
+    public function test(): void
+    {
+        $node = new ClassMethod('SomeClass');
+        $node->flags = Visibility::PUBLIC | Visibility::STATIC;
+        $this->visibilityManipulator->changeNodeVisibility($node, Visibility::PROTECTED);
+        $this->assertSame(Visibility::PROTECTED | Visibility::STATIC, $node->flags);
+    }
+}

--- a/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
+++ b/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace Rector\Tests\Privatization\NodeManipulator;
 
 use PhpParser\Node\Stmt\ClassMethod;

--- a/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
+++ b/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
@@ -6,11 +6,9 @@ declare(strict_types=1);
 namespace Rector\Tests\Privatization\NodeManipulator;
 
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\CodingStyle\ClassNameImport\ShortNameResolver;
 use Rector\Core\ValueObject\Visibility;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Testing\PHPUnit\AbstractTestCase;
-use Rector\Testing\TestingParser\TestingParser;
 
 final class VisibilityManipulatorTest extends AbstractTestCase
 {

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -147,7 +147,7 @@ final class VisibilityManipulator
     {
         $isStatic = $node instanceof ClassMethod && $node->isStatic();
         if ($isStatic) {
-            $this->removeVisibility($node);
+            $this->removeVisibilityFlag($node, Visibility::STATIC);
         }
 
         if ($visibility !== Visibility::STATIC && $visibility !== Visibility::ABSTRACT && $visibility !== Visibility::FINAL) {
@@ -157,7 +157,7 @@ final class VisibilityManipulator
         $this->addVisibilityFlag($node, $visibility);
 
         if ($isStatic) {
-            $this->makeStatic($node);
+            $this->addVisibilityFlag($node, Visibility::STATIC);
         }
     }
 }

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -147,7 +147,7 @@ final class VisibilityManipulator
     {
         $isStatic = $node instanceof ClassMethod && $node->isStatic();
         if ($isStatic) {
-            $this->removeVisibilityFlag($node, Visibility::STATIC);
+            $this->makeNonStatic($node);
         }
 
         if ($visibility !== Visibility::STATIC && $visibility !== Visibility::ABSTRACT && $visibility !== Visibility::FINAL) {
@@ -157,7 +157,7 @@ final class VisibilityManipulator
         $this->addVisibilityFlag($node, $visibility);
 
         if ($isStatic) {
-            $this->addVisibilityFlag($node, Visibility::STATIC);
+            $this->makeStatic($node);
         }
     }
 }


### PR DESCRIPTION
Previously the VisibilityManipulator would strip public, protected and/or private visibility. This caused the ChangeMethodVisibilityRector to cause problems described in https://github.com/rectorphp/rector/issues/6829

refs: https://github.com/rectorphp/rector/issues/6829
closes: https://github.com/rectorphp/rector/issues/6829