### PR TITLE
[Reflection] Clean up getAncestors() call, use merge parents and interfaces

### DIFF
--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -82,18 +82,13 @@ final class FamilyRelationsAnalyzer
             throw new ShouldNotHappenException();
         }
 
-        $ancestorClassReflections = $classReflection->getAncestors();
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
 
         $propertyName = $this->nodeNameResolver->getName($property);
         $kindPropertyFetch = $this->getKindPropertyFetch($property);
 
-        $className = $classReflection->getName();
-
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
             $ancestorClassName = $ancestorClassReflection->getName();
-            if ($ancestorClassName === $className) {
-                continue;
-            }
 
             if ($ancestorClassReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
@@ -115,12 +115,8 @@ final class ClassMethodParamVendorLockResolver
         string $methodName,
         string $filePathPartName
     ): bool {
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
-            // skip self
-            if ($ancestorClassReflection === $classReflection) {
-                continue;
-            }
-
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
             // parent type
             if (! $ancestorClassReflection->hasNativeMethod($methodName)) {
                 continue;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -41,17 +41,19 @@ final class ClassMethodReturnVendorLockResolver
 
     private function isVendorLockedByAncestors(ClassReflection $classReflection, string $methodName): bool
     {
-        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
-        foreach ($ancestorClassReflections as $ancestorClassReflection) {
-            $nativeClassReflection = $ancestorClassReflection->getNativeReflection();
-
-            $nativeClassHasMethod = $nativeClassReflection->hasMethod($methodName);
-            // this should avoid detecting @method as real method
-            if (! $nativeClassHasMethod) {
+        foreach ($classReflection->getAncestors() as $ancestorClassReflections) {
+            if ($ancestorClassReflections === $classReflection) {
                 continue;
             }
 
-            $parentClassMethodReflection = $ancestorClassReflection->getNativeMethod($methodName);
+            $nativeClassReflection = $ancestorClassReflections->getNativeReflection();
+
+            // this should avoid detecting @method as real method
+            if (! $nativeClassReflection->hasMethod($methodName)) {
+                continue;
+            }
+
+            $parentClassMethodReflection = $ancestorClassReflections->getNativeMethod($methodName);
             $parametersAcceptor = $parentClassMethodReflection->getVariants()[0];
             if (! $parametersAcceptor instanceof FunctionVariantWithPhpDocs) {
                 continue;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -45,7 +45,7 @@ final class ClassMethodReturnVendorLockResolver
         foreach ($ancestorClassReflections as $ancestorClassReflections) {
             $nativeClassReflection = $ancestorClassReflections->getNativeReflection();
 
-            $nativeClassHasMethod =  $nativeClassReflection->hasMethod($methodName);
+            $nativeClassHasMethod = $nativeClassReflection->hasMethod($methodName);
             // this should avoid detecting @method as real method
             if (! $nativeClassHasMethod) {
                 continue;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -41,11 +41,8 @@ final class ClassMethodReturnVendorLockResolver
 
     private function isVendorLockedByAncestors(ClassReflection $classReflection, string $methodName): bool
     {
-        foreach ($classReflection->getAncestors() as $ancestorClassReflections) {
-            if ($ancestorClassReflections === $classReflection) {
-                continue;
-            }
-
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        foreach ($ancestorClassReflections as $ancestorClassReflections) {
             $nativeClassReflection = $ancestorClassReflections->getNativeReflection();
 
             // this should avoid detecting @method as real method

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -45,8 +45,9 @@ final class ClassMethodReturnVendorLockResolver
         foreach ($ancestorClassReflections as $ancestorClassReflections) {
             $nativeClassReflection = $ancestorClassReflections->getNativeReflection();
 
+            $nativeClassHasMethod =  $nativeClassReflection->hasMethod($methodName);
             // this should avoid detecting @method as real method
-            if (! $nativeClassReflection->hasMethod($methodName)) {
+            if (! $nativeClassHasMethod) {
                 continue;
             }
 

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -42,8 +42,8 @@ final class ClassMethodReturnVendorLockResolver
     private function isVendorLockedByAncestors(ClassReflection $classReflection, string $methodName): bool
     {
         $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
-        foreach ($ancestorClassReflections as $ancestorClassReflections) {
-            $nativeClassReflection = $ancestorClassReflections->getNativeReflection();
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
+            $nativeClassReflection = $ancestorClassReflection->getNativeReflection();
 
             $nativeClassHasMethod = $nativeClassReflection->hasMethod($methodName);
             // this should avoid detecting @method as real method
@@ -51,7 +51,7 @@ final class ClassMethodReturnVendorLockResolver
                 continue;
             }
 
-            $parentClassMethodReflection = $ancestorClassReflections->getNativeMethod($methodName);
+            $parentClassMethodReflection = $ancestorClassReflection->getNativeMethod($methodName);
             $parametersAcceptor = $parentClassMethodReflection->getVariants()[0];
             if (! $parametersAcceptor instanceof FunctionVariantWithPhpDocs) {
                 continue;

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -45,14 +45,12 @@ final class PhpAttributeAnalyzer
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        $ancestorClassReflections = $classReflection->getAncestors();
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
             $ancestorClassName = $ancestorClassReflection->getName();
-            if ($ancestorClassName === $className) {
-                continue;
-            }
-
             $class = $this->astResolver->resolveClassFromName($ancestorClassName);
+
             if (! $class instanceof Class_) {
                 continue;
             }

--- a/src/NodeManipulator/ClassManipulator.php
+++ b/src/NodeManipulator/ClassManipulator.php
@@ -31,11 +31,8 @@ final class ClassManipulator
         }
 
         $classReflection = $this->reflectionProvider->getClass($objectType->getClassName());
-        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
-            if ($classReflection === $ancestorClassReflection) {
-                continue;
-            }
-
+        $ancestorClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        foreach ($ancestorClassReflections as $ancestorClassReflection) {
             if (! $ancestorClassReflection->hasMethod($oldMethod)) {
                 continue;
             }


### PR DESCRIPTION
One by one cleaning up `$classReflection->getAncestors()` so no need to compare current classname with the ancestor.