### PR TITLE
Ensure autoloader is loaded in globally installed Rector

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -96,6 +96,7 @@ final class AutoloadIncluder
      */
     public function autoloadProjectAutoloaderFile(): void
     {
+        $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../../autoload.php');
         $this->loadIfExistsAndNotLoadedYet(getcwd() . '/vendor/autoload.php');
     }
 

--- a/bin/rector.php
+++ b/bin/rector.php
@@ -91,10 +91,12 @@ final class AutoloadIncluder
     /**
      * In case Rector is installed as vendor dependency,
      * this autoloads the project vendor/autoload.php, including Rector
+     *
+     * This also accounts for running a globally installed Rector from the global composer vendor dir
      */
     public function autoloadProjectAutoloaderFile(): void
     {
-        $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../../autoload.php');
+        $this->loadIfExistsAndNotLoadedYet(getcwd() . '/vendor/autoload.php');
     }
 
     public function autoloadFromCommandLine(): void

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "rector/phpstan-rules": "^0.4.15",
         "spatie/enum": "^3.10",
         "symplify/coding-standard": "^10.0.9",
-        "symplify/easy-ci": "^10.0.9",
+        "symplify/easy-ci": "10.0.9",
         "symplify/easy-coding-standard": "^10.0.9",
         "symplify/easy-testing": "^10.0.9",
         "symplify/monorepo-builder": "^10.0.9",


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6903

When running a globally installed Rector, autoloading of the projects vendors is not happening

This PR changes that 

To replicate the problem

```
git clone git@github.com:MGatner/rector-error.git
cd rector-error
composer install 
composer global install rector/rector
rector process -vv
```

Before this PR:

```
 [ERROR] Could not process "src/MyException.php" file, due to:
         "System error: "PHPStan\BetterReflection\Reflection\ReflectionClass
         "CodeIgniter\Exceptions\ExceptionInterface" could not be found in the
         located source"
         Run Rector with "--debug" option and post the report here:
         https://github.com/rectorphp/rector/issues/new". On line: 26
```

After this PR


<img width="1109" alt="Screenshot 2022-01-16 at 00 29 46" src="https://user-images.githubusercontent.com/400092/149642509-7e84fdea-8345-4e77-98e6-eafa8d3b145a.png">

Tagging @MGatner 