### PR TITLE
[Scoper] Clean up missing use with prefixed

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -225,10 +225,7 @@ return [
                 return $content;
             }
 
-            $content = Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-
-            // add missing use statements prefixes
-            return Strings::replace($content, '#use Symfony\\\\Polyfill#', 'use ' . $prefix . ' Symfony\Polyfill');
+            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
         },
 
         // remove namespace from polyfill stubs


### PR DESCRIPTION
The string replace is not applied, even applied, it will invalid as there is space in replacement.

```
return Strings::replace($content, '#use Symfony\\\\Polyfill#', 'use ' . $prefix . ' Symfony\Polyfill');
```

so it can be removed. 