### PR TITLE
[Php81][TypeDeclaration] Handle ReadOnlyPropertyRector + ReturnTypeDeclarationRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -134,7 +134,7 @@ final class UnionTypeMapper implements TypeMapperInterface
         }
 
         if ($nullabledTypeNode instanceof ComplexType) {
-            throw new ShouldNotHappenException();
+            return $nullabledTypeNode;
         }
 
         return new NullableType($nullabledTypeNode);

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -23,7 +23,6 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\Core\Enum\ObjectReference;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;

--- a/tests/Issues/ComplexReadOnly/ComplexReadOnlyTest.php
+++ b/tests/Issues/ComplexReadOnly/ComplexReadOnlyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ComplexReadOnly;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ComplexReadOnlyTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/ComplexReadOnly/Fixture/fixture.php.inc
+++ b/tests/Issues/ComplexReadOnly/Fixture/fixture.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ComplexReadOnly\Fixture;
+
+final class Fixture
+{
+    public function __construct(
+        private array|null $condExprs
+    ) {
+    }
+
+    public function getCondExprs(): array|null
+    {
+        if ($this->condExprs === []) {
+            return null;
+        }
+
+        return $this->condExprs;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ComplexReadOnly\Fixture;
+
+final class Fixture
+{
+    public function __construct(
+        private array|null $condExprs
+    ) {
+    }
+
+    public function getCondExprs(): array|null
+    {
+        if ($this->condExprs === []) {
+            return null;
+        }
+
+        return $this->condExprs;
+    }
+}
+
+?>

--- a/tests/Issues/ComplexReadOnly/Fixture/fixture.php.inc
+++ b/tests/Issues/ComplexReadOnly/Fixture/fixture.php.inc
@@ -28,7 +28,7 @@ namespace Rector\Core\Tests\Issues\ComplexReadOnly\Fixture;
 final class Fixture
 {
     public function __construct(
-        private array|null $condExprs
+        private readonly array|null $condExprs
     ) {
     }
 

--- a/tests/Issues/ComplexReadOnly/config/configured_rule.php
+++ b/tests/Issues/ComplexReadOnly/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ReturnTypeDeclarationRector::class);
+    $services->set(ReadOnlyPropertyRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
final class Fixture
{
    public function __construct(
        private array|null $condExprs
    ) {
    }

    public function getCondExprs(): array|null
    {
        if ($this->condExprs === []) {
            return null;
        }

        return $this->condExprs;
    }
}
```

It currently produce:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\ComplexReadOnly\ComplexReadOnlyTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Look at "Rector\PHPStanStaticTypeMapper\TypeMapper\UnionTypeMapper::mapToPhpParserNode()" on line 137
```

Applied rules:

```php
Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
```

split of https://github.com/rectorphp/rector-src/pull/1364#issuecomment-984535634 