### PR TITLE
[Php80] Handle abstract method on StringableForToStringRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/StringableForToStringRector/Fixture/in_abstract_method.php.inc
+++ b/rules-tests/Php80/Rector/Class_/StringableForToStringRector/Fixture/in_abstract_method.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\StringableForToStringRector\Fixture;
+
+abstract class SomeAbstractMethod
+{
+    public abstract function __toString();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\StringableForToStringRector\Fixture;
+
+abstract class SomeAbstractMethod implements \Stringable
+{
+    public abstract function __toString(): string;
+}
+
+?>

--- a/rules/Php80/Rector/Class_/StringableForToStringRector.php
+++ b/rules/Php80/Rector/Class_/StringableForToStringRector.php
@@ -121,6 +121,10 @@ CODE_SAMPLE
 
     private function processNotStringType(ClassMethod $toStringClassMethod): void
     {
+        if ($toStringClassMethod->isAbstract()) {
+            return;
+        }
+
         $hasReturn = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($toStringClassMethod, Return_::class);
 
         if (! $hasReturn) {


### PR DESCRIPTION
Given the following code:

```php
abstract class SomeAbstractMethod
{
    public abstract function __toString();
}
```

It currently produce:

```diff
-    public abstract function __toString();
+    public abstract function __toString(): string
+    {
+        return '';
+    }
```

which abstract method should not has body, which cause error:

```bash
Abstract function SomeAbstractMethod::__toString() cannot contain body
```

This PR try to fix it.