### PR TITLE
Add failing test fixture for CatchExceptionNameMatchingTypeRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/more_then_one_method_contains_try_catch.php.inc
+++ b/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/more_then_one_method_contains_try_catch.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+use Throwable;
+
+final class MoreThanOneMethodContainsTryCatch
+{
+    public function run()
+    {
+        try {
+        } catch (Throwable $exception) {
+        }
+    }
+
+    public function more()
+    {
+        try {
+        } catch (Throwable $exception) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+use Throwable;
+
+final class MoreThanOneMethodContainsTryCatch
+{
+    public function run()
+    {
+        try {
+        } catch (Throwable $throwable) {
+        }
+    }
+
+    public function more()
+    {
+        try {
+        } catch (Throwable $throwable) {
+        }
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/more_then_one_try_catch.php.inc
+++ b/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/more_then_one_try_catch.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+use Throwable;
+
+final class MoreThanOneTryCatch
+{
+    public function run()
+    {
+        try {
+        } catch (Throwable $exception) {
+        }
+        try {
+        } catch (Throwable $exception) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+use Throwable;
+
+final class MoreThanOneTryCatch
+{
+    public function run()
+    {
+        try {
+        } catch (Throwable $throwable) {
+        }
+        try {
+        } catch (Throwable $throwable) {
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for CatchExceptionNameMatchingTypeRector

Based on https://getrector.org/demo/1ec7a6d4-03fe-6fec-ba76-7f95d7ea94f7

If more than one method contains a mismatched exception name, this rule will fix only one mismatched name.