### PR TITLE
in some cases StartAndEnd is null RemoveNodesStartAndEndResolver

### DIFF
--- a/packages/BetterPhpDocParser/Printer/RemoveNodesStartAndEndResolver.php
+++ b/packages/BetterPhpDocParser/Printer/RemoveNodesStartAndEndResolver.php
@@ -26,8 +26,13 @@ final class RemoveNodesStartAndEndResolver
         $lastEndPosition = null;
 
         foreach ($removedChildNodes as $removedChildNode) {
-            /** @var StartAndEnd $removedPhpDocNodeInfo */
+            /** @var StartAndEnd|null $removedPhpDocNodeInfo */
             $removedPhpDocNodeInfo = $removedChildNode->getAttribute(PhpDocAttributeKey::START_AND_END);
+
+            // it's not there when comment block has empty row "\s\*\n"
+            if (is_null($removedPhpDocNodeInfo)) {
+                continue;
+            }
 
             // change start position to start of the line, so the whole line is removed
             $seekPosition = $removedPhpDocNodeInfo->getStart();

--- a/packages/BetterPhpDocParser/Printer/RemoveNodesStartAndEndResolver.php
+++ b/packages/BetterPhpDocParser/Printer/RemoveNodesStartAndEndResolver.php
@@ -30,7 +30,7 @@ final class RemoveNodesStartAndEndResolver
             $removedPhpDocNodeInfo = $removedChildNode->getAttribute(PhpDocAttributeKey::START_AND_END);
 
             // it's not there when comment block has empty row "\s\*\n"
-            if (is_null($removedPhpDocNodeInfo)) {
+            if (! $removedPhpDocNodeInfo instanceof StartAndEnd) {
                 continue;
             }
 


### PR DESCRIPTION
On empty lines 
```
/**
* Comment
* 
* @Annotation...
*/
```
fatal error occured, $removedPhpDocNodeInfo was null