### PR TITLE
 [Rectify] [Php81] Enable Rectify on ArraySpreadInsteadOfArrayMergeRector on php 8.1 

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,6 @@ use Rector\CodingStyle\ValueObject\ReturnArrayClassMethodToYield;
 use Rector\Core\Configuration\Option;
 use Rector\Nette\Set\NetteSetList;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
-use Rector\Php74\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
 use Rector\Php81\Rector\ClassConst\FinalizePublicClassConstantRector;
@@ -19,6 +18,7 @@ use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\FuncCall\Php81ResourceReturnToObjectRector;
 use Rector\Php81\Rector\FunctionLike\IntersectionTypesRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 use Rector\Set\ValueObject\LevelSetList;
@@ -87,11 +87,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         MyCLabsClassToEnumRector::class,
         SpatieEnumClassToEnumRector::class,
 
-        // temporary skip it to avoid unrelated change string key array unpack on php 8.1 PR https://github.com/rectorphp/rector-src/pull/1380
-        // @todo remove when enabling it on different PR
-        ArraySpreadInsteadOfArrayMergeRector::class,
-
-        // temporary skip non readonly property rector
+        // temporary skip all with enable ArraySpreadInsteadOfArrayMergeRector
         ReturnNeverTypeRector::class,
         FinalizePublicClassConstantRector::class,
         MyCLabsMethodCallToEnumConstRector::class,

--- a/rector.php
+++ b/rector.php
@@ -18,7 +18,6 @@ use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\FuncCall\Php81ResourceReturnToObjectRector;
 use Rector\Php81\Rector\FunctionLike\IntersectionTypesRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
-use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 use Rector\Set\ValueObject\LevelSetList;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -29,6 +29,7 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
         // "new X" or "X::static()"
+        /** @var array<string, string> $shortNamesToFullyQualifiedNames */
         $shortNamesToFullyQualifiedNames = $this->shortNameResolver->resolveFromFile($file);
         $loweredShortNameFullyQualified = $fullyQualifiedObjectType->getShortNameLowered();
 

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -143,9 +143,7 @@ final class ShortNameResolver
         });
 
         $docBlockShortNamesToFullyQualifiedNames = $this->resolveFromStmtsDocBlocks($stmts);
-        /**
-         * @var array<string, string> $result
-         */
+        /** @var array<string, string> $result */
         $result = [...$shortNamesToFullyQualifiedNames, ...$docBlockShortNamesToFullyQualifiedNames];
         return $result;
     }

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -143,7 +143,11 @@ final class ShortNameResolver
         });
 
         $docBlockShortNamesToFullyQualifiedNames = $this->resolveFromStmtsDocBlocks($stmts);
-        return [...$shortNamesToFullyQualifiedNames, ...$docBlockShortNamesToFullyQualifiedNames];
+        /**
+         * @var array<string, string> $result
+         */
+        $result = [...$shortNamesToFullyQualifiedNames, ...$docBlockShortNamesToFullyQualifiedNames];
+        return $result;
     }
 
     /**

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -143,7 +143,7 @@ final class ShortNameResolver
         });
 
         $docBlockShortNamesToFullyQualifiedNames = $this->resolveFromStmtsDocBlocks($stmts);
-        return array_merge($shortNamesToFullyQualifiedNames, $docBlockShortNamesToFullyQualifiedNames);
+        return [...$shortNamesToFullyQualifiedNames, ...$docBlockShortNamesToFullyQualifiedNames];
     }
 
     /**

--- a/rules/MockeryToProphecy/Rector/ClassMethod/MockeryCreateMockToProphizeRector.php
+++ b/rules/MockeryToProphecy/Rector/ClassMethod/MockeryCreateMockToProphizeRector.php
@@ -102,10 +102,7 @@ CODE_SAMPLE
 
             $collectedVariableTypesByNames = $this->mockVariableCollector->collectMockVariableName($node);
 
-            $this->mockVariableTypesByNames = array_merge(
-                $this->mockVariableTypesByNames,
-                $collectedVariableTypesByNames
-            );
+            $this->mockVariableTypesByNames = [...$this->mockVariableTypesByNames, ...$collectedVariableTypesByNames];
 
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
             if ($parentNode instanceof Arg) {

--- a/rules/MockeryToProphecy/Rector/ClassMethod/MockeryCreateMockToProphizeRector.php
+++ b/rules/MockeryToProphecy/Rector/ClassMethod/MockeryCreateMockToProphizeRector.php
@@ -102,7 +102,9 @@ CODE_SAMPLE
 
             $collectedVariableTypesByNames = $this->mockVariableCollector->collectMockVariableName($node);
 
-            $this->mockVariableTypesByNames = [...$this->mockVariableTypesByNames, ...$collectedVariableTypesByNames];
+            /** @var array<string, class-string> $result */
+            $result = [...$this->mockVariableTypesByNames, ...$collectedVariableTypesByNames];
+            $this->mockVariableTypesByNames = $result;
 
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
             if ($parentNode instanceof Arg) {

--- a/src/Configuration/RenamedClassesDataCollector.php
+++ b/src/Configuration/RenamedClassesDataCollector.php
@@ -28,7 +28,7 @@ final class RenamedClassesDataCollector
      */
     public function addOldToNewClasses(array $oldToNewClasses): void
     {
-        $this->oldToNewClasses = array_merge($this->oldToNewClasses, $oldToNewClasses);
+        $this->oldToNewClasses = [...$this->oldToNewClasses, ...$oldToNewClasses];
     }
 
     /**

--- a/src/Configuration/RenamedClassesDataCollector.php
+++ b/src/Configuration/RenamedClassesDataCollector.php
@@ -28,7 +28,9 @@ final class RenamedClassesDataCollector
      */
     public function addOldToNewClasses(array $oldToNewClasses): void
     {
-        $this->oldToNewClasses = [...$this->oldToNewClasses, ...$oldToNewClasses];
+        /** @var array<string, string> $oldToNewClasses */
+        $oldToNewClasses = [...$this->oldToNewClasses, ...$oldToNewClasses];
+        $this->oldToNewClasses = $oldToNewClasses;
     }
 
     /**

--- a/src/NonPhpFile/Rector/RenameClassNonPhpRector.php
+++ b/src/NonPhpFile/Rector/RenameClassNonPhpRector.php
@@ -139,7 +139,7 @@ CODE_SAMPLE
      */
     private function getRenameClasses(): array
     {
-        return array_merge($this->renameClasses, $this->renamedClassesDataCollector->getOldToNewClasses());
+        return [...$this->renameClasses, ...$this->renamedClassesDataCollector->getOldToNewClasses()];
     }
 
     private function createOldClassRegex(string $oldClass): string

--- a/src/NonPhpFile/Rector/RenameClassNonPhpRector.php
+++ b/src/NonPhpFile/Rector/RenameClassNonPhpRector.php
@@ -139,7 +139,9 @@ CODE_SAMPLE
      */
     private function getRenameClasses(): array
     {
-        return [...$this->renameClasses, ...$this->renamedClassesDataCollector->getOldToNewClasses()];
+        /** @var array<string, string> $renameClasses */
+        $renameClasses = [...$this->renameClasses, ...$this->renamedClassesDataCollector->getOldToNewClasses()];
+        return $renameClasses;
     }
 
     private function createOldClassRegex(string $oldClass): string


### PR DESCRIPTION
`ArraySpreadInsteadOfArrayMergeRector` when running on php 8.1, it make array string unpack applied.