### PR TITLE
[Scoped] Enable vendor/rector/* to be downgraded with parallel

### DIFF
--- a/build/downgrade-rector.sh
+++ b/build/downgrade-rector.sh
@@ -33,7 +33,7 @@ export IFS=";"
 for directory in $directories; do
     echo "[NOTE] Downgrading '$directory' directory\n"
 
-    if printf '%s' "$directory" | grep -Eq '^(vendor/(symfony|symplify|rector)|rules|utils).*'; then
+    if printf '%s' "$directory" | grep -Eq '^(vendor/(symfony|symplify)|rules|utils).*'; then
         echo "downgrading with no parallel...\n"
         CONFIG_PATH_DOWNGRADE="build/config/config-downgrade.php"
     else


### PR DESCRIPTION
@TomasVotruba thank you for the fix for Class Not Found on parallel, the `vendor/rector/*` now can be downgraded via parallel 

This PR enable it.