### PR TITLE
[Scoper] Add polyfill-php81 to file path to remove namespace

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -22,6 +22,7 @@ $filePathsToRemoveNamespace = [
     'vendor/symfony/polyfill-intl-grapheme/bootstrap80.php',
     'vendor/symfony/polyfill-mbstring/bootstrap.php',
     'vendor/symfony/polyfill-mbstring/bootstrap80.php',
+    'vendor/symfony/polyfill-php81/bootstrap.php',
     'vendor/symfony/polyfill-php80/bootstrap.php',
     'vendor/symfony/polyfill-php74/bootstrap.php',
     'vendor/symfony/polyfill-php73/bootstrap.php',


### PR DESCRIPTION
There is polyfill-php81 namespaced in rector/rector 

https://github.com/rectorphp/rector/tree/main/vendor/symfony/polyfill-php81

and still namespaced 

https://github.com/rectorphp/rector/blob/655dde840ef6286ce3f0189467abc9ccd2a757ff/vendor/symfony/polyfill-php81/bootstrap.php#L3

It should be added to exclude list.