### PR TITLE
[ClassReflection] Use merge getParents() and getInterfaces() for get ancestors

### DIFF
--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -82,23 +82,16 @@ final class FamilyRelationsAnalyzer
             throw new ShouldNotHappenException();
         }
 
-        $ancestorClassReflections = $classReflection->getAncestors();
-
         $propertyName = $this->nodeNameResolver->getName($property);
         $kindPropertyFetch = $this->getKindPropertyFetch($property);
-
-        $className = $classReflection->getName();
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
 
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
-            $ancestorClassName = $ancestorClassReflection->getName();
-            if ($ancestorClassName === $className) {
-                continue;
-            }
-
             if ($ancestorClassReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;
             }
 
+            $ancestorClassName = $ancestorClassReflection->getName();
             $class = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection, $ancestorClassName);
             if (! $class instanceof Class_) {
                 continue;

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -326,7 +326,9 @@ final class NodeTypeResolver
         }
 
         $classReflection = $this->reflectionProvider->getClass($resolvedObjectType->getClassName());
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
             if ($ancestorClassReflection->hasTraitUse($requiredObjectType->getClassName())) {
                 return true;
             }

--- a/packages/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
@@ -91,8 +91,9 @@ final class StaticCallMethodCallTypeResolver implements NodeTypeResolverInterfac
         }
 
         $classReflection = $this->reflectionProvider->getClass($referencedClass);
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
 
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
             if (! $ancestorClassReflection->hasMethod($methodName)) {
                 continue;
             }

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
@@ -115,12 +115,8 @@ final class ClassMethodParamVendorLockResolver
         string $methodName,
         string $filePathPartName
     ): bool {
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
-            // skip self
-            if ($ancestorClassReflection === $classReflection) {
-                continue;
-            }
-
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
             // parent type
             if (! $ancestorClassReflection->hasNativeMethod($methodName)) {
                 continue;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -41,15 +41,13 @@ final class ClassMethodReturnVendorLockResolver
 
     private function isVendorLockedByAncestors(ClassReflection $classReflection, string $methodName): bool
     {
-        foreach ($classReflection->getAncestors() as $ancestorClassReflections) {
-            if ($ancestorClassReflections === $classReflection) {
-                continue;
-            }
-
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        foreach ($ancestorClassReflections as $ancestorClassReflections) {
             $nativeClassReflection = $ancestorClassReflections->getNativeReflection();
+            $hasMethod = $nativeClassReflection->hasMethod($methodName);
 
             // this should avoid detecting @method as real method
-            if (! $nativeClassReflection->hasMethod($methodName)) {
+            if (! $hasMethod) {
                 continue;
             }
 

--- a/packages/VendorLocker/NodeVendorLocker/PropertyTypeVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/PropertyTypeVendorLockResolver.php
@@ -34,7 +34,8 @@ final class PropertyTypeVendorLockResolver
             return false;
         }
 
-        if (count($classReflection->getAncestors()) === 1) {
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        if ($ancestorClassReflections === []) {
             return false;
         }
 

--- a/rules/DowngradePhp72/NodeAnalyzer/SealedClassAnalyzer.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/SealedClassAnalyzer.php
@@ -21,6 +21,7 @@ final class SealedClassAnalyzer
             return false;
         }
 
-        return count($classReflection->getAncestors()) === 1;
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        return $ancestorClassReflections === [];
     }
 }

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -45,12 +45,10 @@ final class PhpAttributeAnalyzer
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        $ancestorClassReflections = $classReflection->getAncestors();
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
             $ancestorClassName = $ancestorClassReflection->getName();
-            if ($ancestorClassName === $className) {
-                continue;
-            }
 
             $class = $this->astResolver->resolveClassFromName($ancestorClassName);
             if (! $class instanceof Class_) {

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -30,7 +30,8 @@ final class ClassConstManipulator
             return false;
         }
 
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
             $ancestorClass = $this->astResolver->resolveClassFromClassReflection(
                 $ancestorClassReflection,
                 $ancestorClassReflection->getName()

--- a/src/NodeManipulator/ClassManipulator.php
+++ b/src/NodeManipulator/ClassManipulator.php
@@ -31,11 +31,9 @@ final class ClassManipulator
         }
 
         $classReflection = $this->reflectionProvider->getClass($objectType->getClassName());
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
-            if ($classReflection === $ancestorClassReflection) {
-                continue;
-            }
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
 
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
             if (! $ancestorClassReflection->hasMethod($oldMethod)) {
                 continue;
             }

--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -24,23 +24,6 @@ final class StaticEasyPrefixer
     ];
 
     /**
-     * @var string[]
-     */
-    private const EXCLUDED_NAMESPACES = [
-        // naturally
-        'Rector\*',
-        // we use this API a lot
-        'PhpParser\*',
-        'Ssch\TYPO3Rector\*',
-
-        // phpstan needs to be here, as phpstan/vendor autoload is statically generated and namespaces cannot be changed
-        'PHPStan\*',
-
-        // this is public API of a Rector rule
-        'Symplify\RuleDocGenerator\*',
-    ];
-
-    /**
      * @return string[]
      */
     public static function getExcludedNamespacesAndClasses(): array

--- a/utils/compiler/src/Unprefixer.php
+++ b/utils/compiler/src/Unprefixer.php
@@ -8,12 +8,6 @@ use Nette\Utils\Strings;
 
 final class Unprefixer
 {
-    /**
-     * @var string
-     * @see https://regex101.com/r/P8sXfr/1
-     */
-    private const QUOTED_VALUE_REGEX = '#\'\\\\(\w|@)#';
-
     public static function unprefixQuoted(string $content, string $prefix): string
     {
         $match = sprintf('\'%s\\\\r\\\\n\'', $prefix);

--- a/utils/rule-doc-generator/src/Category/RectorCategoryInferer.php
+++ b/utils/rule-doc-generator/src/Category/RectorCategoryInferer.php
@@ -11,17 +11,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class RectorCategoryInferer implements CategoryInfererInterface
 {
-    /**
-     * @see https://regex101.com/r/wyW01F/1
-     * @var string
-     */
-    private const RECTOR_CATEGORY_REGEX = '#Rector\\\\(?<' . self::CATEGORY . '>\w+)\\\\#';
-
-    /**
-     * @var string
-     */
-    private const CATEGORY = 'category';
-
     public function infer(RuleDefinition $ruleDefinition): ?string
     {
         $matches = Strings::match($ruleDefinition->getRuleClass(), self::RECTOR_CATEGORY_REGEX);


### PR DESCRIPTION
So no need to check classname === ancestor classname as `getAncestors()` got current classname as well.