### PR TITLE
[DowngradePhp54] Add DowngradeThisInClosureRector

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 507 Rules Overview
+# 508 Rules Overview
 
 <br>
 
@@ -38,7 +38,7 @@
 
 - [DowngradePhp80](#downgradephp80) (28)
 
-- [DowngradePhp81](#downgradephp81) (8)
+- [DowngradePhp81](#downgradephp81) (9)
 
 - [EarlyReturn](#earlyreturn) (11)
 
@@ -5852,6 +5852,35 @@ Removes union type property type definition, adding `@var` annotations instead.
 <br>
 
 ## DowngradePhp81
+
+### DowngradeArrayIsListRector
+
+Replace `array_is_list()` function
+
+- class: [`Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector`](../rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php)
+
+```diff
+-array_is_list([1 => 'apple', 'orange']);
++$arrayIsList = function (array $array) : bool {
++    if (function_exists('array_is_list')) {
++        return array_is_list($array);
++    }
++    if ($array === []) {
++        return true;
++    }
++    $current_key = 0;
++    foreach ($array as $key => $noop) {
++        if ($key !== $current_key) {
++            return false;
++        }
++        ++$current_key;
++    }
++    return true;
++};
++$arrayIsList([1 => 'apple', 'orange']);
+```
+
+<br>
 
 ### DowngradeArraySpreadStringKeyRector
 

--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -3918,7 +3918,7 @@ Remove static from closure
 
 ### DowngradeThisInClosureRector
 
-Downgrade `$this->` inside to use assigned `$self` = `$this` before Closure
+Downgrade `$this->` inside Closure to use assigned `$self` = `$this` before Closure
 
 - class: [`Rector\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector`](../rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php)
 

--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 506 Rules Overview
+# 507 Rules Overview
 
 <br>
 
@@ -20,7 +20,7 @@
 
 - [DowngradePhp53](#downgradephp53) (1)
 
-- [DowngradePhp54](#downgradephp54) (6)
+- [DowngradePhp54](#downgradephp54) (7)
 
 - [DowngradePhp55](#downgradephp55) (4)
 
@@ -3910,6 +3910,33 @@ Remove static from closure
 +        return function () {
              return true;
          };
+     }
+ }
+```
+
+<br>
+
+### DowngradeThisInClosureRector
+
+Downgrade `$this->` inside to use assigned `$self` = `$this` before Closure
+
+- class: [`Rector\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector`](../rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php)
+
+```diff
+ class SomeClass
+ {
+     public $property = 'test';
+
+     public function run()
+     {
+-        $function = function () {
+-            echo $this->property;
++        $self = $this;
++        $function = function () use ($self) {
++            echo $self->property;
+         };
+
+         $function();
      }
  }
 ```

--- a/config/set/downgrade-php54.php
+++ b/config/set/downgrade-php54.php
@@ -6,6 +6,7 @@ use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\DowngradePhp54\Rector\Array_\ShortArrayToLongArrayRector;
 use Rector\DowngradePhp54\Rector\Closure\DowngradeStaticClosureRector;
+use Rector\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector;
 use Rector\DowngradePhp54\Rector\FuncCall\DowngradeIndirectCallByArrayRector;
 use Rector\DowngradePhp54\Rector\FunctionLike\DowngradeCallableTypeDeclarationRector;
 use Rector\DowngradePhp54\Rector\LNumber\DowngradeBinaryNotationRector;
@@ -23,4 +24,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeCallableTypeDeclarationRector::class);
     $services->set(DowngradeBinaryNotationRector::class);
     $services->set(DowngradeInstanceMethodCallRector::class);
+    $services->set(DowngradeThisInClosureRector::class);
 };

--- a/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/DowngradeThisInClosureRectorTest.php
+++ b/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/DowngradeThisInClosureRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeThisInClosureRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/deep_closure.php.inc
+++ b/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/deep_closure.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class DeepClosure
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $function = function () {
+            $f = function () {
+                echo $this->property;
+            };
+            $f();
+        };
+
+        $function();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class DeepClosure
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $self = $this;
+        $function = function () use($self) {
+            $f = function () use($self) {
+                echo $self->property;
+            };
+            $f();
+        };
+
+        $function();
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/fixture.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class Fixture
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $function = function () {
+            echo $this->property;
+        };
+
+        $function();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class Fixture
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $self = $this;
+        $function = function () use($self) {
+            echo $self->property;
+        };
+
+        $function();
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/self_variable_exists.php.inc
+++ b/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/self_variable_exists.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class SelfVariableExists
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $self = 'test';
+        $function = function () {
+            echo $this->property;
+        };
+
+        $function();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class SelfVariableExists
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $self = 'test';
+        $self2 = $this;
+        $function = function () use($self2) {
+            echo $self2->property;
+        };
+
+        $function();
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/skip_in_anonymous_class.php.inc
+++ b/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/skip_in_anonymous_class.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class SkipInAnonymousClass
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $function = function () {
+            new class {
+                public function test()
+                {
+                    echo $this->property;
+                }
+            };
+        };
+
+        $function();
+    }
+}

--- a/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/skip_private_property.php.inc
+++ b/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/Fixture/skip_private_property.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\Fixture;
+
+class SkipPrivateProperty
+{
+    private $property = 'test';
+
+    public function run()
+    {
+        $function = function () {
+            echo $this->property;
+        };
+
+        $function();
+    }
+}

--- a/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeThisInClosureRector::class);
+};

--- a/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
+++ b/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp54\Rector\Closure;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\ClosureUse;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Reflection\Php\PhpPropertyReflection;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Reflection\ReflectionResolver;
+use Rector\Naming\Naming\VariableNaming;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\DowngradeThisInClosureRectorTest
+ */
+final class DowngradeThisInClosureRector extends AbstractRector
+{
+    public function __construct(
+        private readonly VariableNaming $variableNaming,
+        private readonly ReflectionResolver $reflectionResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Downgrade $this-> inside to use assigned $self = $this before Closure', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $function = function () {
+            echo $this->property;
+        };
+
+        $function();
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public $property = 'test';
+
+    public function run()
+    {
+        $self = $this;
+        $function = function () use ($self) {
+            echo $self->property;
+        };
+
+        $function();
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Closure::class];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $closureParentFunctionLike = $this->betterNodeFinder->findParentByTypes(
+            $node,
+            [ClassMethod::class, Function_::class]
+        );
+
+        /** @var PropertyFetch[] $propertyFetches */
+        $propertyFetches = $this->betterNodeFinder->find($node->stmts, function (Node $subNode) use (
+            $closureParentFunctionLike
+        ): bool {
+            // multiple deep Closure may access $this, unless its parent is not Closure
+            $parent = $this->betterNodeFinder->findParentByTypes($subNode, [ClassMethod::class, Function_::class]);
+
+            if ($parent instanceof FunctionLike && $parent !== $closureParentFunctionLike) {
+                return false;
+            }
+
+            if (! $subNode instanceof PropertyFetch) {
+                return false;
+            }
+
+            if (! $this->nodeNameResolver->isName($subNode->var, 'this')) {
+                return false;
+            }
+
+            $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($subNode);
+            if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
+                return false;
+            }
+
+            return $phpPropertyReflection->isPublic();
+        });
+
+        if ($propertyFetches === []) {
+            return null;
+        }
+
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        $selfVariable = new Variable($this->variableNaming->createCountedValueName('self', $scope));
+        $expression = new Expression(new Assign($selfVariable, new Variable('this')));
+
+        $currentStmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $currentStmt);
+
+        $this->traverseNodesWithCallable($node, function (Node $subNode) use ($selfVariable): ?Closure {
+            if (! $subNode instanceof Closure) {
+                return null;
+            }
+
+            $subNode->uses = array_merge($subNode->uses, [new ClosureUse($selfVariable)]);
+            return $subNode;
+        });
+
+        foreach ($propertyFetches as $propertyFetch) {
+            $propertyFetch->var = $selfVariable;
+        }
+
+        return $node;
+    }
+}

--- a/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
+++ b/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
@@ -37,7 +37,7 @@ final class DowngradeThisInClosureRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Downgrade $this-> inside to use assigned $self = $this before Closure', [
+        return new RuleDefinition('Downgrade $this-> inside Closure to use assigned $self = $this before Closure', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 class SomeClass

--- a/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
+++ b/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
@@ -23,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @changelog https://wiki.php.net/rfc/closures/object-extension
+ *
  * @see \Rector\Tests\DowngradePhp54\Rector\Closure\DowngradeThisInClosureRector\DowngradeThisInClosureRectorTest
  */
 final class DowngradeThisInClosureRector extends AbstractRector


### PR DESCRIPTION
Given the following code in PHP 5.3:

```php
class SomeClass
{
    public $property = 'test';

    public function run()
    {
        $function = function () {
            echo $this->property;
        };

        $function();
    }
}
```

got the following error:

```
Fatal error: Using $this when not in object context
```

Ref https://3v4l.org/guc4r#v5.3.29

This PR add `DowngradeThisInClosureRector` for downgrade php 5.4 to 5.3 for `$this` in closure to change to:

```diff
-        $function = function () {
-            echo $this->property;
+        $self = $this;
+        $function = function () use($self) {
+            echo $self->property;
         };
```

It currently only works for public method. 

Limitation:

- For private/protected method, it may need `ReflectionProperty`, but probably better in different PR.
- It only detect PropertyFetch, for MethodCall may need a different PR.