### PR TITLE
[Scoped] Exclude rules from parallel downgrade

### DIFF
--- a/build/downgrade-rector.sh
+++ b/build/downgrade-rector.sh
@@ -33,7 +33,7 @@ export IFS=";"
 for directory in $directories; do
     echo "[NOTE] Downgrading '$directory' directory\n"
 
-    if printf '%s' "$directory" | grep -Eq '^(vendor/(symfony|symplify|rector)|utils).*'; then
+    if printf '%s' "$directory" | grep -Eq '^(vendor/(symfony|symplify|rector)|rules|utils).*'; then
         echo "downgrading with no parallel...\n"
         CONFIG_PATH_DOWNGRADE="build/config/config-downgrade.php"
     else


### PR DESCRIPTION
Because it cause error in CI which I cannot reproduce locally https://github.com/rectorphp/rector-src/runs/4704007658?check_suite_focus=true#step:9:68342

```bash
 [ERROR] Could not process some files, due to:                                  
         "Child process error: PHP Fatal error:  Declaration of                 
         Rector\Naming\ValueObject\ParamRename::getFunctionLike() must be       
         compatible with                                                        
         Rector\Naming\Contract\RenameParamValueObjectInterface::getFunctionLike
         ():                                                                    
         PhpParser\Node\Stmt\ClassMethod|PhpParser\Node\Stmt\Function_|PhpParser
         \Node\Expr\Closure in rules/Naming/ValueObject/ParamRename.php:66      
         Fatal error: Declaration of                                            
         Rector\Naming\ValueObject\ParamRename::getFunctionLike() must be       
         compatible with                                                        
         Rector\Naming\Contract\RenameParamValueObjectInterface::getFunctionLike
         ():                                                                    
         PhpParser\Node\Stmt\ClassMethod|PhpParser\Node\Stmt\Function_|PhpParser
         \Node\Expr\Closure in rules/Naming/ValueObject/ParamRename.php:66      
         ".   
```
