### PR TITLE
[DeadCode] Handle used in anonymous class on RemoveUnusedConstructorParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/used_in_inner_class.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/used_in_inner_class.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class UsedInInnerClass
+{
+    private $hey;
+
+    public function __construct($hey, $man)
+    {
+        $this->hey = $hey;
+
+        new class {
+            public function __construct($man)
+            {
+
+            }
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class UsedInInnerClass
+{
+    private $hey;
+
+    public function __construct($hey)
+    {
+        $this->hey = $hey;
+
+        new class {
+            public function __construct()
+            {
+            }
+        };
+    }
+}
+
+?>

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -25,7 +25,7 @@ final class ParamAnalyzer
 
     public function isParamUsedInClassMethod(ClassMethod $classMethod, Param $param): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst((array) $classMethod->stmts, function (Node $node) use (
+        return (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped($classMethod, function (Node $node) use (
             $param
         ): bool {
             if (! $node instanceof Variable) {


### PR DESCRIPTION
Given the following code:

```php
final class UsedInInnerClass
{
    private $hey;

    public function __construct($hey, $man)
    {
        $this->hey = $hey;

        new class {
            public function __construct($man)
            {

            }
        };
    }
}
```

The `$man` variable both need to be removed as different scope.