### PR TITLE
Add failing test fixture for CatchExceptionNameMatchingTypeRector, AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/tests/Issues/Issue6972/DoNotAddDefaultValueForExceptionRectorTest.php
+++ b/tests/Issues/Issue6972/DoNotAddDefaultValueForExceptionRectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue6972;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/6972
+ */
+final class DoNotAddDefaultValueForExceptionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue6972/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6972/Fixture/fixture.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6972\Fixture;
+
+use Exception;
+
+final class Fixture
+{
+    public function run()
+    {
+        try {
+            $this->doSomething();
+        } catch (Exception $throwable) {
+            throw $throwable;
+        }
+    }
+
+    public function doSomething()
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue6972\Fixture;
+
+use Exception;
+
+final class Fixture
+{
+    public function run()
+    {
+        try {
+            $this->doSomething();
+        } catch (Exception $exception) {
+            throw $exception;
+        }
+    }
+
+    public function doSomething()
+    {
+    }
+}
+?>

--- a/tests/Issues/Issue6972/config/configured_rule.php
+++ b/tests/Issues/Issue6972/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
+use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
+use Rector\Php70\Rector\FunctionLike\ExceptionHandlerTypehintRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ExceptionHandlerTypehintRector::class);
+    $services->set(CatchExceptionNameMatchingTypeRector::class);
+    $services->set(AddDefaultValueForUndefinedVariableRector::class);
+};


### PR DESCRIPTION
# Failing Test for CatchExceptionNameMatchingTypeRector, AddDefaultValueForUndefinedVariableRector
Based on https://getrector.org/demo/1ec7f26d-bcb0-61a0-ac18-a5fd5121dc8a

ref: https://github.com/rectorphp/rector/issues/6972