### PR TITLE
[Core] Apply CREATED_BY_RULE attribute as array collection of applied Rector rule

### DIFF
--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
@@ -40,7 +40,7 @@ final class ExprUsedInNextNodeAnalyzer
 
     private function hasIfChangedByRemoveAlwaysElseRector(If_ $if): bool
     {
-        $createdByRule = $if->getAttribute(AttributeKey::CREATED_BY_RULE);
-        return $createdByRule === RemoveAlwaysElseRector::class;
+        $createdByRule = $if->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
+        return in_array(RemoveAlwaysElseRector::class, $createdByRule, true);
     }
 }

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeArrayFilterNullableCallbackRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeArrayFilterNullableCallbackRector.php
@@ -96,8 +96,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE);
-        if ($createdByRule === self::class) {
+        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
+        if (in_array(self::class, $createdByRule, true)) {
             return null;
         }
 
@@ -106,7 +106,6 @@ CODE_SAMPLE
             $args = [$args[0]];
             $node->args = $args;
 
-            $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
             return $node;
         }
 
@@ -117,7 +116,6 @@ CODE_SAMPLE
         $node->args[1] = new Arg($this->createNewArgFirstTernary($args));
         $node->args[2] = new Arg($this->createNewArgSecondTernary($args));
 
-        $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
         return $node;
     }
 

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -82,7 +82,6 @@ CODE_SAMPLE
             $originalNode = clone $node;
             $if = new If_($node->cond);
             $if->stmts = $node->stmts;
-            $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
 
             $this->nodesToAddCollector->addNodeBeforeNode($if, $node);
             $this->mirrorComments($if, $node);
@@ -110,7 +109,6 @@ CODE_SAMPLE
             $this->nodesToAddCollector->addNodesAfterNode($node->else->stmts, $node);
             $node->else = null;
 
-            $node->setAttribute(AttributeKey::CREATED_BY_RULE, self::class);
             return $node;
         }
 

--- a/src/NodeDecorator/CreatedByRuleDecorator.php
+++ b/src/NodeDecorator/CreatedByRuleDecorator.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\NodeDecorator;
+
+use PhpParser\Node;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class CreatedByRuleDecorator
+{
+    public function decorate(Node $node, string $rectorClass): void
+    {
+        $mergeCreatedByRule = array_merge(
+            $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [],
+            [$rectorClass]
+        );
+        $mergeCreatedByRule = array_unique($mergeCreatedByRule);
+
+        $node->setAttribute(
+            AttributeKey::CREATED_BY_RULE,
+            $mergeCreatedByRule
+        );
+    }
+}

--- a/src/NodeDecorator/CreatedByRuleDecorator.php
+++ b/src/NodeDecorator/CreatedByRuleDecorator.php
@@ -11,15 +11,9 @@ final class CreatedByRuleDecorator
 {
     public function decorate(Node $node, string $rectorClass): void
     {
-        $mergeCreatedByRule = array_merge(
-            $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [],
-            [$rectorClass]
-        );
+        $mergeCreatedByRule = array_merge($node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [], [$rectorClass]);
         $mergeCreatedByRule = array_unique($mergeCreatedByRule);
 
-        $node->setAttribute(
-            AttributeKey::CREATED_BY_RULE,
-            $mergeCreatedByRule
-        );
+        $node->setAttribute(AttributeKey::CREATED_BY_RULE, $mergeCreatedByRule);
     }
 }

--- a/src/PhpParser/NodeVisitor/CreatedByRuleNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/CreatedByRuleNodeVisitor.php
@@ -6,25 +6,20 @@ namespace Rector\Core\PhpParser\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
+use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class CreatedByRuleNodeVisitor extends NodeVisitorAbstract
 {
     public function __construct(
+        private readonly CreatedByRuleDecorator $createdByRuleDecorator,
         private readonly string $rectorClass
     ) {
     }
 
     public function enterNode(Node $node)
     {
-        $node->setAttribute(
-            AttributeKey::CREATED_BY_RULE,
-            array_unique(array_merge(
-                $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [],
-                [$this->rectorClass]
-            ))
-        );
-
+        $this->createdByRuleDecorator->decorate($node, $this->rectorClass);
         return $node;
     }
 }

--- a/src/PhpParser/NodeVisitor/CreatedByRuleNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/CreatedByRuleNodeVisitor.php
@@ -17,7 +17,14 @@ final class CreatedByRuleNodeVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node)
     {
-        $node->setAttribute(AttributeKey::CREATED_BY_RULE, $this->rectorClass);
+        $node->setAttribute(
+            AttributeKey::CREATED_BY_RULE,
+            array_unique(array_merge(
+                $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [],
+                [$this->rectorClass]
+            ))
+        );
+
         return $node;
     }
 }

--- a/src/PhpParser/NodeVisitor/CreatedByRuleNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/CreatedByRuleNodeVisitor.php
@@ -7,7 +7,6 @@ namespace Rector\Core\PhpParser\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class CreatedByRuleNodeVisitor extends NodeVisitorAbstract
 {

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -268,20 +268,20 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         $this->connectParentNodes($node);
 
         // is different node type? do not traverse children to avoid looping
-        if ($originalNode::class !== $node::class) {
-            $this->infiniteLoopValidator->process($node, $originalNode, static::class);
-
-            // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
-            $originalNodeHash = spl_object_hash($originalNode);
-
-            if ($originalNode instanceof Stmt && $node instanceof Expr) {
-                $node = new Expression($node);
-            }
-
-            $this->nodesToReturn[$originalNodeHash] = $node;
-
+        if ($originalNode::class === $node::class) {
             return $node;
         }
+
+        $this->infiniteLoopValidator->process($node, $originalNode, static::class);
+
+        // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
+        $originalNodeHash = spl_object_hash($originalNode);
+
+        if ($originalNode instanceof Stmt && $node instanceof Expr) {
+            $node = new Expression($node);
+        }
+
+        $this->nodesToReturn[$originalNodeHash] = $node;
 
         return $node;
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -253,7 +253,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return $originalNode;
         }
 
-        // changed!
+        // not changed, return node early
         if (! $this->changedNodeAnalyzer->hasNodeChanged($originalNode, $node)) {
             return $node;
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -267,11 +267,12 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         $this->mirrorAttributes($originalAttributes, $node);
         $this->connectParentNodes($node);
 
-        // is different node type? do not traverse children to avoid looping
+        // is equals node type? return node early
         if ($originalNode::class === $node::class) {
             return $node;
         }
 
+        // is different node type? do not traverse children to avoid looping
         $this->infiniteLoopValidator->process($node, $originalNode, static::class);
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown

--- a/src/Validation/InfiniteLoopValidator.php
+++ b/src/Validation/InfiniteLoopValidator.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\Exception\NodeTraverser\InfiniteLoopTraversingException;
+use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\NodeVisitor\CreatedByRuleNodeVisitor;
 use Rector\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector;
@@ -27,7 +28,8 @@ final class InfiniteLoopValidator
     ];
 
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly CreatedByRuleDecorator $createdByRuleDecorator
     ) {
     }
 
@@ -63,7 +65,7 @@ final class InfiniteLoopValidator
     {
         $nodeTraverser = new NodeTraverser();
 
-        $createdByRuleNodeVisitor = new CreatedByRuleNodeVisitor($rectorClass);
+        $createdByRuleNodeVisitor = new CreatedByRuleNodeVisitor($this->createdByRuleDecorator, $rectorClass);
         $nodeTraverser->addVisitor($createdByRuleNodeVisitor);
 
         $nodeTraverser->traverse([$node]);

--- a/src/Validation/InfiniteLoopValidator.php
+++ b/src/Validation/InfiniteLoopValidator.php
@@ -40,10 +40,10 @@ final class InfiniteLoopValidator
             return;
         }
 
-        $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE);
+        $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
 
         // special case
-        if ($createdByRule === $rectorClass) {
+        if (in_array($rectorClass, $createdByRule, true)) {
             // does it contain the same node type as input?
             $originalNodeClass = $originalNode::class;
 


### PR DESCRIPTION
Apply `AttributeKey::CREATED_BY_RULE` value as array with consists of collection rules applied into node to avoid overlapped re-fill with other rule that make check is invalid.