### PR TITLE
[Php74] Add Generic object type back to TypedPropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/generic_object_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/generic_object_type.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+/**
+ * @template T of object
+ */
+final class GenericObjectType
+{
+    /**
+     * @var T
+     */
+    private $command;
+
+    /**
+     * @param T $command
+     */
+    public function __construct(object $command)
+    {
+        $this->command = $command;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+/**
+ * @template T of object
+ */
+final class GenericObjectType
+{
+    /**
+     * @var T
+     */
+    private object $command;
+
+    /**
+     * @param T $command
+     */
+    public function __construct(object $command)
+    {
+        $this->command = $command;
+    }
+}
+
+?>


### PR DESCRIPTION
It was added at https://github.com/rectorphp/rector/pull/6378 but possibly removed due to extracting to TypeDeclaration rules.

This PR try to re-add its functionality.