### PR TITLE
Do not prepend a "\" to the type, if it is already Fully Qualified

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
-use PHP_CodeSniffer\Reports\Full;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -62,6 +62,10 @@ final class ObjectTypeMapper implements TypeMapperInterface
             return new IdentifierTypeNode($type->getClassName());
         }
 
+        if ($type instanceof FullyQualifiedObjectType && str_starts_with($type->getClassName(), '\\')) {
+            return new IdentifierTypeNode($type->getClassName());
+        }
+
         return new IdentifierTypeNode('\\' . $type->getClassName());
     }
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
+use PHP_CodeSniffer\Reports\Full;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
@@ -87,7 +88,13 @@ final class ObjectTypeMapper implements TypeMapperInterface
         }
 
         if ($type instanceof FullyQualifiedObjectType) {
-            return new FullyQualified($type->getClassName());
+            $className = $type->getClassName();
+
+            if(str_starts_with($className, '\\')) {
+                // skip leading \
+                return new FullyQualified(substr($className, 1));
+            }
+            return new FullyQualified($className);
         }
 
         if (! $type instanceof GenericObjectType) {

--- a/tests/Issues/Issue7023/DoNotPrependAnotherBackslashIfAlreadyPresent73Test.php
+++ b/tests/Issues/Issue7023/DoNotPrependAnotherBackslashIfAlreadyPresent73Test.php
@@ -11,7 +11,7 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 /**
  * @see https://github.com/rectorphp/rector/issues/7023
  */
-final class DoNotPrependAnotherBackslashIfAlreadyPresentTest extends AbstractRectorTestCase
+final class DoNotPrependAnotherBackslashIfAlreadyPresent73Test extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
@@ -26,11 +26,11 @@ final class DoNotPrependAnotherBackslashIfAlreadyPresentTest extends AbstractRec
      */
     public function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture/7.4');
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture/7.3');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/config/configured_rule.php';
+        return __DIR__ . '/config/configured_rule_73.php';
     }
 }

--- a/tests/Issues/Issue7023/DoNotPrependAnotherBackslashIfAlreadyPresentTest.php
+++ b/tests/Issues/Issue7023/DoNotPrependAnotherBackslashIfAlreadyPresentTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue7023;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7023
+ */
+final class DoNotPrependAnotherBackslashIfAlreadyPresentTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue7023/Fixture/7.3/fixture.php.inc
+++ b/tests/Issues/Issue7023/Fixture/7.3/fixture.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7023\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Acme\Entity\User;
+
+/**
+ * @ORM\Entity
+ */
+class Fixture
+{
+
+    /**
+     * @ORM\ManyToOne(targetEntity="\Acme\Entity\User", inversedBy="images")
+     * @ORM\JoinColumn(name="data_id", nullable=true)
+     * @var User
+     */
+    private $user;
+}
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7023\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Acme\Entity\User;
+
+/**
+ * @ORM\Entity
+ */
+class Fixture
+{
+
+    /**
+     * @ORM\ManyToOne(targetEntity="\Acme\Entity\User", inversedBy="images")
+     * @ORM\JoinColumn(name="data_id", nullable=true)
+     * @var \Acme\Entity\User|null
+     */
+    private $user;
+}
+?>

--- a/tests/Issues/Issue7023/Fixture/7.4/fixture.php.inc
+++ b/tests/Issues/Issue7023/Fixture/7.4/fixture.php.inc
@@ -13,7 +13,7 @@ class Fixture
 
     /**
      * @ORM\ManyToOne(targetEntity="\Acme\Entity\User", inversedBy="images")
-     * @ORM\JoinColumn(name="data_id", nullable=false)
+     * @ORM\JoinColumn(name="data_id", nullable=true)
      * @var User
      */
     private $user;
@@ -35,7 +35,7 @@ class Fixture
 
     /**
      * @ORM\ManyToOne(targetEntity="\Acme\Entity\User", inversedBy="images")
-     * @ORM\JoinColumn(name="data_id", nullable=false)
+     * @ORM\JoinColumn(name="data_id", nullable=true)
      * @var User
      */
     private ?\Acme\Entity\User $user = null;

--- a/tests/Issues/Issue7023/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7023/Fixture/fixture.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7023\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Acme\Entity\User;
+
+/**
+ * @ORM\Entity
+ */
+class Fixture
+{
+
+    /**
+     * @ORM\ManyToOne(targetEntity="\Acme\Entity\User", inversedBy="images")
+     * @ORM\JoinColumn(name="data_id", nullable=false)
+     * @var User
+     */
+    private $user;
+}
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7023\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Acme\Entity\User;
+
+/**
+ * @ORM\Entity
+ */
+class Fixture
+{
+
+    /**
+     * @ORM\ManyToOne(targetEntity="\Acme\Entity\User", inversedBy="images")
+     * @ORM\JoinColumn(name="data_id", nullable=false)
+     * @var User
+     */
+    private ?\Acme\Entity\User $user = null;
+}
+?>

--- a/tests/Issues/Issue7023/config/configured_rule.php
+++ b/tests/Issues/Issue7023/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Doctrine\Rector\Property\TypedPropertyFromToOneRelationTypeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(TypedPropertyFromToOneRelationTypeRector::class);
+};

--- a/tests/Issues/Issue7023/config/configured_rule_73.php
+++ b/tests/Issues/Issue7023/config/configured_rule_73.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Doctrine\Rector\Property\TypedPropertyFromToOneRelationTypeRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersionFeature::TYPED_PROPERTIES - 1);
+
+    $services = $containerConfigurator->services();
+    $services->set(TypedPropertyFromToOneRelationTypeRector::class);
+};


### PR DESCRIPTION
If the type is already fully qualified, we do not need to prepend a "\"

Fixes https://github.com/rectorphp/rector/issues/7023