### PR TITLE
Add failing test fixture for ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/demo_file.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class DemoFile
+{
+    public function __construct(private array $data) {}
+    
+    public function run()
+    {
+    	unset($this->data['item']);
+        
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for ReadOnlyPropertyRector

Based on https://getrector.org/demo/640164ab-845f-4cd0-ab7c-859723adb1bb
Fix https://github.com/rectorphp/rector/issues/7066