### PR TITLE
[Parallel] Using RectorConfigsResolver to use set bootstrap config

### DIFF
--- a/packages/Parallel/Command/WorkerCommandLineFactory.php
+++ b/packages/Parallel/Command/WorkerCommandLineFactory.php
@@ -96,11 +96,6 @@ final class WorkerCommandLineFactory
         // @see https://github.com/symfony/symfony/issues/1238
         $workerCommandArray[] = '--no-ansi';
 
-        if ($input->hasOption(Option::CONFIG)) {
-            $workerCommandArray[] = '--config';
-            $workerCommandArray[] = $input->getOption(Option::CONFIG);
-        }
-
         return implode(' ', $workerCommandArray);
     }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\Configuration;
 
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
+use Rector\Core\Bootstrap\RectorConfigsResolver;
 use Rector\Core\ValueObject\Configuration;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -48,6 +49,7 @@ final class ConfigurationFactory
         $isParallel = $this->parameterProvider->provideBoolParameter(Option::PARALLEL);
         $parallelPort = (string) $input->getOption(Option::PARALLEL_PORT);
         $parallelIdentifier = (string) $input->getOption(Option::PARALLEL_IDENTIFIER);
+        $rectorConfigsResolver = new RectorConfigsResolver();
 
         return new Configuration(
             $isDryRun,
@@ -57,7 +59,7 @@ final class ConfigurationFactory
             $fileExtensions,
             $paths,
             $showDiffs,
-            null,
+            $rectorConfigsResolver->provide(),
             $parallelPort,
             $parallelIdentifier,
             $isParallel


### PR DESCRIPTION
@TomasVotruba this is seems the correct way to get Bootstrap config instead of pull from `$input` in https://github.com/rectorphp/rector-src/pull/1620 as there is already check for `$projectConfigFile`

https://github.com/rectorphp/rector-src/blob/a66be5920506820182d0208d20f02e5e8a4096d7/packages/Parallel/Command/WorkerCommandLineFactory.php#L69-L72

which previously always null for parallel, pull from `RectorConfigsResolver` make it works.
