### PR TITLE
[Downgrade 7.0] Fix value calls that do not lex or lex differently in PHP 5.6

### DIFF
--- a/config/set/downgrade-php70.php
+++ b/config/set/downgrade-php70.php
@@ -11,6 +11,7 @@ use Rector\DowngradePhp70\Rector\Declare_\DowngradeStrictTypeDeclarationRector;
 use Rector\DowngradePhp70\Rector\Expression\DowngradeDefineArrayConstantRector;
 use Rector\DowngradePhp70\Rector\FuncCall\DowngradeDirnameLevelsRector;
 use Rector\DowngradePhp70\Rector\FuncCall\DowngradeSessionStartArrayOptionsRector;
+use Rector\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector;
 use Rector\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector;
 use Rector\DowngradePhp70\Rector\FunctionLike\DowngradeThrowableTypeDeclarationRector;
 use Rector\DowngradePhp70\Rector\GroupUse\SplitGroupedUseImportsRector;
@@ -38,6 +39,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeDefineArrayConstantRector::class);
     $services->set(DowngradeDirnameLevelsRector::class);
     $services->set(DowngradeSessionStartArrayOptionsRector::class);
+    $services->set(DowngradeUncallableValueCallToCallUserFuncRector::class);
     $services->set(SplitGroupedUseImportsRector::class);
     $services->set(DowngradeClosureCallRector::class);
     $services->set(DowngradeGeneratedScalarTypesRector::class);

--- a/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/DowngradeUncallableValueCallToCallUserFuncRectorTest.php
+++ b/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/DowngradeUncallableValueCallToCallUserFuncRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeUncallableValueCallToCallUserFuncRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/func-call.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/func-call.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+function foo() {
+    return function() {
+        echo "foo";
+    };
+};
+
+foo()();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+function foo() {
+    return function() {
+        echo "foo";
+    };
+};
+
+call_user_func(foo());
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/iife.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/iife.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+(function($a, $b) {
+    // Immediately invoked function expression
+})($arg1, $arg2);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+call_user_func(function($a, $b) {
+    // Immediately invoked function expression
+}, $arg1, $arg2);
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/property.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/property.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+($foo->mailer)($arg1, $arg2);
+($foo->mailer)();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+call_user_func($foo->mailer, $arg1, $arg2);
+call_user_func($foo->mailer);
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/static-property.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/Fixture/static-property.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+class Foo {
+    public function foo()
+    {
+        (self::$foo)($arg1, $arg2);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\Fixture;
+
+class Foo {
+    public function foo()
+    {
+        call_user_func(self::$foo, $arg1, $arg2);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeUncallableValueCallToCallUserFuncRector::class);
+};

--- a/rules/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector.php
+++ b/rules/DowngradePhp70/Rector/FuncCall/DowngradeUncallableValueCallToCallUserFuncRector.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp70\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Name;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/uniform_variable_syntax
+ *
+ * @see \Rector\Tests\DowngradePhp70\Rector\FuncCall\DowngradeUncallableValueCallToCallUserFuncRector\DowngradeUncallableValueCallToCallUserFuncRectorTest
+ */
+final class DowngradeUncallableValueCallToCallUserFuncRector extends AbstractRector
+{
+    /** @var array<class-string<Expr>> */
+    private const INDIRECT_CALLABLE_EXPR = [
+       // Interpreted as MethodCall without parentheses.
+        PropertyFetch::class,
+       // Interpreted as StaticCall without parentheses.
+        StaticPropertyFetch::class,
+        Closure::class,
+        // The first function call does not even need to be wrapped in parentheses
+        // but PHP 5 still does not like curried functions like `f($args)($moreArgs)`.
+        FuncCall::class,
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Downgrade calling a value that is not directly callable in PHP 5 (property, static property, closure, …) to call_user_func.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class Foo
+{
+    /** @var callable */
+    public $handler;
+    /** @var callable */
+    public static $staticHandler;
+}
+
+$foo = new Foo;
+($foo->handler)(/* args */);
+($foo::$staticHandler)(41);
+
+(function() { /* … */ })();
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class Foo
+{
+    /** @var callable */
+    public $handler;
+    /** @var callable */
+    public static $staticHandler;
+}
+
+$foo = new Foo;
+call_user_func($foo->handler, /* args */);
+call_user_func($foo::$staticHandler, 41);
+
+call_user_func(function() { /* … */ });
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?FuncCall
+    {
+        if ($node->name instanceof Name) {
+            return null;
+        }
+        if (! $this->isNotDirectlyCallableInPhp5($node->name)) {
+            return null;
+        }
+
+        $args = array_merge([new Arg($node->name)], $node->args);
+
+        return new FuncCall(new Name('call_user_func'), $args);
+    }
+
+    private function isNotDirectlyCallableInPhp5(Expr $expr): bool
+    {
+        return in_array($expr::class, self::INDIRECT_CALLABLE_EXPR, true);
+    }
+}


### PR DESCRIPTION
PHP 7.0 implemented [Uniform Variable Syntax RFC](https://wiki.php.net/rfc/uniform_variable_syntax), which allows many expressions that did not previously parse and changes parsing of some less common ones.