### PR TITLE
[Core] Fix return type of ConfigurableCallValuesCollectingPhpFileLoader use latest symfony 6

### DIFF
--- a/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
+++ b/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
@@ -23,10 +23,7 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
         parent::__construct($containerBuilder, $fileLocator);
     }
 
-    /**
-     * @param mixed $resource
-     */
-    public function load($resource, string $type = null): mixed
+    public function load(mixed $resource, string $type = null): mixed
     {
         // this call collects root values
         $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
@@ -39,9 +36,9 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
     }
 
     public function import(
-        $resource,
+        mixed $resource,
         string $type = null,
-        $ignoreErrors = false,
+        bool|string $ignoreErrors = false,
         string $sourceResource = null,
         $exclude = null
     ): mixed {

--- a/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
+++ b/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
@@ -26,7 +26,7 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
     /**
      * @param mixed $resource
      */
-    public function load($resource, string $type = null): void
+    public function load($resource, string $type = null): mixed
     {
         // this call collects root values
         $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
@@ -34,6 +34,8 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
         parent::load($resource, $type);
 
         $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
+
+        return null;
     }
 
     public function import(
@@ -42,13 +44,15 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
         $ignoreErrors = false,
         string $sourceResource = null,
         $exclude = null
-    ): void {
+    ): mixed {
         // this call collects root values
         $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
 
         parent::import($resource, $type, $ignoreErrors, $sourceResource, $exclude);
 
         $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
+
+        return null;
     }
 
     private function collectConfigureCallsFromJustImportedConfigurableRectorDefinitions(): void


### PR DESCRIPTION
Running composer update will cause error on test and build:

First, run composer update;

```bash
composer update
```

Then

1. Run unit test

```bash
➜  rector-src git:(main) vendor/bin/phpunit tests/Issues 
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.

PHP Fatal error:  Declaration of Rector\Core\DependencyInjection\Loader\ConfigurableCallValuesCollectingPhpFileLoader::load($resource, ?string $type = null): void must be compatible with Symfony\Component\DependencyInjection\Loader\PhpFileLoader::load(mixed $resource, ?string $type = null): mixed in /Users/samsonasik/www/rector-src/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php on line 29

Fatal error: Declaration of Rector\Core\DependencyInjection\Loader\ConfigurableCallValuesCollectingPhpFileLoader::load($resource, ?string $type = null): void must be compatible with Symfony\Component\DependencyInjection\Loader\PhpFileLoader::load(mixed $resource, ?string $type = null): mixed in /Users/samsonasik/www/rector-src/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php on line 29
```

2. Downgrade 

```
export PHP71_BIN_PATH=/opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php PHP80_BIN_PATH=/opt/homebrew/Cellar/php@8.0/8.0.14/bin/php && sh ./full_build.sh


[NOTE] Running downgrade in 'rector-build' directory

PHP Fatal error:  Declaration of Rector\Core\DependencyInjection\Loader\ConfigurableCallValuesCollectingPhpFileLoader::load($resource, ?string $type = null): void must be compatible with Symfony\Component\DependencyInjection\Loader\PhpFileLoader::load(mixed $resource, ?string $type = null): mixed in /Users/samsonasik/www/rector-src/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php on line 29
Fatal error: Declaration of Rector\Core\DependencyInjection\Loader\ConfigurableCallValuesCollectingPhpFileLoader::load($resource, ?string $type = null): void must be compatible with Symfony\Component\DependencyInjection\Loader\PhpFileLoader::load(mixed $resource, ?string $type = null): mixed in /Users/samsonasik/www/rector-src/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php on line 29
```

Changing ConfigurableCallValuesCollectingPhpFileLoader fix the issue 

Fixes https://github.com/rectorphp/rector/issues/7000