### PR TITLE
[DowngradePhp70][Transform] Add #[\ReturnTypeWillChange] on Downgrade + transform ArrayObject::getIterator() to keep working on php 8.1

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/PhpDocFromTypeDeclarationDecorator.php
@@ -42,6 +42,9 @@ final class PhpDocFromTypeDeclarationDecorator
         'PHPStan\Type\MixedType' => [
             'ArrayAccess' => ['offsetGet'],
         ],
+        'Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType' => [
+            'ArrayAccess' => ['getIterator'],
+        ],
     ];
 
     public function __construct(

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/extends_arrayobject.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/extends_arrayobject.php.inc
@@ -2,6 +2,9 @@
 
 namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
 
+/**
+ * @see https://github.com/laminas/laminas-stdlib/pull/54
+ */
 class ArrayStack extends \ArrayObject
 {
     public function getIterator(): \Iterator
@@ -17,6 +20,9 @@ class ArrayStack extends \ArrayObject
 
 namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
 
+/**
+ * @see https://github.com/laminas/laminas-stdlib/pull/54
+ */
 class ArrayStack extends \ArrayObject
 {
     /**

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/extends_arrayobject.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/extends_arrayobject.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
+
+class ArrayStack extends \ArrayObject
+{
+    public function getIterator(): \Iterator
+    {
+        $array = $this->getArrayCopy();
+        return new ArrayIterator(array_reverse($array));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
+
+class ArrayStack extends \ArrayObject
+{
+    /**
+     * @return \Iterator
+     */
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+        $array = $this->getArrayCopy();
+        return new ArrayIterator(array_reverse($array));
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/override_arrayobject_get_iterator.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/override_arrayobject_get_iterator.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
+
+/**
+ * @see https://github.com/laminas/laminas-stdlib/pull/54
+ */
+class OverrideArrayObjectGetIterator extends \ArrayObject
+{
+    public function getIterator(): \Iterator
+    {
+        $array = $this->getArrayCopy();
+        return new ArrayIterator(array_reverse($array));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
+
+/**
+ * @see https://github.com/laminas/laminas-stdlib/pull/54
+ */
+class OverrideArrayObjectGetIterator extends \ArrayObject
+{
+    /**
+     * @return \Iterator
+     */
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+        $array = $this->getArrayCopy();
+        return new ArrayIterator(array_reverse($array));
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/override_arrayobject_get_iterator.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/FunctionLike/DowngradeScalarTypeDeclarationRector/Fixture/override_arrayobject_get_iterator.php.inc
@@ -2,15 +2,10 @@
 
 namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
 
-/**
- * @see https://github.com/laminas/laminas-stdlib/pull/54
- */
 class OverrideArrayObjectGetIterator extends \ArrayObject
 {
     public function getIterator(): \Iterator
     {
-        $array = $this->getArrayCopy();
-        return new ArrayIterator(array_reverse($array));
     }
 }
 
@@ -20,9 +15,6 @@ class OverrideArrayObjectGetIterator extends \ArrayObject
 
 namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
 
-/**
- * @see https://github.com/laminas/laminas-stdlib/pull/54
- */
 class OverrideArrayObjectGetIterator extends \ArrayObject
 {
     /**
@@ -31,8 +23,6 @@ class OverrideArrayObjectGetIterator extends \ArrayObject
     #[\ReturnTypeWillChange]
     public function getIterator()
     {
-        $array = $this->getArrayCopy();
-        return new ArrayIterator(array_reverse($array));
     }
 }
 

--- a/rules-tests/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector/Fixture/override_arrayobject_get_iterator.php.inc
+++ b/rules-tests/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector/Fixture/override_arrayobject_get_iterator.php.inc
@@ -2,15 +2,10 @@
 
 namespace Rector\Tests\Transform\Rector\ClassMethod\ReturnTypeWillChangeRector\Fixture;
 
-/**
- * @see https://github.com/laminas/laminas-stdlib/pull/54
- */
 class OverrideArrayObjectGetIterator extends \ArrayObject
 {
     public function getIterator()
     {
-        $array = $this->getArrayCopy();
-        return new ArrayIterator(array_reverse($array));
     }
 }
 
@@ -20,16 +15,11 @@ class OverrideArrayObjectGetIterator extends \ArrayObject
 
 namespace Rector\Tests\Transform\Rector\ClassMethod\ReturnTypeWillChangeRector\Fixture;
 
-/**
- * @see https://github.com/laminas/laminas-stdlib/pull/54
- */
 class OverrideArrayObjectGetIterator extends \ArrayObject
 {
     #[\ReturnTypeWillChange]
     public function getIterator()
     {
-        $array = $this->getArrayCopy();
-        return new ArrayIterator(array_reverse($array));
     }
 }
 

--- a/rules-tests/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector/Fixture/override_arrayobject_get_iterator.php.inc
+++ b/rules-tests/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector/Fixture/override_arrayobject_get_iterator.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
+namespace Rector\Tests\Transform\Rector\ClassMethod\ReturnTypeWillChangeRector\Fixture;
 
 /**
  * @see https://github.com/laminas/laminas-stdlib/pull/54
  */
-class ArrayStack extends \ArrayObject
+class OverrideArrayObjectGetIterator extends \ArrayObject
 {
-    public function getIterator(): \Iterator
+    public function getIterator()
     {
         $array = $this->getArrayCopy();
         return new ArrayIterator(array_reverse($array));
@@ -18,16 +18,13 @@ class ArrayStack extends \ArrayObject
 -----
 <?php
 
-namespace Rector\Tests\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector\Fixture;
+namespace Rector\Tests\Transform\Rector\ClassMethod\ReturnTypeWillChangeRector\Fixture;
 
 /**
  * @see https://github.com/laminas/laminas-stdlib/pull/54
  */
-class ArrayStack extends \ArrayObject
+class OverrideArrayObjectGetIterator extends \ArrayObject
 {
-    /**
-     * @return \Iterator
-     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {


### PR DESCRIPTION
Given the following code, on `DowngradeScalarTypeDeclarationRector`:

```php
class ArrayStack extends \ArrayObject
{
    public function getIterator(): \Iterator
    {
        $array = $this->getArrayCopy();
        return new ArrayIterator(array_reverse($array));
    }
}
```

It only remove `\Iterator` and add `@return \Iterator`, and if the code is using in php 8.1, it will got notice:

```bash
Deprecated: Return type of ArrayStack::getIterator() should either be compatible with ArrayObject::getIterator(): Iterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /in/uZl8U on line 8
```

ref https://3v4l.org/uZl8U#v8.1.2

This PR fix it by register it to `PhpDocFromTypeDeclarationDecorator::ADD_RETURN_TYPE_WILL_CHANGE` constant  value.

ref https://github.com/laminas/laminas-stdlib/pull/54 for inspiration.