### PR TITLE
[Php 8.1 Dep] Update stringy vendor patches to update with #[\ReturnTypeWillChange]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,6 +154,9 @@
         "patches": {
             "symfony/dependency-injection": [
                 "patches/symfony-dependency-injection-loader-configurator-servicesconfigurator-php.patch"
+            ],
+            "danielstjules/stringy": [
+                "patches/danielstjules-stringy-src-stringy-php.patch"
             ]
         },
         "branch-alias": {

--- a/patches/danielstjules-stringy-src-stringy-php.patch
+++ b/patches/danielstjules-stringy-src-stringy-php.patch
@@ -1,0 +1,48 @@
+--- /dev/null
++++ ../src/Stringy.php
+@@ -267,6 +267,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      *
+      * @return int The number of characters in the string, given the encoding
+      */
++    #[\ReturnTypeWillChange]
+     public function count()
+     {
+         return $this->length();
+@@ -450,6 +451,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      *
+      * @return \ArrayIterator An iterator for the characters in the string
+      */
++    #[\ReturnTypeWillChange]
+     public function getIterator()
+     {
+         return new ArrayIterator($this->chars());
+@@ -847,6 +849,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @param  mixed   $offset The index to check
+      * @return boolean Whether or not the index exists
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetExists($offset)
+     {
+         $length = $this->length();
+@@ -870,6 +873,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @throws \OutOfBoundsException If the positive or negative offset does
+      *                               not exist
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetGet($offset)
+     {
+         $offset = (int) $offset;
+@@ -890,6 +894,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @param  mixed      $value  Value to set
+      * @throws \Exception When called
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetSet($offset, $value)
+     {
+         // Stringy is immutable, cannot directly set char
+@@ -903,6 +908,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @param  mixed      $offset The index of the character
+      * @throws \Exception When called
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetUnset($offset)


### PR DESCRIPTION
Split part of https://github.com/rectorphp/rector-src/pull/1364#issuecomment-984577128 which stringy needs update methods to use `#[\ReturnTypeWillChange]` when used in php 8.1

while wait for PR https://github.com/danielstjules/Stringy/pull/208 to be merged.