### PR TITLE
[Feature] Add 3 new rectors for fixing incorrect null type in @var, @param and @return

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 507 Rules Overview
+# 510 Rules Overview
 
 <br>
 
@@ -88,7 +88,7 @@
 
 - [Transform](#transform) (35)
 
-- [TypeDeclaration](#typedeclaration) (23)
+- [TypeDeclaration](#typedeclaration) (26)
 
 - [Visibility](#visibility) (3)
 
@@ -11563,6 +11563,30 @@ Change null in argument, that is now not nullable anymore
 
 <br>
 
+### ParamAnnotationIncorrectNullableRector
+
+Add or remove null type from `@param` phpdoc typehint based on php parameter type declaration
+
+- class: [`Rector\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector`](../rules/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector.php)
+
+```diff
+ final class SomeClass
+ {
+     /**
+-     * @param \DateTime[] $dateTimes
++     * @param \DateTime[]|null $dateTimes
+      */
+     public function setDateTimes(?array $dateTimes): self
+     {
+         $this->dateTimes = $dateTimes;
+
+         return $this;
+     }
+ }
+```
+
+<br>
+
 ### ParamTypeByMethodCallTypeRector
 
 Change param type based on passed method call type
@@ -11696,6 +11720,28 @@ Add `@var` to properties that are missing it
      public function run()
      {
          $this->value = 123;
+     }
+ }
+```
+
+<br>
+
+### ReturnAnnotationIncorrectNullableRector
+
+Add or remove null type from `@return` phpdoc typehint based on php return type declaration
+
+- class: [`Rector\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector`](../rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php)
+
+```diff
+ final class SomeClass
+ {
+     /**
+-     * @return \DateTime[]
++     * @return \DateTime[]|null
+      */
+     public function getDateTimes(): ?array
+     {
+         return $this->dateTimes;
      }
  }
 ```
@@ -11866,6 +11912,25 @@ Complete property type based on getter strict types
      {
          return $this->name;
      }
+ }
+```
+
+<br>
+
+### VarAnnotationIncorrectNullableRector
+
+Add or remove null type from `@var` phpdoc typehint based on php property type declaration
+
+- class: [`Rector\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector`](../rules/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector.php)
+
+```diff
+ final class SomeClass
+ {
+     /**
+-     * @var DateTime[]
++     * @var DateTime[]|null
+      */
+     private ?array $dateTimes;
  }
 ```
 

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-complex.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-complex.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationComplex
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @param \DateTime[] $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationComplex
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null-on-scalar.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null-on-scalar.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @param string|null $text
+     */
+    public function setDateTimes(string $text): self
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @param string $text
+     */
+    public function setDateTimes(string $text): self
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null-with-non-null-default-value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null-with-non-null-default-value.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullWithNonNullDefaultValue
+{
+    /**
+     * @param bool|null $flag
+     */
+    public function setFlag(bool $flag = true): self
+    {
+        $this->flag = $flag;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullWithNonNullDefaultValue
+{
+    /**
+     * @param bool $flag
+     */
+    public function setFlag(bool $flag = true): self
+    {
+        $this->flag = $flag;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null-with-null-default-value-from-const.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null-with-null-default-value-from-const.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullWithNonNullDefaultValueFromConst
+{
+    private const FLAG_DEFAULT_VALUE = true;
+
+    /**
+     * @param bool|null $flag
+     */
+    public function setFlag(bool $flag = self::FLAG_DEFAULT_VALUE): self
+    {
+        $this->flag = $flag;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullWithNonNullDefaultValueFromConst
+{
+    private const FLAG_DEFAULT_VALUE = true;
+
+    /**
+     * @param bool $flag
+     */
+    public function setFlag(bool $flag = self::FLAG_DEFAULT_VALUE): self
+    {
+        $this->flag = $flag;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @param \DateTime[] $dateTimes
+     */
+    public function setDateTimes(array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-multiple.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-multiple.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullMultiple
+{
+    /**
+     * @param \DateTime[] $dateTimes
+     * @param array<\DateTimeImmutable> $immutableDateTimes
+     * @param array<\DateTimeInterface>|null $dateTimeInterfaces
+     */
+    public function setDateTimes(?array $dateTimes, ?array $immutableDateTimes, ?array $dateTimeInterfaces): self
+    {
+        $this->dateTimes = $dateTimes;
+        $this->immutableDateTimes = $immutableDateTimes;
+        $this->dateTimeInterfaces = $dateTimeInterfaces;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullMultiple
+{
+    /**
+     * @param \DateTime[]|null $dateTimes
+     * @param \DateTimeImmutable[]|null $immutableDateTimes
+     * @param array<\DateTimeInterface>|null $dateTimeInterfaces
+     */
+    public function setDateTimes(?array $dateTimes, ?array $immutableDateTimes, ?array $dateTimeInterfaces): self
+    {
+        $this->dateTimes = $dateTimes;
+        $this->immutableDateTimes = $immutableDateTimes;
+        $this->dateTimeInterfaces = $dateTimeInterfaces;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-with-default-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-with-default-null.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullWithDefaultNull
+{
+    /**
+     * @param \DateTime[] $dateTimes
+     */
+    public function setDateTimes(array $dateTimes = null): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullWithDefaultNull
+{
+    /**
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(array $dateTimes = null): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-with-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-with-generic-syntax.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @param array<int,\DateTime> $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-with-nested-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null-with-nested-generic-syntax.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @param array<int, array<string, \DateTime>> $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @param array<int, array<string, \DateTime>>|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-is-missing-null.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNull
+{
+    /**
+     * @param \DateTime[] $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIsMissingNull
+{
+    /**
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-missing-null-with-non-null-default-value-from-const.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-annotation-missing-null-with-non-null-default-value-from-const.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullWithNullDefaultValueFromConst
+{
+    private const FLAG_DEFAULT_VALUE = null;
+
+    /**
+     * @param bool $flag
+     */
+    public function setFlag(bool $flag = self::FLAG_DEFAULT_VALUE): self
+    {
+        $this->flag = $flag;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullWithNullDefaultValueFromConst
+{
+    private const FLAG_DEFAULT_VALUE = null;
+
+    /**
+     * @param bool|null $flag
+     */
+    public function setFlag(bool $flag = self::FLAG_DEFAULT_VALUE): self
+    {
+        $this->flag = $flag;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-union-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-union-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @param \DateTime[]|\DateTimeImmutable[]|null $dateTimes
+     */
+    public function setDateTimes(array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @param \DateTime[]|\DateTimeImmutable[] $dateTimes
+     */
+    public function setDateTimes(array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-union-annotation-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/param-union-annotation-missing-null.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamUnionAnnotationMissingNull
+{
+    /**
+     * @param \DateTime[]|\DateTimeImmutable[] $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamUnionAnnotationMissingNull
+{
+    /**
+     * @param \DateTime[]|\DateTimeImmutable[]|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-broken-param-annotation.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-broken-param-annotation.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipBrokenParamAnnotation
+{
+    /** @param 'week'|'month'|'year' $dateTimes */
+    public function setDateTimes(string $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-complex-on-phpdoc-parser-failure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-complex-on-phpdoc-parser-failure.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipParamAnnotationComplexOnPhpdocParserFailure
+{
+    /**
+     * Parser fails to interpret annotations when there is no comma after AppAssert\Country in Assert\All, this is likely a bug in rector or one
+     * of its dependencies. But we will skip these cases safely, so no worries.
+     *
+     * @OA\Property(property="dateTimes[]", default="null")
+     * @Serializer\Groups({"export"})
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country
+     * })
+     * @Serializer\VirtualProperty
+     * @param \DateTime[] $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-when-it-already-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-when-it-already-includes-null.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipParamAnnotationWhenItAlreadyIncludesNull
+{
+    /**
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-when-property-has-no-type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-when-property-has-no-type.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipParamAnnotationWhenPropertyHasNoType
+{
+    /**
+     * @param \DateTime[] $dateTimes
+     */
+    public function setDateTimes($dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-with-default-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-with-default-null.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipParamAnnotationWithDefaultNull
+{
+    /**
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(array $dateTimes = null): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipParamAnnotationWithGenericSyntaxWhenNullIsNotMissing
+{
+    /**
+     * @param array<int,\DateTime>|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-with-nullable-default-non-null-value.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-param-annotation-with-nullable-default-non-null-value.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipParamAnnotationWithDefaultNull
+{
+    /**
+     * @param bool|null $flag
+     */
+    public function setDateTimes(?bool $flag = true): self
+    {
+        $this->flag = $flag;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-when-default-param-value-is-null-as-string.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/Fixture/skip-when-default-param-value-is-null-as-string.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipWhenDefaultParamValueIsNullAsString
+{
+    /**
+     * @param string $text
+     */
+    public function setDateTimes(string $text = 'null'): self
+    {
+        $this->$text = $text;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/ParamAnnotationIncorrectNullableRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/ParamAnnotationIncorrectNullableRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ParamAnnotationIncorrectNullableRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/config/config.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector/config/config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector;
+
+use Rector\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ParamAnnotationIncorrectNullableRector::class);
+};

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-already-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-already-includes-null.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationAlreadyIncludesNull
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-complex.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-complex.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationComplex
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationComplex
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null-on-scalar.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null-on-scalar.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @return string|null
+     */
+    public function getDateTimes(): array
+    {
+        return $this->text;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @return string
+     */
+    public function getDateTimes(): array
+    {
+        return $this->text;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-generic-syntax.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @return array<int,\DateTime>
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-nested-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-nested-generic-syntax.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @return array<int, array<string, \DateTime>>
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @return array<int, array<string, \DateTime>>|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNull
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNull
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]|null
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-missing-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationMissingNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationMissingNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-broken-return-annotation.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-broken-return-annotation.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipBrokenReturnAnnotation
+{
+    /** @return # */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-complex-on-phpdoc-parser-failure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-complex-on-phpdoc-parser-failure.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationComplexOnPhpdocParserFailure
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country
+     * })
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-no-type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-no-type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationWhenMethodHasNoReturnType
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes()
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-non-nullable-type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-non-nullable-type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationWhenPropertyHasNonNullableType
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationWithGenericSyntaxWhenNullIsNotMissing
+{
+    /**
+     * @return  array<int,\DateTime>|null $dateTimes
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/ReturnAnnotationIncorrectNullableRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/ReturnAnnotationIncorrectNullableRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ReturnAnnotationIncorrectNullableRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/config/config.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/config/config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector;
+
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ReturnAnnotationIncorrectNullableRector::class);
+};

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-broken-var-annotation.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-broken-var-annotation.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipBrokenVarAnnotation
+{
+    /** @phpstan-var 'week'|'month'|'year' */
+    private ?string $interval;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-complex-on-phpdoc-parser-failure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-complex-on-phpdoc-parser-failure.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipVarAnnotationComplexOnPhpdocParserFailure
+{
+    /**
+     * Parser fails to interpret annotations when there is no comma after AppAssert\Country in Assert\All, this is likely a bug in rector or one
+     * of its dependencies. But we will skip these cases safely, so no worries.
+     *
+     * @OA\Property(property="countryCodes[]", default="null", example="CZ")
+     * @Serializer\Groups({"export"})
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country
+     * })
+     * @Serializer\Type("array<string>")
+     * @var string[]
+     */
+    private ?array $countryCodes = null;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-when-it-already-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-when-it-already-includes-null.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipVarAnnotationWhenItAlreadyIncludesNull
+{
+    /**
+     * @var \DateTime[]|null
+     */
+    private ?array $dateTimes;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-when-property-has-no-type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-when-property-has-no-type.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipVarAnnotationWhenPropertyHasNoType
+{
+    /**
+     * @var \DateTime[]
+     */
+    private $dateTimes;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/skip-var-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipVarAnnotationWithGenericSyntaxWhenNullIsNotMissing
+{
+    /**
+     * @var array<int,\DateTime>|null
+     */
+    private ?array $dateTimes;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-complex.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-complex.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationComplex
+{
+    /**
+     * @OA\Property(property="countryCodes[]", default="null", example="CZ")
+     * @Serializer\Groups({"export"})
+     * @Serializer\Type("array<string>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @var string[]
+     */
+    private ?array $countryCodes = null;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationComplex
+{
+    /**
+     * @OA\Property(property="countryCodes[]", default="null", example="CZ")
+     * @Serializer\Groups({"export"})
+     * @Serializer\Type("array<string>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @var string[]|null
+     */
+    private ?array $countryCodes = null;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-incorrectly-includes-null-on-scalar.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-incorrectly-includes-null-on-scalar.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @var string|null
+     */
+    private string $text;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @var string
+     */
+    private string $text;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @var \DateTime[]|null
+     */
+    private array $dateTimes;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @var \DateTime[]
+     */
+    private array $dateTimes;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-is-missing-null-with-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-is-missing-null-with-generic-syntax.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @var array<int,\DateTime>
+     */
+    private ?array $dateTimes;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @var \DateTime[]|null
+     */
+    private ?array $dateTimes;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-is-missing-null-with-nested-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-is-missing-null-with-nested-generic-syntax.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @var array<int, array<string, \DateTime>>
+     */
+    private ?array $dateTimes;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @var array<int, array<string, \DateTime>>|null
+     */
+    private ?array $dateTimes;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-is-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-annotation-is-missing-null.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIsMissingNull
+{
+    /**
+     * @var \DateTime[]
+     */
+    private ?array $dateTimes;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarAnnotationIsMissingNull
+{
+    /**
+     * @var \DateTime[]|null
+     */
+    private ?array $dateTimes;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-union-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-union-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @var \DateTime[]|\DateTimeImmutable[]|null
+     */
+    private array $dateTimes;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @var \DateTime[]|\DateTimeImmutable[]
+     */
+    private array $dateTimes;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-union-annotation-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/var-union-annotation-missing-null.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarUnionAnnotationMissingNull
+{
+    /**
+     * @var \DateTime[]|\DateTimeImmutable[]
+     */
+    private ?array $dateTimes;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class VarUnionAnnotationMissingNull
+{
+    /**
+     * @var \DateTime[]|\DateTimeImmutable[]|null
+     */
+    private ?array $dateTimes;
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/VarAnnotationIncorrectNullableRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/VarAnnotationIncorrectNullableRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class VarAnnotationIncorrectNullableRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/config/config.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/config/config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\Rector\VarAnnotationMissingNullableRectorTest;
+
+use Rector\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(VarAnnotationIncorrectNullableRector::class);
+};

--- a/rules/TypeDeclaration/Guard/PhpDocNestedAnnotationGuard.php
+++ b/rules/TypeDeclaration/Guard/PhpDocNestedAnnotationGuard.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Guard;
+
+use Nette\Utils\Strings;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class PhpDocNestedAnnotationGuard
+{
+    /**
+     * Regex is used to count annotations including nested annotations
+     *
+     * @see https://regex101.com/r/G7wODT/1
+     */
+    private const SIMPLE_ANNOTATION_REGEX = '/@[A-z]+\(?/i';
+
+    private PhpDocInfoFactory $phpDocInfoFactory;
+
+    public function __construct(PhpDocInfoFactory $phpDocInfoFactory)
+    {
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
+    }
+
+    /**
+     * Check if rector accidentally skipped annotation during parsing which it should not have (this bug is likely related to parsing of annotations
+     * in phpstan / rector)
+     */
+    public function isPhpDocCommentCorrectlyParsed(\PhpParser\Node $node): bool
+    {
+        $comments = $node->getAttribute(AttributeKey::COMMENTS, []);
+        if (count($comments) !== 1) {
+            return true;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
+        /** @var \PhpParser\Comment\Doc $phpDoc */
+        $phpDoc = $comments[0];
+        $originalPhpDocText = $phpDoc->getText();
+
+        /**
+         * This is a safeguard to skip cases where the PhpStan / Rector phpdoc parser parses annotations incorrectly (ie.: nested annotations)
+         */
+        $parsedPhpDocText = (string) $phpDocInfo->getPhpDocNode();
+
+        return ! $this->hasAnnotationCountChanged($originalPhpDocText, $parsedPhpDocText);
+    }
+
+    public function hasAnnotationCountChanged(string $originalPhpDocText, string $updatedPhpDocText): bool
+    {
+        $originalAnnotationCount = count(Strings::matchAll($originalPhpDocText, self::SIMPLE_ANNOTATION_REGEX));
+        $reconstructedAnnotationCount = count(Strings::matchAll($updatedPhpDocText, self::SIMPLE_ANNOTATION_REGEX));
+
+        return $originalAnnotationCount !== $reconstructedAnnotationCount;
+    }
+}

--- a/rules/TypeDeclaration/Helper/PhpDocNullableTypeHelper.php
+++ b/rules/TypeDeclaration/Helper/PhpDocNullableTypeHelper.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Helper;
+
+use function count;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Param;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\TypeAnalyzer\UnionTypeAnalyzer;
+
+class PhpDocNullableTypeHelper
+{
+    private UnionTypeAnalyzer $unionTypeAnalyzer;
+
+    private StaticTypeMapper $staticTypeMapper;
+
+    private ValueResolver $valueResolver;
+
+    public function __construct(
+        UnionTypeAnalyzer $unionTypeAnalyzer,
+        StaticTypeMapper $staticTypeMapper,
+        ValueResolver $valueResolver,
+    ) {
+        $this->unionTypeAnalyzer = $unionTypeAnalyzer;
+        $this->staticTypeMapper = $staticTypeMapper;
+        $this->valueResolver = $valueResolver;
+    }
+
+    /**
+     * @return \PHPStan\Type\Type|null Returns null if it was not possible to resolve new php doc type or if update is not required
+     */
+    public function resolveUpdatedPhpDocTypeFromPhpDocTypeAndPhpParserType(
+        Type $phpDocType,
+        Type $phpParserType
+    ): ?Type {
+        return $this->resolveUpdatedPhpDocTypeFromPhpDocTypeAndPhpParserTypeNullInfo(
+            $phpDocType,
+            $this->isParserTypeContainingNullType($phpParserType)
+        );
+    }
+
+    /**
+     * @return \PHPStan\Type\Type|null Returns null if it was not possible to resolve new php doc param type or if update is not required
+     */
+    public function resolveUpdatedPhpDocTypeFromPhpDocTypeAndParamNode(Type $phpDocType, Param $param): ?Type
+    {
+        if ($param->type === null) {
+            return null;
+        }
+
+        $phpParserType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+
+        if ($phpParserType instanceof UnionType) {
+            $isPhpParserTypeContainingNullType = $this->unionTypeAnalyzer->isUnionTypeContainingNullType(
+                $phpParserType
+            );
+        } elseif ($param->default !== null) {
+            $value = $this->valueResolver->getValue($param->default);
+            $isPhpParserTypeContainingNullType = $value === null || ($param->default instanceof ConstFetch && $value === 'null');
+        } else {
+            $isPhpParserTypeContainingNullType = false;
+        }
+
+        return $this->resolveUpdatedPhpDocTypeFromPhpDocTypeAndPhpParserTypeNullInfo(
+            $phpDocType,
+            $isPhpParserTypeContainingNullType
+        );
+    }
+
+    private function isItRequiredToRemoveOrAddNullTypeToUnion(
+        bool $phpDocTypeContainsNullType,
+        bool $phpParserTypeContainsNullType,
+    ): bool {
+        return ($phpParserTypeContainsNullType && ! $phpDocTypeContainsNullType) || (! $phpParserTypeContainsNullType && $phpDocTypeContainsNullType);
+    }
+
+    /**
+     * @param \PHPStan\Type\Type[] $updatedDocTypes
+     */
+    private function composeUpdatedPhpDocType(array $updatedDocTypes): mixed
+    {
+        if (count($updatedDocTypes) === 1) {
+            $updatedPhpDocType = $updatedDocTypes[0];
+        } else {
+            try {
+                $updatedPhpDocType = new UnionType($updatedDocTypes);
+            } catch (ShouldNotHappenException $exception) {
+                return null;
+            }
+        }
+
+        return $updatedPhpDocType;
+    }
+
+    private function isParserTypeContainingNullType(Type $phpParserType): bool
+    {
+        $phpParserTypeContainsNullType = false;
+
+        if ($phpParserType instanceof UnionType) {
+            $phpParserTypeContainsNullType = $this->unionTypeAnalyzer->isUnionTypeContainingNullType($phpParserType);
+        }
+
+        return $phpParserTypeContainsNullType;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    private function resolveUpdatedPhpDocTypeFromPhpDocTypeAndPhpParserTypeNullInfo(
+        Type $phpDocType,
+        bool $isPhpParserTypeContainingNullType
+    ): mixed {
+        /** @var array<\PHPStan\Type\NullType|\PHPStan\Type\UnionType> $updatedDocTypes */
+        $updatedDocTypes = [];
+        $phpDocTypeContainsNullType = false;
+        if ($phpDocType instanceof UnionType) {
+            $phpDocTypeContainsNullType = $this->unionTypeAnalyzer->isUnionTypeContainingNullType($phpDocType);
+            foreach ($phpDocType->getTypes() as $subType) {
+                if ($subType instanceof NullType) {
+                    continue;
+                }
+                $updatedDocTypes[] = $subType;
+            }
+        } else {
+            $updatedDocTypes[] = $phpDocType;
+        }
+
+        if (! $this->isItRequiredToRemoveOrAddNullTypeToUnion(
+            $phpDocTypeContainsNullType,
+            $isPhpParserTypeContainingNullType
+        )) {
+            return null;
+        }
+
+        if ($isPhpParserTypeContainingNullType) {
+            $updatedDocTypes[] = new NullType();
+        }
+
+        return $this->composeUpdatedPhpDocType($updatedDocTypes);
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamAnnotationIncorrectNullableRector.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
+use Rector\TypeDeclaration\Guard\PhpDocNestedAnnotationGuard;
+use Rector\TypeDeclaration\Helper\PhpDocNullableTypeHelper;
+use Rector\TypeDeclaration\PhpDocParser\ParamPhpDocNodeFactory;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamAnnotationIncorrectNullableRector\ParamAnnotationIncorrectNullableRectorTest
+ */
+final class ParamAnnotationIncorrectNullableRector extends AbstractRector
+{
+    private TypeComparator $typeComparator;
+
+    private PhpDocNullableTypeHelper $phpDocNullableTypeHelper;
+
+    private PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard;
+
+    private ParamPhpDocNodeFactory $paramPhpDocNodeFactory;
+
+    public function __construct(
+        TypeComparator $typeComparator,
+        PhpDocNullableTypeHelper $phpDocNullableTypeHelper,
+        PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard,
+        ParamPhpDocNodeFactory $paramPhpDocNodeFactory,
+    ) {
+        $this->typeComparator = $typeComparator;
+        $this->phpDocNullableTypeHelper = $phpDocNullableTypeHelper;
+        $this->phpDocNestedAnnotationGuard = $phpDocNestedAnnotationGuard;
+        $this->paramPhpDocNodeFactory = $paramPhpDocNodeFactory;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add or remove null type from @param phpdoc typehint based on php parameter type declaration',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @param \DateTime[] $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @param \DateTime[]|null $dateTimes
+     */
+    public function setDateTimes(?array $dateTimes): self
+    {
+        $this->dateTimes = $dateTimes;
+
+        return $this;
+    }
+}
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(\PhpParser\Node $node): ?\PhpParser\Node
+    {
+        if ($node->getParams() === []) {
+            return null;
+        }
+
+        if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
+            return null;
+        }
+
+        if (! $this->phpDocNestedAnnotationGuard->isPhpDocCommentCorrectlyParsed($node)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $docNode = $phpDocInfo->getPhpDocNode();
+        $wasAnyParamTagUpdated = $this->wasUpdateOfParamTagsRequired($docNode, $node, $phpDocInfo);
+
+        if (! $wasAnyParamTagUpdated) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function matchParamByName(string $desiredParamName, ClassMethod $functionLike): ?Param
+    {
+        foreach ($functionLike->getParams() as $param) {
+            $paramName = $this->nodeNameResolver->getName($param);
+            if ('$' . $paramName !== $desiredParamName) {
+                continue;
+            }
+
+            return $param;
+        }
+
+        return null;
+    }
+
+    private function changeParamType(PhpDocInfo $phpDocInfo, Type $newType, Param $param, string $paramName): void
+    {
+        // better skip, could crash hard
+        if ($phpDocInfo->hasInvalidTag('@param')) {
+            return;
+        }
+
+        $phpDocType = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode(
+            $newType,
+            \Rector\PHPStanStaticTypeMapper\Enum\TypeKind::PARAM()
+        );
+        $paramTagValueNode = $phpDocInfo->getParamTagValueByName($paramName);
+        // override existing type
+        if ($paramTagValueNode !== null) {
+            // already set
+            $currentType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
+                $paramTagValueNode->type,
+                $param
+            );
+            if ($this->typeComparator->areTypesEqual($currentType, $newType)) {
+                return;
+            }
+            $paramTagValueNode->type = $phpDocType;
+        } else {
+            $paramTagValueNode = $this->paramPhpDocNodeFactory->create($phpDocType, $param);
+            $phpDocInfo->addTagValueNode($paramTagValueNode);
+        }
+    }
+
+    /**
+     * This method performs update of param tags if required - the name is a bit forced because of its return type :/
+     */
+    private function wasUpdateOfParamTagsRequired(PhpDocNode $docNode, ClassMethod $node, PhpDocInfo $phpDocInfo): bool
+    {
+        $paramTagValueNodes = $docNode->getParamTagValues();
+        $paramTagWasUpdated = false;
+        foreach ($paramTagValueNodes as $paramTagValueNode) {
+            if ($paramTagValueNode->type === null) {
+                continue;
+            }
+
+            $param = $this->matchParamByName($paramTagValueNode->parameterName, $node);
+            if (! $param instanceof Param) {
+                continue;
+            }
+
+            $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($paramTagValueNode->type, $node);
+            $updatedPhpDocType = $this->phpDocNullableTypeHelper->resolveUpdatedPhpDocTypeFromPhpDocTypeAndParamNode(
+                $docType,
+                $param
+            );
+
+            if ($updatedPhpDocType === null) {
+                continue;
+            }
+
+            $this->changeParamType($phpDocInfo, $updatedPhpDocType, $param, $paramTagValueNode->parameterName);
+            $paramTagWasUpdated = true;
+        }
+
+        return $paramTagWasUpdated;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Guard\PhpDocNestedAnnotationGuard;
+use Rector\TypeDeclaration\Helper\PhpDocNullableTypeHelper;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\ReturnAnnotationIncorrectNullableRectorTest
+ */
+final class ReturnAnnotationIncorrectNullableRector extends AbstractRector
+{
+    private PhpDocTypeChanger $phpDocTypeChanger;
+
+    private PhpDocNullableTypeHelper $phpDocNullableTypeHelper;
+
+    private PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard;
+
+    public function __construct(
+        PhpDocTypeChanger $phpDocTypeChanger,
+        PhpDocNullableTypeHelper $phpDocNullableTypeHelper,
+        PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard,
+    ) {
+        $this->phpDocTypeChanger = $phpDocTypeChanger;
+        $this->phpDocNullableTypeHelper = $phpDocNullableTypeHelper;
+        $this->phpDocNestedAnnotationGuard = $phpDocNestedAnnotationGuard;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add or remove null type from @return phpdoc typehint based on php return type declaration',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(\PhpParser\Node $node): ?\PhpParser\Node
+    {
+        $returnType = $node->getReturnType();
+
+        if ($returnType === null) {
+            return null;
+        }
+
+        if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
+            return null;
+        }
+
+        if (! $this->phpDocNestedAnnotationGuard->isPhpDocCommentCorrectlyParsed($node)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if ($returnTagValueNode === null) {
+            return null;
+        }
+
+        $phpStanDocTypeNode = $returnTagValueNode->type;
+        $phpParserType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnType);
+        $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($phpStanDocTypeNode, $node);
+
+        $updatedPhpDocType = $this->phpDocNullableTypeHelper->resolveUpdatedPhpDocTypeFromPhpDocTypeAndPhpParserType(
+            $docType,
+            $phpParserType
+        );
+
+        if ($updatedPhpDocType === null) {
+            return null;
+        }
+
+        $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $updatedPhpDocType);
+
+        return $node;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Property;
+
+use function count;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\MixedType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Guard\PhpDocNestedAnnotationGuard;
+use Rector\TypeDeclaration\Helper\PhpDocNullableTypeHelper;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\VarAnnotationIncorrectNullableRectorTest
+ */
+final class VarAnnotationIncorrectNullableRector extends AbstractRector
+{
+    private PhpDocTypeChanger $phpDocTypeChanger;
+
+    private PhpDocNullableTypeHelper $phpDocNullableTypeHelper;
+
+    private PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard;
+
+    public function __construct(
+        PhpDocTypeChanger $phpDocTypeChanger,
+        PhpDocNullableTypeHelper $phpDocNullableTypeHelper,
+        PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard
+    ) {
+        $this->phpDocTypeChanger = $phpDocTypeChanger;
+        $this->phpDocNullableTypeHelper = $phpDocNullableTypeHelper;
+        $this->phpDocNestedAnnotationGuard = $phpDocNestedAnnotationGuard;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add or remove null type from @var phpdoc typehint based on php property type declaration',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @var DateTime[]
+     */
+    private ?array $dateTimes;
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @var DateTime[]|null
+     */
+    private ?array $dateTimes;
+}
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(\PhpParser\Node $node): ?\PhpParser\Node
+    {
+        if (count($node->props) !== 1) {
+            return null;
+        }
+
+        if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
+            return null;
+        }
+
+        if (! $this->phpDocNestedAnnotationGuard->isPhpDocCommentCorrectlyParsed($node)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        if (! $this->isVarDocAlreadySet($phpDocInfo)) {
+            return null;
+        }
+
+        if ($node->type === null) {
+            return null;
+        }
+
+        $phpParserType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->type);
+
+        $varTagValueNode = $phpDocInfo->getVarTagValueNode();
+        if ($varTagValueNode === null || $varTagValueNode->type === null) {
+            return null;
+        }
+
+        $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($varTagValueNode->type, $node);
+
+        $updatedPhpDocType = $this->phpDocNullableTypeHelper->resolveUpdatedPhpDocTypeFromPhpDocTypeAndPhpParserType(
+            $docType,
+            $phpParserType
+        );
+
+        if ($updatedPhpDocType === null) {
+            return null;
+        }
+
+        $this->phpDocTypeChanger->changeVarType($phpDocInfo, $updatedPhpDocType);
+
+        return $node;
+    }
+
+    private function isVarDocAlreadySet(PhpDocInfo $phpDocInfo): bool
+    {
+        foreach (['@var', '@phpstan-var', '@psalm-var'] as $tagName) {
+            $varType = $phpDocInfo->getVarType($tagName);
+            if (! $varType instanceof MixedType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/rules/TypeDeclaration/TypeAnalyzer/UnionTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/UnionTypeAnalyzer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\TypeAnalyzer;
+
+use PHPStan\Type\NullType;
+use PHPStan\Type\UnionType;
+
+final class UnionTypeAnalyzer
+{
+    public function isUnionTypeContainingNullType(UnionType $propertyType): bool
+    {
+        foreach ($propertyType->getTypes() as $subType) {
+            if ($subType instanceof NullType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Hi, here are 3 rectors which I wanted to share. I have added them to the `TypeDeclaration` directory but if there is a better place please let me know.

- **ParamAnnotationIncorrectNullableRector**
  - Adds or removes `null` type from `@param` phpdoc typehint based on php parameter type declaration
- **ReturnAnnotationIncorrectNullableRector**
  - Adds or removes `null` type from `@return` phpdoc typehint based on php return type declaration
- **VarAnnotationIncorrectNullableRector**
  - Adds or removes `null` type from `@var` phpdoc typehint based on php property type declaration

Some background info: Basically we had a lot of these problems in our project where the phpdocs were incorrect, ie the php type was nullable, for example `?array` but the php doc said it was simply `SomeObject[]`, not `SomeObject[]|null` as it should. Or vice versa, the phpdoc stated it was `SomeObject[]|null` but it was actually non nullable `array` type. Among other things, this was then confusing phpstan and leading to all sorts of problems. These 3 rector rules solved this problem for us.