### PR TITLE
[Scoped] Fix scoped build for casted array_key_last

### DIFF
--- a/rules/Php80/Rector/Class_/StringableForToStringRector.php
+++ b/rules/Php80/Rector/Class_/StringableForToStringRector.php
@@ -124,7 +124,8 @@ CODE_SAMPLE
         $hasReturn = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($toStringClassMethod, Return_::class);
 
         if (! $hasReturn) {
-            $lastKey = array_key_last((array) $toStringClassMethod->stmts);
+            $stmts = (array) $toStringClassMethod->stmts;
+            $lastKey = array_key_last($stmts);
             $lastKey = $lastKey === null
                 ? 0
                 : (int) $lastKey + 1;


### PR DESCRIPTION
Fix for error:

```bash
Parse error: rector-prefixed-downgraded/rules/Php80/Rector/Class_/StringableForToStringRector.php:114
    112|         $hasReturn = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($toStringClassMethod, \PhpParser\Node\Stmt\Return_::class);
    113|         if (!$hasReturn) {
  > 114|             \end((array) $toStringClassMethod->stmts);
    115|             $lastKey = \key((array) $toStringClassMethod->stmts);
```

ref https://github.com/rectorphp/rector-src/runs/4505677100?check_suite_focus=true#step:14:80

ref https://github.com/rectorphp/rector-src/pull/1473/files#r767706986

The `DowngradeArrayKeyFirstLastRector` need to updated next to adapt its condition.