### PR TITLE
[DowngradePhp74] Do not remove non-null default value on nullable on DowngradeTypedPropertyRector

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector/Fixture/nullable_type_with_default_not_null.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector/Fixture/nullable_type_with_default_not_null.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture;
 
-class WithDefaultValue
+class NullableTypeWithDefaultNotNull
 {
     protected ?string $test = "test";
 }
@@ -13,7 +13,7 @@ class WithDefaultValue
 
 namespace Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture;
 
-class WithDefaultValue
+class NullableTypeWithDefaultNotNull
 {
     /**
      * @var string|null

--- a/rules-tests/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector/Fixture/with_default_value.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector/Fixture/with_default_value.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class WithDefaultValue
+{
+    protected ?string $test = "test";
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class WithDefaultValue
+{
+    /**
+     * @var string|null
+     */
+    protected $test = "test";
+}
+
+?>

--- a/rules/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector.php
@@ -66,7 +66,8 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->type instanceof NullableType) {
+        $default = $node->props[0]->default;
+        if ($node->type instanceof NullableType && $default instanceof Node && $this->valueResolver->isNull($default)) {
             $node->props[0]->default = null;
         }
 

--- a/rules/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/DowngradePhp74/Rector/Property/DowngradeTypedPropertyRector.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp74\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\ComplexType;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
@@ -67,7 +68,7 @@ CODE_SAMPLE
         }
 
         $default = $node->props[0]->default;
-        if ($node->type instanceof NullableType && $default instanceof Node && $this->valueResolver->isNull($default)) {
+        if ($node->type instanceof NullableType && $default instanceof Expr && $this->valueResolver->isNull($default)) {
             $node->props[0]->default = null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6925