### PR TITLE
[Scoped] Fix PHP71_BIN_PATH: unbound variable on local full_build.sh

### DIFF
--- a/full_build.sh
+++ b/full_build.sh
@@ -42,7 +42,7 @@ cp ../preload.php .
 #
 #   export PHP71_BIN_PATH=/opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php && sh ./full_build.sh
 #
-if [ -z "$PHP71_BIN_PATH" ]; then
+if test -z ${PHP71_BIN_PATH+y}; then
     eval "bin/rector list --ansi";
 else
     eval "$PHP71_BIN_PATH bin/rector list --ansi";


### PR DESCRIPTION
@TomasVotruba I found a bug on possible error on local scoped script when PHP71_BIN_PATH env never defined in any session of terminal, that cause error:

```bash
./full_build.sh: line 45: PHP71_BIN_PATH: unbound variable
```

This PR solve it, also retry scoped build CI.