### PR TITLE
Add failing test fixture for ExplicitBoolCompareRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/If_/ExplicitBoolCompareRector/Fixture/skip_type_by_var_doc.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/ExplicitBoolCompareRector/Fixture/skip_type_by_var_doc.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+class SkipTypeByVarDoc {
+    public function test () {
+        /**
+        * @var int $notInt
+        */
+        $notInt = '';
+        if ($notInt) {}
+    }
+}
+?>
+-----


### PR DESCRIPTION
# Failing Test for ExplicitBoolCompareRector

Based on https://getrector.org/demo/1ec8fe29-a999-6fc6-9731-c9e497d2fc2c