### PR TITLE
running phpstan with dockerc-compose resulted memory exhaustion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
             "vendor/bin/ecs check --fix --ansi",
             "vendor/bin/ecs check-markdown README.md --fix --ansi"
         ],
-        "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify",
+        "phpstan": "php -dmemory_limit=1G vendor/bin/phpstan analyse --ansi --error-format symplify",
         "phpstan-config": "vendor/bin/phpstan analyse config --ansi --error-format symplify",
         "docs": [
             "vendor/bin/rule-doc-generator generate packages rules --output-file build/rector_rules_overview.md --ansi --categorize --configure-method",


### PR DESCRIPTION
When running `composer phpstan`

![image](https://user-images.githubusercontent.com/20553410/158066726-973335ca-6cc2-4cec-a9ca-1b215dfa595b.png)
