### PR TITLE
[Scoper] Exclude Attribute polyfill class from class_alias (take 1)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -615,3 +615,8 @@ parameters:
 
         # mapper re-use
         - '#Parameter \#1 \$type of method Rector\\PHPStanStaticTypeMapper\\TypeMapper\\ObjectWithoutClassTypeMapper\:\:mapToPhpParserNode\(\) expects PHPStan\\Type\\ObjectWithoutClassType, PHPStan\\Type\\Accessory\\Has(Property|Method)Type given#'
+
+        # due to new https://github.com/symplify/symplify/pull/3912 NoMixedPropertyFetcherRule
+        - '#Anonymous variables in a property fetch can lead to false dead property\. Make sure the variable type is known#'
+        # due to new https://github.com/symplify/symplify/pull/3913 NoMixedMethodCallerRule
+        - '#Anonymous variables in a method call can lead to false dead methods\. Make sure the variable type is known#'

--- a/scoper.php
+++ b/scoper.php
@@ -46,6 +46,7 @@ const UNPREFIX_CLASSES_BY_FILE = [
         'Symplify\ComposerJsonManipulator\ValueObject\ComposerJson',
     ],
     'packages/Testing/PHPUnit/AbstractTestCase.php' => ['PHPUnit\Framework\TestCase'],
+    'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php' => ['Attribute'],
 ];
 // see https://github.com/humbug/php-scoper
 return [


### PR DESCRIPTION
@TomasVotruba @leighman this is part of https://github.com/rectorphp/rector/issues/6951, start with removing class_alias from Attribute polyfill.