### PR TITLE
 [DeadCode] Handle no stmts inside Try on RemoveDeadTryCatchRector 

### DIFF
--- a/packages/FileFormatter/FileFormatter.php
+++ b/packages/FileFormatter/FileFormatter.php
@@ -53,8 +53,7 @@ final class FileFormatter
     private function sniffOriginalFileContent(
         File $file,
         EditorConfigConfigurationBuilder $editorConfigConfigurationBuilder
-    ): void
-    {
+    ): void {
         // Try to sniff into the original content to get the indentation and new line
         $indent = Indent::fromContent($file->getOriginalFileContent());
         $editorConfigConfigurationBuilder->withIndent($indent);

--- a/packages/FileFormatter/FileFormatter.php
+++ b/packages/FileFormatter/FileFormatter.php
@@ -8,8 +8,6 @@ use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\Application\File;
 use Rector\FileFormatter\Contract\Formatter\FileFormatterInterface;
 use Rector\FileFormatter\EditorConfig\EditorConfigParser;
-use Rector\FileFormatter\Exception\InvalidNewLineStringException;
-use Rector\FileFormatter\Exception\ParseIndentException;
 use Rector\FileFormatter\ValueObject\EditorConfigConfiguration;
 use Rector\FileFormatter\ValueObject\Indent;
 use Rector\FileFormatter\ValueObject\NewLine;
@@ -55,19 +53,13 @@ final class FileFormatter
     private function sniffOriginalFileContent(
         File $file,
         EditorConfigConfigurationBuilder $editorConfigConfigurationBuilder
-    ): void {
+    ): void
+    {
         // Try to sniff into the original content to get the indentation and new line
-        try {
-            $indent = Indent::fromContent($file->getOriginalFileContent());
-            $editorConfigConfigurationBuilder->withIndent($indent);
-        } catch (ParseIndentException) {
-        }
-
-        try {
-            $newLine = NewLine::fromContent($file->getOriginalFileContent());
-            $editorConfigConfigurationBuilder->withNewLine($newLine);
-        } catch (InvalidNewLineStringException) {
-        }
+        $indent = Indent::fromContent($file->getOriginalFileContent());
+        $editorConfigConfigurationBuilder->withIndent($indent);
+        $newLine = NewLine::fromContent($file->getOriginalFileContent());
+        $editorConfigConfigurationBuilder->withNewLine($newLine);
     }
 
     private function createEditorConfiguration(

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PhpParser\NodeTraverser;
-use PHPStan\AnalysedCodeException;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeContext;
@@ -196,12 +195,8 @@ final class PHPStanNodeScopeResolver
     ): void {
         $dependentFiles = [];
         foreach ($stmts as $stmt) {
-            try {
-                $nodeDependentFiles = $this->dependencyResolver->resolveDependencies($stmt, $mutatingScope);
-                $dependentFiles = array_merge($dependentFiles, $nodeDependentFiles);
-            } catch (AnalysedCodeException) {
-                // @ignoreException
-            }
+            $nodeDependentFiles = $this->dependencyResolver->resolveDependencies($stmt, $mutatingScope);
+            $dependentFiles = array_merge($dependentFiles, $nodeDependentFiles);
         }
 
         $this->changedFilesDetector->addFileWithDependencies($smartFileInfo, $dependentFiles);

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/drop_with_empty_finally.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/drop_with_empty_finally.php.inc
@@ -25,7 +25,6 @@ class DropWithEmptyFinally
 {
     public function run()
     {
-
     }
 }
 

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/fixture.php.inc
@@ -25,7 +25,6 @@ class Fixture
 {
     public function run()
     {
-
     }
 }
 

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/multiple_dead_catches.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/multiple_dead_catches.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class MultipleDeadCatches
+{
+    public function run()
+    {
+        try {
+            // some code
+        }
+        catch (Throwable $throwable) {
+            throw $throwable;
+        } catch (Exception $exception) {
+            throw $exception;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class MultipleDeadCatches
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/no_stmts.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/no_stmts.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class NoStmts
+{
+    public function run()
+    {
+        try {
+        }
+        catch (Throwable $throwable) {
+            throw $throwable;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class NoStmts
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/no_stmts_in_both_try_catch.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/no_stmts_in_both_try_catch.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class NoStmtsInBothTryCatch
+{
+    public function run()
+    {
+        try {
+        }
+        catch (Throwable $throwable) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class NoStmtsInBothTryCatch
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/no_stmts_in_finally.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/no_stmts_in_finally.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class NoStmtsInFinally
+{
+    public function run()
+    {
+        try {
+            // some code
+        } catch (\Throwable $throwable) {
+            throw $throwable;
+        } finally {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class NoStmtsInFinally
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/only_comment_in_finally.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/only_comment_in_finally.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class OnlyCommentInFinally
+{
+    public function run()
+    {
+        try {
+            // some code
+        } catch (\Throwable $throwable) {
+            throw $throwable;
+        } finally {
+            // a comment
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class OnlyCommentInFinally
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/skip_has_stmt_in_try_empty_catch.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/skip_has_stmt_in_try_empty_catch.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+use InvalidArgumentException;
+
+class SkipHasStmtInTryEmptyCatch
+{
+    public function run()
+    {
+        try {
+            $this->call();
+        }
+        catch (Throwable $throwable) {
+        }
+    }
+}

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -6,7 +6,6 @@ namespace Rector\DeadCode\Rector\TryCatch;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Throw_;
@@ -65,34 +64,21 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): null|TryCatch|array
     {
-        foreach ($node->catches as $catch) {
-            if ($catch->stmts === []) {
-                continue;
-            }
-
-            if (! isset($catch->stmts[0])) {
-                return null;
-            }
-
-            if (count($catch->stmts) !== 1) {
-                return null;
-            }
-
-            if ($catch->stmts[0] instanceof Nop) {
-                continue;
-            }
-
-            if (! $catch->stmts[0] instanceof Throw_) {
-                return null;
-            }
+        if ($this->shouldSkip($node)) {
+            return null;
         }
 
-        if ($node->finally instanceof Finally_ && count($node->finally->stmts) === 1 && isset($node->finally->stmts[0]) && $node->finally->stmts[0] instanceof Nop) {
-            $this->removeNode($node);
-            return $node;
-        }
+        if ($node->finally instanceof Finally_) {
+            if ($node->finally->stmts === []) {
+                $this->removeNode($node);
+                return $node;
+            }
 
-        if ($node->finally instanceof Finally_ && $node->finally->stmts !== []) {
+            if ($this->hasOnlyNopStmt($node->finally->stmts)) {
+                $this->removeNode($node);
+                return $node;
+            }
+
             return null;
         }
 
@@ -101,11 +87,46 @@ CODE_SAMPLE
             return $node;
         }
 
-        if (count($node->stmts) === 1 && isset($node->stmts[0]) && $node->stmts[0] instanceof Nop) {
+        if ($this->hasOnlyNopStmt($node->stmts)) {
             $this->removeNode($node);
             return $node;
         }
 
         return $node->stmts;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function hasOnlyNopStmt(array $stmts): bool
+    {
+        return count($stmts) === 1 && isset($stmts[0]) && $stmts[0] instanceof Nop;
+    }
+
+    private function shouldSkip(TryCatch $tryCatch): bool
+    {
+        foreach ($tryCatch->catches as $catch) {
+            if ($catch->stmts === []) {
+                continue;
+            }
+
+            if (! isset($catch->stmts[0])) {
+                return true;
+            }
+
+            if (count($catch->stmts) !== 1) {
+                return true;
+            }
+
+            if ($catch->stmts[0] instanceof Nop) {
+                continue;
+            }
+
+            if (! $catch->stmts[0] instanceof Throw_) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\TryCatch;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Throw_;
@@ -59,9 +60,9 @@ CODE_SAMPLE
 
     /**
      * @param TryCatch $node
-     * @return Node|Node[]|null
+     * @return TryCatch|Stmt[]|null
      */
-    public function refactor(Node $node): null|array|Node
+    public function refactor(Node $node): null|TryCatch|Stmt
     {
         if (count($node->catches) !== 1) {
             return null;

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\TryCatch;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\TryCatch;
 use Rector\Core\Rector\AbstractRector;
@@ -42,7 +42,6 @@ class SomeClass
 {
     public function run()
     {
-        // some code
     }
 }
 CODE_SAMPLE
@@ -60,9 +59,8 @@ CODE_SAMPLE
 
     /**
      * @param TryCatch $node
-     * @return Stmt[]|null
      */
-    public function refactor(Node $node): ?array
+    public function refactor(Node $node): null|array|Node
     {
         if (count($node->catches) !== 1) {
             return null;
@@ -85,6 +83,16 @@ CODE_SAMPLE
 
         if (! $this->nodeComparator->areNodesEqual($onlyCatch->var, $onlyCatchStmt->expr)) {
             return null;
+        }
+
+        if ($node->stmts === []) {
+            $this->removeNode($node);
+            return $node;
+        }
+
+        if (count($node->stmts) === 1 && isset($node->stmts[0]) && $node->stmts[0] instanceof Nop) {
+            $this->removeNode($node);
+            return $node;
         }
 
         return $node->stmts;

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -59,6 +59,7 @@ CODE_SAMPLE
 
     /**
      * @param TryCatch $node
+     * @return Node|Node[]|null
      */
     public function refactor(Node $node): null|array|Node
     {

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -60,9 +60,9 @@ CODE_SAMPLE
 
     /**
      * @param TryCatch $node
-     * @return TryCatch|Stmt[]|null
+     * @return null|TryCatch|Stmt[]
      */
-    public function refactor(Node $node): null|TryCatch|Stmt
+    public function refactor(Node $node): null|TryCatch|array
     {
         if (count($node->catches) !== 1) {
             return null;

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -127,8 +127,8 @@ CODE_SAMPLE
             }
         }
 
-       // if ($tryCatch->stmts !== [] && ! $this->hasOnlyNopStmt($tryCatch->stmts)) {
-      //      return true;
+        // if ($tryCatch->stmts !== [] && ! $this->hasOnlyNopStmt($tryCatch->stmts)) {
+        //      return true;
         //}
 
         return false;

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -127,6 +127,10 @@ CODE_SAMPLE
             }
         }
 
+       // if ($tryCatch->stmts !== [] && ! $this->hasOnlyNopStmt($tryCatch->stmts)) {
+      //      return true;
+        //}
+
         return false;
     }
 }


### PR DESCRIPTION
Currently, given the following code:

```php
        try {
        }
        catch (Throwable $throwable) {
            throw $throwable;
        }
```

without any stmts inside `Try` statement, the try catch is not removed, which should be removed.

ref https://getrector.org/demo/cb07fb5b-f624-42f5-aee1-558ca1968ce0

This PR apply:

- remove the try catch if no stmts
- remove the left over blank line for Nop doesn't has parent in stmts.
- allow removal multiple dead catches
- handle empty in try, catch, and finally
- allow removal for only comment in try catch finally
