### PR TITLE
[FinalizePublicClassConstantRector] Skip final class

### DIFF
--- a/rules-tests/Php81/Rector/ClassConst/FinalizePublicClassConstantRector/Fixture/skip_final_class.php.inc
+++ b/rules-tests/Php81/Rector/ClassConst/FinalizePublicClassConstantRector/Fixture/skip_final_class.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\ClassConst\FinalizePublicClassConstantRector\Fixture;
+
+final class DemoFile
+{
+    public const TEST_CONSTANT = 'test';
+}
+?>


### PR DESCRIPTION
# Failing Test for FinalizePublicClassConstantRector

Based on https://getrector.org/demo/1ec7d0d7-7bb2-68cc-b5e0-11dedf8f8668

Solves https://github.com/rectorphp/rector/issues/6964