### PR TITLE
[TypeDeclaration] Add void upper inner function has return on ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/upper_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/upper_void.php.inc
@@ -6,11 +6,9 @@ class UpperVoid
 {
     public function upperVoid()
     {
-        new class {
-            public function toString()
-            {
-                return 'test';
-            }
+        function toString()
+        {
+            return 'test';
         };
     }
 }
@@ -25,11 +23,9 @@ class UpperVoid
 {
     public function upperVoid(): void
     {
-        new class {
-            public function toString(): string
-            {
-                return 'test';
-            }
+        function toString(): string
+        {
+            return 'test';
         };
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/upper_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/upper_void.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+class UpperVoid
+{
+    public function upperVoid()
+    {
+        new class {
+            public function toString()
+            {
+                return 'test';
+            }
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+class UpperVoid
+{
+    public function upperVoid(): void
+    {
+        new class {
+            public function toString(): string
+            {
+                return 'test';
+            }
+        };
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -122,8 +122,8 @@ final class ReturnTypeInferer
     private function resolveTypeWithVoidHandling(FunctionLike $functionLike, Type $resolvedType): Type
     {
         if ($resolvedType instanceof VoidType) {
-            $hasReturnValue = (bool) $this->betterNodeFinder->findFirst(
-                (array) $functionLike->getStmts(),
+            $hasReturnValue = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+                $functionLike,
                 function (Node $subNode): bool {
                     if (! $subNode instanceof Return_) {
                         return false;

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -6,9 +6,12 @@ namespace Rector\TypeDeclaration\TypeInferer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\UnionType as PhpParserUnionType;
 use PHPStan\Reflection\ClassReflection;
@@ -121,7 +124,8 @@ final class ReturnTypeInferer
 
     private function resolveTypeWithVoidHandling(FunctionLike $functionLike, Type $resolvedType): Type
     {
-        if ($resolvedType instanceof VoidType) {
+        if ($resolvedType instanceof VoidType && ! $functionLike instanceof ArrowFunction) {
+            /** @var ClassMethod|Function_|Closure $functionLike */
             $hasReturnValue = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
                 $functionLike,
                 function (Node $subNode): bool {


### PR DESCRIPTION
Given the following code:

```php
class UpperVoid
{
    public function upperVoid()
    {
        function toString()
        {
            return 'test';
        };
    }
}
```

it currently produce inner return type hint only:

```diff
     public function upperVoid()
     {
-        function toString()
+        function toString(): string
```

which upper class method doesn't return anything, that can return `void`.

This PR try to solve it.