### PR TITLE
[DowngradePhp73] Add back direct (array) cast on array_key_last usage

### DIFF
--- a/rules/Php80/Rector/Class_/StringableForToStringRector.php
+++ b/rules/Php80/Rector/Class_/StringableForToStringRector.php
@@ -128,8 +128,7 @@ CODE_SAMPLE
         $hasReturn = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($toStringClassMethod, Return_::class);
 
         if (! $hasReturn) {
-            $stmts = (array) $toStringClassMethod->stmts;
-            $lastKey = array_key_last($stmts);
+            $lastKey = array_key_last((array) $toStringClassMethod->stmts);
             $lastKey = $lastKey === null
                 ? 0
                 : (int) $lastKey + 1;


### PR DESCRIPTION
as there is already `DowngradeArrayKeyFirstLastRector` fix for it at https://github.com/rectorphp/rector-src/pull/1478. I tried locally, and its applied:


```diff
-            $lastKey = array_key_last((array) $toStringClassMethod->stmts);
+            $stmts = (array) $toStringClassMethod->stmts;
+            end($stmts);
+            $lastKey = key($stmts);
```