### PR TITLE
[Downgrade Php 7.2] Add opt-out parameter for unsafe types to avoid piling list of safe types

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -14,6 +14,7 @@ use Rector\Core\Stubs\PHPStanStubLoader;
 use Rector\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\Set\ValueObject\DowngradeLevelSetList;
+use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\StyleInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -37,50 +38,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_71);
 
     $services = $containerConfigurator->services();
+
     $services->set(DowngradeParameterTypeWideningRector::class)
         ->configure([
-            DowngradeParameterTypeWideningRector::SAFE_TYPES => [
-                // phsptan
-                Type::class,
-                RectorInterface::class,
-                // php-parser
-                NodeVisitorAbstract::class,
-                NodeVisitor::class,
-                ConfigurableRectorInterface::class,
-                OutputInterface::class,
-                StyleInterface::class,
-                PhpDocNodeVisitorInterface::class,
-                Node::class,
-                NodeNameResolverInterface::class,
-                // phpstan
-                SourceLocator::class,
-                \PHPStan\PhpDocParser\Ast\Node::class,
-                \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode::class,
-                \PHPStan\PhpDocParser\Ast\NodeAttributes::class,
-                \PhpParser\Parser::class,
-                \Rector\Naming\Contract\RenameParamValueObjectInterface::class,
-                \Symplify\RuleDocGenerator\Contract\RuleCodeSamplePrinterInterface::class,
-                \Symplify\RuleDocGenerator\Contract\Category\CategoryInfererInterface::class,
-                \PhpParser\PrettyPrinterAbstract::class,
-                \Helmich\TypoScriptParser\Parser\Traverser\Visitor::class,
-                \Symplify\SymplifyKernel\Contract\LightKernelInterface::class,
-                \Symfony\Component\String\Slugger\SluggerInterface::class,
-                \Psr\Log\LoggerInterface::class,
-                // phsptan
-                \PHPStan\Type\DynamicStaticMethodReturnTypeExtension::class,
-                \PHPStan\Type\DynamicFunctionReturnTypeExtension::class,
-                \PHPStan\Type\DynamicFunctionThrowTypeExtension::class,
-                \PHPStan\Type\DynamicMethodReturnTypeExtension::class,
-                \PHPStan\Type\DynamicMethodThrowTypeExtension::class,
-                \PHPStan\Type\DynamicReturnTypeExtensionRegistry::class,
-                \PHPStan\Type\DynamicStaticMethodReturnTypeExtension::class,
-                \PHPStan\Type\DynamicStaticMethodThrowTypeExtension::class,
-            ],
-            DowngradeParameterTypeWideningRector::SAFE_TYPES_TO_METHODS => [
-                ContainerInterface::class => [
-                    'setParameter',
-                    'getParameter',
-                    'hasParameter',
+            DowngradeParameterTypeWideningRector::UNSAFE_TYPES_TO_METHODS => [
+                Loader::class => [
+                    'load'
                 ],
             ],
         ]);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -628,3 +628,12 @@ parameters:
 
         # complex detection
         - '#Cognitive complexity for "Rector\\Core\\DependencyInjection\\Collector\\ConfigureCallValuesCollector\:\:addConfigureCallValues\(\)" is \d+, keep it under 10#'
+
+        # will be removed soon
+        -
+             message: '#Class cognitive complexity is 31, keep it under 30#'
+             path: rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+
+        -
+             message: '#Cognitive complexity for "Rector\\DowngradePhp72\\Rector\\ClassMethod\\DowngradeParameterTypeWideningRector\:\:isSafeType\(\)" is 14, keep it under 10#'
+             path: rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php


### PR DESCRIPTION
Seeing the list of safe types in `downgrade-config.php`, it looks like we only have to maintain all the interfaces and parent types.

On the other hand, there are just 2 methods that are currently unsafe:

* in Symfony Loader interface
* in PSR Container interface

Instead of a "removing all types bug X", we should use "remove types on these known cases", to safe work and make list of weak methods easy to see.