### PR TITLE
[DeadCode] Handle empty try and catch on RemoveDeadTryCatchRector

### DIFF
--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/empty_try_and_catch.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/empty_try_and_catch.php.inc
@@ -2,15 +2,14 @@
 
 namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
 
-class DropWithEmptyFinally
+class EmptyTryAndCatch
 {
     public function run()
     {
         try {
             // some code
-        } catch (\Throwable $throwable) {
-            throw $throwable;
-        } finally {
+        }
+        catch (Throwable $throwable) {
         }
     }
 }
@@ -21,7 +20,7 @@ class DropWithEmptyFinally
 
 namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
 
-class DropWithEmptyFinally
+class EmptyTryAndCatch
 {
     public function run()
     {

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/fixture.php.inc
@@ -25,7 +25,6 @@ class Fixture
 {
     public function run()
     {
-
     }
 }
 

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/multi_lines_different_throw_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/multi_lines_different_throw_variable.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class SkipMultiLinesDifferentThrowVariable
+{
+    public function run($variable)
+    {
+        try {
+            $this->doSomething();
+            $this->doSomethingElse();
+        }
+        catch (Throwable $throwable) {
+            throw $variable;
+        }
+    }
+}

--- a/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/skip_has_stmt_empty_catch_throw.php.inc
+++ b/rules-tests/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector/Fixture/skip_has_stmt_empty_catch_throw.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector\Fixture;
+
+class SkipHasStmtEmptyCatchThrow
+{
+    public function run()
+    {
+        try {
+            $this->call();
+        }
+        catch (Throwable $throwable) {
+        }
+    }
+}

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -6,7 +6,6 @@ namespace Rector\DeadCode\Rector\TryCatch;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Throw_;
@@ -60,22 +59,6 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Stmt[] $stmts
-     */
-    private function isEmpty(array $stmts): bool
-    {
-        if ($stmts === []) {
-            return true;
-        }
-
-        if (count($stmts) > 1) {
-            return false;
-        }
-
-        return $stmts[0] instanceof Nop;
-    }
-
-    /**
      * @param TryCatch $node
      * @return Stmt[]|null|TryCatch
      */
@@ -112,5 +95,21 @@ CODE_SAMPLE
         }
 
         return $node->stmts;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function isEmpty(array $stmts): bool
+    {
+        if ($stmts === []) {
+            return true;
+        }
+
+        if (count($stmts) > 1) {
+            return false;
+        }
+
+        return $stmts[0] instanceof Nop;
     }
 }

--- a/scoper.php
+++ b/scoper.php
@@ -138,15 +138,11 @@ return [
 
         // fixes https://github.com/rectorphp/rector/issues/7017
         function (string $filePath, string $prefix, string $content): string {
-            if (!str_ends_with($filePath, 'vendor/symfony/string/ByteString.php')) {
+            if (! str_ends_with($filePath, 'vendor/symfony/string/ByteString.php')) {
                 return $content;
             }
 
-            return Strings::replace(
-                $content,
-                '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#',
-                '\\\\1_\\\\2'
-            );
+            return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
         },
 
         // unprefixed ContainerConfigurator


### PR DESCRIPTION
Given the following code:

```php
        try {
            // some code
        }
        catch (Throwable $throwable) {
        }
```

can be removed. This PR handle it, also remove left over Nop stmt.