### PR TITLE
[DowngradePhp72] Add DowngradePhp72JsonConstRector

### DIFF
--- a/config/set/downgrade-php72.php
+++ b/config/set/downgrade-php72.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector;
+use Rector\DowngradePhp72\Rector\ConstFetch\DowngradePhp72JsonConstRector;
 use Rector\DowngradePhp72\Rector\FuncCall\DowngradeJsonDecodeNullAssociativeArgRector;
 use Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector;
 use Rector\DowngradePhp72\Rector\FuncCall\DowngradeStreamIsattyRector;
@@ -21,4 +22,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradePregUnmatchedAsNullConstantRector::class);
     $services->set(DowngradeStreamIsattyRector::class);
     $services->set(DowngradeJsonDecodeNullAssociativeArgRector::class);
+    $services->set(DowngradePhp72JsonConstRector::class);
 };

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/DowngradePhp72JsonConstRectorTest.php
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/DowngradePhp72JsonConstRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector;
+namespace Rector\Tests\DowngradePhp72\Rector\ConstFetch\DowngradePhp72JsonConstRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/DowngradePhp72JsonConstRectorTest.php
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/DowngradePhp72JsonConstRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradePhp72JsonConstRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $inDecoder = new Decoder($connection, true, 512, \JSON_INVALID_UTF8_IGNORE);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $inDecoder = new Decoder($connection, true, 512, 0);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/skip_different_constant.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/skip_different_constant.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class SkipDifferentConstant
+{
+    public function run()
+    {
+        json_encode($a, JSON_HEX_TAG);
+    }
+}

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp72\Rector\ConstFetch\DowngradePhp72JsonConstRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradePhp72JsonConstRector::class);
+};

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -13,12 +13,13 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @changelog https://www.php.net/manual/en/function.json-encode.php#refsect1-function.json-encode-changelog
+ *
  * @see \Rector\Tests\DowngradePhp72\Rector\ConstFetch\DowngradePhp72JsonConstRector\DowngradePhp72JsonConstRectorTest
  */
 final class DowngradePhp72JsonConstRector extends AbstractRector
 {
     /**
-     * @var array
+     * @var array<string>
      */
     private const CONSTANTS = [
         'JSON_INVALID_UTF8_IGNORE',

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -21,23 +21,22 @@ final class DowngradePhp72JsonConstRector extends AbstractRector
     /**
      * @var array<string>
      */
-    private const CONSTANTS = [
-        'JSON_INVALID_UTF8_IGNORE',
-        'JSON_INVALID_UTF8_SUBSTITUTE',
-    ];
+    private const CONSTANTS = ['JSON_INVALID_UTF8_IGNORE', 'JSON_INVALID_UTF8_SUBSTITUTE'];
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Change Json constant that available only in php 7.2 to 0', [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Change Json constant that available only in php 7.2 to 0',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 $inDecoder = new Decoder($connection, true, 512, \JSON_INVALID_UTF8_IGNORE);
 CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
+                    ,
+                    <<<'CODE_SAMPLE'
 $inDecoder = new Decoder($connection, true, 512, 0);
 CODE_SAMPLE
-        )
+                ),
             ]
         );
     }

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp72\Rector\ConstFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://www.php.net/manual/en/function.json-encode.php#refsect1-function.json-encode-changelog
+ * @see \Rector\Tests\DowngradePhp72\Rector\ConstFetch\DowngradePhp72JsonConstRector\DowngradePhp72JsonConstRectorTest
+ */
+final class DowngradePhp72JsonConstRector extends AbstractRector
+{
+    /**
+     * @var array
+     */
+    private const CONSTANTS = [
+        'JSON_INVALID_UTF8_IGNORE',
+        'JSON_INVALID_UTF8_SUBSTITUTE',
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change Json constant that available only in php 7.2 to 0', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$inDecoder = new Decoder($connection, true, 512, \JSON_INVALID_UTF8_IGNORE);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$inDecoder = new Decoder($connection, true, 512, 0);
+CODE_SAMPLE
+        )
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ConstFetch::class];
+    }
+
+    /**
+     * @param ConstFetch $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->nodeNameResolver->isNames($node, self::CONSTANTS)) {
+            return null;
+        }
+
+        return new ConstFetch(new Name('0'));
+    }
+}


### PR DESCRIPTION
Add `DowngradePhp72JsonConstRector` for https://github.com/symplify/symplify/issues/3920, using prefix:

"DowngradePhp72" prefix on purpose as constant downgrade for json const will be needed for php 7.1 and php 7.3 as well, ref https://www.php.net/manual/en/function.json-encode.php#refsect1-function.json-encode-changelog

So next, we can add:

- DowngradePhp73JsonConstRector
- DowngradePhp71JsonConstRector

so inclusion in rector.php will can identify which one is used, reference for "Downgrade"`PhpXy` prefix:

https://github.com/rectorphp/rector-src/blob/1090aa6e8a5012beab9f3a8c7cff21e3db5ab149/rules/DowngradePhp80/Rector/Instanceof_/DowngradePhp80ResourceReturnToObjectRector.php#L19

as re-used 

https://github.com/rectorphp/rector-src/blob/1090aa6e8a5012beab9f3a8c7cff21e3db5ab149/rules/DowngradePhp81/Rector/Instanceof_/DowngradePhp81ResourceReturnToObjectRector.php#L20