### PR TITLE
[Core] Use StaticNonPhpFileSuffixes value object in PhpFilesFinder

### DIFF
--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -5,20 +5,12 @@ declare(strict_types=1);
 namespace Rector\Core\FileSystem;
 
 use Rector\Caching\UnchangedFilesFilter;
+use Rector\Core\Util\StringUtils;
+use Rector\Core\ValueObject\StaticNonPhpFileSuffixes;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class PhpFilesFinder
 {
-    /**
-     * @var string[]
-     */
-    private const NON_PHP_FILE_EXTENSIONS = [
-        // Laravel
-        '.blade.php',
-        // Smarty
-        '.tpl',
-    ];
-
     public function __construct(
         private readonly FilesFinder $filesFinder,
         private readonly UnchangedFilesFilter $unchangedFilesFilter
@@ -36,11 +28,8 @@ final class PhpFilesFinder
         // filter out non-PHP files
         foreach ($phpFileInfos as $key => $phpFileInfo) {
             $pathName = $phpFileInfo->getPathname();
-            foreach (self::NON_PHP_FILE_EXTENSIONS as $nonPHPFileExtension) {
-                if (str_ends_with($pathName, $nonPHPFileExtension)) {
-                    unset($phpFileInfos[$key]);
-                    continue 2;
-                }
+            if (StringUtils::isMatch($pathName, StaticNonPhpFileSuffixes::getSuffixRegexPattern())) {
+                unset($phpFileInfos[$key]);
             }
         }
 

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -25,10 +25,11 @@ final class PhpFilesFinder
     {
         $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles($paths);
 
+        $suffixRegexPattern = StaticNonPhpFileSuffixes::getSuffixRegexPattern();
         // filter out non-PHP files
         foreach ($phpFileInfos as $key => $phpFileInfo) {
             $pathName = $phpFileInfo->getPathname();
-            if (StringUtils::isMatch($pathName, StaticNonPhpFileSuffixes::getSuffixRegexPattern())) {
+            if (StringUtils::isMatch($pathName, $suffixRegexPattern)) {
                 unset($phpFileInfos[$key]);
             }
         }

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -24,10 +24,7 @@ final class PhpFilesFinder
     public function findInPaths(array $paths): array
     {
         $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles($paths);
-
         $suffixRegexPattern = StaticNonPhpFileSuffixes::getSuffixRegexPattern();
-        // .blade.php will be checked early
-        $suffixRegexPattern = str_replace('blade\.php|', '', $suffixRegexPattern);
 
         // filter out non-PHP files
         foreach ($phpFileInfos as $key => $phpFileInfo) {

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -27,7 +27,7 @@ final class PhpFilesFinder
 
         $suffixRegexPattern = StaticNonPhpFileSuffixes::getSuffixRegexPattern();
         // .blade.php will be checked early
-        $suffixRegexPattern = str_replace('blade\.php', '', $suffixRegexPattern);
+        $suffixRegexPattern = str_replace('blade\.php|', '', $suffixRegexPattern);
 
         // filter out non-PHP files
         foreach ($phpFileInfos as $key => $phpFileInfo) {

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -29,6 +29,25 @@ final class PhpFilesFinder
         // filter out non-PHP files
         foreach ($phpFileInfos as $key => $phpFileInfo) {
             $pathName = $phpFileInfo->getPathname();
+
+            /**
+             *  check .blade.php early so next .php check in next if can be skipped
+             */
+            if (str_ends_with($pathName, '.blade.php')) {
+                unset($phpFileInfos[$key]);
+                continue;
+            }
+
+            /**
+             * obvious
+             */
+            if (str_ends_with($pathName, '.php')) {
+                continue;
+            }
+
+            /**
+             * only check with regex when needed
+             */
             if (StringUtils::isMatch($pathName, $suffixRegexPattern)) {
                 unset($phpFileInfos[$key]);
             }

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -26,6 +26,9 @@ final class PhpFilesFinder
         $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles($paths);
 
         $suffixRegexPattern = StaticNonPhpFileSuffixes::getSuffixRegexPattern();
+        // .blade.php will be checked early
+        $suffixRegexPattern = str_replace('blade\.php', '', $suffixRegexPattern);
+
         // filter out non-PHP files
         foreach ($phpFileInfos as $key => $phpFileInfo) {
             $pathName = $phpFileInfo->getPathname();

--- a/src/ValueObject/StaticNonPhpFileSuffixes.php
+++ b/src/ValueObject/StaticNonPhpFileSuffixes.php
@@ -9,7 +9,7 @@ final class StaticNonPhpFileSuffixes
     /**
      * @var string[]
      */
-    final public const SUFFIXES = ['neon', 'yaml', 'xml', 'yml', 'twig', 'latte', 'blade.php'];
+    final public const SUFFIXES = ['neon', 'yaml', 'xml', 'yml', 'twig', 'latte', 'blade.php', 'tpl'];
 
     public static function getSuffixRegexPattern(): string
     {


### PR DESCRIPTION
- Re-use existing `StaticNonPhpFileSuffixes::SUFFIXES` definition of list of suffix for non php files.
- add `tpl` for smarty, moved from `PhpFilesFinder` to `StaticNonPhpFileSuffixes::SUFFIXES` constant.