### PR TITLE
Composer > Define allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -166,6 +166,11 @@
     },
     "config": {
         "sort-packages": true,
-        "platform-check": false
+        "platform-check": false,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "rector/extension-installer": true,
+            "cweagans/composer-patches": true
+        }
     }
 }


### PR DESCRIPTION
Needed for Composer 2.2.0 (found with 2.2.0-RC1)
```
composer self-update --preview
```