### PR TITLE
Add failing test fixture for ChangeSwitchToMatchRector

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/cases_mix_up_default_in_first_case.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/cases_mix_up_default_in_first_case.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class CasesMixUpDefaultInFirstCase
+{
+    public function run($value)
+    {
+        switch ($value) {
+            case 'foo':
+            default:
+                $string = 'foo';
+                break;
+            case 'other':
+                $string = 'bar';
+                break;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class CasesMixUpDefaultInFirstCase
+{
+    public function run($value)
+    {
+        $string = match ($value) {
+            'other' => 'bar',
+            default => 'foo',
+        };
+    }
+}
+
+?>


### PR DESCRIPTION
Hi,

Currently, if $value is set to _foo_, the new `match() `will return '_bar_' instead of '_foo_'. This breaks the logic.
Linked issue : https://github.com/rectorphp/rector/issues/6880

Note : I had two options for building the `match()`, I'll let you decide which is better:

```
$string = match ($value) {
            'other' => 'bar',
            default => 'foo',
        };
```

or

```
$string = match ($value) {
            'other' => 'bar',
            'foo' => 'foo',
            default => 'foo',
        };
```

This is my first contribution to Rector, do not hesitate to give me feedback :)

Thanks,
Alex