### PR TITLE
test run in phpstan 1.4.8

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "phpstan/phpstan": "1.4.7"
+        "phpstan/phpstan": "^1.4.8"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^4.13.2",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.2",
-        "phpstan/phpstan": "1.4.7",
+        "phpstan/phpstan": "^1.4.8",
         "phpstan/phpstan-phpunit": "^1.0",
         "psr/log": "^2.0",
         "react/child-process": "^0.6.4",

--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/VariableTypeResolver/Fixture/argument_typehint.php.inc
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/VariableTypeResolver/Fixture/argument_typehint.php.inc
@@ -8,4 +8,4 @@ use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\VariableTypeResolver\Sourc
 
 array_map(function (AnotherType $useUse) {
     return $useUse;
-}, []);
+}, [new AnotherType]);

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/return_type_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/return_type_object.php.inc
@@ -6,9 +6,9 @@ use PhpParser\Node\Stmt\Class_;
 
 class ReturnTypeObject
 {
-    public function shouldSkip()
+    public function shouldSkip(Class_ $class)
     {
-        $nonAnonymousClassNodes = array_filter([], function (Class_ $classNode) {
+        $nonAnonymousClassNodes = array_filter([$class], function (Class_ $classNode) {
             return $classNode->name;
         });
     }
@@ -24,9 +24,9 @@ use PhpParser\Node\Stmt\Class_;
 
 class ReturnTypeObject
 {
-    public function shouldSkip()
+    public function shouldSkip(Class_ $class)
     {
-        $nonAnonymousClassNodes = array_filter([], function (Class_ $classNode): ?\PhpParser\Node\Identifier {
+        $nonAnonymousClassNodes = array_filter([$class], function (Class_ $classNode): ?\PhpParser\Node\Identifier {
             return $classNode->name;
         });
     }


### PR DESCRIPTION
Checked locally, it seems run test in latest composer update got the following error:

```bash
There was 1 error:

1) Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\VariableTypeResolver\VariableTypeResolverTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc', 2, PHPStan\Type\ObjectType Object (...))
Error: Class "Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\VariableTypeResolver\Fixture\NewClass" not found

/Users/samsonasik/www/rector-src/packages-tests/NodeTypeResolver/PerNodeTypeResolver/VariableTypeResolver/Fixture/assignment_class.php.inc:25
/Users/samsonasik/www/rector-src/packages/Testing/TestingParser/TestingParser.php:44
/Users/samsonasik/www/rector-src/packages-tests/NodeTypeResolver/PerNodeTypeResolver/AbstractNodeTypeResolverTest.php:37
/Users/samsonasik/www/rector-src/packages-tests/NodeTypeResolver/PerNodeTypeResolver/VariableTypeResolver/VariableTypeResolverTest.php:24

--

There was 1 failure:

1) Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\VariableTypeResolver\VariableTypeResolverTest::test with data set #3 ('/Users/samsonasik/www/rector-...hp.inc', 1, PHPStan\Type\ObjectType Object (...))
Failed asserting that PHPStan\Type\NeverType Object (...) is an instance of interface "PHPStan\Type\TypeWithClassName".

/Users/samsonasik/www/rector-src/packages-tests/NodeTypeResolver/PerNodeTypeResolver/VariableTypeResolver/VariableTypeResolverTest.php:27
```

this PR check with empty commit to run it in CI.