### PR TITLE
[Php74] Remove TemplateType check on TypedPropertyRector

### DIFF
--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
@@ -139,21 +138,6 @@ CODE_SAMPLE
         $varType = $this->varDocPropertyTypeInferer->inferProperty($node);
         if ($varType instanceof MixedType) {
             return null;
-        }
-
-        if ($varType instanceof UnionType) {
-            $types = $varType->getTypes();
-
-            if (count($types) === 2 && $types[1] instanceof TemplateType) {
-                $templateType = $types[1];
-
-                $node->type = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
-                    $templateType->getBound(),
-                    TypeKind::PROPERTY()
-                );
-
-                return $node;
-            }
         }
 
         if ($this->objectTypeAnalyzer->isSpecial($varType)) {


### PR DESCRIPTION
The `TemplateType` was introduced in https://github.com/rectorphp/rector/pull/6378 

The functionality then moved to `TypedPropertyFromAssignsRector` https://github.com/rectorphp/rector-src/blob/4cf6522e7703687d7673d316ec60c5f21ec37dec/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/generic_object_type.php.inc

also, even the code exists, the `$varType` is no longer detected as `UnionType` for `@template` usage, so the code check has no effect so it can be removed.