### PR TITLE
[Doc] Fix composer docs generation ConfiguredCodeSample in RemoveUnusedPrivatePropertyRector

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -3529,7 +3529,25 @@ Remove unused private method
 
 Remove unused private properties
 
+:wrench: **configure it!**
+
 - class: [`Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector`](../rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php)
+
+```php
+use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(RemoveUnusedPrivatePropertyRector::class)
+        ->configure([
+            RemoveUnusedPrivatePropertyRector::REMOVE_ASSIGN_SIDE_EFFECT => true,
+        ]);
+};
+```
+
+↓
 
 ```diff
  class SomeClass

--- a/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
@@ -11,7 +11,7 @@ use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Removing\NodeManipulator\ComplexNodeRemover;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
@@ -46,7 +46,7 @@ final class RemoveUnusedPrivatePropertyRector extends AbstractRector implements 
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove unused private properties', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -59,6 +59,10 @@ class SomeClass
 {
 }
 CODE_SAMPLE
+,
+                [
+                    self::REMOVE_ASSIGN_SIDE_EFFECT => true,
+                ]
             ),
         ]);
     }


### PR DESCRIPTION
`RemoveUnusedPrivatePropertyRector` is got configurable at https://github.com/rectorphp/rector-src/pull/1948, the `CodeSample` needs to be changed to `ConfiguredCodeSample` to fix command:

```
composer docs
```

that got error:

```
 ! [NOTE] Resolving rule definitions                                                                                    

 ! [NOTE] Printing rule definitions                                                                                     


In CodeSamplePrinter.php line 81:
                                                                                                                                                                                                             
  The "Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector" rule implements "Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface" and code sample must be "Symplify\RuleDocGenerator  
  \ValueObject\CodeSample\ConfiguredCodeSample"                                                                                                                                                              
                                                                                                                                                                                                             

generate [--output-file OUTPUT-FILE] [--categorize] [--configure-method] [-c|--config CONFIG] [--] <paths>...

Script vendor/bin/rule-doc-generator generate packages rules --output-file build/rector_rules_overview.md --ansi --categorize --configure-method handling the docs event returned with error code 1
```
