### PR TITLE
[Arguments] Handle by pass 2nd argument default value on ArgumentAdderRector

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/by_pass_2nd_arg_value.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/by_pass_2nd_arg_value.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class ByPass2ndArgValue
+{
+    public function run()
+    {
+        $containerBuilder = new SomeMultiArg();
+        $containerBuilder->run(1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class ByPass2ndArgValue
+{
+    public function run()
+    {
+        $containerBuilder = new SomeMultiArg();
+        $containerBuilder->run(1);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/by_pass_2nd_arg_value.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/by_pass_2nd_arg_value.php.inc
@@ -26,7 +26,7 @@ class ByPass2ndArgValue
     public function run()
     {
         $containerBuilder = new SomeMultiArg();
-        $containerBuilder->run(1);
+        $containerBuilder->run(1, 2, 4);
     }
 }
 

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Source/SomeMultiArg.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Source/SomeMultiArg.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source;
+
+class SomeMultiArg
+{
+    public function run($a = 1, $b = 2, $c = 3)
+    {
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
@@ -11,6 +11,7 @@ use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeClass;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeContainerBuilder;
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeParentClient;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -52,5 +53,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 ArgumentAddingScope::SCOPE_CLASS_METHOD
             ),
             new ArgumentAdder(SomeClass::class, 'withoutTypeOrDefaultValue', 0, 'arguments', [], $arrayType),
+            new ArgumentAdder(SomeMultiArg::class, 'run', 2, 'c', 4),
         ]);
 };


### PR DESCRIPTION
@astronom This should show the issue on https://github.com/rectorphp/rector-symfony/issues/134 which configuration try to fill 3rd position, while in actual call, it only fill 1st position. The 2nd position must be filled with default value if exists, then fill the 3rd position per-configuration.

Fixes https://github.com/rectorphp/rector-symfony/issues/134