### PR TITLE
[Alternative][Validation] Add AllowEmptyConfigurableRectorInterface

### DIFF
--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Util\StringUtils;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\ConsistentPregDelimiterRectorTest
  */
-final class ConsistentPregDelimiterRector extends AbstractRector implements ConfigurableRectorInterface
+final class ConsistentPregDelimiterRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface
 {
     /**
      * @api

--- a/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
+++ b/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
@@ -8,7 +8,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\LNumber;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Util\StringUtils;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -27,7 +27,7 @@ use Webmozart\Assert\Assert;
  * Taking the most generic use case to the account: https://wiki.php.net/rfc/numeric_literal_separator#should_it_be_the_role_of_an_ide_to_group_digits
  * The final check should be done manually
  */
-final class AddLiteralSeparatorToNumberRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface
+final class AddLiteralSeparatorToNumberRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface, MinPhpVersionInterface
 {
     /**
      * @api

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -18,7 +18,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\NodeAnalyzer\PropertyAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\PhpParser\AstResolver;
@@ -47,7 +47,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see \Rector\Tests\Php74\Rector\Property\TypedPropertyRector\ImportedTest
  * @see \Rector\Tests\Php74\Rector\Property\TypedPropertyRector\UnionTypedPropertyRectorTest
  */
-final class TypedPropertyRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface
+final class TypedPropertyRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface, MinPhpVersionInterface
 {
     /**
      * @var string

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\VoidType;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\TypeInferer\SilentVoidResolver;
@@ -24,7 +24,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector\AddVoidReturnTypeWhereNoReturnRectorTest
  */
-final class AddVoidReturnTypeWhereNoReturnRector extends AbstractRector implements MinPhpVersionInterface, ConfigurableRectorInterface
+final class AddVoidReturnTypeWhereNoReturnRector extends AbstractRector implements MinPhpVersionInterface, AllowEmptyConfigurableRectorInterface
 {
     /**
      * @var string using phpdoc instead of a native void type can ease the migration path for consumers of code beeing processed.

--- a/src/Contract/Rector/AllowEmptyConfigurableRectorInterface.php
+++ b/src/Contract/Rector/AllowEmptyConfigurableRectorInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Contract\Rector;
+
+interface AllowEmptyConfigurableRectorInterface extends ConfigurableRectorInterface
+{
+}

--- a/src/Validation/Collector/EmptyConfigurableRectorCollector.php
+++ b/src/Validation/Collector/EmptyConfigurableRectorCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Validation\Collector;
 
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\NonPhpFile\Rector\RenameClassNonPhpRector;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -28,6 +29,10 @@ final class EmptyConfigurableRectorCollector
 
         foreach ($this->containerBuilder->getServiceIds() as $serviceId) {
             if (! is_a($serviceId, ConfigurableRectorInterface::class, true)) {
+                continue;
+            }
+
+            if (is_a($serviceId, AllowEmptyConfigurableRectorInterface::class, true)) {
                 continue;
             }
 


### PR DESCRIPTION
- Add AllowEmptyConfigurableRectorInterface interface for alternative to not show warning on allowed rector rule to have default fallback config

Alternative for https://github.com/rectorphp/rector-src/pull/1414

**Before**

![Screen Shot 2021-12-08 at 10 19 10](https://user-images.githubusercontent.com/459648/145142440-1a013f7f-6ba1-42af-8193-41c6b046a5cb.png)

**After**

![Screen Shot 2021-12-08 at 10 19 39](https://user-images.githubusercontent.com/459648/145142494-10436792-1c66-41a6-bda2-32399e03cab8.png)

I will create separate PR for moving `Rector\Php74\Rector\Function_\ReservedFnFunctionRector` to `Transform` namespace.


Fixes https://github.com/rectorphp/rector/issues/6850
Closes https://github.com/rectorphp/rector-src/pull/1414
