### PR TITLE
Enable MemoryCacheStorage in more CI setups

### DIFF
--- a/config/parameters.php
+++ b/config/parameters.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OndraM\CiDetector\CiDetector;
 use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
 use Rector\Core\Configuration\Option;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -39,8 +40,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // use faster in-memory cache in CI.
     // CI always starts from scratch, therefore IO intensive caching is not worth it
-    $runsInGithubAction = getenv('GITHUB_ACTION');
-    if ($runsInGithubAction !== false) {
+    $ciDetector = new CiDetector();
+    if ($ciDetector->isCiDetected() !== false) {
         $parameters->set(Option::CACHE_CLASS, MemoryCacheStorage::class);
     }
 };


### PR DESCRIPTION
Currently only the ENV `GITHUB_ACTION` is checked, but GitLab CI provides a similar variable: `GITLAB_CI`.

https://docs.gitlab.com/ee/ci/variables/predefined_variables.html

There is also a more generic `CI` variable, but wasn't 100% sure that would be good one as it might be too generic to break things.