### PR TITLE
[EarlyReturn] Refactor RemoveAlwaysElseRector to return array of Nodes to avoid node in else marked as removed

### DIFF
--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -81,10 +81,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->nodesToAddCollector->isActive()) {
-            return null;
-        }
-
         if ($this->hasDynamicMethodCallOnFetchThis($node)) {
             return null;
         }

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -98,11 +98,7 @@ CODE_SAMPLE
                 $nodesToReturnAfterNode = array_merge($nodesToReturnAfterNode, [$originalNode->else]);
             }
 
-            return [
-                $if,
-                $node,
-                ...$nodesToReturnAfterNode
-            ];
+            return [$if, $node, ...$nodesToReturnAfterNode];
         }
 
         if ($node->else !== null) {

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -82,7 +82,6 @@ CODE_SAMPLE
             $if = new If_($node->cond);
             $if->stmts = $node->stmts;
 
-            $nodesToReturnBeforeNode = [$if];
             $this->mirrorComments($if, $node);
 
             /** @var ElseIf_ $firstElseIf */
@@ -100,7 +99,7 @@ CODE_SAMPLE
             }
 
             return [
-                ...$nodesToReturnBeforeNode,
+                $if,
                 $node,
                 ...$nodesToReturnAfterNode
             ];

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -90,9 +90,7 @@ CODE_SAMPLE
             $node->stmts = $firstElseIf->stmts;
             $this->mirrorComments($node, $firstElseIf);
 
-            $statements = $this->getStatementsElseIfs($node);
-            $nodesToReturnAfterNode = $statements;
-
+            $nodesToReturnAfterNode = $this->getStatementsElseIfs($node);
             if ($originalNode->else instanceof Else_) {
                 $node->else = null;
                 $nodesToReturnAfterNode = array_merge($nodesToReturnAfterNode, [$originalNode->else]);

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -70,6 +70,7 @@ CODE_SAMPLE
 
     /**
      * @param If_ $node
+     * @return Node[]|null
      */
     public function refactor(Node $node): ?array
     {

--- a/tests/Issues/Issue6670/Fixture/do_not_remove_used_class_method.php.inc
+++ b/tests/Issues/Issue6670/Fixture/do_not_remove_used_class_method.php.inc
@@ -9,6 +9,7 @@ final class DoNotRemoveUsedClassMethod
         if (true === false) {
             return -1;
         } else {
+            echo 'a statement';
             return $this->notUnused();
         }
     }
@@ -31,6 +32,7 @@ final class DoNotRemoveUsedClassMethod
         if (true === false) {
             return -1;
         }
+        echo 'a statement';
         return $this->notUnused();
     }
 


### PR DESCRIPTION
When we use these 2 rules:

```
RemoveUnusedPrivateMethodRector
RemoveAlwaysElseRector
```

Call private method inside `else` can make marked the nodes inside else as removed, which actualy used after the `If`, eg:

```php
final class DoNotRemoveUsedClassMethod
{
    public function doSomething(): int
    {
        if (true === false) {
            return -1;
        } else {
            echo 'a statement';
            return $this->notUnused();
        }
    }

    private function notUnused(): int
    {
        // This is some code that is very important
    }
}
```

at current fixture:

https://github.com/rectorphp/rector-src/blob/c44bfcc00ed4fa5d22f820876c10017238eb164d/tests/Issues/Issue6670/Fixture/do_not_remove_used_class_method.php.inc#L11-L16

We previously handling it with check that there is already `nodesToAddCollector->isActive()`:

https://github.com/rectorphp/rector-src/blob/c44bfcc00ed4fa5d22f820876c10017238eb164d/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php#L84-L86

which not specific. 

This use case can happen when used along with other rules as well, so I refactored the array of Nodes instead of using `nodesToAddCollector` service to add node before/add node after removing else.

This PR make it so the other rules that may along with `RemoveAlwaysElseRector` no need to check with `NodesToAddCollector->isActive()` check.