### PR TITLE
[Privatization] Skip parent static property used by parent method on PrivatizeFinalClassPropertyRector

### DIFF
--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_static_protected_used_by_parent.php.inc
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_static_protected_used_by_parent.php.inc
@@ -8,4 +8,5 @@ final class KeepParentStaticProtectedUsedByParent extends AbstractClassWithProte
 {
     protected static $valueStatic = 100;
     protected static $valueStatic2 = 100;
+    protected static $valueStatic3 = 100;
 }

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_static_protected_used_by_parent.php.inc
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_static_protected_used_by_parent.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture;
+
+use Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Source\AbstractClassWithProtectedProperty;
+
+final class KeepParentStaticProtectedUsedByParent extends AbstractClassWithProtectedProperty
+{
+    protected static $valueStatic = 100;
+}

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_static_protected_used_by_parent.php.inc
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_static_protected_used_by_parent.php.inc
@@ -7,4 +7,5 @@ use Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector
 final class KeepParentStaticProtectedUsedByParent extends AbstractClassWithProtectedProperty
 {
     protected static $valueStatic = 100;
+    protected static $valueStatic2 = 100;
 }

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
@@ -10,4 +10,9 @@ abstract class AbstractClassWithProtectedProperty
      * @var int
      */
     protected $value = 1000;
+
+    public function run()
+    {
+        static::$valueStatic = 1000;
+    }
 }

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
@@ -15,4 +15,9 @@ abstract class AbstractClassWithProtectedProperty
     {
         static::$valueStatic = 1000;
     }
+
+    public function run2()
+    {
+        self::$valueStatic = 1000;
+    }
 }

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
@@ -18,6 +18,6 @@ abstract class AbstractClassWithProtectedProperty
 
     public function run2()
     {
-        self::$valueStatic = 1000;
+        self::$valueStatic2 = 1000;
     }
 }

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
@@ -20,4 +20,9 @@ abstract class AbstractClassWithProtectedProperty
     {
         self::$valueStatic2 = 1000;
     }
+
+    public function run3()
+    {
+        \Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture\KeepParentStaticProtectedUsedByParent::$valueStatic3 = 1000;
+    }
 }

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -133,7 +133,11 @@ CODE_SAMPLE
         return false;
     }
 
-    private function isFoundInParentClassMethods(ClassReflection $parentClassReflection, string $propertyName, string $className): bool
+    private function isFoundInParentClassMethods(
+        ClassReflection $parentClassReflection,
+        string $propertyName,
+        string $className
+    ): bool
     {
         $classLike = $this->astResolver->resolveClassFromName($parentClassReflection->getName());
         if (! $classLike instanceof ClassLike) {

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
         $classReflection = $scope->getClassReflection();
 
         $propertyName = $this->getName($property);
-        $className = $this->nodeNameResolver->getName($class);
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         foreach ($classReflection->getParents() as $parentClassReflection) {
             if ($parentClassReflection->hasProperty($propertyName)) {

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -137,8 +137,7 @@ CODE_SAMPLE
         ClassReflection $parentClassReflection,
         string $propertyName,
         string $className
-    ): bool
-    {
+    ): bool {
         $classLike = $this->astResolver->resolveClassFromName($parentClassReflection->getName());
         if (! $classLike instanceof ClassLike) {
             return false;


### PR DESCRIPTION
Given the following code:

```php
abstract class AbstractClassWithProtectedProperty
{
    public function run()
    {
        static::$valueStatic = 1000;
    }
}

final class KeepParentStaticProtectedUsedByParent extends AbstractClassWithProtectedProperty
{
    private static $valueStatic = 100;
}
```

it currently produce:

```diff
-    protected static $valueStatic = 100;
+    private static $valueStatic = 100;
```

which should be skipped as when changed, it may cause error:

```
Cannot access private property KeepParentStaticProtectedUsedByParent::$valueStatic
```

ref https://3v4l.org/V9T31