### PR TITLE
Add failing test fixture for ClosureToArrowFunctionRector

### DIFF
--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+function() {
+    /** @psalm-suppress UndefinedFunction */
+    return ff();
+};
+?>
+-----
+<?php
+
+fn() => 
+    /** @psalm-suppress UndefinedFunction */
+    ff();
+?>


### PR DESCRIPTION
# Failing Test for ClosureToArrowFunctionRector

Based on https://getrector.org/demo/1ec6e7f1-7c0f-684e-9843-a7cd56252edf