### PR TITLE
Use ::class constant instead of a string

### DIFF
--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -23,7 +23,6 @@ use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 /**
  * Factory so Symfony app can use services from PHPStan container
- * @see packages/NodeTypeResolver/config/config.yaml:17
  */
 final class PHPStanServicesFactory
 {

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -126,7 +126,7 @@ final class PHPStanServicesFactory
     private function resolveExtensionConfigs(): array
     {
         // same logic as in PHPStan for extension installed - https://github.com/phpstan/phpstan-src/blob/5956ec4f6cd09c8d7db9466ed4e7f25706f37a43/src/Command/CommandHelper.php#L195-L222
-        if (! class_exists('PHPStan\ExtensionInstaller\GeneratedConfig')) {
+        if (! class_exists(GeneratedConfig::class)) {
             return [];
         }
 


### PR DESCRIPTION
Found while digging into the code.

This notation works even if the class doesn't exist.