### PR TITLE
[Core] Remove no longer needed empty start and end tag check on BetterStandardPrinter

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -36,18 +36,6 @@ final class BetterStandardPrinter extends Standard
 {
     /**
      * @var string
-     * @see https://regex101.com/r/QA7mai/1
-     */
-    private const EMPTY_STARTING_TAG_REGEX = '/^<\\?php\\s+\\?>\\n?/';
-
-    /**
-     * @var string
-     * @see https://regex101.com/r/IVNkrt/1
-     */
-    private const EMPTY_ENDING_TAG_REGEX = '/<\\?php$/';
-
-    /**
-     * @var string
      * @see https://regex101.com/r/jUFizd/1
      */
     private const NEWLINE_END_REGEX = "#\n$#";
@@ -113,12 +101,6 @@ final class BetterStandardPrinter extends Standard
         $this->tabOrSpaceIndentCharacter = $this->indentCharacterDetector->detect($origTokens);
 
         $content = parent::printFormatPreserving($newStmts, $origStmts, $origTokens);
-
-        // strip empty starting/ending php tags
-        if (array_key_exists(0, $stmts) && $stmts[0] instanceof FileWithoutNamespace) {
-            $content = Strings::replace($content, self::EMPTY_STARTING_TAG_REGEX, '');
-            $content = Strings::replace(\rtrim($content), self::EMPTY_ENDING_TAG_REGEX, '') . "\n";
-        }
 
         // add new line in case of added stmts
         if (count($stmts) !== count($origStmts) && ! StringUtils::isMatch($content, self::NEWLINE_END_REGEX)) {


### PR DESCRIPTION
@staabm as there is recursive check on `resolveNewStmts()` on 

https://github.com/rectorphp/rector-src/blob/2487d9fe67e6cb4fdc9747895a63d6d6c305bb98/src/PhpParser/Printer/BetterStandardPrinter.php#L457

The empty start tag and end tag seems no longer needed, and I tried **e2e** tests seems working ok.

![Screen Shot 2021-12-24 at 17 43 56](https://user-images.githubusercontent.com/459648/147346108-05bd647b-71bb-4f99-8edc-40eb89cfe404.png)


ref https://github.com/rectorphp/rector-src/pull/1329