### PR TITLE
[Scoped] Clean up early run on downgrade src/function

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -48,9 +48,6 @@ jobs:
             # install only prod dependencies - do not use ramsey, it uses cache including "dev", we want to avoid it here
             -   run: composer install --no-dev --ansi
 
-            # early downgrade individual functions
-            -   run: bin/rector process src/functions -c build/config/config-downgrade.php --ansi
-
             # 1. copy files to $NESTED_DIRECTORY directory Exclude the scoped/nested directories to prevent rsync from copying in a loop
             -  run: rsync --exclude rector-build -av * rector-build --quiet
             -  run: rm -rf rector-build/packages-tests rector-build/rules-tests rector-build/tests rector-build/bin/generate-changelog.php rector-build/bin/validate-phpstan-version.php rector-build/bin/clean-phpstan.php rector-build/vendor/tracy/tracy/examples


### PR DESCRIPTION
downgrade early `src/functions` seems no longer needed. Let's give it a try.