### PR TITLE
[[Dep] Fixing rector-generator require-dev packages (step 3)

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -82,7 +82,7 @@ jobs:
                     php-version: 7.1
                     coverage: none
             -   run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi
-            -   run: php-parallel-lint/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/rector/rector-nette/tests --exclude rector-prefixed-downgraded/vendor/symfony/polyfill-mbstring/bootstrap80.php --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/ssch/typo3-rector/templates/maker --exclude rector-prefixed-downgraded/vendor/symfony/console/Event --exclude rector-prefixed-downgraded/vendor/symfony/console/EventListener --exclude rector-prefixed-downgraded/vendor/symfony/console/Tester
+            -   run: php-parallel-lint/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/rector/rector-nette/tests --exclude rector-prefixed-downgraded/vendor/symfony/polyfill-mbstring/bootstrap80.php --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/ssch/typo3-rector/templates/maker --exclude rector-prefixed-downgraded/vendor/symfony/console/Event --exclude rector-prefixed-downgraded/vendor/symfony/console/EventListener --exclude rector-prefixed-downgraded/vendor/symfony/console/Tester --exclude vendor/rector/rector-generator/templates
 
             # 5. copy repository meta files
             -   run: |


### PR DESCRIPTION
Exclude vendor/rector/rector-generator/templates from parallel lint.