### PR TITLE
[Php71] Skip Type from @param doc on BinaryOpBetweenNumberAndStringRector

### DIFF
--- a/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/from_typed_param.php.inc
+++ b/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/from_typed_param.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class FromTypedParam
+{
+    public function run(?int $id)
+    {
+        return $id !== null && $id !== 'null';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class FromTypedParam
+{
+    public function run(?int $id)
+    {
+        return $id !== null && $id !== 0;
+    }
+}
+
+?>

--- a/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/skip_type_by_param_doc.php.inc
+++ b/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/skip_type_by_param_doc.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class SkipTypeByParamDoc
+{
+    /**
+     * @param int|null  $id
+     */
+    public function run($id)
+    {
+        return $id !== null && $id !== 'null';
+    }
+}

--- a/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/skip_type_by_param_doc2.php.inc
+++ b/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/skip_type_by_param_doc2.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class SkipTypeByParamDoc2
+{
+    /**
+     * @param int|null  $id
+     */
+    public function run($id)
+    {
+        return $id !== null && 'null' !== $id;
+    }
+}

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -50,9 +50,9 @@ final class RecastingRemovalRector extends AbstractRector
     ];
 
     public function __construct(
-        private PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private ReflectionResolver $reflectionResolver,
-        private ExprAnalyzer $exprAnalyzer
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ExprAnalyzer $exprAnalyzer
     ) {
     }
 

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Expr\Cast\Object_;
 use PhpParser\Node\Expr\Cast\String_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\FunctionLike;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
@@ -26,6 +25,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -50,8 +50,9 @@ final class RecastingRemovalRector extends AbstractRector
     ];
 
     public function __construct(
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private readonly ReflectionResolver $reflectionResolver
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private ReflectionResolver $reflectionResolver,
+        private ExprAnalyzer $exprAnalyzer
     ) {
     }
 
@@ -116,7 +117,7 @@ CODE_SAMPLE
     private function shouldSkip(Expr $expr): bool
     {
         if (! $this->propertyFetchAnalyzer->isPropertyFetch($expr)) {
-            return $this->isNonTypedFromParam($expr);
+            return $this->exprAnalyzer->isNonTypedFromParam($expr);
         }
 
         /** @var PropertyFetch|StaticPropertyFetch $expr */
@@ -134,24 +135,5 @@ CODE_SAMPLE
 
         $nativeType = $phpPropertyReflection->getNativeType();
         return $nativeType instanceof MixedType;
-    }
-
-    private function isNonTypedFromParam(Expr $expr): bool
-    {
-        $functionLike = $this->betterNodeFinder->findParentType($expr, FunctionLike::class);
-        if (! $functionLike instanceof FunctionLike) {
-            return false;
-        }
-
-        $params = $functionLike->getParams();
-        foreach ($params as $param) {
-            if (! $this->nodeComparator->areNodesEqual($param->var, $expr)) {
-                continue;
-            }
-
-            return $param->type === null;
-        }
-
-        return false;
     }
 }

--- a/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
+++ b/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
@@ -91,9 +91,11 @@ CODE_SAMPLE
         if ($node instanceof Coalesce) {
             return null;
         }
+
         if ($this->exprAnalyzer->isNonTypedFromParam($node->left)) {
             return null;
         }
+
         if ($this->exprAnalyzer->isNonTypedFromParam($node->right)) {
             return null;
         }

--- a/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
+++ b/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
@@ -30,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class BinaryOpBetweenNumberAndStringRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private ExprAnalyzer $exprAnalyzer
+        private readonly ExprAnalyzer $exprAnalyzer
     ) {
     }
 
@@ -91,10 +91,10 @@ CODE_SAMPLE
         if ($node instanceof Coalesce) {
             return null;
         }
-
-        if ($this->exprAnalyzer->isNonTypedFromParam($node->left) || $this->exprAnalyzer->isNonTypedFromParam(
-            $node->right
-        )) {
+        if ($this->exprAnalyzer->isNonTypedFromParam($node->left)) {
+            return null;
+        }
+        if ($this->exprAnalyzer->isNonTypedFromParam($node->right)) {
             return null;
         }
 

--- a/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
+++ b/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\MagicConst\Line;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\Constant\ConstantStringType;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -28,6 +29,10 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class BinaryOpBetweenNumberAndStringRector extends AbstractRector implements MinPhpVersionInterface
 {
+    public function __construct(private ExprAnalyzer $exprAnalyzer)
+    {
+    }
+
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::BINARY_OP_NUMBER_STRING;
@@ -83,6 +88,10 @@ CODE_SAMPLE
         }
 
         if ($node instanceof Coalesce) {
+            return null;
+        }
+
+        if ($this->exprAnalyzer->isNonTypedFromParam($node->left) || $this->exprAnalyzer->isNonTypedFromParam($node->right)) {
             return null;
         }
 

--- a/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
+++ b/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
@@ -29,8 +29,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class BinaryOpBetweenNumberAndStringRector extends AbstractRector implements MinPhpVersionInterface
 {
-    public function __construct(private ExprAnalyzer $exprAnalyzer)
-    {
+    public function __construct(
+        private ExprAnalyzer $exprAnalyzer
+    ) {
     }
 
     public function provideMinPhpVersion(): int
@@ -91,7 +92,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->exprAnalyzer->isNonTypedFromParam($node->left) || $this->exprAnalyzer->isNonTypedFromParam($node->right)) {
+        if ($this->exprAnalyzer->isNonTypedFromParam($node->left) || $this->exprAnalyzer->isNonTypedFromParam(
+            $node->right
+        )) {
             return null;
         }
 

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -13,8 +13,8 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 final class ExprAnalyzer
 {
     public function __construct(
-        private NodeComparator $nodeComparator,
-        private BetterNodeFinder $betterNodeFinder,
+        private readonly NodeComparator $nodeComparator,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\NodeAnalyzer;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use Rector\Core\PhpParser\Comparing\NodeComparator;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+
+final class ExprAnalyzer
+{
+    public function __construct(
+        private NodeComparator $nodeComparator,
+        private BetterNodeFinder $betterNodeFinder,
+    ) {
+    }
+
+    public function isNonTypedFromParam(Expr $expr): bool
+    {
+        if (! $expr instanceof Variable) {
+            return false;
+        }
+
+        $functionLike = $this->betterNodeFinder->findParentType($expr, FunctionLike::class);
+        if (! $functionLike instanceof FunctionLike) {
+            return false;
+        }
+
+        $params = $functionLike->getParams();
+        foreach ($params as $param) {
+            if (! $this->nodeComparator->areNodesEqual($param->var, $expr)) {
+                continue;
+            }
+
+            return $param->type === null;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Given the following code:

```php
class SkipTypeByParamDoc
{
    /**
     * @param int|null  $id
     */
    public function run($id)
    {
        return $id !== null && $id !== 'null';
    }
}
```

It currently produce:

```diff
-        return $id !== null && $id !== 'null';
+        return $id !== null && $id !== 0;
```

which invalid as param is not typed and docblock can be the invalid one. It should be skipped. This PR skipped it.