### PR TITLE
Add failing test fixture for ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/preserve-generator.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/preserve-generator.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @return \Generator<int>
+     **/
+    public function generator()
+    {
+        yield 5;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @return \Generator<int>
+     **/
+    public function generator(): \Generator
+    {
+        yield 5;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for ReturnTypeDeclarationRector

Based on https://getrector.org/demo/1ec89bdc-a24f-68ce-b1af-894c7ad7ac39

[Issue 6989](https://github.com/rectorphp/rector/issues/6989)
