### PR TITLE
[Core] Clean up AbstractRector: Apply InfiniteLoopValidator only before refactor

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -244,11 +244,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return null;
         }
 
-        /** @var Node|array<Node> $node */
-        if (! $this->infiniteLoopValidator->isValid($node, $originalNode, static::class)) {
-            return null;
-        }
-
         /** @var Node $originalNode */
         if (is_array($node)) {
             $this->createdByRuleDecorator->decorate($node, $originalNode, static::class);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -233,7 +233,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
         $originalNode ??= clone $node;
 
-        if (! $this->infiniteLoopValidator->isValid($node, $originalNode, static::class)) {
+        if (! $this->infiniteLoopValidator->isValid($originalNode, static::class)) {
             return null;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -246,6 +246,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
         /** @var Node $originalNode */
         if (is_array($node)) {
+            /** @var array<Node> $node */
             $this->createdByRuleDecorator->decorate($node, $originalNode, static::class);
 
             $originalNodeHash = spl_object_hash($originalNode);
@@ -259,6 +260,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         }
 
         // not changed, return node early
+        /** @var Node $node */
         if (! $this->changedNodeAnalyzer->hasNodeChanged($originalNode, $node)) {
             return $node;
         }

--- a/src/Validation/InfiniteLoopValidator.php
+++ b/src/Validation/InfiniteLoopValidator.php
@@ -23,7 +23,7 @@ final class InfiniteLoopValidator
     public function isValid(Node|array $node, Node $originalNode, string $rectorClass): bool
     {
         if ($this->nodeComparator->areNodesEqual($node, $originalNode)) {
-            return true;
+            return ! $this->hasInCreatedByRule($originalNode, $rectorClass);
         }
 
         $isFound = (bool) $this->betterNodeFinder->findFirst(
@@ -35,11 +35,12 @@ final class InfiniteLoopValidator
             return true;
         }
 
-        $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-        if ($createdByRule === []) {
-            return true;
-        }
+        return ! $this->hasInCreatedByRule($originalNode, $rectorClass);
+    }
 
-        return ! in_array($rectorClass, $createdByRule, true);
+    private function hasInCreatedByRule(Node $originalNode, string $rectorClass): bool
+    {
+        $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
+        return in_array($rectorClass, $createdByRule, true);
     }
 }

--- a/src/Validation/InfiniteLoopValidator.php
+++ b/src/Validation/InfiniteLoopValidator.php
@@ -5,42 +5,13 @@ declare(strict_types=1);
 namespace Rector\Core\Validation;
 
 use PhpParser\Node;
-use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class InfiniteLoopValidator
 {
-    public function __construct(
-        private readonly NodeComparator $nodeComparator,
-        private readonly BetterNodeFinder $betterNodeFinder
-    ) {
-    }
-
-    /**
-     * @param Node|array<Node> $node
-     */
-    public function isValid(Node|array $node, Node $originalNode, string $rectorClass): bool
-    {
-        if ($this->nodeComparator->areNodesEqual($node, $originalNode)) {
-            return ! $this->hasInCreatedByRule($originalNode, $rectorClass);
-        }
-
-        $isFound = (bool) $this->betterNodeFinder->findFirst(
-            $node,
-            fn (Node $subNode): bool => $this->nodeComparator->areNodesEqual($node, $subNode)
-        );
-
-        if (! $isFound) {
-            return true;
-        }
-
-        return ! $this->hasInCreatedByRule($originalNode, $rectorClass);
-    }
-
-    private function hasInCreatedByRule(Node $originalNode, string $rectorClass): bool
+    public function isValid(Node $originalNode, string $rectorClass): bool
     {
         $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-        return in_array($rectorClass, $createdByRule, true);
+        return ! in_array($rectorClass, $createdByRule, true);
     }
 }


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/1771 which check both in before and after refactor.

This PR remove check on after refactor, with early check rector class is in original node's `AttributeKey::CREATED_BY_RULE` attribute on `InfiniteLoopValidator::isValid()`