### PR TITLE
[DX] Remove @deprecated docblock for only bool passing config in rector rules

### DIFF
--- a/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/DoctrineAnnotationClassToAttributeRector.php
@@ -38,7 +38,6 @@ use Webmozart\Assert\Assert;
 final class DoctrineAnnotationClassToAttributeRector extends AbstractRector implements ConfigurableRectorInterface, MinPhpVersionInterface
 {
     /**
-     * @deprecated
      * @var string
      */
     public const REMOVE_ANNOTATIONS = 'remove_annotations';

--- a/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
+++ b/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
@@ -14,7 +14,6 @@ use Webmozart\Assert\Assert;
 abstract class AbstractFalsyScalarRuleFixerRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @deprecated
      * @var string
      */
     final public const TREAT_AS_NON_EMPTY = 'treat_as_non_empty';


### PR DESCRIPTION
Per addition of `INLINE_PUBLIC` constant for define `bool` config on `TypedPropertyRector` on https://github.com/rectorphp/rector-src/pull/1745, the only bool config constant should not has `@deprecated` docs on other rules, so it can support both usage of :

```php
    $services->set(DoctrineAnnotationClassToAttributeRector::class)
        ->configure([
            DoctrineAnnotationClassToAttributeRector::REMOVE_ANNOTATIONS => false,
        ]);
```

or

```php
    $services->set(DoctrineAnnotationClassToAttributeRector::class)
        ->configure([false]);
```

for consistency usage.