### PR TITLE
[Php81] Skip dynamic class on NewInInitializerRector

### DIFF
--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/skip_dynamic_new.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/skip_dynamic_new.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
+
+use stdClass;
+
+class SkipDynamicNew
+{
+    private object $stdClass;
+
+    public function __construct(
+        string $fallbackClass,
+        ?stdClass $stdClass = null
+    ) {
+        $this->stdClass = $stdClass ?? new $fallbackClass;
+    }
+}

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -7,6 +7,8 @@ namespace Rector\Php81\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
@@ -96,7 +98,7 @@ CODE_SAMPLE
                     continue;
                 }
 
-                if (! $toPropertyAssign->expr->right instanceof New_) {
+                if (! $toPropertyAssign->expr->right instanceof New_ || ! $toPropertyAssign->expr->right->class instanceof FullyQualified) {
                     continue;
                 }
 

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -96,8 +96,10 @@ CODE_SAMPLE
                 if (! $toPropertyAssign->expr instanceof Coalesce) {
                     continue;
                 }
-
-                if (! $toPropertyAssign->expr->right instanceof New_ || ! $toPropertyAssign->expr->right->class instanceof FullyQualified) {
+                if (! $toPropertyAssign->expr->right instanceof New_) {
+                    continue;
+                }
+                if (! $toPropertyAssign->expr->right->class instanceof FullyQualified) {
                     continue;
                 }
 

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Php81\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
@@ -97,11 +98,7 @@ CODE_SAMPLE
                     continue;
                 }
 
-                if (! $toPropertyAssign->expr->right instanceof New_) {
-                    continue;
-                }
-
-                if (! $toPropertyAssign->expr->right->class instanceof FullyQualified) {
+                if ($this->isNotNewOrWithDynamicClass($toPropertyAssign->expr->right)) {
                     continue;
                 }
 
@@ -123,6 +120,11 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::NEW_INITIALIZERS;
+    }
+
+    private function isNotNewOrWithDynamicClass(Expr $expr): bool
+    {
+        return ! $expr instanceof New_ || ! $expr->class instanceof FullyQualified;
     }
 
     private function processPropertyPromotion(ClassMethod $classMethod, Param $param, string $paramName): void

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -96,9 +96,11 @@ CODE_SAMPLE
                 if (! $toPropertyAssign->expr instanceof Coalesce) {
                     continue;
                 }
+
                 if (! $toPropertyAssign->expr->right instanceof New_) {
                     continue;
                 }
+
                 if (! $toPropertyAssign->expr->right->class instanceof FullyQualified) {
                     continue;
                 }

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -7,7 +7,6 @@ namespace Rector\Php81\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;


### PR DESCRIPTION
Given the following class:

```php
class SkipDynamicNew
{
    private object $stdClass;

    public function __construct(
        string $fallbackClass,
        ?stdClass $stdClass = null
    ) {
        $this->stdClass = $stdClass ?? new $fallbackClass;
    }
}
```

it produce:

```diff
-    private object $stdClass;
-
-    public function __construct(
-        string $fallbackClass,
-        ?stdClass $stdClass = null
-    ) {
-        $this->stdClass = $stdClass ?? new $fallbackClass;
+    public function __construct(string $fallbackClass, private stdClass $stdClass = new $fallbackClass)
+    {
     }
```

which invalid and cause error:

```bash
Fatal error: Cannot use dynamic class name in constant expression
```

ref https://3v4l.org/RVfne#v8.1.2