### PR TITLE
[DeadCode] Clean casted CallLike in Assign Expr on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/cast_problem.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/cast_problem.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class CastProblem
+{
+    public function run()
+    {
+        $response = (object) $this->api_post("whatever", []);
+        
+        return 5;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class CastProblem
+{
+    public function run()
+    {
+        $this->api_post("whatever", []);
+        
+        return 5;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/clean_cast_assign_expr_call_like.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/clean_cast_assign_expr_call_like.php.inc
@@ -2,12 +2,12 @@
 
 namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
 
-final class CastProblem
+final class CleanCastAssignExprCallLike
 {
     public function run()
     {
         $response = (object) $this->api_post("whatever", []);
-        
+
         return 5;
     }
 }
@@ -18,12 +18,12 @@ final class CastProblem
 
 namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
 
-final class CastProblem
+final class CleanCastAssignExprCallLike
 {
     public function run()
     {
         $this->api_post("whatever", []);
-        
+
         return 5;
     }
 }

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
@@ -109,11 +110,21 @@ CODE_SAMPLE
 
         if ($this->hasCallLikeInAssignExpr($node->expr)) {
             // keep the expr, can have side effect
-            return $node->expr;
+            return $this->cleanCastedExpr($node->expr);
         }
 
         $this->removeNode($node);
         return $node;
+    }
+
+    private function cleanCastedExpr(Expr $expr): Expr
+    {
+        if (! $expr instanceof Cast) {
+            return $expr;
+        }
+
+        $castedExpr = $expr->expr;
+        return $this->cleanCastedExpr($castedExpr);
     }
 
     private function hasCallLikeInAssignExpr(Expr $expr): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-src/pull/1888