### PR TITLE
[Scoped] Remove psr/http-message dep on downgrade scoped

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -46,10 +46,7 @@ jobs:
                     COMPOSER_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
             # install only prod dependencies - do not use ramsey, it uses cache including "dev", we want to avoid it here
-            # somehow psr/http-message needed now when downgrading ssch/typo3-rector
-            -   run: |
-                    composer require psr/http-message --ansi
-                    composer update --no-dev --ansi
+            -   run: composer install --no-dev --ansi
 
             # early downgrade individual functions
             -   run: bin/rector process src/functions -c build/config/config-downgrade.php --ansi

--- a/full_build.sh
+++ b/full_build.sh
@@ -16,14 +16,9 @@ rm -rf composer.lock
 rm -rf vendor
 composer clear-cache
 
-# somehow needed now when downgrading ssch/typo3-rector
-composer require psr/http-message --ansi
-composer update --no-dev --ansi
+composer install --no-dev --ansi
 
 rsync --exclude rector-build -av * rector-build --quiet
-
-# back to original composer.json
-git checkout composer.json
 
 rm -rf rector-build/packages-tests rector-build/rules-tests rector-build/tests rector-build/bin/generate-changelog.php rector-build/bin/validate-phpstan-version.php
 


### PR DESCRIPTION
I tried locally, it seems psr/http-message no longer needed for downgrade scoped. Let's give it  a try.