### PR TITLE
[Strict] Skip possible result object or int on BooleanInIfConditionRuleFixerRector

### DIFF
--- a/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/skip_result_object.php.inc
+++ b/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/skip_result_object.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+class ForwardCompatibilityResult {
+
+}
+
+class QueryBuilder {
+    /**
+     * Executes this query using the bound parameters and their types.
+     *
+     * @return ForwardCompatibilityResult|int
+     *
+     * @throws Exception
+     */
+    public function execute()
+    {
+        if ($this->type === self::SELECT) {
+            return new ForwardCompatibilityResult();
+        }
+
+        return 1;
+    }
+}
+
+class SkipResultObject
+{
+    public function insert(): bool {
+        $queryBuilder = new QueryBuilder();
+        if ($queryBuilder->execute()) {
+            return false;
+        }
+
+        throw new \RuntimeException('...');
+    }
+}

--- a/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/skip_result_object.php.inc
+++ b/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/skip_result_object.php.inc
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * FUTURE NOTE: Dont add namespace to this Fixture:
+ *
+ * Skip Result Object or int only reproducible when on non-namespaced class
+ * and collection of class is on single file
+ */
 class ForwardCompatibilityResult {
 
 }

--- a/rules/Strict/NodeFactory/ExactCompareFactory.php
+++ b/rules/Strict/NodeFactory/ExactCompareFactory.php
@@ -113,7 +113,7 @@ final class ExactCompareFactory
             $compareExprs[] = $this->createNotIdenticalFalsyCompare($unionedType, $expr, $treatAsNotEmpty);
         }
 
-        /** @var Expr $truthyExpr */
+        /** @var ?Expr $truthyExpr */
         $truthyExpr = array_shift($compareExprs);
         foreach ($compareExprs as $compareExpr) {
             if (! $compareExpr instanceof Expr) {

--- a/rules/Strict/NodeFactory/ExactCompareFactory.php
+++ b/rules/Strict/NodeFactory/ExactCompareFactory.php
@@ -120,6 +120,10 @@ final class ExactCompareFactory
                 return null;
             }
 
+            if (! $truthyExpr instanceof Expr) {
+                return null;
+            }
+
             /** @var Expr $compareExpr */
             $truthyExpr = new BooleanOr($truthyExpr, $compareExpr);
         }


### PR DESCRIPTION
It only reproducible on non-namespaced file and use multiple classes in single file on Fixture, not extracted.

Fixes https://github.com/rectorphp/rector/issues/7095