### PR TITLE
Fix AddClosureReturnTypeRector for union types of mutually related classes

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -330,11 +330,7 @@ final class UnionTypeMapper implements TypeMapperInterface
 
     private function areTypeWithClassNamesRelated(TypeWithClassName $firstType, TypeWithClassName $secondType): bool
     {
-        if ($firstType->accepts($secondType, false)->yes()) {
-            return true;
-        }
-
-        return $secondType->accepts($firstType, false)
+        return $firstType->accepts($secondType, false)
             ->yes();
     }
 

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/more_generic_response.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/more_generic_response.php.inc
@@ -18,3 +18,24 @@ final class MoreGenericResponse
         };
     }
 }
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector\Fixture;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MoreGenericResponse
+{
+    public function run()
+    {
+        $result = function (): \Symfony\Component\HttpFoundation\Response {
+            if (mt_rand(0, 100)) {
+                return new RedirectResponse();
+            }
+
+            return new Response();
+        };
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/more_generic_response.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/more_generic_response.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector\Fixture;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MoreGenericResponse
+{
+    public function run()
+    {
+        $result = function () {
+            if (mt_rand(0, 100)) {
+                return new RedirectResponse();
+            }
+
+            return new Response();
+        };
+    }
+}


### PR DESCRIPTION
- add test case for first closure
- add known return type
