### PR TITLE
[DeadCode] Keep assign expr when Assign Expr has CallLike on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/assign_expr_has_call_like.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/assign_expr_has_call_like.php.inc
@@ -2,12 +2,12 @@
 
 namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
 
-final class DemoFile
-{ 
+final class AssignExprHasCallLike
+{
     public function validate() {
        throw new Exception();
     }
-    
+
     public function test($params)
     {
         $tmp = isset($params['test']) ? $this->validate($params['test']) : null;
@@ -19,12 +19,12 @@ final class DemoFile
 
 namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
 
-final class DemoFile
-{ 
+final class AssignExprHasCallLike
+{
     public function validate() {
        throw new Exception();
     }
-    
+
     public function test($params)
     {
         isset($params['test']) ? $this->validate($params['test']) : null;

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/demo_file.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/demo_file.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class DemoFile
+{ 
+    public function validate() {
+       throw new Exception();
+    }
+    
+    public function test($params)
+    {
+        $tmp = isset($params['test']) ? $this->validate($params['test']) : null;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class DemoFile
+{ 
+    public function validate() {
+       throw new Exception();
+    }
+    
+    public function test($params)
+    {
+        isset($params['test']) ? $this->validate($params['test']) : null;
+    }
+}
+?>

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -116,7 +116,8 @@ CODE_SAMPLE
 
     private function hasCallLikeInAssignExpr(Expr $expr): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($expr,
+        return (bool) $this->betterNodeFinder->findFirst(
+            $expr,
             fn (Node $subNode): bool => $this->sideEffectNodeDetector->detectCallExpr($subNode)
         );
     }

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -105,7 +105,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->hasCallAssignExpr($node->expr)) {
+        if ($this->hasCallLikeInAssignExpr($node->expr)) {
             // keep the expr, can have side effect
             return $node->expr;
         }
@@ -114,7 +114,7 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function hasCallAssignExpr(Expr $expr): bool
+    private function hasCallLikeInAssignExpr(Expr $expr): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($expr,
             fn (Node $subNode): bool => $this->sideEffectNodeDetector->detectCallExpr($subNode)

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\Assign;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -104,13 +105,20 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->sideEffectNodeDetector->detectCallExpr($node->expr)) {
+        if ($this->hasCallAssignExpr($node->expr)) {
             // keep the expr, can have side effect
             return $node->expr;
         }
 
         $this->removeNode($node);
         return $node;
+    }
+
+    private function hasCallAssignExpr(Expr $expr): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst($expr,
+            fn (Node $subNode): bool => $this->sideEffectNodeDetector->detectCallExpr($subNode)
+        );
     }
 
     private function shouldSkip(Assign $assign): bool


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/1824
Fixes https://github.com/rectorphp/rector/issues/7009