### PR TITLE
[DX] Deprecate show command

### DIFF
--- a/.github/workflows/code_analysis_no_dev.yaml
+++ b/.github/workflows/code_analysis_no_dev.yaml
@@ -17,10 +17,6 @@ jobs:
                         name: 'Rector List'
                         run: bin/rector list --ansi
 
-                    -
-                        name: 'Show command'
-                        run: bin/rector show --ansi
-
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
         timeout-minutes: 30

--- a/src/Console/Command/ShowCommand.php
+++ b/src/Console/Command/ShowCommand.php
@@ -55,7 +55,8 @@ final class ShowCommand extends Command
                 PHP_EOL
             );
             $this->outputStyle->warning($warningMessage);
-            return self::SUCCESS;
+
+            return self::FAILURE;
         }
 
         $rectorCount = count($rectors);
@@ -66,6 +67,12 @@ final class ShowCommand extends Command
         $message = sprintf('%d loaded Rectors', $rectorCount);
         $this->outputStyle->success($message);
 
-        return Command::SUCCESS;
+        $this->outputStyle->error(
+            'The "show" command is deprecated and will be removed, as it was used only for more output on Rector run. Use the "--debug" option and process command for debugging output instead.'
+        );
+        // to spot the error message
+        sleep(3);
+
+        return Command::FAILURE;
     }
 }


### PR DESCRIPTION
The "show" command was used only for more output on Rector run.  Kinda of "debug" command.

Now we should use the "--debug" option and process command for debugging output instead :+1: 