### PR TITLE
[DeadCode] Fix remove unreachable after mark test skipped

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_marked_skipped_test_static_file.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_marked_skipped_test_static_file.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipMarkedSkippedTestStaticFile extends TestCase
+{
+    public function testMultipleArguments(): void
+    {
+        static::markTestSkipped('Skip it');
+
+        $this->assertTrue('...');
+    }
+}

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -149,7 +149,7 @@ CODE_SAMPLE
     private function isAfterMarkTestSkippedMethodCall(Stmt $stmt): bool
     {
         return (bool) $this->betterNodeFinder->findFirstPrevious($stmt, function (Node $node): bool {
-            if (! $node instanceof MethodCall) {
+            if (! $node instanceof MethodCall && ! $node instanceof StaticCall) {
                 return false;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6884

- add test case for https://github.com/rectorphp/rector/issues/6884
- skip static mark test as skipped in RemoveUnreachableStatementRector
