### PR TITLE
[DeadCode] Handle RemoveUnusedConstructorParamRector + RemoveUnusedPrivatePropertyRector

### DIFF
--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\NodeAnalyzer\ParamAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
+use Rector\Removing\NodeManipulator\ComplexNodeRemover;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveUnusedConstructorParamRector extends AbstractRector
 {
     public function __construct(
-        private readonly ParamAnalyzer $paramAnalyzer
+        private readonly ParamAnalyzer $paramAnalyzer,
+        private readonly ComplexNodeRemover $complexNodeRemover
     ) {
     }
 
@@ -89,14 +91,28 @@ CODE_SAMPLE
             return null;
         }
 
-        foreach ($node->params as $param) {
-            if ($this->paramAnalyzer->isParamUsedInClassMethod($node, $param)) {
+        return $this->processRemoveParams($node);
+    }
+
+    private function processRemoveParams(ClassMethod $classMethod): ?ClassMethod
+    {
+        $paramKeysToBeRemoved = [];
+
+        foreach ($classMethod->params as $key => $param) {
+            if ($this->paramAnalyzer->isParamUsedInClassMethod($classMethod, $param)) {
                 continue;
             }
 
-            $this->nodeRemover->removeParam($node, $param);
+            $paramKeysToBeRemoved[] = $key;
         }
 
-        return null;
+        $removedParamKeys = $this->complexNodeRemover
+                                ->processRemoveParamWithKeys($classMethod->params, $paramKeysToBeRemoved);
+
+        if ($removedParamKeys === []) {
+            return null;
+        }
+
+        return $classMethod;
     }
 }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector.php
@@ -107,7 +107,7 @@ CODE_SAMPLE
         }
 
         $removedParamKeys = $this->complexNodeRemover
-                                ->processRemoveParamWithKeys($classMethod->params, $paramKeysToBeRemoved);
+            ->processRemoveParamWithKeys($classMethod->params, $paramKeysToBeRemoved);
 
         if ($removedParamKeys === []) {
             return null;

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -72,6 +72,7 @@ final class ComplexNodeRemover
     /**
      * @param Param[] $params
      * @param int[] $paramKeysToBeRemoved
+     * @return mixed[]
      */
     public function processRemoveParamWithKeys(array $params, array $paramKeysToBeRemoved): array
     {

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -72,7 +72,7 @@ final class ComplexNodeRemover
     /**
      * @param Param[] $params
      * @param int[] $paramKeysToBeRemoved
-     * @return mixed[]
+     * @return int[]
      */
     public function processRemoveParamWithKeys(array $params, array $paramKeysToBeRemoved): array
     {

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -220,9 +220,11 @@ final class ComplexNodeRemover
      * @param Param[] $params
      * @param int[] $paramKeysToBeRemoved
      */
-    private function processRemoveParamWithKeys(array $params, array $paramKeysToBeRemoved): void
+    public function processRemoveParamWithKeys(array $params, array $paramKeysToBeRemoved): array
     {
         $totalKeys = count($params) - 1;
+        $removedParamKeys = [];
+
         foreach ($paramKeysToBeRemoved as $paramKeyToBeRemoved) {
             $startNextKey = $paramKeyToBeRemoved + 1;
             for ($nextKey = $startNextKey; $nextKey <= $totalKeys; ++$nextKey) {
@@ -236,11 +238,14 @@ final class ComplexNodeRemover
                     continue;
                 }
 
-                return;
+                return [];
             }
 
             $this->nodeRemover->removeNode($params[$paramKeyToBeRemoved]);
+            $removedParamKeys[] = $paramKeyToBeRemoved;
         }
+
+        return $removedParamKeys;
     }
 
     private function isExpressionVariableNotAssign(Node $node): bool

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -70,6 +70,38 @@ final class ComplexNodeRemover
     }
 
     /**
+     * @param Param[] $params
+     * @param int[] $paramKeysToBeRemoved
+     */
+    public function processRemoveParamWithKeys(array $params, array $paramKeysToBeRemoved): array
+    {
+        $totalKeys = count($params) - 1;
+        $removedParamKeys = [];
+
+        foreach ($paramKeysToBeRemoved as $paramKeyToBeRemoved) {
+            $startNextKey = $paramKeyToBeRemoved + 1;
+            for ($nextKey = $startNextKey; $nextKey <= $totalKeys; ++$nextKey) {
+                if (! isset($params[$nextKey])) {
+                    // no next param, break the inner loop, remove the param
+                    break;
+                }
+
+                if (in_array($nextKey, $paramKeysToBeRemoved, true)) {
+                    // keep searching next key not in $paramKeysToBeRemoved
+                    continue;
+                }
+
+                return [];
+            }
+
+            $this->nodeRemover->removeNode($params[$paramKeyToBeRemoved]);
+            $removedParamKeys[] = $paramKeyToBeRemoved;
+        }
+
+        return $removedParamKeys;
+    }
+
+    /**
      * @param Assign[] $assigns
      */
     private function processRemovePropertyAssigns(array $assigns): void
@@ -214,38 +246,6 @@ final class ComplexNodeRemover
         }
 
         return false;
-    }
-
-    /**
-     * @param Param[] $params
-     * @param int[] $paramKeysToBeRemoved
-     */
-    public function processRemoveParamWithKeys(array $params, array $paramKeysToBeRemoved): array
-    {
-        $totalKeys = count($params) - 1;
-        $removedParamKeys = [];
-
-        foreach ($paramKeysToBeRemoved as $paramKeyToBeRemoved) {
-            $startNextKey = $paramKeyToBeRemoved + 1;
-            for ($nextKey = $startNextKey; $nextKey <= $totalKeys; ++$nextKey) {
-                if (! isset($params[$nextKey])) {
-                    // no next param, break the inner loop, remove the param
-                    break;
-                }
-
-                if (in_array($nextKey, $paramKeysToBeRemoved, true)) {
-                    // keep searching next key not in $paramKeysToBeRemoved
-                    continue;
-                }
-
-                return [];
-            }
-
-            $this->nodeRemover->removeNode($params[$paramKeyToBeRemoved]);
-            $removedParamKeys[] = $paramKeyToBeRemoved;
-        }
-
-        return $removedParamKeys;
     }
 
     private function isExpressionVariableNotAssign(Node $node): bool

--- a/tests/Issues/RemoveUnusedParamInMiddle/Fixture/do_not_remove_parameter_in_middle.php.inc
+++ b/tests/Issues/RemoveUnusedParamInMiddle/Fixture/do_not_remove_parameter_in_middle.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveUnusedParamInMiddle\Fixture;
+
+final class DoNotRemoveParameterInMiddle
+{
+    private $propertyA;
+    private $propertyB;
+    private $propertyC;
+
+    public function __construct($propertyA, $propertyB, $propertyC)
+    {
+        $this->propertyA = $propertyA;
+        $this->propertyB = $propertyB;
+        $this->propertyC = $propertyC;
+    }
+
+    public function run()
+    {
+        echo $this->propertyA;
+        echo $this->propertyC;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveUnusedParamInMiddle\Fixture;
+
+final class DoNotRemoveParameterInMiddle
+{
+    private $propertyA;
+    private $propertyC;
+
+    public function __construct($propertyA, $propertyB, $propertyC)
+    {
+        $this->propertyA = $propertyA;
+        $this->propertyC = $propertyC;
+    }
+
+    public function run()
+    {
+        echo $this->propertyA;
+        echo $this->propertyC;
+    }
+}
+
+?>

--- a/tests/Issues/RemoveUnusedParamInMiddle/RemoveUnusedParamInMiddleTest.php
+++ b/tests/Issues/RemoveUnusedParamInMiddle/RemoveUnusedParamInMiddleTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveUnusedParamInMiddle;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveUnusedParamInMiddleTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RemoveUnusedParamInMiddle/config/configured_rule.php
+++ b/tests/Issues/RemoveUnusedParamInMiddle/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
+use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemoveUnusedConstructorParamRector::class);
+    $services->set(RemoveUnusedPrivatePropertyRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
final class DoNotRemoveParameterInMiddle
{
    private $propertyA;
    private $propertyB;
    private $propertyC;

    public function __construct($propertyA, $propertyB, $propertyC)
    {
        $this->propertyA = $propertyA;
        $this->propertyB = $propertyB;
        $this->propertyC = $propertyC;
    }

    public function run()
    {
        echo $this->propertyA;
        echo $this->propertyC;
    }
}
```

It currently produce:

```diff
 final class DoNotRemoveParameterInMiddle
 {
     private $propertyA;
-    private $propertyB;
     private $propertyC;
 
-    public function __construct($propertyA, $propertyB, $propertyC)
+    public function __construct($propertyA, $propertyC)
     {
         $this->propertyA = $propertyA;
-        $this->propertyB = $propertyB;
         $this->propertyC = $propertyC;
     }
```

which middle parameter is removed, and cause a BC break. The middle parameter should not be deleted.

Applied rules:

```php
Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
```