### PR TITLE
[Core] Use phar list files via RecursiveIteratorIterator on PHPStanStubLoader

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -3,12 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
-use Rector\Core\Stubs\PHPStanStubLoader;
 use Rector\Set\ValueObject\DowngradeLevelSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-$phpStanStubLoader = new PHPStanStubLoader();
-$phpStanStubLoader->loadStubs();
 
 require_once  __DIR__ . '/../target-repository/stubs-rector/PHPUnit/Framework/TestCase.php';
 require_once  __DIR__ . '/../../stubs/Composer/EventDispatcher/EventSubscriberInterface.php';

--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -35,35 +35,3 @@ spl_autoload_register(function (string $class): void {
         }
     }
 });
-
-if (! interface_exists('UnitEnum')) {
-    /**
-     * @since 8.1
-     */
-    interface UnitEnum
-    {
-        /**
-         * @return static[]
-         */
-        public static function cases(): array;
-    }
-}
-
-if (! interface_exists('BackedEnum')) {
-    /**
-     * @since 8.1
-     */
-    interface BackedEnum extends UnitEnum {
-        /**
-         * @param int|string $value
-         * @return $this
-         */
-        public static function from($value);
-
-        /**
-         * @param int|string $value
-         * @return $this|null
-         */
-        public static function tryFrom($value);
-    }
-}

--- a/packages/NodeTypeResolver/NodeTypeResolver/TraitTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/TraitTypeResolver.php
@@ -56,10 +56,6 @@ final class TraitTypeResolver implements NodeTypeResolverInterface
             return $types[0];
         }
 
-        if (count($types) > 1) {
-            return new UnionType($types);
-        }
-
-        return new MixedType();
+        return new UnionType($types);
     }
 }

--- a/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
+++ b/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
@@ -123,6 +123,6 @@ final class RemoveExtraParametersRector extends AbstractRector implements MinPhp
             $parameterCounts[] = count($parametersAcceptor->getParameters());
         }
 
-        return (int) max($parameterCounts);
+        return max($parameterCounts);
     }
 }


### PR DESCRIPTION
The PHPStan phar file runtime got updated over time, I think it is better to use `RecursiveIteratorIterator` check its runtime directory under phptan.phar to list of files and load it. 

This PR apply it, also clean up bootstrap.php file for `UnitEnum` and `BackedEnum` fallback as already in PHPStan runtime files, also fix phpstan notice on latest phpstan version 1.5.4 https://github.com/phpstan/phpstan/releases/tag/1.5.4