### PR TITLE
[Php55] Move GetCalledClassToSelfClassRector + GetCalledClassToStaticClassRector from php 7.4 to 5.5 SetList

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -54,7 +54,7 @@
 
 - [Php54](#php54) (2)
 
-- [Php55](#php55) (3)
+- [Php55](#php55) (5)
 
 - [Php56](#php56) (2)
 
@@ -66,7 +66,7 @@
 
 - [Php73](#php73) (9)
 
-- [Php74](#php74) (16)
+- [Php74](#php74) (14)
 
 - [Php80](#php80) (17)
 
@@ -6740,6 +6740,44 @@ Change `__CLASS__` to self::class
 
 <br>
 
+### GetCalledClassToSelfClassRector
+
+Change `get_called_class()` to self::class on final class
+
+- class: [`Rector\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector`](../rules/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector.php)
+
+```diff
+ final class SomeClass
+ {
+    public function callOnMe()
+    {
+-       var_dump(get_called_class());
++       var_dump(self::class);
+    }
+ }
+```
+
+<br>
+
+### GetCalledClassToStaticClassRector
+
+Change `get_called_class()` to static::class on non-final class
+
+- class: [`Rector\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector`](../rules/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector.php)
+
+```diff
+ class SomeClass
+ {
+    public function callOnMe()
+    {
+-       var_dump(get_called_class());
++       var_dump(static::class);
+    }
+ }
+```
+
+<br>
+
 ### PregReplaceEModifierRector
 
 The /e modifier is no longer supported, use preg_replace_callback instead
@@ -7833,44 +7871,6 @@ Change `filter_var()` with slash escaping to `addslashes()`
  $var= "Satya's here!";
 -filter_var($var, FILTER_SANITIZE_MAGIC_QUOTES);
 +addslashes($var);
-```
-
-<br>
-
-### GetCalledClassToSelfClassRector
-
-Change `get_called_class()` to self::class on final class
-
-- class: [`Rector\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector`](../rules/Php74/Rector/FuncCall/GetCalledClassToSelfClassRector.php)
-
-```diff
- final class SomeClass
- {
-    public function callOnMe()
-    {
--       var_dump(get_called_class());
-+       var_dump(self::class);
-    }
- }
-```
-
-<br>
-
-### GetCalledClassToStaticClassRector
-
-Change `get_called_class()` to static::class on non-final class
-
-- class: [`Rector\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector`](../rules/Php74/Rector/FuncCall/GetCalledClassToStaticClassRector.php)
-
-```diff
- class SomeClass
- {
-    public function callOnMe()
-    {
--       var_dump(get_called_class());
-+       var_dump(static::class);
-    }
- }
 ```
 
 <br>

--- a/config/set/php55.php
+++ b/config/set/php55.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
+use Rector\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector;
+use Rector\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector;
 use Rector\Php55\Rector\FuncCall\PregReplaceEModifierRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -12,4 +14,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(StringClassNameToClassConstantRector::class);
     $services->set(ClassConstantToSelfClassRector::class);
     $services->set(PregReplaceEModifierRector::class);
+    $services->set(GetCalledClassToSelfClassRector::class);
+    $services->set(GetCalledClassToStaticClassRector::class);
 };

--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -9,8 +9,6 @@ use Rector\Php74\Rector\Double\RealToFloatTypeCastRector;
 use Rector\Php74\Rector\FuncCall\ArrayKeyExistsOnPropertyRector;
 use Rector\Php74\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Php74\Rector\FuncCall\FilterVarToAddSlashesRector;
-use Rector\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector;
-use Rector\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector;
 use Rector\Php74\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector;
 use Rector\Php74\Rector\Function_\ReservedFnFunctionRector;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
@@ -41,10 +39,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FilterVarToAddSlashesRector::class);
 
     $services->set(ExportToReflectionFunctionRector::class);
-
-    $services->set(GetCalledClassToSelfClassRector::class);
-
-    $services->set(GetCalledClassToStaticClassRector::class);
 
     $services->set(MbStrrposEncodingArgumentPositionRector::class);
 

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/anonymous_class.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/anonymous_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
 
 new class {
     public function callOnMe()
@@ -13,7 +13,7 @@ new class {
 -----
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
 
 new class {
     public function callOnMe()

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
 
 final class Fixture
 {
@@ -14,7 +14,7 @@ final class Fixture
 -----
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
 
 final class Fixture
 {

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/skip_on_non_final_class.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/skip_on_non_final_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
 
 class SkipOnNonFinalClass
 {

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/skip_trait.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/Fixture/skip_trait.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector\Fixture;
 
 trait SkipTrait
 {

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/GetCalledClassToSelfClassRectorTest.php
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/GetCalledClassToSelfClassRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/config/configured_rule.php
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector/config/configured_rule.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Rector\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector;
+use Rector\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
-    $services->set(GetCalledClassToStaticClassRector::class);
+    $services->set(GetCalledClassToSelfClassRector::class);
 };

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
 
 class Fixture
 {
@@ -14,7 +14,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
 
 class Fixture
 {

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/skip_anonymous_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
 
 new class {
     public function callOnMe()

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/skip_on_final_class.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/skip_on_final_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
 
 final class SkipOnFinalClass
 {

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/some_trait.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/some_trait.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
 
 trait SomeTrait
 {
@@ -14,7 +14,7 @@ trait SomeTrait
 -----
 <?php
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
 
 trait SomeTrait
 {

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/GetCalledClassToStaticClassRectorTest.php
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/GetCalledClassToStaticClassRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector;
+namespace Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/config/configured_rule.php
+++ b/rules-tests/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector/config/configured_rule.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Rector\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector;
+use Rector\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
-    $services->set(GetCalledClassToSelfClassRector::class);
+    $services->set(GetCalledClassToStaticClassRector::class);
 };

--- a/rules/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector.php
+++ b/rules/Php55/Rector/FuncCall/GetCalledClassToSelfClassRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Php74\Rector\FuncCall;
+namespace Rector\Php55\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -16,11 +16,11 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @changelog https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
- * @see https://3v4l.org/dJgXd
- * @see \Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector\GetCalledClassToStaticClassRectorTest
+ * @changelog https://www.php.net/ChangeLog-5.php#5.5.0
+ * @see https://3v4l.org/GU9dP
+ * @see \Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector\GetCalledClassToSelfClassRectorTest
  */
-final class GetCalledClassToStaticClassRector extends AbstractRector implements MinPhpVersionInterface
+final class GetCalledClassToSelfClassRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(private readonly ClassAnalyzer $classAnalyzer)
     {
@@ -28,10 +28,10 @@ final class GetCalledClassToStaticClassRector extends AbstractRector implements 
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Change get_called_class() to static::class on non-final class', [
+        return new RuleDefinition('Change get_called_class() to self::class on final class', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-class SomeClass
+final class SomeClass
 {
    public function callOnMe()
    {
@@ -41,11 +41,11 @@ class SomeClass
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
-class SomeClass
+final class SomeClass
 {
    public function callOnMe()
    {
-       var_dump(static::class);
+       var_dump(self::class);
    }
 }
 CODE_SAMPLE
@@ -71,16 +71,17 @@ CODE_SAMPLE
         }
 
         $class = $this->betterNodeFinder->findParentType($node, Class_::class);
-        if (! $class instanceof Class_) {
-            return $this->nodeFactory->createClassConstFetch(ObjectReference::STATIC(), 'class');
-        }
 
-        if ($this->classAnalyzer->isAnonymousClass($class)) {
+        if (! $class instanceof Class_) {
             return null;
         }
 
-        if (! $class->isFinal()) {
-            return $this->nodeFactory->createClassConstFetch(ObjectReference::STATIC(), 'class');
+        if ($class->isFinal()) {
+            return $this->nodeFactory->createClassConstFetch(ObjectReference::SELF(), 'class');
+        }
+
+        if ($this->classAnalyzer->isAnonymousClass($class)) {
+            return $this->nodeFactory->createClassConstFetch(ObjectReference::SELF(), 'class');
         }
 
         return null;

--- a/rules/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector.php
+++ b/rules/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Php74\Rector\FuncCall;
+namespace Rector\Php55\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -16,11 +16,11 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @changelog https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
- * @see https://3v4l.org/GU9dP
- * @see \Rector\Tests\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector\GetCalledClassToSelfClassRectorTest
+ * @changelog https://www.php.net/ChangeLog-5.php#5.5.0
+ * @see https://3v4l.org/dJgXd
+ * @see \Rector\Tests\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector\GetCalledClassToStaticClassRectorTest
  */
-final class GetCalledClassToSelfClassRector extends AbstractRector implements MinPhpVersionInterface
+final class GetCalledClassToStaticClassRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(private readonly ClassAnalyzer $classAnalyzer)
     {
@@ -28,10 +28,10 @@ final class GetCalledClassToSelfClassRector extends AbstractRector implements Mi
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Change get_called_class() to self::class on final class', [
+        return new RuleDefinition('Change get_called_class() to static::class on non-final class', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-final class SomeClass
+class SomeClass
 {
    public function callOnMe()
    {
@@ -41,11 +41,11 @@ final class SomeClass
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
-final class SomeClass
+class SomeClass
 {
    public function callOnMe()
    {
-       var_dump(self::class);
+       var_dump(static::class);
    }
 }
 CODE_SAMPLE
@@ -71,17 +71,16 @@ CODE_SAMPLE
         }
 
         $class = $this->betterNodeFinder->findParentType($node, Class_::class);
-
         if (! $class instanceof Class_) {
-            return null;
-        }
-
-        if ($class->isFinal()) {
-            return $this->nodeFactory->createClassConstFetch(ObjectReference::SELF(), 'class');
+            return $this->nodeFactory->createClassConstFetch(ObjectReference::STATIC(), 'class');
         }
 
         if ($this->classAnalyzer->isAnonymousClass($class)) {
-            return $this->nodeFactory->createClassConstFetch(ObjectReference::SELF(), 'class');
+            return null;
+        }
+
+        if (! $class->isFinal()) {
+            return $this->nodeFactory->createClassConstFetch(ObjectReference::STATIC(), 'class');
         }
 
         return null;

--- a/tests/Issues/GetCalledClassToSelfAndStatic/config/configured_rule.php
+++ b/tests/Issues/GetCalledClassToSelfAndStatic/config/configured_rule.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Rector\Php74\Rector\FuncCall\GetCalledClassToSelfClassRector;
-use Rector\Php74\Rector\FuncCall\GetCalledClassToStaticClassRector;
+use Rector\Php55\Rector\FuncCall\GetCalledClassToSelfClassRector;
+use Rector\Php55\Rector\FuncCall\GetCalledClassToStaticClassRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {


### PR DESCRIPTION
Per noted at https://wiki.php.net/rfc/deprecations_php_7_4#changelog, the `get_called_class()` is not deprecated, it checked still working on php 7.4 https://3v4l.org/Mvi0Q#v7.4.28

The `static::class` and `self::class` exists since php 5.5, so I think it is better to move to php 5.5 SetList, ref https://3v4l.org/GU9dP#v5.5.38

The `provideMinPhpVersion()` already return `PhpVersionFeature::CLASSNAME_CONSTANT` which for PHP 5.5.