### PR TITLE
[Core] Refactor RectifiedAnalyzer to only exclude Class_

### DIFF
--- a/packages/NodeRemoval/AssignRemover.php
+++ b/packages/NodeRemoval/AssignRemover.php
@@ -30,9 +30,14 @@ final class AssignRemover
         $parent = $assign->getAttribute(AttributeKey::PARENT_NODE);
         if ($parent instanceof Expression) {
             $this->nodeRemover->removeNode($assign);
-        } else {
-            $this->nodesToReplaceCollector->addReplaceNodeWithAnotherNode($assign, $assign->expr);
-            $this->rectorChangeCollector->notifyNodeFileInfo($assign->expr);
+            return;
+        }
+
+        $this->nodesToReplaceCollector->addReplaceNodeWithAnotherNode($assign, $assign->expr);
+        $this->rectorChangeCollector->notifyNodeFileInfo($assign->expr);
+
+        if ($parent instanceof Assign) {
+            $this->removeAssignNode($parent);
         }
     }
 }

--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
@@ -6,10 +6,7 @@ namespace Rector\DeadCode\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Stmt\If_;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class ExprUsedInNextNodeAnalyzer
 {
@@ -23,24 +20,7 @@ final class ExprUsedInNextNodeAnalyzer
     {
         return (bool) $this->betterNodeFinder->findFirstNext(
             $expr,
-            function (Node $node) use ($expr): bool {
-                $isUsed = $this->exprUsedInNodeAnalyzer->isUsed($node, $expr);
-
-                if ($isUsed) {
-                    return true;
-                }
-
-                /**
-                 * handle when used along with RemoveAlwaysElseRector
-                 */
-                return $node instanceof If_ && $this->hasIfChangedByRemoveAlwaysElseRector($node);
-            }
+            fn (Node $node) : bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $expr)
         );
-    }
-
-    private function hasIfChangedByRemoveAlwaysElseRector(If_ $if): bool
-    {
-        $createdByRule = $if->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-        return in_array(RemoveAlwaysElseRector::class, $createdByRule, true);
     }
 }

--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNextNodeAnalyzer.php
@@ -20,7 +20,7 @@ final class ExprUsedInNextNodeAnalyzer
     {
         return (bool) $this->betterNodeFinder->findFirstNext(
             $expr,
-            fn (Node $node) : bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $expr)
+            fn (Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $expr)
         );
     }
 }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\ValueObject\Application\File;
@@ -18,17 +17,12 @@ use Rector\Core\ValueObject\RectifiedNode;
  *
  * Limitation:
  *
- *   It only check against Node which not Assign or Class_
+ *   It only check against Node which not a Class_
  *
  * which possibly changed by other process.
  */
 final class RectifiedAnalyzer
 {
-    /**
-     * @var array<class-string<Node>>
-     */
-    private const EXCLUDE_NODES = [Assign::class, Class_::class];
-
     /**
      * @var array<string, RectifiedNode|null>
      */
@@ -36,7 +30,7 @@ final class RectifiedAnalyzer
 
     public function verify(RectorInterface $rector, Node $node, File $currentFile): ?RectifiedNode
     {
-        if (in_array($node::class, self::EXCLUDE_NODES, true)) {
+        if ($node instanceof Class_) {
             return null;
         }
 


### PR DESCRIPTION
This is next step for verify node re-changed by rule for : 

```bash
Same Rector Rule <-> Same Node <-> Same File
```

which previously, we excluded the following nodes as limitation of `Nodes` to be checked:
- `Assign`
- `Class_`. 

This PR remove `Assign` from exclusion, by change `AssignRemover` to look up parent node, if parent node is an `Assign`, recursive call the `AssignRemover` to the parent node.

With its change, the `ExprUsedInNextNodeAnalyzer` no longer need a tweak for check next node is an `If_` and modified by `RemoveAlwaysElseRector`, as already handled in `RectifiedAnalyzer` for `Assign` check.