### PR TITLE
[Scoped] Fix scoped Uninitialized string offset -1 error

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -140,7 +140,7 @@ final class ApplicationFileProcessor
             }
 
             // not relevant for us
-            if ($code === E_DEPRECATED) {
+            if (in_array($code, [E_DEPRECATED, E_WARNING], true)) {
                 return true;
             }
 


### PR DESCRIPTION
Fixing scoped build error, ref https://github.com/rectorphp/rector-src/runs/4643749917?check_suite_focus=true#step:9:9039

```bash
 [ERROR] Could not process                                                      
         "phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/
         phpstan.phar/src/Type/Constant/ConstantStringType.php" file, due to:   
         "Uninitialized string offset -1". On line: 222                
```

by PR https://github.com/rectorphp/rector-src/pull/1577