### PR TITLE
[Downgrade PHP 7.0] Move Throwable out of type hints

### DIFF
--- a/config/set/downgrade-php70.php
+++ b/config/set/downgrade-php70.php
@@ -12,6 +12,7 @@ use Rector\DowngradePhp70\Rector\Expression\DowngradeDefineArrayConstantRector;
 use Rector\DowngradePhp70\Rector\FuncCall\DowngradeDirnameLevelsRector;
 use Rector\DowngradePhp70\Rector\FuncCall\DowngradeSessionStartArrayOptionsRector;
 use Rector\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector;
+use Rector\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector;
 use Rector\DowngradePhp70\Rector\GroupUse\SplitGroupedUseImportsRector;
 use Rector\DowngradePhp70\Rector\MethodCall\DowngradeClosureCallRector;
 use Rector\DowngradePhp70\Rector\MethodCall\DowngradeMethodCallOnCloneRector;
@@ -26,6 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services = $containerConfigurator->services();
     $services->set(DowngradeScalarTypeDeclarationRector::class);
+    $services->set(DowngradeThrowableTypeDeclarationRector::class);
     $services->set(DowngradeStrictTypeDeclarationRector::class);
     $services->set(DowngradeSelfTypeDeclarationRector::class);
     $services->set(DowngradeAnonymousClassRector::class);

--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -182,6 +182,9 @@ final class PhpDocFromTypeDeclarationDecorator
         if ($returnType instanceof UnionType) {
             $returnType = $this->typeUnwrapper->unwrapNullableType($returnType);
         }
+        if ($returnType instanceof ObjectType) {
+            return $returnType->equals($requireType);
+        }
 
         return $returnType::class === $requireType::class;
     }

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/DowngradeThrowableTypeDeclarationRectorTest.php
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/DowngradeThrowableTypeDeclarationRectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeThrowableTypeDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP 8.0
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/docblock_exists.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/docblock_exists.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class DocblockExists {
+    /**
+     * This property is the best one
+     */
+    public function someFunction(\Throwable $anything)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class DocblockExists {
+    /**
+     * This property is the best one
+     * @param \Throwable $anything
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class DocblockTagExists {
+    /**
+     * This property is the best one
+     * @param \Throwable $anything
+     */
+    public function someFunction(\Throwable $anything)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class DocblockTagExists {
+    /**
+     * This property is the best one
+     * @param \Throwable $anything
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class Fixture
+{
+    public function someFunction(\Throwable $anything)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class Fixture
+{
+    /**
+     * @param \Throwable $anything
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/multiple_matching_params.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/multiple_matching_params.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class MultipleMatchingParams
+{
+    public function someFunction(\Throwable $anything, string $someOtherVar, \Throwable $someOtherObject)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class MultipleMatchingParams
+{
+    /**
+     * @param \Throwable $anything
+     * @param \Throwable $someOtherObject
+     */
+    public function someFunction($anything, string $someOtherVar, $someOtherObject)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/multiple_params.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/multiple_params.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class MultipleParams
+{
+    public function someFunction(\Throwable $anything, string $someOtherVar)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class MultipleParams
+{
+    /**
+     * @param \Throwable $anything
+     */
+    public function someFunction($anything, string $someOtherVar)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/nullable.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/nullable.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class Fixture
+{
+    public function someFunction(?\Throwable $anything): ?\Throwable
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class Fixture
+{
+    /**
+     * @param \Throwable|null $anything
+     * @return \Throwable|null
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/on_closure.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/on_closure.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class OnClosure
+{
+    public function run()
+    {
+        $foo = array_filter(
+            $list,
+            function (\Throwable $fieldArgValue) {
+              return is_null($fieldArgValue);
+            }
+          );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class OnClosure
+{
+    public function run()
+    {
+        $foo = array_filter(
+            $list,
+            function ($fieldArgValue) {
+              return is_null($fieldArgValue);
+            }
+          );
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/return_docblock_exists.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/return_docblock_exists.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class ReturnDocblockExists {
+    /**
+     * This property is the best one
+     */
+    public function getAnything(): \Throwable
+    {
+        return new \Exception('Yikes!');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class ReturnDocblockExists {
+    /**
+     * This property is the best one
+     * @return \Throwable
+     */
+    public function getAnything()
+    {
+        return new \Exception('Yikes!');
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/return_docblock_tag_exists.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/return_docblock_tag_exists.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class ReturnDocblockTagExists {
+    /**
+     * This property is the best one
+     * @return \Throwable
+     */
+    public function getAnything(): \Throwable
+    {
+        return new \Exception('Yikes!');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+class ReturnDocblockTagExists {
+    /**
+     * This property is the best one
+     * @return \Throwable
+     */
+    public function getAnything()
+    {
+        return new \Exception('Yikes!');
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/return_fixture.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/Fixture/return_fixture.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+final class ReturnFixture
+{
+    public function getAnything(): \Throwable
+    {
+        return new \Exception('Yikes!');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\Fixture;
+
+final class ReturnFixture
+{
+    /**
+     * @return \Throwable
+     */
+    public function getAnything()
+    {
+        return new \Exception('Yikes!');
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeThrowableTypeDeclarationRector::class);
+};

--- a/rules/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector.php
+++ b/rules/DowngradePhp70/Rector/FunctionLike/DowngradeThrowableTypeDeclarationRector.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp70\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocParser\PhpDocFromTypeDeclarationDecorator;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector\DowngradeThrowableTypeDeclarationRectorTest
+ */
+final class DowngradeThrowableTypeDeclarationRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocFromTypeDeclarationDecorator $phpDocFromTypeDeclarationDecorator,
+    ) {
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Function_::class, ClassMethod::class, Closure::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace `Throwable` type hints by PHPDoc tags',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function foo(\Throwable $e): ?\Throwable
+    {
+        return new \Exception("Troubles");
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /**
+     * @param \Throwable $e
+     * @return \Throwable|null
+     */
+    public function foo($e)
+    {
+        return new \Exception("Troubles");
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param ClassMethod|Function_|Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $throwableType = new ObjectType('Throwable');
+
+        foreach ($node->getParams() as $param) {
+            $this->phpDocFromTypeDeclarationDecorator->decorateParamWithSpecificType($param, $node, $throwableType);
+        }
+
+        if (! $this->phpDocFromTypeDeclarationDecorator->decorateReturnWithSpecificType($node, $throwableType)) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/tests/Issues/IssueDowngradeThrowableType/DowngradeThrowableTypeTest.php
+++ b/tests/Issues/IssueDowngradeThrowableType/DowngradeThrowableTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeThrowableType;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeThrowableTypeTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueDowngradeThrowableType/Fixture/arrow_function_param_throwable.php.inc
+++ b/tests/Issues/IssueDowngradeThrowableType/Fixture/arrow_function_param_throwable.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeThrowableType\Fixture;
+
+use Throwable;
+
+class ArrowFunctionParamThrowable
+{
+    public function run()
+    {
+        $value = fn (Throwable $param): bool => true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeThrowableType\Fixture;
+
+use Throwable;
+
+class ArrowFunctionParamThrowable
+{
+    public function run()
+    {
+        $value = function ($param) : bool {
+            return true;
+        };
+    }
+}
+
+?>

--- a/tests/Issues/IssueDowngradeThrowableType/Fixture/arrow_function_return_throwable.php.inc
+++ b/tests/Issues/IssueDowngradeThrowableType/Fixture/arrow_function_return_throwable.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeThrowableType\Fixture;
+
+use Throwable;
+
+final class ArrowFunctionReturnThrowable
+{
+    public function run()
+    {
+        $value = fn () : ?Throwable => new \Exception('Yikes!');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeThrowableType\Fixture;
+
+use Throwable;
+
+final class ArrowFunctionReturnThrowable
+{
+    public function run()
+    {
+        $value = function () {
+            return new \Exception('Yikes!');
+        };
+    }
+}
+
+?>

--- a/tests/Issues/IssueDowngradeThrowableType/config/configured_rule.php
+++ b/tests/Issues/IssueDowngradeThrowableType/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector;
+use Rector\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ArrowFunctionToAnonymousFunctionRector::class);
+    $services->set(DowngradeThrowableTypeDeclarationRector::class);
+};


### PR DESCRIPTION
It is only available on PHP 7.0+:
https://www.php.net/manual/en/class.throwable.php
