### PR TITLE
[TypeDeclaration] Handle inner Closure on ReturnTypeFromReturnNewRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/inner_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/inner_closure.php.inc
@@ -2,14 +2,12 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
 
-use stdClass;
-
-final class InnerFunction
+final class InnerClosure
 {
     public function __construct()
     {
         $a = function () {
-            return new stdClass;
+            return new \stdClass;
         };
     }
 }
@@ -20,14 +18,12 @@ final class InnerFunction
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
 
-use stdClass;
-
-final class InnerFunction
+final class InnerClosure
 {
     public function __construct()
     {
-        $a = function () {
-            return new stdClass;
+        $a = function (): \stdClass {
+            return new \stdClass;
         };
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/inner_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/inner_function.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+use stdClass;
+
+final class InnerFunction
+{
+    public function __construct()
+    {
+        $a = function () {
+            return new stdClass;
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+use stdClass;
+
+final class InnerFunction
+{
+    public function __construct()
+    {
+        $a = function () {
+            return new stdClass;
+        };
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
             $returns = [new Return_($node->expr)];
         } else {
             /** @var Return_[] $returns */
-            $returns = $this->betterNodeFinder->findInstanceOf((array) $node->stmts, Return_::class);
+            $returns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($node, Return_::class);
         }
 
         if ($returns === []) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -71,7 +72,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class, Function_::class, ArrowFunction::class];
+        return [ClassMethod::class, Function_::class, Closure::class, ArrowFunction::class];
     }
 
     /**

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -458,6 +458,10 @@ final class BetterNodeFinder
             /** @var T[] $nodes */
             $nodes = $this->findInstanceOf((array) $functionLike->stmts, $type);
 
+            if ($nodes === []) {
+                continue;
+            }
+
             foreach ($nodes as $key => $node) {
                 $parentFunctionLike = $this->findParentByTypes(
                     $node,
@@ -467,6 +471,10 @@ final class BetterNodeFinder
                 if ($parentFunctionLike !== $functionLike) {
                     unset($nodes[$key]);
                 }
+            }
+
+            if ($nodes === []) {
+                continue;
             }
 
             $foundNodes = array_merge($foundNodes, $nodes);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -438,6 +438,47 @@ final class BetterNodeFinder
         return false;
     }
 
+    /**
+     * @template T of Node
+     * @param array<class-string<T>>|class-string<T> $types
+     * @return T[]
+     */
+    public function findInstancesOfInFunctionLikeScoped(
+        ClassMethod | Function_ | Closure $functionLike,
+        string|array $types
+    ): array {
+        if (is_string($types)) {
+            $types = [$types];
+        }
+
+        /** @var T[] $foundNodes */
+        $foundNodes = [];
+
+        foreach ($types as $type) {
+            /** @var T[] $nodes */
+            $nodes = $this->findInstanceOf((array) $functionLike->stmts, $type);
+
+            if ($nodes === []) {
+                continue;
+            }
+
+            $foundNodes = array_merge($foundNodes, $nodes);
+        }
+
+        foreach ($foundNodes as $key => $foundNode) {
+            $parentFunctionLike = $this->findParentByTypes(
+                $foundNode,
+                [ClassMethod::class, Function_::class, Closure::class]
+            );
+
+            if ($parentFunctionLike !== $functionLike) {
+                unset($foundNodes[$key]);
+            }
+        }
+
+        return $foundNodes;
+    }
+
     public function findFirstInFunctionLikeScoped(
         ClassMethod | Function_ | Closure $functionLike,
         callable $filter

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -458,22 +458,18 @@ final class BetterNodeFinder
             /** @var T[] $nodes */
             $nodes = $this->findInstanceOf((array) $functionLike->stmts, $type);
 
-            if ($nodes === []) {
-                continue;
+            foreach ($nodes as $key => $node) {
+                $parentFunctionLike = $this->findParentByTypes(
+                    $node,
+                    [ClassMethod::class, Function_::class, Closure::class]
+                );
+
+                if ($parentFunctionLike !== $functionLike) {
+                    unset($nodes[$key]);
+                }
             }
 
             $foundNodes = array_merge($foundNodes, $nodes);
-        }
-
-        foreach ($foundNodes as $key => $foundNode) {
-            $parentFunctionLike = $this->findParentByTypes(
-                $foundNode,
-                [ClassMethod::class, Function_::class, Closure::class]
-            );
-
-            if ($parentFunctionLike !== $functionLike) {
-                unset($foundNodes[$key]);
-            }
         }
 
         return $foundNodes;


### PR DESCRIPTION
Given the following code:

```php
final class InnerClosure
{
    public function __construct()
    {
        $a = function () {
            return new \stdClass;
        };
    }
}
```

It currently produce parent classmethod, 

```diff
-    public function __construct()
+    public function __construct(): \stdClass
     {
         $a = function () {
```

which invalid. This PR try to fix it.

Fixes https://github.com/rectorphp/rector/issues/6858