### PR TITLE
[vendor-patches] Add back patches/danielstjules-stringy-src-stringy-php.patch to patches directory

### DIFF
--- a/patches/danielstjules-stringy-src-stringy-php.patch
+++ b/patches/danielstjules-stringy-src-stringy-php.patch
@@ -1,0 +1,48 @@
+--- /dev/null
++++ ../src/Stringy.php
+@@ -267,6 +267,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      *
+      * @return int The number of characters in the string, given the encoding
+      */
++    #[\ReturnTypeWillChange]
+     public function count()
+     {
+         return $this->length();
+@@ -450,6 +451,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      *
+      * @return \ArrayIterator An iterator for the characters in the string
+      */
++    #[\ReturnTypeWillChange]
+     public function getIterator()
+     {
+         return new ArrayIterator($this->chars());
+@@ -847,6 +849,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @param  mixed   $offset The index to check
+      * @return boolean Whether or not the index exists
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetExists($offset)
+     {
+         $length = $this->length();
+@@ -870,6 +873,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @throws \OutOfBoundsException If the positive or negative offset does
+      *                               not exist
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetGet($offset)
+     {
+         $offset = (int) $offset;
+@@ -890,6 +894,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @param  mixed      $value  Value to set
+      * @throws \Exception When called
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetSet($offset, $value)
+     {
+         // Stringy is immutable, cannot directly set char
+@@ -903,6 +908,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
+      * @param  mixed      $offset The index of the character
+      * @throws \Exception When called
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetUnset($offset)


### PR DESCRIPTION
Because new release of `rector-symfony` while it doesn't has vendor patch to URL based yet https://github.com/rectorphp/rector-symfony/commit/1c76befd5a64d57bd0732aad989b06fd3ed3cb33

ref https://github.com/rectorphp/rector-src/pull/1377#issuecomment-987520400