### PR TITLE
[DeadCode] Ensure parent assign is Expression Stmt for RemoveUnusedVariableAssignRector

### DIFF
--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -227,7 +227,7 @@ CODE_SAMPLE
     private function refactorUsedVariable(Assign $assign): null|Expr
     {
         $parentNode = $assign->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parentNode instanceof Node) {
+        if (! $parentNode instanceof Expression) {
             return null;
         }
 
@@ -238,10 +238,7 @@ CODE_SAMPLE
             if (
                 $assign->var instanceof Variable &&
                 ! $this->isUsedInPreviousNode($assign->var) &&
-                ! $this->exprUsedInNextNodeAnalyzer->isUsed($assign->var) && $this->isUsedInAssignExpr(
-                    $assign->expr,
-                    $assign
-                )) {
+                ! $this->exprUsedInNextNodeAnalyzer->isUsed($assign->var)) {
                 return $this->cleanCastedExpr($assign->expr);
             }
 


### PR DESCRIPTION
To avoid the following romoval while used in next node after if:

```diff
-        if ([] === $publishers = Publisher::discover($directory)) {
+        if ([] === Publisher::discover($directory)) {
             CLI::write(lang('Publisher.publishMissing', [$directory]));

             return;
         }

         foreach ($publishers as $publisher)
    ----------- end diff -----------
```

I can't reproduce it in tests, possibly due to multiple rules applied, but it happen.