### PR TITLE
[TypeDeclaration] Prevent existing type override by mixed

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/FixturePhp73/skip_override_existing_type_by_mixed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/FixturePhp73/skip_override_existing_type_by_mixed.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector\FixturePhp73;
+
+final class SkipOverrideExistingTypeByMixed
+{
+    /**
+     * @var array<string, bool>
+     */
+    private $rules = [];
+
+    /**
+     * @return array<string, bool>
+     */
+    public function getRules(): array
+    {
+        return $this->rules;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
@@ -89,6 +90,10 @@ CODE_SAMPLE
 
         $getterReturnType = $this->getterTypeDeclarationPropertyTypeInferer->inferProperty($node);
         if (! $getterReturnType instanceof Type) {
+            return null;
+        }
+
+        if ($getterReturnType instanceof MixedType) {
             return null;
         }
 


### PR DESCRIPTION
Existing type override by mixed type in php doc.

```diff
     /**
-     * @var array<string, bool>
+     * @var mixed
      */
     private $rules = [];
```