### PR TITLE
Update test fixture: Do not remove `true|T` from phpdoc as it cannot be narrowed to native `bool|T` type hint

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/true_pseudo_type.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/true_pseudo_type.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+final class TruePseudoType
+{
+    /**
+     * @return true|int
+     */
+    public function go($value)
+    {
+        return (int) $value ?? true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+final class TruePseudoType
+{
+    /**
+     * @return true|int
+     */
+    public function go($value): int|bool
+    {
+        return (int) $value ?? true;
+    }
+}
+
+?>


### PR DESCRIPTION
Original code does not compile

https://3v4l.org/klALN