### PR TITLE
[Php81] Skip override abstract method on NewInInitializerRector

### DIFF
--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -6,8 +6,8 @@ namespace Rector\FamilyTree\NodeAnalyzer;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\PhpMethodReflection;
-use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 use PHPStan\Reflection\ReflectionProvider;
+use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 
 final class ClassChildAnalyzer
 {
@@ -40,6 +40,28 @@ final class ClassChildAnalyzer
         return false;
     }
 
+    public function hasParentClassMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        return $this->resolveParentClassMethods($classReflection, $methodName) !== [];
+    }
+
+    public function hasAbstractParentClassMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        $parentClassMethods = $this->resolveParentClassMethods($classReflection, $methodName);
+        if ($parentClassMethods === []) {
+            return false;
+        }
+
+        /** @var PhpMethodReflection[] $e */
+        foreach ($parentClassMethods as $parentClassMethod) {
+            if ($parentClassMethod->isAbstract()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @return PhpMethodReflection[]
      */
@@ -63,27 +85,5 @@ final class ClassChildAnalyzer
         }
 
         return $parentClassMethods;
-    }
-
-    public function hasParentClassMethod(ClassReflection $classReflection, string $methodName): bool
-    {
-        return $this->resolveParentClassMethods($classReflection, $methodName) !== [];
-    }
-
-    public function hasAbstractParentClassMethod(ClassReflection $classReflection, string $methodName): bool
-    {
-        $parentClassMethods = $this->resolveParentClassMethods($classReflection, $methodName);
-        if ($parentClassMethods === []) {
-            return false;
-        }
-
-        /** @var PhpMethodReflection[] $e */
-        foreach ($parentClassMethods as $parentClassMethod) {
-            if ($parentClassMethod->isAbstract()) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -6,14 +6,12 @@ namespace Rector\FamilyTree\NodeAnalyzer;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\PhpMethodReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 
 final class ClassChildAnalyzer
 {
     public function __construct(
-        private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer
     ) {
     }
 

--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -52,7 +52,6 @@ final class ClassChildAnalyzer
             return false;
         }
 
-        /** @var PhpMethodReflection[] $e */
         foreach ($parentClassMethods as $parentClassMethod) {
             if ($parentClassMethod->isAbstract()) {
                 return true;

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/skip_override_abstract_method.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/skip_override_abstract_method.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
+
+use DateTime;
+use Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Source\OverrideAbstractMethod;
+
+class SkipOverrideAbstractMethod extends OverrideAbstractMethod
+{
+    private DateTime $dateTime;
+
+    public function __construct(
+        ?DateTime $dateTime = null
+    ) {
+        $this->dateTime = $dateTime ?? new DateTime('now');
+    }
+}

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Source/OverrideAbstractMethod.php
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Source/OverrideAbstractMethod.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Source;
+
+use DateTime;
+
+abstract class OverrideAbstractMethod
+{
+    abstract public function __construct(
+        ?DateTime $dateTime = null
+    );
+}

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -187,7 +187,7 @@ CODE_SAMPLE
             return [];
         }
 
-        if ($classMethod->stmts === []) {
+        if ((array) $classMethod->stmts === []) {
             return [];
         }
 

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -14,9 +14,12 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\FamilyTree\NodeAnalyzer\ClassChildAnalyzer;
 use Rector\Php81\NodeAnalyzer\ComplexNewAnalyzer;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -30,7 +33,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class NewInInitializerRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ComplexNewAnalyzer $complexNewAnalyzer
+        private readonly ComplexNewAnalyzer $complexNewAnalyzer,
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ClassChildAnalyzer $classChildAnalyzer
     ) {
     }
 
@@ -87,6 +92,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isOverrideAbstractMethod($node)) {
+            return null;
+        }
+
         foreach ($params as $param) {
             /** @var string $paramName */
             $paramName = $this->getName($param->var);
@@ -122,6 +131,17 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::NEW_INITIALIZERS;
+    }
+
+    private function isOverrideAbstractMethod(ClassMethod $classMethod): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflectionFromClassMethod($classMethod);
+        $methodName = $this->nodeNameResolver->getName($classMethod);
+
+        return $classReflection instanceof ClassReflection && $this->classChildAnalyzer->hasAbstractParentClassMethod(
+            $classReflection,
+            $methodName
+        );
     }
 
     private function processPropertyPromotion(ClassMethod $classMethod, Param $param, string $paramName): void

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -55,6 +55,17 @@ final class ReflectionResolver
         return $this->reflectionProvider->getClass($className);
     }
 
+    public function resolveClassReflectionFromClassMethod(ClassMethod $classMethod): ?ClassReflection
+    {
+        $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
+
+        if (! $scope instanceof Scope) {
+            return null;
+        }
+
+        return $scope->getClassReflection();
+    }
+
     /**
      * @param class-string $className
      */


### PR DESCRIPTION
when in __construct, there is abstract method __construct, it will cause error:

```bash
Fatal error: Declaration of SkipOverrideAbstractMethod::__construct(DateTime $dateTime = <expression>) must be compatible with OverrideAbstractMethod::__construct(?DateTime $dateTime = null)
```

ref https://3v4l.org/FdaVl