### PR TITLE
Fix memory leak

### DIFF
--- a/config/phpstan/parser.neon
+++ b/config/phpstan/parser.neon
@@ -2,21 +2,21 @@
 # this file overrides definitions from the config above
 services:
     defaultAnalysisParser:
-        factory: @cachedPathRoutingParser
+        factory: @pathRoutingParser
         arguments!: []
 
-    cachedPathRoutingParser:
+    cachedRectorParser:
         class: PHPStan\Parser\CachedParser
         arguments:
-            originalParser: @pathRoutingParser
+            originalParser: @rectorParser
             cachedNodesByStringCountMax: %cache.nodesByStringCountMax%
         autowired: false
 
     pathRoutingParser:
         class: PHPStan\Parser\PathRoutingParser
         arguments:
-            currentPhpVersionRichParser: @rectorParser
-            currentPhpVersionSimpleParser: @rectorParser
+            currentPhpVersionRichParser: @cachedRectorParser
+            currentPhpVersionSimpleParser: @cachedRectorParser
             php8Parser: @php8Parser
         autowired: false
 

--- a/config/phpstan/parser.neon
+++ b/config/phpstan/parser.neon
@@ -2,8 +2,15 @@
 # this file overrides definitions from the config above
 services:
     defaultAnalysisParser:
-        factory: @pathRoutingParser
+        factory: @cachedPathRoutingParser
         arguments!: []
+
+    cachedPathRoutingParser:
+        class: PHPStan\Parser\CachedParser
+        arguments:
+            originalParser: @pathRoutingParser
+            cachedNodesByStringCountMax: %cache.nodesByStringCountMax%
+        autowired: false
 
     pathRoutingParser:
         class: PHPStan\Parser\PathRoutingParser


### PR DESCRIPTION
Fixes: https://github.com/rectorphp/rector/issues/6913

So I used git bisect and found the problem. It wasn't about PHPStan 1.3 at all, it was about the parser config.

In my testing (when downgrading vendor/symfony to PHP 7.1 like I do in phpstan-src):

dev-main: 2074 MB
After my first commit: 1282 MB
After my second commit: 1180 MB