### PR TITLE
[Parallel] Increase ParallelFileProcessor::TIMEOUT_IN_SECONDS to 120

### DIFF
--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -41,7 +41,7 @@ final class ParallelFileProcessor
     /**
      * @var int
      */
-    final public const TIMEOUT_IN_SECONDS = 60;
+    final public const TIMEOUT_IN_SECONDS = 120;
 
     /**
      * @var int


### PR DESCRIPTION
Tested in macbook pro 2011 dual core i5, running parallel on CodeIgniter4 project, with 60 seconds timeout, it got error:

```bash
vendor/bin/rector 
 120/688 [▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░]  17%
                                                                                                                        
 [ERROR] Could not process                                                                                              
         "/Users/samsonasik/www/CodeIgniter4/vendor/rector/rector/vendor/symplify/easy-parallel/src/ValueObject/Parallel
         Process.php" file, due to:                                                                                     
         "Child process timed out after 60 seconds". On line: 100                                                       
                                                                                                                        

                                                                                                                        
 [ERROR] Could not process some files, due to:                                                                          
         "Reached system errors count limit of 20, exiting...".                                                                                                                               
```

with 120 seconds, it got working ok:

```bash
vendor/bin/rector --clear-cache
 688/688 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                                                                                                                        
                                                                                                                                                                                                                     
                                                                                                                        
```