### PR TITLE
Add failing test fixture for ArrayShapeFromConstantArrayReturnRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector/Fixture/key_with_colon.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector/Fixture/key_with_colon.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector\Fixture;
+
+final class KeyWithColon
+{
+    public function run(string $name)
+    {
+        return ['prefix:key' => $name];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector\Fixture;
+
+final class KeyWithColon
+{
+    /**
+     * @return array{"prefix:key": string}
+     */
+    public function run(string $name)
+    {
+        return ['prefix:key' => $name];
+    }
+}
+
+?>


### PR DESCRIPTION
The generated array shape is invalid if the array key contains some special characters such as `:` and `@`.