### PR TITLE
[Php56] Skip AddDefaultValueForUndefinedVariableRector on empty() check

### DIFF
--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_empty_check.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_empty_check.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class SkipEmptyCheck
+{
+    public function run($check)
+    {
+        if ($check) {
+            $data = 'value';
+        }
+
+        return ! empty($data)
+            ? $data
+            : 'default';
+    }
+
+    public function run2()
+    {
+        if (empty($data)) {
+            $data[] = 'test';
+        }
+
+        return $data;
+    }
+}

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_empty_check.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_empty_check.php.inc
@@ -15,7 +15,18 @@ class SkipEmptyCheck
             : 'default';
     }
 
-    public function run2()
+    public function run2($check)
+    {
+        if ($check) {
+            $data = 'value';
+        }
+
+        return empty($data)
+            ? 'default'
+            : $data;
+    }
+
+    public function run3()
     {
         if (empty($data)) {
             $data[] = 'test';

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -141,6 +141,11 @@ final class UndefinedVariableResolver
             return true;
         }
 
+        $nodeScope = $variable->getAttribute(AttributeKey::SCOPE);
+        if (! $nodeScope instanceof Scope) {
+            return true;
+        }
+
         $variableName = $this->nodeNameResolver->getName($variable);
 
         // skip $this, as probably in outer scope

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -90,9 +90,9 @@ final class UndefinedVariableResolver
         return array_unique($undefinedVariables);
     }
 
-    private function issetOrUnsetParent(Node $parentNode): bool
+    private function issetOrUnsetOrEmptyParent(Node $parentNode): bool
     {
-        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class], true);
+        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true);
     }
 
     private function isAsCoalesceLeft(Node $parentNode, Variable $variable): bool
@@ -124,11 +124,7 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        if ($this->issetOrUnsetParent($parentNode)) {
-            return true;
-        }
-
-        if ($this->hasEmptyCheck($parentNode)) {
+        if ($this->issetOrUnsetOrEmptyParent($parentNode)) {
             return true;
         }
 
@@ -162,11 +158,6 @@ final class UndefinedVariableResolver
         }
 
         return $this->hasPreviousCheckedWithEmpty($variable);
-    }
-
-    private function hasEmptyCheck(Node $node): bool
-    {
-        return $node instanceof Empty_;
     }
 
     private function hasPreviousCheckedWithIsset(Variable $variable): bool
@@ -206,14 +197,12 @@ final class UndefinedVariableResolver
     private function isStaticVariable(Node $parentNode): bool
     {
         // definition of static variable
-        if ($parentNode instanceof StaticVar) {
-            $parentParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-            if ($parentParentNode instanceof Static_) {
-                return true;
-            }
+        if (! $parentNode instanceof StaticVar) {
+            return false;
         }
 
-        return false;
+        $parentParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
+        return $parentParentNode instanceof Static_;
     }
 
     private function isListAssign(Node $node): bool

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -189,8 +189,8 @@ final class UndefinedVariableResolver
                 return false;
             }
 
-            $variable = $subNode->expr;
-            return $this->nodeComparator->areNodesEqual($variable, $variable);
+            $subNodeExpr = $subNode->expr;
+            return $this->nodeComparator->areNodesEqual($subNodeExpr, $variable);
         });
     }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -196,11 +196,11 @@ final class UndefinedVariableResolver
 
     private function isStaticVariable(Node $parentNode): bool
     {
-        // definition of static variable
         if (! $parentNode instanceof StaticVar) {
             return false;
         }
 
+        // definition of static variable
         $parentParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
         return $parentParentNode instanceof Static_;
     }


### PR DESCRIPTION
`empty()` has same result with `! isset()` which now `isset()` and `! isset()` check already skipped at 

https://github.com/rectorphp/rector-src/blob/main/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_isset_check.php.inc

ref https://3v4l.org/DkGD7#v5.6.40

So `empty()` should be skipped as well.