### PR TITLE
[Transform] Handle property exists via Property Promotion on NewToMethodCallRector

### DIFF
--- a/rules-tests/Transform/Rector/New_/NewToMethodCallRector/Fixture/property_exists_via_property_promotion.php.inc
+++ b/rules-tests/Transform/Rector/New_/NewToMethodCallRector/Fixture/property_exists_via_property_promotion.php.inc
@@ -8,7 +8,6 @@ final class PropertyExistsViaPropertyPromotion
 {
     public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $mySomeFactory)
     {
-        $this->mySomeFactory = $mySomeFactory;
     }
     public function default()
     {
@@ -28,7 +27,6 @@ final class PropertyExistsViaPropertyPromotion
 {
     public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $mySomeFactory)
     {
-        $this->mySomeFactory = $mySomeFactory;
     }
     public function default()
     {

--- a/rules-tests/Transform/Rector/New_/NewToMethodCallRector/Fixture/property_exists_via_property_promotion.php.inc
+++ b/rules-tests/Transform/Rector/New_/NewToMethodCallRector/Fixture/property_exists_via_property_promotion.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Fixture;
+
+use Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClass;
+
+final class PropertyExistsViaPropertyPromotion
+{
+    public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $mySomeFactory)
+    {
+        $this->mySomeFactory = $mySomeFactory;
+    }
+    public function default()
+    {
+        new MyClass('abcd');
+        $class = new MyClass('abcd');
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Fixture;
+
+use Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClass;
+
+final class PropertyExistsViaPropertyPromotion
+{
+    public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $mySomeFactory)
+    {
+        $this->mySomeFactory = $mySomeFactory;
+    }
+    public function default()
+    {
+        $this->mySomeFactory->create('abcd');
+        $class = $this->mySomeFactory->create('abcd');
+    }
+}
+?>

--- a/rules/Transform/Rector/New_/NewToMethodCallRector.php
+++ b/rules/Transform/Rector/New_/NewToMethodCallRector.php
@@ -103,7 +103,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $propertyName = $this->propertyManipulator->resolveExistingClassPropertyWithType(
+            $propertyName = $this->propertyManipulator->resolveExistingClassPropertyNameByType(
                 $class,
                 $newToMethodCall->getServiceObjectType()
             );

--- a/rules/Transform/Rector/New_/NewToMethodCallRector.php
+++ b/rules/Transform/Rector/New_/NewToMethodCallRector.php
@@ -10,9 +10,9 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
-use PHPStan\Type\ObjectType;
 use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PostRector\Collector\PropertyToAddCollector;
 use Rector\PostRector\ValueObject\PropertyMetadata;
@@ -33,6 +33,7 @@ final class NewToMethodCallRector extends AbstractRector implements Configurable
 
     public function __construct(
         private readonly ClassNaming $classNaming,
+        private readonly PropertyManipulator $propertyManipulator,
         private readonly PropertyToAddCollector $propertyToAddCollector
     ) {
     }
@@ -102,7 +103,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $propertyName = $this->getExistingFactoryPropertyName(
+            $propertyName = $this->propertyManipulator->resolveExistingClassPropertyWithType(
                 $class,
                 $newToMethodCall->getServiceObjectType()
             );
@@ -136,18 +137,5 @@ CODE_SAMPLE
         Assert::allIsAOf($configuration, NewToMethodCall::class);
 
         $this->newsToMethodCalls = $configuration;
-    }
-
-    private function getExistingFactoryPropertyName(Class_ $class, ObjectType $factoryObjectType): ?string
-    {
-        foreach ($class->getProperties() as $property) {
-            if (! $this->isObjectType($property, $factoryObjectType)) {
-                continue;
-            }
-
-            return $this->getName($property);
-        }
-
-        return null;
     }
 }

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -199,7 +199,7 @@ final class PropertyManipulator
         return false;
     }
 
-    public function resolveExistingClassPropertyWithType(Class_ $class, Type $type): ?string
+    public function resolveExistingClassPropertyNameByType(Class_ $class, Type $type): ?string
     {
         foreach ($class->getProperties() as $property) {
             $propertyType = $this->nodeTypeResolver->getType($property);

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -20,11 +20,13 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -33,7 +35,9 @@ use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\MethodName;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\Php80\NodeAnalyzer\PromotedPropertyResolver;
 use Rector\ReadWrite\Guard\VariableToConstantGuard;
 use Rector\ReadWrite\NodeAnalyzer\ReadWritePropertyAnalyzer;
 use Symplify\PackageBuilder\Php\TypeChecker;
@@ -75,7 +79,9 @@ final class PropertyManipulator
         private readonly PropertyFetchFinder $propertyFetchFinder,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private readonly NodeTypeResolver $nodeTypeResolver,
+        private readonly PromotedPropertyResolver $promotedPropertyResolver
     ) {
     }
 
@@ -191,6 +197,30 @@ final class PropertyManipulator
         }
 
         return false;
+    }
+
+    public function resolveExistingClassPropertyWithType(Class_ $class, Type $type): ?string
+    {
+        foreach ($class->getProperties() as $property) {
+            $propertyType = $this->nodeTypeResolver->getType($property);
+            if (! $propertyType->equals($type)) {
+                continue;
+            }
+
+            return $this->nodeNameResolver->getName($property);
+        }
+
+        $promotedPropertyParams = $this->promotedPropertyResolver->resolveFromClass($class);
+        foreach ($promotedPropertyParams as $promotedPropertyParam) {
+            $paramType = $this->nodeTypeResolver->getType($promotedPropertyParam);
+            if (! $paramType->equals($type)) {
+                continue;
+            }
+
+            return $this->nodeNameResolver->getName($promotedPropertyParam);
+        }
+
+        return null;
     }
 
     private function isInlineStmtWithConstructMethod(


### PR DESCRIPTION
Given the following code:

```php
<?php

namespace Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Fixture;

use Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClass;

final class PropertyExistsViaPropertyPromotion
{
    public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $mySomeFactory)
    {
    }
    public function default()
    {
        new MyClass('abcd');
        $class = new MyClass('abcd');
    }
}
```

It produce double register:

```diff
-    public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $mySomeFactory)
+    public function __construct(private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $mySomeFactory, private \Rector\Tests\Transform\Rector\New_\NewToMethodCallRector\Source\MyClassFactory $myClassFactory)
     {
     }
     public function default()
     {
-        new MyClass('abcd');
-        $class = new MyClass('abcd');
+        $this->myClassFactory->create('abcd');
+        $class = $this->myClassFactory->create('abcd');
     }
```

which should be just use existing when exists, like other fixture 