### PR TITLE
[ISSUE-7099] Added failing test case for disappearing if-empty statement

### DIFF
--- a/tests/Issues/Issue7099/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7099/Fixture/fixture.php.inc
@@ -1,0 +1,113 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7099\Fixture;
+
+class Document {
+
+}
+
+class View {
+    private $data;
+
+    public function __construct($data) {
+        $this->data = $data;
+    }
+
+    /** @return mixed */
+    public function getData() {
+        return $this->data;
+    }
+}
+
+class DocumentRepository
+{
+    public function findById(int $id): ?Document {
+        return $id === 1 ? new Document() : null;
+    }
+}
+
+class SomeController
+{
+    private DocumentRepository $documentRepository;
+
+    public function __construct(
+        DocumentRepository $documentRepository,
+    ) {
+        $this->documentRepository = $documentRepository;
+    }
+
+    public function getDocumentAction(int $id): View
+    {
+        $document = $this->documentRepository->findById($id);
+
+        if (empty($document)) {
+            return $this->view([]);
+        }
+
+        return $this->view($document);
+    }
+
+    protected function view($data = null): View
+    {
+        return new View($data);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7099\Fixture;
+
+class Document {
+
+}
+
+class View {
+    private $data;
+
+    public function __construct($data) {
+        $this->data = $data;
+    }
+
+    /** @return mixed */
+    public function getData() {
+        return $this->data;
+    }
+}
+
+class DocumentRepository
+{
+    public function findById(int $id): ?Document {
+        return $id === 1 ? new Document() : null;
+    }
+}
+
+class SomeController
+{
+    private DocumentRepository $documentRepository;
+
+    public function __construct(
+        DocumentRepository $documentRepository,
+    ) {
+        $this->documentRepository = $documentRepository;
+    }
+
+    public function getDocumentAction(int $id): View
+    {
+        $document = $this->documentRepository->findById($id);
+
+        if (!$document instanceof \Rector\Core\Tests\Issues\Issue7099\Fixture\Document) {
+            return $this->view([]);
+        }
+
+        return $this->view($document);
+    }
+
+    protected function view($data = null): View
+    {
+        return new View($data);
+    }
+}
+
+?>

--- a/tests/Issues/Issue7099/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7099/Fixture/fixture.php.inc
@@ -2,54 +2,19 @@
 
 namespace Rector\Core\Tests\Issues\Issue7099\Fixture;
 
-class Document {
+use Rector\Core\Tests\Issues\Issue7099\Source\Document;
 
-}
-
-class View {
-    private $data;
-
-    public function __construct($data) {
-        $this->data = $data;
-    }
-
-    /** @return mixed */
-    public function getData() {
-        return $this->data;
-    }
-}
-
-class DocumentRepository
+class Controller
 {
-    public function findById(int $id): ?Document {
-        return $id === 1 ? new Document() : null;
-    }
-}
-
-class SomeController
-{
-    private DocumentRepository $documentRepository;
-
-    public function __construct(
-        DocumentRepository $documentRepository,
-    ) {
-        $this->documentRepository = $documentRepository;
-    }
-
-    public function getDocumentAction(int $id): View
+    public function getDocumentAction(int $id): ?Document
     {
-        $document = $this->documentRepository->findById($id);
+        $document = $id === 1 ? new Document() : null;
 
         if (empty($document)) {
-            return $this->view([]);
+            return null;
         }
 
-        return $this->view($document);
-    }
-
-    protected function view($data = null): View
-    {
-        return new View($data);
+        return $document;
     }
 }
 
@@ -59,54 +24,19 @@ class SomeController
 
 namespace Rector\Core\Tests\Issues\Issue7099\Fixture;
 
-class Document {
+use Rector\Core\Tests\Issues\Issue7099\Source\Document;
 
-}
-
-class View {
-    private $data;
-
-    public function __construct($data) {
-        $this->data = $data;
-    }
-
-    /** @return mixed */
-    public function getData() {
-        return $this->data;
-    }
-}
-
-class DocumentRepository
+class Controller
 {
-    public function findById(int $id): ?Document {
-        return $id === 1 ? new Document() : null;
-    }
-}
-
-class SomeController
-{
-    private DocumentRepository $documentRepository;
-
-    public function __construct(
-        DocumentRepository $documentRepository,
-    ) {
-        $this->documentRepository = $documentRepository;
-    }
-
-    public function getDocumentAction(int $id): View
+    public function getDocumentAction(int $id): ?Document
     {
-        $document = $this->documentRepository->findById($id);
+        $document = $id === 1 ? new Document() : null;
 
-        if (!$document instanceof \Rector\Core\Tests\Issues\Issue7099\Fixture\Document) {
-            return $this->view([]);
+        if (!$document instanceof \Rector\Core\Tests\Issues\Issue7099\Source\Document) {
+            return null;
         }
 
-        return $this->view($document);
-    }
-
-    protected function view($data = null): View
-    {
-        return new View($data);
+        return $document;
     }
 }
 

--- a/tests/Issues/Issue7099/RuleCombinationShouldNotRemoveIfEmptyStmtRectorTest.php
+++ b/tests/Issues/Issue7099/RuleCombinationShouldNotRemoveIfEmptyStmtRectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue7099;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7099
+ */
+final class RuleCombinationShouldNotRemoveIfEmptyStmtRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue7099/Source/Document.php
+++ b/tests/Issues/Issue7099/Source/Document.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7099\Source;
+
+class Document
+{
+
+}

--- a/tests/Issues/Issue7099/config/configured_rule.php
+++ b/tests/Issues/Issue7099/config/configured_rule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(\Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector::class);
+
+    // TODO: The problem disappears when BooleanInTernaryOperatorRuleFixerRector is removed,
+    // TODO: despite the fact that it is not being applied (remove this comment after the test is passing)
+    $services->set(\Rector\Strict\Rector\Ternary\BooleanInTernaryOperatorRuleFixerRector::class)
+        ->configure([
+            \Rector\Strict\Rector\Ternary\BooleanInTernaryOperatorRuleFixerRector::TREAT_AS_NON_EMPTY => false,
+        ]);
+
+    $services->set(\Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::class)
+        ->configure([
+            \Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::TREAT_AS_NON_EMPTY => false,
+        ]);
+};


### PR DESCRIPTION
Added failing test case for https://github.com/rectorphp/rector/issues/7099, it can be run with:

 ```sh
vendor/bin/phpunit --filter RuleCombinationShouldNotRemoveIfEmptyStmtRectorTest
```