### PR TITLE
[PHPStan] Fix PHPStan notice on ParallelFileProcessor

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -469,6 +469,7 @@ parameters:
                  - src/*/*Processor.php
                  - rules/Composer/Application/FileProcessor/ComposerFileProcessor.php
                  - src/Contract/Processor/FileProcessorInterface.php
+                 - packages/Parallel/Application/ParallelFileProcessor.php
 
         - '#Call to function property_exists\(\) with PhpParser\\Node\\Stmt\\ClassLike and (.*?) will always evaluate to true#'
 


### PR DESCRIPTION
Tried locally, PHPStan got notice:

```
composer phpstan         
> php -dmemory_limit=1G vendor/bin/phpstan analyse --ansi --error-format symplify
Note: Using configuration file /Users/samsonasik/www/rector-src/phpstan.neon.
 1512/1512 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  packages/Parallel/Application/ParallelFileProcessor.php:59
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Instead of array shape, use value object with specific types in constructor and getters#'
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


                                                                                                                        
 [ERROR] Found 1 errors           
```

This PR ignored it in phpstan.neon