### PR TITLE
[ReadOnlyPropertyRector] Add failing test for cloned properties

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_write_also_cloned_property.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_write_also_cloned_property.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipWriteAlsoClonedProperty
+{
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
Adds failing test for https://github.com/rectorphp/rector/issues/6898.

Fixing this appears not to be a simple task (esp for a rector noob like myself) as I'm unsure how this is managing to figure out whether a property is written to or not.

If someone else wants to take over this PR, feel free. In the meantime I will continue to try to fix, if only for my own education purposes, but I don't want that to get in the way of this issue being resolved.