### PR TITLE
[Php74] Skip protected property on final class with parent not loaded on TypedPropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_protected_property_with_parent_not_loaded.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_protected_property_with_parent_not_loaded.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SkipProtectedPropertyWithParentNotLoaded extends NotLoadedClass
+{
+    /**
+     * @var string
+     */
+    protected $type;
+}

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\ComplexType;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Analyser\Scope;
@@ -272,7 +271,8 @@ CODE_SAMPLE
         return false;
     }
 
-    private function isSafeProtectedProperty(Property $property, Class_ $class): bool {
+    private function isSafeProtectedProperty(Property $property, Class_ $class): bool
+    {
         if (! $property->isProtected()) {
             return false;
         }

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -275,7 +275,11 @@ CODE_SAMPLE
         return false;
     }
 
-    private function isSafeProtectedProperty(Property $property, ClassReflection $classReflection, ?ClassLike $classLike): bool
+    private function isSafeProtectedProperty(
+        Property $property,
+        ClassReflection $classReflection,
+        ?ClassLike $classLike
+    ): bool
     {
         if (! $property->isProtected()) {
             return false;

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -232,8 +232,10 @@ CODE_SAMPLE
             return true;
         }
 
-        // skip trait properties, as they ar unpredictable based on class context they appear in
-        // skip interface properties, as interface not allowed to have property
+        /**
+         * - skip trait properties, as they ar unpredictable based on class context they appear in
+         * - skip interface properties as well, as interface not allowed to have property
+         */
         $class = $this->betterNodeFinder->findParentType($property, Class_::class);
         if (! $class instanceof Class_) {
             return true;

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -232,7 +232,7 @@ CODE_SAMPLE
         }
 
         /**
-         * - skip trait properties, as they ar unpredictable based on class context they appear in
+         * - skip trait properties, as they are unpredictable based on class context they appear in
          * - skip interface properties as well, as interface not allowed to have property
          */
         $class = $this->betterNodeFinder->findParentType($property, Class_::class);

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -7,6 +7,7 @@ namespace Rector\Php74\Rector\Property;
 use PhpParser\Node;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
@@ -34,6 +35,7 @@ use Rector\VendorLocker\VendorLockResolver;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://wiki.php.net/rfc/typed_properties_v2#proposal
@@ -248,7 +250,7 @@ CODE_SAMPLE
         }
 
         // is we're in final class, the type can be changed
-        return ! ($this->isSafeProtectedProperty($property, $classReflection));
+        return ! ($this->isSafeProtectedProperty($property, $classReflection, $classLike));
     }
 
     private function isModifiedByTrait(ClassLike $classLike, string $propertyName): bool
@@ -273,7 +275,7 @@ CODE_SAMPLE
         return false;
     }
 
-    private function isSafeProtectedProperty(Property $property, ClassReflection $classReflection): bool
+    private function isSafeProtectedProperty(Property $property, ClassReflection $classReflection, ?ClassLike $classLike): bool
     {
         if (! $property->isProtected()) {
             return false;
@@ -283,6 +285,8 @@ CODE_SAMPLE
             return false;
         }
 
-        return $classReflection->getParents() === [];
+        // there is no final interface
+        Assert::isInstanceOf($classLike, Class_::class);
+        return ! $classLike->extends instanceof FullyQualified;
     }
 }

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -279,8 +279,7 @@ CODE_SAMPLE
         Property $property,
         ClassReflection $classReflection,
         ?ClassLike $classLike
-    ): bool
-    {
+    ): bool {
         if (! $property->isProtected()) {
             return false;
         }

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -35,7 +35,6 @@ use Rector\VendorLocker\VendorLockResolver;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://wiki.php.net/rfc/typed_properties_v2#proposal
@@ -277,10 +276,7 @@ CODE_SAMPLE
         return false;
     }
 
-    private function isSafeProtectedProperty(
-        Property $property,
-        Class_ $class
-    ): bool {
+    private function isSafeProtectedProperty(Property $property, Class_ $class): bool {
         if (! $property->isProtected()) {
             return false;
         }

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -254,13 +254,9 @@ CODE_SAMPLE
         return ! ($this->isSafeProtectedProperty($property, $class));
     }
 
-    private function isModifiedByTrait(ClassLike $classLike, string $propertyName): bool
+    private function isModifiedByTrait(Class_ $class, string $propertyName): bool
     {
-        if (! $classLike instanceof Class_) {
-            return false;
-        }
-
-        foreach ($classLike->getTraitUses() as $traitUse) {
+        foreach ($class->getTraitUses() as $traitUse) {
             foreach ($traitUse->traits as $traitName) {
                 $trait = $this->astResolver->resolveClassFromName($traitName->toString());
                 if (! $trait instanceof Trait_) {


### PR DESCRIPTION
Parent Class can be not loaded due to autoload overlapped. Given the following code:

```php
final class SkipProtectedPropertyWithParentNotLoaded extends NotLoadedClass
{
    /**
     * @var string
     */
    protected $type;
}
```

It currently produce:

```diff
-    /**
-     * @var string
-     */
-    protected $type;
+    protected string $type;
```

which should be skipped.