### PR TITLE
Add failing test fixture for ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/avoid_invalid_type_hint_suggestion.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/avoid_invalid_type_hint_suggestion.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+/**
+ * @template T
+ */
+final class AvoidInvalidTypeHintSuggestion
+{
+    /**
+     * Same signature as "findOneBy" by Doctrine (ObjectRepository).
+     *
+     * @psalm-return ?T
+     * @return null|object
+     */
+    public function findOneBy()
+    {
+        return null;
+    }
+
+    /**
+     * Shouldn't suggest "?mixed" as type-hint since it's invalid.
+     */
+    public function myOwnFunctionUsingADoctrineRepository()
+    {
+        return $this->findOneBy();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+/**
+ * @template T
+ */
+final class AvoidInvalidTypeHintSuggestion
+{
+    /**
+     * Same signature as "findOneBy" by Doctrine (ObjectRepository).
+     *
+     * @psalm-return ?T
+     * @return null|object
+     */
+    public function findOneBy()
+    {
+        return null;
+    }
+
+    /**
+     * Shouldn't suggest "?mixed" as type-hint since it's invalid.
+     */
+    public function myOwnFunctionUsingADoctrineRepository(): ?object
+    {
+        return $this->findOneBy();
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for ReturnTypeDeclarationRector

Based on https://getrector.org/demo/1ec62885-75e7-6a88-baad-bfbdc0fa0190

See: https://github.com/rectorphp/rector/issues/6887

I created the fixture using the same code as my example, but I'm noticing a different behavior running the test locally. The online demo adds `: ?mixed` while the current dev branch doesn't add anything...

Please let me know if you need me to change anything.