### PR TITLE
[Php81] Fix property with attribute inlined on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class WithAttribute
+{
+    #[Serializer\Since(Option::SINCE_20211124)]
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class WithAttribute
+{
+    #[Serializer\Since(Option::SINCE_20211124)]
+    private readonly string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}
+
+?>

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -12,6 +12,7 @@ use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\ValueObject\Visibility;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -117,6 +118,12 @@ CODE_SAMPLE
         }
 
         $this->visibilityManipulator->makeReadonly($property);
+
+        $attributeGroups = $property->attrGroups;
+        if ($attributeGroups !== []) {
+            $property->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        }
+
         return $property;
     }
 


### PR DESCRIPTION
Given the following code:

```php
    #[Serializer\Since(Option::SINCE_20211124)]
    private string $name;
```

It currently produce inlined readonly:

```diff
-    private readonly string $name;
+    #[Serializer\Since(Option::SINCE_20211124)]private readonly string $name;
```

which should be on next line of attribute. This PR try to fix it.

Fixes https://github.com/rectorphp/rector/issues/7021