### PR TITLE
[DowngradePhp80] Add #[\ReturnTypeWillChange] on DowngradeMixedTypeDeclarationRector on implements ArrayAccess

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -119,7 +119,7 @@ final class PhpDocFromTypeDeclarationDecorator
 
         if ($functionLike instanceof ClassMethod) {
             $classLike = $this->betterNodeFinder->findParentType($functionLike, ClassLike::class);
-            if ($classLike instanceof ClassLike && $this->isRequireReturnAddWillChange($classLike, $functionLike)) {
+            if ($classLike instanceof ClassLike && $this->isRequireReturnTypeWillChange($classLike, $functionLike)) {
                 $attributeGroup = $this->phpAttributeGroupFactory->createFromClass(
                     self::RETURN_TYPE_WILL_CHANGE_ATTRIBUTE
                 );
@@ -132,7 +132,7 @@ final class PhpDocFromTypeDeclarationDecorator
         return true;
     }
 
-    private function isRequireReturnAddWillChange(ClassLike $classLike, ClassMethod $classMethod): bool
+    private function isRequireReturnTypeWillChange(ClassLike $classLike, ClassMethod $classMethod): bool
     {
         if ($classLike instanceof Trait_) {
             return false;

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -134,7 +134,7 @@ final class PhpDocFromTypeDeclarationDecorator
 
         $className  = (string) $this->nodeNameResolver->getName($classLike);
         $objectClass = new ObjectType($className);
-        $methodName = (string) $this->nodeNameResolver->getName($classMethod);
+        $methodName = $this->nodeNameResolver->getName($classMethod);
 
         foreach (self::ADD_RETURN_TYPE_WILL_CHANGE as $class => $methods) {
             $objectClassConfig = new ObjectType($class);

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -21,6 +21,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpAttribute\Printer\PhpAttributeGroupFactory;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -49,7 +50,8 @@ final class PhpDocFromTypeDeclarationDecorator
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly TypeUnwrapper $typeUnwrapper,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory
+        private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -158,6 +160,10 @@ final class PhpDocFromTypeDeclarationDecorator
             }
 
             if (! in_array($methodName, $methods, true)) {
+                continue;
+            }
+
+            if ($this->phpAttributeAnalyzer->hasPhpAttribute($classMethod, self::RETURN_TYPE_WILL_CHANGE_ATTRIBUTE)) {
                 continue;
             }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -66,21 +66,25 @@ final class PhpDocFromTypeDeclarationDecorator
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
         $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $type);
 
-        if ($functionLike instanceof ClassMethod) {
-            $classLike = $this->betterNodeFinder->findParentByTypes($functionLike, [Class_::class, Interface_::class]);
-            if ($classLike instanceof ClassLike && $this->isRequireReturnTypeWillChange(
-                $type::class,
-                $classLike,
-                $functionLike
-            )) {
-                $attributeGroup = $this->phpAttributeGroupFactory->createFromClass(
-                    self::RETURN_TYPE_WILL_CHANGE_ATTRIBUTE
-                );
-                $functionLike->attrGroups[] = $attributeGroup;
-            }
+        $functionLike->returnType = null;
+
+        if (! $functionLike instanceof ClassMethod) {
+            return;
         }
 
-        $functionLike->returnType = null;
+        $classLike = $this->betterNodeFinder->findParentByTypes($functionLike, [Class_::class, Interface_::class]);
+        if (! $classLike instanceof ClassLike) {
+            return;
+        }
+
+        if (! $this->isRequireReturnTypeWillChange($type::class, $classLike, $functionLike)) {
+            return;
+        }
+
+        $attributeGroup = $this->phpAttributeGroupFactory->createFromClass(
+            self::RETURN_TYPE_WILL_CHANGE_ATTRIBUTE
+        );
+        $functionLike->attrGroups[] = $attributeGroup;
     }
 
     /**

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -61,6 +61,16 @@ final class PhpDocFromTypeDeclarationDecorator
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
         $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $type);
 
+        if ($functionLike instanceof ClassMethod) {
+            $classLike = $this->betterNodeFinder->findParentType($functionLike, ClassLike::class);
+            if ($classLike instanceof ClassLike && $this->isRequireReturnTypeWillChange($classLike, $functionLike)) {
+                $attributeGroup = $this->phpAttributeGroupFactory->createFromClass(
+                    self::RETURN_TYPE_WILL_CHANGE_ATTRIBUTE
+                );
+                $functionLike->attrGroups[] = $attributeGroup;
+            }
+        }
+
         $functionLike->returnType = null;
     }
 
@@ -115,16 +125,6 @@ final class PhpDocFromTypeDeclarationDecorator
 
         if (! $this->isTypeMatch($functionLike->returnType, $requireType)) {
             return false;
-        }
-
-        if ($functionLike instanceof ClassMethod) {
-            $classLike = $this->betterNodeFinder->findParentType($functionLike, ClassLike::class);
-            if ($classLike instanceof ClassLike && $this->isRequireReturnTypeWillChange($classLike, $functionLike)) {
-                $attributeGroup = $this->phpAttributeGroupFactory->createFromClass(
-                    self::RETURN_TYPE_WILL_CHANGE_ATTRIBUTE
-                );
-                $functionLike->attrGroups[] = $attributeGroup;
-            }
         }
 
         $this->decorate($functionLike);

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -128,7 +128,6 @@ final class PhpDocFromTypeDeclarationDecorator
         }
 
         $this->decorate($functionLike);
-
         return true;
     }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -10,10 +10,11 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
-use PhpParser\Node\Stmt\Trait_;
+use PhpParser\Node\Stmt\Interface_;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -66,7 +67,7 @@ final class PhpDocFromTypeDeclarationDecorator
         $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $type);
 
         if ($functionLike instanceof ClassMethod) {
-            $classLike = $this->betterNodeFinder->findParentType($functionLike, ClassLike::class);
+            $classLike = $this->betterNodeFinder->findParentByTypes($functionLike, [Class_::class, Interface_::class]);
             if ($classLike instanceof ClassLike && $this->isRequireReturnTypeWillChange(
                 $type::class,
                 $classLike,
@@ -141,10 +142,6 @@ final class PhpDocFromTypeDeclarationDecorator
 
     private function isRequireReturnTypeWillChange(string $type, ClassLike $classLike, ClassMethod $classMethod): bool
     {
-        if ($classLike instanceof Trait_) {
-            return false;
-        }
-
         if (! array_key_exists($type, self::ADD_RETURN_TYPE_WILL_CHANGE)) {
             return false;
         }

--- a/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/already_has_return_type_will_change.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/already_has_return_type_will_change.php.inc
@@ -7,7 +7,7 @@ use Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclaratio
 class AlreadyHasReturnTypeWillChange extends Options
 {
     #[\ReturnTypeWillChange]
-    public function offsetGet(): mixed
+    public function offsetGet($offset): mixed
     {
     }
 }
@@ -26,7 +26,7 @@ class AlreadyHasReturnTypeWillChange extends Options
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet()
+    public function offsetGet($offset)
     {
     }
 }

--- a/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/already_has_return_type_will_change.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/already_has_return_type_will_change.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Source\Options;
+
+class AlreadyHasReturnTypeWillChange extends Options
+{
+    #[\ReturnTypeWillChange]
+    public function offsetGet(): mixed
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Source\Options;
+
+class AlreadyHasReturnTypeWillChange extends Options
+{
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/array_access_offset_get.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/array_access_offset_get.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Source\Options;
+
+class ArrayAccessOffsetGet extends Options
+{
+    public function offsetGet(): mixed
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Source\Options;
+
+class ArrayAccessOffsetGet extends Options
+{
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/array_access_offset_get.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/array_access_offset_get.php.inc
@@ -6,7 +6,7 @@ use Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclaratio
 
 class ArrayAccessOffsetGet extends Options
 {
-    public function offsetGet(): mixed
+    public function offsetGet($offset): mixed
     {
     }
 }
@@ -25,7 +25,7 @@ class ArrayAccessOffsetGet extends Options
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet()
+    public function offsetGet($offset)
     {
     }
 }

--- a/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/array_access_offset_get2.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Fixture/array_access_offset_get2.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Fixture;
+
+use ArrayAccess;
+
+interface Bridge extends ArrayAccess
+{
+    public function offsetGet($offset): mixed;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Fixture;
+
+use ArrayAccess;
+
+interface Bridge extends ArrayAccess
+{
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset);
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Source/Options.php
+++ b/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeMixedTypeDeclarationRector/Source/Options.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector\Source;
+
+use ArrayAccess;
+
+abstract class Options implements ArrayAccess
+{
+
+}


### PR DESCRIPTION
Fixes https://github.com/symplify/symplify/issues/3850 to avoid symplify easy-coding-standard notice by add `#[\ReturnTypeWillChange]` as the original has return type `mixed` and implements `ArrayAccess` so can be used in php 8.1 after downgraded.