### PR TITLE
[CodeQuality] Skip ExplicitMethodCallOverMagicGetSetRector on method no param + variadic

### DIFF
--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_no_param_on_assign.php.inc
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_no_param_on_assign.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source\ObjectWithMagicCallsNoParam;
+
+final class SkipNoMethodNoParamOnAssign
+{
+    public function run(ObjectWithMagicCallsNoParam $obj)
+    {
+        $obj->name = 20;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_variadic_param_on_assign.php.inc
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_no_method_variadic_param_on_assign.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source\ObjectWithMagicCallsVariadicParam;
+
+final class SkipNoMethodVariadicParamOnAssign
+{
+    public function run(ObjectWithMagicCallsVariadicParam $obj)
+    {
+        $obj->name = 20;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsNoParam.php
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsNoParam.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source;
+
+use Nette\SmartObject;
+
+final class ObjectWithMagicCallsNoParam
+{
+    // adds magic __get() and __set() methods
+    use SmartObject;
+
+    private $name;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName()
+    {
+        $this->name = 'test';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsVariadicParam.php
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsVariadicParam.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source;
+
+use Nette\SmartObject;
+
+final class ObjectWithMagicCallsVariadicParam
+{
+    // adds magic __get() and __set() methods
+    use SmartObject;
+
+    private $name;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName(...$params)
+    {
+        if (isset($params[1])) {
+            $this->name = $params[0] . $params[1];
+            return;
+        }
+
+        $this->name = current($params);
+    }
+}

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -182,19 +182,35 @@ CODE_SAMPLE
             return null;
         }
 
-        $scope = $propertyFetch->getAttribute(AttributeKey::SCOPE);
-        if ($scope instanceof Scope) {
-            $methodReflection = $propertyCallerType->getMethod($setterMethodName, $scope);
-
-            if ($methodReflection instanceof ResolvedMethodReflection) {
-                $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
-                $parameters = $parametersAcceptor->getParameters();
-                if (count($parameters) !== 1 || $parameters[0]->isVariadic()) {
-                    return null;
-                }
-            }
+        if ($this->hasNoParamOrVariadic($propertyCallerType, $propertyFetch, $setterMethodName)) {
+            return null;
         }
 
         return $this->nodeFactory->createMethodCall($propertyFetch->var, $setterMethodName, [$expr]);
+    }
+
+    private function hasNoParamOrVariadic(
+        ObjectType $objectType,
+        PropertyFetch $propertyFetch,
+        string $setterMethodName
+    ): bool {
+        $scope = $propertyFetch->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return false;
+        }
+
+        $methodReflection = $objectType->getMethod($setterMethodName, $scope);
+
+        if (! $methodReflection instanceof ResolvedMethodReflection) {
+            return false;
+        }
+
+        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+        $parameters = $parametersAcceptor->getParameters();
+        if (count($parameters) !== 1) {
+            return true;
+        }
+
+        return $parameters[0]->isVariadic();
     }
 }

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -188,7 +188,7 @@ CODE_SAMPLE
 
             if ($methodReflection instanceof ResolvedMethodReflection) {
                 $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
-                if (count($parametersAcceptor->getParameters()) > 1) {
+                if (count($parametersAcceptor->getParameters()) !== 1) {
                     return null;
                 }
             }

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -188,7 +188,8 @@ CODE_SAMPLE
 
             if ($methodReflection instanceof ResolvedMethodReflection) {
                 $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
-                if (count($parametersAcceptor->getParameters()) !== 1) {
+                $parameters = $parametersAcceptor->getParameters();
+                if (count($parameters) !== 1 || $parameters[0]->isVariadic()) {
                     return null;
                 }
             }


### PR DESCRIPTION
Continue on https://github.com/rectorphp/rector-src/pull/1763 that it should be skipped when existing method has no param + variadic