### PR TITLE
[Doc] Update documentation for Class was not found on autoload

### DIFF
--- a/build/target-repository/docs/static_reflection_and_autoload.md
+++ b/build/target-repository/docs/static_reflection_and_autoload.md
@@ -104,7 +104,7 @@ Other solution is by register the path of the class to composer.json's `"files"`
 After that, run:
 
 ```bash
-composer update
+composer dump-autoload
 ```
 
 and re-run the rector.

--- a/build/target-repository/docs/static_reflection_and_autoload.md
+++ b/build/target-repository/docs/static_reflection_and_autoload.md
@@ -90,3 +90,21 @@ In this case you may want to try one of the following solutions:
         //          as much as you can or you will slow down each run
     ]);
 ```
+
+Other solution is by register the path of the class to composer.json's `"files"` config, eg:
+
+```javascript
+    "autoload-dev": {
+        "files": [
+            "vendor/acme/my-custom-dependency/src/Your/Own/Namespace/TheAffectedClass.php"
+        ]
+    }
+```
+
+After that, run:
+
+```bash
+composer update
+```
+
+and re-run the rector.


### PR DESCRIPTION
Based on possible tweak solution on:

- https://github.com/rectorphp/rector/issues/6841#issuecomment-991915633
- https://github.com/rectorphp/rector/issues/6852#issuecomment-991900246

by using "files" config in composer autoload as even can't be loaded by "classmap" config.

Fixes https://github.com/rectorphp/rector/issues/6841
Fixes https://github.com/rectorphp/rector/issues/6852