### PR TITLE
[Scoped] Ensure remove bin/generate-changelog.php before commit

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -100,7 +100,7 @@ jobs:
                     token: ${{ secrets.ACCESS_TOKEN }}
 
             # remove remote files, to avoid piling up dead code in remote repository
-            -   run: rm -rf remote-repository/.github remote-repository/config remote-repository/src remote-repository/rules remote-repository/packages  remote-repository/vendor
+            -   run: rm -rf remote-repository/.github remote-repository/config remote-repository/src remote-repository/rules remote-repository/packages remote-repository/vendor remote-repository/bin/generate-changelog.php
 
             -   run: cp -a rector-prefixed-downgraded/. remote-repository
 


### PR DESCRIPTION
The `bin/generate-changelog.php` currently still exists in rector scoped 

https://github.com/rectorphp/rector/blob/eeefa260aa8c000faf1b42474ac86e0220b748f0/bin/generate-changelog.php

This is ensure it is removed first.