### PR TITLE
[Php56] Skip inside by passed cases on AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/direct_switch_case_no_default.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/direct_switch_case_no_default.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class DirectSwitchCaseNoDefault
+{
+    public function run($type)
+    {
+        switch ($type) {
+            case 'a':
+                $value = 'A';
+                break;
+            case 'b':
+                $value = 'B';
+                break;
+        }
+
+        return $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class DirectSwitchCaseNoDefault
+{
+    public function run($type)
+    {
+        $value = null;
+        switch ($type) {
+            case 'a':
+                $value = 'A';
+                break;
+            case 'b':
+                $value = 'B';
+                break;
+        }
+
+        return $value;
+    }
+}
+
+?>

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_inside_by_passed_case.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_inside_by_passed_case.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class SkipInsideByPassedCase
+{
+    public function run($type)
+    {
+        switch ($type) {
+            case 'a':
+            case 'b':
+                switch ($type) {
+                    case 'a':
+                        $value = 'A';
+                        break;
+                    case 'b':
+                        $value = 'B';
+                        break;
+                }
+
+                return $value;
+        }
+    }
+}

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -67,7 +67,12 @@ final class UndefinedVariableResolver
                 return null;
             }
 
-            if ($this->shouldSkipVariable($node)) {
+            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+            if (! $parentNode instanceof Node) {
+                return null;
+            }
+
+            if ($this->shouldSkipVariable($node, $parentNode)) {
                 return null;
             }
 
@@ -106,13 +111,8 @@ final class UndefinedVariableResolver
         return in_array($parentNode::class, [Assign::class, AssignRef::class], true);
     }
 
-    private function shouldSkipVariable(Variable $variable): bool
+    private function shouldSkipVariable(Variable $variable, Node $parentNode): bool
     {
-        $parentNode = $variable->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parentNode instanceof Node) {
-            return true;
-        }
-
         if ($this->variableAnalyzer->isStaticOrGlobal($variable)) {
             return true;
         }
@@ -171,7 +171,8 @@ final class UndefinedVariableResolver
             return false;
         }
 
-        return (bool) $this->betterNodeFinder->findParentType($previousSwitch, Case_::class);
+        $parentSwitch = $previousSwitch->getAttribute(AttributeKey::PARENT_NODE);
+        return $parentSwitch instanceof Case_;
     }
 
     private function isDifferentWithOriginalNodeOrNoScope(Variable $variable): bool

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -157,10 +157,10 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        return $this->isInSwitchCaseWithParentCase($variable);
+        return $this->isAfterSwitchCaseWithParentCase($variable);
     }
 
-    private function isInSwitchCaseWithParentCase(Variable $variable): bool
+    private function isAfterSwitchCaseWithParentCase(Variable $variable): bool
     {
         $previousSwitch = $this->betterNodeFinder->findFirstPreviousOfNode(
             $variable,

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -157,10 +157,10 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        return $this->inSwitchCaseWithParentCase($variable);
+        return $this->isInSwitchCaseWithParentCase($variable);
     }
 
-    private function inSwitchCaseWithParentCase(Variable $variable): bool
+    private function isInSwitchCaseWithParentCase(Variable $variable): bool
     {
         $previousSwitch = $this->betterNodeFinder->findFirstPreviousOfNode(
             $variable,


### PR DESCRIPTION
Given the following code with parent - child switch case by passed:

```php
class SkipInsideByPassedCase
{
    public function run($type)
    {
        switch ($type) {
            case 'a':
            case 'b':
                switch ($type) {
                    case 'a':
                        $value = 'A';
                        break;
                    case 'b':
                        $value = 'B';
                        break;
                }

                return $value;
        }
    }
}
```

The `$value` initialization can be skipped, as it always filled, as $type is always `a` or `b` by upper switch -> case passed.