### PR TITLE
[Php81] Add Enum_ support when running on PHP 8.1 on AstResolver+ClassLikeAstResolver+RemoveEmptyMethodCallRector

### DIFF
--- a/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Interface_;
@@ -140,7 +141,7 @@ CODE_SAMPLE
     }
 
     private function shouldSkipClassMethod(
-        Class_ | Trait_ | Interface_ $classLike,
+        Class_ | Trait_ | Interface_ | Enum_ $classLike,
         MethodCall $methodCall,
         TypeWithClassName $typeWithClassName
     ): bool {

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
@@ -213,7 +214,7 @@ final class AstResolver
     public function resolveClassFromClassReflection(
         ClassReflection $classReflection,
         string $className
-    ): Trait_ | Class_ | Interface_ | null {
+    ): Trait_ | Class_ | Interface_ | Enum_ | null {
         return $this->classLikeAstResolver->resolveClassFromClassReflection($classReflection, $className);
     }
 

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -71,7 +71,7 @@ final class AstResolver
     ) {
     }
 
-    public function resolveClassFromName(string $className): Class_ | Trait_ | Interface_ | null
+    public function resolveClassFromName(string $className): Class_ | Trait_ | Interface_ | Enum_ | null
     {
         if (! $this->reflectionProvider->hasClass($className)) {
             return null;
@@ -83,7 +83,7 @@ final class AstResolver
 
     public function resolveClassFromObjectType(
         TypeWithClassName $typeWithClassName
-    ): Class_ | Trait_ | Interface_ | null {
+    ): Class_ | Trait_ | Interface_ | Enum_ | null {
         return $this->resolveClassFromName($typeWithClassName->getClassName());
     }
 

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -6,6 +6,7 @@ namespace Rector\Core\PhpParser;
 
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Reflection\ClassReflection;
@@ -32,7 +33,7 @@ final class ClassLikeAstResolver
     public function resolveClassFromClassReflection(
         ClassReflection $classReflection,
         string $className
-    ): Trait_ | Class_ | Interface_ | null {
+    ): Trait_ | Class_ | Interface_ | Enum_ | null {
         if ($classReflection->isBuiltin()) {
             return null;
         }

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -117,7 +117,7 @@ final class BetterStandardPrinter extends Standard
         // strip empty starting/ending php tags
         if (array_key_exists(0, $stmts) && $stmts[0] instanceof FileWithoutNamespace) {
             $content = Strings::replace($content, self::EMPTY_STARTING_TAG_REGEX, '');
-            $content = Strings::replace(\rtrim($content), self::EMPTY_ENDING_TAG_REGEX, '',) . "\n";
+            $content = Strings::replace(\rtrim($content), self::EMPTY_ENDING_TAG_REGEX, '') . "\n";
         }
 
         // add new line in case of added stmts

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -117,7 +117,7 @@ final class BetterStandardPrinter extends Standard
         // strip empty starting/ending php tags
         if (array_key_exists(0, $stmts) && $stmts[0] instanceof FileWithoutNamespace) {
             $content = Strings::replace($content, self::EMPTY_STARTING_TAG_REGEX, '');
-            $content = Strings::replace(\rtrim($content), self::EMPTY_ENDING_TAG_REGEX, '', ) ."\n";
+            $content = Strings::replace(\rtrim($content), self::EMPTY_ENDING_TAG_REGEX, '',) . "\n";
         }
 
         // add new line in case of added stmts


### PR DESCRIPTION
Split of handle on php 8.1 on PR https://github.com/rectorphp/rector-src/pull/1364#issuecomment-984262906