### PR TITLE
Proper container configurator API

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/Fixture/fixture.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\UseRectorContainerConfiguratorRector\Fixture;
+
+return static function (\Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator): void {
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\UseRectorContainerConfiguratorRector\Fixture;
+
+return static function (\Rector\Core\DependencyInjection\Loader\Configurator\RectorContainerConfigurator $containerConfigurator): void {
+};
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/Fixture/skip_non_return_static.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/Fixture/skip_non_return_static.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\UseRectorContainerConfiguratorRector\Fixture;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+array_map(
+    function (ContainerConfigurator $containerConfigurator): void {
+    },
+    []
+);

--- a/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/UseRectorContainerConfiguratorRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/UseRectorContainerConfiguratorRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\UseRectorContainerConfiguratorRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class UseRectorContainerConfiguratorRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/config/config.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector/config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\TypeDeclaration\Rector\Closure\UseRectorContainerConfiguratorRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(UseRectorContainerConfiguratorRector::class);
+};

--- a/rules/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/UseRectorContainerConfiguratorRector.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Closure;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Closure\UseRectorContainerConfiguratorRector\UseRectorContainerConfiguratorRectorTest
+ */
+final class UseRectorContainerConfiguratorRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition("Use RectorContainerConfigurator instead Symfony's one", [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+};
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Rector\Core\DependencyInjection\Loader\Configurator\RectorContainerConfigurator;
+
+return static function (RectorContainerConfigurator $containerConfigurator): void {
+};
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Closure::class];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        $firstParam = $node->getParams()[0] ?? null;
+
+        if (! $firstParam instanceof Param) {
+            return null;
+        }
+
+        if (! $this->nodeTypeResolver->isObjectType(
+            $firstParam,
+            new ObjectType('Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator')
+        )) {
+            return null;
+        }
+
+        $firstParamName = $this->nodeNameResolver->getName($firstParam->var->name);
+
+        if ($firstParamName === null) {
+            return null;
+        }
+
+        $node->params[0] = $this->nodeFactory->createParamFromNameAndType(
+            $firstParamName,
+            new ObjectType('Rector\Core\DependencyInjection\Loader\Configurator\RectorContainerConfigurator')
+        );
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::SCALAR_TYPES;
+    }
+
+    private function shouldSkip(Closure $node): bool
+    {
+        return ! $node->static || $this->betterNodeFinder->findParentType($node, Return_::class) === null;
+    }
+}

--- a/src/DependencyInjection/Loader/Configurator/RectorContainerConfigurator.php
+++ b/src/DependencyInjection/Loader/Configurator/RectorContainerConfigurator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+/**
+ * @api
+ * Same as Symfony container configurator, with patched return type for "set()" method for easier DX.
+ * It is an alias for internal class that is prefixed during build, so it's basically for keeping stable public API.
+ */
+final class RectorContainerConfigurator extends ContainerConfigurator
+{
+}


### PR DESCRIPTION
As discussed in [#7035](https://github.com/rectorphp/rector/discussions/7035) here's implementation of `RectorServiceConfigurator` and rector for migrating from Symfony's one.

## Rector rule

I've tested it on Rector's codebase and it works, but it's unnecessary to refactor internal code since `symfony/dependency-injection` is patched and locally has proper return type. Also I did not add `UseRectorContainerConfiguratorRector` to any rule set because I think it should be opt-in for end users (explicit use in the config). But if you would like to add it, just let me know where it should be.