### PR TITLE
[Php80] Handle parent with typed param on AddParamBasedOnParentClassMethodRector

### DIFF
--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/fixture_has_parent_typed_param.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/fixture_has_parent_typed_param.php.inc
@@ -4,7 +4,6 @@ namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethod
 
 use Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Source\ParentWithTypedParam;
 
-// ref https://3v4l.org/4Mgrt
 class B extends ParentWithTypedParam{
     public function execute()
     {
@@ -19,9 +18,8 @@ namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethod
 
 use Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Source\ParentWithTypedParam;
 
-// ref https://3v4l.org/4Mgrt
 class B extends ParentWithTypedParam{
-    public function execute($foo)
+    public function execute(int $foo)
     {
     }
 }

--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/fixture_has_parent_typed_param.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/fixture_has_parent_typed_param.php.inc
@@ -4,6 +4,7 @@ namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethod
 
 use Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Source\ParentWithTypedParam;
 
+// ref https://3v4l.org/4Mgrt
 class B extends ParentWithTypedParam{
     public function execute()
     {
@@ -18,8 +19,9 @@ namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethod
 
 use Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Source\ParentWithTypedParam;
 
+// ref https://3v4l.org/4Mgrt
 class B extends ParentWithTypedParam{
-    public function execute(int $foo)
+    public function execute($foo)
     {
     }
 }

--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/fixture_typed_param.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/fixture_typed_param.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Source\ParentWithTypedParam;
+
+class B extends ParentWithTypedParam{
+    public function execute()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Source\ParentWithTypedParam;
+
+class B extends ParentWithTypedParam{
+    public function execute(int $foo)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Source/ParentWithTypedParam.php
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Source/ParentWithTypedParam.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Source;
+
+class ParentWithTypedParam
+{
+    public function execute(int $foo)
+    {
+    }
+}

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -17,6 +17,7 @@ use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -208,9 +209,12 @@ CODE_SAMPLE
                 $paramDefault = new ConstFetch(new Name($printParamDefault));
             }
 
-            $paramType = $parentClassMethodParam->type === null
-                ? null
-                : new Identifier((string) $this->nodeNameResolver->getName($parentClassMethodParam->type));
+            if ($parentClassMethodParam->type == null) {
+                $paramType = null;
+            } else {
+                $paramType = $parentClassMethodParam->type;
+                $paramType->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            }
 
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
             $node->params[$key] = new Param(

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -211,7 +211,7 @@ CODE_SAMPLE
             $node->params[$key] = new Param(
                 new Variable($paramName),
                 $paramDefault,
-                $parentClassMethodParam->type,
+                null,
                 $parentClassMethodParam->byRef,
                 $parentClassMethodParam->variadic,
                 [],

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Rector\Php80\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -208,14 +210,9 @@ CODE_SAMPLE
                 $paramDefault = new ConstFetch(new Name($printParamDefault));
             }
 
-            if ($parentClassMethodParam->type === null) {
-                $paramType = null;
-            } else {
-                $paramType = $parentClassMethodParam->type;
-                $paramType->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            }
-
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
+            $paramType = $this->resolveParamType($parentClassMethodParam);
+
             $node->params[$key] = new Param(
                 new Variable($paramName),
                 $paramDefault,
@@ -229,6 +226,18 @@ CODE_SAMPLE
         }
 
         return $node;
+    }
+
+    private function resolveParamType(Param $param): null|Identifier|Name|ComplexType
+    {
+        if ($param->type === null) {
+            return null;
+        }
+
+        $paramType = $param->type;
+        $paramType->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+
+        return $paramType;
     }
 
     /**

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -209,7 +208,7 @@ CODE_SAMPLE
                 $paramDefault = new ConstFetch(new Name($printParamDefault));
             }
 
-            if ($parentClassMethodParam->type == null) {
+            if ($parentClassMethodParam->type === null) {
                 $paramType = null;
             } else {
                 $paramType = $parentClassMethodParam->type;

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -208,10 +208,9 @@ CODE_SAMPLE
                 $paramDefault = new ConstFetch(new Name($printParamDefault));
             }
 
-            $typeName = $this->print($parentClassMethodParam->type);
             $paramType = $parentClassMethodParam->type === null
                 ? null
-                : new Identifier($typeName);
+                : new Identifier($this->print($parentClassMethodParam->type));
 
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
             $node->params[$key] = new Param(

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -210,7 +210,7 @@ CODE_SAMPLE
 
             $paramType = $parentClassMethodParam->type === null
                 ? null
-                : new Identifier($this->print($parentClassMethodParam->type));
+                : new Identifier($this->nodeNameResolver->getName($parentClassMethodParam->type));
 
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
             $node->params[$key] = new Param(

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -207,11 +208,16 @@ CODE_SAMPLE
                 $paramDefault = new ConstFetch(new Name($printParamDefault));
             }
 
+            $typeName = $this->print($parentClassMethodParam->type);
+            $paramType = $parentClassMethodParam->type === null
+                ? null
+                : new Identifier($typeName);
+
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
             $node->params[$key] = new Param(
                 new Variable($paramName),
                 $paramDefault,
-                null,
+                $paramType,
                 $parentClassMethodParam->byRef,
                 $parentClassMethodParam->variadic,
                 [],

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -210,7 +210,7 @@ CODE_SAMPLE
 
             $paramType = $parentClassMethodParam->type === null
                 ? null
-                : new Identifier($this->nodeNameResolver->getName($parentClassMethodParam->type));
+                : new Identifier((string) $this->nodeNameResolver->getName($parentClassMethodParam->type));
 
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
             $node->params[$key] = new Param(


### PR DESCRIPTION
When parent class has typed param:

```php
class A
{
    public function foo(int $foo)
    {
        
    }
}

class B extends A
{
    public function foo()
    {
        
    }
}
```

It currently produce internal php-parser error:

```bash
1) Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\AddParamBasedOnParentClassMethodRectorTest::test with data set #10 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
assert($startPos >= 0 && $endPos >= 0) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:535
```

this PR try to solve it.