### PR TITLE
end ; token on FollowedByCommaAnalyzer

### DIFF
--- a/rules/DowngradePhp73/Tokenizer/FollowedByCommaAnalyzer.php
+++ b/rules/DowngradePhp73/Tokenizer/FollowedByCommaAnalyzer.php
@@ -25,7 +25,7 @@ final class FollowedByCommaAnalyzer
             }
 
             // without comma
-            if (in_array($currentToken, [')', '('], true)) {
+            if (in_array($currentToken, ['(', ')', ';'], true)) {
                 return false;
             }
 


### PR DESCRIPTION
**Before**

```diff
➜  rector-src git:(end-token-comma) bin/rector process vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php --config build/config/config-downgrade.php --dry-run
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:57

    ---------- begin diff ----------
@@ @@

     /**
      * {@inheritdoc}
+     * @return mixed[]|bool|float|int|string|null
      */
-    public function get(string $name): array|bool|string|int|float|null
+    public function get(string $name)
     {
         if (!\array_key_exists($name, $this->parameters)) {
             if (!$name) {
@@ @@
             $alternatives = [];
             foreach ($this->parameters as $key => $parameterValue) {
                 $lev = levenshtein($name, $key);
-                if ($lev <= \strlen($name) / 3 || str_contains($key, $name)) {
+                if ($lev <= \strlen($name) / 3 || strpos($key, $name) !== false) {
                     $alternatives[] = $key;
                 }
             }

             $nonNestedAlternative = null;
-            if (!\count($alternatives) && str_contains($name, '.')) {
+            if (!\count($alternatives) && strpos($name, '.') !== false) {
                 $namePartsLength = array_map('strlen', explode('.', $name));
                 $key = substr($name, 0, -1 * (1 + array_pop($namePartsLength)));
                 while (\count($namePartsLength)) {
@@ @@

     /**
      * {@inheritdoc}
+     * @param mixed[]|bool|float|int|string|null $value
      */
-    public function set(string $name, array|bool|string|int|float|null $value)
+    public function set(string $name, $value)
     {
         $this->parameters[$name] = $value;
     }
@@ @@
      * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
      * @throws RuntimeException                    when a given parameter has a type problem
+     * @param mixed $value
+     * @return mixed
      */
-    public function resolveValue(mixed $value, array $resolving = []): mixed
+    public function resolveValue($value, array $resolving = [])
     {
         if (\is_array($value)) {
             $args = [];
@@ @@
      * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
      * @throws RuntimeException                    when a given parameter has a type problem
+     * @return mixed
      */
-    public function resolveString(string $value, array $resolving = []): mixed
+    public function resolveString(string $value, array $resolving = [])
     {
         // we do this to deal with non string values (Boolean, integer, ...)
         // as the preg_replace_callback throw an exception when trying
@@ @@

     /**
      * {@inheritdoc}
+     * @param mixed $value
+     * @return mixed
      */
-    public function escapeValue(mixed $value): mixed
+    public function escapeValue($value)
     {
         if (\is_string($value)) {
             return str_replace('%', '%%', $value);
@@ @@

     /**
      * {@inheritdoc}
+     * @param mixed $value
+     * @return mixed
      */
-    public function unescapeValue(mixed $value): mixed
+    public function unescapeValue($value)
     {
         if (\is_string($value)) {
             return str_replace('%%', '%', $value);
    ----------- end diff -----------

Applied rules:
 * DowngradeTrailingCommasInFunctionCallsRector
 * DowngradeTrailingCommasInParamUseRector
 * DowngradeStrContainsRector (https://wiki.php.net/rfc/str_contains)
 * DowngradeMixedTypeDeclarationRector
 * DowngradeUnionTypeDeclarationRector
```

**After**

```diff
➜  rector-src git:(end-token-comma) bin/rector process vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php --config build/config/config-downgrade.php --dry-run
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) vendor/symfony/dependency-injection/ParameterBag/ParameterBag.php:57

    ---------- begin diff ----------
@@ @@

     /**
      * {@inheritdoc}
+     * @return mixed[]|bool|float|int|string|null
      */
-    public function get(string $name): array|bool|string|int|float|null
+    public function get(string $name)
     {
         if (!\array_key_exists($name, $this->parameters)) {
             if (!$name) {
@@ @@
             $alternatives = [];
             foreach ($this->parameters as $key => $parameterValue) {
                 $lev = levenshtein($name, $key);
-                if ($lev <= \strlen($name) / 3 || str_contains($key, $name)) {
+                if ($lev <= \strlen($name) / 3 || strpos($key, $name) !== false) {
                     $alternatives[] = $key;
                 }
             }

             $nonNestedAlternative = null;
-            if (!\count($alternatives) && str_contains($name, '.')) {
+            if (!\count($alternatives) && strpos($name, '.') !== false) {
                 $namePartsLength = array_map('strlen', explode('.', $name));
                 $key = substr($name, 0, -1 * (1 + array_pop($namePartsLength)));
                 while (\count($namePartsLength)) {
@@ @@

     /**
      * {@inheritdoc}
+     * @param mixed[]|bool|float|int|string|null $value
      */
-    public function set(string $name, array|bool|string|int|float|null $value)
+    public function set(string $name, $value)
     {
         $this->parameters[$name] = $value;
     }
@@ @@
      * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
      * @throws RuntimeException                    when a given parameter has a type problem
+     * @param mixed $value
+     * @return mixed
      */
-    public function resolveValue(mixed $value, array $resolving = []): mixed
+    public function resolveValue($value, array $resolving = [])
     {
         if (\is_array($value)) {
             $args = [];
@@ @@
      * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
      * @throws RuntimeException                    when a given parameter has a type problem
+     * @return mixed
      */
-    public function resolveString(string $value, array $resolving = []): mixed
+    public function resolveString(string $value, array $resolving = [])
     {
         // we do this to deal with non string values (Boolean, integer, ...)
         // as the preg_replace_callback throw an exception when trying
@@ @@

     /**
      * {@inheritdoc}
+     * @param mixed $value
+     * @return mixed
      */
-    public function escapeValue(mixed $value): mixed
+    public function escapeValue($value)
     {
         if (\is_string($value)) {
             return str_replace('%', '%%', $value);
@@ @@

     /**
      * {@inheritdoc}
+     * @param mixed $value
+     * @return mixed
      */
-    public function unescapeValue(mixed $value): mixed
+    public function unescapeValue($value)
     {
         if (\is_string($value)) {
             return str_replace('%%', '%', $value);
    ----------- end diff -----------

Applied rules:
 * DowngradeStrContainsRector (https://wiki.php.net/rfc/str_contains)
 * DowngradeMixedTypeDeclarationRector
 * DowngradeUnionTypeDeclarationRector
```