### PR TITLE
[Privatization] Skip property with attributes in ChangeReadOnlyPropertyWithDefaultValueToConstantRector

### DIFF
--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_attribute.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_attribute.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+class SkipAttribute
+{
+    #[ORM\Column(type: 'json')]
+    private string $parameters = '{}';
+}

--- a/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
@@ -130,6 +130,14 @@ CODE_SAMPLE
             return true;
         }
 
-        return $this->isObjectType($classLike, new ObjectType('PHP_CodeSniffer\Sniffs\Sniff'));
+        if ($property->getAttributes() !== []) {
+            return true;
+        }
+
+        if ($this->isObjectType($classLike, new ObjectType('PHP_CodeSniffer\Sniffs\Sniff'))) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
@@ -130,14 +130,10 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($property->getAttributes() !== []) {
+        if ($property->attrGroups !== []) {
             return true;
         }
 
-        if ($this->isObjectType($classLike, new ObjectType('PHP_CodeSniffer\Sniffs\Sniff'))) {
-            return true;
-        }
-
-        return false;
+        return $this->isObjectType($classLike, new ObjectType('PHP_CodeSniffer\Sniffs\Sniff'));
     }
 }


### PR DESCRIPTION
- Do not run `ChangeReadOnlyPropertyWithDefaultValueToConstantRector` on properties with attributes
- fix attributes to attrGroups
