### PR TITLE
[DowngradePhp81] Handle New_ inside array on DowngradeNewInInitializerRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector/Fixture/new_in_array.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector/Fixture/new_in_array.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector\Fixture;
+
+use stdClass;
+
+class NewInArray
+{
+    public function __construct(public array $property = [
+        'a' => new stdClass()
+    ])
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector\Fixture;
+
+use stdClass;
+
+class NewInArray
+{
+    public function __construct(public ?array $property = null)
+    {
+        $this->property = $property ?? [
+            'a' => new stdClass()
+        ];
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -211,10 +211,7 @@ CODE_SAMPLE
 
             $hasNew = $param->default === null
                 ? false
-                : (bool) $this->betterNodeFinder->findFirstInstanceOf(
-                    $param->default,
-                    New_::class
-                );
+                : (bool) $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class);
 
             if ($param->default !== null && ! $hasNew) {
                 $property->props[0]->default = $param->default;

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -209,7 +209,10 @@ CODE_SAMPLE
             $property->type = $param->type;
             $this->decoratePropertyWithParamDocInfo($param, $property);
 
-            if ($param->default !== null && ! $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class)) {
+            if ($param->default !== null && ! $this->betterNodeFinder->findFirstInstanceOf(
+                $param->default,
+                New_::class
+            )) {
                 $property->props[0]->default = $param->default;
             }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp80\Rector\Class_;
 
 use PhpParser\Comment;
 use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -208,7 +209,7 @@ CODE_SAMPLE
             $property->type = $param->type;
             $this->decoratePropertyWithParamDocInfo($param, $property);
 
-            if ($param->default !== null) {
+            if ($param->default !== null && ! $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class)) {
                 $property->props[0]->default = $param->default;
             }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -209,10 +209,14 @@ CODE_SAMPLE
             $property->type = $param->type;
             $this->decoratePropertyWithParamDocInfo($param, $property);
 
-            if ($param->default !== null && ! $this->betterNodeFinder->findFirstInstanceOf(
-                $param->default,
-                New_::class
-            )) {
+            $hasNew = $param->default === null
+                ? false
+                : (bool) $this->betterNodeFinder->findFirstInstanceOf(
+                    $param->default,
+                    New_::class
+                );
+
+            if ($param->default !== null && ! $hasNew) {
                 $property->props[0]->default = $param->default;
             }
 

--- a/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
+++ b/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp81\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\ComplexType;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp\Coalesce as AssignCoalesce;
@@ -18,6 +19,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
@@ -95,15 +97,7 @@ CODE_SAMPLE
     private function shouldSkip(FunctionLike $functionLike): bool
     {
         foreach ($functionLike->getParams() as $param) {
-            if ($param->default === null) {
-                continue;
-            }
-
-            if (! (bool) $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class)) {
-                continue;
-            }
-
-            if ($param->type instanceof IntersectionType) {
+            if ($this->isParamSkipped($param)) {
                 continue;
             }
 
@@ -129,31 +123,44 @@ CODE_SAMPLE
         );
     }
 
+    private function isParamSkipped(Param $param): bool
+    {
+        if ($param->default === null) {
+            return true;
+        }
+
+        $hasNew = (bool) $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class);
+        if (! $hasNew) {
+            return true;
+        }
+
+        return $param->type instanceof IntersectionType;
+    }
+
     private function replaceNewInParams(FunctionLike $functionLike): FunctionLike
     {
         $isConstructor = $functionLike instanceof ClassMethod && $this->isName($functionLike, MethodName::CONSTRUCT);
 
         $stmts = [];
         foreach ($functionLike->getParams() as $param) {
-            if ($param->default === null) {
+            if ($this->isParamSkipped($param)) {
                 continue;
             }
 
-            if (! (bool) $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class)) {
-                continue;
-            }
+            /** @var Expr $default */
+            $default = $param->default;
 
             // check for property promotion
             if ($isConstructor && $param->flags > 0) {
                 $propertyFetch = new PropertyFetch(new Variable('this'), $param->var->name);
-                $coalesce = new Coalesce($param->var, $param->default);
+                $coalesce = new Coalesce($param->var, $default);
                 $assign = new Assign($propertyFetch, $coalesce);
 
                 if ($param->type !== null) {
                     $param->type = $this->ensureNullableType($param->type);
                 }
             } else {
-                $assign = new AssignCoalesce($param->var, $param->default);
+                $assign = new AssignCoalesce($param->var, $default);
             }
 
             $stmts[] = new Expression($assign);

--- a/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
+++ b/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
@@ -95,7 +95,11 @@ CODE_SAMPLE
     private function shouldSkip(FunctionLike $functionLike): bool
     {
         foreach ($functionLike->getParams() as $param) {
-            if (! $param->default instanceof New_) {
+            if ($param->default === null) {
+                continue;
+            }
+
+            if (! (bool) $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class)) {
                 continue;
             }
 
@@ -131,7 +135,11 @@ CODE_SAMPLE
 
         $stmts = [];
         foreach ($functionLike->getParams() as $param) {
-            if (! $param->default instanceof New_) {
+            if ($param->default === null) {
+                continue;
+            }
+
+            if (! (bool) $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class)) {
                 continue;
             }
 

--- a/tests/Issues/DowngradeNewInArrayInitializerPromotion/DowngradeNewInArrayInitializerPromotionTest.php
+++ b/tests/Issues/DowngradeNewInArrayInitializerPromotion/DowngradeNewInArrayInitializerPromotionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\DowngradeNewInArrayInitializerPromotion;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeNewInArrayInitializerPromotionTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DowngradeNewInArrayInitializerPromotion/Fixture/new_in_array.php.inc
+++ b/tests/Issues/DowngradeNewInArrayInitializerPromotion/Fixture/new_in_array.php.inc
@@ -6,6 +6,9 @@ use stdClass;
 
 class NewInArray
 {
+    /**
+     * @param array<string, object> $property
+     */
     public function __construct(public array $property = [
         'a' => new stdClass()
     ])
@@ -23,12 +26,19 @@ use stdClass;
 
 class NewInArray
 {
+    /**
+     * @var array<string, object>
+     */
     public $property;
+    /**
+     * @param array<string, object> $property
+     */
     public function __construct(array $property = null)
     {
-        $this->property = $property ?? [
+        $property ??= [
             'a' => new stdClass()
         ];
+        $this->property = $property;
     }
 }
 

--- a/tests/Issues/DowngradeNewInArrayInitializerPromotion/Fixture/new_in_array.php.inc
+++ b/tests/Issues/DowngradeNewInArrayInitializerPromotion/Fixture/new_in_array.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector\Fixture;
+namespace Rector\Core\Tests\Issues\DowngradeNewInArrayInitializerPromotion\Fixture;
 
 use stdClass;
 
@@ -17,13 +17,14 @@ class NewInArray
 -----
 <?php
 
-namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector\Fixture;
+namespace Rector\Core\Tests\Issues\DowngradeNewInArrayInitializerPromotion\Fixture;
 
 use stdClass;
 
 class NewInArray
 {
-    public function __construct(public ?array $property = null)
+    public $property;
+    public function __construct(array $property = null)
     {
         $this->property = $property ?? [
             'a' => new stdClass()

--- a/tests/Issues/DowngradeNewInArrayInitializerPromotion/config/configured_rule.php
+++ b/tests/Issues/DowngradeNewInArrayInitializerPromotion/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector;
+use Rector\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector;
+use Rector\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeNewInInitializerRector::class);
+    $services->set(DowngradePropertyPromotionRector::class);
+    $services->set(DowngradeTypedPropertyRector::class);
+};


### PR DESCRIPTION
@TomasVotruba I tried to solve on https://github.com/rectorphp/rector-src/runs/4537147879?check_suite_focus=true#step:14:80

I tried downgrade command locally and it seems cause create property, but assign new in property, which still invalid, I will looking into it.

```diff
➜  rector-src git:(handle-new-in-array) bin/rector process vendor/rector/rector-doctrine/src/NodeManipulator/ColumnPropertyTypeResolver.php -c build/config/config-downgrade.php --dry-run
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) vendor/rector/rector-doctrine/src/NodeManipulator/ColumnPropertyTypeResolver.php:23

    ---------- begin diff ----------
@@ @@
      * @var string
      */
     private const DATE_TIME_INTERFACE = 'DateTimeInterface';
-
     /**
+     * @readonly
+     * @var \Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory
+     */
+    private $phpDocInfoFactory;
+    /**
+     * @var \Rector\NodeTypeResolver\PHPStan\Type\TypeFactory
+     */
+    private $typeFactory;
+    /**
+     * @var array<string, \PHPStan\Type\Type>
+     */
+    private $doctrineTypeToScalarType = [
+        'tinyint' => new BooleanType(),
+        // integers
+        'smallint' => new IntegerType(),
+        'mediumint' => new IntegerType(),
+        'int' => new IntegerType(),
+        'integer' => new IntegerType(),
+        'bigint' => new IntegerType(),
+        'numeric' => new IntegerType(),
+        // floats
+        'decimal' => new FloatType(),
+        'float' => new FloatType(),
+        'double' => new FloatType(),
+        'real' => new FloatType(),
+        // strings
+        'tinytext' => new StringType(),
+        'mediumtext' => new StringType(),
+        'longtext' => new StringType(),
+        'text' => new StringType(),
+        'varchar' => new StringType(),
+        'string' => new StringType(),
+        'char' => new StringType(),
+        'longblob' => new StringType(),
+        'blob' => new StringType(),
+        'mediumblob' => new StringType(),
+        'tinyblob' => new StringType(),
+        'binary' => new StringType(),
+        'varbinary' => new StringType(),
+        'set' => new StringType(),
+        // date time objects
+        'date' => new ObjectType(self::DATE_TIME_INTERFACE),
+        'datetime' => new ObjectType(self::DATE_TIME_INTERFACE),
+        'timestamp' => new ObjectType(self::DATE_TIME_INTERFACE),
+        'time' => new ObjectType(self::DATE_TIME_INTERFACE),
+        'year' => new ObjectType(self::DATE_TIME_INTERFACE),
+    ];
+    /**
      * @param array<string, Type> $doctrineTypeToScalarType
      * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/basic-mapping.html#doctrine-mapping-types
      */
-    public function __construct(
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private TypeFactory $typeFactory,
-        private array $doctrineTypeToScalarType = [
+    public function __construct(PhpDocInfoFactory $phpDocInfoFactory, TypeFactory $typeFactory, array $doctrineTypeToScalarType = null)
+    {
+        $doctrineTypeToScalarType = $doctrineTypeToScalarType ?? [
             'tinyint' => new BooleanType(),
             // integers
             'smallint' => new IntegerType(),
@@ @@
             'timestamp' => new ObjectType(self::DATE_TIME_INTERFACE),
             'time' => new ObjectType(self::DATE_TIME_INTERFACE),
             'year' => new ObjectType(self::DATE_TIME_INTERFACE),
-        ],
-    ) {
+        ];
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
+        $this->typeFactory = $typeFactory;
+        $this->doctrineTypeToScalarType = $doctrineTypeToScalarType;
     }

     public function resolve(Property $property): ?Type
    ----------- end diff -----------

Applied rules:
 * DowngradeNullCoalescingOperatorRector (https://wiki.php.net/rfc/null_coalesce_equal_operator)
 * DowngradeTypedPropertyRector
 * DowngradeTrailingCommasInParamUseRector
 * DowngradeAttributeToAnnotationRector (https://php.watch/articles/php-attributes#syntax)
 * DowngradePropertyPromotionRector (https://wiki.php.net/rfc/constructor_promotion)
 * DowngradeNewInInitializerRector (https://wiki.php.net/rfc/new_in_initializers)
 * DowngradeReadonlyPropertyRector (https://wiki.php.net/rfc/readonly_properties_v2)


                                                                                                                        
 [OK] 1 file would have changed (dry-run) by Rector                                                                     
                                                                                                                        
```