### PR TITLE
Revert "Fix $this/self docblock compare removed on on-final class, as it can refer to child this type (#1246)"

### DIFF
--- a/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -105,7 +105,7 @@ final class TypeComparator
             return false;
         }
 
-        return true;
+        return $this->isThisTypeInFinalClass($phpStanDocType, $phpParserNodeType, $node);
     }
 
     public function isSubtype(Type $checkedType, Type $mainType): bool
@@ -265,5 +265,17 @@ final class TypeComparator
             && $phpStanDocType instanceof ConstantScalarType
             && $phpParserNodeType->isSuperTypeOf($phpStanDocType)
                 ->yes();
+    }
+
+    private function isThisTypeInFinalClass(Type $phpStanDocType, Type $phpParserNodeType, Node $node): bool
+    {
+
+        /**
+         * Special case for $this/(self|static) compare
+         *
+         * $this refers to the exact object identity, not just the same type. Therefore, it's valid and should not be removed
+         * @see https://wiki.php.net/rfc/this_return_type for more context
+         */
+        return ! ($phpStanDocType instanceof ThisType && $phpParserNodeType instanceof StaticType);
     }
 }

--- a/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\TypeComparator;
 
 use PhpParser\Node;
-use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -23,7 +21,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\NodeTypeResolver\PHPStan\TypeHasher;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -108,7 +105,7 @@ final class TypeComparator
             return false;
         }
 
-        return $this->isThisTypeInFinalClass($phpStanDocType, $phpParserNodeType, $node);
+        return true;
     }
 
     public function isSubtype(Type $checkedType, Type $mainType): bool
@@ -268,21 +265,5 @@ final class TypeComparator
             && $phpStanDocType instanceof ConstantScalarType
             && $phpParserNodeType->isSuperTypeOf($phpStanDocType)
                 ->yes();
-    }
-
-    private function isThisTypeInFinalClass(Type $phpStanDocType, Type $phpParserNodeType, Node $node): bool
-    {
-        // special case for non-final $this/self compare; in case of interface/abstract class, it can be another $this
-        if ($phpStanDocType instanceof ThisType && $phpParserNodeType instanceof ThisType) {
-            $scope = $node->getAttribute(AttributeKey::SCOPE);
-            if ($scope instanceof Scope) {
-                $classReflection = $scope->getClassReflection();
-                if ($classReflection instanceof ClassReflection) {
-                    return $classReflection->isFinal();
-                }
-            }
-        }
-
-        return true;
     }
 }

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_self_this_final_class.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_self_this_final_class.php.inc
@@ -12,19 +12,3 @@ final class SkipUnionSelfThisFinalClass
         return $this;
     }
 }
-
-?>
------
-<?php
-
-namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
-
-final class SkipUnionSelfThisFinalClass
-{
-    public function withFromId(int $fromId): self
-    {
-        return $this;
-    }
-}
-
-?>

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_static_this_class.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_static_this_class.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+class SkipUnionStaticThisClass
+{
+    /**
+     * @return $this
+     */
+    public function withFromId(int $fromId): static
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
This reverts commit a2c2979a

_I'm trying to fix UnionTypes rule so it does not report false-positives and I can run it in CI._

The commit mentioned above broke the rule as it removes `$this` types while those should stay.

As said in https://github.com/rectorphp/rector-src/pull/1665#discussion_r783083803, this can be handled after Phpstan is able to distinguish between `$this` and `self`. That means until then Rector should not touch such code.

It's better not to do anything rather than do it the wrong way.