### PR TITLE
[NodeTypeResolver] Remove deprecated NodeTypeResolver resolve method

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -17,8 +17,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
-use PhpParser\Node\Param;
-use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
@@ -107,19 +105,6 @@ final class NodeTypeResolver
         }
 
         return $this->isMatchingUnionType($resolvedType, $requiredObjectType);
-    }
-
-    /**
-     * @deprecated
-     * @see use NodeTypeResolver::getType() instead
-     */
-    public function resolve(Node $node): Type
-    {
-        $errorMessage = sprintf('Method "%s" is deprecated. Use "getType()" instead', __METHOD__);
-        trigger_error($errorMessage, E_USER_WARNING);
-        sleep(3);
-
-        return $this->getType($node);
     }
 
     public function getType(Node $node): Type


### PR DESCRIPTION
`NodeTypeResolver::resolve()` class method is deprecated and it seems no longer used. I think it can be removed.