### PR TITLE
[Core] Do not show DowngradeAttributeToAnnotationRector when updated docblock, but not attribute

### DIFF
--- a/e2e/applied-rule-change-docblock/rector.php
+++ b/e2e/applied-rule-change-docblock/rector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Rector\Core\Configuration\Option;
+use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
+use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -15,4 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(RenameClassRector::class)
         ->configure(['DateTime' => 'DateTimeInterface']);
+    $services->set(DowngradeAttributeToAnnotationRector::class)
+        ->configure([new DowngradeAttributeToAnnotation('Symfony\Component\Routing\Annotation\Route')]);
 };

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -89,7 +89,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
         if ($type instanceof FullyQualifiedObjectType) {
             $className = $type->getClassName();
 
-            if(str_starts_with($className, '\\')) {
+            if (str_starts_with($className, '\\')) {
                 // skip leading \
                 return new FullyQualified(substr($className, 1));
             }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
@@ -91,8 +92,9 @@ final class ObjectTypeMapper implements TypeMapperInterface
 
             if (str_starts_with($className, '\\')) {
                 // skip leading \
-                return new FullyQualified(substr($className, 1));
+                return new FullyQualified(Strings::substring($className, 1));
             }
+
             return new FullyQualified($className);
         }
 

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -136,7 +136,7 @@ CODE_SAMPLE
         );
     }
 
-    private function refactorClassConst(ClassConst $classConst): ClassConst
+    private function refactorClassConst(ClassConst $classConst): ?ClassConst
     {
         foreach ($classConst->consts as $key => $singleClassConst) {
             if (! $singleClassConst->value instanceof ConstFetch) {
@@ -151,7 +151,7 @@ CODE_SAMPLE
             return $classConst;
         }
 
-        return $classConst;
+        return null;
     }
 
     private function handleEmptyStringToNullMatch(FuncCall $funcCall, Variable $variable): FuncCall

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -85,8 +85,10 @@ CODE_SAMPLE
             // remove comma
             $last->setAttribute(AttributeKey::FUNC_ARGS_TRAILING_COMMA, false);
             $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+
+            return $node;
         }
 
-        return $node;
+        return null;
     }
 }

--- a/rules/DowngradePhp73/Tokenizer/FollowedByCommaAnalyzer.php
+++ b/rules/DowngradePhp73/Tokenizer/FollowedByCommaAnalyzer.php
@@ -25,7 +25,7 @@ final class FollowedByCommaAnalyzer
             }
 
             // without comma
-            if ($currentToken === ')') {
+            if (in_array($currentToken, [')', '('], true)) {
                 return false;
             }
 

--- a/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -87,6 +87,10 @@ CODE_SAMPLE
             $node->value .= '.0';
         }
 
+        if (! str_contains($node->value, '_')) {
+            return null;
+        }
+
         return $node;
     }
 
@@ -94,11 +98,7 @@ CODE_SAMPLE
     {
         // "_" notation can be applied to decimal numbers only
         if ($node instanceof LNumber) {
-            if ($node->getAttribute(AttributeKey::KIND) !== LNumber::KIND_DEC) {
-                return false;
-            }
-
-            return $node->value >= 1000;
+            return $node->getAttribute(AttributeKey::KIND) === LNumber::KIND_DEC;
         }
 
         return true;

--- a/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -94,7 +94,10 @@ CODE_SAMPLE
     {
         // "_" notation can be applied to decimal numbers only
         if ($node instanceof LNumber) {
-            return $node->getAttribute(AttributeKey::KIND) === LNumber::KIND_DEC && $node->value >= 1000;
+            if ($node->getAttribute(AttributeKey::KIND) !== LNumber::KIND_DEC) {
+                return false;
+            }
+            return $node->value >= 1000;
         }
 
         return true;

--- a/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
     {
         // "_" notation can be applied to decimal numbers only
         if ($node instanceof LNumber) {
-            return $node->getAttribute(AttributeKey::KIND) === LNumber::KIND_DEC;
+            return $node->getAttribute(AttributeKey::KIND) === LNumber::KIND_DEC && $node->value >= 1000;
         }
 
         return true;

--- a/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -97,6 +97,7 @@ CODE_SAMPLE
             if ($node->getAttribute(AttributeKey::KIND) !== LNumber::KIND_DEC) {
                 return false;
             }
+
             return $node->value >= 1000;
         }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -87,9 +87,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        $isDowngraded = null;
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-
-        $isDowngaded = false;
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
                 $attributeToAnnotation = $this->matchAttributeToAnnotation($attribute, $this->attributesToAnnotations);

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -34,6 +34,8 @@ final class DowngradeAttributeToAnnotationRector extends AbstractRector implemen
      */
     private array $attributesToAnnotations = [];
 
+    private bool $isDowngraded = false;
+
     public function __construct(
         private readonly DoctrineAnnotationFactory $doctrineAnnotationFactory
     ) {
@@ -87,7 +89,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $isDowngraded = null;
+        $this->isDowngraded = false;
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
@@ -110,16 +112,16 @@ CODE_SAMPLE
                     $phpDocInfo->addTagValueNode($doctrineAnnotation);
                 }
 
-                $isDowngraded = true;
+                $this->isDowngraded = true;
             }
-        }
-
-        if ($isDowngraded === null) {
-            return null;
         }
 
         // cleanup empty attr groups
         $this->cleanupEmptyAttrGroups($node);
+
+        if (! $this->isDowngraded) {
+            return null;
+        }
 
         return $node;
     }
@@ -143,6 +145,7 @@ CODE_SAMPLE
             }
 
             unset($node->attrGroups[$key]);
+            $this->isDowngraded = true;
         }
     }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -114,7 +114,7 @@ CODE_SAMPLE
             }
         }
 
-        if (! $isDowngraded) {
+        if ($isDowngraded === null) {
             return null;
         }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -89,6 +89,7 @@ CODE_SAMPLE
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
+        $isDowngaded = false;
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
                 $attributeToAnnotation = $this->matchAttributeToAnnotation($attribute, $this->attributesToAnnotations);
@@ -109,7 +110,13 @@ CODE_SAMPLE
                     );
                     $phpDocInfo->addTagValueNode($doctrineAnnotation);
                 }
+
+                $isDowngraded = true;
             }
+        }
+
+        if (! $isDowngraded) {
+            return null;
         }
 
         // cleanup empty attr groups

--- a/rules/Removing/Rector/Class_/RemoveInterfacesRector.php
+++ b/rules/Removing/Rector/Class_/RemoveInterfacesRector.php
@@ -60,10 +60,16 @@ CODE_SAMPLE
             return null;
         }
 
+        $isInterfacesRemoved = false;
         foreach ($node->implements as $key => $implement) {
             if ($this->isNames($implement, $this->interfacesToRemove)) {
                 unset($node->implements[$key]);
+                $isInterfacesRemoved = true;
             }
+        }
+
+        if (! $isInterfacesRemoved) {
+            return null;
         }
 
         return $node;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -242,6 +242,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return null;
         }
 
+        /** @var Node $originalNode */
         $rectorWithLineChange = new RectorWithLineChange($this::class, $originalNode->getLine());
         $this->file->addRectorClassWithLine($rectorWithLineChange);
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -242,7 +242,8 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return null;
         }
 
-        $this->applyRectorWithLineChange($originalNode);
+        $rectorWithLineChange = new RectorWithLineChange($this::class, $originalNode->getLine());
+        $this->file->addRectorClassWithLine($rectorWithLineChange);
 
         /** @var Node $originalNode */
         if (is_array($node)) {
@@ -429,12 +430,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
     protected function removeNodes(array $nodes): void
     {
         $this->nodeRemover->removeNodes($nodes);
-    }
-
-    private function applyRectorWithLineChange(Node $originalNode): void
-    {
-        $rectorWithLineChange = new RectorWithLineChange($this::class, $originalNode->getLine());
-        $this->file->addRectorClassWithLine($rectorWithLineChange);
     }
 
     /**


### PR DESCRIPTION
PR https://github.com/rectorphp/rector-src/pull/1861 cause DowngradeAttributeToAnnotationRector shown when docblock updated, but not attribute, which invalid.

This PR try to fix it.