### PR TITLE
[DowngradePhp81] Add DowngradeArrayIsListRector

### DIFF
--- a/config/set/downgrade-php81.php
+++ b/config/set/downgrade-php81.php
@@ -6,6 +6,7 @@ use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\DowngradePhp81\Rector\Array_\DowngradeArraySpreadStringKeyRector;
 use Rector\DowngradePhp81\Rector\ClassConst\DowngradeFinalizePublicClassConstantRector;
+use Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector;
 use Rector\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallableSyntaxRector;
 use Rector\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector;
 use Rector\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector;
@@ -27,4 +28,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradePhp81ResourceReturnToObjectRector::class);
     $services->set(DowngradeReadonlyPropertyRector::class);
     $services->set(DowngradeArraySpreadStringKeyRector::class);
+    $services->set(DowngradeArrayIsListRector::class);
 };

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/DowngradeArrayIsListRectorTest.php
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/DowngradeArrayIsListRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeArrayIsListRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector\Fixture;
+
+array_is_list([1 => 'apple', 'orange']);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector\Fixture;
+
+$arrayIsList = function (array $array) : bool {
+    if (function_exists('array_is_list')) {
+        return array_is_list($array);
+    }
+    if ($array === []) {
+        return true;
+    }
+    $current_key = 0;
+    foreach ($array as $key => $noop) {
+        if ($key !== $current_key) {
+            return false;
+        }
+        ++$current_key;
+    }
+    return true;
+};
+$arrayIsList([1 => 'apple', 'orange']);
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/skip_not_array_is_list.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/skip_not_array_is_list.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector\Fixture;
+
+strlen('test');

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/variable_exists.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/variable_exists.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector\Fixture;
+
+$arrayIsList = false;
+array_is_list([1 => 'apple', 'orange']);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector\Fixture;
+
+$arrayIsList = false;
+$arrayIsList2 = function (array $array) : bool {
+    if (function_exists('array_is_list')) {
+        return array_is_list($array);
+    }
+    if ($array === []) {
+        return true;
+    }
+    $current_key = 0;
+    foreach ($array as $key => $noop) {
+        if ($key !== $current_key) {
+            return false;
+        }
+        ++$current_key;
+    }
+    return true;
+};
+$arrayIsList2([1 => 'apple', 'orange']);
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeArrayIsListRector::class);
+};

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp81\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\PhpParser\Parser\InlineCodeParser;
+use Rector\Core\Rector\AbstractRector;
+use Rector\DowngradePhp72\NodeAnalyzer\FunctionExistsFunCallAnalyzer;
+use Rector\Naming\Naming\VariableNaming;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/is_list
+ *
+ * @see \Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector\DowngradeArrayIsListRectorTest
+ */
+final class DowngradeArrayIsListRector extends AbstractRector
+{
+    public function __construct(
+        private readonly InlineCodeParser $inlineCodeParser,
+        private readonly FunctionExistsFunCallAnalyzer $functionExistsFunCallAnalyzer,
+        private readonly VariableNaming $variableNaming
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace array_is_list() function', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+array_is_list([1 => 'apple', 'orange']);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$arrayIsList = function (array $array) : bool {
+    if (function_exists('array_is_list')) {
+        return array_is_list($array);
+    }
+    if ($array === []) {
+        return true;
+    }
+    $current_key = 0;
+    foreach ($array as $key => $noop) {
+        if ($key !== $current_key) {
+            return false;
+        }
+        ++$current_key;
+    }
+    return true;
+};
+$arrayIsList([1 => 'apple', 'orange']);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?FuncCall
+    {
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        $currentStmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
+        if (! $currentStmt instanceof Stmt) {
+            return null;
+        }
+
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        $variable = new Variable($this->variableNaming->createCountedValueName('arrayIsList', $scope));
+
+        $function = $this->createClosure();
+        $expression = new Expression(new Assign($variable, $function));
+
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $currentStmt);
+
+        return new FuncCall($variable, $node->args);
+    }
+
+    private function createClosure(): Closure
+    {
+        $stmts = $this->inlineCodeParser->parse(__DIR__ . '/../../snippet/array_is_list_closure.php.inc');
+
+        /** @var Expression $expression */
+        $expression = $stmts[0];
+
+        $expr = $expression->expr;
+        if (! $expr instanceof Closure) {
+            throw new ShouldNotHappenException();
+        }
+
+        return $expr;
+    }
+
+    private function shouldSkip(FuncCall $funcCall): bool
+    {
+        if (! $this->nodeNameResolver->isName($funcCall, 'array_is_list')) {
+            return true;
+        }
+
+        if ($this->functionExistsFunCallAnalyzer->detect($funcCall, 'array_is_list')) {
+            return true;
+        }
+
+        $args = $funcCall->getArgs();
+        return count($args) !== 1;
+    }
+}

--- a/rules/DowngradePhp81/snippet/array_is_list_closure.php.inc
+++ b/rules/DowngradePhp81/snippet/array_is_list_closure.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+function (array $array) : bool {
+    if (function_exists('array_is_list')) {
+        return array_is_list($array);
+    }
+    if ($array === []) {
+        return true;
+    }
+    $current_key = 0;
+    foreach ($array as $key => $noop) {
+        if ($key !== $current_key) {
+            return false;
+        }
+        ++$current_key;
+    }
+    return true;
+};


### PR DESCRIPTION
Php 8.1 has new function `array_is_list()` which can be downgraded to :

```diff
-array_is_list([1 => 'apple', 'orange']);
+$arrayIsList = function (array $array) : bool {
+    if (function_exists('array_is_list')) {
+        return array_is_list($array);
+    }
+    if ($array === []) {
+        return true;
+    }
+    $current_key = 0;
+    foreach ($array as $key => $noop) {
+        if ($key !== $current_key) {
+            return false;
+        }
+        ++$current_key;
+    }
+    return true;
+};
+$arrayIsList([1 => 'apple', 'orange']);
```

ref https://php.watch/versions/8.1/array_is_list#array_is_list-polyfill