### PR TITLE
Fix stub PHPUnit\Framework\TestCase

### DIFF
--- a/build/target-repository/stubs-rector/PHPUnit/Framework/TestCase.php
+++ b/build/target-repository/stubs-rector/PHPUnit/Framework/TestCase.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace PHPUnit\Framework;
 
-if (class_exists('PHPUnit\Framework\TestCase')) {
-    return;
-}
-
-abstract class TestCase
-{
+if (! class_exists('PHPUnit\Framework\TestCase')) {
+    abstract class TestCase
+    {
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7073
Fixes https://github.com/rectorphp/rector/issues/7074

return early seems by passed when included, the solution is use `! class_exists()` and make the class stub inside it:

```
namespace PHPUnit\Framework;

if (! class_exists('PHPUnit\Framework\TestCase')) {
    abstract class TestCase
    {
    }
}
```