### PR TITLE
[DeadCode] Skip not identifier name on RemoveUnusedPrivateMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_not_identifier_name.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_not_identifier_name.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+final class SkipNotIdentifierName
+{
+    public function run(string $name)
+    {
+        return $this->{'do' . $name}();
+    }
+
+    private function doFoo()
+    {
+        return 5;
+    }
+
+    private function doBar()
+    {
+        return 4;
+    }
+}

--- a/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\NodeAnalyzer;
 
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
 use PHPStan\Type\TypeWithClassName;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -33,6 +34,10 @@ final class CallCollectionAnalyzer
 
             if ($callerType->getClassName() !== $className) {
                 continue;
+            }
+
+            if (! $call->name instanceof Identifier) {
+                return true;
             }
 
             // the method is used


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7102