### PR TITLE
[Php74][TypeDeclaration] Register TypedPropertyFromAssignsRector to php74 config set

### DIFF
--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -17,10 +17,14 @@ use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
 use Rector\Php74\Rector\Property\TypedPropertyRector;
 use Rector\Php74\Rector\StaticCall\ExportToReflectionFunctionRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
+
+    $services->set(TypedPropertyFromAssignsRector::class);
+
     $services->set(TypedPropertyRector::class);
 
     $services->set(RenameFunctionRector::class)

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/default_value_null_in_construct.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/default_value_null_in_construct.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class DefaultValueNullParamAssignConstruct
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    public function __construct(array $data = null)
+    {
+        $this->data = $data;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class DefaultValueNullParamAssignConstruct
+{
+    private ?array $data = null;
+
+    public function __construct(array $data = null)
+    {
+        $this->data = $data;
+    }
+}
+
+?>

--- a/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/ExplicitPublicClassMethodRectorTest.php
+++ b/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/ExplicitPublicClassMethodRectorTest.php
@@ -31,4 +31,3 @@ final class ExplicitPublicClassMethodRectorTest extends AbstractRectorTestCase
         return __DIR__ . '/config/configured_rule.php';
     }
 }
-

--- a/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/config/configured_rule.php
+++ b/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/config/configured_rule.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Rector\Core\ValueObject\Visibility;
 use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -10,4 +9,3 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(ExplicitPublicClassMethodRector::class);
 };
-

--- a/rules/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector.php
+++ b/rules/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector.php
@@ -7,6 +7,7 @@ namespace Rector\Visibility\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\Visibility;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -68,7 +69,7 @@ CODE_SAMPLE
         }
 
         // explicitly public
-        if ($this->visibilityManipulator->hasVisibility($node, \Rector\Core\ValueObject\Visibility::PUBLIC)) {
+        if ($this->visibilityManipulator->hasVisibility($node, Visibility::PUBLIC)) {
             return null;
         }
 

--- a/rules/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector.php
+++ b/rules/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector.php
@@ -7,7 +7,6 @@ namespace Rector\Visibility\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Rector\AbstractRector;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;

--- a/src/Console/Style/RectorConsoleOutputStyle.php
+++ b/src/Console/Style/RectorConsoleOutputStyle.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class RectorConsoleOutputStyle extends SymfonyStyle
 {
     /**
-     * @var mixed|ProgressBar
+     * @var ProgressBar|null
      */
     public $progressBar;
 


### PR DESCRIPTION
To handle issue like in https://github.com/rectorphp/rector-src/pull/2025 for default null assign in construct which user can just run:

```
composer require rector/rector
vendor/bin/rector init
vendor/bin/rector
```

and it already broke with the following code:

```php
final class DefaultValueNullParamAssignConstruct
{
    /**
     * @var array
     */
    private $data;

    public function __construct(array $data = null)
    {
        $this->data = $data;
    }
}
```

as with only `TypedPropertyRector`, it will change to:

```diff
-    /**
-     * @var array
-     */
-    private $data;
+    private array $data;
```

which should be:

```diff
-    /**
-     * @var array
-     */
-    private $data;
+    private ?array $data = null;
```

I also added fixture for it, for remove `null` property initialization on property as always filled in construct, that's possibly the improvement `RemoveNullPropertyInitializationRector` in separate PR.