### PR TITLE
[DowngradePhp81] Fix DowngradeArraySpreadStringKeyRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector/Fixture/array_spread_string_key.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector/Fixture/array_spread_string_key.php.inc
@@ -26,7 +26,7 @@ class ArraySpreadStringKey
         $parts = ['a' => 'b'];
         $parts2 = ['c' => 'd'];
 
-        $result = [...$parts, ...$parts2];
+        $result = array_merge($parts, $parts2);
     }
 }
 

--- a/rules-tests/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector/Fixture/array_spread_string_key_by_doc.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector/Fixture/array_spread_string_key_by_doc.php.inc
@@ -30,7 +30,7 @@ class ArraySpreadStringKeyByDoc
         /** @var array<string, string> $parts2 */
         $parts2 = $this->data2();
 
-        $result = [...$parts, ...$parts2];
+        $result = array_merge($parts, $parts2);
     }
 }
 

--- a/rules/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector.php
+++ b/rules/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector.php
@@ -7,7 +7,8 @@ namespace Rector\DowngradePhp81\Rector\Array_;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
-use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
 use Rector\DowngradePhp74\Rector\Array_\DowngradeArraySpreadRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -81,7 +82,17 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $item->key instanceof String_) {
+            if (! $item->unpack) {
+                continue;
+            }
+
+            $type = $this->nodeTypeResolver->getType($item->value);
+            if (! $type instanceof ArrayType) {
+                continue;
+            }
+
+            $keyType = $type->getKeyType();
+            if ($keyType instanceof IntegerType) {
                 return true;
             }
         }


### PR DESCRIPTION
Previous PR https://github.com/rectorphp/rector-src/pull/1369 has equal before and after in fixtures, which incorrect.