### PR TITLE
[CodingStyle] Handle direct pass string config on ConsistentPregDelimiterRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/DirectStringConfigTest.php
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/DirectStringConfigTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DirectStringConfigTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureDirectStringConfig');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/direct_string_configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/FixtureDirectStringConfig/fixture.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/FixtureDirectStringConfig/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        preg_match('~value~', $value);
+        preg_match_all('~value~im', $value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        preg_match('/value/', $value);
+        preg_match_all('/value/im', $value);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/config/direct_string_configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/config/direct_string_configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ConsistentPregDelimiterRector::class)
+        ->configure(['/']);
+};

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -161,7 +161,7 @@ CODE_SAMPLE
 
     public function configure(array $configuration): void
     {
-        $this->delimiter = $configuration[self::DELIMITER] ?? '#';
+        $this->delimiter = $configuration[self::DELIMITER] ?? (string) current($configuration);
     }
 
     private function refactorFuncCall(FuncCall $funcCall): ?FuncCall


### PR DESCRIPTION
Continue of PR : 

- https://github.com/rectorphp/rector-src/pull/1761

Currently, direct pass string config:

```php
    $services->set(ConsistentPregDelimiterRector::class)
        ->configure(['/']);
```

is fallback to '#', this PR change to fallback to current configuration passed:

```diff
-        $this->delimiter = $configuration[self::DELIMITER] ?? '#';
+        $this->delimiter = $configuration[self::DELIMITER] ?? (string) current($configuration);
```