### PR TITLE
[Core] Move $originalAttributes = $node->getAttributes(); on Node changed on AbstractRector::enterNode()

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -225,8 +225,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         // show current Rector class on --debug
         $this->printDebugApplying();
 
-        $originalAttributes = $node->getAttributes();
-
         $node = $this->refactor($node);
 
         // nothing to change → continue
@@ -252,6 +250,8 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             // will be replaced in leaveNode() the original node must be passed
             return $originalNode;
         }
+
+        $originalAttributes = $node->getAttributes();
 
         // update parents relations - must run before connectParentNodes()
         /** @var Node $node */

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -251,7 +251,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
             return $originalNode;
         }
 
-        $originalAttributes = $node->getAttributes();
+        $originalAttributes = $originalNode->getAttributes();
 
         // update parents relations - must run before connectParentNodes()
         /** @var Node $node */


### PR DESCRIPTION
It currently defined before refactor(), when if nothing to change, it never used, it can be moved after Node changed on return Node.