### PR TITLE
[TypeDeclaration][Php 8.1] Do not change parent anonymous class method return type to never on ReturnNeverTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_anonymous_class_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_anonymous_class_method.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\
 use Exception;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Source\MixedReturn;
 
-final class DoNotChangeParentAnonymousMethodCall
+final class DoNotChangeParentAnonymousClassMethod
 {
     public function run()
     {
@@ -27,7 +27,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\
 use Exception;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Source\MixedReturn;
 
-final class DoNotChangeParentAnonymousMethodCall
+final class DoNotChangeParentAnonymousClassMethod
 {
     public function run()
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_anonymous_method_call.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_anonymous_method_call.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+use Exception;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Source\MixedReturn;
+
+final class DoNotChangeParentAnonymousMethodCall
+{
+    public function run()
+    {
+        new class implements MixedReturn {
+            public function run()
+            {
+                throw new Exception('test');
+            }
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+use Exception;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Source\MixedReturn;
+
+final class DoNotChangeParentAnonymousMethodCall
+{
+    public function run()
+    {
+        new class implements MixedReturn {
+            public function run(): never
+            {
+                throw new Exception('test');
+            }
+        };
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -109,7 +109,9 @@ CODE_SAMPLE
         }
 
         $hasNeverNodes = $this->betterNodeFinder->hasInstancesOf($node, []);
-        $hasNeverNodes = $this->betterNodeFinder->findFirst((array) $node->stmts, function (Node $subNode) use ($node): bool {
+        $hasNeverNodes = $this->betterNodeFinder->findFirst((array) $node->stmts, function (Node $subNode) use (
+            $node
+        ): bool {
             if (! in_array($subNode::class, [Node\Expr\Throw_::class, Throw_::class], true)) {
                 return false;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -108,8 +108,7 @@ CODE_SAMPLE
             return true;
         }
 
-        $hasNeverNodes = $this->betterNodeFinder->hasInstancesOf($node, []);
-        $hasNeverNodes = $this->betterNodeFinder->findFirst((array) $node->stmts, function (Node $subNode) use (
+        $hasNeverNodes = (bool) $this->betterNodeFinder->findFirst((array) $node->stmts, function (Node $subNode) use (
             $node
         ): bool {
             if (! in_array($subNode::class, [Node\Expr\Throw_::class, Throw_::class], true)) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -108,7 +108,19 @@ CODE_SAMPLE
             return true;
         }
 
-        $hasNeverNodes = $this->betterNodeFinder->hasInstancesOf($node, [Node\Expr\Throw_::class, Throw_::class]);
+        $hasNeverNodes = $this->betterNodeFinder->hasInstancesOf($node, []);
+        $hasNeverNodes = $this->betterNodeFinder->findFirst((array) $node->stmts, function (Node $subNode) use ($node): bool {
+            if (! in_array($subNode::class, [Node\Expr\Throw_::class, Throw_::class], true)) {
+                return false;
+            }
+
+            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
+            if (! $parentFunctionOrClassMethod) {
+                return false;
+            }
+
+            return $parentFunctionOrClassMethod === $node;
+        });
 
         $hasNeverFuncCall = $this->hasNeverFuncCall($node);
         if (! $hasNeverNodes && ! $hasNeverFuncCall) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -115,10 +115,6 @@ CODE_SAMPLE
             }
 
             $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
-            if (! $parentFunctionOrClassMethod) {
-                return false;
-            }
-
             return $parentFunctionOrClassMethod === $node;
         });
 


### PR DESCRIPTION
Given the following code:

```php
final class DoNotChangeParentAnonymousClassMethod
{
    public function run()
    {
        new class implements MixedReturn {
            public function run()
            {
                throw new Exception('test');
            }
        };
    }
}
```

which anonymous class to have method that return never, it currently change to:

```diff
-    public function run()
+    public function run(): never
     {
         new class implements MixedReturn {
-            public function run()
+            public function run(): never
```

which the `never` type should only applied to inner anonymous function, not ClassMethod that has it, apply the change will make Fatal error:

```bash
Fatal error: Uncaught TypeError: FromAnonymous::run(): never-returning function must not implicitly return
```

ref https://3v4l.org/OcljB#v8.1rc3

This PR try to fix it