### PR TITLE
[Core] Reduce getNewStmts() call on FormatPerservingPrinter

### DIFF
--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -65,13 +65,17 @@ final class FormatPerservingPrinter
      */
     private function resolveNewStmts(File $file): array
     {
-        if (count($file->getNewStmts()) === 1) {
-            $onlyStmt = $file->getNewStmts()[0];
-            if ($onlyStmt instanceof FileWithoutNamespace) {
-                return $onlyStmt->stmts;
-            }
+        $newStmts = $file->getNewStmts();
+
+        if (count($newStmts) !== 1) {
+            return $newStmts;
         }
 
-        return $file->getNewStmts();
+        $onlyStmt = $newStmts[0];
+        if (! $onlyStmt instanceof FileWithoutNamespace) {
+            return $newStmts;
+        }
+
+        return $onlyStmt->stmts;
     }
 }

--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -6,6 +6,7 @@ namespace Rector\Core\PhpParser\Printer;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Namespace_;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\ValueObject\Application\File;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -71,6 +72,7 @@ final class FormatPerservingPrinter
             return $newStmts;
         }
 
+        /** @var Namespace_|FileWithoutNamespace $onlyStmt */
         $onlyStmt = $newStmts[0];
         if (! $onlyStmt instanceof FileWithoutNamespace) {
             return $newStmts;


### PR DESCRIPTION
- assign `file->getNewStmts()` to variable to avoid repetitive its call.
- return early.