### PR TITLE
[CodeQuality] Handle inner function return exactly DateTime on DateTimeToDateTimeInterfaceRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector/Fixture/inner_return_datetime.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector/Fixture/inner_return_datetime.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\DateTimeToDateTimeInterfaceRector\Fixture;
+
+use DateTime;
+
+class InnerReturnDateTime
+{
+    public static function run(DateTime $dateTime): DateTime
+    {
+        function () {
+            return new DateTime('now');
+        };
+
+        return $dateTime;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\DateTimeToDateTimeInterfaceRector\Fixture;
+
+use DateTime;
+
+class InnerReturnDateTime
+{
+    /**
+     * @param \DateTime|\DateTimeImmutable $dateTime
+     * @return \DateTime|\DateTimeImmutable
+     */
+    public static function run(\DateTimeInterface $dateTime): \DateTimeInterface
+    {
+        function () {
+            return new DateTime('now');
+        };
+
+        return $dateTime;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/DateTimeToDateTimeInterfaceRector.php
@@ -191,8 +191,8 @@ CODE_SAMPLE
 
     private function shouldSkipExactlyReturnDateTime(ClassMethod $classMethod): bool
     {
-        $return = $this->betterNodeFinder->findFirst(
-            (array) $classMethod->stmts,
+        $return = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+            $classMethod,
             fn (Node $node): bool => $node instanceof Return_
         );
         if (! $return instanceof Return_) {


### PR DESCRIPTION
Given the following code:

```php
class InnerReturnDateTime
{
    public static function run(DateTime $dateTime): DateTime
    {
        function () {
            return new DateTime('now');
        };

        return $dateTime;
    }
}
```

currently skipped, it should actually apply `DateTimeInterface` to ClassMethod as exactly return `DateTime` is only in inner function, not upper class method.