### PR TITLE
[Core][EarlyReturn][Php73] Fix used along tweak between JsonThrowOnErrorRector + ChangeAndIfToEarlyReturnRector

### DIFF
--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -149,7 +149,7 @@ CODE_SAMPLE
         array $conditions,
         Return_ $ifNextReturnClone,
         array $afters
-    ): ?array {
+    ): array {
         $ifs = $this->invertedIfFactory->createFromConditions($if, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $if);
 

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -127,20 +127,6 @@ CODE_SAMPLE
         return $this->processReplaceIfs($node, $booleanAndConditions, $ifNextReturnClone, $afters);
     }
 
-    /**
-     * @param Node[] $nodes
-     */
-    private function hasJsonEncodeOrJsonDecode(array $nodes): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst($nodes, function (Node $subNode): bool {
-            if (! $subNode instanceof FuncCall) {
-                return false;
-            }
-
-            return $this->nodeNameResolver->isNames($subNode, ['json_encode', 'json_decode']);
-        });
-    }
-
     private function isInLoopWithoutContinueOrBreak(If_ $if): bool
     {
         if (! $this->contextAnalyzer->isInLoop($if)) {
@@ -165,11 +151,6 @@ CODE_SAMPLE
         Return_ $ifNextReturnClone,
         array $afters
     ): ?array {
-        // handle for used along with JsonThrowOnErrorRector
-        if ($this->hasJsonEncodeOrJsonDecode($afters)) {
-            return null;
-        }
-
         $ifs = $this->invertedIfFactory->createFromConditions($if, $conditions, $ifNextReturnClone);
         $this->mirrorComments($ifs[0], $if);
 

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
     /**
      * @param Expr[] $conditions
      * @param Node[] $afters
-     * @return Node[]|null
+     * @return Node[]
      */
     private function processReplaceIfs(
         If_ $if,

--- a/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
@@ -7,7 +7,6 @@ namespace Rector\EarlyReturn\Rector\If_;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -35,34 +35,33 @@ final class RectifiedAnalyzer
 
         /** @var RectifiedNode $rectifiedNode */
         $rectifiedNode = $this->previousFileWithNodes[$realPath];
-
-        if ($rectifiedNode->getRectorClass() === $rector::class && $rectifiedNode->getNode() === $node) {
-            // re-set to refill next
-            $this->previousFileWithNodes[$realPath] = null;
-            return $rectifiedNode;
-        }
-
-        if ($node instanceof Stmt) {
-            return null;
-        }
-
-        $stmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        if ($stmt instanceof Stmt) {
-            return null;
-        }
-
-        $startTokenPos = $node->getStartTokenPos();
-        $endTokenPos = $node->getEndTokenPos();
-        if ($startTokenPos < 0) {
-            return null;
-        }
-
-        if ($endTokenPos < 0) {
+        if ($this->shouldContinue($rectifiedNode, $rector, $node)) {
             return null;
         }
 
         // re-set to refill next
         $this->previousFileWithNodes[$realPath] = null;
         return $rectifiedNode;
+    }
+
+    private function shouldContinue(RectifiedNode $rectifiedNode, RectorInterface $rector, Node $node): bool
+    {
+        if ($rectifiedNode->getRectorClass() === $rector::class && $rectifiedNode->getNode() === $node) {
+            return false;
+        }
+
+        if ($node instanceof Stmt) {
+            return true;
+        }
+
+        $stmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        if ($stmt instanceof Stmt) {
+            return true;
+        }
+
+        $startTokenPos = $node->getStartTokenPos();
+        $endTokenPos = $node->getEndTokenPos();
+
+        return $startTokenPos < 0 || $endTokenPos < 0;
     }
 }

--- a/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
+++ b/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
@@ -17,9 +17,13 @@ namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
 
 function f()
 {
-    if (true && true) {
-        json_decode($a, null, 512, JSON_THROW_ON_ERROR);
+    if (!true) {
+        return;
     }
+    if (!true) {
+        return;
+    }
+    json_decode($a, null, 512, JSON_THROW_ON_ERROR);
 }
 
 ?>


### PR DESCRIPTION
Previously, when `JsonThrowOnErrorRector` used along with `ChangeAndIfToEarlyReturnRector`, it requires tweak 

https://github.com/rectorphp/rector-src/blob/fe18774733b802743b1f6d100be17ab36bfce2cf/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php#L133-L142

and 

https://github.com/rectorphp/rector-src/blob/fe18774733b802743b1f6d100be17ab36bfce2cf/rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php#L168-L171

to be checked.

This PR remove it, with refactor `RectifiedAnalyzer` to check if current Stmt is not Stmt, then verify start token pos and end token pos that was caused error:

```bash
1) Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\JsonThrowWithChangeAndIfTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
assert($itemStartPos >= 0 && $itemEndPos >= 0) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:865
```

so check not that is not rectified if it < 0 so it continue to next rule.