### PR TITLE
[TypeDeclaration][Php 8.1] Do not skip return on parent anonymous class method

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_skip_return_parent_anonymous_class_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_skip_return_parent_anonymous_class_method.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+final class DoNotSkipReturnParentAnonymousClassMethod
+{
+    public function run()
+    {
+        new class {
+            public function run()
+            {
+                return;
+            }
+        };
+
+        exit();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+final class DoNotSkipReturnParentAnonymousClassMethod
+{
+    public function run(): never
+    {
+        new class {
+            public function run()
+            {
+                return;
+            }
+        };
+
+        exit();
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -97,8 +97,7 @@ CODE_SAMPLE
 
     private function shouldSkip(ClassMethod | Function_ $node): bool
     {
-        $return = $this->betterNodeFinder->findFirstInstanceOf($node, Return_::class);
-        if ($return instanceof Return_) {
+        if ($this->hasReturnNode($node)) {
             return true;
         }
 
@@ -127,6 +126,20 @@ CODE_SAMPLE
         }
 
         return $this->isName($node->returnType, 'never');
+    }
+
+    private function hasReturnNode(ClassMethod | Function_ $functionLike): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst((array) $functionLike->stmts, function (Node $subNode) use (
+            $functionLike
+        ): bool {
+            if (! $subNode instanceof Return_) {
+                return false;
+            }
+
+            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
+            return $parentFunctionOrClassMethod === $functionLike;
+        });
     }
 
     /**


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/1402, when return only in inner anonymous class, the skipped one is only in anonymous class.