### PR TITLE
[Php71] Skip iterable on CountOnNullRector

### DIFF
--- a/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_on_iterable.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_on_iterable.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\FuncCall\CountOnNullRector\Fixture;
+
+final class SkipOnIterable
+{
+    private function findAll(): iterable
+    {
+        return [];
+    }
+
+    public function run()
+    {
+        return count($this->findAll());
+    }
+}

--- a/rules/Php71/Rector/FuncCall/CountOnNullRector.php
+++ b/rules/Php71/Rector/FuncCall/CountOnNullRector.php
@@ -142,6 +142,10 @@ CODE_SAMPLE
 
     private function isAlwaysIterableType(Type $possibleUnionType): bool
     {
+        if ($possibleUnionType->isIterable()->yes()) {
+            return true;
+        }
+
         if (! $possibleUnionType instanceof UnionType) {
             return false;
         }


### PR DESCRIPTION
Given the following code:

```php
final class SkipOnIterable
{
    private function findAll(): iterable
    {
        return [];
    }

    public function run()
    {
        return count($this->findAll());
    }
}
```

It currently produce:

```diff
-        return count($this->findAll());
+        return is_array($this->findAll()) || $this->findAll() instanceof \Countable ? count($this->findAll()) : 0;
```

which should be skipped.