### PR TITLE
Add failing test for trailing optional parameter

### DIFF
--- a/rules-tests/Php80/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/uses_with_less_params.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/uses_with_less_params.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+final class UsesWithLess
+{
+    public function blah($optional = 1, $required, $optional_2 = 2)
+    {
+    }
+
+    public function process()
+    {
+        $this->blah(1, 5);
+        $this->blah(1, 5, 2);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+final class UsesWithLess
+{
+    public function blah($required, $optional = 1, $optional_2 = 2)
+    {
+    }
+
+    public function process()
+    {
+        $this->blah(5, 1);
+        $this->blah(5, 1, 2);
+    }
+}
+
+?>


### PR DESCRIPTION
Rule seems to miss uses where there are additional parameters available but the argument is not provided.
Presume it's to do with the count check but not sure what it should be