### PR TITLE
Add testcase for renameNamespace duplication.

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -113,9 +113,9 @@ final class PhpDocInfoFactory
         }
 
         $phpDocChildNodes = $phpDocNode->children;
-        $lastChildNode = array_pop($phpDocChildNodes);
+        $phpDocChildNode = array_pop($phpDocChildNodes);
 
-        $startAndEnd = $lastChildNode->getAttribute(PhpDocAttributeKey::START_AND_END);
+        $startAndEnd = $phpDocChildNode->getAttribute(PhpDocAttributeKey::START_AND_END);
 
         if ($startAndEnd instanceof StartAndEnd) {
             $phpDocNode->setAttribute(PhpDocAttributeKey::LAST_PHP_DOC_TOKEN_POSITION, $startAndEnd->getEnd());

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -113,9 +113,9 @@ final class PhpDocInfoFactory
         }
 
         $phpDocChildNodes = $phpDocNode->children;
-        $phpDocChildNode = array_pop($phpDocChildNodes);
+        $lastChildNode = array_pop($phpDocChildNodes);
 
-        $startAndEnd = $phpDocChildNode->getAttribute(PhpDocAttributeKey::START_AND_END);
+        $startAndEnd = $lastChildNode->getAttribute(PhpDocAttributeKey::START_AND_END);
 
         if ($startAndEnd instanceof StartAndEnd) {
             $phpDocNode->setAttribute(PhpDocAttributeKey::LAST_PHP_DOC_TOKEN_POSITION, $startAndEnd->getEnd());

--- a/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/fixture6.php.inc
+++ b/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/fixture6.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Repositories;
+
+class BlogRepository {
+}
+
+function index()
+{
+    \App\Repositories\BlogRepository::class;
+}
+
+?>
+-----
+<?php
+
+namespace App\Repositories\Example;
+
+class BlogRepository {
+}
+
+function index()
+{
+    \App\Repositories\Example\BlogRepository::class;
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/config/configured_rule.php
@@ -14,5 +14,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'Old\Long\AnyNamespace' => 'Short\AnyNamespace',
             'PHPUnit_Framework_' => 'PHPUnit\Framework\\',
             'Foo\Bar' => 'Foo\Tmp',
+            'App\Repositories' => 'App\Repositories\Example',
         ]);
 };


### PR DESCRIPTION
When moving class a level deeper in the namespace there seems to be a nesting loop.

Example: https://getrector.org/demo/1ec83675-2110-65f0-a94c-6929b91df106