### PR TITLE
[DowngradePhp70][DowngradePhp80] Test for combine DowngradeScalarTypeDeclarationRector + DowngradeStringReturnTypeOnToStringRector

### DIFF
--- a/tests/Issues/DowngradeScalarString/DowngradeScalarStringTest.php
+++ b/tests/Issues/DowngradeScalarString/DowngradeScalarStringTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\DowngradeScalarString;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeScalarStringTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DowngradeScalarString/Fixture/return_string.php.inc
+++ b/tests/Issues/DowngradeScalarString/Fixture/return_string.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\DowngradeScalarString\Fixture;
+
+class AbstractReturnString
+{
+    public function __toString(): string
+    {
+        return 'value';
+    }
+}
+
+class ReturnString extends AbstractReturnString
+{
+    public function __toString()
+    {
+        return 'value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\DowngradeScalarString\Fixture;
+
+class AbstractReturnString
+{
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return 'value';
+    }
+}
+
+class ReturnString extends AbstractReturnString
+{
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return 'value';
+    }
+}
+
+?>

--- a/tests/Issues/DowngradeScalarString/Fixture/return_string.php.inc
+++ b/tests/Issues/DowngradeScalarString/Fixture/return_string.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Core\Tests\Issues\DowngradeScalarString\Fixture;
 
-class AbstractReturnString
+abstract class AbstractReturnString
 {
     public function __toString(): string
     {
@@ -24,7 +24,7 @@ class ReturnString extends AbstractReturnString
 
 namespace Rector\Core\Tests\Issues\DowngradeScalarString\Fixture;
 
-class AbstractReturnString
+abstract class AbstractReturnString
 {
     /**
      * @return string

--- a/tests/Issues/DowngradeScalarString/config/configured_rule.php
+++ b/tests/Issues/DowngradeScalarString/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp70\Rector\FunctionLike\DowngradeScalarTypeDeclarationRector;
+use Rector\DowngradePhp80\Rector\ClassMethod\DowngradeStringReturnTypeOnToStringRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeStringReturnTypeOnToStringRector::class);
+    $services->set(DowngradeScalarTypeDeclarationRector::class);
+};


### PR DESCRIPTION
PR https://github.com/rectorphp/rector-src/pull/1750 add `string` return type on current class method when parent has `string` return type, while `DowngradeScalarTypeDeclarationRector` remove scalar type.

This PR adds tests for combine use DowngradeScalarTypeDeclarationRector + DowngradeStringReturnTypeOnToStringRector to keep it working as the type will be removed when combined