### PR TITLE
[PHP81] Skip readonly on promoted property change

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_changed_promoted_property.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_changed_promoted_property.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipConditionallyChangedProperty
+{
+    public function __construct(private Converter $converter)
+    {
+        if ($this->converter instanceof CacheableConverter) {
+            $this->converter = clone $this->converter;
+            $this->converter->reset();
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for ReadOnlyPropertyRector
Based on https://getrector.org/demo/1e2cb1b3-8dd5-46fc-925b-1df01d0b73c0

This is probably due to constructor property promotion generating additional assignment that is not visible by rector, related to https://github.com/rectorphp/rector/issues/7012.