### PR TITLE
[Core] Fix AbstractRector::enterNode() @return doc

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -206,7 +206,7 @@ CODE_SAMPLE;
     }
 
     /**
-     * @return Node|int|null
+     * @return Node|null
      */
     final public function enterNode(Node $node)
     {


### PR DESCRIPTION
`AbstractRector::enterNode()`  never return `int`, so `int` can be removed from `@return` doc.