### PR TITLE
[CodeQuality] Skip multi params on method on on setValue($a, $b, $c ...) on ExplicitMethodCallOverMagicGetSetRector on assign

### DIFF
--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_multi_param_on_assign.php.inc
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_multi_param_on_assign.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source\ObjectWithMagicCallsMultiParam;
+
+final class SkipNoMethodOnMultiParam
+{
+    public function run(ObjectWithMagicCallsMultiParam $obj)
+    {
+        $obj->name = 20;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_multi_param_on_assign2.php.inc
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_multi_param_on_assign2.php.inc
@@ -4,10 +4,11 @@ namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMa
 
 use Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source\ObjectWithMagicCallsMultiParam;
 
-final class SkipNoMethodOnMultiParamOnAssign
+final class SkipNoMethodOnMultiParamOnAssign2
 {
-    public function run(ObjectWithMagicCallsMultiParam $obj)
+    public function run()
     {
+        $obj = new ObjectWithMagicCallsMultiParam();
         $obj->name = 20;
     }
 }

--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsMultiParam.php
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsMultiParam.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source;
+
+use Nette\SmartObject;
+
+final class ObjectWithMagicCallsMultiParam
+{
+    // adds magic __get() and __set() methods
+    use SmartObject;
+
+    private $name;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name, string $value)
+    {
+        $this->name = $name . $value;
+    }
+}

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -9,9 +9,12 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -176,6 +179,15 @@ CODE_SAMPLE
         $setterMethodName = 'set' . ucfirst($propertyName);
         if (! $propertyCallerType->hasMethod($setterMethodName)->yes()) {
             return null;
+        }
+
+        $scope = $propertyFetch->getAttribute(AttributeKey::SCOPE);
+        if ($scope instanceof Scope) {
+            $methodReflection = $propertyCallerType->getMethod($setterMethodName, $scope);
+            $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+            if (count($parametersAcceptor->getParameters()) > 1) {
+                return null;
+            }
         }
 
         return $this->nodeFactory->createMethodCall($propertyFetch->var, $setterMethodName, [$expr]);

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ResolvedMethodReflection;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
@@ -184,9 +185,12 @@ CODE_SAMPLE
         $scope = $propertyFetch->getAttribute(AttributeKey::SCOPE);
         if ($scope instanceof Scope) {
             $methodReflection = $propertyCallerType->getMethod($setterMethodName, $scope);
-            $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
-            if (count($parametersAcceptor->getParameters()) > 1) {
-                return null;
+
+            if ($methodReflection instanceof ResolvedMethodReflection) {
+                $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+                if (count($parametersAcceptor->getParameters()) > 1) {
+                    return null;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/6980