### PR TITLE
[CodingStyle] Skip new line on ConsistentPregDelimiterRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/skip_new_line.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/skip_new_line.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+use Nette\Utils\Strings;
+
+class SkipNewLine
+{
+    public function run()
+    {
+        $content = 'some texte';
+        $parts = preg_split("/(\r\n|\n|\r){2}/", $content);
+    }
+}

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -183,7 +183,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function isHasNewLineWithUnicodeModifier(string $string): bool
+    private function hasNewLineWithUnicodeModifier(string $string): bool
     {
         $matchInnerRegex = Strings::match($string, self::INNER_REGEX);
         $matchInnerUnionRegex = Strings::match($string, self::INNER_UNICODE_REGEX);
@@ -212,7 +212,7 @@ CODE_SAMPLE
         /** @var String_ $string */
         $string = $arg->value;
 
-        if ($this->isHasNewLineWithUnicodeModifier($string->value)) {
+        if ($this->hasNewLineWithUnicodeModifier($string->value)) {
             return;
         }
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -196,7 +196,7 @@ CODE_SAMPLE
             return false;
         }
 
-        if ($matchInnerRegex !== $matchInnerUnionRegex) {
+        if ($matchInnerRegex === $matchInnerUnionRegex) {
             return false;
         }
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -39,6 +39,20 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Allo
 
     /**
      * @var string
+     * @see https://regex101.com/r/nnuwUo/1
+     *
+     * For modifiers see https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
+     */
+    private const INNER_UNICODE_REGEX = '#(?<content>.*?)(?<close>[imsxeADSUXJu]*)$#u';
+
+    /**
+     * @var string
+     * @see https://regex101.com/r/KpCzg6/1
+     */
+    private const NEW_LINE_REGEX = '#(\\r|\\n)#';
+
+    /**
+     * @var string
      * @see https://regex101.com/r/EyXsV6/6
      */
     private const DOUBLE_QUOTED_REGEX = '#^"(?<delimiter>.{1}).{1,}\k<delimiter>[imsxeADSUXJu]*"$#';
@@ -177,6 +191,16 @@ CODE_SAMPLE
 
         /** @var String_ $string */
         $string = $arg->value;
+
+        $matchInnerRegex = Strings::match($string->value, self::INNER_REGEX);
+        $matchInnerUnionRegex = Strings::match($string->value, self::INNER_UNICODE_REGEX);
+
+        if ($matchInnerRegex && $matchInnerUnionRegex) {
+            if ($matchInnerUnionRegex === $matchInnerUnionRegex && StringUtils::isMatch($matchInnerUnionRegex['content'], '#(\\r|\\n)#')) {
+                return;
+            }
+        }
+
         $string->value = Strings::replace($string->value, self::INNER_REGEX, function (array $match) use (
             &$string
         ): string {

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -183,7 +183,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function isHasNewLine(string $string): bool
+    private function isHasNewLineWithUnicodeModifier(string $string): bool
     {
         $matchInnerRegex = Strings::match($string, self::INNER_REGEX);
         $matchInnerUnionRegex = Strings::match($string, self::INNER_UNICODE_REGEX);
@@ -212,7 +212,7 @@ CODE_SAMPLE
         /** @var String_ $string */
         $string = $arg->value;
 
-        if ($this->isHasNewLine($string->value)) {
+        if ($this->isHasNewLineWithUnicodeModifier($string->value)) {
             return;
         }
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -183,6 +183,26 @@ CODE_SAMPLE
         return null;
     }
 
+    private function isHasNewLine(string $string): bool
+    {
+        $matchInnerRegex = Strings::match($string, self::INNER_REGEX);
+        $matchInnerUnionRegex = Strings::match($string, self::INNER_UNICODE_REGEX);
+
+        if (! is_array($matchInnerRegex)) {
+            return false;
+        }
+
+        if (! is_array($matchInnerUnionRegex)) {
+            return false;
+        }
+
+        if ($matchInnerRegex !== $matchInnerUnionRegex) {
+            return false;
+        }
+
+        return StringUtils::isMatch($matchInnerUnionRegex['content'], self::NEW_LINE_REGEX);
+    }
+
     private function refactorArgument(Arg $arg): void
     {
         if (! $arg->value instanceof String_) {
@@ -192,13 +212,8 @@ CODE_SAMPLE
         /** @var String_ $string */
         $string = $arg->value;
 
-        $matchInnerRegex = Strings::match($string->value, self::INNER_REGEX);
-        $matchInnerUnionRegex = Strings::match($string->value, self::INNER_UNICODE_REGEX);
-
-        if ($matchInnerRegex && $matchInnerUnionRegex) {
-            if ($matchInnerUnionRegex === $matchInnerUnionRegex && StringUtils::isMatch($matchInnerUnionRegex['content'], '#(\\r|\\n)#')) {
-                return;
-            }
+        if ($this->isHasNewLine($string->value)) {
+            return;
         }
 
         $string->value = Strings::replace($string->value, self::INNER_REGEX, function (array $match) use (

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -193,8 +193,7 @@ final class ReturnTypeInferer
     private function shouldSkipExcludedTypeInferer(
         ReturnTypeInfererInterface $returnTypeInferer,
         array $excludedInferers
-    ): bool
-    {
+    ): bool {
         foreach ($excludedInferers as $excludedInferer) {
             if (is_a($returnTypeInferer, $excludedInferer)) {
                 return true;

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -190,10 +190,13 @@ final class ReturnTypeInferer
     /**
      * @param array<class-string<ReturnTypeInfererInterface>> $excludedInferers
      */
-    private function shouldSkipExcludedTypeInferer(ReturnTypeInfererInterface $return, array $excludedInferers): bool
+    private function shouldSkipExcludedTypeInferer(
+        ReturnTypeInfererInterface $returnTypeInferer,
+        array $excludedInferers
+    ): bool
     {
         foreach ($excludedInferers as $excludedInferer) {
-            if (is_a($return, $excludedInferer)) {
+            if (is_a($returnTypeInferer, $excludedInferer)) {
                 return true;
             }
         }


### PR DESCRIPTION
Given the following code:

```php
        $content = 'some texte';
        $parts = preg_split("/(\r\n|\n|\r){2}/", $content);
```

currently produce:

```diff
         $content = 'some texte';
-        $parts = preg_split("/(\r\n|\n|\r){2}/", $content);
+        $parts = preg_split("#(
+|
){2}#", $content);
```

which should be fixed.

This PR try to fix it. 

Fixes https://github.com/rectorphp/rector/issues/6868