### PR TITLE
Fix wrong typos rebase

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -379,7 +379,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
 ### AbsolutizeRequireAndIncludePathRector
 
-include/require to absolute path. This Rector might introduce backwards incompatible code, when the include/require beeing changed depends on the current working directory.
+include/require to absolute path. This Rector might introduce backwards incompatible code, when the include/require being changed depends on the current working directory.
 
 - class: [`Rector\CodeQuality\Rector\Include_\AbsolutizeRequireAndIncludePathRector`](../rules/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector.php)
 
@@ -434,7 +434,7 @@ Split 2 assigns ands to separate line
 
 ### ArrayKeyExistsTernaryThenValueToCoalescingRector
 
-Change `array_key_exists()` ternary to coalesing
+Change `array_key_exists()` ternary to coalescing
 
 - class: [`Rector\CodeQuality\Rector\Ternary\ArrayKeyExistsTernaryThenValueToCoalescingRector`](../rules/CodeQuality/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php)
 
@@ -1261,7 +1261,7 @@ Simplify array_search to in_array
 
 ### SimplifyBoolIdenticalTrueRector
 
-Symplify bool value compare to true or false
+Simplify bool value compare to true or false
 
 - class: [`Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector`](../rules/CodeQuality/Rector/Identical/SimplifyBoolIdenticalTrueRector.php)
 
@@ -3349,7 +3349,7 @@ Remove unused parent call with no parent class
 
 ### RemovePhpVersionIdCheckRector
 
-Remove unneded PHP_VERSION_ID check
+Remove unneeded PHP_VERSION_ID check
 
 :wrench: **configure it!**
 
@@ -5513,7 +5513,7 @@ change instanceof Object to is_resource
 
 ### DowngradePropertyPromotionRector
 
-Change constructor property promotion to property asssign
+Change constructor property promotion to property assign
 
 - class: [`Rector\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector`](../rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php)
 

--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1261,7 +1261,7 @@ Simplify array_search to in_array
 
 ### SimplifyBoolIdenticalTrueRector
 
-Simplify bool value compare to true or false
+Symplify bool value compare to true or false
 
 - class: [`Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector`](../rules/CodeQuality/Rector/Identical/SimplifyBoolIdenticalTrueRector.php)
 

--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1261,7 +1261,7 @@ Simplify array_search to in_array
 
 ### SimplifyBoolIdenticalTrueRector
 
-Symplify bool value compare to true or false
+Simplify bool value compare to true or false
 
 - class: [`Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector`](../rules/CodeQuality/Rector/Identical/SimplifyBoolIdenticalTrueRector.php)
 

--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/reassign_on_not_typed_param.php.inc
@@ -8,7 +8,7 @@ use stdClass;
 /**
  * @param DateTime|stdClass $value
  */
-function reasssignOnNotTypedParam($value)
+function reassignOnNotTypedParam($value)
 {
     $value = rand(0, 1)
         ? new stdClass
@@ -37,7 +37,7 @@ use stdClass;
 /**
  * @param DateTime|stdClass $value
  */
-function reasssignOnNotTypedParam($value)
+function reassignOnNotTypedParam($value)
 {
     $value = rand(0, 1)
         ? new stdClass

--- a/rules/CodeQuality/Rector/Identical/SimplifyBoolIdenticalTrueRector.php
+++ b/rules/CodeQuality/Rector/Identical/SimplifyBoolIdenticalTrueRector.php
@@ -22,7 +22,7 @@ final class SimplifyBoolIdenticalTrueRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Symplify bool value compare to true or false',
+            'Simplify bool value compare to true or false',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector.php
+++ b/rules/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector.php
@@ -24,7 +24,7 @@ final class AbsolutizeRequireAndIncludePathRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'include/require to absolute path. This Rector might introduce backwards incompatible code, when the include/require beeing changed depends on the current working directory.',
+            'include/require to absolute path. This Rector might introduce backwards incompatible code, when the include/require being changed depends on the current working directory.',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/CodeQuality/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
+++ b/rules/CodeQuality/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
@@ -24,7 +24,7 @@ final class ArrayKeyExistsTernaryThenValueToCoalescingRector extends AbstractRec
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Change array_key_exists() ternary to coalesing',
+            'Change array_key_exists() ternary to coalescing',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
+++ b/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
@@ -52,7 +52,7 @@ final class RemovePhpVersionIdCheckRector extends AbstractRector implements Conf
             self::PHP_VERSION_CONSTRAINT => PhpVersion::PHP_80,
         ];
         return new RuleDefinition(
-            'Remove unneded PHP_VERSION_ID check',
+            'Remove unneeded PHP_VERSION_ID check',
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -38,7 +38,7 @@ final class DowngradePropertyPromotionRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Change constructor property promotion to property asssign', [
+        return new RuleDefinition('Change constructor property promotion to property assign', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 class SomeClass

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -28,7 +28,7 @@ use Webmozart\Assert\Assert;
 final class AddVoidReturnTypeWhereNoReturnRector extends AbstractRector implements MinPhpVersionInterface, AllowEmptyConfigurableRectorInterface
 {
     /**
-     * @var string using phpdoc instead of a native void type can ease the migration path for consumers of code beeing processed.
+     * @var string using phpdoc instead of a native void type can ease the migration path for consumers of code being processed.
      */
     final public const USE_PHPDOC = 'use_phpdoc';
 


### PR DESCRIPTION
@TomasVotruba this is fix the typos in docs while generated from source at https://github.com/rectorphp/rector-src/pull/1682 which PR https://github.com/rectorphp/rector-src/pull/1684 from @PhilETaylor directly change docs which make it rolled back.