### PR TITLE
Add failing test fixture for CallableThisArrayToAnonymousFunctionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/demo_file.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/demo_file.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class DemoFile
+{
+    public function run(callable $transform)
+    {
+        $transform();
+    }
+    
+    public function run2()
+    {
+        $this->run([static::class, 'test']);
+    }
+    
+    public static function test(): void
+    {
+        echo 'test';
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class DemoFile
+{
+    public function run(callable $transform)
+    {
+        $transform();
+    }
+    
+    public function run2()
+    {
+        $this->run(function () : void {
+            static::test();
+        });
+    }
+    
+    public static function test(): void
+    {
+        echo 'test';
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for CallableThisArrayToAnonymousFunctionRector

Based on https://getrector.org/demo/1ec74754-9153-677e-92f6-f53ce8cf82e4

Failing test for: https://github.com/rectorphp/rector/issues/6935#issuecomment-1012156852