### PR TITLE
[Scoped] Using php-parallel-lint 1.3.1

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -81,7 +81,7 @@ jobs:
                 with:
                     php-version: 7.1
                     coverage: none
-            -   run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi
+            -   run: composer create-project php-parallel-lint/php-parallel-lint:1.3.1 php-parallel-lint --ansi
             -   run: php-parallel-lint/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/rector/rector-nette/tests --exclude rector-prefixed-downgraded/vendor/symfony/polyfill-mbstring/bootstrap80.php --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/ssch/typo3-rector/templates/maker --exclude rector-prefixed-downgraded/vendor/symfony/console/Event --exclude rector-prefixed-downgraded/vendor/symfony/console/EventListener --exclude rector-prefixed-downgraded/vendor/symfony/console/Tester --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/contracts/Cache/ItemInterface.php --exclude rector-prefixed-downgraded/vendor/symfony/dependency-injection/ExpressionLanguageProvider.php
 
             # 5. copy repository meta files

--- a/.github/workflows/php_linter.yaml
+++ b/.github/workflows/php_linter.yaml
@@ -21,6 +21,6 @@ jobs:
                     php-version: 8.1
                     coverage: none
 
-            -   run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint
+            -   run: composer create-project php-parallel-lint/php-parallel-lint:1.3.1 php-parallel-lint
 
             -   run: php-parallel-lint/parallel-lint src bin/rector config tests packages rules --colors --exclude rules/psr4/tests/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/Source --exclude packages/node-type-resolver/tests/PerNodeTypeResolver/PropertyFetchTypeResolver/Source --exclude rules/nette-kdyby/tests/Rector/MethodCall/ReplaceEventManagerWithEventSubscriberRector/Source/ExpectedSomeClassCopyEvent.php --exclude rules/nette-kdyby/tests/Rector/MethodCall/ReplaceMagicPropertyEventWithEventClassRector/Source --exclude rules/type-declaration/tests/Rector/ClassMethod/ParamTypeFromStrictTypedPropertyRector/Source


### PR DESCRIPTION
Latest php-parallel-lint 1.3.2 https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.2  cause error on scoped build 

ref https://github.com/rectorphp/rector-src/runs/5275779357?check_suite_focus=true#step:13:39

```bash

Generating autoload files
Error: Could not scan for classes inside "./tests/" which does not appear to be a file nor a folder

                                                                                                
  [RuntimeException]                                                                            
  Could not scan for classes inside "./tests/" which does not appear to be a file nor a folder  
```

This PR pin to working version 1.3.1 