### PR TITLE
Fix access to optional array key when using `debug_backtrace()` function

### DIFF
--- a/src/Exception/ShouldNotHappenException.php
+++ b/src/Exception/ShouldNotHappenException.php
@@ -26,11 +26,11 @@ final class ShouldNotHappenException extends Exception
     {
         $debugBacktrace = debug_backtrace();
 
-        $class = $debugBacktrace[2]['class'] ?? null;
-        $function = (string) $debugBacktrace[2]['function'];
-        $line = (int) $debugBacktrace[1]['line'];
+        $class = isset($debugBacktrace[2]['class']) ? (string) $debugBacktrace[2]['class'] : null;
+        $function = isset($debugBacktrace[2]['function']) ? (string) $debugBacktrace[2]['function'] : '';
+        $line = isset($debugBacktrace[1]['line']) ? (int) $debugBacktrace[1]['line'] : 0;
 
-        $method = $class ? ($class . '::' . $function) : $function;
+        $method = $class !== null ? ($class . '::' . $function) : $function;
 
         return sprintf('Look at "%s()" on line %d', $method, $line);
     }


### PR DESCRIPTION
As per title, both the `function` and `line` keys are optional in the frames of the stacktrace, so proper checking must be added to avoid crashing and PHPStan complaining.