### PR TITLE
[DeadCode] Handle variable reference on openssl_sign() on RemoveUnusedVariableAssignRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -590,3 +590,14 @@ parameters:
         - '#Instead of "new ClassReflection\(\)" use ReflectionProvider service or "\(new PHPStan\\Reflection\\ClassReflection\(<desired_type>\)\)" for static reflection to work#'
 
         - '#Callable callable\(PHPStan\\Type\\Type\)\: PHPStan\\Type\\Type invoked with 2 parameters, 1 required#'
+
+        # PHPStan 1.4.7
+        - '#Call to static method Webmozart\\Assert\\Assert\:\:allIsAOf|isAOf\(\) with .* will always evaluate to true#'
+
+        -
+            path: src/PhpParser/Node/BetterNodeFinder.php
+            message: '#Instead of "instanceof/is_a\(\)" use ReflectionProvider service or "\(new ObjectType\(<desired_type>\)\)\->isSuperTypeOf\(<element_type>\)" for static reflection to work#'
+
+        -
+            path: src/PhpParser/Node/BetterNodeFinder.php
+            message: '#Method Rector\\Core\\PhpParser\\Node\\BetterNodeFinder\:\:findParentByTypes\(\) should return T of PhpParser\\Node\|null but returns PhpParser\\Node#'

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/variable_reference.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/variable_reference.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class VariableReference
+{
+    public function create_signature()
+    {
+        $pkeyid = "some_public_key";
+
+		    $ok = openssl_sign("blah", $signature, $pkeyid);
+
+		    return $signature;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class VariableReference
+{
+    public function create_signature()
+    {
+        $pkeyid = "some_public_key";
+
+		    openssl_sign("blah", $signature, $pkeyid);
+
+		    return $signature;
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -192,11 +192,7 @@ CODE_SAMPLE
             return $this->isUsedInPreviousAssign($assign, $expr);
         }
 
-        foreach ($expr->args as $arg) {
-            if (! $arg instanceof Arg) {
-                continue;
-            }
-
+        foreach ($expr->getArgs() as $arg) {
             $variable = $arg->value;
 
             if ($this->isUsedInPreviousAssign($assign, $variable)) {
@@ -240,6 +236,7 @@ CODE_SAMPLE
         // check if next node is if
         if (! $if instanceof If_) {
             if (
+                $assign->var instanceof Variable &&
                 ! $this->isUsedInPreviousNode($assign->var) &&
                 ! $this->exprUsedInNextNodeAnalyzer->isUsed($assign->var) && $this->isUsedInAssignExpr(
                 $assign->expr,

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\Assign;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
@@ -187,7 +186,8 @@ CODE_SAMPLE
         );
     }
 
-    private function isUsedInAssignExpr(CallLike | Expr $expr, Assign $assign): bool {
+    private function isUsedInAssignExpr(CallLike | Expr $expr, Assign $assign): bool
+    {
         if (! $expr instanceof CallLike) {
             return $this->isUsedInPreviousAssign($assign, $expr);
         }
@@ -239,9 +239,9 @@ CODE_SAMPLE
                 $assign->var instanceof Variable &&
                 ! $this->isUsedInPreviousNode($assign->var) &&
                 ! $this->exprUsedInNextNodeAnalyzer->isUsed($assign->var) && $this->isUsedInAssignExpr(
-                $assign->expr,
-                $assign
-            )) {
+                    $assign->expr,
+                    $assign
+                )) {
                 return $this->cleanCastedExpr($assign->expr);
             }
 

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -160,10 +160,7 @@ CODE_SAMPLE
 
     private function isUsed(Assign $assign, Variable $variable): bool
     {
-        $isUsedPrev = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
-            $variable,
-            fn (Node $node): bool => $this->usedVariableNameAnalyzer->isVariableNamed($node, $variable)
-        );
+        $isUsedPrev = $this->isUsedInPreviousNode($variable);
 
         if ($isUsedPrev) {
             return true;
@@ -180,6 +177,14 @@ CODE_SAMPLE
         }
 
         return $this->isUsedInAssignExpr($expr, $assign);
+    }
+
+    private function isUsedInPreviousNode(Variable $variable): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+            $variable,
+            fn (Node $node): bool => $this->usedVariableNameAnalyzer->isVariableNamed($node, $variable)
+        );
     }
 
     private function isUsedInAssignExpr(CallLike | Expr $expr, Assign $assign): bool {
@@ -234,7 +239,9 @@ CODE_SAMPLE
 
         // check if next node is if
         if (! $if instanceof If_) {
-            if (! $this->exprUsedInNextNodeAnalyzer->isUsed($assign->var) && $this->isUsedInAssignExpr(
+            if (
+                ! $this->isUsedInPreviousNode($assign->var) &&
+                ! $this->exprUsedInNextNodeAnalyzer->isUsed($assign->var) && $this->isUsedInAssignExpr(
                 $assign->expr,
                 $assign
             )) {

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -68,7 +68,7 @@ final class PureFunctionDetector
 
         // well-known functions
         'libxml_use_internal_errors', 'libxml_disable_entity_loader', 'curl_exec',
-        'mt_srand', 'openssl_pkcs7_sign',
+        'mt_srand', 'openssl_pkcs7_sign', 'openssl_sign',
         'mt_rand', 'rand', 'random_int', 'random_bytes',
         'wincache_ucache_delete', 'wincache_ucache_set', 'wincache_ucache_inc',
         'class_alias',


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/1887

- [x] Register `openssl_sign()` to impure function list
- [x] Verify variable assign never used on impure function assign, then remove it.  