### PR TITLE
[DeadCode][CodingStyle] Handle SplitDoubleAssignRector+RemoveUnusedPrivatePropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_multi_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_multi_assign.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+final class SkipMultiAssign
+{
+    private $content_type;
+
+    public function run()
+    {
+        $this->content_type = $content_type = "Something";
+
+        return $content_type;
+    }
+}

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -57,6 +57,10 @@ final class ComplexNodeRemover
                 return;
             }
 
+            if ($assign->expr instanceof Assign) {
+                return;
+            }
+
             $assigns[] = $assign;
         }
 

--- a/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/extracted_assign.php.inc
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/extracted_assign.php.inc
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
 
-final class MultiAssignExtract
+final class ExtractedAssign
 {
     private $content_type;
 
@@ -25,7 +25,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
 
-final class MultiAssignExtract
+final class ExtractedAssign
 {
     public function run()
     {

--- a/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/extracted_assign.php.inc
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/extracted_assign.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+
+final class MultiAssignExtract
+{
+    private $content_type;
+
+    public function run()
+    {
+        $this->content_type = "Something";
+        $content_type = "Something";
+
+        return $content_type;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+
+final class MultiAssignExtract
+{
+    public function run()
+    {
+        $content_type = "Something";
+
+        return $content_type;
+    }
+}
+
+?>

--- a/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/multi_assign_extract.php.inc
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/multi_assign_extract.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+
+final class MultiAssignExtract
+{
+    private $content_type;
+
+    public function run()
+    {
+        $this->content_type = $content_type = "Something";
+
+        return $content_type;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+
+final class MultiAssignExtract
+{
+    private $content_type;
+
+    public function run()
+    {
+        $this->content_type = "Something";
+        $content_type = "Something";
+
+        return $content_type;
+    }
+}
+
+?>

--- a/tests/Issues/SplitMultiAssignRemovePrivate/SplitMultiAssignRemovePrivateTest.php
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/SplitMultiAssignRemovePrivateTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SplitMultiAssignRemovePrivateTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/SplitMultiAssignRemovePrivate/config/configured_rule.php
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
+use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(SplitDoubleAssignRector::class);
+    $services->set(RemoveUnusedPrivatePropertyRector::class);
+};


### PR DESCRIPTION
- [x] Skip multi assign on RemoveUnusedPrivatePropertyRector
- [x] Extract multi assign first when used along with  SplitDoubleAssignRector
- [x] Safely removed after extracted

In execution, it needs to be run twice to apply remove property changes, extract first with `SplitDoubleAssignRector`, then remove with `RemoveUnusedPrivatePropertyRector`.

Closes https://github.com/rectorphp/rector-src/pull/1941