### PR TITLE
[NodeTypeResolver] Fix undefined method ReflectionProperty::getDefaultValue() on php 7.x

### DIFF
--- a/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -162,7 +162,10 @@ final class ArrayTypeAnalyzer
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($node);
         if ($phpPropertyReflection instanceof PhpPropertyReflection) {
             $reflectionProperty = $phpPropertyReflection->getNativeReflection();
-            return is_array($reflectionProperty->getDefaultValue());
+            $defaultValue = $reflectionProperty->getDeclaringClass()
+                ->getDefaultProperties()[$propertyName] ?? null;
+
+            return is_array($defaultValue);
         }
 
         return false;

--- a/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -162,8 +162,8 @@ final class ArrayTypeAnalyzer
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($node);
         if ($phpPropertyReflection instanceof PhpPropertyReflection) {
             $reflectionProperty = $phpPropertyReflection->getNativeReflection();
-            $defaultValue = $reflectionProperty->getDeclaringClass()
-                ->getDefaultProperties()[$propertyName] ?? null;
+            $reflectionClass = $reflectionProperty->getDeclaringClass();
+            $defaultValue = $reflectionClass->getDefaultProperties()[$reflectionProperty->getName()] ?? null;
 
             return is_array($defaultValue);
         }


### PR DESCRIPTION
Currently rector got error : 
```bash
PHP Fatal error:  Uncaught Error: Call to undefined method ReflectionProperty::getDefaultValue() in /home/runner/work/CodeIgniter4/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php:168

Fatal error: Uncaught Error: Call to undefined method ReflectionProperty::getDefaultValue() in /home/runner/work/CodeIgniter4/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php:168
```

When running on php 7.x

This PR try to fix it based on phpmanual comment https://www.php.net/manual/en/reflectionproperty.getdefaultvalue.php#126007

Note: New rector rule is needed for it.

Fixes https://github.com/rectorphp/rector/issues/6869