### PR TITLE
[Php80] Fix configure should not remove annotation directly passed bool value

### DIFF
--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/FixtureShouldNotRemoveAnnotationDirectConfig/required_keep_old.php.inc
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/FixtureShouldNotRemoveAnnotationDirectConfig/required_keep_old.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\FixtureShouldNotRemoveAnnotation;
+
+use Doctrine\Common\Annotations\Annotation\Required;
+
+/**
+ * @annotation
+ */
+final class RequiredKeepOld
+{
+    /** @Required */
+    public $requiredField;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\FixtureShouldNotRemoveAnnotation;
+
+use Doctrine\Common\Annotations\Annotation\Required;
+
+/**
+ * @annotation
+ */
+#[\Attribute]
+final class RequiredKeepOld
+{
+    /** @Required */
+    public $requiredField;
+    public function __construct($requiredField)
+    {
+        $this->requiredField = $requiredField;
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/FixtureShouldNotRemoveAnnotationDirectConfig/skip_already_added.php.inc
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/FixtureShouldNotRemoveAnnotationDirectConfig/skip_already_added.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector\FixtureShouldNotRemoveAnnotation;
+
+use Attribute;
+
+/**
+ * @Annotation
+ */
+#[Attribute]
+final class SkipAlreadyAdded
+{
+}

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/ShouldNotRemoveAnnotationDirectConfigRectorTest.php
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/ShouldNotRemoveAnnotationDirectConfigRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ShouldNotRemoveAnnotationDirectConfigRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureShouldNotRemoveAnnotationDirectConfig');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configure_direct_shouldnot_remove_annotation.php';
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/config/configure_direct_shouldnot_remove_annotation.php
+++ b/rules-tests/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector/config/configure_direct_shouldnot_remove_annotation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DoctrineAnnotationClassToAttributeRector::class)
+        ->configure([false]);
+};

--- a/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
@@ -169,7 +169,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $shouldRemoveAnnotations = $configuration[self::REMOVE_ANNOTATIONS] ?? true;
+        $shouldRemoveAnnotations = $configuration[self::REMOVE_ANNOTATIONS] ?? (bool) current($configuration);
         Assert::boolean($shouldRemoveAnnotations);
         $this->shouldRemoveAnnotations = $shouldRemoveAnnotations;
     }

--- a/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
+++ b/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
@@ -26,7 +26,7 @@ abstract class AbstractFalsyScalarRuleFixerRector extends AbstractRector impleme
      */
     public function configure(array $configuration): void
     {
-        $treatAsNonEmpty = $configuration[self::TREAT_AS_NON_EMPTY] ?? false;
+        $treatAsNonEmpty = $configuration[self::TREAT_AS_NON_EMPTY] ?? (bool) current($configuration);
         Assert::boolean($treatAsNonEmpty);
 
         $this->treatAsNonEmpty = $treatAsNonEmpty;

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -124,7 +124,7 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        $usePhpdoc = $configuration[self::USE_PHPDOC] ?? false;
+        $usePhpdoc = $configuration[self::USE_PHPDOC] ?? (bool) current($configuration);
         Assert::boolean($usePhpdoc);
 
         $this->usePhpdoc = $usePhpdoc;


### PR DESCRIPTION
The `DoctrineAnnotationClassToAttributeRector::REMOVE_ANNOTATIONS` constant is deprecated, so the usage of this:

```php
    $services->set(DoctrineAnnotationClassToAttributeRector::class)
        ->configure([
            DoctrineAnnotationClassToAttributeRector::REMOVE_ANNOTATIONS => false,
        ]);
```

is deprecated, changing the config to:

```php
    $services->set(DoctrineAnnotationClassToAttributeRector::class)
        ->configure([false]);
```

will cause invalid result as currently fallback to true. 

https://github.com/rectorphp/rector-src/blob/8320d290031d91d232e3dd5b1b8779fbcb6e5a07/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php#L172

When rector service defintion not call `configure()`, it will never called when never used, so it is safe, eg on PR https://github.com/rectorphp/rector-src/pull/1745 that existing tests doesn't has it configured, that's use `AllowEmptyConfigurableRectorInterface`

This PR change to direct value of current config casted:

```diff
-        $shouldRemoveAnnotations = $configuration[self::REMOVE_ANNOTATIONS] ?? true;
+        $shouldRemoveAnnotations = $configuration[self::REMOVE_ANNOTATIONS] ?? (bool) current($configuration);
```