### PR TITLE
[EarlyReturn][Php80] Fix used along tweak between Php8ResourceReturnToObjectRector+ChangeOrIfReturnToEarlyReturnRector

### DIFF
--- a/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
@@ -93,11 +92,6 @@ CODE_SAMPLE
             return null;
         }
 
-        // maybe used along with Php8ResourceReturnToObjectRector rule
-        if ($this->isMaybeUsedAlongWithResourceToObjectRector($node->cond)) {
-            return null;
-        }
-
         /** @var Return_ $return */
         $return = $node->stmts[0];
 
@@ -116,27 +110,6 @@ CODE_SAMPLE
 
         $this->mirrorComments($ifs[0], $node);
         return $ifs;
-    }
-
-    private function isMaybeUsedAlongWithResourceToObjectRector(BooleanOr $booleanOr): bool
-    {
-        if ($booleanOr->left instanceof FuncCall) {
-            if (! $this->nodeNameResolver->isName($booleanOr->left, 'is_resource')) {
-                return false;
-            }
-
-            return $booleanOr->right instanceof Instanceof_;
-        }
-
-        if ($booleanOr->right instanceof FuncCall) {
-            if (! $this->nodeNameResolver->isName($booleanOr->right, 'is_resource')) {
-                return false;
-            }
-
-            return $booleanOr->left instanceof Instanceof_;
-        }
-
-        return false;
     }
 
     /**
@@ -189,6 +162,6 @@ CODE_SAMPLE
             return $this->isInstanceofCondOnly($booleanOr->right);
         }
 
-        return $booleanOr->right instanceof Instanceof_;
+        return $booleanOr->left instanceof Instanceof_ || $booleanOr->right instanceof Instanceof_;
     }
 }


### PR DESCRIPTION
Previously, when `Php8ResourceReturnToObjectRector` and `ChangeOrIfReturnToEarlyReturnRector`, it requires tweak:

https://github.com/rectorphp/rector-src/blob/0f22f0c55f3993933486e4472ac2bf400fa43bb7/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php#L121-L140

and

https://github.com/rectorphp/rector-src/blob/0f22f0c55f3993933486e4472ac2bf400fa43bb7/rules/EarlyReturn/Rector/If_/ChangeOrIfReturnToEarlyReturnRector.php#L97-L99

This PR remove it, by check BooleanOr left or right is an `Instanceof_` object.

By this PR, I think Refresh PHPStan tweak issue mostly fixed in rector-src code base.

Fixes https://github.com/rectorphp/rector/issues/6723
Closes https://github.com/rectorphp/rector-src/pull/1297