### PR TITLE
[CodeQuality] Fix code sample of InlineConstructorDefaultToPropertyRector

### DIFF
--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -45,6 +45,10 @@ CODE_SAMPLE
 final class SomeClass
 {
     private $name = 'John';
+
+    public function __construct()
+    {
+    }
 }
 CODE_SAMPLE
             ),


### PR DESCRIPTION
The current code sample is misleading and gives the false impression that the constructor could be removed.