### PR TITLE
[DowngradePhp73] Skip inside define check on DowngradePhp73JsonConstRector

### DIFF
--- a/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/skip_inside_define_check.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/skip_inside_define_check.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradePhp73JsonConstRector\Fixture;
+
+class SkipInsideDefineCheck
+{
+    public function run($options)
+    {
+        if (\defined('JSON_THROW_ON_ERROR')) {
+            $options = $options & ~\JSON_THROW_ON_ERROR;
+        }
+    }
+}


### PR DESCRIPTION
ref https://github.com/rectorphp/rector-src/pull/1782#issuecomment-1033121021

The existing functionaly is:

```diff
         if (\defined('JSON_THROW_ON_ERROR')) {
-            $options = $options & ~\JSON_THROW_ON_ERROR;
+            $options = $options & ~0;
```

which invalid and should be skipped.