### PR TITLE
[Scoped] Add missing utils to downgrade paths

### DIFF
--- a/utils/compiler/src/Command/DowngradePathsCommand.php
+++ b/utils/compiler/src/Command/DowngradePathsCommand.php
@@ -47,6 +47,7 @@ final class DowngradePathsCommand extends Command
             'vendor/symplify vendor/nikic src packages',
             'vendor/ssch',
             'rules',
+            'utils',
             'bin rector.php',
         ], $downgradePaths);
 


### PR DESCRIPTION
Fixing downgrade scoped error https://github.com/rectorphp/rector-src/runs/4417920630?check_suite_focus=true#step:11:14 as not included in downgrade paths.