### PR TITLE
[PHP 8.0] Fix skip of silent key in annotation to attribute

### DIFF
--- a/packages/PhpAttribute/AttributeArrayNameInliner.php
+++ b/packages/PhpAttribute/AttributeArrayNameInliner.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
+use Rector\Core\Exception\NotImplementedYetException;
 use Webmozart\Assert\Assert;
 
 final class AttributeArrayNameInliner
@@ -66,6 +67,11 @@ final class AttributeArrayNameInliner
                 if ($arrayItem->key instanceof String_) {
                     $arrayItemString = $arrayItem->key;
                     $newArgs[] = new Arg($arrayItem->value, false, false, [], new Identifier($arrayItemString->value));
+                } elseif ($arrayItem->key === null) {
+                    // silent key
+                    $newArgs[] = new Arg($arrayItem->value);
+                } else {
+                    throw new NotImplementedYetException(get_debug_type($arrayItem->key));
                 }
             }
         }

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/first_param_is_silent.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/first_param_is_silent.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
+
+/**
+ * @GenericAnnotation("sample", itemOperations="yes")
+ */
+final class FirstParamIsSilent
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
+
+#[GenericAnnotation('sample', itemOperations: 'yes')]
+final class FirstParamIsSilent
+{
+}
+
+?>


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/pull/132#issuecomment-1067894198

This will fix your bug, cc @Jean85 