### PR TITLE
[ECS] Skip FunctionTypehintSpaceFixer for add space on &$variable

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
@@ -74,6 +75,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/packages-tests/NameImporting/NodeAnalyzer/UseAnalyzer/UseAnalyzerTest.php',
             '*TypeResolverTest.php',
             __DIR__ . '/rules-tests/CodingStyle/Node/UseManipulator/UseManipulatorTest.php',
+        ],
+
+        // skip add space on &$variable
+        FunctionTypehintSpaceFixer::class => [
+            __DIR__ . '/src/PhpParser/Printer/BetterStandardPrinter.php',
+            __DIR__ . '/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php',
+            __DIR__ . '/rules/Php70/EregToPcreTransformer.php',
         ],
     ]);
 

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -206,7 +206,7 @@ final class EregToPcreTransformer
     /**
      * @param mixed[] $r
      */
-    private function processBracket(string $content, int $i, int $l, array & $r, int $rr): int
+    private function processBracket(string $content, int $i, int $l, array &$r, int $rr): int
     {
         // special case
         if ($i + 1 < $l && $content[$i + 1] === ')') {
@@ -281,7 +281,7 @@ final class EregToPcreTransformer
     /**
      * @param mixed[] $r
      */
-    private function processCurlyBracket(string $s, int $i, array & $r, int $rr): int
+    private function processCurlyBracket(string $s, int $i, array &$r, int $rr): int
     {
         $ii = strpos($s, '}', $i);
         if ($ii === false) {

--- a/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
+++ b/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
@@ -23,7 +23,7 @@ final class RectorServiceConfigurator extends ServiceConfigurator
         $this->ensureClassIsConfigurable($this->id);
 
         // decorate with value object inliner so Symfony understands, see https://getrector.org/blog/2020/09/07/how-to-inline-value-object-in-symfony-php-config
-        array_walk_recursive($configuration, function (& $value) {
+        array_walk_recursive($configuration, function (&$value) {
             if (is_object($value)) {
                 $value = ValueObjectInliner::inline($value);
             }

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -209,7 +209,7 @@ final class BetterStandardPrinter extends Standard
     protected function pArray(
         array $nodes,
         array $origNodes,
-        int & $pos,
+        int &$pos,
         int $indentAdjustment,
         string $parentNodeType,
         string $subNodeName,


### PR DESCRIPTION
Based on https://github.com/rectorphp/rector-src/pull/1385#discussion_r762423186, the `FunctionTypehintSpaceFixer` needs to be skipped on various places to avoid apply space on `&$variable` on php 8.1