### PR TITLE
[Php74] Skip curly variable in string quoted on CurlyToSquareBracketArrayStringRector

### DIFF
--- a/rules-tests/Php74/Rector/ArrayDimFetch/CurlyToSquareBracketArrayStringRector/Fixture/skip_curly_variable_in_string_quoted.php.inc
+++ b/rules-tests/Php74/Rector/ArrayDimFetch/CurlyToSquareBracketArrayStringRector/Fixture/skip_curly_variable_in_string_quoted.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\ArrayDimFetch\CurlyToSquareBracketArrayStringRector\Fixture;
+
+class SkipCurlyVariableInStringQuoted
+{
+    public function run()
+    {
+        $a = ['akey' => 'AVAL'];
+
+        echo "abc ${row['akey']} xyz";
+    }
+}

--- a/rules/Php74/Tokenizer/FollowedByCurlyBracketAnalyzer.php
+++ b/rules/Php74/Tokenizer/FollowedByCurlyBracketAnalyzer.php
@@ -12,13 +12,13 @@ final class FollowedByCurlyBracketAnalyzer
     public function isFollowed(File $file, Node $node): bool
     {
         $oldTokens = $file->getOldTokens();
-        $startTokenPost = $node->getStartTokenPos();
+        $endTokenPost = $node->getEndTokenPos();
 
-        if (isset($oldTokens[$startTokenPost][1]) && $oldTokens[$startTokenPost][1] === '${') {
-            return false;
+        if (isset($oldTokens[$endTokenPost]) && $oldTokens[$endTokenPost] === '}') {
+            $startTokenPost = $node->getStartTokenPos();
+            return ! (isset($oldTokens[$startTokenPost][1]) && $oldTokens[$startTokenPost][1] === '${');
         }
 
-        $endTokenPost = $node->getEndTokenPos();
-        return isset($oldTokens[$endTokenPost]) && $oldTokens[$endTokenPost] === '}';
+        return false;
     }
 }

--- a/rules/Php74/Tokenizer/FollowedByCurlyBracketAnalyzer.php
+++ b/rules/Php74/Tokenizer/FollowedByCurlyBracketAnalyzer.php
@@ -12,13 +12,13 @@ final class FollowedByCurlyBracketAnalyzer
     public function isFollowed(File $file, Node $node): bool
     {
         $oldTokens = $file->getOldTokens();
-        $endTokenPost = $node->getEndTokenPos();
         $startTokenPost = $node->getStartTokenPos();
 
         if (isset($oldTokens[$startTokenPost][1]) && $oldTokens[$startTokenPost][1] === '${') {
             return false;
         }
 
+        $endTokenPost = $node->getEndTokenPos();
         return isset($oldTokens[$endTokenPost]) && $oldTokens[$endTokenPost] === '}';
     }
 }

--- a/rules/Php74/Tokenizer/FollowedByCurlyBracketAnalyzer.php
+++ b/rules/Php74/Tokenizer/FollowedByCurlyBracketAnalyzer.php
@@ -13,6 +13,11 @@ final class FollowedByCurlyBracketAnalyzer
     {
         $oldTokens = $file->getOldTokens();
         $endTokenPost = $node->getEndTokenPos();
+        $startTokenPost = $node->getStartTokenPos();
+
+        if (isset($oldTokens[$startTokenPost][1]) && $oldTokens[$startTokenPost][1] === '${') {
+            return false;
+        }
 
         return isset($oldTokens[$endTokenPost]) && $oldTokens[$endTokenPost] === '}';
     }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6954

Given the following code:

```php
        $a = ['akey' => 'AVAL'];

        echo "abc ${row['akey']} xyz";
```

It currently produce:

```diff
-        echo "abc ${row['akey']} xyz";
+        echo "abc {row['akey']} xyz";
```

which should be skipped.