### PR TITLE
[Php81] Skip ReadOnlyPropertyRector on Entity id

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity.php.inc
@@ -33,7 +33,7 @@ class News
     /**
      * Get id.
      *
-     * @return integer
+     * @return string
      */
     public function getId()
     {

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity.php.inc
@@ -1,0 +1,66 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use Ramsey\Uuid\UuidInterface;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * News
+ *
+ * @ORM\Table(name="news")
+ * @ORM\Entity(repositoryClass="DoctrineFixtureDemo\Repository\NewsRepository")
+ */
+class News
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Id()
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
+     */
+    private UuidInterface $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="title", type="string", length=50, nullable=false)
+     */
+    private $title;
+
+    /**
+     * Get id.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * Set title.
+     *
+     * @param string $title
+     *
+     * @return self
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Get title.
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity2.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity2.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use Ramsey\Uuid\UuidInterface;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * News
+ */
+#[ORM\Table(name: 'news')]
+#[ORM\Entity(repositoryClass: 'DoctrineFixtureDemo\Repository\NewsRepository')]
+class News2
+{
+    /**
+     * @var UuidInterface
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'Ramsey\Uuid\Doctrine\UuidGenerator')]
+    private UuidInterface $id;
+
+    /**
+     * @var string
+     */
+    #[ORM\Column(name: 'title', type: 'string', length: 50, nullable: false)]
+    private $title;
+
+    /**
+     * Get id.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return (string) $this->id;
+    }
+
+    /**
+     * Set title.
+     *
+     * @param string $title
+     *
+     * @return self
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Get title.
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
@@ -27,6 +28,7 @@ use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\MethodName;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\ReadWrite\Guard\VariableToConstantGuard;
 use Rector\ReadWrite\NodeAnalyzer\ReadWritePropertyAnalyzer;
 use Symplify\PackageBuilder\Php\TypeChecker;
@@ -37,6 +39,22 @@ use Symplify\PackageBuilder\Php\TypeChecker;
  */
 final class PropertyManipulator
 {
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_NOT_READONLY_ANNOTATION = [
+        '@ORM\Entity',
+        '@ORM\Table',
+    ];
+
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_NOT_READONLY_ANNOTATION_CLASS_ORATTRIBUTES = [
+        'Doctrine\ORM\Mapping\Entity',
+        'Doctrine\ORM\Mapping\Table',
+    ];
+
     public function __construct(
         private AssignManipulator $assignManipulator,
         private BetterNodeFinder $betterNodeFinder,
@@ -46,7 +64,8 @@ final class PropertyManipulator
         private TypeChecker $typeChecker,
         private PropertyFetchFinder $propertyFetchFinder,
         private ReflectionResolver $reflectionResolver,
-        private NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver,
+        private PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -96,6 +115,21 @@ final class PropertyManipulator
 
     public function isPropertyChangeableExceptConstructor(Property | Param $propertyOrParam): bool
     {
+        $class = $this->betterNodeFinder->findParentType($propertyOrParam, Class_::class);
+        if ($class instanceof Class_) {
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);
+            if ($phpDocInfo->hasByAnnotationClasses(self::ALLOWED_NOT_READONLY_ANNOTATION_CLASS_ORATTRIBUTES)) {
+                return true;
+            }
+
+            if ($this->phpAttributeAnalyzer->hasPhpAttributes(
+                $class,
+                self::ALLOWED_NOT_READONLY_ANNOTATION_CLASS_ORATTRIBUTES
+            )) {
+                return true;
+            }
+        }
+
         $propertyFetches = $this->propertyFetchFinder->findPrivatePropertyFetches($propertyOrParam);
 
         foreach ($propertyFetches as $propertyFetch) {

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -42,15 +42,7 @@ final class PropertyManipulator
     /**
      * @var string[]
      */
-    private const ALLOWED_NOT_READONLY_ANNOTATION = [
-        '@ORM\Entity',
-        '@ORM\Table',
-    ];
-
-    /**
-     * @var string[]
-     */
-    private const ALLOWED_NOT_READONLY_ANNOTATION_CLASS_ORATTRIBUTES = [
+    private const ALLOWED_NOT_READONLY_ANNOTATION_CLASS_OR_ATTRIBUTES = [
         'Doctrine\ORM\Mapping\Entity',
         'Doctrine\ORM\Mapping\Table',
     ];
@@ -118,13 +110,13 @@ final class PropertyManipulator
         $class = $this->betterNodeFinder->findParentType($propertyOrParam, Class_::class);
         if ($class instanceof Class_) {
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);
-            if ($phpDocInfo->hasByAnnotationClasses(self::ALLOWED_NOT_READONLY_ANNOTATION_CLASS_ORATTRIBUTES)) {
+            if ($phpDocInfo->hasByAnnotationClasses(self::ALLOWED_NOT_READONLY_ANNOTATION_CLASS_OR_ATTRIBUTES)) {
                 return true;
             }
 
             if ($this->phpAttributeAnalyzer->hasPhpAttributes(
                 $class,
-                self::ALLOWED_NOT_READONLY_ANNOTATION_CLASS_ORATTRIBUTES
+                self::ALLOWED_NOT_READONLY_ANNOTATION_CLASS_OR_ATTRIBUTES
             )) {
                 return true;
             }


### PR DESCRIPTION
Doctrine Entity id usually has only public getter, no setter. Given the following code:

```php
use Ramsey\Uuid\UuidInterface;
use Doctrine\ORM\Mapping as ORM;

/**
 * News
 *
 * @ORM\Table(name="news")
 * @ORM\Entity(repositoryClass="DoctrineFixtureDemo\Repository\NewsRepository")
 */
class News
{
    /**
     * @var UuidInterface
     *
     * @ORM\Id()
     * @ORM\Column(type="uuid", unique=true)
     * @ORM\GeneratedValue(strategy="CUSTOM")
     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
     */
    private UuidInterface $id;

    /**
     * @var string
     *
     * @ORM\Column(name="title", type="string", length=50, nullable=false)
     */
    private $title;

    /**
     * Get id.
     *
     * @return string
     */
    public function getId()
    {
        return (string) $this->id;
    }

    /**
     * Set title.
     *
     * @param string $title
     *
     * @return self
     */
    public function setTitle($title)
    {
        $this->title = $title;

        return $this;
    }

    /**
     * Get title.
     *
     * @return string
     */
    public function getTitle()
    {
        return $this->title;
    }
}
```

It currently produce:

```diff
-    private UuidInterface $id;
+    private readonly UuidInterface $id;
```

which I think should be skipped.