### PR TITLE
[Scoped] Update full_build.sh Local script to test locally to avoid error on php 7.1 and 7.2

### DIFF
--- a/full_build.sh
+++ b/full_build.sh
@@ -29,10 +29,10 @@ rm -rf rector-build/packages-tests rector-build/rules-tests rector-build/tests r
 
 sh build/downgrade-rector.sh rector-build
 
+cd rector-build
+
 # avoid syntax error in php 7.1 and 7.2
 rm rector.php
-
-cd rector-build
 
 # Update to your local php 7.1 path
 /opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php bin/rector list --ansi

--- a/full_build.sh
+++ b/full_build.sh
@@ -28,13 +28,30 @@ git checkout composer.json
 rm -rf rector-build/packages-tests rector-build/rules-tests rector-build/tests rector-build/bin/generate-changelog.php rector-build/bin/validate-phpstan-version.php
 
 sh build/downgrade-rector.sh rector-build
-sh build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
 
-cd rector-prefixed-downgraded
-cp ../build/target-repository/bootstrap.php .
-cp ../preload.php .
-bin/rector list --ansi
-bin/rector process vendor/symfony/string/Slugger/ --dry-run
+# avoid syntax error in php 7.1 and 7.2
+rm rector.php
+
+cd rector-build
+
+# Update to your local php 7.1 path
+/opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php bin/rector list --ansi
 
 cd ..
-rm -rf rector-prefixed-downgraded
+rm -rf rector-build
+
+# Prefixed build only works on PHP < 8.1 now, so only able to run on CI.
+# We may need a way to specify PHP path on run build/build-rector-scoped.sh, eg:
+#
+#     /path/to/php/bin/php build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
+#
+#
+# sh build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
+# cd rector-prefixed-downgraded
+# cp ../build/target-repository/bootstrap.php .
+# cp ../preload.php .
+# bin/rector list --ansi
+# bin/rector process vendor/symfony/string/Slugger/ --dry-run
+
+# cd ..
+# rm -rf rector-prefixed-downgraded

--- a/full_build.sh
+++ b/full_build.sh
@@ -34,6 +34,9 @@ cd rector-build
 # avoid syntax error in php 7.1 and 7.2
 rm rector.php
 
+cp ../build/target-repository/bootstrap.php .
+cp ../preload.php .
+
 # Update to your local php 7.1 path
 /opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php bin/rector list --ansi
 


### PR DESCRIPTION
It is only local script that updated to remove `rector.php` first before run `bin/rector list --ansi` on php 7.1 and/or 7.2.