### PR TITLE
[Php81] Skip non private modifier on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_non_private_property.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_non_private_property.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipNonPrivateProperty
+{
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_non_private_property2.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_non_private_property2.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+class SkipNonPrivateProperty2
+{
+    public function __construct(
+        public string $name
+    ) {
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
+++ b/rules-tests/Privatization/NodeManipulator/VisibilityManipulatorTest.php
@@ -21,9 +21,9 @@ final class VisibilityManipulatorTest extends AbstractTestCase
 
     public function test(): void
     {
-        $node = new ClassMethod('SomeClass');
-        $node->flags = Visibility::PUBLIC | Visibility::STATIC;
-        $this->visibilityManipulator->changeNodeVisibility($node, Visibility::PROTECTED);
-        $this->assertSame(Visibility::PROTECTED | Visibility::STATIC, $node->flags);
+        $classMethod = new ClassMethod('SomeClass');
+        $classMethod->flags = Visibility::PUBLIC | Visibility::STATIC;
+        $this->visibilityManipulator->changeNodeVisibility($classMethod, Visibility::PROTECTED);
+        $this->assertSame(Visibility::PROTECTED | Visibility::STATIC, $classMethod->flags);
     }
 }

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Core\ValueObject\Visibility;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -101,6 +102,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->flags !== Visibility::PRIVATE) {
+            return null;
+        }
+
         $this->visibilityManipulator->makeReadonly($node);
         return $node;
     }
@@ -112,7 +117,7 @@ CODE_SAMPLE
 
     private function refactorParam(Param $param): Param | null
     {
-        if ($param->flags === 0) {
+        if ($param->flags !== Visibility::PRIVATE) {
             return null;
         }
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -12,6 +12,9 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Core\ValueObject\Visibility;
 use Webmozart\Assert\Assert;
 
+/**
+ * @see \Rector\Tests\Privatization\NodeManipulator\VisibilityManipulatorTest
+ */
 final class VisibilityManipulator
 {
     public function hasVisibility(ClassMethod | Property | ClassConst | Param $node, int $visibility): bool


### PR DESCRIPTION
Avoid error on public modifier like : 

```bash
1) Rector\Tests\BetterPhpDocParser\PhpDocInlineHtml\TestInlineHtmlTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Error: Cannot modify readonly property Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace::$stmts
``` 

on https://github.com/rectorphp/rector-src/pull/1364#issuecomment-984394205