### PR TITLE
[NodeTypeResolver] Move handle previous reassign cast on getType to NodeTypeResolver::getType()

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -119,7 +119,9 @@ final class NodeTypeResolver
 
     public function getType(Node $node): Type
     {
-        $previousCastedAssign = $this->betterNodeFinder->findFirstPreviousOfNode($node, function (Node $subNode) use ($node): bool {
+        $previousCastedAssign = $this->betterNodeFinder->findFirstPreviousOfNode($node, function (Node $subNode) use (
+            $node
+        ): bool {
             if (! $subNode instanceof Assign) {
                 return false;
             }

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -134,8 +134,6 @@ final class EregToPcreTransformer
                 }
 
                 $start = true;
-
-                $i = (int) $i;
                 [$cls, $i] = $this->processSquareBracket($content, $i, $l, $cls, $start);
 
                 if ($i >= $l) {
@@ -190,8 +188,6 @@ final class EregToPcreTransformer
                 $r[$rr] .= $char;
                 ++$i;
             } elseif ($char === '{') {
-                $i = (int) $i;
-
                 $i = $this->processCurlyBracket($content, $i, $r, $rr);
             }
         }

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -7,7 +7,6 @@ namespace Rector\Php81\Rector\FuncCall;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Cast\String_ as CastString_;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
@@ -190,31 +189,10 @@ CODE_SAMPLE
             }
         }
 
-        if ($this->isCastedReassign($argValue)) {
-            return null;
-        }
-
         $args[$position]->value = new CastString_($argValue);
         $funcCall->args = $args;
 
         return $funcCall;
-    }
-
-    private function isCastedReassign(Expr $expr): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($expr, function (Node $subNode) use (
-            $expr
-        ): bool {
-            if (! $subNode instanceof Assign) {
-                return false;
-            }
-
-            if (! $this->nodeComparator->areNodesEqual($subNode->var, $expr)) {
-                return false;
-            }
-
-            return $subNode->expr instanceof CastString_;
-        });
     }
 
     private function isAnErrorTypeFromParentScope(Expr $expr, Type $type): bool


### PR DESCRIPTION
Previously, in PR https://github.com/rectorphp/rector-src/pull/1655, it require to check on the rule to get type of previously re-assigned with cast so use its cast type.

This PR add the get type from the previuos assign expr cast to `NodeTypeResolver` so the functionality work on other rules that uses `NodeTypeResolver::getType()`