### PR TITLE
[Php74] Skip readonly on RestoreDefaultNullToNullableTypePropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+class SkipReadonly
+{
+    public readonly ?string $name;
+}

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -90,6 +90,10 @@ CODE_SAMPLE
             return true;
         }
 
+        if ($property->isReadonly()) {
+            return true;
+        }
+
         // is variable assigned in constructor
         $propertyName = $this->getName($property);
 


### PR DESCRIPTION
Given the following code:

```php
class SkipReadonly
{
    public readonly ?string $name;
}
```

it currently produce:

```diff
-    public readonly ?string $name;
+    public readonly ?string $name = null;
```

which shuld be skipped as it will cause error:

```bash
Fatal error: Readonly property SkipReadonly::$name cannot have default value
```

ref https://3v4l.org/cadOJ
Fixes https://github.com/rectorphp/rector/issues/6959