### PR TITLE
[ReturnTypeDeclaration][Php 8.1] Do not skip yield parent anonymous class method

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_skip_yield_parent_anonymous_class_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_skip_yield_parent_anonymous_class_method.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+final class DoNotSkipYieldParentAnonymousClassMethod
+{
+    public function run()
+    {
+        new class {
+            public function run()
+            {
+                yield 1;
+                exit();
+            }
+        };
+
+        exit();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+final class DoNotSkipYieldParentAnonymousClassMethod
+{
+    public function run(): never
+    {
+        new class {
+            public function run()
+            {
+                yield 1;
+                exit();
+            }
+        };
+
+        exit();
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -103,23 +103,15 @@ CODE_SAMPLE
         }
 
         $yieldAndConditionalNodes = array_merge([Yield_::class], ControlStructure::CONDITIONAL_NODE_SCOPE_TYPES);
-        $hasNotNeverNodes = $this->betterNodeFinder->hasInstancesOf($node, $yieldAndConditionalNodes);
+        $hasNotNeverNodes = $this->hasNotNeverNodes($node, $yieldAndConditionalNodes);
+
         if ($hasNotNeverNodes) {
             return true;
         }
 
-        $hasNeverNodes = (bool) $this->betterNodeFinder->findFirst((array) $node->stmts, function (Node $subNode) use (
-            $node
-        ): bool {
-            if (! in_array($subNode::class, [Node\Expr\Throw_::class, Throw_::class], true)) {
-                return false;
-            }
-
-            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
-            return $parentFunctionOrClassMethod === $node;
-        });
-
+        $hasNeverNodes = $this->hasNeverNodes($node);
         $hasNeverFuncCall = $this->hasNeverFuncCall($node);
+
         if (! $hasNeverNodes && ! $hasNeverFuncCall) {
             return true;
         }
@@ -135,6 +127,37 @@ CODE_SAMPLE
         }
 
         return $this->isName($node->returnType, 'never');
+    }
+
+    /**
+     * @param class-string<Node>[] $yieldAndConditionalNodes
+     */
+    private function hasNotNeverNodes(ClassMethod | Function_ $functionLike, array $yieldAndConditionalNodes): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst((array) $functionLike->stmts, function (Node $subNode) use (
+            $functionLike, $yieldAndConditionalNodes
+        ): bool {
+            if (! in_array($subNode::class, $yieldAndConditionalNodes, true)) {
+                return false;
+            }
+
+            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
+            return $parentFunctionOrClassMethod === $functionLike;
+        });
+    }
+
+    private function hasNeverNodes(ClassMethod | Function_ $functionLike): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst((array) $functionLike->stmts, function (Node $subNode) use (
+            $functionLike
+        ): bool {
+            if (! in_array($subNode::class, [Node\Expr\Throw_::class, Throw_::class], true)) {
+                return false;
+            }
+
+            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
+            return $parentFunctionOrClassMethod === $functionLike;
+        });
     }
 
     private function hasNeverFuncCall(ClassMethod | Function_ $functionLike): bool

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -135,7 +135,8 @@ CODE_SAMPLE
     private function hasNotNeverNodes(ClassMethod | Function_ $functionLike, array $yieldAndConditionalNodes): bool
     {
         return (bool) $this->betterNodeFinder->findFirst((array) $functionLike->stmts, function (Node $subNode) use (
-            $functionLike, $yieldAndConditionalNodes
+            $functionLike,
+            $yieldAndConditionalNodes
         ): bool {
             if (! in_array($subNode::class, $yieldAndConditionalNodes, true)) {
                 return false;


### PR DESCRIPTION
continue of https://github.com/rectorphp/rector-src/pull/1400, when yield is in inner anonymous class under ClassMethod, it should not be skipped to have return never.

the skipped one is inside anonymous function only, when outide, it will check for never type.