### PR TITLE
[Php74] Skip array var type filled default null in __construct on TypedPropertyRector

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -42,6 +42,7 @@ use Rector\NodeTypeResolver\NodeTypeCorrector\AccessoryNonEmptyStringTypeCorrect
 use Rector\NodeTypeResolver\NodeTypeCorrector\GenericClassStringTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeCorrector\HasOffsetTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeResolver\IdentifierTypeResolver;
+use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\TypeDeclaration\PHPStan\Type\ObjectTypeSpecifier;
 
@@ -253,6 +254,10 @@ final class NodeTypeResolver
     public function getFullyQualifiedClassName(TypeWithClassName $typeWithClassName): string
     {
         if ($typeWithClassName instanceof ShortenedObjectType) {
+            return $typeWithClassName->getFullyQualifiedName();
+        }
+
+        if ($typeWithClassName instanceof AliasedObjectType) {
             return $typeWithClassName->getFullyQualifiedName();
         }
 

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_array_type_filled_default_null.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_array_type_filled_default_null.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SkipArrayTypeFilledDefaultNull
+{
+    /**
+     * @var array
+     */
+    private $property;
+
+    public function __construct(array $property = null)
+    {
+        $this->property = $property;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/array_type_filled_default_null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/array_type_filled_default_null.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class ArrayTypeFilledDefaultNull
+{
+    /**
+     * @var array
+     */
+    private $property;
+
+    public function __construct(array $property = null)
+    {
+        $this->property = $property;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class ArrayTypeFilledDefaultNull
+{
+    private ?array $property = null;
+
+    public function __construct(array $property = null)
+    {
+        $this->property = $property;
+    }
+}
+
+?>

--- a/rules/Naming/Naming/PropertyNaming.php
+++ b/rules/Naming/Naming/PropertyNaming.php
@@ -17,6 +17,7 @@ use Rector\Naming\RectorNamingInflector;
 use Rector\Naming\ValueObject\ExpectedName;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
+use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\SelfObjectType;
 
 /**
@@ -83,7 +84,9 @@ final class PropertyNaming
             return null;
         }
 
-        $className = $this->nodeTypeResolver->getFullyQualifiedClassName($type);
+        $className = $type instanceof AliasedObjectType
+            ? $type->getClassName()
+            : $this->nodeTypeResolver->getFullyQualifiedClassName($type);
 
         // generic types are usually mix of parent type and specific type - various way to handle it
         if ($type instanceof GenericObjectType) {

--- a/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
@@ -12,6 +12,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -20,6 +21,7 @@ use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
@@ -38,7 +40,9 @@ final class VarDocPropertyTypeInferer
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly PropertyFetchFinder $propertyFetchFinder,
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PropertyManipulator $propertyManipulator
+        private readonly PropertyManipulator $propertyManipulator,
+        private readonly AssignToPropertyTypeInferer $assignToPropertyTypeInferer,
+        private readonly NodeTypeResolver $nodeTypeResolver
     ) {
     }
 
@@ -51,6 +55,11 @@ final class VarDocPropertyTypeInferer
             return new MixedType();
         }
 
+        $class = $this->betterNodeFinder->findParentType($property, Class_::class);
+        if (! $class instanceof Class_) {
+            return new MixedType();
+        }
+
         // default value type must be added to each resolved type if set
         $propertyDefaultValue = $property->props[0]->default;
         if ($propertyDefaultValue instanceof Expr) {
@@ -59,7 +68,37 @@ final class VarDocPropertyTypeInferer
             $resolvedType = $this->makeNullableForAccessedBeforeInitialization($property, $resolvedType, $phpDocInfo);
         }
 
-        return $this->genericClassStringTypeNormalizer->normalize($resolvedType);
+        $resolvedType = $this->genericClassStringTypeNormalizer->normalize($resolvedType);
+        $propertyName = $this->nodeNameResolver->getName($property);
+        $assignInferredPropertyType = $this->assignToPropertyTypeInferer->inferPropertyInClassLike(
+            $property,
+            $propertyName,
+            $class
+        );
+
+        if (! $assignInferredPropertyType instanceof Type) {
+            return $resolvedType;
+        }
+
+        if ($resolvedType::class === $assignInferredPropertyType::class) {
+            return $resolvedType;
+        }
+
+        if (
+            $resolvedType instanceof TypeWithClassName &&
+            $assignInferredPropertyType instanceof TypeWithClassName
+        ) {
+            $classNameResolvedType = $this->nodeTypeResolver->getFullyQualifiedClassName($resolvedType);
+            $classNameInferredPropertyType = $this->nodeTypeResolver->getFullyQualifiedClassName(
+                $assignInferredPropertyType
+            );
+
+            if ($classNameResolvedType === $classNameInferredPropertyType) {
+                return $resolvedType;
+            }
+        }
+
+        return new MixedType();
     }
 
     private function makeNullableForAccessedBeforeInitialization(

--- a/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
@@ -104,9 +104,16 @@ final class VarDocPropertyTypeInferer
         return new MixedType();
     }
 
-    private function isAssignInferredUnionTypesMoreThanResolvedType(Type $resolvedType, Type $assignInferredPropertyType): bool
+    private function isAssignInferredUnionTypesMoreThanResolvedType(
+        Type $resolvedType,
+        Type $assignInferredPropertyType
+    ): bool
     {
-        return $resolvedType instanceof UnionType && $assignInferredPropertyType instanceof UnionType && count($assignInferredPropertyType->getTypes()) > count($resolvedType->getTypes());
+        return $resolvedType instanceof UnionType && $assignInferredPropertyType instanceof UnionType && count(
+            $assignInferredPropertyType->getTypes()
+        ) > count(
+            $resolvedType->getTypes()
+        );
     }
 
     private function isBothTypeWithClassName(Type $resolvedType, Type $assignInferredPropertyType): bool

--- a/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
@@ -107,13 +107,10 @@ final class VarDocPropertyTypeInferer
     private function isAssignInferredUnionTypesMoreThanResolvedType(
         Type $resolvedType,
         Type $assignInferredPropertyType
-    ): bool
-    {
+    ): bool {
         return $resolvedType instanceof UnionType && $assignInferredPropertyType instanceof UnionType && count(
             $assignInferredPropertyType->getTypes()
-        ) > count(
-            $resolvedType->getTypes()
-        );
+        ) > count($resolvedType->getTypes());
     }
 
     private function isBothTypeWithClassName(Type $resolvedType, Type $assignInferredPropertyType): bool

--- a/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
@@ -80,15 +80,18 @@ final class VarDocPropertyTypeInferer
             return $resolvedType;
         }
 
+        if ($this->isAssignInferredUnionTypesMoreThanResolvedType($resolvedType, $assignInferredPropertyType)) {
+            return new MixedType();
+        }
+
         if ($resolvedType::class === $assignInferredPropertyType::class) {
             return $resolvedType;
         }
 
-        if (
-            $resolvedType instanceof TypeWithClassName &&
-            $assignInferredPropertyType instanceof TypeWithClassName
-        ) {
+        if ($this->isBothTypeWithClassName($resolvedType, $assignInferredPropertyType)) {
+            /** @var TypeWithClassName $resolvedType */
             $classNameResolvedType = $this->nodeTypeResolver->getFullyQualifiedClassName($resolvedType);
+            /** @var TypeWithClassName $assignInferredPropertyType */
             $classNameInferredPropertyType = $this->nodeTypeResolver->getFullyQualifiedClassName(
                 $assignInferredPropertyType
             );
@@ -99,6 +102,16 @@ final class VarDocPropertyTypeInferer
         }
 
         return new MixedType();
+    }
+
+    private function isAssignInferredUnionTypesMoreThanResolvedType(Type $resolvedType, Type $assignInferredPropertyType): bool
+    {
+        return $resolvedType instanceof UnionType && $assignInferredPropertyType instanceof UnionType && count($assignInferredPropertyType->getTypes()) > count($resolvedType->getTypes());
+    }
+
+    private function isBothTypeWithClassName(Type $resolvedType, Type $assignInferredPropertyType): bool
+    {
+        return $resolvedType instanceof TypeWithClassName && $assignInferredPropertyType instanceof TypeWithClassName;
     }
 
     private function makeNullableForAccessedBeforeInitialization(


### PR DESCRIPTION
Given the following code:

```php
final class SkipArrayTypeFilledDefaultNull
{
    /**
     * @var array
     */
    private $property;

    public function __construct(array $property = null)
    {
        $this->property = $property;
    }
}
```

It currently produce:

```diff
-    private $property;
+    private array $property;
```

which make error : 

```
Fatal error: Uncaught TypeError: Cannot assign null to property SkipArrayTypeFilledDefaultNull::$property of type array
```

There is `TypedPropertyFromAssignsRector` that specifically handle it, so it can be skipped in `TypedPropertyRector`.