### PR TITLE
[Core] Remove ClassLike_ tweak on RectifiedAnalyzer

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -21,7 +21,7 @@ final class RectifiedAnalyzer
      */
     private array $previousFileWithNodes = [];
 
-    public function verify(RectorInterface $rector, Node $node, ?Node $originalNode, File $currentFile): ?RectifiedNode
+    public function verify(RectorInterface $rector, Node $node, File $currentFile): ?RectifiedNode
     {
         $smartFileInfo = $currentFile->getSmartFileInfo();
         $realPath = $smartFileInfo->getRealPath();

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -8,8 +8,6 @@ use PhpParser\Node;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\RectifiedNode;
-use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * This service verify if the Node already rectified with same Rector rule before current Rector rule with condition
@@ -22,11 +20,6 @@ final class RectifiedAnalyzer
      * @var array<string, RectifiedNode|null>
      */
     private array $previousFileWithNodes = [];
-
-    public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
-    ) {
-    }
 
     public function verify(RectorInterface $rector, Node $node, ?Node $originalNode, File $currentFile): ?RectifiedNode
     {
@@ -45,20 +38,6 @@ final class RectifiedAnalyzer
         }
 
         if ($rectifiedNode->getNode() !== $node) {
-            return null;
-        }
-
-        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-        $nodeName = $this->nodeNameResolver->getName($node);
-        $originalNodeName = $originalNode instanceof Node
-            ? $this->nodeNameResolver->getName($originalNode)
-            : null;
-
-        if (is_string($nodeName) && $nodeName === $originalNodeName && $createdByRule !== [] && ! in_array(
-            $rector::class,
-            $createdByRule,
-            true
-        )) {
             return null;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -217,8 +217,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return null;
         }
 
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-        if ($this->shouldSkipCurrentNode($node, $originalNode)) {
+        if ($this->shouldSkipCurrentNode($node)) {
             return null;
         }
 
@@ -231,7 +230,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
         $originalAttributes = $node->getAttributes();
 
-        $originalNode ??= clone $node;
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE) ?? clone $node;
 
         if (! $this->infiniteLoopValidator->isValid($originalNode, static::class)) {
             return null;
@@ -459,7 +458,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         return false;
     }
 
-    private function shouldSkipCurrentNode(Node $node, ?Node $originalNode): bool
+    private function shouldSkipCurrentNode(Node $node): bool
     {
         if ($this->nodesToRemoveCollector->isNodeRemoved($node)) {
             return true;
@@ -474,7 +473,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return true;
         }
 
-        $rectifiedNode = $this->rectifiedAnalyzer->verify($this, $node, $originalNode, $this->file);
+        $rectifiedNode = $this->rectifiedAnalyzer->verify($this, $node, $this->file);
         return $rectifiedNode instanceof RectifiedNode;
     }
 

--- a/tests/Issues/IssueConstructorPromotionRename/config/configured_rule.php
+++ b/tests/Issues/IssueConstructorPromotionRename/config/configured_rule.php
@@ -8,6 +8,6 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
-    $services->set(RenamePropertyToMatchTypeRector::class);
     $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
+    $services->set(RenamePropertyToMatchTypeRector::class);
 };


### PR DESCRIPTION
This PR replace tweak of `ClassLike_` exclude on PR : 

- https://github.com/rectorphp/rector-src/pull/1754

With re-sort the service definition on multiple service applied, on this case is:

```diff
+   $services->set(RenamePropertyToMatchTypeRector::class);
    $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
-   $services->set(RenamePropertyToMatchTypeRector::class);
```

Actually, even without re-sort service definition, the result is still valid, that's just need to be run twice:

```diff
-    private $a;
-    public function __construct(\DateTimeInterface $a)
+    public function __construct(private \DateTimeInterface $a)
     {
-        $this->a = $a;
         dump($a);
```

to show the result:

https://github.com/rectorphp/rector-src/blob/50d19784ab0ae6e4098ca4ce224af44d414b82f3/tests/Issues/IssueConstructorPromotionRename/Fixture/fixture.php.inc#L28-L32

which is safer instead of by passed to next rules for repetitive refactor with:

```
 Same Rector Rule <-> Same Node <-> Same File
```