### PR TITLE
[Parallel] Add Option PARALLEL_TIMEOUT_IN_SECONDS and PARALLEL_SYSTEM_ERROR_COUNT_LIMIT constant to allow reconfigure it in rector config

### DIFF
--- a/config/parameters.php
+++ b/config/parameters.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
 use Rector\Core\Configuration\Option;
-use Rector\Parallel\Application\ParallelFileProcessor;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -22,8 +21,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PARALLEL, false);
     $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, 16);
     $parameters->set(Option::PARALLEL_JOB_SIZE, 20);
-    $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, ParallelFileProcessor::TIMEOUT_IN_SECONDS);
-    $parameters->set(Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT, ParallelFileProcessor::SYSTEM_ERROR_COUNT_LIMIT);
+    $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, 120);
+    $parameters->set(Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT, 20);
 
     // FQN class importing
     $parameters->set(Option::AUTO_IMPORT_NAMES, false);

--- a/config/parameters.php
+++ b/config/parameters.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
 use Rector\Core\Configuration\Option;
+use Rector\Parallel\Application\ParallelFileProcessor;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -21,6 +22,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PARALLEL, false);
     $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, 16);
     $parameters->set(Option::PARALLEL_JOB_SIZE, 20);
+    $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, ParallelFileProcessor::TIMEOUT_IN_SECONDS);
+    $parameters->set(Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT, ParallelFileProcessor::SYSTEM_ERROR_COUNT_LIMIT);
 
     // FQN class importing
     $parameters->set(Option::AUTO_IMPORT_NAMES, false);

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -39,16 +39,6 @@ use Throwable;
  */
 final class ParallelFileProcessor
 {
-    /**
-     * @var int
-     */
-    final public const TIMEOUT_IN_SECONDS = 120;
-
-    /**
-     * @var int
-     */
-    final public const SYSTEM_ERROR_COUNT_LIMIT = 20;
-
     private ProcessPool|null $processPool = null;
 
     public function __construct(

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -125,7 +125,9 @@ final class ParallelFileProcessor
         };
 
         $timeoutInSeconds = $this->parameterProvider->provideIntParameter(Option::PARALLEL_TIMEOUT_IN_SECONDS);
-        $systemErrorCountLimit = $this->parameterProvider->provideIntParameter(Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT);
+        $systemErrorCountLimit = $this->parameterProvider->provideIntParameter(
+            Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT
+        );
 
         for ($i = 0; $i < $numberOfProcesses; ++$i) {
             // nothing else to process, stop now
@@ -143,11 +145,7 @@ final class ParallelFileProcessor
                 $serverPort,
             );
 
-            $parallelProcess = new ParallelProcess(
-                $workerCommandLine,
-                $streamSelectLoop,
-                $timeoutInSeconds
-            );
+            $parallelProcess = new ParallelProcess($workerCommandLine, $streamSelectLoop, $timeoutInSeconds);
 
             $parallelProcess->start(
                 // 1. callable on data

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -185,7 +185,9 @@ final class ParallelFileProcessor
                     $postFileCallback($json[Bridge::FILES_COUNT]);
 
                     $systemErrorsCount += $json[Bridge::SYSTEM_ERRORS_COUNT];
-                    if ($systemErrorsCount >= $this->parameterProvider->provideIntParameter(Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT)) {
+                    if ($systemErrorsCount >= $this->parameterProvider->provideIntParameter(
+                        Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT
+                    )) {
                         $reachedInternalErrorsCountLimit = true;
                         $this->processPool->quitAll();
                     }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -200,4 +200,14 @@ final class Option
      * @var string
      */
     final public const PARALLEL_MAX_NUMBER_OF_PROCESSES = 'parallel-max-number-of-processes';
+
+    /**
+     * @var string
+     */
+    final public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
+
+    /**
+     * @var string
+     */
+    final public const PARALLEL_SYSTEM_ERROR_COUNT_LIMIT = 'parallel-system-error-count-limit';
 }


### PR DESCRIPTION
To allow user to configure based on condition of the computer they used.