### PR TITLE
[DowngradePhp72] Handle in BitwiseOr on DowngradePhp72JsonConstRector

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwise
+{
+    public function run()
+    {
+        $argument = json_encode($argument, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwise
+{
+    public function run()
+    {
+        $argument = json_encode($argument, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRec
 
 class InBitwise
 {
-    public function run()
+    public function run($argument)
     {
         $argument = json_encode($argument, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
     }
@@ -22,7 +22,7 @@ namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRec
 
 class InBitwise
 {
-    public function run()
+    public function run($argument)
     {
         $argument = json_encode($argument, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwiseUseAll
+{
+    public function run()
+    {
+        $argument = json_encode($argument, JSON_INVALID_UTF8_IGNORE | JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwiseUseAll
+{
+    public function run()
+    {
+        $argument = json_encode($argument, 0);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRec
 
 class InBitwiseUseAll
 {
-    public function run()
+    public function run($argument)
     {
         $argument = json_encode($argument, JSON_INVALID_UTF8_IGNORE | JSON_INVALID_UTF8_SUBSTITUTE);
     }
@@ -22,7 +22,7 @@ namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRec
 
 class InBitwiseUseAll
 {
-    public function run()
+    public function run($argument)
     {
         $argument = json_encode($argument, 0);
     }

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all_in_between.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all_in_between.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwiseUseAllInBetween
+{
+    public function run($argument)
+    {
+        $argument = json_encode($argument, JSON_INVALID_UTF8_IGNORE | JSON_HEX_TAG | JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwiseUseAllInBetween
+{
+    public function run($argument)
+    {
+        $argument = json_encode($argument, JSON_HEX_TAG);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all_in_between_variable.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/in_bitwise_use_all_in_between_variable.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwiseUseAllInBetweenVariable
+{
+    public function run($argument, $variable)
+    {
+        $argument = json_encode($argument, JSON_INVALID_UTF8_IGNORE | $variable | JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class InBitwiseUseAllInBetweenVariable
+{
+    public function run($argument, $variable)
+    {
+        $argument = json_encode($argument, $variable);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/skip_bitwise_different_constants.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector/Fixture/skip_bitwise_different_constants.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePhp72JsonConstRector\Fixture;
+
+class SkipBitwiseDifferentConstant
+{
+    public function run($argument)
+    {
+        $argument = json_encode($argument, JSON_HEX_TAG | JSON_PRETTY_PRINT);
+    }
+}

--- a/rules/DowngradePhp72/NodeManipulator/JsonConstCleaner.php
+++ b/rules/DowngradePhp72/NodeManipulator/JsonConstCleaner.php
@@ -52,22 +52,8 @@ final class JsonConstCleaner
      */
     private function cleanByBitwiseOr(BitwiseOr $bitwiseOr, array $constants): ?Expr
     {
-        $isLeftTransformed = false;
-        $isRightTransformed = false;
-
-        if ($bitwiseOr->left instanceof ConstFetch && $this->nodeNameResolver->isNames(
-            $bitwiseOr->left,
-            $constants
-        )) {
-            $isLeftTransformed = true;
-        }
-
-        if ($bitwiseOr->right instanceof ConstFetch && $this->nodeNameResolver->isNames(
-            $bitwiseOr->right,
-            $constants
-        )) {
-            $isRightTransformed = true;
-        }
+        $isLeftTransformed = $this->isTransformed($bitwiseOr->left, $constants);
+        $isRightTransformed = $this->isTransformed($bitwiseOr->right, $constants);
 
         if (! $isLeftTransformed && ! $isRightTransformed) {
             return null;
@@ -82,5 +68,13 @@ final class JsonConstCleaner
         }
 
         return new ConstFetch(new Name('0'));
+    }
+
+    /**
+     * @param string[] $constants
+     */
+    private function isTransformed(Expr $expr, array $constants): bool
+    {
+        return $expr instanceof ConstFetch && $this->nodeNameResolver->isNames($expr, $constants);
     }
 }

--- a/rules/DowngradePhp72/NodeManipulator/JsonConstCleaner.php
+++ b/rules/DowngradePhp72/NodeManipulator/JsonConstCleaner.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp72\NodeManipulator;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use Rector\Core\PhpParser\Comparing\NodeComparator;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class JsonConstCleaner
+{
+    public function __construct(
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly NodeComparator $nodeComparator
+    ) {
+    }
+
+    /**
+     * @param string[] $constants
+     */
+    public function clean(ConstFetch|BitwiseOr $node, array $constants): ConstFetch|Expr|null
+    {
+        if ($node instanceof ConstFetch) {
+            return $this->cleanByConstFetch($node, $constants);
+        }
+
+        return $this->cleanByBitwiseOr($node, $constants);
+    }
+
+    /**
+     * @param string[] $constants
+     */
+    private function cleanByConstFetch(ConstFetch $constFetch, array $constants): ?ConstFetch
+    {
+        if (! $this->nodeNameResolver->isNames($constFetch, $constants)) {
+            return null;
+        }
+
+        $parent = $constFetch->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parent instanceof BitwiseOr) {
+            return new ConstFetch(new Name('0'));
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string[] $constants
+     */
+    private function cleanByBitwiseOr(BitwiseOr $bitwiseOr, array $constants): ?Expr
+    {
+        $zeroConstFetch = new ConstFetch(new Name('0'));
+        $transformed = false;
+
+        if ($bitwiseOr->left instanceof ConstFetch && $this->nodeNameResolver->isNames(
+            $bitwiseOr->left,
+            $constants
+        )) {
+            $transformed = true;
+            $bitwiseOr->left = $zeroConstFetch;
+        }
+
+        if ($bitwiseOr->right instanceof ConstFetch && $this->nodeNameResolver->isNames(
+            $bitwiseOr->right,
+            $constants
+        )) {
+            $transformed = true;
+            $bitwiseOr->right = $zeroConstFetch;
+        }
+
+        if (! $transformed) {
+            return null;
+        }
+
+        if ($this->nodeComparator->areNodesEqual($bitwiseOr->left, $bitwiseOr->right)) {
+            return $zeroConstFetch;
+        }
+
+        return $this->nodeComparator->areNodesEqual($bitwiseOr->left, $zeroConstFetch)
+            ? $bitwiseOr->right
+            : $bitwiseOr->left;
+    }
+}

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -79,15 +79,24 @@ CODE_SAMPLE
 
     private function processBitwiseOr(BitwiseOr $bitwiseOr, ConstFetch $zeroConstFetch): ?Expr
     {
-        if ($bitwiseOr->left instanceof ConstFetch && $this->nodeNameResolver->isNames($bitwiseOr->left, self::CONSTANTS)) {
+        if ($bitwiseOr->left instanceof ConstFetch && $this->nodeNameResolver->isNames(
+            $bitwiseOr->left,
+            self::CONSTANTS
+        )) {
             $bitwiseOr->left = $zeroConstFetch;
         }
 
-        if ($bitwiseOr->right instanceof ConstFetch && $this->nodeNameResolver->isNames($bitwiseOr->right, self::CONSTANTS)) {
+        if ($bitwiseOr->right instanceof ConstFetch && $this->nodeNameResolver->isNames(
+            $bitwiseOr->right,
+            self::CONSTANTS
+        )) {
             $bitwiseOr->right = $zeroConstFetch;
         }
 
-        if ($this->nodeComparator->areNodesEqual($bitwiseOr->left, $zeroConstFetch) && $this->nodeComparator->areNodesEqual($bitwiseOr->right, $zeroConstFetch)) {
+        if ($this->nodeComparator->areNodesEqual(
+            $bitwiseOr->left,
+            $zeroConstFetch
+        ) && $this->nodeComparator->areNodesEqual($bitwiseOr->right, $zeroConstFetch)) {
             return $zeroConstFetch;
         }
 

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -105,10 +105,8 @@ CODE_SAMPLE
             return $zeroConstFetch;
         }
 
-        if ($this->nodeComparator->areNodesEqual($bitwiseOr->left, $zeroConstFetch)) {
-            return $bitwiseOr->right;
-        }
-
-        return $bitwiseOr->left;
+        return $this->nodeComparator->areNodesEqual($bitwiseOr->left, $zeroConstFetch)
+            ? $bitwiseOr->right
+            : $bitwiseOr->left;
     }
 }

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -34,9 +34,11 @@ final class DowngradePhp72JsonConstRector extends AbstractRector
                 new CodeSample(
                     <<<'CODE_SAMPLE'
 $inDecoder = new Decoder($connection, true, 512, \JSON_INVALID_UTF8_IGNORE);
+$inDecoder = new Decoder($connection, true, 512, \JSON_INVALID_UTF8_SUBSTITUTE);
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
+$inDecoder = new Decoder($connection, true, 512, 0);
 $inDecoder = new Decoder($connection, true, 512, 0);
 CODE_SAMPLE
                 ),

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -79,10 +79,13 @@ CODE_SAMPLE
 
     private function processBitwiseOr(BitwiseOr $bitwiseOr, ConstFetch $zeroConstFetch): ?Expr
     {
+        $transformed = false;
+
         if ($bitwiseOr->left instanceof ConstFetch && $this->nodeNameResolver->isNames(
             $bitwiseOr->left,
             self::CONSTANTS
         )) {
+            $transformed = true;
             $bitwiseOr->left = $zeroConstFetch;
         }
 
@@ -90,13 +93,15 @@ CODE_SAMPLE
             $bitwiseOr->right,
             self::CONSTANTS
         )) {
+            $transformed = true;
             $bitwiseOr->right = $zeroConstFetch;
         }
 
-        if ($this->nodeComparator->areNodesEqual(
-            $bitwiseOr->left,
-            $zeroConstFetch
-        ) && $this->nodeComparator->areNodesEqual($bitwiseOr->right, $zeroConstFetch)) {
+        if (! $transformed) {
+            return null;
+        }
+
+        if ($this->nodeComparator->areNodesEqual($bitwiseOr->left, $bitwiseOr->right)) {
             return $zeroConstFetch;
         }
 
@@ -104,10 +109,6 @@ CODE_SAMPLE
             return $bitwiseOr->right;
         }
 
-        if ($this->nodeComparator->areNodesEqual($bitwiseOr->right, $zeroConstFetch)) {
-            return $bitwiseOr->left;
-        }
-
-        return null;
+        return $bitwiseOr->left;
     }
 }


### PR DESCRIPTION
Currently, given the following code:

```php
$argument = json_encode($argument, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
```

produce:

```diff
- $argument = json_encode($argument, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE); 
+ $argument = json_encode($argument, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | 0);
```

which should be cleaned from the bitwise instead.