### PR TITLE
[Core] Fix mergin of result in PhpFileProcessor

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -14,6 +14,7 @@ use Rector\Core\ValueObject\Reporting\FileDiff;
 use Rector\FileFormatter\FileFormatter;
 use Rector\Parallel\ValueObject\Bridge;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symplify\PackageBuilder\Yaml\ParametersMerger;
 use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class ApplicationFileProcessor
@@ -27,6 +28,7 @@ final class ApplicationFileProcessor
         private readonly FileFormatter $fileFormatter,
         private readonly RemovedAndAddedFilesProcessor $removedAndAddedFilesProcessor,
         private readonly SymfonyStyle $symfonyStyle,
+        private readonly ParametersMerger $parametersMerger,
         private readonly array $fileProcessors = []
     ) {
     }
@@ -71,7 +73,7 @@ final class ApplicationFileProcessor
                 $result = $fileProcessor->process($file, $configuration);
 
                 if (is_array($result)) {
-                    $systemErrorsAndFileDiffs = array_merge($systemErrorsAndFileDiffs, $result);
+                    $systemErrorsAndFileDiffs = $this->parametersMerger->merge($systemErrorsAndFileDiffs, $result);
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6849

Correction of previous PR https://github.com/rectorphp/rector-src/pull/1412/files

<br>

@samsonasik The file processors will have to be stateless for parallel to work correctly. That means there cannot be any "cache" properties in any file processors.

* The parallel will run e.g. 16 file processors in paralell with 16 files. Each has to return result (objects serialized to json) just for that file, then die.
* The json will be then merged in main proccess and json string deserialized back to objects.

<br>

The bug here was rather incorrect mering. I forgot the `array_merge()` skips nested mergin and overrides the `file_diff` only with last one.


<br>

I tried your original script (just narrowed to single directory):

```bash
bin/rector process rules/Removing -c build/config/config-downgrade.php --clear-cache -n
```

And the result seems ok (11 files changed before, 11 files changed now):

![image](https://user-images.githubusercontent.com/924196/145036833-46a8fcac-be6e-44d6-9696-49e96be89b17.png)



