### PR TITLE
[CodeQuality][EarlyReturn] Handle SimplifyIfElseToTernaryRector + ChangeIfElseValueAssignToEarlyReturnRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector/Fixture/use_on_return_after_if_else_assign.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector/Fixture/use_on_return_after_if_else_assign.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector\Fixture;
+
+class UseOnReturnAfterIfElseAssign
+{
+    public function run()
+    {
+        if (empty($value)) {
+            $this->arrayBuilt[][$key] = true;
+        } else {
+            $this->arrayBuilt[][$key] = $value;
+        }
+
+        return $this->arrayBuilt[][$key];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector\Fixture;
+
+class UseOnReturnAfterIfElseAssign
+{
+    public function run()
+    {
+        $this->arrayBuilt[][$key] = empty($value) ? true : $value;
+
+        return $this->arrayBuilt[][$key];
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector/Fixture/use_on_return_after_if_else_assign.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector/Fixture/use_on_return_after_if_else_assign.php.inc
@@ -2,17 +2,17 @@
 
 namespace Rector\Tests\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector\Fixture;
 
-class UseOnReturnAfterIfElseAssign
+final class UseOnReturnAfterIfElseAssign
 {
-    public function run()
+    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
     {
-        if (empty($value)) {
-            $this->arrayBuilt[][$key] = true;
+        if (method_exists($data, 'toRawArray')) {
+            $properties = $data->toRawArray();
         } else {
-            $this->arrayBuilt[][$key] = $value;
+            $properties = (array) $data;
         }
 
-        return $this->arrayBuilt[][$key];
+        return $properties;
     }
 }
 
@@ -22,13 +22,13 @@ class UseOnReturnAfterIfElseAssign
 
 namespace Rector\Tests\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector\Fixture;
 
-class UseOnReturnAfterIfElseAssign
+final class UseOnReturnAfterIfElseAssign
 {
-    public function run()
+    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
     {
-        $this->arrayBuilt[][$key] = empty($value) ? true : $value;
+        $properties = method_exists($data, 'toRawArray') ? $data->toRawArray() : (array) $data;
 
-        return $this->arrayBuilt[][$key];
+        return $properties;
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector/Fixture/use_on_return_after_if_else_assign.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector/Fixture/use_on_return_after_if_else_assign.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector\Fixt
 
 final class UseOnReturnAfterIfElseAssign
 {
-    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
+    public static function classToArray($data): array
     {
         if (method_exists($data, 'toRawArray')) {
             $properties = $data->toRawArray();
@@ -24,7 +24,7 @@ namespace Rector\Tests\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector\Fixt
 
 final class UseOnReturnAfterIfElseAssign
 {
-    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
+    public static function classToArray($data): array
     {
         $properties = method_exists($data, 'toRawArray') ? $data->toRawArray() : (array) $data;
 

--- a/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -131,6 +131,10 @@ CODE_SAMPLE
 
     private function isNextReturnRemoved(If_ $if, Expr $expr): bool
     {
+        if (! $this->nodesToRemoveCollector->isActive()) {
+            return false;
+        }
+
         $next = $if->getAttribute(AttributeKey::NEXT_NODE);
 
         if ($next instanceof Return_ && $next->expr instanceof Expr && $this->nodeComparator->areNodesEqual(

--- a/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -126,6 +126,7 @@ CODE_SAMPLE
 
         $expression = new Expression($assign);
         $this->mirrorComments($expression, $node);
+
         return $expression;
     }
 

--- a/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -12,7 +12,9 @@ use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Return_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -118,10 +120,33 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isNextReturnRemoved($node, $ifAssignVar)) {
+            return null;
+        }
+
         $expression = new Expression($assign);
         $this->mirrorComments($expression, $node);
-
         return $expression;
+    }
+
+    private function isNextReturnRemoved(If_ $if, Expr $expr): bool
+    {
+        $next = $if->getAttribute(AttributeKey::NEXT_NODE);
+
+        if ($next instanceof Return_ && $next->expr instanceof Expr && $this->nodeComparator->areNodesEqual(
+            $next->expr,
+            $expr
+        )) {
+            $nodesToRemove = $this->nodesToRemoveCollector->getNodesToRemove();
+
+            foreach ($nodesToRemove as $nodeToRemove) {
+                if ($this->nodeComparator->areNodesEqual($next, $nodeToRemove)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Issues/IfElseAssignReturnUsed/Fixture/fixture.php.inc
+++ b/tests/Issues/IfElseAssignReturnUsed/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
+
+final class UseOnReturnAfterTernary
+{
+    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
+    {
+        if (method_exists($data, 'toRawArray')) {
+            $properties = $data->toRawArray();
+        } else {
+            $properties = (array) $data;
+        }
+
+        return $properties;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
+
+final class UseOnReturnAfterTernary
+{
+    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
+    {
+        return \method_exists($data, 'toRawArray') ? $data->toRawArray() : (array) $data;
+    }
+}
+
+?>

--- a/tests/Issues/IfElseAssignReturnUsed/Fixture/fixture.php.inc
+++ b/tests/Issues/IfElseAssignReturnUsed/Fixture/fixture.php.inc
@@ -30,7 +30,11 @@ final class UseOnReturnAfterTernary
 {
     public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
     {
-        return \method_exists($data, 'toRawArray') ? $data->toRawArray() : (array) $data;
+        if (method_exists($data, 'toRawArray')) {
+            return $data->toRawArray();
+        }
+
+        return (array) $data;
     }
 }
 

--- a/tests/Issues/IfElseAssignReturnUsed/Fixture/use_on_return_after_if_else_assign.php.inc
+++ b/tests/Issues/IfElseAssignReturnUsed/Fixture/use_on_return_after_if_else_assign.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
 
 final class UseOnReturnAfterIfElseAssign
 {
-    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
+    public static function classToArray($data): array
     {
         if (method_exists($data, 'toRawArray')) {
             $properties = $data->toRawArray();
@@ -28,7 +28,7 @@ namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
 
 final class UseOnReturnAfterIfElseAssign
 {
-    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
+    public static function classToArray($data): array
     {
         if (method_exists($data, 'toRawArray')) {
             return $data->toRawArray();

--- a/tests/Issues/IfElseAssignReturnUsed/Fixture/use_on_return_after_if_else_assign.php.inc
+++ b/tests/Issues/IfElseAssignReturnUsed/Fixture/use_on_return_after_if_else_assign.php.inc
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
 
-final class UseOnReturnAfterTernary
+final class UseOnReturnAfterIfElseAssign
 {
     public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
     {
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
 
-final class UseOnReturnAfterTernary
+final class UseOnReturnAfterIfElseAssign
 {
     public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
     {

--- a/tests/Issues/IfElseAssignReturnUsed/IfElseAssignReturnUsedTest.php
+++ b/tests/Issues/IfElseAssignReturnUsed/IfElseAssignReturnUsedTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class IfElseAssignReturnUsedTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IfElseAssignReturnUsed/config/configured_rule.php
+++ b/tests/Issues/IfElseAssignReturnUsed/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
+use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::EARLY_RETURN);
+
+    $services = $containerConfigurator->services();
+    $services->set(ChangeIfElseValueAssignToEarlyReturnRector::class);
+    $services->set(SimplifyIfElseToTernaryRector::class);
+};

--- a/tests/Issues/IfElseAssignReturnUsed/config/configured_rule.php
+++ b/tests/Issues/IfElseAssignReturnUsed/config/configured_rule.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
-use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(SetList::EARLY_RETURN);
-
     $services = $containerConfigurator->services();
     $services->set(ChangeIfElseValueAssignToEarlyReturnRector::class);
     $services->set(SimplifyIfElseToTernaryRector::class);


### PR DESCRIPTION
Given the following code:

```php
final class UseOnReturnAfterIfElseAssign
{
    public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
    {
        if (method_exists($data, 'toRawArray')) {
            $properties = $data->toRawArray();
        } else {
            $properties = (array) $data;
        }

        return $properties;
    }
}
```

It currently produce:

```diff
-        if (method_exists($data, 'toRawArray')) {
-            $properties = $data->toRawArray();
-        } else {
-            $properties = (array) $data;
-        }
-
-        return $properties;
+        $properties = method_exists($data, 'toRawArray') ? $data->toRawArray() : (array) $data;
```

which return is removed, which should be kept.

This PR try to Fixes https://github.com/rectorphp/rector/issues/6955