### PR TITLE
[Core] Add BetterNodeFinder::hasInstancesOfInFunctionLikeScoped() to handle only true when has same parent FunctionLike

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -103,13 +103,19 @@ CODE_SAMPLE
         }
 
         $yieldAndConditionalNodes = array_merge([Yield_::class], ControlStructure::CONDITIONAL_NODE_SCOPE_TYPES);
-        $hasNotNeverNodes = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, $yieldAndConditionalNodes);
+        $hasNotNeverNodes = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
+            $node,
+            $yieldAndConditionalNodes
+        );
 
         if ($hasNotNeverNodes) {
             return true;
         }
 
-        $hasNeverNodes = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, [Node\Expr\Throw_::class, Throw_::class]);
+        $hasNeverNodes = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
+            $node,
+            [Node\Expr\Throw_::class, Throw_::class]
+        );
         $hasNeverFuncCall = $this->hasNeverFuncCall($node);
 
         if (! $hasNeverNodes && ! $hasNeverFuncCall) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -97,18 +97,19 @@ CODE_SAMPLE
 
     private function shouldSkip(ClassMethod | Function_ $node): bool
     {
-        if ($this->hasReturnNode($node)) {
+        $hasReturn = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, Return_::class);
+        if ($hasReturn) {
             return true;
         }
 
         $yieldAndConditionalNodes = array_merge([Yield_::class], ControlStructure::CONDITIONAL_NODE_SCOPE_TYPES);
-        $hasNotNeverNodes = $this->hasNotNeverNodes($node, $yieldAndConditionalNodes);
+        $hasNotNeverNodes = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, $yieldAndConditionalNodes);
 
         if ($hasNotNeverNodes) {
             return true;
         }
 
-        $hasNeverNodes = $this->hasNeverNodes($node);
+        $hasNeverNodes = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, [Node\Expr\Throw_::class, Throw_::class]);
         $hasNeverFuncCall = $this->hasNeverFuncCall($node);
 
         if (! $hasNeverNodes && ! $hasNeverFuncCall) {
@@ -126,52 +127,6 @@ CODE_SAMPLE
         }
 
         return $this->isName($node->returnType, 'never');
-    }
-
-    private function hasReturnNode(ClassMethod | Function_ $functionLike): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst((array) $functionLike->stmts, function (Node $subNode) use (
-            $functionLike
-        ): bool {
-            if (! $subNode instanceof Return_) {
-                return false;
-            }
-
-            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
-            return $parentFunctionOrClassMethod === $functionLike;
-        });
-    }
-
-    /**
-     * @param class-string<Node>[] $yieldAndConditionalNodes
-     */
-    private function hasNotNeverNodes(ClassMethod | Function_ $functionLike, array $yieldAndConditionalNodes): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst((array) $functionLike->stmts, function (Node $subNode) use (
-            $functionLike,
-            $yieldAndConditionalNodes
-        ): bool {
-            if (! in_array($subNode::class, $yieldAndConditionalNodes, true)) {
-                return false;
-            }
-
-            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
-            return $parentFunctionOrClassMethod === $functionLike;
-        });
-    }
-
-    private function hasNeverNodes(ClassMethod | Function_ $functionLike): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst((array) $functionLike->stmts, function (Node $subNode) use (
-            $functionLike
-        ): bool {
-            if (! in_array($subNode::class, [Node\Expr\Throw_::class, Throw_::class], true)) {
-                return false;
-            }
-
-            $parentFunctionOrClassMethod = $this->betterNodeFinder->findParentByTypes($subNode, $this->getNodeTypes());
-            return $parentFunctionOrClassMethod === $functionLike;
-        });
     }
 
     private function hasNeverFuncCall(ClassMethod | Function_ $functionLike): bool

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -410,6 +410,31 @@ final class BetterNodeFinder
 
     /**
      * @template T of Node
+     * @param array<class-string<T>>|class-string<T> $types
+     */
+    public function hasInstancesOfInFunctionLikeScoped(ClassMethod | Function_ $functionLike, string|array $types): bool
+    {
+        if (is_string($types)) {
+            $types = [$types];
+        }
+
+        foreach ($types as $type) {
+            $foundNode = $this->findFirstInstanceOf((array) $functionLike->stmts, $type);
+            if (! $foundNode instanceof Node) {
+                continue;
+            }
+
+            $parentFunctionLike = $this->findParentType($foundNode, $functionLike::class);
+            if ($parentFunctionLike === $functionLike) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @template T of Node
      * @param Node|Node[] $nodes
      * @param class-string<T> $type
      */


### PR DESCRIPTION
To reduce repetitive check on verify found node has same FunctionLike (ClassMethod and Function_), the use case is found in the `ReturnNeverTypeRector` at previous PRs  https://github.com/rectorphp/rector-src/pull/1400 https://github.com/rectorphp/rector-src/pull/1402 https://github.com/rectorphp/rector-src/pull/1403