### PR TITLE
[TypeDeclaration] Skip return type iterable on ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/yield_strings.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/yield_strings.php.inc
@@ -20,7 +20,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeR
 class YieldStrings
 {
     /**
-     * @return \Generator<string>
+     * @return \Iterator<string>
      */
     public function getValues(): iterable
     {

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_return_type_iterable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_return_type_iterable.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+final class SkipReturnTypeIterable
+{
+    /**
+      * @return iterable<string, mixed[]>
+      */
+    public function run(): iterable
+    {
+        yield from $this->getData();
+    }
+
+    private function getData(): array
+    {
+        return [];
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/YieldNodesReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/YieldNodesReturnTypeInfererTypeInferer.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\NodeTraverser;
 use PHPStan\Type\MixedType;
@@ -56,6 +57,10 @@ final class YieldNodesReturnTypeInfererTypeInferer implements ReturnTypeInfererI
 
         $returnType = $functionLike->getReturnType();
         $className = 'Generator';
+
+        if ($returnType instanceof Identifier && $returnType->name === 'iterable') {
+            $className = 'Iterator';
+        }
 
         if ($returnType instanceof Name && ! $this->nodeNameResolver->isName($returnType, 'Generator')) {
             $className = $this->nodeNameResolver->getName($returnType);


### PR DESCRIPTION
ref https://github.com/symplify/symplify/pull/3928#discussion_r805221746

it currently produce return type `Generator` which seems caused by PR https://github.com/rectorphp/rector-src/pull/1794