### PR TITLE
[Scoped] Speed up downgrade build by exclude ssch/typo3-rector/config from downgrade

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -78,5 +78,6 @@ final class DowngradeRectorConfig
         'vendor/myclabs/php-enum/src/PHPUnit/Comparator.php',
 
         'vendor/rector/rector-generator/templates',
+        'vendor/ssch/typo3-rector/config',
     ];
 }


### PR DESCRIPTION
@TomasVotruba @sabbelasichon I found out that downgrading `ssch/typo3-rector/config` take long time, while the config is php 7.1 compatible code and nothing to downgrade:

Running the following command:

```bash
time bin/rector process vendor/ssch/typo3-rector/config  -c build/config/config-downgrade.php --dry-run
```

Got:

![Screen Shot 2021-12-23 at 15 36 12](https://user-images.githubusercontent.com/459648/147212643-45cd8d78-ac57-4f9c-bba7-fe846cb78ccd.png)

Above shown that it took **4 minutes** while nothing to downgrade. This PR apply exclude `ssch/typo3-rector/config` to downgrade.

It has `11 MB` size:

```bash
➜  rector-src git:(speed-up-scoping) du -hs vendor/ssch/typo3-rector/config 
 11M    vendor/ssch/typo3-rector/config
```

Note: in `ssch/typo3-rector` repository https://github.com/sabbelasichon/typo3-rector, probably need a weekly or daily automatic pull request to make code in `config` directory always php 7.1 compatible code.
