### PR TITLE
[TypeDeclaration] Keep original return type if same as unioned

### DIFF
--- a/packages/ReadWrite/Guard/VariableToConstantGuard.php
+++ b/packages/ReadWrite/Guard/VariableToConstantGuard.php
@@ -103,7 +103,7 @@ final class VariableToConstantGuard
         return $referencePositions;
     }
 
-    private function getArgumentPosition(FuncCall $funcCall, Arg $desiredArg): int
+    private function getArgumentPosition(FuncCall $funcCall, Arg $desiredArg): int|string
     {
         foreach ($funcCall->args as $position => $arg) {
             if ($arg !== $desiredArg) {

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_shared_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_shared_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\SourceForPhp80\FirstTypeUsing;
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\SourceForPhp80\GenericSharedInterface;
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\SourceForPhp80\SecondTypeUsing;
+
+final class SkipSharedType
+{
+    public function get(): GenericSharedInterface
+    {
+        if (mt_rand(0, 1)) {
+            return new FirstTypeUsing();
+        }
+
+        return new SecondTypeUsing();
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/FirstTypeUsing.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/FirstTypeUsing.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\SourceForPhp80;
+
+final class FirstTypeUsing implements GenericSharedInterface
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/GenericSharedInterface.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/GenericSharedInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\SourceForPhp80;
+
+interface GenericSharedInterface
+{
+
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/GenericSharedInterface.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/GenericSharedInterface.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\SourceForPhp80;
 
 interface GenericSharedInterface
 {
-
 }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/SecondTypeUsing.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/SourceForPhp80/SecondTypeUsing.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\SourceForPhp80;
+
+final class SecondTypeUsing implements GenericSharedInterface
+{
+}

--- a/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
+++ b/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
@@ -117,13 +117,13 @@ final class ReturnTypeAlreadyAddedChecker
         }
 
         // skip nullable type
-        $nullType = new NullType();
-        if ($type->isSuperTypeOf($nullType)->yes()) {
+        if ($type->isSuperTypeOf(new NullType())->yes()) {
             return false;
         }
 
         $classMethodReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnTypeNode);
-        return $type->isSuperTypeOf($classMethodReturnType)
+
+        return $classMethodReturnType->isSuperTypeOf($type)
             ->yes();
     }
 


### PR DESCRIPTION
- add shared type fixture
- [TypeDeclaration] Keep original return type if same as unioned
