### PR TITLE
Bump min to PHP 7.2

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -72,11 +72,11 @@ jobs:
             # 3. prefix classes
             -   run: sh build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
 
-            # 4. lint the code for PHP 7.1 - this must happen here, as setup-php allows only one PHP version switch: https://github.com/shivammathur/setup-php/issues/434
+            # 4. lint the code for PHP 7.2 - this must happen here, as setup-php allows only one PHP version switch: https://github.com/shivammathur/setup-php/issues/434
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 7.1
+                    php-version: 7.2
                     coverage: none
             -   run: composer global require php-parallel-lint/php-parallel-lint
             -   run: /home/runner/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/rector/rector-nette/tests --exclude rector-prefixed-downgraded/vendor/symfony/polyfill-mbstring/bootstrap80.php --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/ssch/typo3-rector/templates/maker --exclude rector-prefixed-downgraded/vendor/symfony/console/Event --exclude rector-prefixed-downgraded/vendor/symfony/console/EventListener --exclude rector-prefixed-downgraded/vendor/symfony/console/Tester --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/contracts/Cache/ItemInterface.php --exclude rector-prefixed-downgraded/vendor/symfony/dependency-injection/ExpressionLanguageProvider.php

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Head to [`rectorphp/rector`](http://github.com/rectorphp/rector) for documentati
 
 ## Building `rectorphp/rector`
 
-Code of this repository requires PHP 8. For `rector/rector` package user the build downgrades code to PHP 7.1 and higher.
+Code of this repository requires PHP 8. For `rector/rector` package user the build downgrades code to PHP 7.2 and higher.
 
 ## How to Contribute
 

--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -25,7 +25,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::SKIP, DowngradeRectorConfig::DEPENDENCY_EXCLUDE_PATHS);
     $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan-for-downgrade.neon');
 
-    $containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_71);
+    $containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_72);
 
     $services = $containerConfigurator->services();
 

--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
 use Rector\Core\Stubs\PHPStanStubLoader;
-use Rector\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector;
 use Rector\Set\ValueObject\DowngradeLevelSetList;
-use Symfony\Component\Config\Loader\Loader;
-use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 $phpStanStubLoader = new PHPStanStubLoader();
@@ -26,14 +23,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan-for-downgrade.neon');
 
     $containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_72);
-
-    $services = $containerConfigurator->services();
-
-    $services->set(DowngradeParameterTypeWideningRector::class)
-        ->configure([
-            LoaderInterface::class => ['load'],
-            Loader::class => ['import'],
-        ]);
 };
 
 /**

--- a/build/target-repository/.github/workflows/along_other_packages.yaml
+++ b/build/target-repository/.github/workflows/along_other_packages.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                php_version: ['7.2', '7.3', '7.4', '8.0', '8.1']
                 commands:
                     -
                         name: 'Composer Dependency'

--- a/build/target-repository/.github/workflows/bare_run.yaml
+++ b/build/target-repository/.github/workflows/bare_run.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                php_version: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
         steps:
             -   uses: actions/checkout@v2

--- a/build/target-repository/.github/workflows/e2e.yaml
+++ b/build/target-repository/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                php_version: ['7.2', '7.3', '7.4', '8.0', '8.1']
                 directory:
                     - 'e2e/attributes'
                     - 'e2e/define-constant'

--- a/build/target-repository/.github/workflows/e2e_global.yaml
+++ b/build/target-repository/.github/workflows/e2e_global.yaml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                php_version: ['7.2', '7.3', '7.4', '8.0', '8.1']
                 directory:
                     - 'e2e/global-install'
 

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -6,7 +6,7 @@
         "bin/rector"
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.2|^8.0",
         "phpstan/phpstan": "^1.4.8"
     },
     "autoload": {

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "phpstan/phpstan": "^1.4.8"
+        "phpstan/phpstan": "^1.5"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^4.13.2",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.2",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5",
         "phpstan/phpstan-phpunit": "^1.0",
         "psr/log": "^2.0",
         "react/child-process": "^0.6.4",

--- a/full_build.sh
+++ b/full_build.sh
@@ -38,7 +38,7 @@ cp ../preload.php .
 #
 # usage:
 #
-#   export PHP72_BIN_PATH=/opt/homebrew/Cellar/php@7.2/7.2.33_4/bin/php PHP80_BIN_PATH=/opt/homebrew/Cellar/php@8.0/8.0.14/bin/php && sh ./full_build.sh
+#   export PHP72_BIN_PATH=/opt/homebrew/Cellar/php@7.2/7.2.34_4/bin/php PHP80_BIN_PATH=/opt/homebrew/Cellar/php@8.0/8.0.17/bin/php && sh ./full_build.sh
 #
 if test -z ${PHP72_BIN_PATH+y}; then
     bin/rector list --ansi;

--- a/full_build.sh
+++ b/full_build.sh
@@ -32,19 +32,19 @@ rm rector.php
 cp ../build/target-repository/bootstrap.php .
 cp ../preload.php .
 
-# Check php 7.1 can be used locally with PHP71_BIN_PATH env
+# Check php 7.2 can be used locally with PHP72_BIN_PATH env
 # Prefixing build only works on php < 8.0, can be used locally with PHP80_BIN_PATH env
 
 #
 # usage:
 #
-#   export PHP71_BIN_PATH=/opt/homebrew/Cellar/php@7.1/7.1.33_4/bin/php PHP80_BIN_PATH=/opt/homebrew/Cellar/php@8.0/8.0.14/bin/php && sh ./full_build.sh
+#   export PHP72_BIN_PATH=/opt/homebrew/Cellar/php@7.2/7.2.33_4/bin/php PHP80_BIN_PATH=/opt/homebrew/Cellar/php@8.0/8.0.14/bin/php && sh ./full_build.sh
 #
-if test -z ${PHP71_BIN_PATH+y}; then
+if test -z ${PHP72_BIN_PATH+y}; then
     bin/rector list --ansi;
 else
-    echo "verify downgraded rector with specify PHP71_BIN_PATH env";
-    $PHP71_BIN_PATH bin/rector list --ansi;
+    echo "verify downgraded rector with specify PHP72_BIN_PATH env";
+    $PHP72_BIN_PATH bin/rector list --ansi;
 fi
 
 cd ..
@@ -59,13 +59,13 @@ cd rector-prefixed-downgraded
 cp ../build/target-repository/bootstrap.php .
 cp ../preload.php .
 
-if test -z ${PHP71_BIN_PATH+y}; then
+if test -z ${PHP72_BIN_PATH+y}; then
     bin/rector list --ansi;
     bin/rector process vendor/symfony/string/Slugger/ --dry-run;
 else
-    echo "verify scoped rector with specify PHP71_BIN_PATH env";
-    $PHP71_BIN_PATH bin/rector list --ansi;
-    $PHP71_BIN_PATH bin/rector process vendor/symfony/string/Slugger/ --dry-run;
+    echo "verify scoped rector with specify PHP72_BIN_PATH env";
+    $PHP72_BIN_PATH bin/rector list --ansi;
+    $PHP72_BIN_PATH bin/rector process vendor/symfony/string/Slugger/ --dry-run;
 fi
 
 cd ..

--- a/full_build.sh
+++ b/full_build.sh
@@ -26,7 +26,7 @@ sh build/downgrade-rector.sh rector-build
 
 cd rector-build
 
-# avoid syntax error in php 7.1 and 7.2
+# avoid syntax error in php 7.2
 rm rector.php
 
 cp ../build/target-repository/bootstrap.php .

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -43,10 +43,6 @@ final class PHPStanStubLoader
                 continue;
             }
 
-            if ($vendorPath === '') {
-                continue;
-            }
-
             foreach (self::STUBS as $stub) {
                 $path = $this->getStubPath($vendorPath, $stub);
                 if ($path === null) {


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/7068

* PHPStan will go to PHP 7.2 in next 1.5 release with 0.8 % installs on PHP 7.1 - see https://github.com/phpstan/phpstan/releases/tag/1.5.0
* Rector is now used on PHP 7.1 only by 0.2 % - https://packagist.org/packages/rector/rector/php-stats

![image](https://user-images.githubusercontent.com/924196/159489122-7a0a52cc-3c5b-4466-ace2-d3c7d652c846.png)

Time to follow up :chart_with_upwards_trend: 
