### PR TITLE
use type-safe `PrivatesAccessor`

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -198,11 +198,9 @@ final class PHPStanNodeScopeResolver
         NodeScopeResolver $nodeScopeResolver
     ): void {
         // 1. get PHPStan locator
-        /** @var ClassReflector $classReflector */
-        $classReflector = $this->privatesAccessor->getPrivateProperty($nodeScopeResolver, 'classReflector');
+        $classReflector = $this->privatesAccessor->getPrivatePropertyOfClass($nodeScopeResolver, 'classReflector', ClassReflector::class);
 
-        /** @var SourceLocator $sourceLocator */
-        $sourceLocator = $this->privatesAccessor->getPrivateProperty($classReflector, 'sourceLocator');
+        $sourceLocator = $this->privatesAccessor->getPrivatePropertyOfClass($classReflector, 'sourceLocator', SourceLocator::class);
 
         // 2. get Rector locator
         $aggregateSourceLocator = new AggregateSourceLocator([
@@ -210,6 +208,6 @@ final class PHPStanNodeScopeResolver
             $this->renamedClassesSourceLocator,
             $this->parentAttributeSourceLocator,
         ]);
-        $this->privatesAccessor->setPrivateProperty($classReflector, 'sourceLocator', $aggregateSourceLocator);
+        $this->privatesAccessor->setPrivatePropertyOfClass($classReflector, 'sourceLocator', $aggregateSourceLocator, AggregateSourceLocator::class);
     }
 }


### PR DESCRIPTION
with the changes from https://github.com/symplify/symplify/pull/3860, we could make this call sites typesafe.

I guess there are even more spots in the codebase which could benefit, but I figured I would leave this PR here as a demo of the symplify changes