### PR TITLE
[DowngradePhp72] Handle in assign on DowngradePregUnmatchedAsNullConstantRector

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/in_assign.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/in_assign.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector\Fixture;
+
+function inAssign($pattern, $subject, $matches, $flags, $offset)
+{
+    $result = preg_match($pattern, $subject, $matches, $flags | PREG_UNMATCHED_AS_NULL, $offset);
+    if ($result === false) {
+        throw \Composer\Pcre\PcreException::fromFunction('preg_match', $pattern);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/in_assign.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/in_assign.php.inc
@@ -11,3 +11,23 @@ function inAssign($pattern, $subject, $matches, $flags, $offset)
 }
 
 ?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector\Fixture;
+
+function inAssign($pattern, $subject, $matches, $flags, $offset)
+{
+    preg_match($pattern, $subject, $matches, $flags | PREG_UNMATCHED_AS_NULL, $offset);
+    array_walk_recursive($matches, function (&$value) {
+        if ($value === '') {
+            $value = null;
+        }
+    });
+    $result = $matches === [] ? false : 1;
+    if ($result === false) {
+        throw \Composer\Pcre\PcreException::fromFunction('preg_match', $pattern);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/in_assign.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/in_assign.php.inc
@@ -18,7 +18,7 @@ namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNu
 
 function inAssign($pattern, $subject, $matches, $flags, $offset)
 {
-    preg_match($pattern, $subject, $matches, $flags | PREG_UNMATCHED_AS_NULL, $offset);
+    preg_match($pattern, $subject, $matches, $flags, $offset);
     array_walk_recursive($matches, function (&$value) {
         if ($value === '') {
             $value = null;

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -219,11 +219,21 @@ CODE_SAMPLE
     {
         $matchesVariable = $funcCall->args[2]->value;
 
-        return new Ternary(
+        $ternary = new Ternary(
             new Identical($matchesVariable, new Array_([])),
             $this->nodeFactory->createFalse(),
             new LNumber(1)
         );
+
+        $currentStatement = $assign->getAttribute(AttributeKey::CURRENT_STATEMENT);
+
+        $expressions = [
+            new Expression($funcCall),
+            new Expression($replaceEmptyStringToNull)
+        ];
+        $this->nodesToAddCollector->addNodesBeforeNode($expressions, $currentStatement);
+
+        return $ternary;
     }
 
     private function processInIf(If_ $if, FuncCall $funcCall, FuncCall $replaceEmptyStringToNull): FuncCall

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -223,11 +223,9 @@ CODE_SAMPLE
     {
         $matchesVariable = $funcCall->args[2]->value;
 
-        $ternary = new Ternary(
-            new Identical($matchesVariable, new Array_([])),
-            $this->nodeFactory->createFalse(),
-            new LNumber(1)
-        );
+        $identical = new Identical($matchesVariable, new Array_([]));
+        $lNumber = new LNumber(1);
+        $ternary = new Ternary($identical, $this->nodeFactory->createFalse(), $lNumber);
 
         $currentStatement = $assign->getAttribute(AttributeKey::CURRENT_STATEMENT);
 
@@ -266,8 +264,10 @@ CODE_SAMPLE
         if ($if->stmts !== []) {
             $firstStmt = $if->stmts[0];
             $this->nodesToAddCollector->addNodeBeforeNode($funcCall, $firstStmt);
-        } else {
-            $if->stmts[0] = new Expression($funcCall);
+
+            return;
         }
+
+        $if->stmts[0] = new Expression($funcCall);
     }
 }

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -98,8 +98,12 @@ final class DowngradePregUnmatchedAsNullConstantRector extends AbstractRector
         }
 
         $node = $this->handleEmptyStringToNullMatch($node, $variable);
-        unset($node->args[3]);
 
+        if ($node instanceof Ternary) {
+            return $node;
+        }
+
+        unset($node->args[3]);
         return $node;
     }
 
@@ -227,10 +231,7 @@ CODE_SAMPLE
 
         $currentStatement = $assign->getAttribute(AttributeKey::CURRENT_STATEMENT);
 
-        $expressions = [
-            new Expression($funcCall),
-            new Expression($replaceEmptyStringToNull)
-        ];
+        $expressions = [new Expression($funcCall), new Expression($replaceEmptyStringToNull)];
         $this->nodesToAddCollector->addNodesBeforeNode($expressions, $currentStatement);
 
         return $ternary;

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -198,6 +198,10 @@ CODE_SAMPLE
             return $this->processInIf($if, $funcCall, $replaceEmptystringToNull);
         }
 
+        if ($parent instanceof Assign && $parent->expr === $funcCall) {
+            $parent = $funcCall;
+        }
+
         if (! $parent instanceof Identical) {
             throw new NotImplementedYetException();
         }


### PR DESCRIPTION
Current rector build scoped got the following error due to update to `composer/pcre 3.0.0`:

```bash
bin/rector process vendor/composer/pcre/src/Preg.php -c build/config/config-downgrade.php --dry-run -vvv --clear-cache 
[parsing] vendor/composer/pcre/src/Preg.php
[refactoring] vendor/composer/pcre/src/Preg.php
    [applying] Rector\Removing\Rector\Class_\RemoveInterfacesRector
    [applying] Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector
    [applying] Rector\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector
    [applying] Rector\DowngradePhp81\Rector\ClassConst\DowngradeFinalizePublicClassConstantRector
    [applying] Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector
    [applying] Rector\DowngradePhp73\Rector\String_\DowngradeFlexibleHeredocSyntaxRector
    [applying] Rector\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector
    [applying] Rector\DowngradePhp81\Rector\FunctionLike\DowngradePureIntersectionTypeRector
    [applying] Rector\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector
    [applying] Rector\DowngradePhp80\Rector\FunctionLike\DowngradeUnionTypeDeclarationRector
    [applying] Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector
    [applying] Rector\DowngradePhp80\Rector\ClassMethod\DowngradeStaticTypeDeclarationRector
    [applying] Rector\DowngradePhp80\Rector\ClassMethod\DowngradeAbstractPrivateMethodInTraitRector
    [applying] Rector\DowngradePhp80\Rector\ClassMethod\DowngradeTrailingCommasInParamUseRector
    [applying] Rector\DowngradePhp80\Rector\ClassMethod\DowngradeRecursiveDirectoryIteratorHasChildrenRector
    [applying] Rector\DowngradePhp80\Rector\ClassMethod\DowngradeStringReturnTypeOnToStringRector
    [applying] Rector\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector
    [applying] Rector\DowngradePhp74\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector
    [applying] Rector\DowngradePhp72\Rector\FunctionLike\DowngradeObjectTypeDeclarationRector
    [applying] Rector\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector
    [applying] Rector\DowngradePhp81\Rector\Property\DowngradeReadonlyPropertyRector
    [applying] Rector\DowngradePhp73\Rector\ConstFetch\DowngradePhp73JsonConstRector
    [applying] Rector\DowngradePhp72\Rector\ConstFetch\DowngradePhp72JsonConstRector
    [applying] Rector\DowngradePhp74\Rector\LNumber\DowngradeNumericLiteralSeparatorRector
    [applying] Rector\DowngradePhp80\Rector\MethodCall\DowngradeNamedArgumentRector
    [applying] Rector\DowngradePhp80\Rector\New_\DowngradeArbitraryExpressionsSupportRector
    [applying] Rector\DowngradePhp73\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector
    [applying] Rector\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector
    [applying] Rector\DowngradePhp80\Rector\Expression\DowngradeThrowExprRector
    [applying] Rector\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallableSyntaxRector
    [applying] Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrContainsRector
    [applying] Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrStartsWithRector
    [applying] Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrEndsWithRector
    [applying] Rector\DowngradePhp80\Rector\FuncCall\DowngradeArrayFilterNullableCallbackRector
    [applying] Rector\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector
    [applying] Rector\DowngradePhp74\Rector\FuncCall\DowngradeStripTagsCallWithArrayRector
    [applying] Rector\DowngradePhp74\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector
    [applying] Rector\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLastRector
    [applying] Rector\DowngradePhp73\Rector\FuncCall\SetCookieOptionsArrayToArgumentsRector
    [applying] Rector\DowngradePhp73\Rector\FuncCall\DowngradeIsCountableRector

In DowngradePregUnmatchedAsNullConstantRector.php line 202:
                                                      
  [Rector\Core\Exception\NotImplementedYetException]  
                                                      

Exception trace:
  at /Users/samsonasik/www/rector-src/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php:202
 Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector->processReplace() at /Users/samsonasik/www/rector-src/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php:177
 Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector->handleEmptyStringToNullMatch() at /Users/samsonasik/www/rector-src/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php:84
 Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector->refactor() at /Users/samsonasik/www/rector-src/src/Rector/AbstractRector.php:233
 Rector\Core\Rector\AbstractRector->enterNode() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:123
 PhpParser\NodeTraverser->traverseNode() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:146
 PhpParser\NodeTraverser->traverseNode() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 PhpParser\NodeTraverser->traverseNode() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 PhpParser\NodeTraverser->traverseArray() at /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:91
 PhpParser\NodeTraverser->traverse() at /Users/samsonasik/www/rector-src/src/PhpParser/NodeTraverser/RectorNodeTraverser.php:44
 Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser->traverse() at /Users/samsonasik/www/rector-src/src/Application/FileProcessor.php:40
 Rector\Core\Application\FileProcessor->refactor() at /Users/samsonasik/www/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:109
 Rector\Core\Application\FileProcessor\PhpFileProcessor->refactorNodesWithRectors() at /Users/samsonasik/www/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:64
 Rector\Core\Application\FileProcessor\PhpFileProcessor->process() at /Users/samsonasik/www/rector-src/src/Application/ApplicationFileProcessor.php:132
 Rector\Core\Application\ApplicationFileProcessor->processFiles() at /Users/samsonasik/www/rector-src/src/Application/ApplicationFileProcessor.php:91
 Rector\Core\Application\ApplicationFileProcessor->run() at /Users/samsonasik/www/rector-src/src/Console/Command/ProcessCommand.php:96
 Rector\Core\Console\Command\ProcessCommand->execute() at /Users/samsonasik/www/rector-src/vendor/symfony/console/Command/Command.php:291
 Symfony\Component\Console\Command\Command->run() at /Users/samsonasik/www/rector-src/vendor/symfony/console/Application.php:989
 Symfony\Component\Console\Application->doRunCommand() at /Users/samsonasik/www/rector-src/vendor/symfony/console/Application.php:299
 Symfony\Component\Console\Application->doRun() at /Users/samsonasik/www/rector-src/src/Console/ConsoleApplication.php:79
 Rector\Core\Console\ConsoleApplication->doRun() at /Users/samsonasik/www/rector-src/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at /Users/samsonasik/www/rector-src/bin/rector.php:72
 require_once() at /Users/samsonasik/www/rector-src/bin/rector:4

process [-n|--dry-run] [-a|--autoload-file AUTOLOAD-FILE] [--no-progress-bar] [--no-diffs] [--output-format OUTPUT-FORMAT] [--memory-limit MEMORY-LIMIT] [--clear-cache] [--port PORT] [--identifier IDENTIFIER] [--] [<source>...]
```

This PR try to fix it. 

Fixes https://github.com/rectorphp/rector/issues/7025