### PR TITLE
[Php74] Skip null|false type on TypedPropertyRector on php 8.0 feature enabled

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -15,6 +15,7 @@ use PhpParser\NodeAbstract;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -128,15 +129,16 @@ final class UnionTypeMapper implements TypeMapperInterface
             return null;
         }
 
-        if ($nullabledTypeNode instanceof NullableType) {
+        if (in_array($nullabledTypeNode::class, [NullableType::class, ComplexType::class], true)) {
             return $nullabledTypeNode;
         }
 
-        if ($nullabledTypeNode instanceof ComplexType) {
-            return $nullabledTypeNode;
+        /** @var Name $nullabledTypeNode */
+        if (! $this->nodeNameResolver->isName($nullabledTypeNode, 'false')) {
+            return new NullableType($nullabledTypeNode);
         }
 
-        return new NullableType($nullabledTypeNode);
+        return null;
     }
 
     private function shouldSkipIterable(UnionType $unionType): bool
@@ -253,8 +255,8 @@ final class UnionTypeMapper implements TypeMapperInterface
         $phpParserUnionedTypes = [];
 
         foreach ($unionType->getTypes() as $unionedType) {
-            // void type is not allowed in union
-            if ($unionedType instanceof VoidType) {
+            // void type and mixed type are not allowed in union
+            if (in_array($unionedType::class, [MixedType::class, VoidType::class], true)) {
                 return null;
             }
 

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/null_false_other_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/null_false_other_type.php.inc
@@ -18,7 +18,7 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionInt
 
 final class NullFalseOtherType
 {
-    private \stdClass|false|null $unionValue;
+    private \stdClass|false|null $unionValue = null;
 }
 
 ?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class SkipNullFalse
+{
+    /**
+     * @var null|false
+     */
+    private $unionValue;
+}

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false_mixed.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false_mixed.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class SkipNullFalseMixed
+{
+    /**
+     * @var null|false|mixed
+     */
+    private $unionValue;
+}

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false_mixed_object.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false_mixed_object.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class SkipNullFalseMixedObject
+{
+    /**
+     * @var null|false|mixed|object
+     */
+    private $unionValue;
+}

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false_other_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_null_false_other_type.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class NullFalseOtherType
+{
+    /**
+     * @var null|false|\stdClass
+     */
+    private $unionValue;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class NullFalseOtherType
+{
+    private \stdClass|false|null $unionValue;
+}
+
+?>

--- a/rules/Php74/TypeAnalyzer/ObjectTypeAnalyzer.php
+++ b/rules/Php74/TypeAnalyzer/ObjectTypeAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Php74\TypeAnalyzer;
 
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -24,11 +23,6 @@ final class ObjectTypeAnalyzer
             : [$varType];
 
         foreach ($types as $type) {
-            if ($type instanceof MixedType) {
-                // mixed does not exists in PHP 7.4
-                return true;
-            }
-
             if (! $type instanceof FullyQualifiedObjectType) {
                 continue;
             }


### PR DESCRIPTION
Given the following code:

```php
final class SkipNullFalse
{
    /**
     * @var null|false
     */
    private $unionValue;
}
```

On php 8.0 feature enabled, it currently produce:

```diff
-    private $unionValue;
+    private ?false $unionValue = null;
```

which invalid, ref https://3v4l.org/QL3dT#v8.0.15