### PR TITLE
[Php74] Update example code and description on TypedPropertyRector

### DIFF
--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -82,7 +82,7 @@ final class TypedPropertyRector extends AbstractRector implements AllowEmptyConf
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Changes property `@var` annotations from annotation or by its default value to type.',
+            'Changes property `@var` annotations or its default value to type.',
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -102,7 +102,7 @@ final class SomeClass
 {
     private int $count;
 
-    private bool $isDone;
+    private bool $isDone = false;
 }
 CODE_SAMPLE
                 ,

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -82,7 +82,7 @@ final class TypedPropertyRector extends AbstractRector implements AllowEmptyConf
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Changes property `@var` annotations from annotation to type.',
+            'Changes property `@var` annotations from annotation or by its default value to type.',
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'
@@ -92,6 +92,8 @@ final class SomeClass
      * @var int
      */
     private $count;
+
+    private $isDone = false;
 }
 CODE_SAMPLE
                     ,
@@ -99,6 +101,8 @@ CODE_SAMPLE
 final class SomeClass
 {
     private int $count;
+
+    private bool $isDone;
 }
 CODE_SAMPLE
                 ,

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -82,7 +82,7 @@ final class TypedPropertyRector extends AbstractRector implements AllowEmptyConf
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Changes property `@var` annotations or its default value to type.',
+            'Changes property type by `@var` annotations or default value.',
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'


### PR DESCRIPTION
`TypedPropertyRector` not only update by `@var`, but also by default value, ref for fixture 

https://github.com/rectorphp/rector-src/blob/main/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/default_values_bool.php.inc

so the example code and description need to be updated.