### PR TITLE
[Core] Refactor RectifiedAnalyzer: remove exclude _Class

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -23,8 +23,9 @@ final class RectifiedAnalyzer
      */
     private array $previousFileWithNodes = [];
 
-    public function __construct(private readonly NodeNameResolver $nodeNameResolver)
-    {
+    public function __construct(
+        private readonly NodeNameResolver $nodeNameResolver
+    ) {
     }
 
     public function verify(RectorInterface $rector, Node $node, Node $originalNode, File $currentFile): ?RectifiedNode
@@ -51,7 +52,13 @@ final class RectifiedAnalyzer
         $nodeName = $this->nodeNameResolver->getName($node);
         $originalNodeName = $this->nodeNameResolver->getName($node);
 
-        if (is_string($nodeName) && is_string($originalNodeName) && $nodeName === $originalNodeName && $createdByRule !== [] && ! in_array($rector::class, $createdByRule, true)) {
+        if (is_string($nodeName) && is_string(
+            $originalNodeName
+        ) && $nodeName === $originalNodeName && $createdByRule !== [] && ! in_array(
+            $rector::class,
+            $createdByRule,
+            true
+        )) {
             return null;
         }
 

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -28,7 +28,7 @@ final class RectifiedAnalyzer
     ) {
     }
 
-    public function verify(RectorInterface $rector, Node $node, Node $originalNode, File $currentFile): ?RectifiedNode
+    public function verify(RectorInterface $rector, Node $node, ?Node $originalNode, File $currentFile): ?RectifiedNode
     {
         $smartFileInfo = $currentFile->getSmartFileInfo();
         $realPath = $smartFileInfo->getRealPath();
@@ -50,7 +50,9 @@ final class RectifiedAnalyzer
 
         $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
         $nodeName = $this->nodeNameResolver->getName($node);
-        $originalNodeName = $this->nodeNameResolver->getName($node);
+        $originalNodeName = $originalNode instanceof Node
+            ? $this->nodeNameResolver->getName($originalNode)
+            : null;
 
         if (is_string($nodeName) && $nodeName === $originalNodeName && $createdByRule !== [] && ! in_array(
             $rector::class,

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -52,9 +52,7 @@ final class RectifiedAnalyzer
         $nodeName = $this->nodeNameResolver->getName($node);
         $originalNodeName = $this->nodeNameResolver->getName($node);
 
-        if (is_string($nodeName) && is_string(
-            $originalNodeName
-        ) && $nodeName === $originalNodeName && $createdByRule !== [] && ! in_array(
+        if (is_string($nodeName) && $nodeName === $originalNodeName && $createdByRule !== [] && ! in_array(
             $rector::class,
             $createdByRule,
             true

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -286,19 +286,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         return $node;
     }
 
-    private function createdByRule(array | Node $node, Node $originalNode): void
-    {
-        if ($node instanceof Node) {
-            $node = [$node];
-        }
-
-        foreach ($node as $subNode) {
-            $this->createdByRuleDecorator->decorate($subNode, static::class);
-        }
-
-        $this->createdByRuleDecorator->decorate($originalNode, static::class);
-    }
-
     /**
      * Replacing nodes in leaveNode() method avoids infinite recursion
      * see"infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
@@ -439,6 +426,19 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
     protected function removeNodes(array $nodes): void
     {
         $this->nodeRemover->removeNodes($nodes);
+    }
+
+    private function createdByRule(array | Node $node, Node $originalNode): void
+    {
+        if ($node instanceof Node) {
+            $node = [$node];
+        }
+
+        foreach ($node as $subNode) {
+            $this->createdByRuleDecorator->decorate($subNode, static::class);
+        }
+
+        $this->createdByRuleDecorator->decorate($originalNode, static::class);
     }
 
     /**

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -272,7 +272,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
         // is different node type? do not traverse children to avoid looping
         $this->infiniteLoopValidator->process($node, $originalNode, static::class);
-        $this->createdByRule($node, $originalNode);
+        $this->createdByRuleDecorator->decorate($node, static::class);
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
         $originalNodeHash = spl_object_hash($originalNode);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -217,7 +217,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return null;
         }
 
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE) ?? clone $node;
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
         if ($this->shouldSkipCurrentNode($node, $originalNode)) {
             return null;
         }
@@ -230,6 +230,8 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         $this->printDebugApplying();
 
         $originalAttributes = $node->getAttributes();
+        $originalNode = $originalNode ?? clone $node;
+
         $node = $this->refactor($node);
 
         // nothing to change → continue
@@ -458,7 +460,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         return false;
     }
 
-    private function shouldSkipCurrentNode(Node $node, Node $originalNode): bool
+    private function shouldSkipCurrentNode(Node $node, ?Node $originalNode): bool
     {
         if ($this->nodesToRemoveCollector->isNodeRemoved($node)) {
             return true;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -437,8 +437,8 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             $node = [$node];
         }
 
-        foreach ($node as $subNode) {
-            $this->createdByRuleDecorator->decorate($subNode, static::class);
+        foreach ($node as $singleNode) {
+            $this->createdByRuleDecorator->decorate($singleNode, static::class);
         }
 
         $this->createdByRuleDecorator->decorate($originalNode, static::class);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -428,6 +428,9 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         $this->nodeRemover->removeNodes($nodes);
     }
 
+    /**
+     * @param array<Node>|Node $node
+     */
     private function createdByRule(array | Node $node, Node $originalNode): void
     {
         if ($node instanceof Node) {

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -230,7 +230,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         $this->printDebugApplying();
 
         $originalAttributes = $node->getAttributes();
-        $originalNode = $originalNode ?? clone $node;
+        $originalNode ??= clone $node;
 
         $node = $this->refactor($node);
 


### PR DESCRIPTION
This is next step of https://github.com/rectorphp/rector-src/pull/1681 for verify node re-changed by rule for : 

```bash
Same Rector Rule <-> Same Node <-> Same File
```

which previously still excluded the `Class_`Node.

This PR remove `_Class` from exclusion with check:

- applied check `AttributeKey::CREATED_BY_RULE` in both Node and original Node.
- compare original node name and changed node name if they are a string
- check if `AttributeKey::CREATED_BY_RULE` is not empty, and the applied rule is not part of it, it means the changes are in deep body, which repetitive apply with same Rector Rule -> Same Node -> same File may happen.
