### PR TITLE
Add failing test fixture for `RemoveUnusedVariableAssignRector`

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/cast_problem.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/cast_problem.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class CastProblem
+{
+    public function run()
+    {
+        $response = (object) $this->api_post("whatever", []);
+        
+        return 5;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class CastProblem
+{
+    public function run()
+    {
+        $this->api_post("whatever", []);
+        
+        return 5;
+    }
+}
+
+?>


### PR DESCRIPTION
Cast should not cause the possibly-side-effecting method call to be removed.