### PR TITLE
[Privatization] Skip class constant from parent on ChangeReadOnlyVariableWithDefaultValueToConstantRector

### DIFF
--- a/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_class_constant_from_parent.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_class_constant_from_parent.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector\Fixture;
+
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\While_;
+
+class Bar
+{
+    protected const LOOP_NODES = [
+        Do_::class,
+        For_::class,
+        While_::class,
+    ];
+}
+
+class ClassConstantInsideCurrentClassAlreadyDefined extends Bar
+{
+    public function run()
+    {
+        $loopNodes = parent::LOOP_NODES;
+        foreach ($loopNodes as $loopNode) {
+            echo $loopNode;
+        }
+    }
+}
+
+(new ClassConstantInsideCurrentClassAlreadyDefined())->run();

--- a/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_class_constant_from_parent2.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_class_constant_from_parent2.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector\Fixture;
+
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\While_;
+
+class Bar
+{
+    protected const LOOP_NODES = [
+        Do_::class,
+        For_::class,
+        While_::class,
+    ];
+}
+
+class ClassConstantInsideCurrentClassAlreadyDefined extends Bar
+{
+    public function run()
+    {
+        $loopNodes = self::LOOP_NODES;
+        foreach ($loopNodes as $loopNode) {
+            echo $loopNode;
+        }
+    }
+}
+
+(new ClassConstantInsideCurrentClassAlreadyDefined())->run();

--- a/src/NodeManipulator/VariableManipulator.php
+++ b/src/NodeManipulator/VariableManipulator.php
@@ -79,7 +79,11 @@ final class VariableManipulator
                     return null;
                 }
 
-                if ($node->expr instanceof ClassConstFetch && $this->isOutsideClass($node->expr, $currentClass, $currentClassName)) {
+                if ($node->expr instanceof ClassConstFetch && $this->isOutsideClass(
+                    $node->expr,
+                    $currentClass,
+                    $currentClassName
+                )) {
                     return null;
                 }
 
@@ -102,7 +106,11 @@ final class VariableManipulator
         );
     }
 
-    private function isOutsideClass(ClassConstFetch $classConstFetch, Class_ $currentClass, string $currentClassName): bool
+    private function isOutsideClass(
+        ClassConstFetch $classConstFetch,
+        Class_ $currentClass,
+        string $currentClassName
+    ): bool
     {
         /**
          * Dynamic class already checked on $this->exprAnalyzer->isDynamicValue() early

--- a/src/NodeManipulator/VariableManipulator.php
+++ b/src/NodeManipulator/VariableManipulator.php
@@ -108,7 +108,7 @@ final class VariableManipulator
          * @var Name $class
          */
         $class = $classConstFetch->class;
-        if ($class->isSpecialClassName()) {
+        if ($this->nodeNameResolver->isName($class, 'self')) {
             return false;
         }
 

--- a/src/NodeManipulator/VariableManipulator.php
+++ b/src/NodeManipulator/VariableManipulator.php
@@ -110,8 +110,7 @@ final class VariableManipulator
         ClassConstFetch $classConstFetch,
         Class_ $currentClass,
         string $currentClassName
-    ): bool
-    {
+    ): bool {
         /**
          * Dynamic class already checked on $this->exprAnalyzer->isDynamicValue() early
          * @var Name $class


### PR DESCRIPTION
Given the following code:

```php
use PhpParser\Node\Stmt\Do_;
use PhpParser\Node\Stmt\For_;
use PhpParser\Node\Stmt\While_;

class Bar
{
    protected const LOOP_NODES = [
        Do_::class,
        For_::class,
        While_::class,
    ];
}

class ClassConstantInsideCurrentClassAlreadyDefined extends Bar
{
    public function run()
    {
        $loopNodes = parent::LOOP_NODES;
        foreach ($loopNodes as $loopNode) {
            echo $loopNode;
        }
    }
}

(new ClassConstantInsideCurrentClassAlreadyDefined())->run();
```

It currently produce:

```diff
+    private const LOOP_NODES = parent::LOOP_NODES;
     public function run()
     {
-        $loopNodes = parent::LOOP_NODES;
-        foreach ($loopNodes as $loopNode) {
+        foreach (self::LOOP_NODES as $loopNode) {
```

which cause error:

```
Access level to ClassConstantInsideCurrentClassAlreadyDefined::LOOP_NODES must be protected (as in class Bar) or weaker
```

ref https://3v4l.org/nMDBs

This PR try to fix it.