### PR TITLE
[TypeDeclaration][Php 8.1] Do not change parent function to never on ReturnNeverTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_function.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+use Exception;
+
+final class DoNotChangeParentFunction
+{
+    public function run()
+    {
+        function run()
+        {
+            throw new Exception('test');
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+use Exception;
+
+final class DoNotChangeParentFunction
+{
+    public function run()
+    {
+        function run()
+        {
+            throw new Exception('test');
+        }
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/do_not_change_parent_function.php.inc
@@ -27,7 +27,7 @@ final class DoNotChangeParentFunction
 {
     public function run()
     {
-        function run()
+        function run(): never
         {
             throw new Exception('test');
         }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -424,7 +424,7 @@ final class BetterNodeFinder
                 continue;
             }
 
-            $parentFunctionLike = $this->findParentType($foundNode, $functionLike::class);
+            $parentFunctionLike = $this->findParentByTypes($foundNode, [ClassMethod::class, Function_::class]);
             if ($parentFunctionLike === $functionLike) {
                 return true;
             }


### PR DESCRIPTION
Given the following code:

```php
final class DoNotChangeParentFunction
{
    public function run()
    {
        function run()
        {
            throw new Exception('test');
        }
    }
}
```

currently produce:

```diff
-    public function run()
+    public function run(): never
     {
-        function run()
+        function run(): never
```

which the classmethod run should not be changed, only inner function.