### PR TITLE
[Scoped] Fix build downgrade

### DIFF
--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeArrayFilterNullableCallbackRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeArrayFilterNullableCallbackRector.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PHPStan\Type\MixedType;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -88,10 +89,17 @@ CODE_SAMPLE
             return null;
         }
 
+        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE);
+        if ($createdByRule === self::class) {
+            return null;
+        }
+
         // direct null check ConstFetch
         if ($args[1]->value instanceof ConstFetch && $this->valueResolver->isNull($args[1]->value)) {
             $args = [$args[0]];
             $node->args = $args;
+
+            $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
             return $node;
         }
 
@@ -103,6 +111,7 @@ CODE_SAMPLE
         $node->args[1] = new Arg($this->createNewArgFirstTernary($args));
         $node->args[2] = new Arg($this->createNewArgSecondTernary($args));
 
+        $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
         return $node;
     }
 


### PR DESCRIPTION
This is to avoid error like in latest build: https://github.com/rectorphp/rector-src/runs/4667411662?check_suite_focus=true#step:9:37506

```
PHP Fatal error:  Uncaught TypeError: PHPStan\Type\Constant\ConstantIntegerType::__construct(): Argument #1 ($value) must be of type int, string given, called in phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php on line 1039 and defined in phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Type/Constant/ConstantIntegerType.php:27
```

This PR try to fix it.