### PR TITLE
Fix handling of $this return type in UnionTypes rule

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_static_this_class.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_static_this_class.php.inc
@@ -2,12 +2,12 @@
 
 namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
 
-final class SkipUnionSelfThisFinalClass
+class SkipUnionStaticThisClass
 {
     /**
      * @return $this
      */
-    public function withFromId(int $fromId): self
+    public function withFromId(int $fromId): static
     {
         return $this;
     }


### PR DESCRIPTION
`$this` refers to the exact object identity, not just the same type. Therefore, it's valid and should not be removed
@see https://wiki.php.net/rfc/this_return_type for more context

Fixes https://github.com/rectorphp/rector-src/pull/1246