### PR TITLE
Remove closure dead param (add fixture)

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/remove_closure_param.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/remove_closure_param.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+$fcn =
+    /** @param int|string $_ */
+    static fn (int|string $_) : int => 0;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+$fcn =
+    static fn (int|string $_) : int => 0;
+
+?>


### PR DESCRIPTION
_I always check how to fix the rule but no success so far_

_The param is detected dead and marked as `PhpDocNodeTraverser::NODE_REMOVE`. Did not find out where this should be removed actually._