### PR TITLE
[RemoveFinalFromConstRector]

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 519 Rules Overview
+# 520 Rules Overview
 
 <br>
 
@@ -10,7 +10,7 @@
 
 - [CodeQuality](#codequality) (70)
 
-- [CodingStyle](#codingstyle) (34)
+- [CodingStyle](#codingstyle) (35)
 
 - [Compatibility](#compatibility) (1)
 
@@ -2248,6 +2248,22 @@ Non-magic PHP object methods cannot start with "__"
 -        $anotherObject->__getSurname();
 +        $anotherObject->getSurname();
      }
+ }
+```
+
+<br>
+
+### RemoveFinalFromConstRector
+
+Remove final from constants in classes defined as final
+
+- class: [`Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector`](../rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php)
+
+```diff
+ final class SomeClass
+ {
+-    final public const NAME = 'value';
++    public const NAME = 'value';
  }
 ```
 

--- a/config/set/coding-style.php
+++ b/config/set/coding-style.php
@@ -6,6 +6,7 @@ use Rector\CodingStyle\Rector\Assign\PHPStormVarAnnotationRector;
 use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\Class_\AddArrayDefaultToArrayPropertyRector;
+use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
 use Rector\CodingStyle\Rector\ClassConst\SplitGroupedConstantsAndPropertiesRector;
 use Rector\CodingStyle\Rector\ClassConst\VarConstantCommentRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
@@ -68,4 +69,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(PostIncDecToPreIncDecRector::class);
     $services->set(UnSpreadOperatorRector::class);
     $services->set(NewlineAfterStatementRector::class);
+    $services->set(RemoveFinalFromConstRector::class);
 };

--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
-
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
 use Rector\Php81\Rector\ClassConst\FinalizePublicClassConstantRector;
 use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
@@ -28,5 +26,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(NewInInitializerRector::class);
     $services->set(IntersectionTypesRector::class);
     $services->set(NullToStrictStringFuncCallArgRector::class);
-    $services->set(RemoveFinalFromConstRector::class);
 };

--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
@@ -27,4 +28,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(NewInInitializerRector::class);
     $services->set(IntersectionTypesRector::class);
     $services->set(NullToStrictStringFuncCallArgRector::class);
+    $services->set(RemoveFinalFromConstRector::class);
 };

--- a/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/Fixture/skip_non_final_const.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/Fixture/skip_non_final_const.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector\Fixture;
+
+final class SkipNonFinalConst
+{
+    public const NAME = 'value';
+}

--- a/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/Fixture/some_class.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/Fixture/some_class.php.inc
@@ -15,7 +15,7 @@ namespace Rector\Tests\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector\
 
 final class SomeClass
 {
-    public final const NAME = 'value';
+    public const NAME = 'value';
 }
 
 ?>

--- a/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/Fixture/some_class.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/Fixture/some_class.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector\Fixture;
+
+final class SomeClass
+{
+    final public const NAME = 'value';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector\Fixture;
+
+final class SomeClass
+{
+    public final const NAME = 'value';
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/RemoveFinalFromConstRectorTest.php
+++ b/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/RemoveFinalFromConstRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveFinalFromConstRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/config/configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemoveFinalFromConstRector::class);
+};

--- a/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
+++ b/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -70,5 +71,10 @@ CODE_SAMPLE
         }
 
         return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::FINAL_CLASS_CONSTANTS;
     }
 }

--- a/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
+++ b/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
@@ -68,9 +68,10 @@ CODE_SAMPLE
 
         if ($parentClass->isFinal() && $node->isFinal()) {
             $this->visibilityManipulator->removeFinal($node);
+            return $node;
         }
 
-        return $node;
+        return null;
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
+++ b/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassConst;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -18,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Tests\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector\RemoveFinalFromConstRectorTest
  */
-final class RemoveFinalFromConstRector extends AbstractRector
+final class RemoveFinalFromConstRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly VisibilityManipulator $visibilityManipulator

--- a/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
+++ b/rules/CodingStyle/Rector/ClassConst/RemoveFinalFromConstRector.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\ClassConst;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://php.watch/versions/8.1/final-class-const
+ *
+ * @see \Rector\Tests\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector\RemoveFinalFromConstRectorTest
+ */
+final class RemoveFinalFromConstRector extends AbstractRector
+{
+    public function __construct(
+        private readonly VisibilityManipulator $visibilityManipulator
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove final from constants in classes defined as final', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    final public const NAME = 'value';
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public const NAME = 'value';
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassConst::class];
+    }
+
+    /**
+     * @param ClassConst $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $parentClass = $this->betterNodeFinder->findParentType($node, Class_::class);
+
+        if (! $parentClass instanceof Class_) {
+            return null;
+        }
+
+        if ($parentClass->isFinal() && $node->isFinal()) {
+            $this->visibilityManipulator->removeFinal($node);
+        }
+
+        return $node;
+    }
+}


### PR DESCRIPTION
- Added a rule to remove `final` from constants when they belong to a `final` class to avoid issues with other static analysis tools like https://github.com/nunomaduro/phpinsightslike where you start getting "errors" like:

> ::error file=/var/www/ACL/Add.php,line=11::* [Unnecessary final modifier] Unnecessary FINAL modifier in FINAL class

```php
// before
final class A {
    final public const AC = 'const';
}

// after
final class A {
    public const AC = 'const';
}
```