### PR TITLE
[Core] Remove deprecated addNodes?(?:Before|After)Node method on AbstractRector

### DIFF
--- a/rules/DowngradePhp56/Rector/FuncCall/DowngradeArrayFilterUseConstantRector.php
+++ b/rules/DowngradePhp56/Rector/FuncCall/DowngradeArrayFilterUseConstantRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
             ? $this->applyArrayFilterUseKey($args, $closure, $variable)
             : $this->applyArrayFilterUseBoth($args, $closure, $variable);
 
-        $this->addNodeBeforeNode($foreach, $currentStatement);
+        $this->nodesToAddCollector->addNodeBeforeNode($foreach, $currentStatement);
 
         return $variable;
     }

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
 
     private function addAssignNewVariable(FuncCall $funcCall, Expr $expr, Expr|Variable $variable): void
     {
-        $this->addNodeBeforeNode(new Expression(new Assign($variable, $expr)), $funcCall);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression(new Assign($variable, $expr)), $funcCall);
     }
 
     private function resolveCastedArray(Expr $expr): Expr|Variable

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionClassGetConstantsFilterRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionClassGetConstantsFilterRector.php
@@ -141,12 +141,12 @@ CODE_SAMPLE
             $variableReflectionClassConstants,
             new MethodCall($methodCall->var, 'getReflectionConstants')
         );
-        $this->addNodeBeforeNode(new Expression($assign), $currentStmt);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($assign), $currentStmt);
 
         $result = $this->variableNaming->createCountedValueName('result', $scope);
         $variableResult = new Variable($result);
         $assignVariableResult = new Assign($variableResult, new Array_());
-        $this->addNodeBeforeNode(new Expression($assignVariableResult), $currentStmt);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($assignVariableResult), $currentStmt);
 
         $ifs = [];
         $valueVariable = new Variable('value');
@@ -174,7 +174,7 @@ CODE_SAMPLE
             'array_walk',
             [$variableReflectionClassConstants, $closure]
         );
-        $this->addNodeBeforeNode(new Expression($funcCall), $currentStmt);
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($funcCall), $currentStmt);
 
         return $variableResult;
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -386,40 +386,6 @@ CODE_SAMPLE;
         return $stmt;
     }
 
-    /**
-     * @deprecated Use refactor() return of [] or directly $nodesToAddCollector
-     * @param Node[] $newNodes
-     */
-    protected function addNodesAfterNode(array $newNodes, Node $positionNode): void
-    {
-        $this->nodesToAddCollector->addNodesAfterNode($newNodes, $positionNode);
-    }
-
-    /**
-     * @param Node[] $newNodes
-     * @deprecated Use refactor() return of [] or directly $nodesToAddCollector
-     */
-    protected function addNodesBeforeNode(array $newNodes, Node $positionNode): void
-    {
-        $this->nodesToAddCollector->addNodesBeforeNode($newNodes, $positionNode);
-    }
-
-    /**
-     * @deprecated Use refactor() return of [] or directly $nodesToAddCollector
-     */
-    protected function addNodeAfterNode(Node $newNode, Node $positionNode): void
-    {
-        $this->nodesToAddCollector->addNodeAfterNode($newNode, $positionNode);
-    }
-
-    /**
-     * @deprecated Use refactor() return of [] or directly $nodesToAddCollector
-     */
-    protected function addNodeBeforeNode(Node $newNode, Node $positionNode): void
-    {
-        $this->nodesToAddCollector->addNodeBeforeNode($newNode, $positionNode);
-    }
-
     protected function removeNode(Node $node): void
     {
         $this->nodeRemover->removeNode($node);


### PR DESCRIPTION
The methods are deprecated and the recommended way is to return array of nodes or use directly `$this->nodesToAddCollector->()` call.