### PR TITLE
[TypeDeclaration] Fix ReturnTypeAlreadyAddedChecker on return key of array

### DIFF
--- a/packages/ReadWrite/Guard/VariableToConstantGuard.php
+++ b/packages/ReadWrite/Guard/VariableToConstantGuard.php
@@ -110,7 +110,6 @@ final class VariableToConstantGuard
                 continue;
             }
 
-            /** @var int $position */
             return $position;
         }
 

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_defined_as_string.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_defined_as_string.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyDefinedAsString
+{
+    /**
+     * @param array<string, string> $data
+     */
+    public function getKey(array $data, string $value)
+    {
+        foreach ($data as $key => $d) {
+            if ($d !== $value) {
+                continue;
+            }
+
+            return $key;
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyDefinedAsString
+{
+    /**
+     * @param array<string, string> $data
+     */
+    public function getKey(array $data, string $value): string
+    {
+        foreach ($data as $key => $d) {
+            if ($d !== $value) {
+                continue;
+            }
+
+            return $key;
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyOfFuncCallArg
+{
+    public function getKey(FuncCall $funcCall, Arg $desiredArg)
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if ($arg !== $desiredArg) {
+                continue;
+            }
+
+            return $position;
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyOfFuncCallArg
+{
+    public function getKey(FuncCall $funcCall, Arg $desiredArg): int
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if ($arg !== $desiredArg) {
+                continue;
+            }
+
+            return $position;
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg2.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyOfFuncCallArg2
+{
+    public function getKey(FuncCall $funcCall, Arg $desiredArg)
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if (rand(0, 1)) {
+                return $position;
+            }
+
+            if (rand(1, 2)) {
+                return $position;
+            }
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyOfFuncCallArg2
+{
+    public function getKey(FuncCall $funcCall, Arg $desiredArg): int
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if (rand(0, 1)) {
+                return $position;
+            }
+
+            if (rand(1, 2)) {
+                return $position;
+            }
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg2.php.inc
@@ -8,7 +8,7 @@ use Rector\Core\Exception\ShouldNotHappenException;
 
 final class KeyOfFuncCallArg2
 {
-    public function getKey(FuncCall $funcCall, Arg $desiredArg)
+    public function getKey(FuncCall $funcCall)
     {
         foreach ($funcCall->args as $position => $arg) {
             if (rand(0, 1)) {
@@ -36,7 +36,7 @@ use Rector\Core\Exception\ShouldNotHappenException;
 
 final class KeyOfFuncCallArg2
 {
-    public function getKey(FuncCall $funcCall, Arg $desiredArg): int
+    public function getKey(FuncCall $funcCall): int
     {
         foreach ($funcCall->args as $position => $arg) {
             if (rand(0, 1)) {

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg3_no_benevolent.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/key_of_funccal_arg3_no_benevolent.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyOfFuncCallArg3NoBenevolent
+{
+    public function getKey(FuncCall $funcCall)
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if (rand(0, 1)) {
+                return $position;
+            }
+
+            if (rand(1, 2)) {
+                return 'test';
+            }
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class KeyOfFuncCallArg3NoBenevolent
+{
+    public function getKey(FuncCall $funcCall): int|string
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if (rand(0, 1)) {
+                return $position;
+            }
+
+            if (rand(1, 2)) {
+                return 'test';
+            }
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_key_of_funccal_arg_has_return_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_key_of_funccal_arg_has_return_type.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class SkipKeyOfFuncCallArgHasReturnType
+{
+    public function getKey(FuncCall $funcCall, Arg $desiredArg): int
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if ($arg !== $desiredArg) {
+                continue;
+            }
+
+            return $position;
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_key_of_funccal_arg_with_possible_no_return_expr.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp80/skip_key_of_funccal_arg_with_possible_no_return_expr.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp80;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Exception\ShouldNotHappenException;
+
+final class SkipKeyOfFuncCallArgWithPossibleNoReturnExpr
+{
+    public function getKey(FuncCall $funcCall, Arg $desiredArg)
+    {
+        foreach ($funcCall->args as $position => $arg) {
+            if (rand(0, 1)) {
+                return $position;
+            }
+
+            if (rand(1, 2)) {
+                return;
+            }
+        }
+
+        throw new ShouldNotHappenException();
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -159,7 +159,7 @@ CODE_SAMPLE
         return $arrowFunction;
     }
 
-    private function isUnionPossibleReturnsVoid(ClassMethod | Function_ | Closure | ArrowFunction $node): bool
+    private function isUnionPossibleReturnsVoid(ClassMethod | Function_ | Closure $node): bool
     {
         $inferReturnType = $this->returnTypeInferer->inferFunctionLike($node);
         if ($inferReturnType instanceof UnionType) {
@@ -191,6 +191,10 @@ CODE_SAMPLE
     {
         if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::SCALAR_TYPES)) {
             return true;
+        }
+
+        if ($node instanceof ArrowFunction) {
+            return $node->returnType !== null;
         }
 
         if ($node->returnType !== null) {

--- a/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
+++ b/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
@@ -27,6 +27,7 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Traversable;
 
 final class ReturnTypeAlreadyAddedChecker
@@ -123,7 +124,12 @@ final class ReturnTypeAlreadyAddedChecker
 
         $classMethodReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnTypeNode);
 
-        return $classMethodReturnType->isSuperTypeOf($type)
+        if ($classMethodReturnType instanceof FullyQualifiedObjectType) {
+            return $classMethodReturnType->isSuperTypeOf($type)
+                ->yes();
+        }
+
+        return $type->isSuperTypeOf($classMethodReturnType)
             ->yes();
     }
 

--- a/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
+++ b/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
@@ -124,13 +124,8 @@ final class ReturnTypeAlreadyAddedChecker
 
         $classMethodReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnTypeNode);
 
-        if ($classMethodReturnType instanceof FullyQualifiedObjectType) {
-            return $classMethodReturnType->isSuperTypeOf($type)
+        return $classMethodReturnType->isSuperTypeOf($type)
                 ->yes();
-        }
-
-        return $type->isSuperTypeOf($classMethodReturnType)
-            ->yes();
     }
 
     private function isStaticTypeIterable(Type $type): bool

--- a/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
+++ b/rules/TypeDeclaration/TypeAlreadyAddedChecker/ReturnTypeAlreadyAddedChecker.php
@@ -27,7 +27,6 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\StaticTypeMapper\StaticTypeMapper;
-use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Traversable;
 
 final class ReturnTypeAlreadyAddedChecker
@@ -125,7 +124,7 @@ final class ReturnTypeAlreadyAddedChecker
         $classMethodReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnTypeNode);
 
         return $classMethodReturnType->isSuperTypeOf($type)
-                ->yes();
+            ->yes();
     }
 
     private function isStaticTypeIterable(Type $type): bool

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -172,22 +172,23 @@ final class ReturnTypeInferer
         }
 
         $returns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($functionLike, Return_::class);
-        $returns = array_filter($returns, fn ($v): bool => $v->expr instanceof Expr);
+        $returnsWithExpr = array_filter($returns, fn ($v): bool => $v->expr instanceof Expr);
 
-        if (count($returns) !== 1) {
+        if ($returns !== $returnsWithExpr) {
             return $unionType;
         }
 
-        $return = current($returns);
-        /** @var Expr $expr */
-        $expr = $return->expr;
-        $type = $this->nodeTypeResolver->getType($expr);
+        foreach ($returnsWithExpr as $returnWithExpr) {
+            /** @var Expr $expr */
+            $expr = $returnWithExpr->expr;
+            $type = $this->nodeTypeResolver->getType($expr);
 
-        if ($type instanceof BenevolentUnionType) {
-            return $types[0];
+            if (! $type instanceof BenevolentUnionType) {
+                return $unionType;
+            }
         }
 
-        return $unionType;
+        return $types[0];
     }
 
     private function isAutoImportWithFullyQualifiedReturn(bool $isAutoImport, FunctionLike $functionLike): bool

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -178,6 +178,10 @@ final class ReturnTypeInferer
             return $unionType;
         }
 
+        if ($returnsWithExpr === []) {
+            return $unionType;
+        }
+
         foreach ($returnsWithExpr as $returnWithExpr) {
             /** @var Expr $expr */
             $expr = $returnWithExpr->expr;


### PR DESCRIPTION
@TomasVotruba it fixes `ReturnTypeAlreadyAddedChecker` for return `int` detection for array key .