### PR TITLE
[Core] [DeadCode] Refactor RectifiedAnalyzer and ExprUsedInNextNodeAnalyzer

### DIFF
--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
@@ -30,6 +30,9 @@ final class ExprUsedInNextNodeAnalyzer
                     return true;
                 }
 
+                /**
+                 * handle when used along with RemoveAlwaysElseRector
+                 */
                 return $node instanceof If_ && $this->hasIfChangedByRemoveAlwaysElseRector($node);
             }
         );

--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Rector\DeadCode\NodeAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\If_;
-use PHPStan\Analyser\Scope;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -22,37 +19,18 @@ final class ExprUsedInNextNodeAnalyzer
     ) {
     }
 
-    /**
-     * $isCheckNameScope parameter is used to whether to check scope of Name that may be renamed
-     * @see https://github.com/rectorphp/rector/issues/6675
-     */
-    public function isUsed(Expr $expr, bool $isCheckNameScope = false): bool
+    public function isUsed(Expr $expr): bool
     {
         return (bool) $this->betterNodeFinder->findFirstNext(
             $expr,
-            function (Node $node) use ($expr, $isCheckNameScope): bool {
-                if ($isCheckNameScope && $node instanceof Name) {
-                    $scope = $node->getAttribute(AttributeKey::SCOPE);
-                    $resolvedName = $node->getAttribute(AttributeKey::RESOLVED_NAME);
-                    $next = $node->getAttribute(AttributeKey::NEXT_NODE);
+            function (Node $node) use ($expr): bool {
+                $isUsed = $this->exprUsedInNodeAnalyzer->isUsed($node, $expr);
 
-                    if (! $scope instanceof Scope && ! $resolvedName instanceof Name && $next instanceof Arg) {
-                        return true;
-                    }
+                if ($isUsed) {
+                    return true;
                 }
 
-                if (! $node instanceof If_) {
-                    return $this->exprUsedInNodeAnalyzer->isUsed($node, $expr);
-                }
-
-                /**
-                 * handle when used along with RemoveAlwaysElseRector
-                 */
-                if (! $this->hasIfChangedByRemoveAlwaysElseRector($node)) {
-                    return $this->exprUsedInNodeAnalyzer->isUsed($node, $expr);
-                }
-
-                return true;
+                return $node instanceof If_ && $this->hasIfChangedByRemoveAlwaysElseRector($node);
             }
         );
     }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Stmt\Class_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\ValueObject\Application\File;
@@ -19,7 +19,7 @@ use Rector\Core\ValueObject\RectifiedNode;
  *
  * Some limitations:
  *
- *   - only check against Stmt which not ClassLike.
+ *   - only check against Node which not Assign or Class_
  *   - The checked node doesn't has PhpDocInfo changed.
  *
  * which possibly changed by other process.
@@ -31,6 +31,14 @@ final class RectifiedAnalyzer
      */
     private array $previousFileWithNodes = [];
 
+    /**
+     * @var array<class-string<Node>>
+     */
+    private const EXCLUDE_NODES = [
+        Assign::class,
+        Class_::class,
+    ];
+
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
@@ -38,11 +46,7 @@ final class RectifiedAnalyzer
 
     public function verify(RectorInterface $rector, Node $node, File $currentFile): ?RectifiedNode
     {
-        if (! $node instanceof Stmt) {
-            return null;
-        }
-
-        if ($node instanceof ClassLike) {
+        if (in_array($node::class, self::EXCLUDE_NODES, true)) {
             return null;
         }
 

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -27,17 +27,14 @@ use Rector\Core\ValueObject\RectifiedNode;
 final class RectifiedAnalyzer
 {
     /**
+     * @var array<class-string<Node>>
+     */
+    private const EXCLUDE_NODES = [Assign::class, Class_::class];
+
+    /**
      * @var array<string, RectifiedNode|null>
      */
     private array $previousFileWithNodes = [];
-
-    /**
-     * @var array<class-string<Node>>
-     */
-    private const EXCLUDE_NODES = [
-        Assign::class,
-        Class_::class,
-    ];
 
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory


### PR DESCRIPTION
- Update `RectifiedAnalyzer` to use specific `Nodes` ( `Assign` and `Class_` ) for allowed apply : 

```   
   Rector Rule <-> Same Node <-> Same File
```

- Clean up `ExprUsedInNextNodeAnalyzer` as `$isCheckNameScope` 2nd parameter no longer needed.
