### PR TITLE
[DowngradePhp80] Add DowngradeNumberFormatNoFourthArgRector

### DIFF
--- a/config/set/downgrade-php80.php
+++ b/config/set/downgrade-php80.php
@@ -17,6 +17,7 @@ use Rector\DowngradePhp80\Rector\ClassMethod\DowngradeTrailingCommasInParamUseRe
 use Rector\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector;
 use Rector\DowngradePhp80\Rector\Expression\DowngradeThrowExprRector;
 use Rector\DowngradePhp80\Rector\FuncCall\DowngradeArrayFilterNullableCallbackRector;
+use Rector\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector;
 use Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrContainsRector;
 use Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrEndsWithRector;
 use Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrStartsWithRector;
@@ -80,4 +81,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeReflectionPropertyGetDefaultValueRector::class);
     $services->set(DowngradeReflectionClassGetConstantsFilterRector::class);
     $services->set(DowngradeArrayFilterNullableCallbackRector::class);
+    $services->set(DowngradeNumberFormatNoFourthArgRector::class);
 };

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/DowngradeNumberFormatNoFourthArgRectorTest.php
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/DowngradeNumberFormatNoFourthArgRectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeNumberFormatNoFourthArgRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     * @requires PHP 8.0
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        return number_format(1000, 2, ',');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        return number_format(1000, 2, ',', ',');
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_different_func_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_different_func_call.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector\Fixture;
+
+class SkipDifferentFuncCall
+{
+    public function run(string $data)
+    {
+        return strlen($data);
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_has_fourth_arg.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_has_fourth_arg.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector\Fixture;
+
+class SkipHasFourthArg
+{
+    public function run(float $data)
+    {
+        return number_format($data, 2, ',', '.');
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_named_arg.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_named_arg.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector\Fixture;
+
+class SkipNamedArg
+{
+    public function run(float $data)
+    {
+        return number_format(num: $data, decimals: 2);
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_no_third_arg.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/Fixture/skip_no_third_arg.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector\Fixture;
+
+class SkipNoThirdArg
+{
+    public function run(float $data)
+    {
+        return number_format($data, 2);
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeNumberFormatNoFourthArgRector::class);
+};

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://www.php.net/manual/en/function.number-format.php#refsect1-function.number-format-changelog
+ *
+ * @see Rector\Tests\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector\DowngradeNumberFormatNoFourthArgRectorTest
+ */
+final class DowngradeNumberFormatNoFourthArgRector extends AbstractRector
+{
+    public function __construct(private readonly ArgsAnalyzer $argsAnalyzer)
+    {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Downgrade number_format arg to fill 4th arg when only 3rd arg filled',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return number_format(1000, 2, ',');
+    }
+}
+CODE_SAMPLE
+,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return number_format(1000, 2, ',', ',');
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function shouldSkip(FuncCall $funcCall): bool
+    {
+        if (! $this->nodeNameResolver->isName($funcCall, 'number_format')) {
+            return true;
+        }
+
+        $args = $funcCall->getArgs();
+        if ($this->argsAnalyzer->hasNamedArg($args)) {
+            return true;
+        }
+
+        if (isset($args[3])) {
+            return true;
+        }
+
+        return ! isset($args[2]);
+    }
+}

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\Rector\AbstractRector;
-use Rector\Core\Reflection\ReflectionResolver;
 use ReflectionFunction;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -23,8 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DowngradeNumberFormatNoFourthArgRector extends AbstractRector
 {
     public function __construct(
-        private readonly ArgsAnalyzer $argsAnalyzer,
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ArgsAnalyzer $argsAnalyzer
     ) {
     }
 

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\String_;
 use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Reflection\ReflectionResolver;
+use ReflectionFunction;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DowngradeNumberFormatNoFourthArgRector extends AbstractRector
 {
     public function __construct(
-        private readonly ArgsAnalyzer $argsAnalyzer
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -69,6 +74,9 @@ CODE_SAMPLE
         if ($this->shouldSkip($node)) {
             return null;
         }
+
+        $reflectionFunction = new ReflectionFunction('number_format');
+        $node->args[3] = new Arg(new String_($reflectionFunction->getParameters()[3]->getDefaultValue()));
 
         return $node;
     }

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeNumberFormatNoFourthArgRector.php
@@ -18,8 +18,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeNumberFormatNoFourthArgRector extends AbstractRector
 {
-    public function __construct(private readonly ArgsAnalyzer $argsAnalyzer)
-    {
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/src/NodeAnalyzer/ArgsAnalyzer.php
+++ b/src/NodeAnalyzer/ArgsAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\VariadicPlaceholder;
 
 final class ArgsAnalyzer
@@ -40,5 +41,19 @@ final class ArgsAnalyzer
         }
 
         return true;
+    }
+
+    /**
+     * @param Arg[] $args
+     */
+    public function hasNamedArg(array $args): bool
+    {
+        foreach ($args as $arg) {
+            if ($arg->name instanceof Identifier) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -225,7 +225,7 @@ final class BetterNodeFinder
 
     /**
      * @param Node|Node[] $nodes
-     * @param callable(Node $filter): bool $filter
+     * @param callable(Node $node): bool $filter
      */
     public function findFirst(Node | array $nodes, callable $filter): ?Node
     {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -224,6 +224,7 @@ final class BetterNodeFinder
     }
 
     /**
+     * @param Node|Node[] $nodes
      * @param callable(Node $filter): bool $filter
      */
     public function findFirst(Node | array $nodes, callable $filter): ?Node

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -224,8 +224,8 @@ final class BetterNodeFinder
     }
 
     /**
-     * @param Node|Node[] $nodes
-     * @param callable(Node $node): bool $filter
+     * @param Node|Node[] $filters
+     * @param callable(Node $filter): bool $filter
      */
     public function findFirst(Node | array $nodes, callable $filter): ?Node
     {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -224,7 +224,6 @@ final class BetterNodeFinder
     }
 
     /**
-     * @param Node|Node[] $filters
      * @param callable(Node $filter): bool $filter
      */
     public function findFirst(Node | array $nodes, callable $filter): ?Node


### PR DESCRIPTION
In php 8.0, number_format allow up to 3rd argument without 4th argument, eg:

```php
echo number_format(1000, 2, ',');
```

but it will cause error in php 7.x, ref https://3v4l.org/pq9e1

This PR add `DowngradeNumberFormatNoFourthArgRector` to add 4th argument by default value.