### PR TITLE
[Transform] Move ReservedFnFunctionRector from Php74 to Transform namespace

### DIFF
--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -11,7 +11,6 @@ use Rector\Php74\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Php74\Rector\FuncCall\FilterVarToAddSlashesRector;
 use Rector\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector;
 use Rector\Php74\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector;
-use Rector\Php74\Rector\Function_\ReservedFnFunctionRector;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\Php74\Rector\MethodCall\ChangeReflectionTypeToStringToGetNameRector;
 use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
@@ -48,8 +47,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RealToFloatTypeCastRector::class);
 
     $services->set(NullCoalescingOperatorRector::class);
-
-    $services->set(ReservedFnFunctionRector::class);
 
     $services->set(ClosureToArrowFunctionRector::class);
 

--- a/rules-tests/Transform/Rector/Function_/ReservedFnFunctionRector/Fixture/fixture.php.inc
+++ b/rules-tests/Transform/Rector/Function_/ReservedFnFunctionRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\Function_\ReservedFnFunctionRector\Fixture;
+namespace Rector\Tests\Transform\Rector\Function_\ReservedFnFunctionRector\Fixture;
 
 class Fixture
 {
@@ -19,7 +19,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Tests\Php74\Rector\Function_\ReservedFnFunctionRector\Fixture;
+namespace Rector\Tests\Transform\Rector\Function_\ReservedFnFunctionRector\Fixture;
 
 class Fixture
 {

--- a/rules-tests/Transform/Rector/Function_/ReservedFnFunctionRector/ReservedFnFunctionRectorTest.php
+++ b/rules-tests/Transform/Rector/Function_/ReservedFnFunctionRector/ReservedFnFunctionRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php74\Rector\Function_\ReservedFnFunctionRector;
+namespace Rector\Tests\Transform\Rector\Function_\ReservedFnFunctionRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/rules-tests/Transform/Rector/Function_/ReservedFnFunctionRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/Function_/ReservedFnFunctionRector/config/configured_rule.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Rector\Php74\Rector\Function_\ReservedFnFunctionRector;
+use Rector\Transform\Rector\Function_\ReservedFnFunctionRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {

--- a/rules/Transform/Rector/Function_/ReservedFnFunctionRector.php
+++ b/rules/Transform/Rector/Function_/ReservedFnFunctionRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Php74\Rector\Function_;
+namespace Rector\Transform\Rector\Function_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -19,7 +19,7 @@ use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://github.com/php/php-src/pull/3941/files#diff-7e3a1a5df28a1cbd8c0fb6db68f243da
- * @see \Rector\Tests\Php74\Rector\Function_\ReservedFnFunctionRector\ReservedFnFunctionRectorTest
+ * @see \Rector\Tests\Transform\Rector\Function_\ReservedFnFunctionRector\ReservedFnFunctionRectorTest
  */
 final class ReservedFnFunctionRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface
 {


### PR DESCRIPTION
ReservedFnFunctionRector need to be configured to run, while registered in Php74 config set is not configured.

I think it should be moved to Transform namespace.