### PR TITLE
[DeadCode] Skip parent Node is return on RemoveEmptyMethodCallRector

### DIFF
--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector/Fixture/skip_parent_is_return.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector/Fixture/skip_parent_is_return.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector\Source\EmptyMethod;
+
+function run()
+{
+    $obj = new EmptyMethod();
+    return $obj->run();
+}

--- a/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
@@ -116,6 +116,10 @@ CODE_SAMPLE
             return $this->processArrowFunction($parent, $node);
         }
 
+        if (! $parent instanceof Expression) {
+            return null;
+        }
+
         $this->removeNode($node);
 
         return $node;


### PR DESCRIPTION
Given the following code:

```php
function run()
{
    $obj = new EmptyMethod();
    return $obj->run();
}
```

cause error:

```bash
There was 1 error:

1) Rector\Tests\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector\RemoveEmptyMethodCallRectorTest::test with data set #13 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
LogicException: leaveNode() returned invalid value of type integer
```

It should be skipped.

Fixes https://github.com/rectorphp/rector/issues/7104