### PR TITLE
[Php81] Skip ReadOnlyPropertyRector on Stmt is not inline with __construct

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_changed_promoted_property.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_changed_promoted_property.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipConditionallyChangedProperty
+{
+    public function __construct(private Converter $converter)
+    {
+        if ($this->converter instanceof CacheableConverter) {
+            $this->converter = clone $this->converter;
+            $this->converter->reset();
+        }
+    }
+}
+
+?>

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -190,8 +190,7 @@ final class PropertyManipulator
     private function isInlineStmtWithFunctionLike(
         PropertyFetch|StaticPropertyFetch $propertyFetch,
         ClassMethod $classMethod
-    ): bool
-    {
+    ): bool {
         $currentStmt = $propertyFetch->getAttribute(AttributeKey::CURRENT_STATEMENT);
         if (! $currentStmt instanceof Stmt) {
             return false;

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Interface_;
@@ -157,7 +158,7 @@ final class PropertyManipulator
             if ($classMethod instanceof ClassMethod && $this->nodeNameResolver->isName(
                 $classMethod->name,
                 MethodName::CONSTRUCT
-            )) {
+            ) && $this->isInlineStmtWithFunctionLike($propertyFetch, $classMethod)) {
                 continue;
             }
 
@@ -167,6 +168,17 @@ final class PropertyManipulator
         }
 
         return false;
+    }
+
+    private function isInlineStmtWithFunctionLike(PropertyFetch|StaticPropertyFetch $propertyFetch, ClassMethod $classMethod): bool
+    {
+        $currentStmt = $propertyFetch->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        if (! $currentStmt instanceof Stmt) {
+            return false;
+        }
+
+        $parent = $currentStmt->getAttribute(AttributeKey::PARENT_NODE);
+        return $parent === $classMethod;
     }
 
     public function isPropertyChangeable(Property $property): bool

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -170,17 +170,6 @@ final class PropertyManipulator
         return false;
     }
 
-    private function isInlineStmtWithFunctionLike(PropertyFetch|StaticPropertyFetch $propertyFetch, ClassMethod $classMethod): bool
-    {
-        $currentStmt = $propertyFetch->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        if (! $currentStmt instanceof Stmt) {
-            return false;
-        }
-
-        $parent = $currentStmt->getAttribute(AttributeKey::PARENT_NODE);
-        return $parent === $classMethod;
-    }
-
     public function isPropertyChangeable(Property $property): bool
     {
         $propertyFetches = $this->propertyFetchFinder->findPrivatePropertyFetches($property);
@@ -196,6 +185,20 @@ final class PropertyManipulator
         }
 
         return false;
+    }
+
+    private function isInlineStmtWithFunctionLike(
+        PropertyFetch|StaticPropertyFetch $propertyFetch,
+        ClassMethod $classMethod
+    ): bool
+    {
+        $currentStmt = $propertyFetch->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        if (! $currentStmt instanceof Stmt) {
+            return false;
+        }
+
+        $parent = $currentStmt->getAttribute(AttributeKey::PARENT_NODE);
+        return $parent === $classMethod;
     }
 
     private function isChangeableContext(PropertyFetch | StaticPropertyFetch $propertyFetch): bool

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -155,10 +155,10 @@ final class PropertyManipulator
 
             // skip for constructor? it is allowed to set value in constructor method
             $classMethod = $this->betterNodeFinder->findParentType($propertyFetch, ClassMethod::class);
-            if ($classMethod instanceof ClassMethod && $this->nodeNameResolver->isName(
-                $classMethod->name,
-                MethodName::CONSTRUCT
-            ) && $this->isInlineStmtWithFunctionLike($propertyFetch, $classMethod)) {
+            if ($classMethod instanceof ClassMethod && $this->isInlineStmtWithConstructMethod(
+                $propertyFetch,
+                $classMethod
+            )) {
                 continue;
             }
 
@@ -187,10 +187,14 @@ final class PropertyManipulator
         return false;
     }
 
-    private function isInlineStmtWithFunctionLike(
+    private function isInlineStmtWithConstructMethod(
         PropertyFetch|StaticPropertyFetch $propertyFetch,
         ClassMethod $classMethod
     ): bool {
+        if (! $this->nodeNameResolver->isName($classMethod->name, MethodName::CONSTRUCT)) {
+            return false;
+        }
+
         $currentStmt = $propertyFetch->getAttribute(AttributeKey::CURRENT_STATEMENT);
         if (! $currentStmt instanceof Stmt) {
             return false;


### PR DESCRIPTION
For example, when the assignment is inside `If_` condition.

Closes #1845
Fixes https://github.com/rectorphp/rector/issues/7012