### PR TITLE
[ISSUE-7100] Added failing test cases for when accessing array key might lead to PHP Notice: Undefined Index

### DIFF
--- a/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/skip_when_argument_is_array_access.php.inc
+++ b/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/skip_when_argument_is_array_access.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector\Fixture;
+
+class SomeClass {
+    /**
+     * @var array<string>
+     */
+    protected array $labels = [];
+
+    public function getLabel(string $value): string
+    {
+        if (empty($this->labels[$value])) {
+            throw new \InvalidArgumentException(sprintf('%s is missing label for value "%s"', static::class, $value));
+        }
+
+        return $this->labels[$value];
+    }
+}

--- a/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/skip_when_argument_is_static_array_access.php.inc
+++ b/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/skip_when_argument_is_static_array_access.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector\Fixture;
+
+class SomeClass {
+    /**
+     * @var array<string>
+     */
+    protected static array $labels = [];
+
+    public static function getLabel(string $value): string
+    {
+        if (empty(static::$labels[$value])) {
+            throw new \InvalidArgumentException(sprintf('%s is missing label for value "%s"', static::class, $value));
+        }
+
+        return static::$labels[$value];
+    }
+}


### PR DESCRIPTION
Added failing test case for https://github.com/rectorphp/rector/issues/7100, it can be run with:

```sh
vendor/bin/phpunit --filter DisallowedEmptyRuleFixerRectorTest
```

The problem is that `empty($array['someKey])` does not trigger `Undefined Index` notice if the key does not exists. Thus, the rule can introduce regression in its current form. It should either skip these cases or handle them correctly, perhaps `($array['someKey] ?? === '')` on appropriate PHP version.