### PR TITLE
[Core] Remove unnecessary counter tweak for infinite loop on PhpFileProcessor

### DIFF
--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -59,14 +59,7 @@ final class PhpFileProcessor implements FileProcessorInterface
         }
 
         // 2. change nodes with Rectors
-        $loopCounter = 0;
         do {
-            ++$loopCounter;
-
-            if ($loopCounter === 10) { // ensure no infinite loop
-                break;
-            }
-
             $file->changeHasChanged(false);
             $this->refactorNodesWithRectors($file, $configuration);
 


### PR DESCRIPTION
By latest change of PR: 

- https://github.com/rectorphp/rector-src/pull/1776

There shoud be no longer need of tweak of infinite loop on `PhpFileProcessor` as repetitive apply rule to Node on the same file already handled.