### PR TITLE
[Scoper] Rollback attribute exclude, add specify PHP80_BIN_PATH env when run ./full_build.sh locally

### DIFF
--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -41,6 +41,7 @@ wget https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.ph
 if test -z ${PHP80_BIN_PATH+y}; then
     php -d memory_limit=-1 php-scoper.phar add-prefix bin config src packages rules vendor composer.json --output-dir "../$RESULT_DIRECTORY" --config scoper.php --force --ansi --working-dir "$BUILD_DIRECTORY";
 else
+    echo "scoping with specify PHP80_BIN_PATH env";
     $PHP80_BIN_PATH -d memory_limit=-1 php-scoper.phar add-prefix bin config src packages rules vendor composer.json --output-dir "../$RESULT_DIRECTORY" --config scoper.php --force --ansi --working-dir "$BUILD_DIRECTORY";
 fi
 

--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -37,8 +37,12 @@ note "Running scoper to $RESULT_DIRECTORY"
 wget https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.phar -N --no-verbose
 
 # Work around possible PHP memory limits
-php -d memory_limit=-1 php-scoper.phar add-prefix bin config src packages rules vendor composer.json --output-dir "../$RESULT_DIRECTORY" --config scoper.php --force --ansi --working-dir "$BUILD_DIRECTORY"
 
+if test -z ${PHP80_BIN_PATH+y}; then
+    php -d memory_limit=-1 php-scoper.phar add-prefix bin config src packages rules vendor composer.json --output-dir "../$RESULT_DIRECTORY" --config scoper.php --force --ansi --working-dir "$BUILD_DIRECTORY";
+else
+    $PHP80_BIN_PATH -d memory_limit=-1 php-scoper.phar add-prefix bin config src packages rules vendor composer.json --output-dir "../$RESULT_DIRECTORY" --config scoper.php --force --ansi --working-dir "$BUILD_DIRECTORY";
+fi
 
 # note "Dumping Composer Autoload"
 composer dump-autoload --working-dir "$RESULT_DIRECTORY" --ansi --classmap-authoritative --no-dev

--- a/full_build.sh
+++ b/full_build.sh
@@ -37,32 +37,41 @@ rm rector.php
 cp ../build/target-repository/bootstrap.php .
 cp ../preload.php .
 
-# allow to specify PHP71_BIN_PATH env
+# Check php 7.1 can be used locally with PHP71_BIN_PATH env
+# Prefixing build only works on php < 8.0, can be used locally with PHP80_BIN_PATH env
+
+#
 # usage:
 #
-#   export PHP71_BIN_PATH=/opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php && sh ./full_build.sh
+#   export PHP71_BIN_PATH=/opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php PHP80_BIN_PATH=/opt/homebrew/Cellar/php@8.0/8.0.14/bin/php && sh ./full_build.sh
 #
 if test -z ${PHP71_BIN_PATH+y}; then
-    eval "bin/rector list --ansi";
+    bin/rector list --ansi;
 else
-    eval "$PHP71_BIN_PATH bin/rector list --ansi";
+    $PHP71_BIN_PATH bin/rector list --ansi;
 fi
 
 cd ..
-rm -rf rector-build
 
-# Prefixed build only works on PHP < 8.1 now, so only able to run on CI.
 # We may need a way to specify PHP path on run build/build-rector-scoped.sh, eg:
 #
 #     /path/to/php/bin/php build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
 #
 #
-# sh build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
-# cd rector-prefixed-downgraded
-# cp ../build/target-repository/bootstrap.php .
-# cp ../preload.php .
-# bin/rector list --ansi
-# bin/rector process vendor/symfony/string/Slugger/ --dry-run
+sh build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
+cd rector-prefixed-downgraded
+cp ../build/target-repository/bootstrap.php .
+cp ../preload.php .
 
-# cd ..
-# rm -rf rector-prefixed-downgraded
+if test -z ${PHP71_BIN_PATH+y}; then
+    bin/rector list --ansi;
+    bin/rector process vendor/symfony/string/Slugger/ --dry-run;
+else
+    $PHP71_BIN_PATH bin/rector list --ansi;
+    $PHP71_BIN_PATH bin/rector process vendor/symfony/string/Slugger/ --dry-run;
+fi
+
+cd ..
+
+rm -rf rector-prefixed-downgraded
+rm -rf rector-build

--- a/full_build.sh
+++ b/full_build.sh
@@ -48,6 +48,7 @@ cp ../preload.php .
 if test -z ${PHP71_BIN_PATH+y}; then
     bin/rector list --ansi;
 else
+    echo "verify downgraded rector with specify PHP71_BIN_PATH env";
     $PHP71_BIN_PATH bin/rector list --ansi;
 fi
 
@@ -67,6 +68,7 @@ if test -z ${PHP71_BIN_PATH+y}; then
     bin/rector list --ansi;
     bin/rector process vendor/symfony/string/Slugger/ --dry-run;
 else
+    echo "verify scoped rector with specify PHP71_BIN_PATH env";
     $PHP71_BIN_PATH bin/rector list --ansi;
     $PHP71_BIN_PATH bin/rector process vendor/symfony/string/Slugger/ --dry-run;
 fi

--- a/scoper.php
+++ b/scoper.php
@@ -46,7 +46,6 @@ const UNPREFIX_CLASSES_BY_FILE = [
         'Symplify\ComposerJsonManipulator\ValueObject\ComposerJson',
     ],
     'packages/Testing/PHPUnit/AbstractTestCase.php' => ['PHPUnit\Framework\TestCase'],
-    'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php' => ['Attribute'],
 ];
 // see https://github.com/humbug/php-scoper
 return [
@@ -236,6 +235,19 @@ return [
             }
 
             return Strings::replace($content, '#services\->load\(\'#', "services->load('" . $prefix . '\\');
+        },
+
+        function (string $filePath, string $prefix, string $content) use ($filePathsToRemoveNamespace): string {
+            // @see https://regex101.com/r/0jaVB1/1
+            $prefixedNamespacePattern = '#^namespace (.*?);$#m';
+
+            foreach ($filePathsToRemoveNamespace as $filePathToRemoveNamespace) {
+                if (\str_ends_with($filePath, $filePathToRemoveNamespace)) {
+                    return Strings::replace($content, $prefixedNamespacePattern, '');
+                }
+            }
+
+            return $content;
         },
     ],
 ];

--- a/scoper.php
+++ b/scoper.php
@@ -236,18 +236,5 @@ return [
 
             return Strings::replace($content, '#services\->load\(\'#', "services->load('" . $prefix . '\\');
         },
-
-        function (string $filePath, string $prefix, string $content) use ($filePathsToRemoveNamespace): string {
-            // @see https://regex101.com/r/0jaVB1/1
-            $prefixedNamespacePattern = '#^namespace (.*?);$#m';
-
-            foreach ($filePathsToRemoveNamespace as $filePathToRemoveNamespace) {
-                if (\str_ends_with($filePath, $filePathToRemoveNamespace)) {
-                    return Strings::replace($content, $prefixedNamespacePattern, '');
-                }
-            }
-
-            return $content;
-        },
     ],
 ];


### PR DESCRIPTION
rollback https://github.com/rectorphp/rector-src/pull/1747 with add ability to add `PHP80_BIN_PATH` for prefixing since php-scoper only works on php 8.0 to ease check locally on run ./full_build.sh to ease check result locally.

not part of the fix, just process...