### PR TITLE
ArrowFunctionToAnonymousFunctionRector - failing test

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector/Fixture/arrow_function_inside_closure.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector/Fixture/arrow_function_inside_closure.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector\Fixture;
+
+class ErrorsConsoleStyle
+{
+
+    public function table(int $terminalWidth, int $maxHeaderWidth): void
+    {
+        $f = static fn ($rows): array => array_map(static fn ($row): array => array_map(static function ($s) use ($terminalWidth, $maxHeaderWidth) {
+            if ($terminalWidth > $maxHeaderWidth + 5) {
+                return wordwrap(
+                    $s,
+                    $terminalWidth - $maxHeaderWidth - 5,
+                    "\n",
+                    true,
+                );
+            }
+            return $s;
+        }, $row), $rows);
+    }
+
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector\Fixture;
+
+class ErrorsConsoleStyle
+{
+
+    public function table(int $terminalWidth, int $maxHeaderWidth): void
+    {
+        $f = static function ($rows) use ($terminalWidth, $maxHeaderWidth) : array {
+            return array_map(static function ($row) use ($terminalWidth, $maxHeaderWidth) : array {
+                return array_map(static function ($s) use ($terminalWidth, $maxHeaderWidth) {
+                    if ($terminalWidth > $maxHeaderWidth + 5) {
+                        return wordwrap(
+                            $s,
+                            $terminalWidth - $maxHeaderWidth - 5,
+                            "\n",
+                            true,
+                        );
+                    }
+                    return $s;
+                }, $row);
+            }, $rows);
+        };
+    }
+
+}
+
+?>


### PR DESCRIPTION
The failure:

```
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@

     public function table(int $terminalWidth, int $maxHeaderWidth): void
     {
-        $f = static function ($rows) use ($terminalWidth, $maxHeaderWidth) : array {
+        $f = static function ($rows) : array {
             return array_map(static function ($row) use ($terminalWidth, $maxHeaderWidth) : array {
                 return array_map(static function ($s) use ($terminalWidth, $maxHeaderWidth) {
                     if ($terminalWidth > $maxHeaderWidth + 5) {
```