### PR TITLE
[Naming][Php56] Do not add default value init for renamed variable from param on RenameParamToMatchTypeRector+AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -49,8 +49,10 @@ final class UndefinedVariableResolver
     {
         $undefinedVariables = [];
 
+        $variableNamesFromParams = $this->collectVariableNamesFromParams($node);
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable((array) $node->stmts, function (Node $node) use (
-            &$undefinedVariables
+            &$undefinedVariables,
+            $variableNamesFromParams
         ): ?int {
             // entering new scope - break!
             if ($node instanceof FunctionLike && ! $node instanceof ArrowFunction) {
@@ -82,12 +84,31 @@ final class UndefinedVariableResolver
                 return null;
             }
 
+            if (in_array($variableName, $variableNamesFromParams, true)) {
+                return null;
+            }
+
             $undefinedVariables[] = $variableName;
 
             return null;
         });
 
         return array_unique($undefinedVariables);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectVariableNamesFromParams(ClassMethod | Function_ | Closure $node): array
+    {
+        $variableNames = [];
+        foreach ($node->getParams() as $param) {
+            if ($param->var instanceof Variable) {
+                $variableNames[] = (string) $this->nodeNameResolver->getName($param->var);
+            }
+        }
+
+        return $variableNames;
     }
 
     private function issetOrUnsetOrEmptyParent(Node $parentNode): bool

--- a/tests/Issues/RenameParamDefaultInit/Fixture/do_not_add_default_value_init_renamed_variable_from_param.php.inc
+++ b/tests/Issues/RenameParamDefaultInit/Fixture/do_not_add_default_value_init_renamed_variable_from_param.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Core\Tests\Issues\RenameParamDefaultInit\Fixture;
 
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 
-class Fixture
+class DoNotAddDefaultValueInitRenamedVariableFromParam
 {
     public function hasTruePseudoType(BracketsAwareUnionTypeNode $type): bool
     {
@@ -26,7 +26,7 @@ namespace Rector\Core\Tests\Issues\RenameParamDefaultInit\Fixture;
 
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 
-class Fixture
+class DoNotAddDefaultValueInitRenamedVariableFromParam
 {
     public function hasTruePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
     {

--- a/tests/Issues/RenameParamDefaultInit/Fixture/fixture.php.inc
+++ b/tests/Issues/RenameParamDefaultInit/Fixture/fixture.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RenameParamDefaultInit\Fixture;
+
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
+
+class Fixture
+{
+    public function hasTruePseudoType(BracketsAwareUnionTypeNode $type): bool
+    {
+        $unionTypes = $type->types;
+
+        foreach ($unionTypes as $unionType) {}
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RenameParamDefaultInit\Fixture;
+
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
+
+class Fixture
+{
+    public function hasTruePseudoType(BracketsAwareUnionTypeNode $type): bool
+    {
+        $unionTypes = $type->types;
+
+        foreach ($unionTypes as $unionType) {}
+    }
+}
+
+?>

--- a/tests/Issues/RenameParamDefaultInit/Fixture/fixture.php.inc
+++ b/tests/Issues/RenameParamDefaultInit/Fixture/fixture.php.inc
@@ -28,9 +28,9 @@ use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 
 class Fixture
 {
-    public function hasTruePseudoType(BracketsAwareUnionTypeNode $type): bool
+    public function hasTruePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
     {
-        $unionTypes = $type->types;
+        $unionTypes = $bracketsAwareUnionTypeNode->types;
 
         foreach ($unionTypes as $unionType) {}
     }

--- a/tests/Issues/RenameParamDefaultInit/RenameParamDefaultInitTest.php
+++ b/tests/Issues/RenameParamDefaultInit/RenameParamDefaultInitTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RenameParamDefaultInit;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RenameParamDefaultInitTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RenameParamDefaultInit/config/configured_rule.php
+++ b/tests/Issues/RenameParamDefaultInit/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
+use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RenameParamToMatchTypeRector::class);
+    $services->set(AddDefaultValueForUndefinedVariableRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;

class Fixture
{
    public function hasTruePseudoType(BracketsAwareUnionTypeNode $type): bool
    {
        $unionTypes = $type->types;

        foreach ($unionTypes as $unionType) {}
    }
}
```

It currently produce define init null value which invalid as variable is from renamed param:

```diff
     public function hasTruePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
     {
+        $bracketsAwareUnionTypeNode = null;
         $unionTypes = $bracketsAwareUnionTypeNode->types;
```

Applied rules:

```php
Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
```