### PR TITLE
[Php70] Do not take side effect on IfToSpaceshipRector

### DIFF
--- a/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/do_not_take_side_effect.php.inc
+++ b/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/do_not_take_side_effect.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\SideEffect;
+
+class SideEffect {
+
+	public static function foo( $param ) {
+		if ( 0 === strpos( $param, '/*' ) ) {
+			$foo = 1;
+		}
+
+		$foo = 2;
+		return $foo;
+	}
+
+	private static function rsort( $a, $b ) {
+		if ( $a['bar'] === $b['bar'] ) {
+			return 0;
+		} else {
+			return ( $a['bar'] > $b['bar'] ) ? -1 : 1;
+		}
+	}
+
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\SideEffect;
+
+class SideEffect {
+
+	public static function foo( $param ) {
+		if ( 0 === strpos( $param, '/*' ) ) {
+			$foo = 1;
+		}
+
+		$foo = 2;
+		return $foo;
+	}
+
+	private static function rsort( $a, $b ) {
+		return $a['bar'] <=> $b['bar'];
+	}
+
+}
+
+?>

--- a/rules/Php70/Rector/If_/IfToSpaceshipRector.php
+++ b/rules/Php70/Rector/If_/IfToSpaceshipRector.php
@@ -228,7 +228,7 @@ CODE_SAMPLE
         }
     }
 
-    private function processTernary(Ternary $ternary, ?Return_ $nextNode): void
+    private function processTernary(Ternary $ternary, ?Return_ $return): void
     {
         if ($ternary->cond instanceof Smaller) {
             $this->firstValue = $ternary->cond->left;
@@ -239,7 +239,7 @@ CODE_SAMPLE
             }
 
             $this->onGreater = $this->valueResolver->getValue($ternary->else);
-            $this->nextNode = $nextNode;
+            $this->nextNode = $return;
         } elseif ($ternary->cond instanceof Greater) {
             $this->firstValue = $ternary->cond->right;
             $this->secondValue = $ternary->cond->left;
@@ -249,7 +249,7 @@ CODE_SAMPLE
             }
 
             $this->onSmaller = $this->valueResolver->getValue($ternary->else);
-            $this->nextNode = $nextNode;
+            $this->nextNode = $return;
         }
     }
 }

--- a/rules/Php70/Rector/If_/IfToSpaceshipRector.php
+++ b/rules/Php70/Rector/If_/IfToSpaceshipRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
 
     private function processReturnSpaceship(Expr $firstValue, Expr $secondValue): Return_
     {
-        if ($this->nextNode !== null) {
+        if ($this->nextNode instanceof Return_) {
             $this->removeNode($this->nextNode);
         }
 
@@ -169,11 +169,11 @@ CODE_SAMPLE
         if ($if->else !== null) {
             $this->processElse($if->else);
         } else {
-            $this->nextNode = $if->getAttribute(AttributeKey::NEXT_NODE);
-            if ($this->nextNode instanceof Return_ && $this->nextNode->expr instanceof Ternary) {
+            $nextNode = $if->getAttribute(AttributeKey::NEXT_NODE);
+            if ($nextNode instanceof Return_ && $nextNode->expr instanceof Ternary) {
                 /** @var Ternary $ternary */
-                $ternary = $this->nextNode->expr;
-                $this->processTernary($ternary);
+                $ternary = $nextNode->expr;
+                $this->processTernary($ternary, $nextNode);
             }
         }
     }
@@ -224,11 +224,11 @@ CODE_SAMPLE
         /** @var Return_ $returnNode */
         $returnNode = $else->stmts[0];
         if ($returnNode->expr instanceof Ternary) {
-            $this->processTernary($returnNode->expr);
+            $this->processTernary($returnNode->expr, null);
         }
     }
 
-    private function processTernary(Ternary $ternary): void
+    private function processTernary(Ternary $ternary, ?Return_ $nextNode): void
     {
         if ($ternary->cond instanceof Smaller) {
             $this->firstValue = $ternary->cond->left;
@@ -239,6 +239,7 @@ CODE_SAMPLE
             }
 
             $this->onGreater = $this->valueResolver->getValue($ternary->else);
+            $this->nextNode = $nextNode;
         } elseif ($ternary->cond instanceof Greater) {
             $this->firstValue = $ternary->cond->right;
             $this->secondValue = $ternary->cond->left;
@@ -248,6 +249,7 @@ CODE_SAMPLE
             }
 
             $this->onSmaller = $this->valueResolver->getValue($ternary->else);
+            $this->nextNode = $nextNode;
         }
     }
 }

--- a/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
@@ -13,7 +13,6 @@ use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Privatization\NodeFactory\ClassConstantFactory;
 use Rector\Privatization\NodeReplacer\PropertyFetchWithConstFetchReplacer;
-use Symplify\PHPStanRules\Reflection\PropertyAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
@@ -133,6 +133,7 @@ CODE_SAMPLE
         if ($property->attrGroups !== []) {
             return true;
         }
+
         return $this->isObjectType($classLike, new ObjectType('PHP_CodeSniffer\Sniffs\Sniff'));
     }
 }

--- a/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
@@ -133,11 +133,6 @@ CODE_SAMPLE
         if ($property->attrGroups !== []) {
             return true;
         }
-
-        if ($this->isObjectType($classLike, new ObjectType('PHP_CodeSniffer\Sniffs\Sniff'))) {
-            return true;
-        }
-
-        return false;
+        return $this->isObjectType($classLike, new ObjectType('PHP_CodeSniffer\Sniffs\Sniff'));
     }
 }


### PR DESCRIPTION
Copy fixture from https://github.com/rectorphp/rector-src/pull/1675 which in invalid location

Given the following code:

```php
class SideEffect {

	public static function foo( $param ) {
		if ( 0 === strpos( $param, '/*' ) ) {
			$foo = 1;
		}

		$foo = 2;
		return $foo;
	}

	private static function rsort( $a, $b ) {
		if ( $a['bar'] === $b['bar'] ) {
			return 0;
		} else {
			return ( $a['bar'] > $b['bar'] ) ? -1 : 1;
		}
	}

}
```

It currently remove unrelated code to spaceship:

```diff
-
-               $foo = 2;
                return $foo;
```

which should not.

Closes https://github.com/rectorphp/rector-src/pull/1675
Fixes https://github.com/rectorphp/rector/issues/6937