### PR TITLE
[Dep] Fixing rector-generator require-dev packages (step 2)

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -48,9 +48,6 @@ jobs:
             -   run: composer config minimum-stability dev
 
             # test with current commit in a pull-request
-
-            -   run: composer require --dev rector/rector-generator:dev-main
-
             -
                 run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
                 if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/1458, as https://github.com/sabbelasichon/typo3-rector/pull/2755, the tweak in packages tests workflow no longer needed.