### PR TITLE
[VendorLocker] Allow both in vendor for child and parent on ParentClassMethodTypeOverrideGuard

### DIFF
--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -51,8 +51,26 @@ final class ParentClassMethodTypeOverrideGuard
             return false;
         }
 
+        /*
+         * Below verify that both current file name and parent file name is not in the /vendor/, if yes, then allowed.
+         * This can happen when rector run into /vendor/ directory while child and parent both are there.
+         */
+        /** @var Scope $scope */
+        $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
+        /** @var ClassReflection $currentClassReflection */
+        $currentClassReflection = $scope->getClassReflection();
+        /** @var string $currentFileName */
+        $currentFileName = $currentClassReflection->getFileName();
+
+        // child (current)
+        $normalizedCurrentFileName = $this->pathNormalizer->normalizePath($currentFileName);
+        $isCurrentNotInVendor = ! str_contains($normalizedCurrentFileName, '/vendor/');
+
+        // parent
         $normalizedFileName = $this->pathNormalizer->normalizePath($fileName);
-        return ! str_contains($normalizedFileName, '/vendor/');
+        $isParentNotInVendor = ! str_contains($normalizedFileName, '/vendor/');
+
+        return $isCurrentNotInVendor && $isParentNotInVendor;
     }
 
     public function hasParentClassMethod(ClassMethod $classMethod): bool

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -54,6 +54,12 @@ final class ParentClassMethodTypeOverrideGuard
         /*
          * Below verify that both current file name and parent file name is not in the /vendor/, if yes, then allowed.
          * This can happen when rector run into /vendor/ directory while child and parent both are there.
+         *
+         *  @see https://3v4l.org/Rc0RF#v8.0.13
+         *
+         *     - both in /vendor/ -> allowed
+         *     - one of them in /vendor/ -> not allowed
+         *     - both not in /vendor/ -> allowed
          */
         /** @var Scope $scope */
         $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
@@ -64,13 +70,13 @@ final class ParentClassMethodTypeOverrideGuard
 
         // child (current)
         $normalizedCurrentFileName = $this->pathNormalizer->normalizePath($currentFileName);
-        $isCurrentNotInVendor = ! str_contains($normalizedCurrentFileName, '/vendor/');
+        $isCurrentInVendor = str_contains($normalizedCurrentFileName, '/vendor/');
 
         // parent
         $normalizedFileName = $this->pathNormalizer->normalizePath($fileName);
-        $isParentNotInVendor = ! str_contains($normalizedFileName, '/vendor/');
+        $isParentInVendor = str_contains($normalizedFileName, '/vendor/');
 
-        return $isCurrentNotInVendor && $isParentNotInVendor;
+        return ($isCurrentInVendor && $isParentInVendor) || (! $isCurrentInVendor && ! $isParentInVendor);
     }
 
     public function hasParentClassMethod(ClassMethod $classMethod): bool

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/from_anonymous.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/from_anonymous.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+use Exception;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Source\MixedReturn;
+
+new class implements MixedReturn {
+    public function run()
+    {
+        throw new Exception('test');
+    }
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+use Exception;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Source\MixedReturn;
+
+new class implements MixedReturn {
+    public function run(): never
+    {
+        throw new Exception('test');
+    }
+};
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Source/MixedReturn.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Source/MixedReturn.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Source;
+
+interface MixedReturn
+{
+    public function run();
+}


### PR DESCRIPTION
Split of PR https://github.com/rectorphp/rector-src/pull/1395 that was cause error in php 7.2 and php 7.3 scoped.

This part is working when I test build scoped locally on php 7.2.