### PR TITLE
Add failing test fixture for RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_dynamic_variables.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_dynamic_variables.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class DemoFile
+{
+    public function run($something)
+    {
+         foreach($something as $key => $mapped)
+         {
+             ${$key . "_key"} = $mapped;
+         }
+    }
+}
+
+?>


### PR DESCRIPTION
I don't think Rector can know whether the variables are unused.