### PR TITLE
[NodeTypeResolver] Add cast (float), (string), (int) back on ScalarTypeResolver

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php
@@ -35,15 +35,15 @@ final class ScalarTypeResolver implements NodeTypeResolverInterface
     public function resolve(Node $node): Type
     {
         if ($node instanceof DNumber) {
-            return new ConstantFloatType($node->value);
+            return new ConstantFloatType((float) $node->value);
         }
 
         if ($node instanceof String_) {
-            return new ConstantStringType($node->value);
+            return new ConstantStringType((string) $node->value);
         }
 
         if ($node instanceof LNumber) {
-            return new ConstantIntegerType($node->value);
+            return new ConstantIntegerType((int) $node->value);
         }
 
         if ($node instanceof MagicConst) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -594,3 +594,15 @@ parameters:
 
         # return bool on change
         - '#Method "(change|remove)(.*?)" returns bool type, so the name should start with is/has/was#'
+
+        -
+            message: '#Casting to float something that.{1}s already float#'
+            path: packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php #38
+
+        -
+            message: '#Casting to string something that.{1}s already string#'
+            path: packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php #42
+
+        -
+            message: '#Casting to int something that.{1}s already int#'
+            path: packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php #46


### PR DESCRIPTION
This change was applied previously on PR https://github.com/rectorphp/rector-src/pull/1210 

which removed back at PR https://github.com/rectorphp/rector-src/pull/1334/files#diff-1624de7e18f165236c0034fa2263ec433a20254ad47ed4dd6592f2bce61d5892

This PR re-add it as it cause error again: 

```bash
PHP Fatal error:  Uncaught TypeError: PHPStan\Type\Constant\ConstantIntegerType::__construct(): Argument #1 ($value) must be of type int, string given, called in /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php on line 44 and defined in phar:///Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/src/Type/Constant/ConstantIntegerType.php:24
Stack trace:
#0 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php(44): PHPStan\Type\Constant\ConstantIntegerType->__construct('1_000_000')
#1 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver.php(301): Rector\NodeTypeResolver\NodeTypeResolver\ScalarTypeResolver->resolve(Object(PhpParser\Node\Scalar\LNumber))
#2 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/packages/NodeTypeResolver/NodeTypeResolver.php(167): Rector\NodeTypeResolver\NodeTypeResolver->resolveByNodeTypeResolvers(Object(PhpParser\Node\Scalar\LNumber))
#3 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Rector/AbstractRector.php(308): Rector\NodeTypeResolver\NodeTypeResolver->getType(Object(PhpParser\Node\Scalar\LNumber))
#4 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php(111): Rector\Core\Rector\AbstractRector->getType(Object(PhpParser\Node\Scalar\LNumber))
#5 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php(95): Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector->isStringOrStaticNonNumbericString(Object(PhpParser\Node\Scalar\LNumber))
#6 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Rector/AbstractRector.php(237): Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector->refactor(Object(PhpParser\Node\Expr\BinaryOp\Mul))
#7 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(113): Rector\Core\Rector\AbstractRector->enterNode(Object(PhpParser\Node\Expr\BinaryOp\Mul))
#8 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Arg))
#9 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#10 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(133): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Expr\FuncCall))
#11 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(133): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Expr\Assign))
#12 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Expression))
#13 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#14 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\If_))
#15 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#16 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\ClassMethod))
#17 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#18 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Class_))
#19 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#20 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))
#21 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(85): PhpParser\NodeTraverser->traverseArray(Array)
#22 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/PhpParser/NodeTraverser/RectorNodeTraverser.php(56): PhpParser\NodeTraverser->traverse(Array)
#23 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor.php(57): Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser->traverse(Array)
#24 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(143): Rector\Core\Application\FileProcessor->refactor(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#25 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/FileProcessor/PhpFileProcessor.php(103): Rector\Core\Application\FileProcessor\PhpFileProcessor->refactorNodesWithRectors(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#26 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/ApplicationFileProcessor.php(96): Rector\Core\Application\FileProcessor\PhpFileProcessor->process(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#27 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Application/ApplicationFileProcessor.php(74): Rector\Core\Application\ApplicationFileProcessor->processFiles(Array, Object(Rector\Core\ValueObject\Configuration))
#28 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Console/Command/ProcessCommand.php(165): Rector\Core\Application\ApplicationFileProcessor->run(Array, Object(Rector\Core\ValueObject\Configuration))
#29 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Command/Command.php(296): Rector\Core\Console\Command\ProcessCommand->execute(Object(RectorPrefix20211209\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211209\Symfony\Component\Console\Output\ConsoleOutput))
#30 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(897): RectorPrefix20211209\Symfony\Component\Console\Command\Command->run(Object(RectorPrefix20211209\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211209\Symfony\Component\Console\Output\ConsoleOutput))
#31 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(300): RectorPrefix20211209\Symfony\Component\Console\Application->doRunCommand(Object(Rector\Core\Console\Command\ProcessCommand), Object(RectorPrefix20211209\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211209\Symfony\Component\Console\Output\ConsoleOutput))
#32 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/src/Console/ConsoleApplication.php(71): RectorPrefix20211209\Symfony\Component\Console\Application->doRun(Object(RectorPrefix20211209\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211209\Symfony\Component\Console\Output\ConsoleOutput))
#33 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symfony/console/Application.php(196): Rector\Core\Console\ConsoleApplication->doRun(Object(RectorPrefix20211209\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20211209\Symfony\Component\Console\Output\ConsoleOutput))
#34 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/bin/rector.php(56): RectorPrefix20211209\Symfony\Component\Console\Application->run()
#35 /Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/bin/rector(5): require_once('/Users/samsonas...')
#36 {main}
  thrown in phar:///Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/src/Type/Constant/ConstantIntegerType.php on line 24
```