### PR TITLE
[Php74] Handle referenced inner class on ClosureToArrowFunctionRector

### DIFF
--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/referenced_inner_class.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/referenced_inner_class.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
+
+class ReferencedInnerClass
+{
+    public function run()
+    {
+        $callback = function($b) use(&$i) {
+            return new class { public function __construct($i)
+                {
+                }
+            };
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
+
+class ReferencedInnerClass
+{
+    public function run()
+    {
+        $callback = fn($b) => new class { public function __construct($i)
+            {
+            }
+        };
+    }
+}
+
+?>

--- a/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
+++ b/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
@@ -52,7 +52,7 @@ final class ClosureArrowFunctionAnalyzer
             return false;
         }
 
-        return (bool) $this->betterNodeFinder->findFirst([$expr], function (Node $node) use (
+        return (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped($closure, function (Node $node) use (
             $referencedValues
         ): bool {
             foreach ($referencedValues as $referencedValue) {

--- a/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
+++ b/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
@@ -38,14 +38,14 @@ final class ClosureArrowFunctionAnalyzer
             return null;
         }
 
-        if ($this->shouldSkipForUsedReferencedValue($closure, $return->expr)) {
+        if ($this->shouldSkipForUsedReferencedValue($closure)) {
             return null;
         }
 
         return $return->expr;
     }
 
-    private function shouldSkipForUsedReferencedValue(Closure $closure, Expr $expr): bool
+    private function shouldSkipForUsedReferencedValue(Closure $closure): bool
     {
         $referencedValues = $this->resolveReferencedUseVariablesFromClosure($closure);
         if ($referencedValues === []) {


### PR DESCRIPTION
Given the following code:

```php
        $callback = function($b) use(&$i) {
            return new class { public function __construct($i)
                {
                }
            };
        };
```

should be changed to:

```diff
+        $callback = fn($b) => new class { public function __construct($i)
+            {
+            }
```

as `$i` is used in inner anonymous class which out of scoped, which can be cleared up and transformed to arrow function.