### PR TITLE
[DowngradePhp81] Follow parent return type on DowngradeNeverTypeDeclarationRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -44,9 +44,11 @@ final class PhpDocFromTypeDeclarationDecorator
             $functionLike
         )) {
             $returnType = $this->parentClassMethodTypeOverrideGuard->getParentClassMethodNodeType($functionLike);
-            $functionLike->returnType = $returnType;
+            if ($returnType !== null) {
+                $functionLike->returnType = $returnType;
 
-            return;
+                return;
+            }
         }
 
         $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($functionLike->returnType);

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -46,16 +46,23 @@ final class PhpDocFromTypeDeclarationDecorator
             $returnType = $this->parentClassMethodTypeOverrideGuard->getParentClassMethodNodeType($functionLike);
             if ($returnType !== null) {
                 $functionLike->returnType = $returnType;
+                $this->changePhpDocReturnType($functionLike);
 
                 return;
             }
         }
 
-        $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($functionLike->returnType);
+        $this->changePhpDocReturnType($functionLike);
+        $functionLike->returnType = null;
+    }
+
+    private function changePhpDocReturnType(ClassMethod | Function_ | Closure | ArrowFunction $functionLike): void
+    {
+        /** @var $returnType ComplexType|Identifier|Name $returnType */
+        $returnType = $functionLike->returnType;
+        $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnType);
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
         $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $type);
-
-        $functionLike->returnType = null;
     }
 
     /**

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -20,6 +20,7 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 
 final class PhpDocFromTypeDeclarationDecorator
 {
@@ -28,13 +29,18 @@ final class PhpDocFromTypeDeclarationDecorator
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly TypeUnwrapper $typeUnwrapper
+        private readonly TypeUnwrapper $typeUnwrapper,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
     ) {
     }
 
     public function decorate(ClassMethod | Function_ | Closure | ArrowFunction $functionLike): void
     {
         if ($functionLike->returnType === null) {
+            return;
+        }
+
+        if ($functionLike instanceof ClassMethod && ! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed($functionLike)) {
             return;
         }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -43,6 +43,9 @@ final class PhpDocFromTypeDeclarationDecorator
         if ($functionLike instanceof ClassMethod && ! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed(
             $functionLike
         )) {
+            $returnType = $this->parentClassMethodTypeOverrideGuard->getParentClassMethodNodeType($functionLike);
+            $functionLike->returnType = $returnType;
+
             return;
         }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -40,7 +40,9 @@ final class PhpDocFromTypeDeclarationDecorator
             return;
         }
 
-        if ($functionLike instanceof ClassMethod && ! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed($functionLike)) {
+        if ($functionLike instanceof ClassMethod && ! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed(
+            $functionLike
+        )) {
             return;
         }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -56,15 +56,6 @@ final class PhpDocFromTypeDeclarationDecorator
         $functionLike->returnType = null;
     }
 
-    private function changePhpDocReturnType(ClassMethod | Function_ | Closure | ArrowFunction $functionLike): void
-    {
-        /** @var $returnType ComplexType|Identifier|Name $returnType */
-        $returnType = $functionLike->returnType;
-        $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnType);
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
-        $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $type);
-    }
-
     /**
      * @param array<class-string<Type>> $requiredTypes
      */
@@ -120,6 +111,15 @@ final class PhpDocFromTypeDeclarationDecorator
 
         $this->decorate($functionLike);
         return true;
+    }
+
+    private function changePhpDocReturnType(ClassMethod | Function_ | Closure | ArrowFunction $functionLike): void
+    {
+        /** @var ComplexType|Identifier|Name $returnType $returnType */
+        $returnType = $functionLike->returnType;
+        $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnType);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
+        $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $type);
     }
 
     private function isTypeMatch(ComplexType|Identifier|Name $typeNode, Type $requireType): bool

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -14,7 +14,6 @@ use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\NonexistentParentClassType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\Core\PhpParser\AstResolver;
@@ -84,7 +83,8 @@ final class ParentClassMethodTypeOverrideGuard
         return $isCurrentNotInVendor && $isParentNotInVendor;
     }
 
-    public function getParentClassMethodNodeType(ClassMethod $classMethod): ComplexType|Identifier|Name|null {
+    public function getParentClassMethodNodeType(ClassMethod $classMethod): ComplexType|Identifier|Name|null
+    {
         $parentClassMethodReflection = $this->getParentClassMethod($classMethod);
         if (! $parentClassMethodReflection instanceof MethodReflection) {
             return null;

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NonexistentParentClassType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\Core\PhpParser\AstResolver;
@@ -100,20 +101,11 @@ final class ParentClassMethodTypeOverrideGuard
             return null;
         }
 
-        /**
-         * Handle error at DowngradeParentTypeDeclarationRectorTest exception:
-         *
-         *      Rector\Core\Exception\NotImplementedYetException: Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper::mapToPhpParserNode
-         *      for PHPStan\Type\NonexistentParentClassType PHPStan\Type\NonexistentParentClassType
-         *
-         * so return null on usage of PhpDocFromTypeDeclarationDecorator::decorate()
-         * to use original behaviour before PR https://github.com/rectorphp/rector-src/pull/1395
-         */
-        try {
-            return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($parentNativeReturnType, TypeKind::RETURN());
-        } catch (NotImplementedYetException) {
+        if ($parentNativeReturnType instanceof NonexistentParentClassType) {
             return null;
         }
+
+        return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($parentNativeReturnType, TypeKind::RETURN());
     }
 
     public function hasParentClassMethod(ClassMethod $classMethod): bool

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\VendorLocker;
 
-use PhpParser\Node;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
@@ -45,7 +47,7 @@ final class ParentClassMethodTypeOverrideGuard
         $parametersAcceptor = ParametersAcceptorSelector::selectSingle($parentClassMethodReflection->getVariants());
         if ($parametersAcceptor instanceof FunctionVariantWithPhpDocs) {
             $parentNativeReturnType = $parametersAcceptor->getNativeReturnType();
-            if (! $parentNativeReturnType instanceof MixedType && $classMethod->returnType instanceof Node) {
+            if (! $parentNativeReturnType instanceof MixedType && $classMethod->returnType !== null) {
                 $currentType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
                 return $currentType->equals($parentNativeReturnType);
             }
@@ -81,8 +83,7 @@ final class ParentClassMethodTypeOverrideGuard
         return $isCurrentNotInVendor && $isParentNotInVendor;
     }
 
-    public function getParentClassMethodNodeType(ClassMethod $classMethod): ?Node
-    {
+    public function getParentClassMethodNodeType(ClassMethod $classMethod): ComplexType|Identifier|Name|null {
         $parentClassMethodReflection = $this->getParentClassMethod($classMethod);
         if (! $parentClassMethodReflection instanceof MethodReflection) {
             return null;

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\VendorLocker;
 
+use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
@@ -15,6 +16,7 @@ use PHPStan\Type\Type;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\TypeInferer\ParamTypeInferer;
 use Symplify\SmartFileSystem\Normalizer\PathNormalizer;
 
@@ -24,7 +26,8 @@ final class ParentClassMethodTypeOverrideGuard
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly PathNormalizer $pathNormalizer,
         private readonly AstResolver $astResolver,
-        private readonly ParamTypeInferer $paramTypeInferer
+        private readonly ParamTypeInferer $paramTypeInferer,
+        private readonly StaticTypeMapper $staticTypeMapper
     ) {
     }
 
@@ -39,8 +42,12 @@ final class ParentClassMethodTypeOverrideGuard
         }
 
         $parametersAcceptor = ParametersAcceptorSelector::selectSingle($parentClassMethodReflection->getVariants());
-        if ($parametersAcceptor instanceof FunctionVariantWithPhpDocs && ! $parametersAcceptor->getNativeReturnType() instanceof MixedType) {
-            return false;
+        if ($parametersAcceptor instanceof FunctionVariantWithPhpDocs) {
+            $parentNativeReturnType = $parametersAcceptor->getNativeReturnType();
+            if (! $parentNativeReturnType instanceof MixedType && $classMethod->returnType instanceof Node) {
+                $currentType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
+                return $currentType->equals($parentNativeReturnType);
+            }
         }
 
         $classReflection = $parentClassMethodReflection->getDeclaringClass();
@@ -51,8 +58,26 @@ final class ParentClassMethodTypeOverrideGuard
             return false;
         }
 
+        /*
+         * Below verify that both current file name and parent file name is not in the /vendor/, if yes, then allowed.
+         * This can happen when rector run into /vendor/ directory while child and parent both are there.
+         */
+        /** @var Scope $scope */
+        $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
+        /** @var ClassReflection $classReflection */
+        $classReflection = $scope->getClassReflection();
+        /** @var string $currentFileName */
+        $currentFileName = $classReflection->getFileName();
+
+        // child (current)
+        $normalizedCurrentFileName = $this->pathNormalizer->normalizePath($currentFileName);
+        $isCurrentNotInVendor = ! str_contains($normalizedCurrentFileName, '/vendor/');
+
+        // parent
         $normalizedFileName = $this->pathNormalizer->normalizePath($fileName);
-        return ! str_contains($normalizedFileName, '/vendor/');
+        $isParentNotInVendor = ! str_contains($normalizedFileName, '/vendor/');
+
+        return $isCurrentNotInVendor && $isParentNotInVendor;
     }
 
     public function hasParentClassMethod(ClassMethod $classMethod): bool

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -16,7 +16,6 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NonexistentParentClassType;
 use PHPStan\Type\Type;
-use Rector\Core\Exception\NotImplementedYetException;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -51,8 +51,6 @@ final class ParentClassMethodTypeOverrideGuard
             $parentNativeReturnType = $parametersAcceptor->getNativeReturnType();
             if (! $parentNativeReturnType instanceof MixedType && $classMethod->returnType !== null) {
                 return false;
-                $currentType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
-                return $currentType->equals($parentNativeReturnType);
             }
         }
 
@@ -102,6 +100,15 @@ final class ParentClassMethodTypeOverrideGuard
             return null;
         }
 
+        /**
+         * Handle error at DowngradeParentTypeDeclarationRectorTest exception:
+         *
+         *      Rector\Core\Exception\NotImplementedYetException: Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper::mapToPhpParserNode
+         *      for PHPStan\Type\NonexistentParentClassType PHPStan\Type\NonexistentParentClassType
+         *
+         * so return null on usage of PhpDocFromTypeDeclarationDecorator::decorate()
+         * to use original behaviour before PR https://github.com/rectorphp/rector-src/pull/1395
+         */
         try {
             return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($parentNativeReturnType, TypeKind::RETURN());
         } catch (NotImplementedYetException) {

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -14,7 +14,9 @@ use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NonexistentParentClassType;
 use PHPStan\Type\Type;
+use Rector\Core\Exception\NotImplementedYetException;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -48,6 +50,7 @@ final class ParentClassMethodTypeOverrideGuard
         if ($parametersAcceptor instanceof FunctionVariantWithPhpDocs) {
             $parentNativeReturnType = $parametersAcceptor->getNativeReturnType();
             if (! $parentNativeReturnType instanceof MixedType && $classMethod->returnType !== null) {
+                return false;
                 $currentType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
                 return $currentType->equals($parentNativeReturnType);
             }
@@ -99,7 +102,11 @@ final class ParentClassMethodTypeOverrideGuard
             return null;
         }
 
-        return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($parentNativeReturnType, TypeKind::RETURN());
+        try {
+            return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($parentNativeReturnType, TypeKind::RETURN());
+        } catch (NotImplementedYetException) {
+            return null;
+        }
     }
 
     public function hasParentClassMethod(ClassMethod $classMethod): bool

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -67,10 +67,10 @@ final class ParentClassMethodTypeOverrideGuard
          */
         /** @var Scope $scope */
         $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
-        /** @var ClassReflection $classReflection */
-        $classReflection = $scope->getClassReflection();
+        /** @var ClassReflection $currentClassReflection */
+        $currentClassReflection = $scope->getClassReflection();
         /** @var string $currentFileName */
-        $currentFileName = $classReflection->getFileName();
+        $currentFileName = $currentClassReflection->getFileName();
 
         // child (current)
         $normalizedCurrentFileName = $this->pathNormalizer->normalizePath($currentFileName);

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/equal_with_parent_return_type.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/equal_with_parent_return_type.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Fixture;
+
+abstract class SomeParent
+{
+    public abstract function run(): never;
+}
+
+class EqualWithParentReturnType extends SomeParent {
+    public function run(): never
+    {
+        throw new \Exception('test');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Fixture;
+
+abstract class SomeParent
+{
+    /**
+     * @return never
+     */
+    public abstract function run();
+}
+
+class EqualWithParentReturnType extends SomeParent {
+    /**
+     * @return never
+     */
+    public function run()
+    {
+        throw new \Exception('test');
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/follow_parent_return_type.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/follow_parent_return_type.php.inc
@@ -20,7 +20,7 @@ namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDecl
 use Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source\RunnableInterface;
 
 class ImplementorRunnable implements RunnableInterface {
-    public function run(): \stdClass
+    public function run(): ?\stdClass
     {
         throw new \Exception('test');
     }

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/follow_parent_return_type.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/follow_parent_return_type.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source\RunnableInterface;
+
+class ImplementorRunnable implements RunnableInterface {
+    public function run(): never
+    {
+        throw new \Exception('test');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source\RunnableInterface;
+
+class ImplementorRunnable implements RunnableInterface {
+    public function run(): \stdClass
+    {
+        throw new \Exception('test');
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/follow_parent_return_type.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/follow_parent_return_type.php.inc
@@ -20,6 +20,9 @@ namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDecl
 use Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source\RunnableInterface;
 
 class ImplementorRunnable implements RunnableInterface {
+    /**
+     * @return \stdClass|null
+     */
     public function run(): ?\stdClass
     {
         throw new \Exception('test');

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Source/RunnableInterface.php
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Source/RunnableInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source;
+
+interface RunnableInterface
+{
+    public function run(): ?\stdClass;
+}


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/1390, when the class method implements interface method already has never type, eg:

```php
interface Runnable
{
    public function run(): ?stdClass;
}

class ImplementorRunnable implements Runnable
{
    public function run(): never 
    {
        throw new \Exception('test');
    }
}
```

above code in php 8.1 is valid ref https://3v4l.org/npms1#v8.1rc3.

But when it downgraded, it currently produce to:

```diff
-    public function run(): \stdClass
+    /**
+     * @return never
+     */
+    public function run()
```

which will make Fatal error:

```bash
Fatal error: Declaration of ImplementorRunnable::run() must be compatible with Runnable::run(): ?stdClass
```

ref https://3v4l.org/aZ2cq#v8.1rc3

This PR try to fix it.