### PR TITLE
Add failing test for `RemoveUselessReturnTagRector`

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/psalm-return.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/psalm-return.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class PsalmReturn
+{
+    /**
+     * @return string
+     * @psalm-return 'blah-string'
+     */
+    public function blah(): string
+    {
+        return 'blah-string';
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class PsalmReturn
+{
+    /**
+     * @psalm-return 'blah-string'
+     */
+    public function blah(): string
+    {
+        return 'blah-string';
+    }
+}
+
+?>


### PR DESCRIPTION
Psalm allows prefixing of tags. Usually these would provide refinement on top of the type so should not be removed