### PR TITLE
[Configuration] Fix provided type does not have to exists

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Broker\ClassAutoloadingException;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FloatType;
@@ -101,7 +102,12 @@ final class NodeTypeResolver
         }
 
         if ($resolvedType instanceof ObjectType) {
-            return $this->resolveObjectType($resolvedType, $requiredObjectType);
+            try {
+                return $this->resolveObjectType($resolvedType, $requiredObjectType);
+            } catch (ClassAutoloadingException) {
+                // in some type checks, the provided type in rector.php configuration does not have to exists
+                return false;
+            }
         }
 
         return $this->isMatchingUnionType($resolvedType, $requiredObjectType);


### PR DESCRIPTION
In case of configuring type checks in `rector.php` - https://github.com/rectorphp/rector-symfony/blob/b92de39d109c19cd3db5e965fe9a339ff568cfb1/config/sets/symfony/symfony6/symfony-return-types.php#L81

Sometimes the class does not exists. The type check should return `false` in that case, but instead crashes, as PHPStan requires all the objects to exist.

This fixes it
