### PR TITLE
[DowngradePhp74][DowngradePhp80] Apply ternary with method_exists on DowngradeReflectionGetTypeRector + DowngradeReflectionGetAttributesRector

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector/Fixture/some_class.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector/Fixture/some_class.php.inc
@@ -24,7 +24,7 @@ class SomeClass
 {
     public function run(\ReflectionProperty $reflectionProperty)
     {
-        if (null) {
+        if (method_exists($reflectionProperty, 'getType') ? $reflectionProperty->getType() : null) {
             return true;
         }
 

--- a/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector/Fixture/some_class.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector/Fixture/some_class.php.inc
@@ -24,7 +24,7 @@ class SomeClass
 {
     public function run(\ReflectionClass $reflectionClass)
     {
-        if ([]) {
+        if (method_exists($reflectionClass, 'getAttributes') ? $reflectionClass->getAttributes() : []) {
             return true;
         }
 

--- a/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector/Fixture/with_arguments.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector/Fixture/with_arguments.php.inc
@@ -24,7 +24,7 @@ final class WithArguments
 {
     public function run(\ReflectionClass $reflectionClass)
     {
-        if ([]) {
+        if (method_exists($reflectionClass, 'getAttributes') ? $reflectionClass->getAttributes('someName', 1) : []) {
             return true;
         }
 

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -70,7 +70,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param FuncCall|MethodCall|StaticCall $node
+     * @param FuncCall|MethodCall|StaticCall|New_ $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -7,6 +7,7 @@ namespace Rector\DowngradePhp73\Rector\FuncCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DowngradePhp73\Tokenizer\FollowedByCommaAnalyzer;
@@ -65,7 +66,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [FuncCall::class, MethodCall::class, StaticCall::class, Node\Expr\New_::class];
+        return [FuncCall::class, MethodCall::class, StaticCall::class, New_::class];
     }
 
     /**

--- a/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
+++ b/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp74\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -88,8 +90,10 @@ CODE_SAMPLE
         }
 
         $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
+        $args = [new Arg($node->var), new Arg(new String_('getType'))];
+
         return new Ternary(
-            $this->nodeFactory->createFuncCall('method_exists', [$node->var, 'getType']),
+            $this->nodeFactory->createFuncCall('method_exists', $args),
             $node,
             $this->nodeFactory->createNull()
         );

--- a/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
+++ b/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
@@ -81,6 +81,7 @@ CODE_SAMPLE
             return null;
         }
 
+        // avoid infinite loop
         $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE);
         if ($createdByRule === self::class) {
             return null;

--- a/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
+++ b/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
@@ -7,6 +7,7 @@ namespace Rector\DowngradePhp74\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Ternary;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -80,6 +81,16 @@ CODE_SAMPLE
             return null;
         }
 
-        return $this->nodeFactory->createNull();
+        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE);
+        if ($createdByRule === self::class) {
+            return null;
+        }
+
+        $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
+        return new Ternary(
+            $this->nodeFactory->createFuncCall('method_exists', [$node->var, 'getType']),
+            $node,
+            $this->nodeFactory->createNull()
+        );
     }
 }

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
@@ -87,10 +87,6 @@ CODE_SAMPLE
         $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
         $args = [new Arg($node->var), new Arg(new String_('getAttributes'))];
 
-        return new Ternary(
-            $this->nodeFactory->createFuncCall('method_exists', $args),
-            $node,
-            new Array_([])
-        );
+        return new Ternary($this->nodeFactory->createFuncCall('method_exists', $args), $node, new Array_([]));
     }
 }

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
@@ -76,6 +76,7 @@ CODE_SAMPLE
             return null;
         }
 
+        // avoid infinite loop
         $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE);
         if ($createdByRule === self::class) {
             return null;

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
@@ -7,8 +7,10 @@ namespace Rector\DowngradePhp80\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Ternary;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -74,6 +76,16 @@ CODE_SAMPLE
             return null;
         }
 
-        return new Array_([]);
+        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE);
+        if ($createdByRule === self::class) {
+            return null;
+        }
+
+        $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
+        return new Ternary(
+            $this->nodeFactory->createFuncCall('method_exists', [$node->var, 'getAttributes']),
+            $node,
+            new Array_([])
+        );
     }
 }

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -83,8 +85,10 @@ CODE_SAMPLE
         }
 
         $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
+        $args = [new Arg($node->var), new Arg(new String_('getAttributes'))];
+
         return new Ternary(
-            $this->nodeFactory->createFuncCall('method_exists', [$node->var, 'getAttributes']),
+            $this->nodeFactory->createFuncCall('method_exists', $args),
             $node,
             new Array_([])
         );


### PR DESCRIPTION
/cc @ondrejmirtes 

Reason: ref https://github.com/rectorphp/rector/issues/6878#issuecomment-997447578

Fixes https://github.com/rectorphp/rector/issues/6878

Applied changes to:

```php
Rector\DowngradePhp74\Rector\MethodCall\DowngradeReflectionGetTypeRector
Rector\DowngradePhp80\Rector\MethodCall\DowngradeReflectionGetAttributesRector
```