### PR TITLE
Add failing test fixture for `RemoveUnusedVariableAssignRector`

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/variable_reference.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/variable_reference.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class VariableReference
+{
+    public function create_signature()
+    {
+        $pkeyid = "some_public_key";
+
+		    $ok = openssl_sign("blah", $signature, $pkeyid);
+
+		    return $signature;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class VariableReference
+{
+    public function create_signature()
+    {
+        $pkeyid = "some_public_key";
+
+		    openssl_sign("blah", $signature, $pkeyid);
+
+		    return $signature;
+    }
+}
+
+?>


### PR DESCRIPTION
Rector should preserve `openssl_sign` in this case because it writes to the `$signature` variable.