### PR TITLE
[ECS] Skip StandaloneLineConstructorParamFixer

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
@@ -10,6 +9,7 @@ use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\LineLength\DocBlockLineLengthFixer;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLineConstructorParamFixer;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -79,7 +79,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ],
 
         // buggy - cause { inlined
-        BracesFixer::class,
+        StandaloneLineConstructorParamFixer::class,
     ]);
 
     // import SetList here in the end of ecs. is on purpose


### PR DESCRIPTION
Skip StandaloneLineConstructorParamFixer instead of BracesFixer per https://github.com/symplify/symplify/pull/4004#issuecomment-1068969587

 