### PR TITLE
[PostRector] Refactor NodesToRemoveCollector for detection current stmt removed

### DIFF
--- a/packages/NodeCollector/NodeResolver/CurrentStmtResolver.php
+++ b/packages/NodeCollector/NodeResolver/CurrentStmtResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeCollector\NodeResolver;
+
+use PhpParser\Node\Stmt;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class CurrentStmtResolver
+{
+    public function resolve(Stmt $stmt)
+    {
+        $currentStatement = $stmt->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        return $currentStatement instanceof Stmt
+            ? $currentStatement
+            : $stmt;
+    }
+}

--- a/packages/NodeCollector/NodeResolver/CurrentStmtResolver.php
+++ b/packages/NodeCollector/NodeResolver/CurrentStmtResolver.php
@@ -9,7 +9,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class CurrentStmtResolver
 {
-    public function resolve(Stmt $stmt)
+    public function resolve(Stmt $stmt): Stmt
     {
         $currentStatement = $stmt->getAttribute(AttributeKey::CURRENT_STATEMENT);
         return $currentStatement instanceof Stmt

--- a/packages/PostRector/Collector/NodesToRemoveCollector.php
+++ b/packages/PostRector/Collector/NodesToRemoveCollector.php
@@ -18,6 +18,7 @@ use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Provider\CurrentFileProvider;
+use Rector\NodeCollector\NodeResolver\CurrentStmtResolver;
 use Rector\NodeRemoval\BreakingRemovalGuard;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Contract\Collector\NodeCollectorInterface;
@@ -35,7 +36,8 @@ final class NodesToRemoveCollector implements NodeCollectorInterface
         private readonly BreakingRemovalGuard $breakingRemovalGuard,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly NodeComparator $nodeComparator,
-        private readonly CurrentFileProvider $currentFileProvider
+        private readonly CurrentFileProvider $currentFileProvider,
+        private readonly CurrentStmtResolver $currentStmtResolver
     ) {
     }
 
@@ -70,7 +72,16 @@ final class NodesToRemoveCollector implements NodeCollectorInterface
 
     public function isNodeRemoved(Node $node): bool
     {
-        return in_array($node, $this->nodesToRemove, true);
+        if (in_array($node, $this->nodesToRemove, true)) {
+            return true;
+        }
+
+        if ($node instanceof Stmt) {
+            $currentStatement = $this->currentStmtResolver->resolve($node);
+            return in_array($currentStatement, $this->nodesToRemove, true);
+        }
+
+        return false;
     }
 
     public function isActive(): bool

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -28,6 +28,7 @@ use PhpParser\Node\Stmt\Trait_;
 use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\While_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeCollector\NodeResolver\CurrentStmtResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -62,6 +63,10 @@ final class NewlineAfterStatementRector extends AbstractRector
      * @var array<string, true>
      */
     private array $stmtsHashed = [];
+
+    public function __construct(private readonly CurrentStmtResolver $currentStmtResolver)
+    {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -111,11 +116,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($this->nodesToRemoveCollector->isActive()) {
-            return null;
-        }
-
-        $node = $this->resolveCurrentStatement($node);
+        $node = $this->currentStmtResolver->resolve($node);
 
         if (! in_array($node::class, self::STMTS_TO_HAVE_NEXT_NEWLINE, true)) {
             return null;
@@ -165,15 +166,6 @@ CODE_SAMPLE
         $this->nodesToAddCollector->addNodeAfterNode(new Nop(), $node);
 
         return $node;
-    }
-
-    private function resolveCurrentStatement(Stmt $stmt): Stmt
-    {
-        $currentStatement = $stmt->getAttribute(AttributeKey::CURRENT_STATEMENT);
-
-        return $currentStatement instanceof Stmt
-            ? $currentStatement
-            : $stmt;
     }
 
     /**

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -64,8 +64,9 @@ final class NewlineAfterStatementRector extends AbstractRector
      */
     private array $stmtsHashed = [];
 
-    public function __construct(private readonly CurrentStmtResolver $currentStmtResolver)
-    {
+    public function __construct(
+        private readonly CurrentStmtResolver $currentStmtResolver
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
By this refactor, it can reduce unnecessary check in the rector rules with: 

```php
if ($this->nodesToRemoveCollector->isActive()) {
    return null;
}
```

for detection that node already removed.