### PR TITLE
[DeadCode] Add Closure support on RemoveLastReturnRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_class_method.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_class_method.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
+
+class InClassMethod
+{
+    function run($value) {
+        if ($value === 1000) {
+            return;
+        }
+
+        if ($value) {
+            return;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
+
+class InClassMethod
+{
+    function run($value) {
+        if ($value === 1000) {
+            return;
+        }
+
+        if ($value) {
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_closure.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_closure.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
+
+function ($value) {
+    if ($value === 1000) {
+        return;
+    }
+
+    if ($value) {
+        return;
+    }
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
+
+function ($value) {
+    if ($value === 1000) {
+        return;
+    }
+
+    if ($value) {
+    }
+};
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_function.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_function.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
 
-function some_function($value)
+function InFunction($value)
 {
     if ($value === 1000) {
         return;
@@ -19,7 +19,7 @@ function some_function($value)
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
 
-function some_function($value)
+function InFunction($value)
 {
     if ($value === 1000) {
         return;

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_inner_closure.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveLastReturnRector/Fixture/in_inner_closure.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
+
+class InInnerClosure
+{
+    function run($value) {
+        $value = (bool) function ($value) {
+            if ($value === 1000) {
+                return;
+            }
+
+            if ($value) {
+                return;
+            }
+        };
+
+        return $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveLastReturnRector\Fixture;
+
+class InInnerClosure
+{
+    function run($value) {
+        $value = (bool) function ($value) {
+            if ($value === 1000) {
+                return;
+            }
+
+            if ($value) {
+            }
+        };
+
+        return $value;
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
@@ -61,7 +62,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class, Function_::class];
+        return [ClassMethod::class, Function_::class, Closure::class];
     }
 
     /**

--- a/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveLastReturnRector.php
@@ -78,10 +78,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $lastNode instanceof Node) {
-            return null;
-        }
-
         if ($lastNode !== $lastReturn) {
             return null;
         }


### PR DESCRIPTION
Given the following Closure code:

```php
function ($value) {
    if ($value === 1000) {
        return;
    }

    if ($value) {
        return;
    }
};
```

should be transformed to removed last return:

```diff
    if ($value) {
-        return;
    }
```