### PR TITLE
[Scoped] Remove e2e global install take 2

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -100,7 +100,7 @@ jobs:
                     token: ${{ secrets.ACCESS_TOKEN }}
 
             # remove remote files, to avoid piling up dead code in remote repository
-            -   run: rm -rf remote-repository/.github remote-repository/config remote-repository/src remote-repository/rules remote-repository/packages remote-repository/vendor remote-repository/bin/generate-changelog.php
+            -   run: rm -rf remote-repository/.github remote-repository/e2e remote-repository/config remote-repository/src remote-repository/rules remote-repository/packages remote-repository/vendor remote-repository/bin/generate-changelog.php
 
             -   run: cp -a rector-prefixed-downgraded/. remote-repository
 


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/1783 to remove e2e dir first before copy so the e2e/global-install can be removed on scoped rector/rector.