### PR TITLE
[DeadCode] Skip parent not found on RemoveParentCallWithoutParentRector

### DIFF
--- a/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/FixturePhp74/skip_parent_not_found.php.inc
+++ b/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/FixturePhp74/skip_parent_not_found.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Fixture;
+
+class A extends B
+{
+    protected function run()
+    {
+       return parent::run();
+    }
+}

--- a/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
@@ -20,7 +21,6 @@ use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use PHPStan\Reflection\ReflectionProvider;
 
 /**
  * @see \Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\RemoveParentCallWithoutParentRectorTest
@@ -90,7 +90,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($classLike->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass($classLike->extends->toString())) {
+        if ($classLike->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
+            $classLike->extends->toString()
+        )) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -7,6 +7,7 @@ namespace Rector\DeadCode\Rector\StaticCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -19,6 +20,7 @@ use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use PHPStan\Reflection\ReflectionProvider;
 
 /**
  * @see \Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\RemoveParentCallWithoutParentRectorTest
@@ -28,7 +30,8 @@ final class RemoveParentCallWithoutParentRector extends AbstractRector
     public function __construct(
         private readonly ClassMethodManipulator $classMethodManipulator,
         private readonly ParentClassScopeResolver $parentClassScopeResolver,
-        private readonly ClassAnalyzer $classAnalyzer
+        private readonly ClassAnalyzer $classAnalyzer,
+        private readonly ReflectionProvider $reflectionProvider
     ) {
     }
 
@@ -84,6 +87,10 @@ CODE_SAMPLE
         }
 
         if (! $this->isName($node->class, ObjectReference::PARENT()->getValue())) {
+            return null;
+        }
+
+        if ($classLike->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass($classLike->extends->toString())) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6873

When parent not found, it currently got error:

```bash
1) Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Php74Test::test with data set #1 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
LogicException: leaveNode() returned invalid value of type integer
```