### PR TITLE
[Php80] Doc mirror var to param improvement on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocManipulator;
 
-use PHPStan\PhpDocParser\Ast\Node;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocManipulator;
 
+use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
@@ -165,7 +166,7 @@ final class PhpDocTypeChanger
             return;
         }
 
-        if (! $varTag->type instanceof GenericTypeNode) {
+        if (! $varTag->type instanceof GenericTypeNode && ! $varTag->type instanceof SpacingAwareArrayTypeNode) {
             return;
         }
 

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocManipulator;
 
+use PHPStan\PhpDocParser\Ast\Node;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
@@ -19,6 +20,7 @@ use Rector\BetterPhpDocParser\Comment\CommentsMerger;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
+use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareCallableTypeNode;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
@@ -28,6 +30,15 @@ use Rector\TypeDeclaration\PhpDocParser\ParamPhpDocNodeFactory;
 
 final class PhpDocTypeChanger
 {
+    /**
+     * @var array<class-string<Node>>
+     */
+    public const ALLOWED_TYPES = [
+        GenericTypeNode::class,
+        SpacingAwareArrayTypeNode::class,
+        SpacingAwareCallableTypeNode::class,
+    ];
+
     public function __construct(
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly TypeComparator $typeComparator,
@@ -166,7 +177,7 @@ final class PhpDocTypeChanger
             return;
         }
 
-        if (! $varTag->type instanceof GenericTypeNode && ! $varTag->type instanceof SpacingAwareArrayTypeNode) {
+        if (! in_array($varTag->type::class, self::ALLOWED_TYPES, true)) {
             return;
         }
 

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocManipulator;
 
-use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
@@ -19,6 +18,7 @@ use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\Comment\CommentsMerger;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -189,6 +189,7 @@ final class PhpDocTypeChanger
         $paramType = $this->staticTypeMapper->mapPHPStanPhpDocTypeToPHPStanType($varTag, $property);
 
         $this->changeParamType($phpDocInfo, $paramType, $param, $paramVarName);
+        $this->processKeepComments($property, $param);
     }
 
     public function changeVarTypeNode(PhpDocInfo $phpDocInfo, TypeNode $typeNode): void

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/AutoImportTest.php
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/AutoImportTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AutoImportTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureAutoImport');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/auto_import_configured_rule.php';
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/copy_array_string_doc.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/copy_array_string_doc.php.inc
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class CopyArrayStringDoc
+{
+    /**
+     * Comment
+     * @var string[]
+     */
+    private array $map;
+
+    public function __construct(array $map)
+    {
+        $this->map = $map;
+    }
+}
+
+?>
+-----
+<?php declare(strict_types = 1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class CopyArrayStringDoc
+{
+    /**
+     * @param string[] $map
+     */
+    public function __construct(
+        /**
+         * Comment
+         */
+        private array $map
+    )
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureAutoImport/copy_annotation_and_array_string_doc.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureAutoImport/copy_annotation_and_array_string_doc.php.inc
@@ -41,7 +41,8 @@ class CopyAnnotationAndArrayStringDoc
          * @SerializedName("owsy/derived-facts")
          */
         private array $derivedFacts = []
-    ) {
+    )
+    {
     }
 }
 

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureAutoImport/copy_annotation_and_array_string_doc.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureAutoImport/copy_annotation_and_array_string_doc.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\FixtureAutoImport;
+
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+class CopyAnnotationAndArrayStringDoc
+{
+    /**
+     * @var string[]
+     * @SerializedName("owsy/derived-facts")
+     */
+    private array $derivedFacts;
+
+    public function __construct(
+        array $derivedFacts = [],
+    ) {
+        $this->derivedFacts = $derivedFacts;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\FixtureAutoImport;
+
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+class CopyAnnotationAndArrayStringDoc
+{
+    /**
+     * @param string[] $derivedFacts
+     */
+    public function __construct(
+        /**
+         * @SerializedName("owsy/derived-facts")
+         */
+        private array $derivedFacts = []
+    ) {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/config/auto_import_configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/config/auto_import_configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+
+    $services = $containerConfigurator->services();
+    $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
+};

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -14,12 +14,11 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\VariadicAwareParamTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
-use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareCallableTypeNode;
 use Rector\DeadCode\TypeNodeAnalyzer\GenericTypeNodeAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
@@ -56,10 +55,7 @@ final class DeadParamTagValueNodeAnalyzer
             return false;
         }
 
-        if (in_array($paramTagValueNode->type::class, [
-            GenericTypeNode::class,
-            SpacingAwareCallableTypeNode::class,
-        ], true)) {
+        if (in_array($paramTagValueNode->type::class, PhpDocTypeChanger::ALLOWED_TYPES, true)) {
             return false;
         }
 

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -8,11 +8,10 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
-use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareCallableTypeNode;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\DeadCode\TypeNodeAnalyzer\GenericTypeNodeAnalyzer;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
@@ -46,10 +45,7 @@ final class DeadReturnTagValueNodeAnalyzer
             return false;
         }
 
-        if (in_array($returnTagValueNode->type::class, [
-            GenericTypeNode::class,
-            SpacingAwareCallableTypeNode::class,
-        ], true)) {
+        if (in_array($returnTagValueNode->type::class, PhpDocTypeChanger::ALLOWED_TYPES, true)) {
             return false;
         }
 


### PR DESCRIPTION
- [x] Move `@var string[]` to `@param string[]`
- [x] Move list of types to keep to constant for re-use dead use detection
- [x] Move annotation on auto import enabled.

Based on https://github.com/rectorphp/rector-src/pull/1712#issuecomment-1031860687