### PR TITLE
[Core] Fix undefined constant ReflectionClassConstant::IS_PUBLIC in php 7.x

### DIFF
--- a/src/DependencyInjection/Collector/ConfigureCallValuesCollector.php
+++ b/src/DependencyInjection/Collector/ConfigureCallValuesCollector.php
@@ -6,7 +6,6 @@ namespace Rector\Core\DependencyInjection\Collector;
 
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use ReflectionClass;
-use ReflectionClassConstant;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Definition;
 use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
@@ -68,15 +67,17 @@ final class ConfigureCallValuesCollector
                     // fixes bug when 1 item is unwrapped and treated as constant key, without rule having public constant
                     $classReflection = new ReflectionClass($rectorClass);
 
-                    $constantNamesToValues = $classReflection->getConstants(ReflectionClassConstant::IS_PUBLIC);
-                    foreach ($constantNamesToValues as $constantName => $constantValue) {
-                        if ($constantValue === $firstKey) {
-                            $reflectionConstant = $classReflection->getReflectionConstant($constantName);
-                            if ($reflectionConstant === false) {
-                                continue;
-                            }
+                    $reflectionClassConstants = $classReflection->getReflectionConstants();
+                    foreach ($reflectionClassConstants as $reflectionClassConstant) {
+                        if (! $reflectionClassConstant->isPublic()) {
+                            continue;
+                        }
 
-                            if (! str_contains((string) $reflectionConstant->getDocComment(), '@deprecated')) {
+                        $constantValue = $reflectionClassConstant->getValue();
+                        $constantName = $reflectionClassConstant->getName();
+
+                        if ($constantValue === $firstKey) {
+                            if (! str_contains((string) $reflectionClassConstant->getDocComment(), '@deprecated')) {
                                 continue;
                             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6864 that the issue happen since rector 0.12.7 in php 7.x

Ref https://github.com/laminas/laminas-servicemanager-migration/runs/4485249466?check_suite_focus=true#step:3:213