### PR TITLE
[Php80] Handle AnnotationToAttributeRector + ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -15,6 +15,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\Comment\CommentsMerger;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -29,7 +30,8 @@ final class PhpDocTypeChanger
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly TypeComparator $typeComparator,
         private readonly ParamPhpDocNodeFactory $paramPhpDocNodeFactory,
-        private readonly NodeNameResolver $nodeNameResolver
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly CommentsMerger $commentsMerger
     ) {
     }
 
@@ -143,6 +145,7 @@ final class PhpDocTypeChanger
 
         $varTag = $phpDocInfo->getVarTagValueNode();
         if (! $varTag instanceof VarTagValueNode) {
+            $this->commentsMerger->keepComments($param, [$property]);
             return;
         }
 

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -147,16 +147,7 @@ final class PhpDocTypeChanger
 
         $varTag = $phpDocInfo->getVarTagValueNode();
         if (! $varTag instanceof VarTagValueNode) {
-            $this->commentsMerger->keepComments($param, [$property]);
-
-            $paramPhpDocInfo = $this->phpDocInfoFactory->createFromNode($param);
-            if ($paramPhpDocInfo instanceof PhpDocInfo) {
-                $paramVarTag = $paramPhpDocInfo->getVarTagValueNode();
-                if ($paramVarTag instanceof VarTagValueNode && $paramVarTag->description === '') {
-                    $paramPhpDocInfo->removeByType(VarTagValueNode::class);
-                }
-            }
-
+            $this->processKeepComments($property, $param);
             return;
         }
 
@@ -193,5 +184,30 @@ final class PhpDocTypeChanger
         // add completely new one
         $varTagValueNode = new VarTagValueNode($typeNode, '', '');
         $phpDocInfo->addTagValueNode($varTagValueNode);
+    }
+
+    private function processKeepComments(Property $property, Param $param): void
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($param);
+        $varTag = $phpDocInfo->getVarTagValueNode();
+
+        $toBeRemoved = ! $varTag instanceof VarTagValueNode;
+        $this->commentsMerger->keepComments($param, [$property]);
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($param);
+        $varTag = $phpDocInfo->getVarTagValueNode();
+        if (! $toBeRemoved) {
+            return;
+        }
+
+        if (! $varTag instanceof VarTagValueNode) {
+            return;
+        }
+
+        if ($varTag->description !== '') {
+            return;
+        }
+
+        $phpDocInfo->removeByType(VarTagValueNode::class);
     }
 }

--- a/tests/Issues/ConstructorPromoAnnotationToAttribute/ConstructorPromoAnnotationToAttributeTest.php
+++ b/tests/Issues/ConstructorPromoAnnotationToAttribute/ConstructorPromoAnnotationToAttributeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ConstructorPromoAnnotationToAttribute;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ConstructorPromoAnnotationToAttributeTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/ConstructorPromoAnnotationToAttribute/Fixture/fixture.php.inc
+++ b/tests/Issues/ConstructorPromoAnnotationToAttribute/Fixture/fixture.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ConstructorPromoAnnotationToAttribute\Fixture;
+
+use OpenApi\Annotations as OA;
+
+class TestResponse
+{
+    /**
+     * @OA\Property(
+     *     type="array",
+     *     @OA\Items(ref=@Model(type=TestItem::class))
+     * )
+     */
+    public array $items;
+
+    public function __construct(array $items = [])
+    {
+        $this->items = $items;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ConstructorPromoAnnotationToAttribute\Fixture;
+
+use OpenApi\Annotations as OA;
+
+class TestResponse
+{
+    public function __construct(
+        /**
+         * @OA\Property(
+         *     type="array",
+         *     @OA\Items(ref=@Model(type=TestItem::class))
+         * )
+         */
+        public array $items = []
+    )
+    {
+    }
+}
+?>

--- a/tests/Issues/ConstructorPromoAnnotationToAttribute/config/configured_rule.php
+++ b/tests/Issues/ConstructorPromoAnnotationToAttribute/config/configured_rule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
+    $services->set(AnnotationToAttributeRector::class)
+        ->configure([
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\Table'),
+        ]);
+};

--- a/tests/Issues/ConstructorPromoAnnotationToAttribute/config/configured_rule.php
+++ b/tests/Issues/ConstructorPromoAnnotationToAttribute/config/configured_rule.php
@@ -12,7 +12,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
     $services->set(AnnotationToAttributeRector::class)
-        ->configure([
-            new AnnotationToAttribute('Doctrine\ORM\Mapping\Table'),
-        ]);
+        ->configure([new AnnotationToAttribute('Doctrine\ORM\Mapping\Table')]);
 };

--- a/tests/Issues/ConstructorPromoAnnotationToAttribute/config/configured_rule.php
+++ b/tests/Issues/ConstructorPromoAnnotationToAttribute/config/configured_rule.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
-    $services->set(AnnotationToAttributeRector::class)
-        ->configure([new AnnotationToAttribute('Doctrine\ORM\Mapping\Table')]);
+    $services->set(AnnotationToAttributeRector::class);
 };


### PR DESCRIPTION
Given the following code:

```
use OpenApi\Annotations as OA;

class TestResponse
{
    /**
     * @OA\Property(
     *     type="array",
     *     @OA\Items(ref=@Model(type=TestItem::class))
     * )
     */
    public array $items;

    public function __construct(array $items = [])
    {
        $this->items = $items;
    }
}
```

It currently produce:

```diff
-    /**
-     * @OA\Property(
-     *     type="array",
-     *     @OA\Items(ref=@Model(type=TestItem::class))
-     * )
-     */
-    public array $items;
-
-    public function __construct(array $items = [])
+    public function __construct(public array $items = [])
     {
-        $this->items = $items;
     }
```

which the annotation should not removed. Applied rules:

```php
Rector\Php80\Rector\Class_\AnnotationToAttributeRector
Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector
```

This PR try to fixes it.

Closes https://github.com/rectorphp/rector-src/pull/1702
Fixes https://github.com/rectorphp/rector/issues/6949