### PR TITLE
[TypeDeclaration] Handle multiple methods define __construct later on TypedPropertyFromStrictConstructorRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/multi_methods_with_default_value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/multi_methods_with_default_value.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+final class MultiMethodsWithDefaultValue
+{
+    /**
+     * @var string
+     */
+    private $rootView = 'admin.index';
+
+    public function run()
+    {
+        $this->rootView = 'super_admin.index';
+    }
+
+    public function __construct()
+    {
+        $this->rootView = 'super_admin.index';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+final class MultiMethodsWithDefaultValue
+{
+    private string $rootView;
+
+    public function run()
+    {
+        $this->rootView = 'super_admin.index';
+    }
+
+    public function __construct()
+    {
+        $this->rootView = 'super_admin.index';
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -14,6 +14,7 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -138,6 +139,14 @@ CODE_SAMPLE
 
         foreach ($propertyFetches as $propertyFetch) {
             $classMethod = $this->betterNodeFinder->findParentType($propertyFetch, ClassMethod::class);
+            if (! $classMethod instanceof ClassMethod) {
+                continue;
+            }
+
+            if (! $this->nodeNameResolver->isName($classMethod, MethodName::CONSTRUCT)) {
+                continue;
+            }
+
             if (! $this->propertyManipulator->isInlineStmtWithConstructMethod($propertyFetch, $classMethod)) {
                 return false;
             }


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2008, multiple methods with no inlined may remove default value if constructor exists, and the `__construct` method defined later.