### PR TITLE
[Dep] Update to php 8.1 requirement (manual)

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -35,7 +35,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.0
                     coverage: none
 
                 # fixes https://github.com/rectorphp/rector/pull/4559/checks?check_run_id=1359814403, see https://github.com/shivammathur/setup-php#composer-github-oauth

--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -35,7 +35,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
                 # fixes https://github.com/rectorphp/rector/pull/4559/checks?check_run_id=1359814403, see https://github.com/shivammathur/setup-php#composer-github-oauth
@@ -57,6 +57,17 @@ jobs:
 
             # 2. downgrade rector
             -   run: sh build/downgrade-rector.sh rector-build
+
+            # scoped using php-scoper.phar which require #[\ReturnTypeWillChange] inside so use php 8.0 for scoping
+            -
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.0
+                    coverage: none
+
+                # fixes https://github.com/rectorphp/rector/pull/4559/checks?check_run_id=1359814403, see https://github.com/shivammathur/setup-php#composer-github-oauth
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
             # 3. prefix classes
             -   run: sh build/build-rector-scoped.sh rector-build rector-prefixed-downgraded

--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -35,7 +35,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
                 # fixes https://github.com/rectorphp/rector/pull/4559/checks?check_run_id=1359814403, see https://github.com/shivammathur/setup-php#composer-github-oauth

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -59,7 +59,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
             -   uses: "ramsey/composer-install@v1"

--- a/.github/workflows/code_analysis_no_dev.yaml
+++ b/.github/workflows/code_analysis_no_dev.yaml
@@ -30,7 +30,7 @@ jobs:
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
             # must be removed, as local config is missing dev dependencies

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['8.0']
+                php_version: ['8.1']
                 directory:
                     - 'e2e/template-extends'
                     - 'e2e/plain-views'

--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -42,7 +42,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
             -   run: composer config minimum-stability dev

--- a/.github/workflows/php_linter.yaml
+++ b/.github/workflows/php_linter.yaml
@@ -18,7 +18,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
             -   run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -57,7 +57,8 @@ jobs:
             -   run: composer install --no-progress --ansi
 
             ## First run Rector - here can't be --dry-run !!! it would stop the job with it and not commit anything in the future
-            -   run: bin/rector process ${{ matrix.paths }} --ansi --no-progress-bar
+            # temporary disable rectify as splitted from https://github.com/rectorphp/rector-src/pull/1364
+            # -   run: bin/rector process ${{ matrix.paths }} --ansi --no-progress-bar
 
             -   run: vendor/bin/ecs check --fix --ansi
 

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -60,7 +60,7 @@ jobs:
             # temporary disable rectify as splitted from https://github.com/rectorphp/rector-src/pull/1364
             # -   run: bin/rector process ${{ matrix.paths }} --ansi --no-progress-bar
 
-            -   run: vendor/bin/ecs check --fix --ansi
+            # -   run: vendor/bin/ecs check --fix --ansi
 
             # see https://github.com/EndBug/add-and-commit
             -

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -51,7 +51,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     # PHP 7.3 is required, so Rector's code is PHP 7.3 compatible even after refactoring
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
             -   run: composer install --no-progress --ansi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0']
+                php: ['8.1']
                 path:
                     - tests
                     - rules-tests

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -44,7 +44,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none
 
             -   uses: "ramsey/composer-install@v1"

--- a/build/target-repository/.github/workflows/along_other_packages.yaml
+++ b/build/target-repository/.github/workflows/along_other_packages.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
                 commands:
                     -
                         name: 'Composer Dependency'

--- a/build/target-repository/.github/workflows/bare_run.yaml
+++ b/build/target-repository/.github/workflows/bare_run.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
         steps:
             -   uses: actions/checkout@v2

--- a/build/target-repository/.github/workflows/e2e.yaml
+++ b/build/target-repository/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
                 directory:
                     - 'e2e/attributes'
                     - 'e2e/define-constant'

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "homepage": "https://getrector.org",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-dom": "*",
         "ext-json": "*",
         "clue/ndjson-react": "^1.2",

--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -17,11 +17,11 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(ReturnNeverTypeRector::class);
-    $services->set(MyCLabsClassToEnumRector::class);
+    //$services->set(MyCLabsClassToEnumRector::class);
     $services->set(MyCLabsMethodCallToEnumConstRector::class);
     $services->set(FinalizePublicClassConstantRector::class);
     $services->set(ReadOnlyPropertyRector::class);
-    $services->set(SpatieEnumClassToEnumRector::class);
+    //$services->set(SpatieEnumClassToEnumRector::class);
     $services->set(Php81ResourceReturnToObjectRector::class);
     $services->set(NewInInitializerRector::class);
     $services->set(IntersectionTypesRector::class);

--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -17,11 +17,11 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(ReturnNeverTypeRector::class);
-    //$services->set(MyCLabsClassToEnumRector::class);
+    $services->set(MyCLabsClassToEnumRector::class);
     $services->set(MyCLabsMethodCallToEnumConstRector::class);
     $services->set(FinalizePublicClassConstantRector::class);
     $services->set(ReadOnlyPropertyRector::class);
-    //$services->set(SpatieEnumClassToEnumRector::class);
+    $services->set(SpatieEnumClassToEnumRector::class);
     $services->set(Php81ResourceReturnToObjectRector::class);
     $services->set(NewInInitializerRector::class);
     $services->set(IntersectionTypesRector::class);

--- a/e2e/plain-views/composer.json
+++ b/e2e/plain-views/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/e2e/template-extends/composer.json
+++ b/e2e/template-extends/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "myclabs/php-enum": "^1.8"
     },
     "minimum-stability": "dev",

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,8 @@ use Rector\CodingStyle\ValueObject\ReturnArrayClassMethodToYield;
 use Rector\Core\Configuration\Option;
 use Rector\Nette\Set\NetteSetList;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
+use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 use Rector\Set\ValueObject\LevelSetList;
@@ -74,6 +76,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         FinalizeClassesWithoutChildrenRector::class => [
             __DIR__ . '/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php',
         ],
+
+        MyCLabsClassToEnumRector::class,
+        SpatieEnumClassToEnumRector::class,
 
         // test paths
         '*/tests/**/Fixture/*',

--- a/rector.php
+++ b/rector.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     // include the latest PHP version + all bellow in one config!
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_80);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_81);
 
     // include sets
     $containerConfigurator->import(SetList::CODING_STYLE);


### PR DESCRIPTION
@TomasVotruba this is split of https://github.com/rectorphp/rector-src/pull/1364 with manual change only with teskipped:

- rectify CI
- commented `MyCLabsClassToEnumRector` and `SpatieEnumClassToEnumRector` as it make `Enum` syntax upgrade needs to be skipped as it change `PhpVersion` class that extends : 

```diff
use MyCLabs\Enum\Enum;

- final class PhpVersion extends Enum
+ enum PhpVersion : int
```

which will need update currently manually of its usage:

```diff
-PhpVersion::PHP_52;
+PhpVersion::PHP_52->value;
```

and it seems cause change 

also other Enums, eg `ObjectReference` and `ApplicationPhase` manually:

```diff
-        if ($node->toString() === ObjectReference::PARENT()->getValue()) {
+        if ($node->toString() === ObjectReference::PARENT()->value) {
```

```diff
-        }, ApplicationPhase::PARSING());
+        }, ApplicationPhase::PARSING->value);
```

and we may need to create a downgrade rule for it to keep working on scoping.

 I commented the rules at https://github.com/rectorphp/rector-src/commit/99fa67bf060326680dcafc57ce8bc0e56b991d1e