### PR TITLE
[DowngradePhp72] Add DowngradeJsonDecodeNullAssociativeArgRector

### DIFF
--- a/config/set/downgrade-php72.php
+++ b/config/set/downgrade-php72.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector;
+use Rector\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector;
 use Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector;
 use Rector\DowngradePhp72\Rector\FuncCall\DowngradeStreamIsattyRector;
 use Rector\DowngradePhp72\Rector\FunctionLike\DowngradeObjectTypeDeclarationRector;
@@ -19,4 +20,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeParameterTypeWideningRector::class);
     $services->set(DowngradePregUnmatchedAsNullConstantRector::class);
     $services->set(DowngradeStreamIsattyRector::class);
+    $services->set(DowngradeJsonDecodeNullAssociativeArgRector::class);
 };

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/DowngradeJsonDecodeNullAssociativeArgRectorTest.php
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/DowngradeJsonDecodeNullAssociativeArgRectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeJsonDecodeNullAssociativeArgRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP 7.2
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $value = json_decode('{}', null);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $value = json_decode('{}', null);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/fixture.php.inc
@@ -24,7 +24,7 @@ class Fixture
 {
     public function run()
     {
-        $value = json_decode('{}', null);
+        $value = json_decode('{}', false);
     }
 }
 

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/possibly_null.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/possibly_null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector\Fixture;
+
+class PossiblyNull
+{
+    function run(string $json, ?bool $associative)
+    {
+        $value = json_decode($json, $associative);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector\Fixture;
+
+class PossiblyNull
+{
+    function run(string $json, ?bool $associative)
+    {
+        $value = json_decode($json, (bool) $associative);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/skip_already_casted_bool.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/skip_already_casted_bool.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector\Fixture;
+
+class SkipAlreadyCastedBool
+{
+    function run(string $json, ?bool $associative)
+    {
+        $value = json_decode($json, (bool) $associative);
+    }
+}

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/skip_bool_type.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/Fixture/skip_bool_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector\Fixture;
+
+class SkipBoolType
+{
+    public function run(bool $associative)
+    {
+        $value = json_decode('{}', $associative);
+    }
+}

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeJsonDecodeNullAssociativeArgRector::class);
+};

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp72\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -15,6 +17,10 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeJsonDecodeNullAssociativeArgRector extends AbstractRector
 {
+    public function __construct(private readonly ArgsAnalyzer $argsAnalyzer)
+    {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Downgrade json_decode() with null associative argument function', [
@@ -50,6 +56,22 @@ CODE_SAMPLE
     {
         if (! $this->isName($node, 'json_decode')) {
             return null;
+        }
+
+        $args = $node->getArgs();
+        if ($this->argsAnalyzer->hasNamedArg($args)) {
+            return null;
+        }
+
+        if (! isset($args[1])) {
+            return null;
+        }
+
+        $associativeValue = $args[1]->value;
+
+        if ($associativeValue instanceof ConstFetch && $this->valueResolver->isNull($associativeValue)) {
+            $node->args[1]->value = $this->nodeFactory->createFalse();
+            return $node;
         }
 
         return $node;

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp72\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector\DowngradeJsonDecodeNullAssociativeArgRectorTest
+ */
+final class DowngradeJsonDecodeNullAssociativeArgRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Downgrade json_decode() with null associative argument function', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        $value = json_decode($json, null);
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        $value = json_decode($json, false);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node, 'json_decode')) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Type\BooleanType;
 use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -101,6 +102,11 @@ CODE_SAMPLE
         if ($associativeValue instanceof ConstFetch && $this->valueResolver->isNull($associativeValue)) {
             $node->args[1]->value = $this->nodeFactory->createFalse();
             return $node;
+        }
+
+        $originalNode = $associativeValue->getAttribute(AttributeKey::ORIGINAL_NODE);
+        if ($originalNode !== $associativeValue) {
+            return null;
         }
 
         $node->args[1]->value = new Bool_($associativeValue);

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp72\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Cast\Bool_;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Type\BooleanType;
@@ -18,8 +19,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeJsonDecodeNullAssociativeArgRector extends AbstractRector
 {
-    public function __construct(private readonly ArgsAnalyzer $argsAnalyzer)
-    {
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -86,7 +88,7 @@ CODE_SAMPLE
 
         $associativeValue = $args[1]->value;
 
-        if ($associativeValue instanceof Node\Expr\Cast\Bool_) {
+        if ($associativeValue instanceof Bool_) {
             return null;
         }
 
@@ -101,7 +103,7 @@ CODE_SAMPLE
             return $node;
         }
 
-        $node->args[1]->value = new Node\Expr\Cast\Bool_($associativeValue);
+        $node->args[1]->value = new Bool_($associativeValue);
         return $node;
     }
 }

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
@@ -20,24 +20,16 @@ final class DowngradeJsonDecodeNullAssociativeArgRector extends AbstractRector
         return new RuleDefinition('Downgrade json_decode() with null associative argument function', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-class SomeClass
-{
-    public function run()
-    {
-        $value = json_decode($json, null);
-    }
-}
+declare(strict_types=1);
+
+$value = json_decode($json, null);
 CODE_SAMPLE
 
                 ,
                 <<<'CODE_SAMPLE'
-class SomeClass
-{
-    public function run()
-    {
-        $value = json_decode($json, false);
-    }
-}
+declare(strict_types=1);
+
+$value = json_decode($json, false);
 CODE_SAMPLE
             ),
         ]);

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
@@ -78,6 +78,11 @@ CODE_SAMPLE
             return null;
         }
 
+        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
+        if (in_array(self::class, $createdByRule, true)) {
+            return null;
+        }
+
         $args = $node->getArgs();
         if ($this->argsAnalyzer->hasNamedArg($args)) {
             return null;
@@ -102,11 +107,6 @@ CODE_SAMPLE
         if ($associativeValue instanceof ConstFetch && $this->valueResolver->isNull($associativeValue)) {
             $node->args[1]->value = $this->nodeFactory->createFalse();
             return $node;
-        }
-
-        $originalNode = $associativeValue->getAttribute(AttributeKey::ORIGINAL_NODE);
-        if ($originalNode !== $associativeValue) {
-            return null;
         }
 
         $node->args[1]->value = new Bool_($associativeValue);


### PR DESCRIPTION
Currect rector/rector dev-main on php 7.1 got broken build as `nette/utils: 3.2.7` has code 

```php
$value = json_decode($json, null, 512, $flags | JSON_BIGINT_AS_STRING);
```

which make invalid on php 7.1, ref https://3v4l.org/qisBB#v7.1.33

This PR add DowngradeJsonDecodeNullAssociativeArgRector to make it `false` or cast to `(bool)` when not bool type.

Fixes https://github.com/rectorphp/rector/issues/6967