### PR TITLE
[Renaming] Refactor DocBlockNamespaceRenamer to use PhpDocNodeTraverser for RenameNamespaceRector

### DIFF
--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\Node as DocNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -38,29 +39,27 @@ final class DocBlockNamespaceRenamer
         $phpDocNodeTraverser->traverseWithCallable(
             $phpDocInfo->getPhpDocNode(),
             '',
-            function (\PHPStan\PhpDocParser\Ast\Node &$subNode) use (
-                $oldToNewNamespaces
-            ): ?\PHPStan\PhpDocParser\Ast\Node {
-                if ($subNode instanceof IdentifierTypeNode) {
-                    $name = $subNode->name;
-                    $trimmedName = ltrim($subNode->name, '\\');
-
-                    if ($name === $trimmedName) {
-                        return null;
-                    }
-
-                    $renamedNamespaceValueObject = $this->namespaceMatcher->matchRenamedNamespace(
-                        $trimmedName,
-                        $oldToNewNamespaces
-                    );
-                    if (! $renamedNamespaceValueObject instanceof RenamedNamespace) {
-                        return null;
-                    }
-
-                    return new IdentifierTypeNode('\\' . $renamedNamespaceValueObject->getNameInNewNamespace());
+            function (DocNode &$subNode) use ($oldToNewNamespaces): ?DocNode {
+                if (! $subNode instanceof IdentifierTypeNode) {
+                    return null;
                 }
 
-                return null;
+                $name = $subNode->name;
+                $trimmedName = ltrim($subNode->name, '\\');
+
+                if ($name === $trimmedName) {
+                    return null;
+                }
+
+                $renamedNamespaceValueObject = $this->namespaceMatcher->matchRenamedNamespace(
+                    $trimmedName,
+                    $oldToNewNamespaces
+                );
+                if (! $renamedNamespaceValueObject instanceof RenamedNamespace) {
+                    return null;
+                }
+
+                return new IdentifierTypeNode('\\' . $renamedNamespaceValueObject->getNameInNewNamespace());
             }
         );
 

--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
@@ -10,29 +10,15 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\BetterPhpDocParser\ValueObject\PhpDoc\VariadicAwareParamTagValueNode;
-use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Naming\NamespaceMatcher;
 use Rector\Renaming\ValueObject\RenamedNamespace;
+use Symplify\Astral\PhpDocParser\PhpDocNodeTraverser;
 
 final class DocBlockNamespaceRenamer
 {
-    /**
-     * @var array<class-string<PhpDocTagValueNode>>
-     */
-    private const TO_BE_CHANGED = [
-        ReturnTagValueNode::class,
-        VariadicAwareParamTagValueNode::class,
-        VarTagValueNode::class,
-    ];
-
     public function __construct(
         private readonly NamespaceMatcher $namespaceMatcher,
         private readonly PhpDocInfoFactory $phpDocInfoFactory
@@ -47,73 +33,41 @@ final class DocBlockNamespaceRenamer
         array $oldToNewNamespaces
     ): ?Node {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        $phpDocNode = $phpDocInfo->getPhpDocNode();
-        $children = $phpDocNode->children;
 
-        foreach ($children as $child) {
-            if (! $child instanceof PhpDocTagNode) {
-                continue;
+        $phpDocNodeTraverser = new PhpDocNodeTraverser();
+        $phpDocNodeTraverser->traverseWithCallable(
+            $phpDocInfo->getPhpDocNode(),
+            '',
+            function (\PHPStan\PhpDocParser\Ast\Node &$subNode) use (
+                $oldToNewNamespaces
+            ): ?\PHPStan\PhpDocParser\Ast\Node {
+                if ($subNode instanceof IdentifierTypeNode) {
+                    $name = $subNode->name;
+                    $trimmedName = ltrim($subNode->name, '\\');
+
+                    if ($name === $trimmedName) {
+                        return null;
+                    }
+
+                    $renamedNamespaceValueObject = $this->namespaceMatcher->matchRenamedNamespace(
+                        $trimmedName,
+                        $oldToNewNamespaces
+                    );
+                    if (! $renamedNamespaceValueObject instanceof RenamedNamespace) {
+                        return null;
+                    }
+
+                    return new IdentifierTypeNode('\\' . $renamedNamespaceValueObject->getNameInNewNamespace());
+                }
+
+                return null;
             }
-
-            $value = $child->value;
-            if (! in_array($value::class, self::TO_BE_CHANGED, true)) {
-                continue;
-            }
-
-            /** @var ReturnTagValueNode|VariadicAwareParamTagValueNode|VarTagValueNode $value */
-            $this->refactorDocblock($value, $oldToNewNamespaces);
-        }
+        );
 
         if (! $phpDocInfo->hasChanged()) {
             return null;
         }
 
         return $node;
-    }
-
-    /**
-     * @param array<string, string> $oldToNewNamespaces
-     */
-    private function refactorDocblock(
-        ReturnTagValueNode|VariadicAwareParamTagValueNode|VarTagValueNode $value,
-        array $oldToNewNamespaces
-    ): void {
-        /** @var ReturnTagValueNode|VariadicAwareParamTagValueNode|VarTagValueNode $value */
-        $types = $value->type instanceof BracketsAwareUnionTypeNode
-            ? $value->type->types
-            : [$value->type];
-
-        foreach ($types as $key => $type) {
-            if (! $type instanceof IdentifierTypeNode) {
-                continue;
-            }
-
-            $name = $type->name;
-            $trimmedName = ltrim($type->name, '\\');
-
-            if ($name === $trimmedName) {
-                continue;
-            }
-
-            $renamedNamespaceValueObject = $this->namespaceMatcher->matchRenamedNamespace(
-                $trimmedName,
-                $oldToNewNamespaces
-            );
-            if (! $renamedNamespaceValueObject instanceof RenamedNamespace) {
-                continue;
-            }
-
-            $newType = new IdentifierTypeNode('\\' . $renamedNamespaceValueObject->getNameInNewNamespace());
-
-            if ($value->type instanceof BracketsAwareUnionTypeNode) {
-                $types[$key] = $newType;
-            } else {
-                $value->type = $newType;
-            }
-        }
-
-        if ($value->type instanceof BracketsAwareUnionTypeNode) {
-            $value->type->types = $types;
-        }
     }
 }

--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
@@ -39,7 +39,7 @@ final class DocBlockNamespaceRenamer
         $phpDocNodeTraverser->traverseWithCallable(
             $phpDocInfo->getPhpDocNode(),
             '',
-            function (DocNode &$subNode) use ($oldToNewNamespaces): ?DocNode {
+            function (DocNode $subNode) use ($oldToNewNamespaces): ?DocNode {
                 if (! $subNode instanceof IdentifierTypeNode) {
                     return null;
                 }

--- a/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/rename_namespace_docblock_return_array.php.inc
+++ b/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/rename_namespace_docblock_return_array.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace OldNamespace\SubNamespace;
+
+use OldNamespace;
+
+class RenameNamespaceDocblockReturnArray
+{
+    /**
+     * @return \OldNamespace\SubNamespace\RenameNamespaceDocblockReturnArray[]
+     */
+    public function run(\OldNamespace\SubNamespace\RenameNamespaceDocblockReturnArray $argument)
+    {
+        return [$argument];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace NewNamespace\SubNamespace;
+
+use NewNamespace;
+
+class RenameNamespaceDocblockReturnArray
+{
+    /**
+     * @return \NewNamespace\SubNamespace\RenameNamespaceDocblockReturnArray[]
+     */
+    public function run(\NewNamespace\SubNamespace\RenameNamespaceDocblockReturnArray $argument)
+    {
+        return [$argument];
+    }
+}
+
+?>


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/1917, refactor to use `PhpDocNodeTraverser::traverseWithCallable()` to clean up unneeded Node Value type check.