### PR TITLE
[DX] Replace global BetterStandardPrinter from AbstractRector with autowired NodePrinterInterface for easier and specific re-use

### DIFF
--- a/packages-tests/Comments/CommentRemover/CommentRemoverTest.php
+++ b/packages-tests/Comments/CommentRemover/CommentRemoverTest.php
@@ -6,6 +6,7 @@ namespace Rector\Tests\Comments\CommentRemover;
 
 use Iterator;
 use Rector\Comments\CommentRemover;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\FileSystemRector\Parser\FileInfoParser;
 use Rector\Testing\PHPUnit\AbstractTestCase;
@@ -19,14 +20,14 @@ final class CommentRemoverTest extends AbstractTestCase
 
     private FileInfoParser $fileInfoParser;
 
-    private BetterStandardPrinter $betterStandardPrinter;
+    private NodePrinterInterface $nodePrinter;
 
     protected function setUp(): void
     {
         $this->boot();
         $this->commentRemover = $this->getService(CommentRemover::class);
         $this->fileInfoParser = $this->getService(FileInfoParser::class);
-        $this->betterStandardPrinter = $this->getService(BetterStandardPrinter::class);
+        $this->nodePrinter = $this->getService(BetterStandardPrinter::class);
     }
 
     /**
@@ -42,7 +43,7 @@ final class CommentRemoverTest extends AbstractTestCase
 
         $nodesWithoutComments = $this->commentRemover->removeFromNode($nodes);
 
-        $fileContent = $this->betterStandardPrinter->print($nodesWithoutComments);
+        $fileContent = $this->nodePrinter->print($nodesWithoutComments);
         $fileContent = trim($fileContent);
 
         $expectedContent = trim($fileInfoToLocalInputAndExpected->getExpected());
@@ -50,7 +51,7 @@ final class CommentRemoverTest extends AbstractTestCase
         $this->assertSame($fileContent, $expectedContent, $smartFileInfo->getRelativeFilePathFromCwd());
 
         // original nodes are not touched
-        $originalContent = $this->betterStandardPrinter->print($nodes);
+        $originalContent = $this->nodePrinter->print($nodes);
         $this->assertNotSame($expectedContent, $originalContent);
     }
 

--- a/packages/NodeNameResolver/Error/InvalidNameNodeReporter.php
+++ b/packages/NodeNameResolver/Error/InvalidNameNodeReporter.php
@@ -6,9 +6,9 @@ namespace Rector\NodeNameResolver\Error;
 
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -22,7 +22,7 @@ final class InvalidNameNodeReporter
 
     public function __construct(
         private readonly CurrentFileProvider $currentFileProvider,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private readonly NodePrinterInterface $nodePrinter
     ) {
     }
 
@@ -39,7 +39,7 @@ final class InvalidNameNodeReporter
                 'Caused in "%s" file on line %d on code "%s"',
                 $smartFileInfo->getRelativeFilePathFromCwd(),
                 $node->getStartLine(),
-                $this->betterStandardPrinter->print($node)
+                $this->nodePrinter->print($node)
             );
         }
 

--- a/packages/PhpAttribute/Printer/DoctrineAnnotationFactory.php
+++ b/packages/PhpAttribute/Printer/DoctrineAnnotationFactory.php
@@ -9,13 +9,13 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class DoctrineAnnotationFactory
 {
     public function __construct(
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private readonly NodePrinterInterface $nodePrinter
     ) {
     }
 
@@ -40,9 +40,9 @@ final class DoctrineAnnotationFactory
                 $arg->value->setAttribute(AttributeKey::KIND, String_::KIND_DOUBLE_QUOTED);
             }
 
-            $itemValue = $this->betterStandardPrinter->print($arg->value);
+            $itemValue = $this->nodePrinter->print($arg->value);
             if ($arg->name !== null) {
-                $name = $this->betterStandardPrinter->print($arg->name);
+                $name = $this->nodePrinter->print($arg->name);
                 $items[$name] = $itemValue;
             } else {
                 $items[] = $itemValue;

--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -10,9 +10,9 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\ChangesReporting\Collector\RectorChangeCollector;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Contract\Collector\NodeCollectorInterface;
 
@@ -31,7 +31,7 @@ final class NodesToAddCollector implements NodeCollectorInterface
     public function __construct(
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly RectorChangeCollector $rectorChangeCollector,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private readonly NodePrinterInterface $nodePrinter
     ) {
     }
 
@@ -142,7 +142,7 @@ final class NodesToAddCollector implements NodeCollectorInterface
         $foundNode = $this->betterNodeFinder->findParentType($node, Stmt::class);
 
         if (! $foundNode instanceof Stmt) {
-            $printedNode = $this->betterStandardPrinter->print($node);
+            $printedNode = $this->nodePrinter->print($node);
             $errorMessage = sprintf('Could not find parent Stmt of "%s" node', $printedNode);
             throw new ShouldNotHappenException($errorMessage);
         }

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -21,6 +21,7 @@ use PHPStan\Type\Type;
 use Rector\Arguments\NodeAnalyzer\ArgumentAddingScope;
 use Rector\Arguments\NodeAnalyzer\ChangedArgumentsDetector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\Exception\ShouldNotHappenException;
@@ -46,7 +47,8 @@ final class ArgumentAdderRector extends AbstractRector implements ConfigurableRe
     public function __construct(
         private readonly ArgumentAddingScope $argumentAddingScope,
         private readonly ChangedArgumentsDetector $changedArgumentsDetector,
-        private readonly AstResolver $astResolver
+        private readonly AstResolver $astResolver,
+        private readonly NodePrinterInterface $nodePrinter
     ) {
     }
 
@@ -213,7 +215,8 @@ CODE_SAMPLE
                 throw new ShouldNotHappenException('Previous position does not has default value');
             }
 
-            $node->args[$index] = new Arg(new ConstFetch(new Name($this->print($param->default))));
+            $default = $this->nodePrinter->print($param->default);
+            $node->args[$index] = new Arg(new ConstFetch(new Name($default)));
         }
     }
 

--- a/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -27,6 +28,11 @@ final class SimplifyIfElseToTernaryRector extends AbstractRector
      * @var int
      */
     private const LINE_LENGTH_LIMIT = 120;
+
+    public function __construct(
+        private readonly NodePrinterInterface $nodePrinter
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -205,6 +211,7 @@ CODE_SAMPLE
 
     private function isNodeTooLong(Assign $assign): bool
     {
-        return Strings::length($this->print($assign)) > self::LINE_LENGTH_LIMIT;
+        $assignContent = $this->nodePrinter->print($assign);
+        return Strings::length($assignContent) > self::LINE_LENGTH_LIMIT;
     }
 }

--- a/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use Rector\BetterPhpDocParser\Comment\CommentsMerger;
 use Rector\CodeQuality\NodeManipulator\ExprBoolCaster;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -25,7 +26,8 @@ final class SimplifyIfReturnBoolRector extends AbstractRector
 {
     public function __construct(
         private readonly CommentsMerger $commentsMerger,
-        private readonly ExprBoolCaster $exprBoolCaster
+        private readonly ExprBoolCaster $exprBoolCaster,
+        private readonly NodePrinterInterface $nodePrinter
     ) {
     }
 
@@ -138,7 +140,7 @@ CODE_SAMPLE
             return ! $this->valueResolver->isTrueOrFalse($nextNode->expr);
         }
 
-        $condString = $this->print($if->cond);
+        $condString = $this->nodePrinter->print($if->cond);
         if (! \str_contains($condString, '!=')) {
             return ! $this->valueResolver->isTrueOrFalse($nextNode->expr);
         }

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Util\StringUtils;
@@ -85,6 +86,11 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Allo
     ];
 
     private string $delimiter = '#';
+
+    public function __construct(
+        private readonly NodePrinterInterface $nodePrinter
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -219,7 +225,7 @@ CODE_SAMPLE
         $string->value = Strings::replace($string->value, self::INNER_REGEX, function (array $match) use (
             &$string
         ): string {
-            $printedString = $this->betterStandardPrinter->print($string);
+            $printedString = $this->nodePrinter->print($string);
             if (StringUtils::isMatch($printedString, self::DOUBLE_QUOTED_REGEX)) {
                 $string->setAttribute(AttributeKey::IS_REGULAR_PATTERN, true);
             }

--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNodeAnalyzer.php
@@ -9,9 +9,9 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Include_;
 use PhpParser\Node\Expr\Variable;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\NodeAnalyzer\CompactFuncCallAnalyzer;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 
 final class ExprUsedInNodeAnalyzer
 {
@@ -19,7 +19,7 @@ final class ExprUsedInNodeAnalyzer
         private readonly NodeComparator $nodeComparator,
         private readonly UsedVariableNameAnalyzer $usedVariableNameAnalyzer,
         private readonly CompactFuncCallAnalyzer $compactFuncCallAnalyzer,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private readonly NodePrinterInterface $nodePrinter
     ) {
     }
 
@@ -31,7 +31,7 @@ final class ExprUsedInNodeAnalyzer
 
         // variable as variable variable need mark as used
         if ($node instanceof Variable && $expr instanceof Variable) {
-            $print = $this->betterStandardPrinter->print($node);
+            $print = $this->nodePrinter->print($node);
             if (\str_starts_with($print, '${$')) {
                 return true;
             }

--- a/rules/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector.php
+++ b/rules/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector.php
@@ -7,6 +7,7 @@ namespace Rector\DeadCode\Rector\Array_;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -17,6 +18,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveDuplicatedArrayKeyRector extends AbstractRector
 {
+    public function __construct(
+        private readonly NodePrinterInterface $nodePrinter
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove duplicated key in defined arrays.', [
@@ -80,7 +86,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $keyValue = $this->print($arrayItem->key);
+            $keyValue = $this->nodePrinter->print($arrayItem->key);
             $arrayItemsByKeys[$keyValue][] = $arrayItem;
         }
 

--- a/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
+++ b/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -18,6 +19,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyIfElseWithSameContentRector extends AbstractRector
 {
+    public function __construct(
+        private readonly NodePrinterInterface $nodePrinter,
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove if/else if they have same content', [
@@ -77,10 +83,10 @@ CODE_SAMPLE
     private function isIfWithConstantReturns(If_ $if): bool
     {
         $possibleContents = [];
-        $possibleContents[] = $this->print($if->stmts);
+        $possibleContents[] = $this->nodePrinter->print($if->stmts);
 
         foreach ($if->elseifs as $elseif) {
-            $possibleContents[] = $this->print($elseif->stmts);
+            $possibleContents[] = $this->nodePrinter->print($elseif->stmts);
         }
 
         $else = $if->else;
@@ -88,7 +94,7 @@ CODE_SAMPLE
             throw new ShouldNotHappenException();
         }
 
-        $possibleContents[] = $this->print($else->stmts);
+        $possibleContents[] = $this->nodePrinter->print($else->stmts);
 
         $uniqueContents = array_unique($possibleContents);
 

--- a/rules/DowngradePhp70/Rector/String_/DowngradeGeneratedScalarTypesRector.php
+++ b/rules/DowngradePhp70/Rector/String_/DowngradeGeneratedScalarTypesRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeTraverser;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Rector\Core\PhpParser\Parser\InlineCodeParser;
 use Rector\Core\Rector\AbstractRector;
@@ -45,7 +46,8 @@ final class DowngradeGeneratedScalarTypesRector extends AbstractRector
     public function __construct(
         private readonly InlineCodeParser $inlineCodeParser,
         DowngradeScalarTypeDeclarationRector $downgradeScalarTypeDeclarationRector,
-        DowngradeVoidTypeDeclarationRector $downgradeVoidTypeDeclarationRector
+        DowngradeVoidTypeDeclarationRector $downgradeVoidTypeDeclarationRector,
+        private readonly NodePrinterInterface $nodePrinter
     ) {
         $this->phpRectors = [$downgradeScalarTypeDeclarationRector, $downgradeVoidTypeDeclarationRector];
     }
@@ -154,7 +156,7 @@ CODE_SAMPLE
     {
         $refactoredContent = '';
         foreach ($class->stmts as $classStmt) {
-            $refactoredContent .= $this->betterStandardPrinter->prettyPrint([$classStmt]) . PHP_EOL;
+            $refactoredContent .= $this->nodePrinter->prettyPrint([$classStmt]) . PHP_EOL;
         }
 
         return $refactoredContent;

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeManipulator\ClassInsertManipulator;
 use Rector\Core\Rector\AbstractRector;
@@ -32,7 +33,8 @@ final class DowngradePropertyPromotionRector extends AbstractRector
 {
     public function __construct(
         private readonly ClassInsertManipulator $classInsertManipulator,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private readonly NodePrinterInterface $nodePrinter,
     ) {
     }
 
@@ -139,7 +141,7 @@ CODE_SAMPLE
 
     private function setParamAttrGroupAsComment(Param $param): void
     {
-        $attrGroupsPrint = $this->betterStandardPrinter->print($param->attrGroups);
+        $attrGroupsPrint = $this->nodePrinter->print($param->attrGroups);
 
         $comments = $param->getAttribute(AttributeKey::COMMENTS);
         if (is_array($comments)) {

--- a/rules/Php70/Rector/Assign/ListSwapArrayOrderRector.php
+++ b/rules/Php70/Rector/Assign/ListSwapArrayOrderRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\List_;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -22,6 +23,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ListSwapArrayOrderRector extends AbstractRector implements MinPhpVersionInterface
 {
+    public function __construct(
+        private readonly NodePrinterInterface $nodePrinter
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -57,7 +63,7 @@ final class ListSwapArrayOrderRector extends AbstractRector implements MinPhpVer
             }
 
             if ($arrayItem->value instanceof ArrayDimFetch && $arrayItem->value->dim === null) {
-                $printedVariables[] = $this->print($arrayItem->value->var);
+                $printedVariables[] = $this->nodePrinter->print($arrayItem->value->var);
             } else {
                 return null;
             }

--- a/rules/Php71/Rector/TryCatch/MultiExceptionCatchRector.php
+++ b/rules/Php71/Rector/TryCatch/MultiExceptionCatchRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\TryCatch;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -21,6 +22,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MultiExceptionCatchRector extends AbstractRector implements MinPhpVersionInterface
 {
+    public function __construct(
+        private readonly NodePrinterInterface $nodePrinter
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -101,7 +107,7 @@ CODE_SAMPLE
     {
         $catchKeysByContent = [];
         foreach ($tryCatch->catches as $catch) {
-            $catchContent = $this->print($catch->stmts);
+            $catchContent = $this->nodePrinter->print($catch->stmts);
             $catchKeysByContent[$catchContent][] = $catch;
         }
 

--- a/rules/Php72/NodeFactory/AnonymousFunctionFactory.php
+++ b/rules/Php72/NodeFactory/AnonymousFunctionFactory.php
@@ -38,13 +38,13 @@ use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VoidType;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\PhpParser\Parser\SimplePhpParser;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -70,7 +70,7 @@ final class AnonymousFunctionFactory
         private readonly SimplePhpParser $simplePhpParser,
         private readonly NodeComparator $nodeComparator,
         private readonly AstResolver $astResolver,
-        private readonly BetterStandardPrinter $betterStandardPrinter,
+        private readonly NodePrinterInterface $nodePrinter,
         private readonly PrivatesAccessor $privatesAccessor
     ) {
     }
@@ -370,7 +370,7 @@ final class AnonymousFunctionFactory
             return;
         }
 
-        $printDefaultValue = $this->betterStandardPrinter->print($classMethod->params[$key]->default);
+        $printDefaultValue = $this->nodePrinter->print($classMethod->params[$key]->default);
         $param->default = new ConstFetch(new Name($printDefaultValue));
     }
 

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\MethodReflection;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
@@ -32,7 +33,8 @@ final class AddParamBasedOnParentClassMethodRector extends AbstractRector implem
 {
     public function __construct(
         private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
-        private readonly AstResolver $astResolver
+        private readonly AstResolver $astResolver,
+        private readonly NodePrinterInterface $nodePrinter,
     ) {
     }
 
@@ -206,7 +208,7 @@ CODE_SAMPLE
             $paramDefault = $parentClassMethodParam->default;
 
             if ($paramDefault instanceof Expr) {
-                $printParamDefault = $this->print($paramDefault);
+                $printParamDefault = $this->nodePrinter->print($paramDefault);
                 $paramDefault = new ConstFetch(new Name($printParamDefault));
             }
 

--- a/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
+++ b/rules/Restoration/Rector/Namespace_/CompleteImportForPartialAnnotationRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Util\StringUtils;
@@ -27,6 +28,11 @@ final class CompleteImportForPartialAnnotationRector extends AbstractRector impl
      * @var CompleteImportForPartialAnnotation[]
      */
     private array $useImportsToRestore = [];
+
+    public function __construct(
+        private readonly NodePrinterInterface $nodePrinter
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -81,7 +87,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $printedClass = $this->print($class);
+        $printedClass = $this->nodePrinter->print($class);
         $hasChanged = false;
         foreach ($this->useImportsToRestore as $useImportToRestore) {
             $annotationToSeek = '#\*\s+\@' . $useImportToRestore->getAlias() . '#';

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
@@ -19,9 +19,9 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VoidType;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
@@ -39,7 +39,7 @@ final class ReturnedNodesReturnTypeInfererTypeInferer implements ReturnTypeInfer
         private readonly TypeFactory $typeFactory,
         private readonly SplArrayFixedTypeNarrower $splArrayFixedTypeNarrower,
         private readonly AstResolver $reflectionAstResolver,
-        private readonly BetterStandardPrinter $betterStandardPrinter,
+        private readonly NodePrinterInterface $nodePrinter,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly BetterNodeFinder $betterNodeFinder,
     ) {
@@ -183,8 +183,8 @@ final class ReturnedNodesReturnTypeInfererTypeInferer implements ReturnTypeInfer
             return new MixedType();
         }
 
-        $classMethodCacheKey = $this->betterStandardPrinter->print($classMethod);
-        $functionLikeCacheKey = $this->betterStandardPrinter->print($originalFunctionLike);
+        $classMethodCacheKey = $this->nodePrinter->print($classMethod);
+        $functionLikeCacheKey = $this->nodePrinter->print($originalFunctionLike);
 
         if ($classMethodCacheKey === $functionLikeCacheKey) {
             return new MixedType();

--- a/src/Contract/PhpParser/NodePrinterInterface.php
+++ b/src/Contract/PhpParser/NodePrinterInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Contract\PhpParser;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+
+/**
+ * This contract allows to autowire custom printer implementation
+ */
+interface NodePrinterInterface
+{
+    /**
+     * @param Node|Node[]|null $node
+     */
+    public function print(Node | array | null $node): string;
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    public function prettyPrint(array $stmts): string;
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    public function prettyPrintFile(array $stmts): string;
+}

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -6,14 +6,14 @@ namespace Rector\Core\PhpParser\Comparing;
 
 use PhpParser\Node;
 use Rector\Comments\CommentRemover;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class NodeComparator
 {
     public function __construct(
         private readonly CommentRemover $commentRemover,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private readonly NodePrinterInterface $nodePrinter
     ) {
     }
 
@@ -24,7 +24,7 @@ final class NodeComparator
     public function printWithoutComments(Node | array | null $node): string
     {
         $node = $this->commentRemover->removeFromNode($node);
-        $content = $this->betterStandardPrinter->print($node);
+        $content = $this->nodePrinter->print($node);
 
         return trim($content);
     }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -14,8 +14,8 @@ use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PhpParser\Parser;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\Util\StringUtils;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 use Symplify\SmartFileSystem\SmartFileSystem;
@@ -47,7 +47,7 @@ final class InlineCodeParser
     private const ENDING_SEMI_COLON_REGEX = '#;(\s+)?$#';
 
     public function __construct(
-        private readonly BetterStandardPrinter $betterStandardPrinter,
+        private readonly NodePrinterInterface $nodePrinter,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly SimplePhpParser $simplePhpParser,
         private readonly SmartFileSystem $smartFileSystem
@@ -80,7 +80,7 @@ final class InlineCodeParser
 
         if ($expr instanceof Encapsed) {
             // remove "
-            $expr = trim($this->betterStandardPrinter->print($expr), '""');
+            $expr = trim($this->nodePrinter->print($expr), '""');
             // use \$ → $
             $expr = Strings::replace($expr, self::PRESLASHED_DOLLAR_REGEX, '$');
             // use \'{$...}\' → $...
@@ -92,7 +92,7 @@ final class InlineCodeParser
         }
 
         if ($expr instanceof Variable || $expr instanceof PropertyFetch || $expr instanceof StaticPropertyFetch) {
-            return $this->betterStandardPrinter->print($expr);
+            return $this->nodePrinter->print($expr);
         }
 
         throw new ShouldNotHappenException($expr::class . ' ' . __METHOD__);

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -27,6 +27,7 @@ use PhpParser\Node\Stmt\TraitUse;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\PrettyPrinter\Standard;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PhpParser\Printer\Whitespace\IndentCharacterDetector;
 use Rector\Core\Util\StringUtils;
@@ -37,7 +38,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  *
  * @property array<string, array{string, bool, string, null}> $insertionMap
  */
-final class BetterStandardPrinter extends Standard
+final class BetterStandardPrinter extends Standard implements NodePrinterInterface
 {
     /**
      * @var string

--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -7,7 +7,6 @@ namespace Rector\Core\PhpParser\Printer;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
-use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\ValueObject\Application\File;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -43,7 +42,11 @@ final class FormatPerservingPrinter
     {
         $newStmts = $this->resolveNewStmts($file);
 
-        return $this->betterStandardPrinter->printFormatPreserving($newStmts, $file->getOldStmts(), $file->getOldTokens());
+        return $this->betterStandardPrinter->printFormatPreserving(
+            $newStmts,
+            $file->getOldStmts(),
+            $file->getOldTokens()
+        );
     }
 
     public function printParsedStmstAndTokens(File $file): string

--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -7,6 +7,7 @@ namespace Rector\Core\PhpParser\Printer;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\ValueObject\Application\File;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -42,11 +43,7 @@ final class FormatPerservingPrinter
     {
         $newStmts = $this->resolveNewStmts($file);
 
-        return $this->betterStandardPrinter->printFormatPreserving(
-            $newStmts,
-            $file->getOldStmts(),
-            $file->getOldTokens()
-        );
+        return $this->betterStandardPrinter->printFormatPreserving($newStmts, $file->getOldStmts(), $file->getOldTokens());
     }
 
     public function printParsedStmstAndTokens(File $file): string

--- a/src/PhpParser/Printer/NodesWithFileDestinationPrinter.php
+++ b/src/PhpParser/Printer/NodesWithFileDestinationPrinter.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\Printer;
 
+use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\FileSystemRector\Contract\FileWithNodesInterface;
 use Rector\PostRector\Application\PostFileProcessor;
 
 final class NodesWithFileDestinationPrinter
 {
     public function __construct(
-        private readonly BetterStandardPrinter $betterStandardPrinter,
+        private readonly NodePrinterInterface $nodePrinter,
         private readonly PostFileProcessor $postFileProcessor
     ) {
     }
@@ -18,6 +19,6 @@ final class NodesWithFileDestinationPrinter
     public function printNodesWithFileDestination(FileWithNodesInterface $fileWithNodes): string
     {
         $nodes = $this->postFileProcessor->traverse($fileWithNodes->getNodes());
-        return $this->betterStandardPrinter->prettyPrintFile($nodes);
+        return $this->nodePrinter->prettyPrintFile($nodes);
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -31,7 +31,6 @@ use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\ProcessAnalyzer\RectifiedAnalyzer;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -87,8 +86,6 @@ CODE_SAMPLE;
 
     protected NodeTypeResolver $nodeTypeResolver;
 
-    protected BetterStandardPrinter $betterStandardPrinter;
-
     protected RemovedAndAddedFilesCollector $removedAndAddedFilesCollector;
 
     protected ParameterProvider $parameterProvider;
@@ -142,7 +139,6 @@ CODE_SAMPLE;
         NodesToAddCollector $nodesToAddCollector,
         NodeRemover $nodeRemover,
         RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
-        BetterStandardPrinter $betterStandardPrinter,
         NodeNameResolver $nodeNameResolver,
         NodeTypeResolver $nodeTypeResolver,
         SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
@@ -166,7 +162,6 @@ CODE_SAMPLE;
         $this->nodesToAddCollector = $nodesToAddCollector;
         $this->nodeRemover = $nodeRemover;
         $this->removedAndAddedFilesCollector = $removedAndAddedFilesCollector;
-        $this->betterStandardPrinter = $betterStandardPrinter;
         $this->nodeNameResolver = $nodeNameResolver;
         $this->nodeTypeResolver = $nodeTypeResolver;
         $this->simpleCallableNodeTraverser = $simpleCallableNodeTraverser;
@@ -335,14 +330,6 @@ CODE_SAMPLE;
     protected function traverseNodesWithCallable(Node | array $nodes, callable $callable): void
     {
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, $callable);
-    }
-
-    /**
-     * @param Node|Node[]|null $node
-     */
-    protected function print(Node | array | null $node): string
-    {
-        return $this->betterStandardPrinter->print($node);
     }
 
     protected function mirrorComments(Node $newNode, Node $oldNode): void


### PR DESCRIPTION
The `AbstractRector` contains few service that help to re-use often used features via method helper.
Sometimes the service is used only in few rules, yet is still injected in all of them.

One of such services is `BetterStandardPrinter`, a custom printer that simply prints nodes.
This PR removes these methods and services and promotes direct DI injection in case you need it. Instead of `BetterStandardPrinter`, inject `NodePrinterInterface` that can be replaced in case of custom needs.

<br>

How to upgrade your custom rules?

```diff
+public function __construct(
+    private NodePrinterInterface $nodePrinter
+) {}

// ...

-$this->print(...);
+$this->nodePrinter->print(...);
```