### PR TITLE
DowngradeTypedPropertyRector - do not cast false to bool in PHPDoc

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector/Fixture/false_type.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector/Fixture/false_type.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class Foo
+{
+
+    private Foo|Bar|false $prop;
+
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class Foo
+{
+
+    /**
+     * @var \Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture\Bar|\Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture\Foo|false
+     */
+    private $prop;
+
+}
+?>

--- a/rules-tests/DowngradePhp80/Rector/Property/DowngradeUnionTypeTypedPropertyRector/Fixture/false_type.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Property/DowngradeUnionTypeTypedPropertyRector/Fixture/false_type.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Property\DowngradeUnionTypeTypedPropertyRector\Fixture;
+
+class Foo
+{
+
+    private Foo|Bar|false $prop;
+
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Property\DowngradeUnionTypeTypedPropertyRector\Fixture;
+
+class Foo
+{
+
+    /**
+     * @var \Rector\Tests\DowngradePhp80\Rector\Property\DowngradeUnionTypeTypedPropertyRector\Fixture\Bar|\Rector\Tests\DowngradePhp80\Rector\Property\DowngradeUnionTypeTypedPropertyRector\Fixture\Foo|false
+     */
+    private $prop;
+
+}
+?>


### PR DESCRIPTION
The failure:

```
1) Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest::test with data set #7 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules-tests/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector/Fixture/false_type.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 {

     /**
-     * @var false|\Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture\Foo|\Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture\Bar
+     * @var bool|\Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture\Bar|\Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture\Foo
      */
     private $prop;
```