### PR TITLE
[Scoper] Fix scoping on AbstractUnicodeString which has RectorPrefix20220303 on preg_replace

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -138,11 +138,11 @@ return [
 
         // fixes https://github.com/rectorphp/rector/issues/7017
         function (string $filePath, string $prefix, string $content): string {
-            if (! str_ends_with($filePath, 'vendor/symfony/string/ByteString.php')) {
-                return $content;
+            if (str_ends_with($filePath, 'vendor/symfony/string/ByteString.php') || str_ends_with($filePath, 'vendor/symfony/string/AbstractUnicodeString.php')) {
+                return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
             }
 
-            return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
+            return $content;
         },
 
         // unprefixed ContainerConfigurator

--- a/scoper.php
+++ b/scoper.php
@@ -141,9 +141,11 @@ return [
             if (str_ends_with($filePath, 'vendor/symfony/string/ByteString.php')) {
                 return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
             }
+
             if (str_ends_with($filePath, 'vendor/symfony/string/AbstractUnicodeString.php')) {
                 return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
             }
+
             return $content;
         },
 

--- a/scoper.php
+++ b/scoper.php
@@ -138,10 +138,12 @@ return [
 
         // fixes https://github.com/rectorphp/rector/issues/7017
         function (string $filePath, string $prefix, string $content): string {
-            if (str_ends_with($filePath, 'vendor/symfony/string/ByteString.php') || str_ends_with($filePath, 'vendor/symfony/string/AbstractUnicodeString.php')) {
+            if (str_ends_with($filePath, 'vendor/symfony/string/ByteString.php')) {
                 return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
             }
-
+            if (str_ends_with($filePath, 'vendor/symfony/string/AbstractUnicodeString.php')) {
+                return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
+            }
             return $content;
         },
 


### PR DESCRIPTION
Current scoped on AbstractUnicodeString has the followng 'RectorPrefix20220303` in replace:

```php
        $str->string = \mb_strtolower(\preg_replace(['/(\\p{Lu}+)(\\p{Lu}\\p{Ll})/u', '/([\\p{Ll}0-9])(\\p{Lu})/u'], 'RectorPrefix20220303\\1_\\2', $str->string), 'UTF-8');
        return $str;
```

ref https://github.com/rectorphp/rector/blob/52244774008ebeddb669a1429f68ae58f72f8d0f/vendor/symfony/string/AbstractUnicodeString.php#L335

Ref https://github.com/symplify/symplify/pull/3974