### PR TITLE
[DowngradePhp80] Fix DowngradeThrowExprRector on property fetch to use not isset

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector/Fixture/throw_property_fetch.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector/Fixture/throw_property_fetch.php.inc
@@ -34,7 +34,7 @@ final class ThrowPropertyFetch
 
     public function run()
     {
-        if ($this->progressBar === null) {
+        if (!isset($this->progressBar)) {
             throw new \InvalidArgumentException();
         }
         return $this->progressBar;

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -190,8 +190,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            $ifCondNotIsset = new BooleanNot(new Isset_([$coalesce->left]));
-            $if = $this->ifManipulator->createIfExpr($ifCondNotIsset, new Expression($coalesce->right));
+            $if = $this->createIf($coalesce, $coalesce->right);
             return [$if, new Return_($coalesce->left)];
         }
 
@@ -200,8 +199,7 @@ CODE_SAMPLE
 
     private function createIf(Coalesce $coalesce, Throw_ $throw): If_
     {
-        $condExpr = $this->createCondExpr($coalesce);
-
+        $condExpr = new BooleanNot(new Isset_([$coalesce->left]));
         return new If_($condExpr, [
             'stmts' => [new Expression($throw)],
         ]);

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -190,7 +190,8 @@ CODE_SAMPLE
                 return null;
             }
 
-            $if = $this->createIf($coalesce, $coalesce->right);
+            $ifCondNotIsset = new BooleanNot(new Isset_([$coalesce->left]));
+            $if = $this->ifManipulator->createIfExpr($ifCondNotIsset, new Expression($coalesce->right));
             return [$if, new Return_($coalesce->left)];
         }
 

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -199,9 +199,9 @@ CODE_SAMPLE
 
     private function createIf(Coalesce $coalesce, Throw_ $throw): If_
     {
-        $condExpr = new BooleanNot(new Isset_([$coalesce->left]));
+        $booleanNot = new BooleanNot(new Isset_([$coalesce->left]));
 
-        return new If_($condExpr, [
+        return new If_($booleanNot, [
             'stmts' => [new Expression($throw)],
         ]);
     }

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -200,6 +200,7 @@ CODE_SAMPLE
     private function createIf(Coalesce $coalesce, Throw_ $throw): If_
     {
         $condExpr = new BooleanNot(new Isset_([$coalesce->left]));
+
         return new If_($condExpr, [
             'stmts' => [new Expression($throw)],
         ]);


### PR DESCRIPTION
On Coalesce usage, ref https://github.com/rectorphp/rector-src/pull/1415/files#r764486020