### PR TITLE
[Php81] Skip override __construct from interface on NewInInitializerRector

### DIFF
--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -91,18 +91,18 @@ final class ClassChildAnalyzer
     {
         $parentClassMethods = [];
         $parents = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
-        foreach ($parents as $parentClassReflections) {
-            if (! $parentClassReflections->hasMethod($methodName)) {
+        foreach ($parents as $parent) {
+            if (! $parent->hasMethod($methodName)) {
                 continue;
             }
 
-            $methodReflection = $parentClassReflections->getNativeMethod($methodName);
+            $methodReflection = $parent->getNativeMethod($methodName);
             if (! $methodReflection instanceof PhpMethodReflection) {
                 continue;
             }
 
             $methodDeclaringMethodClass = $methodReflection->getDeclaringClass();
-            if ($methodDeclaringMethodClass->getName() === $parentClassReflections->getName()) {
+            if ($methodDeclaringMethodClass->getName() === $parent->getName()) {
                 $parentClassMethods[] = $methodReflection;
             }
         }

--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -46,6 +46,9 @@ final class ClassChildAnalyzer
         return $this->resolveParentClassMethods($classReflection, $methodName) !== [];
     }
 
+    /**
+     * Look both parent class and interface, yes, all PHP interface methods are abstract
+     */
     public function hasAbstractParentClassMethod(ClassReflection $classReflection, string $methodName): bool
     {
         $parentClassMethods = $this->resolveParentClassMethods($classReflection, $methodName);
@@ -87,7 +90,8 @@ final class ClassChildAnalyzer
     private function resolveParentClassMethods(ClassReflection $classReflection, string $methodName): array
     {
         $parentClassMethods = [];
-        foreach ($classReflection->getParents() as $parentClassReflections) {
+        $parents = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        foreach ($parents as $parentClassReflections) {
             if (! $parentClassReflections->hasMethod($methodName)) {
                 continue;
             }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/skip_override_interface_method.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/skip_override_interface_method.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
+
+use DateTime;
+use Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Source\OverrideInterfaceMethod;
+
+class SkipOverrideInterfaceMethod implements OverrideInterfaceMethod
+{
+    private DateTime $dateTime;
+
+    public function __construct(
+        ?DateTime $dateTime = null
+    ) {
+        $this->dateTime = $dateTime ?? new DateTime('now');
+    }
+}

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Source/OverrideInterfaceMethod.php
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Source/OverrideInterfaceMethod.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Source;
+
+use DateTime;
+
+interface OverrideInterfaceMethod
+{
+    public function __construct(
+        ?DateTime $dateTime = null
+    );
+}


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/1740, given the following code:

```php
interface OverrideInterfaceMethod
{
    public function __construct(
        ?DateTime $dateTime = null
    );
}

class SkipOverrideInterfaceMethod implements OverrideInterfaceMethod
{
    private DateTime $dateTime;

    public function __construct(
        ?DateTime $dateTime = null
    ) {
        $this->dateTime = $dateTime ?? new DateTime('now');
    }
}
```

got result:

```diff
-    private DateTime $dateTime;
-
-    public function __construct(
-        ?DateTime $dateTime = null
-    ) {
-        $this->dateTime = $dateTime ?? new DateTime('now');
+    public function __construct(private DateTime $dateTime = new DateTime('now'))
+    {
```

which cause fatal error:

```bash
Fatal error: Declaration of SkipOverrideInterfaceMethod::__construct(DateTime $dateTime = <expression>) must be compatible with OverrideInterfaceMethod::__construct(?DateTime $dateTime = null)
```

ref https://3v4l.org/AiBL5