### PR TITLE
[Php74] Allow standalone mixed type on TypedPropertyRector on php 8.0 feature

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/mixed_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/mixed_type.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+class SomeMixedType
+{
+  /** @var mixed */
+  private $x;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+class SomeMixedType
+{
+  private mixed $x;
+}
+
+?>

--- a/rules/Php74/TypeAnalyzer/ObjectTypeAnalyzer.php
+++ b/rules/Php74/TypeAnalyzer/ObjectTypeAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php74\TypeAnalyzer;
 
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -23,10 +24,11 @@ final class ObjectTypeAnalyzer
             : [$varType];
 
         foreach ($types as $type) {
-            if ($type instanceof \PHPStan\Type\MixedType) {
+            if ($type instanceof MixedType) {
                 // mixed does not exists in PHP 7.4
                 return true;
             }
+
             if (! $type instanceof FullyQualifiedObjectType) {
                 continue;
             }

--- a/rules/Php74/TypeAnalyzer/ObjectTypeAnalyzer.php
+++ b/rules/Php74/TypeAnalyzer/ObjectTypeAnalyzer.php
@@ -26,7 +26,7 @@ final class ObjectTypeAnalyzer
             if ($type instanceof \PHPStan\Type\MixedType) {
                 // mixed does not exists in PHP 7.4
                 return true;
-            }            
+            }
             if (! $type instanceof FullyQualifiedObjectType) {
                 continue;
             }


### PR DESCRIPTION
@connerbw this is continue https://github.com/rectorphp/rector-src/pull/1798 for standalone mixed type when php 8.0 feature enabled:

```
$parameters->set(Option::PHP_VERSION_FEATURES, PhpVersionFeature::INTERSECTION_TYPES);
```