### PR TITLE
[Privatization] Skip ChangeReadOnlyVariableWithDefaultValueToConstantRector when local variable never used

### DIFF
--- a/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -105,7 +105,7 @@ final class TypeComparator
             return false;
         }
 
-        return $this->isThisTypeInFinalClass($phpStanDocType, $phpParserNodeType, $node);
+        return $this->isThisTypeInFinalClass($phpStanDocType, $phpParserNodeType);
     }
 
     public function isSubtype(Type $checkedType, Type $mainType): bool
@@ -267,7 +267,7 @@ final class TypeComparator
                 ->yes();
     }
 
-    private function isThisTypeInFinalClass(Type $phpStanDocType, Type $phpParserNodeType, Node $node): bool
+    private function isThisTypeInFinalClass(Type $phpStanDocType, Type $phpParserNodeType): bool
     {
 
         /**

--- a/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_defined_never_used.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_defined_never_used.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector\Fixture;
+
+class SkipDefinedNeverUsed
+{
+    public function run()
+    {
+        $replacements = [
+            'PHPUnit\Framework\TestCase\Notice' => 'expectNotice',
+            'PHPUnit\Framework\TestCase\Deprecated' => 'expectDeprecation',
+        ];
+    }
+}

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -94,10 +94,10 @@ final class ClassMethodAssignManipulator
 
     /**
      * @return Assign[]
+     * @param mixed[] $readOnlyVariableAssigns
      */
-    private function filterOutNeverUsedNext($readOnlyVariableAssigns)
+    private function filterOutNeverUsedNext(array $readOnlyVariableAssigns): array
     {
-        /** @var Assign[] */
         $filterOutNeverUsedNext = [];
 
         foreach ($readOnlyVariableAssigns as $readOnlyVariableAssign) {

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -75,24 +75,6 @@ final class ClassMethodAssignManipulator
         return $this->variableManipulator->filterOutChangedVariables($readOnlyVariableAssigns, $classMethod);
     }
 
-    /**
-     * @param Assign[] $variableAssigns
-     * @return Assign[]
-     */
-    private function filterOutNeverUsedNext($readOnlyVariableAssigns)
-    {
-        /** @var Assign[] */
-        $filterOutNeverUsedNext = [];
-
-        foreach ($readOnlyVariableAssigns as $readOnlyVariableAssign) {
-            if ($this->exprUsedInNextNodeAnalyzer->isUsed($readOnlyVariableAssign->var)) {
-                $filterOutNeverUsedNext[] = $readOnlyVariableAssign;
-            }
-        }
-
-        return $filterOutNeverUsedNext;
-    }
-
     public function addParameterAndAssignToMethod(
         ClassMethod $classMethod,
         string $name,
@@ -108,6 +90,23 @@ final class ClassMethodAssignManipulator
 
         $classMethodHash = spl_object_hash($classMethod);
         $this->alreadyAddedClassMethodNames[$classMethodHash][] = $name;
+    }
+
+    /**
+     * @return Assign[]
+     */
+    private function filterOutNeverUsedNext($readOnlyVariableAssigns)
+    {
+        /** @var Assign[] */
+        $filterOutNeverUsedNext = [];
+
+        foreach ($readOnlyVariableAssigns as $readOnlyVariableAssign) {
+            if ($this->exprUsedInNextNodeAnalyzer->isUsed($readOnlyVariableAssign->var)) {
+                $filterOutNeverUsedNext[] = $readOnlyVariableAssign;
+            }
+        }
+
+        return $filterOutNeverUsedNext;
     }
 
     /**

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -93,8 +93,8 @@ final class ClassMethodAssignManipulator
     }
 
     /**
+     * @param Assign[] $readOnlyVariableAssigns
      * @return Assign[]
-     * @param mixed[] $readOnlyVariableAssigns
      */
     private function filterOutNeverUsedNext(array $readOnlyVariableAssigns): array
     {

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -98,15 +98,10 @@ final class ClassMethodAssignManipulator
      */
     private function filterOutNeverUsedNext(array $readOnlyVariableAssigns): array
     {
-        $filterOutNeverUsedNext = [];
-
-        foreach ($readOnlyVariableAssigns as $readOnlyVariableAssign) {
-            if ($this->exprUsedInNextNodeAnalyzer->isUsed($readOnlyVariableAssign->var)) {
-                $filterOutNeverUsedNext[] = $readOnlyVariableAssign;
-            }
-        }
-
-        return $filterOutNeverUsedNext;
+        return array_filter(
+            $readOnlyVariableAssigns,
+            fn (Assign $assign): bool => $this->exprUsedInNextNodeAnalyzer->isUsed($assign->var)
+        );
     }
 
     /**

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -24,6 +24,7 @@ use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\Reflection\ReflectionResolver;
+use Rector\DeadCode\NodeAnalyzer\ExprUsedInNextNodeAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -41,7 +42,8 @@ final class ClassMethodAssignManipulator
         private readonly VariableManipulator $variableManipulator,
         private readonly NodeComparator $nodeComparator,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly ArrayDestructVariableFilter $arrayDestructVariableFilter
+        private readonly ArrayDestructVariableFilter $arrayDestructVariableFilter,
+        private readonly ExprUsedInNextNodeAnalyzer $exprUsedInNextNodeAnalyzer
     ) {
     }
 
@@ -64,7 +66,31 @@ final class ClassMethodAssignManipulator
         $readOnlyVariableAssigns = $this->filterOutMultiAssigns($readOnlyVariableAssigns);
         $readOnlyVariableAssigns = $this->filterOutForeachVariables($readOnlyVariableAssigns);
 
+        /**
+         * Remove unused variable assign is task of RemoveUnusedVariableAssignRector
+         * so no need to move to constant early
+         */
+        $readOnlyVariableAssigns = $this->filterOutNeverUsedNext($readOnlyVariableAssigns);
+
         return $this->variableManipulator->filterOutChangedVariables($readOnlyVariableAssigns, $classMethod);
+    }
+
+    /**
+     * @param Assign[] $variableAssigns
+     * @return Assign[]
+     */
+    private function filterOutNeverUsedNext($readOnlyVariableAssigns)
+    {
+        /** @var Assign[] */
+        $filterOutNeverUsedNext = [];
+
+        foreach ($readOnlyVariableAssigns as $readOnlyVariableAssign) {
+            if ($this->exprUsedInNextNodeAnalyzer->isUsed($readOnlyVariableAssign->var)) {
+                $filterOutNeverUsedNext[] = $readOnlyVariableAssign;
+            }
+        }
+
+        return $filterOutNeverUsedNext;
     }
 
     public function addParameterAndAssignToMethod(

--- a/tests/Issues/RemoveReadonlyLocalVariable/Fixture/remove_variable_assign_only.php.inc
+++ b/tests/Issues/RemoveReadonlyLocalVariable/Fixture/remove_variable_assign_only.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\RemoveReadonlyLocalVariable\Fixture;
+
+final class RemoveVariableAssignOnly
+{
+    public function run()
+    {
+        $replacements = [
+            'PHPUnit\Framework\TestCase\Notice' => 'expectNotice',
+            'PHPUnit\Framework\TestCase\Deprecated' => 'expectDeprecation',
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\RemoveReadonlyLocalVariable\Fixture;
+
+final class RemoveVariableAssignOnly
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/tests/Issues/RemoveReadonlyLocalVariable/RemoveReadonlyLocalVariableTest.php
+++ b/tests/Issues/RemoveReadonlyLocalVariable/RemoveReadonlyLocalVariableTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveReadonlyLocalVariable;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveReadonlyLocalVariableTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RemoveReadonlyLocalVariable/config/configured_rule.php
+++ b/tests/Issues/RemoveReadonlyLocalVariable/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
+use Rector\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ChangeReadOnlyVariableWithDefaultValueToConstantRector::class);
+    $services->set(RemoveUnusedVariableAssignRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
class SkipDefinedNeverUsed
{
    public function run()
    {
        $replacements = [
            'PHPUnit\Framework\TestCase\Notice' => 'expectNotice',
            'PHPUnit\Framework\TestCase\Deprecated' => 'expectDeprecation',
        ];
    }
}
```

It currently produce create constant for it, while never used:

```diff
+    /**
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'PHPUnit\Framework\TestCase\Notice' => 'expectNotice',
+        'PHPUnit\Framework\TestCase\Deprecated' => 'expectDeprecation',
+    ];
     public function run()
     {
-        $replacements = [
-            'PHPUnit\Framework\TestCase\Notice' => 'expectNotice',
-            'PHPUnit\Framework\TestCase\Deprecated' => 'expectDeprecation',
-        ];
```

The removal of unused variable should be use `RemoveUnusedVariableAssignRector` rule for it, so the moving to constant need to be skipped.