### PR TITLE
[Php74] Do not remove array of type[] doc type on TypedPropertyRector when php 8.0 feature enabled

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -157,7 +157,7 @@ final class PhpDocTypeChanger
     {
         if ($typeNode instanceof BracketsAwareUnionTypeNode) {
             foreach ($typeNode->types as $type) {
-                if (in_array($type::class, self::ALLOWED_TYPES, true)) {
+                if ($this->isAllowed($type)) {
                     return true;
                 }
             }

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -201,8 +201,6 @@ final class PhpDocTypeChanger
         $phpDocInfo->removeByType(VarTagValueNode::class);
         $param->setAttribute(AttributeKey::PHP_DOC_INFO, $phpDocInfo);
 
-        $functionLike = $param->getAttribute(AttributeKey::PARENT_NODE);
-
         $phpDocInfo = $functionLike->getAttribute(AttributeKey::PHP_DOC_INFO);
         $paramType = $this->staticTypeMapper->mapPHPStanPhpDocTypeToPHPStanType($varTag, $property);
 

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -163,11 +163,7 @@ final class PhpDocTypeChanger
             }
         }
 
-        if (! in_array($typeNode::class, self::ALLOWED_TYPES, true)) {
-            return false;
-        }
-
-        return (string) $typeNode !== 'array';
+        return in_array($typeNode::class, self::ALLOWED_TYPES, true);
     }
 
     public function copyPropertyDocToParam(Property $property, Param $param): void
@@ -187,9 +183,6 @@ final class PhpDocTypeChanger
             return;
         }
 
-        $phpDocInfo->removeByType(VarTagValueNode::class);
-        $param->setAttribute(AttributeKey::PHP_DOC_INFO, $phpDocInfo);
-
         $functionLike = $param->getAttribute(AttributeKey::PARENT_NODE);
         $paramVarName = $this->nodeNameResolver->getName($param->var);
 
@@ -204,6 +197,11 @@ final class PhpDocTypeChanger
         if (! is_string($paramVarName)) {
             return;
         }
+
+        $phpDocInfo->removeByType(VarTagValueNode::class);
+        $param->setAttribute(AttributeKey::PHP_DOC_INFO, $phpDocInfo);
+
+        $functionLike = $param->getAttribute(AttributeKey::PARENT_NODE);
 
         $phpDocInfo = $functionLike->getAttribute(AttributeKey::PHP_DOC_INFO);
         $paramType = $this->staticTypeMapper->mapPHPStanPhpDocTypeToPHPStanType($varTag, $property);

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -153,7 +153,7 @@ final class PhpDocTypeChanger
         }
     }
 
-    public function isAllowed(TypeNode $typeNode)
+    public function isAllowed(TypeNode $typeNode): bool
     {
         if ($typeNode instanceof BracketsAwareUnionTypeNode) {
             foreach ($typeNode->types as $type) {

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/default_values_for_nullable_array.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/default_values_for_nullable_array.php.inc
@@ -18,6 +18,9 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 
 final class DefaultValuesForNullableArray
 {
+    /**
+     * @var mixed[]|null
+     */
     private ?array $rooms = null;
 }
 

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_array_of_string_type_doc.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_array_of_string_type_doc.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class DoNotRemoveArrayOfStringTypeDoc
+{
+	/**
+  	 * @var string|string[]|null
+	 */
+	private $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class DoNotRemoveArrayOfStringTypeDoc
+{
+	/**
+  	 * @var string|string[]|null
+	 */
+	private array|string|null $property = null;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_array_of_string_type_doc.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_array_of_string_type_doc.php.inc
@@ -21,7 +21,7 @@ final class DoNotRemoveArrayOfStringTypeDoc
     /**
      * @var string|string[]|null
      */
-    private array|stirng|null $property = null;
+    private array|string|null $property = null;
 }
 
 ?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_array_of_string_type_doc.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_array_of_string_type_doc.php.inc
@@ -4,10 +4,10 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionInt
 
 final class DoNotRemoveArrayOfStringTypeDoc
 {
-	/**
-  	 * @var string|string[]|null
-	 */
-	private $property;
+    /**
+     * @var string|string[]|null
+     */
+    private $property;
 }
 
 ?>
@@ -18,10 +18,10 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionInt
 
 final class DoNotRemoveArrayOfStringTypeDoc
 {
-	/**
-  	 * @var string|string[]|null
-	 */
-	private array|string|null $property = null;
+    /**
+     * @var string|string[]|null
+     */
+    private array|stirng|null $property = null;
 }
 
 ?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/remove_array_no_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/remove_array_no_type.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class RemoveArrayNoType
+{
+    /**
+     * @var string|array|null
+     */
+    private $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class RemoveArrayNoType
+{
+    private array|string|null $property = null;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/remove_array_of_mixed_type_doc_in_multiple_with_null.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/remove_array_of_mixed_type_doc_in_multiple_with_null.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
 
-final class RemoveArrayOfMixedTypeDocInMultipleWithNull
+final class DoNotRemoveArrayOfMixedTypeDocInMultipleWithNull
 {
     /**
      * @var string|mixed[]|null
@@ -16,8 +16,11 @@ final class RemoveArrayOfMixedTypeDocInMultipleWithNull
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
 
-final class RemoveArrayOfMixedTypeDocInMultipleWithNull
+final class DoNotRemoveArrayOfMixedTypeDocInMultipleWithNull
 {
+    /**
+     * @var string|mixed[]|null
+     */
     private array|string|null $property = null;
 }
 

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/remove_array_of_mixed_type_doc_in_multiple_with_null.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/remove_array_of_mixed_type_doc_in_multiple_with_null.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class RemoveArrayOfMixedTypeDocInMultipleWithNull
+{
+    /**
+     * @var string|mixed[]|null
+     */
+    private $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class RemoveArrayOfMixedTypeDocInMultipleWithNull
+{
+    private array|string|null $property = null;
+}
+
+?>

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc\TagRemover;
 
-use PhpParser\Node;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
@@ -12,9 +11,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\Generic\TemplateObjectWithoutClassType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -22,7 +19,6 @@ use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\DeadCode\PhpDoc\DeadVarTagValueNodeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
-use Rector\StaticTypeMapper\StaticTypeMapper;
 
 final class VarTagRemover
 {

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Generic\TemplateObjectWithoutClassType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -19,7 +19,6 @@ use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\DeadCode\PhpDoc\DeadVarTagValueNodeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
-use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 
 final class VarTagRemover
 {
@@ -106,10 +105,6 @@ final class VarTagRemover
 
     private function isArrayTypeNode(TypeNode $typeNode): bool
     {
-        return in_array(
-            $typeNode::class,
-            [SpacingAwareArrayTypeNode::class, ArrayShapeNode::class],
-            true
-        );
+        return in_array($typeNode::class, [SpacingAwareArrayTypeNode::class, ArrayShapeNode::class], true);
     }
 }

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -19,6 +19,7 @@ use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\DeadCode\PhpDoc\DeadVarTagValueNodeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 
 final class VarTagRemover
 {
@@ -90,23 +91,23 @@ final class VarTagRemover
                 }
 
                 // keep string[], mixed[], etc
-                if ($type instanceof SpacingAwareArrayTypeNode) {
+                if ($this->isArrayTypeNode($type)) {
                     return true;
                 }
             }
         }
 
-        if (! $this->isArrayTypeNode($varTagValueNode)) {
+        if (! $this->isArrayTypeNode($varTagValueNode->type)) {
             return false;
         }
 
         return (string) $varTagValueNode->type !== 'array';
     }
 
-    private function isArrayTypeNode(VarTagValueNode $varTagValueNode): bool
+    private function isArrayTypeNode(TypeNode $typeNode): bool
     {
         return in_array(
-            $varTagValueNode->type::class,
+            $typeNode::class,
             [SpacingAwareArrayTypeNode::class, ArrayShapeNode::class],
             true
         );

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -89,15 +89,10 @@ final class VarTagRemover
                     return true;
                 }
 
-                if (! $type instanceof SpacingAwareArrayTypeNode) {
-                    continue;
+                // keep string[], mixed[], etc
+                if ($type instanceof SpacingAwareArrayTypeNode) {
+                    return true;
                 }
-
-                if ($type->type instanceof IdentifierTypeNode && $type->type->name === 'mixed') {
-                    continue;
-                }
-
-                return true;
             }
         }
 

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -85,13 +85,13 @@ final class VarTagRemover
     {
         if ($varTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
             foreach ($varTagValueNode->type->types as $type) {
-                // keep generic types
-                if ($type instanceof GenericTypeNode) {
+                // keep string[], mixed[], etc
+                if ($this->isArrayTypeNode($type)) {
                     return true;
                 }
 
-                // keep string[], mixed[], etc
-                if ($this->isArrayTypeNode($type)) {
+                // keep generic types
+                if ($type instanceof GenericTypeNode) {
                     return true;
                 }
             }

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -84,7 +84,6 @@ final class VarTagRemover
     {
         if ($varTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
             foreach ($varTagValueNode->type->types as $type) {
-                // keep string[], mixed[], etc
                 if ($this->isArrayTypeNode($type)) {
                     return true;
                 }

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -8,15 +8,11 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Generic\TemplateObjectWithoutClassType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
-use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\DeadCode\PhpDoc\DeadVarTagValueNodeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
 
@@ -25,7 +21,8 @@ final class VarTagRemover
     public function __construct(
         private readonly DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly DeadVarTagValueNodeAnalyzer $deadVarTagValueNodeAnalyzer
+        private readonly DeadVarTagValueNodeAnalyzer $deadVarTagValueNodeAnalyzer,
+        private readonly PhpDocTypeChanger $phpDocTypeChanger
     ) {
     }
 
@@ -67,43 +64,11 @@ final class VarTagRemover
             return;
         }
 
-        // keep generic types
-        if ($varTagValueNode->type instanceof GenericTypeNode) {
-            return;
-        }
-
         // keep string[] etc.
-        if ($this->isNonBasicArrayType($varTagValueNode)) {
+        if ($this->phpDocTypeChanger->isAllowed($varTagValueNode->type)) {
             return;
         }
 
         $phpDocInfo->removeByType(VarTagValueNode::class);
-    }
-
-    private function isNonBasicArrayType(VarTagValueNode $varTagValueNode): bool
-    {
-        if ($varTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
-            foreach ($varTagValueNode->type->types as $type) {
-                if ($this->isArrayTypeNode($type)) {
-                    return true;
-                }
-
-                // keep generic types
-                if ($type instanceof GenericTypeNode) {
-                    return true;
-                }
-            }
-        }
-
-        if (! $this->isArrayTypeNode($varTagValueNode->type)) {
-            return false;
-        }
-
-        return (string) $varTagValueNode->type !== 'array';
-    }
-
-    private function isArrayTypeNode(TypeNode $typeNode): bool
-    {
-        return in_array($typeNode::class, [SpacingAwareArrayTypeNode::class, ArrayShapeNode::class], true);
     }
 }


### PR DESCRIPTION
ref https://github.com/symplify/symplify/pull/3928#discussion_r805221895

It currently var doc with `string[]` type, which should not be removed.