### PR TITLE
[Core] Clean up left over Nop Stmt when its parent Stmt removed

### DIFF
--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/drop_with_empty_finally.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/drop_with_empty_finally.php.inc
@@ -25,7 +25,6 @@ class DropWithEmptyFinally
 {
     public function run()
     {
-
     }
 }
 

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/fixture.php.inc
@@ -25,7 +25,6 @@ class Fixture
 {
     public function run()
     {
-
     }
 }
 

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -42,7 +42,6 @@ class SomeClass
 {
     public function run()
     {
-        // some code
     }
 }
 CODE_SAMPLE

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -292,23 +292,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
     }
 
     /**
-     * @param Node[] $node
-     * @return Node[]
-     */
-    private function verifyNop(array $node, Node $originalNode): array
-    {
-        $firstNodeKey = array_key_first($node);
-        if ($node[$firstNodeKey] instanceof Nop) {
-            unset($node[$firstNodeKey]);
-
-            return $node;
-        }
-
-        $this->mirrorComments($node[$firstNodeKey], $originalNode);
-        return $node;
-    }
-
-    /**
      * Replacing nodes in leaveNode() method avoids infinite recursion
      * see"infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
      */
@@ -449,6 +432,23 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
     protected function removeNodes(array $nodes): void
     {
         $this->nodeRemover->removeNodes($nodes);
+    }
+
+    /**
+     * @param Node[] $node
+     * @return Node[]
+     */
+    private function verifyNop(array $node, Node $originalNode): array
+    {
+        $firstNodeKey = array_key_first($node);
+        if ($node[$firstNodeKey] instanceof Nop) {
+            unset($node[$firstNodeKey]);
+
+            return $node;
+        }
+
+        $this->mirrorComments($node[$firstNodeKey], $originalNode);
+        return $node;
     }
 
     /**

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\NodeVisitorAbstract;
@@ -249,12 +250,10 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
             /** @var array<Node> $node */
             $this->createdByRuleDecorator->decorate($node, $originalNode, static::class);
+            $node = $this->verifyNop($node, $originalNode);
 
             $originalNodeHash = spl_object_hash($originalNode);
             $this->nodesToReturn[$originalNodeHash] = $node;
-
-            $firstNodeKey = array_key_first($node);
-            $this->mirrorComments($node[$firstNodeKey], $originalNode);
 
             // will be replaced in leaveNode() the original node must be passed
             return $originalNode;
@@ -289,6 +288,23 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
         $this->nodesToReturn[$originalNodeHash] = $node;
 
+        return $node;
+    }
+
+    /**
+     * @param Node[] $node
+     * @return Node[]
+     */
+    private function verifyNop(array $node, Node $originalNode): array
+    {
+        $firstNodeKey = array_key_first($node);
+        if ($node[$firstNodeKey] instanceof Nop) {
+            unset($node[$firstNodeKey]);
+
+            return $node;
+        }
+
+        $this->mirrorComments($node[$firstNodeKey], $originalNode);
         return $node;
     }
 


### PR DESCRIPTION
Clean up left over Nop Stmt when its parent Stmt removed, this use case can be found when removing whole try catch stmts on `RemoveDeadTryCatchRector`:

```php
        try {
            // some code
        } catch (\Throwable $throwable) {
            throw $throwable;
        } finally {
        }
```

The whole try, catch, finally are removed, but it was still a blank single line, which a `Nop` stmt that doesn't has its parent Stmt, which can be removed.