### PR TITLE
[FinalizePublicClassConstantRector] Ignore final classes

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 517 Rules Overview
+# 519 Rules Overview
 
 <br>
 
@@ -28,11 +28,11 @@
 
 - [DowngradePhp56](#downgradephp56) (5)
 
-- [DowngradePhp70](#downgradephp70) (18)
+- [DowngradePhp70](#downgradephp70) (19)
 
 - [DowngradePhp71](#downgradephp71) (10)
 
-- [DowngradePhp72](#downgradephp72) (4)
+- [DowngradePhp72](#downgradephp72) (5)
 
 - [DowngradePhp73](#downgradephp73) (6)
 
@@ -4464,6 +4464,29 @@ Downgrade calling a value that is not directly callable in PHP 5 (property, stat
 
 <br>
 
+### DowngradeUnnecessarilyParenthesizedExpressionRector
+
+Remove parentheses around expressions allowed by Uniform variable syntax RFC where they are not necessary to prevent parse errors on PHP 5.
+
+- class: [`Rector\DowngradePhp70\Rector\Expr\DowngradeUnnecessarilyParenthesizedExpressionRector`](../rules/DowngradePhp70/Rector/Expr/DowngradeUnnecessarilyParenthesizedExpressionRector.php)
+
+```diff
+-($f)['foo'];
+-($f)->foo;
+-($f)->foo();
+-($f)::$foo;
+-($f)::foo();
+-($f)();
++$f['foo'];
++$f->foo;
++$f->foo();
++$f::$foo;
++$f::foo();
++$f();
+```
+
+<br>
+
 ### SplitGroupedUseImportsRector
 
 Refactor grouped use imports to standalone lines
@@ -4678,6 +4701,32 @@ Downgrade Symmetric array destructuring to `list()` function
 <br>
 
 ## DowngradePhp72
+
+### DowngradeJsonDecodeNullAssociativeArgRector
+
+Downgrade `json_decode()` with null associative argument function
+
+- class: [`Rector\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector`](../rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php)
+
+```diff
+ declare(strict_types=1);
+
+ function exactlyNull(string $json)
+ {
+-    $value = json_decode($json, null);
++    $value = json_decode($json, true);
+ }
+
+ function possiblyNull(string $json, ?bool $associative)
+ {
++    if ($associative === null) {
++        $associative = true;
++    }
+     $value = json_decode($json, $associative);
+ }
+```
+
+<br>
 
 ### DowngradeObjectTypeDeclarationRector
 

--- a/rules-tests/Php81/Rector/ClassConst/FinalizePublicClassConstantRector/Fixture/skip_final_class.php.inc
+++ b/rules-tests/Php81/Rector/ClassConst/FinalizePublicClassConstantRector/Fixture/skip_final_class.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\ClassConst\FinalizePublicClassConstantRector\Fixture;
+
+final class SkipFinal
+{
+    public const NAME = 'value';
+}

--- a/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
+++ b/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
@@ -60,6 +60,12 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        $parentClass = $this->betterNodeFinder->findParentByTypes($node, Node\Stmt\Class_::class);
+
+        if ($parentClass->isFinal()) {
+            return null;
+        }
+
         if ($node->isPrivate()) {
             return null;
         }

--- a/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
+++ b/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
@@ -60,7 +60,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $parentClass = $this->betterNodeFinder->findParentByTypes($node, Node\Stmt\Class_::class);
+        /** @var Node\Stmt\Class_ $parentClass */
+        $parentClass = $this->betterNodeFinder->findParentByTypes($node, [Node\Stmt\Class_::class]);
 
         if ($parentClass->isFinal()) {
             return null;

--- a/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
+++ b/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
@@ -60,7 +60,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $parentClass = $this->betterNodeFinder->findParentByTypes($node, [Node\Stmt\Class_::class]);
+        $parentClass = $this->betterNodeFinder->findParentType($node, Node\Stmt\Class_::class);
 
         if (! $parentClass instanceof Node\Stmt\Class_) {
             return null;

--- a/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
+++ b/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
@@ -63,7 +63,7 @@ CODE_SAMPLE
         /** @var Node\Stmt\Class_ $parentClass */
         $parentClass = $this->betterNodeFinder->findParentByTypes($node, [Node\Stmt\Class_::class]);
 
-        if ($parentClass->isFinal()) {
+        if (!$parentClass instanceof Node\Stmt\Class_ || $parentClass->isFinal()) {
             return null;
         }
 

--- a/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
+++ b/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
@@ -60,10 +60,13 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        /** @var Node\Stmt\Class_ $parentClass */
         $parentClass = $this->betterNodeFinder->findParentByTypes($node, [Node\Stmt\Class_::class]);
 
-        if (!$parentClass instanceof Node\Stmt\Class_ || $parentClass->isFinal()) {
+        if (! $parentClass instanceof Node\Stmt\Class_) {
+            return null;
+        }
+
+        if ($parentClass->isFinal()) {
             return null;
         }
 


### PR DESCRIPTION
Fixes issue with Rector changing `const` definition to final when the class is already defined as `final`
Fixes https://github.com/rectorphp/rector/issues/6964 
Closes https://github.com/rectorphp/rector-src/pull/1720