### PR TITLE
DowngradePropertyPromotionRector - failing tests

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/array_shapes.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/array_shapes.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+class ArrayShapes
+{
+    /** @param array<string, array{\stdClass, \Exception}> $value */
+    public function __construct(private array $value)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+class ArrayShapes
+{
+    /**
+     * @var array<string, array{\stdClass, \Exception}>
+     */
+    private array $value;
+    /** @param array<string, array{\stdClass, \Exception}> $value */
+    public function __construct(array $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/mixed.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/mixed.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+class MixedTypeInPhpDoc
+{
+    /** @param mixed $value */
+    public function __construct(public $value)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+class MixedTypeInPhpDoc
+{
+    /** @var mixed */
+    public $value;
+    /** @param mixed $value */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/template_type.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/template_type.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+/** @template T of \stdClass */
+class TemplateType
+{
+    /** @param T $value */
+    public function __construct(private \stdClass $value)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+/** @template T of \stdClass */
+class TemplateType
+{
+    /**
+     * @var T
+     */
+    private \stdClass $value;
+    /** @param T $value */
+    public function __construct(\stdClass $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/true_vs_bool.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/true_vs_bool.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+class TrueVsBool
+{
+    /** @param array<string, true> $value */
+    public function __construct(private array $value)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+class TrueVsBool
+{
+    /**
+     * @var array<string, true>
+     */
+    private array $value;
+    /** @param array<string, true> $value */
+    public function __construct(array $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>


### PR DESCRIPTION
The tests fail in these ways:

```
1) Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\DowngradePropertyPromotionRectorTest::test with data set #3 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/mixed.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@

 class MixedTypeInPhpDoc
 {
-    /** @var mixed */
     public $value;
     /** @param mixed $value */
     public function __construct($value)

/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:154
/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:115
/Users/ondrej/Development/rector-src/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/DowngradePropertyPromotionRectorTest.php:19

2) Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\DowngradePropertyPromotionRectorTest::test with data set #7 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/template_type.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 class TemplateType
 {
     /**
-     * @var T
+     * @var \T
      */
     private \stdClass $value;
     /** @param T $value */

/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:154
/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:115
/Users/ondrej/Development/rector-src/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/DowngradePropertyPromotionRectorTest.php:19

3) Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\DowngradePropertyPromotionRectorTest::test with data set #1 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/true_vs_bool.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 class TrueVsBool
 {
     /**
-     * @var array<string, true>
+     * @var array<string, bool>
      */
     private array $value;
     /** @param array<string, true> $value */

/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:154
/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:115
/Users/ondrej/Development/rector-src/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/DowngradePropertyPromotionRectorTest.php:19

4) Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\DowngradePropertyPromotionRectorTest::test with data set #5 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/array_shapes.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 class ArrayShapes
 {
     /**
-     * @var array<string, array{\stdClass, \Exception}>
+     * @var array<string, array<\Exception|\stdClass>>
      */
     private array $value;
     /** @param array<string, array{\stdClass, \Exception}> $value */

/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:154
/Users/ondrej/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:115
/Users/ondrej/Development/rector-src/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/DowngradePropertyPromotionRectorTest.php:19
```