### PR TITLE
Add "Projects using Rector" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,3 @@ Please read [contributing guideline](/CONTRIBUTING.md) for how to contribute to 
 ## Code of Conduct
 
 This project adheres to a [Contributor Code of Conduct](/CODE_OF_CONDUCT.md) By participating in this project and its community, you are expected to uphold this code.
-
-## Projects using Rector
-
-- [`codito/rector-money`](https://packagist.org/packages/codito/rector-money): set of rules related to `moneyphp/money` library. It can help you with upgrading to v4.0 or make your codebase compatible for future upgrade.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Please read [contributing guideline](/CONTRIBUTING.md) for how to contribute to 
 ## Code of Conduct
 
 This project adheres to a [Contributor Code of Conduct](/CODE_OF_CONDUCT.md) By participating in this project and its community, you are expected to uphold this code.
+
+## Projects using Rector
+
+- [`codito/rector-money`](https://packagist.org/packages/codito/rector-money): set of rules related to `moneyphp/money` library. It can help you with upgrading to v4.0 or make your codebase compatible for future upgrade.

--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -147,6 +147,13 @@ See [the contribution guide](/CONTRIBUTING.md) or go to development repository [
 
 <br>
 
+## Projects using Rector
+
+- [`codito/rector-money`](https://packagist.org/packages/codito/rector-money): set of rules related to `moneyphp/money`
+  library. It can help you with upgrading to v4.0 or make your codebase compatible for future upgrade.
+
+<br>
+
 ## Debugging
 
 You can use `--debug` option, that will print nested exceptions output:


### PR DESCRIPTION
As discussed in rectorphp/rector#6588, I've added "Projects using Rector" and linked my package 🙂 