### PR TITLE
Remove useless type castings in `ShouldNotHappenException::createDefaultMessageWithLocation()` method

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -627,3 +627,9 @@ parameters:
 
         # impossible to validate json string is a class-string
         - '#Parameter \#1 \$rectorClass of class Rector\\ChangesReporting\\ValueObject\\RectorWithLineChange constructor expects class\-string<Rector\\Core\\Contract\\Rector\\RectorInterface\>\|Rector\\Core\\Contract\\Rector\\RectorInterface, string given#'
+
+        # will be solved once https://github.com/phpstan/phpstan-src/pull/914 gets released
+        -
+            message: '#sprintf\(\) call mask types does not match provided arguments types#'
+            paths:
+                - src/Exception/ShouldNotHappenException.php

--- a/src/Exception/ShouldNotHappenException.php
+++ b/src/Exception/ShouldNotHappenException.php
@@ -26,9 +26,9 @@ final class ShouldNotHappenException extends Exception
     {
         $debugBacktrace = debug_backtrace();
 
-        $class = isset($debugBacktrace[2]['class']) ? (string) $debugBacktrace[2]['class'] : null;
-        $function = isset($debugBacktrace[2]['function']) ? (string) $debugBacktrace[2]['function'] : '';
-        $line = isset($debugBacktrace[1]['line']) ? (int) $debugBacktrace[1]['line'] : 0;
+        $class = $debugBacktrace[2]['class'] ?? null;
+        $function = $debugBacktrace[2]['function'];
+        $line = $debugBacktrace[1]['line'] ?? 0;
 
         $method = $class !== null ? ($class . '::' . $function) : $function;
 


### PR DESCRIPTION
As per title, after #1648 got merged, my build in `phpstan/phpstan-src` is still failing because of useless type castings in `ShouldNotHappenException::createDefaultMessageWithLocation()`. The `function` key is the only one that should always be present, so checking its presence should is not needed as well