### PR TITLE
[Php81] Skip anonymous class on FinalizePublicClassConstantRector

### DIFF
--- a/rules-tests/Php81/Rector/ClassConst/FinalizePublicClassConstantRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/Php81/Rector/ClassConst/FinalizePublicClassConstantRector/Fixture/skip_anonymous_class.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\ClassConst\FinalizePublicClassConstantRector\Fixture;
+
+new class {
+    public const NAME = 'value';
+};

--- a/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
+++ b/rules/Php81/Rector/ClassConst/FinalizePublicClassConstantRector.php
@@ -77,15 +77,15 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->isPrivate()) {
-            return null;
-        }
-
-        if ($node->isProtected()) {
+        if (! $node->isPublic()) {
             return null;
         }
 
         if ($node->isFinal()) {
+            return null;
+        }
+
+        if ($this->classAnalyzer->isAnonymousClass($class)) {
             return null;
         }
 
@@ -104,10 +104,6 @@ CODE_SAMPLE
 
     private function isClassHasChildren(Class_ $class): bool
     {
-        if ($this->classAnalyzer->isAnonymousClass($class)) {
-            return false;
-        }
-
         $className = (string) $this->nodeNameResolver->getName($class);
         if (! $this->reflectionProvider->hasClass($className)) {
             return false;


### PR DESCRIPTION
anonymous class is not to be extended, so mark its class const as final seems can be skipped.