### PR TITLE
[TypeDeclaration] Make TypedPropertyFromAssignsRector configurable with INLINE_PUBLIC

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -110,7 +110,7 @@ use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ArgumentAdderRector::class)
@@ -151,7 +151,7 @@ use Rector\Arguments\Rector\FuncCall\FunctionArgumentDefaultValueReplacerRector;
 use Rector\Arguments\ValueObject\ReplaceFuncCallArgumentDefaultValue;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(FunctionArgumentDefaultValueReplacerRector::class)
@@ -181,7 +181,7 @@ use Rector\Arguments\Rector\MethodCall\RemoveMethodCallParamRector;
 use Rector\Arguments\ValueObject\RemoveMethodCallParam;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveMethodCallParamRector::class)
@@ -217,7 +217,7 @@ use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ReplaceArgumentDefaultValueRector::class)
@@ -248,7 +248,7 @@ use Rector\Arguments\Rector\FuncCall\SwapFuncCallArgumentsRector;
 use Rector\Arguments\ValueObject\SwapFuncCallArguments;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SwapFuncCallArgumentsRector::class)
@@ -1838,7 +1838,7 @@ Replace PREG delimiter with configured one
 use Rector\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ConsistentPregDelimiterRector::class)
@@ -2016,7 +2016,7 @@ Order attributes by desired names
 use Rector\CodingStyle\Rector\ClassMethod\OrderAttributesRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(OrderAttributesRector::class)
@@ -2087,7 +2087,7 @@ use Rector\CodingStyle\Enum\PreferenceSelfThis;
 use Rector\CodingStyle\Rector\MethodCall\PreferThisOrSelfMethodCallRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(PreferThisOrSelfMethodCallRector::class)
@@ -2163,7 +2163,7 @@ use Rector\CodingStyle\Rector\ClassMethod\ReturnArrayClassMethodToYieldRector;
 use Rector\CodingStyle\ValueObject\ReturnArrayClassMethodToYield;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ReturnArrayClassMethodToYieldRector::class)
@@ -2464,7 +2464,7 @@ use Rector\Composer\Rector\AddPackageToRequireComposerRector;
 use Rector\Composer\ValueObject\PackageAndVersion;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddPackageToRequireComposerRector::class)
@@ -2497,7 +2497,7 @@ use Rector\Composer\Rector\AddPackageToRequireDevComposerRector;
 use Rector\Composer\ValueObject\PackageAndVersion;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddPackageToRequireDevComposerRector::class)
@@ -2530,7 +2530,7 @@ use Rector\Composer\Rector\ChangePackageVersionComposerRector;
 use Rector\Composer\ValueObject\PackageAndVersion;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ChangePackageVersionComposerRector::class)
@@ -2563,7 +2563,7 @@ Remove package from "require" and "require-dev" in `composer.json`
 use Rector\Composer\Rector\RemovePackageComposerRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemovePackageComposerRector::class)
@@ -2596,7 +2596,7 @@ use Rector\Composer\Rector\RenamePackageComposerRector;
 use Rector\Composer\ValueObject\RenamePackage;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenamePackageComposerRector::class)
@@ -2630,7 +2630,7 @@ use Rector\Composer\Rector\ReplacePackageAndVersionComposerRector;
 use Rector\Composer\ValueObject\ReplacePackageAndVersion;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ReplacePackageAndVersionComposerRector::class)
@@ -2725,7 +2725,7 @@ Remove annotation by names
 use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveAnnotationRector::class)
@@ -3254,7 +3254,7 @@ Remove unneeded PHP_VERSION_ID check
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemovePhpVersionIdCheckRector::class)
@@ -3457,7 +3457,7 @@ Remove unused private properties
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveUnusedPrivatePropertyRector::class)
@@ -3723,7 +3723,7 @@ Add method parent call, in case new parent method is added
 use Rector\DependencyInjection\Rector\ClassMethod\AddMethodParentCallRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddMethodParentCallRector::class)
@@ -4684,7 +4684,7 @@ Change param type to match the lowest type in whole family tree
 use Rector\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(DowngradeParameterTypeWideningRector::class)
@@ -5272,7 +5272,7 @@ use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
 use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(DowngradeAttributeToAnnotationRector::class)
@@ -6787,7 +6787,7 @@ Replace string class names by <class>::class constant
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(StringClassNameToClassConstantRector::class)
@@ -7323,7 +7323,7 @@ Changes reserved "Object" name to "<Smart>Object" where <Smart> can be configure
 use Rector\Php71\Rector\Name\ReservedObjectRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ReservedObjectRector::class)
@@ -7685,7 +7685,7 @@ Add "_" as thousands separator in numbers for higher or equals to limitValue con
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddLiteralSeparatorToNumberRector::class)
@@ -7952,7 +7952,7 @@ Changes property type by `@var` annotations or default value.
 use Rector\Php74\Rector\Property\TypedPropertyRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(TypedPropertyRector::class)
@@ -8019,7 +8019,7 @@ use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AnnotationToAttributeRector::class)
@@ -8125,7 +8125,7 @@ Refactor Doctrine `@annotation` annotated class to a PHP 8.0 attribute class
 use Rector\Php80\Rector\Class_\DoctrineAnnotationClassToAttributeRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(DoctrineAnnotationClassToAttributeRector::class)
@@ -8958,7 +8958,7 @@ use Rector\Privatization\Rector\MethodCall\ReplaceStringWithClassConstantRector;
 use Rector\Privatization\ValueObject\ReplaceStringWithClassConstant;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ReplaceStringWithClassConstantRector::class)
@@ -8996,7 +8996,7 @@ use Rector\Removing\Rector\ClassMethod\ArgumentRemoverRector;
 use Rector\Removing\ValueObject\ArgumentRemover;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ArgumentRemoverRector::class)
@@ -9027,7 +9027,7 @@ use Rector\Removing\Rector\FuncCall\RemoveFuncCallArgRector;
 use Rector\Removing\ValueObject\RemoveFuncCallArg;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveFuncCallArgRector::class)
@@ -9057,7 +9057,7 @@ use Rector\Removing\Rector\FuncCall\RemoveFuncCallRector;
 use Rector\Removing\ValueObject\RemoveFuncCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveFuncCallRector::class)
@@ -9086,7 +9086,7 @@ Removes interfaces usage from class.
 use Rector\Removing\Rector\Class_\RemoveInterfacesRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveInterfacesRector::class)
@@ -9117,7 +9117,7 @@ Remove namespace by configured namespace names
 use Rector\Removing\Rector\Namespace_\RemoveNamespaceRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveNamespaceRector::class)
@@ -9148,7 +9148,7 @@ Removes extends class by name
 use Rector\Removing\Rector\Class_\RemoveParentRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveParentRector::class)
@@ -9179,7 +9179,7 @@ Remove specific traits from code
 use Rector\Removing\Rector\Class_\RemoveTraitUseRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveTraitUseRector::class)
@@ -9239,7 +9239,7 @@ use Rector\Renaming\Rector\FileWithoutNamespace\PseudoNamespaceToNamespaceRector
 use Rector\Renaming\ValueObject\PseudoNamespaceToNamespace;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(PseudoNamespaceToNamespaceRector::class)
@@ -9272,7 +9272,7 @@ use Rector\Renaming\Rector\ClassMethod\RenameAnnotationRector;
 use Rector\Renaming\ValueObject\RenameAnnotationByType;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameAnnotationRector::class)
@@ -9313,7 +9313,7 @@ use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameClassConstFetchRector::class)
@@ -9351,7 +9351,7 @@ Replaces defined classes by new ones.
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameClassRector::class)
@@ -9394,7 +9394,7 @@ Replace constant by new ones
 use Rector\Renaming\Rector\ConstFetch\RenameConstantRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameConstantRector::class)
@@ -9432,7 +9432,7 @@ Turns defined function call new one.
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameFunctionRector::class)
@@ -9464,7 +9464,7 @@ use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameMethodRector::class)
@@ -9494,7 +9494,7 @@ Replaces old namespace by new one.
 use Rector\Renaming\Rector\Namespace_\RenameNamespaceRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameNamespaceRector::class)
@@ -9526,7 +9526,7 @@ use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\RenameProperty;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenamePropertyRector::class)
@@ -9556,7 +9556,7 @@ use Rector\Renaming\Rector\StaticCall\RenameStaticMethodRector;
 use Rector\Renaming\ValueObject\RenameStaticMethod;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameStaticMethodRector::class)
@@ -9585,7 +9585,7 @@ Change string value
 use Rector\Renaming\Rector\String_\RenameStringRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RenameStringRector::class)
@@ -9625,7 +9625,7 @@ use Rector\Restoration\Rector\Namespace_\CompleteImportForPartialAnnotationRecto
 use Rector\Restoration\ValueObject\CompleteImportForPartialAnnotation;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(CompleteImportForPartialAnnotationRector::class)
@@ -9741,7 +9741,7 @@ Fixer for PHPStan reports by strict type rule - "PHPStan\Rules\BooleansInConditi
 use Rector\Strict\Rector\BooleanNot\BooleanInBooleanNotRuleFixerRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(BooleanInBooleanNotRuleFixerRector::class)
@@ -9782,7 +9782,7 @@ Fixer for PHPStan reports by strict type rule - "PHPStan\Rules\BooleansInConditi
 use Rector\Strict\Rector\If_\BooleanInIfConditionRuleFixerRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(BooleanInIfConditionRuleFixerRector::class)
@@ -9823,7 +9823,7 @@ Fixer for PHPStan reports by strict type rule - "PHPStan\Rules\BooleansInConditi
 use Rector\Strict\Rector\Ternary\BooleanInTernaryOperatorRuleFixerRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(BooleanInTernaryOperatorRuleFixerRector::class)
@@ -9860,7 +9860,7 @@ Fixer for PHPStan reports by strict type rule - "PHPStan\Rules\DisallowedConstru
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(DisallowedEmptyRuleFixerRector::class)
@@ -9897,7 +9897,7 @@ Fixer for PHPStan reports by strict type rule - "PHPStan\Rules\DisallowedConstru
 use Rector\Strict\Rector\Ternary\DisallowedShortTernaryRuleFixerRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(DisallowedShortTernaryRuleFixerRector::class)
@@ -9936,7 +9936,7 @@ Add the `AllowDynamicProperties` attribute to all classes
 use Rector\Transform\Rector\Class_\AddAllowDynamicPropertiesAttributeRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddAllowDynamicPropertiesAttributeRector::class)
@@ -9969,7 +9969,7 @@ Add interface by used trait
 use Rector\Transform\Rector\Class_\AddInterfaceByTraitRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddInterfaceByTraitRector::class)
@@ -10004,7 +10004,7 @@ use Rector\Transform\Rector\FuncCall\ArgumentFuncCallToMethodCallRector;
 use Rector\Transform\ValueObject\ArgumentFuncCallToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ArgumentFuncCallToMethodCallRector::class)
@@ -10052,7 +10052,7 @@ use Rector\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector;
 use Rector\Transform\ValueObject\AttributeKeyToClassConstFetch;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AttributeKeyToClassConstFetchRector::class)
@@ -10093,7 +10093,7 @@ use Rector\Transform\Rector\MethodCall\CallableInMethodCallToVariableRector;
 use Rector\Transform\ValueObject\CallableInMethodCallToVariable;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(CallableInMethodCallToVariableRector::class)
@@ -10162,7 +10162,7 @@ use Rector\Transform\Rector\Assign\DimFetchAssignToMethodCallRector;
 use Rector\Transform\ValueObject\DimFetchAssignToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(DimFetchAssignToMethodCallRector::class)
@@ -10208,7 +10208,7 @@ use Rector\Transform\Rector\FunctionLike\FileGetContentsAndJsonDecodeToStaticCal
 use Rector\Transform\ValueObject\StaticCallRecipe;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(FileGetContentsAndJsonDecodeToStaticCallRector::class)
@@ -10244,7 +10244,7 @@ Changes use of function calls to use constants
 use Rector\Transform\Rector\FuncCall\FuncCallToConstFetchRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(FuncCallToConstFetchRector::class)
@@ -10282,7 +10282,7 @@ use Rector\Transform\Rector\FuncCall\FuncCallToMethodCallRector;
 use Rector\Transform\ValueObject\FuncCallToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(FuncCallToMethodCallRector::class)
@@ -10327,7 +10327,7 @@ Change configured function calls to new Instance
 use Rector\Transform\Rector\FuncCall\FuncCallToNewRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(FuncCallToNewRector::class)
@@ -10365,7 +10365,7 @@ use Rector\Transform\Rector\FuncCall\FuncCallToStaticCallRector;
 use Rector\Transform\ValueObject\FuncCallToStaticCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(FuncCallToStaticCallRector::class)
@@ -10395,7 +10395,7 @@ use Rector\Transform\Rector\Assign\GetAndSetToMethodCallRector;
 use Rector\Transform\ValueObject\GetAndSetToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(GetAndSetToMethodCallRector::class)
@@ -10425,7 +10425,7 @@ Merges old interface to a new one, that already has its methods
 use Rector\Transform\Rector\Class_\MergeInterfacesRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(MergeInterfacesRector::class)
@@ -10459,7 +10459,7 @@ use Rector\Transform\Rector\MethodCall\MethodCallToAnotherMethodCallWithArgument
 use Rector\Transform\ValueObject\MethodCallToAnotherMethodCallWithArguments;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(MethodCallToAnotherMethodCallWithArgumentsRector::class)
@@ -10494,7 +10494,7 @@ use Rector\Transform\Rector\MethodCall\MethodCallToMethodCallRector;
 use Rector\Transform\ValueObject\MethodCallToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(MethodCallToMethodCallRector::class)
@@ -10535,7 +10535,7 @@ Turns method call `"$this->something()"` to property fetch "$this->something"
 use Rector\Transform\Rector\MethodCall\MethodCallToPropertyFetchRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(MethodCallToPropertyFetchRector::class)
@@ -10573,7 +10573,7 @@ use Rector\Transform\Rector\MethodCall\MethodCallToStaticCallRector;
 use Rector\Transform\ValueObject\MethodCallToStaticCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(MethodCallToStaticCallRector::class)
@@ -10616,7 +10616,7 @@ use Rector\Transform\Rector\New_\NewArgToMethodCallRector;
 use Rector\Transform\ValueObject\NewArgToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(NewArgToMethodCallRector::class)
@@ -10652,7 +10652,7 @@ Change defined new type to constructor injection
 use Rector\Transform\Rector\New_\NewToConstructorInjectionRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(NewToConstructorInjectionRector::class)
@@ -10699,7 +10699,7 @@ use Rector\Transform\Rector\New_\NewToMethodCallRector;
 use Rector\Transform\ValueObject\NewToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(NewToMethodCallRector::class)
@@ -10739,7 +10739,7 @@ use Rector\Transform\Rector\New_\NewToStaticCallRector;
 use Rector\Transform\ValueObject\NewToStaticCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(NewToStaticCallRector::class)
@@ -10775,7 +10775,7 @@ use Rector\Transform\Rector\Class_\ParentClassToTraitsRector;
 use Rector\Transform\ValueObject\ParentClassToTraits;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ParentClassToTraitsRector::class)
@@ -10808,7 +10808,7 @@ use Rector\Transform\Rector\Assign\PropertyAssignToMethodCallRector;
 use Rector\Transform\ValueObject\PropertyAssignToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(PropertyAssignToMethodCallRector::class)
@@ -10839,7 +10839,7 @@ use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
 use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(PropertyFetchToMethodCallRector::class)
@@ -10888,7 +10888,7 @@ Remove the `AllowDynamicProperties` attribute from all classes
 use Rector\Transform\Rector\Class_\RemoveAllowDynamicPropertiesAttributeRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(RemoveAllowDynamicPropertiesAttributeRector::class)
@@ -10922,7 +10922,7 @@ use Rector\Transform\Rector\MethodCall\ReplaceParentCallByPropertyCallRector;
 use Rector\Transform\ValueObject\ReplaceParentCallByPropertyCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ReplaceParentCallByPropertyCallRector::class)
@@ -10957,7 +10957,7 @@ Add #[\ReturnTypeWillChange] attribute to configured instanceof class with metho
 use Rector\Transform\Rector\ClassMethod\ReturnTypeWillChangeRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ReturnTypeWillChangeRector::class)
@@ -10994,7 +10994,7 @@ use Rector\Transform\Rector\MethodCall\ServiceGetterToConstructorInjectionRector
 use Rector\Transform\ValueObject\ServiceGetterToConstructorInjection;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ServiceGetterToConstructorInjectionRector::class)
@@ -11063,7 +11063,7 @@ use Rector\Transform\Rector\StaticCall\StaticCallToFuncCallRector;
 use Rector\Transform\ValueObject\StaticCallToFuncCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(StaticCallToFuncCallRector::class)
@@ -11093,7 +11093,7 @@ use Rector\Transform\Rector\StaticCall\StaticCallToMethodCallRector;
 use Rector\Transform\ValueObject\StaticCallToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(StaticCallToMethodCallRector::class)
@@ -11149,7 +11149,7 @@ use Rector\Transform\Rector\StaticCall\StaticCallToNewRector;
 use Rector\Transform\ValueObject\StaticCallToNew;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(StaticCallToNewRector::class)
@@ -11185,7 +11185,7 @@ use Rector\Transform\Rector\String_\StringToClassConstantRector;
 use Rector\Transform\ValueObject\StringToClassConstant;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(StringToClassConstantRector::class)
@@ -11220,7 +11220,7 @@ Turns defined code uses of `"__toString()"` method  to specific method calls.
 use Rector\Transform\Rector\String_\ToStringToMethodCallRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ToStringToMethodCallRector::class)
@@ -11255,7 +11255,7 @@ use Rector\Transform\Rector\Isset_\UnsetAndIssetToMethodCallRector;
 use Rector\Transform\ValueObject\UnsetAndIssetToMethodCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(UnsetAndIssetToMethodCallRector::class)
@@ -11288,7 +11288,7 @@ use Rector\Transform\Rector\ClassMethod\WrapReturnRector;
 use Rector\Transform\ValueObject\WrapReturn;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(WrapReturnRector::class)
@@ -11423,7 +11423,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddParamTypeDeclarationRector::class)
@@ -11459,7 +11459,7 @@ use Rector\TypeDeclaration\Rector\Property\AddPropertyTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddPropertyTypeDeclaration;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddPropertyTypeDeclarationRector::class)
@@ -11494,7 +11494,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddReturnTypeDeclarationRector::class)
@@ -11530,7 +11530,7 @@ Add return type void to function like without any return
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(AddVoidReturnTypeWhereNoReturnRector::class)
@@ -11871,7 +11871,25 @@ Add return method return type based on strict typed property
 
 Add typed property from assigned types
 
+:wrench: **configure it!**
+
 - class: [`Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector`](../rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php)
+
+```php
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(TypedPropertyFromAssignsRector::class)
+        ->configure([
+            TypedPropertyFromAssignsRector::INLINE_PUBLIC => false,
+        ]);
+};
+```
+
+↓
 
 ```diff
  final class SomeClass
@@ -11964,7 +11982,7 @@ use Rector\Visibility\Rector\ClassConst\ChangeConstantVisibilityRector;
 use Rector\Visibility\ValueObject\ChangeConstantVisibility;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ChangeConstantVisibilityRector::class)
@@ -12002,7 +12020,7 @@ use Rector\Visibility\Rector\ClassMethod\ChangeMethodVisibilityRector;
 use Rector\Visibility\ValueObject\ChangeMethodVisibility;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (\Rector\Config\RectorConfig $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(ChangeMethodVisibilityRector::class)

--- a/config/set/type-declaration.php
+++ b/config/set/type-declaration.php
@@ -11,6 +11,7 @@ use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\Rector\Property\PropertyTypeDeclarationRector;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $services = $rectorConfig->services();
@@ -22,4 +23,5 @@ return static function (RectorConfig $rectorConfig): void {
     $services->set(AddArrayReturnDocTypeRector::class);
     $services->set(ParamTypeByParentCallTypeRector::class);
     $services->set(ParamTypeByMethodCallTypeRector::class);
+    $services->set(TypedPropertyFromAssignsRector::class);
 };

--- a/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -133,27 +133,27 @@ final class TypeComparator
         if (! $assumptionType instanceof Type) {
             return true;
         }
+
         if (! $exactType instanceof Type) {
             return true;
         }
+
         if ($this->areTypesEqual($assumptionType, $exactType)) {
             return true;
         }
-        if ($assumptionType instanceof UnionType) {
-            return (is_countable($assumptionType->getTypes()) ? count($assumptionType->getTypes()) : 0) > (is_countable(
-                $exactType->getTypes()
-            ) ? count(
-                $exactType->getTypes()
-            ) : 0);
+
+        if (! $assumptionType instanceof UnionType) {
+            return true;
         }
-        if ($exactType instanceof UnionType) {
-            return (is_countable($assumptionType->getTypes()) ? count($assumptionType->getTypes()) : 0) > (is_countable(
-                $exactType->getTypes()
-            ) ? count(
-                $exactType->getTypes()
-            ) : 0);
+
+        if (! $exactType instanceof UnionType) {
+            return true;
         }
-        return true;
+
+        $assumpionTypeTypes = $assumptionType->getTypes();
+        $exactTypeTypes = $exactType->getTypes();
+
+        return count($assumpionTypeTypes) > count($exactTypeTypes);
     }
 
     private function areAliasedObjectMatchingFqnObject(Type $firstType, Type $secondType): bool

--- a/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -130,19 +130,30 @@ final class TypeComparator
 
     public function areTypesPossiblyIncluded(?Type $assumptionType, ?Type $exactType): bool
     {
-        if (! $assumptionType instanceof Type || ! $exactType instanceof Type) {
+        if (! $assumptionType instanceof Type) {
             return true;
         }
-
+        if (! $exactType instanceof Type) {
+            return true;
+        }
         if ($this->areTypesEqual($assumptionType, $exactType)) {
             return true;
         }
-
-        if (! $assumptionType instanceof UnionType && ! $exactType instanceof UnionType) {
-            return true;
+        if ($assumptionType instanceof UnionType) {
+            return (is_countable($assumptionType->getTypes()) ? count($assumptionType->getTypes()) : 0) > (is_countable(
+                $exactType->getTypes()
+            ) ? count(
+                $exactType->getTypes()
+            ) : 0);
         }
-
-        return count($assumptionType->getTypes()) > count($exactType->getTypes());
+        if ($exactType instanceof UnionType) {
+            return (is_countable($assumptionType->getTypes()) ? count($assumptionType->getTypes()) : 0) > (is_countable(
+                $exactType->getTypes()
+            ) ? count(
+                $exactType->getTypes()
+            ) : 0);
+        }
+        return true;
     }
 
     private function areAliasedObjectMatchingFqnObject(Type $firstType, Type $secondType): bool

--- a/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -128,6 +128,23 @@ final class TypeComparator
         return $this->arrayTypeComparator->isSubtype($checkedType, $mainType);
     }
 
+    public function areTypesPossiblyIncluded(?Type $assumptionType, ?Type $exactType): bool
+    {
+        if (! $assumptionType instanceof Type || ! $exactType instanceof Type) {
+            return true;
+        }
+
+        if ($this->areTypesEqual($assumptionType, $exactType)) {
+            return true;
+        }
+
+        if (! $assumptionType instanceof UnionType && ! $exactType instanceof UnionType) {
+            return true;
+        }
+
+        return count($assumptionType->getTypes()) > count($exactType->getTypes());
+    }
+
     private function areAliasedObjectMatchingFqnObject(Type $firstType, Type $secondType): bool
     {
         if ($firstType instanceof AliasedObjectType && $secondType instanceof ObjectType && $firstType->getFullyQualifiedName() === $secondType->getClassName()) {

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_union_not_included_in_assigned_types.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_union_not_included_in_assigned_types.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\TypedPropertyByVarAndAssign\Fixture;
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
 
 class SkipUnionNotIncludedInAssignedTypes
 {

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_union_not_included_in_assigned_types.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_union_not_included_in_assigned_types.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\TypedPropertyByVarAndAssign\Fixture;
+
+class SkipUnionNotIncludedInAssignedTypes
+{
+    /**
+     * @var string|false|null
+     */
+    private $property;
+
+    public function run()
+    {
+        $this->property = '';
+    }
+
+    public function run2()
+    {
+        $this->property = true;
+    }
+
+    public function run3()
+    {
+        $this->property = null;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/has_method_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/has_method_type.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureInlinePublic;
 
 final class HasMethodType
 {
@@ -20,7 +20,7 @@ final class HasMethodType
 -----
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureInlinePublic;
 
 final class HasMethodType
 {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/if_else.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/if_else.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureInlinePublic;
 
 final class IfElse
 {
@@ -20,7 +20,7 @@ final class IfElse
 -----
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureInlinePublic;
 
 final class IfElse
 {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/if_else.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/if_else.php.inc
@@ -24,10 +24,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsR
 
 final class IfElse
 {
-    /**
-     * @var int|string
-     */
-    protected $stringOrInteger = 'hi';
+    protected int|string $stringOrInteger = 'hi';
 
     public function setNumber()
     {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/public_property_doc_assign.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/public_property_doc_assign.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureInlinePublic;
 
 use stdClass;
 
@@ -18,16 +18,13 @@ final class PublicPropertyDocAssign
 -----
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureInlinePublic;
 
 use stdClass;
 
 final class PublicPropertyDocAssign
 {
-    /**
-     * @var stdClass|null
-     */
-    public $config = null;
+    public ?\stdClass $config = null;
 
     public function run()
     {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/InlinePublicTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/InlinePublicTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class InlinePublicTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureInlinePublic');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/inline_public_configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/config/inline_public_configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/config/inline_public_configured_rule.php
@@ -12,7 +12,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(TypedPropertyFromAssignsRector::class)
         ->configure([
-            TypedPropertyFromAssignsRector::INLINE_PUBLIC => true
+            TypedPropertyFromAssignsRector::INLINE_PUBLIC => true,
         ]);
 
     $parameters = $containerConfigurator->parameters();

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/config/inline_public_configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/config/inline_public_configured_rule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(TypedPropertyFromAssignsRector::class)
+        ->configure([
+            TypedPropertyFromAssignsRector::INLINE_PUBLIC => true
+        ]);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersionFeature::TYPED_PROPERTIES);
+};

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/config/inline_public_configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/config/inline_public_configured_rule.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
-
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -16,5 +15,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]);
 
     $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersionFeature::TYPED_PROPERTIES);
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersionFeature::INTERSECTION_TYPES);
 };

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -84,10 +84,11 @@ final class SomeClass
         $this->name = 'string';
     }
 }
-CODE_SAMPLE,
-            [
-                self::INLINE_PUBLIC => false,
-            ]
+CODE_SAMPLE
+,
+                [
+                    self::INLINE_PUBLIC => false,
+                ]
             ),
         ]);
     }

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -134,7 +134,7 @@ CODE_SAMPLE
             return $node;
         }
 
-        // public property can be anything with not inline public configured
+        // non-private property can be anything with not inline public configured
         if (! $node->isPrivate() && ! $this->inlinePublic) {
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $inferredType);
             return $node;

--- a/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
@@ -22,6 +22,7 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 use Rector\TypeDeclaration\TypeAnalyzer\GenericClassStringTypeNormalizer;
@@ -40,7 +41,8 @@ final class VarDocPropertyTypeInferer
         private readonly PropertyFetchFinder $propertyFetchFinder,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly PropertyManipulator $propertyManipulator,
-        private readonly AssignToPropertyTypeInferer $assignToPropertyTypeInferer
+        private readonly AssignToPropertyTypeInferer $assignToPropertyTypeInferer,
+        private readonly TypeComparator $typeComparator
     ) {
     }
 
@@ -76,6 +78,10 @@ final class VarDocPropertyTypeInferer
 
         if ($this->shouldAddNull($resolvedType, $assignInferredPropertyType)) {
             $resolvedType = TypeCombinator::addNull($resolvedType);
+        }
+
+        if (! $this->typeComparator->areTypesPossiblyIncluded($resolvedType, $assignInferredPropertyType)) {
+            return new MixedType();
         }
 
         return $resolvedType;

--- a/tests/Issues/TypedPropertyByVarAndAssign/Fixture/fixture.php.inc
+++ b/tests/Issues/TypedPropertyByVarAndAssign/Fixture/fixture.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\TypedPropertyByVarAndAssign\Fixture;
+
+class Fixture
+{
+    /**
+     * @var string|false|null
+     */
+    private $property;
+
+    public function run()
+    {
+        $this->property = '';
+    }
+
+    public function run2()
+    {
+        $this->property = true;
+    }
+
+    public function run3()
+    {
+        $this->property = null;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\TypedPropertyByVarAndAssign\Fixture;
+
+class Fixture
+{
+    /**
+     * @var string|false|null
+     */
+    private bool|string|null $property = null;
+
+    public function run()
+    {
+        $this->property = '';
+    }
+
+    public function run2()
+    {
+        $this->property = true;
+    }
+
+    public function run3()
+    {
+        $this->property = null;
+    }
+}
+
+?>

--- a/tests/Issues/TypedPropertyByVarAndAssign/TypedPropertyByVarAndAssignTest.php
+++ b/tests/Issues/TypedPropertyByVarAndAssign/TypedPropertyByVarAndAssignTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\TypedPropertyByVarAndAssign;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class TypedPropertyByVarAndAssignTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/TypedPropertyByVarAndAssign/config/configured_rule.php
+++ b/tests/Issues/TypedPropertyByVarAndAssign/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $services = $rectorConfig->services();
+    $services->set(TypedPropertyRector::class);
+    $services->set(TypedPropertyFromAssignsRector::class);
+};


### PR DESCRIPTION
The `TypedPropertyRector` share `MakePropertyTypedGuard` guard check with `TypedPropertyFromAssignsRector`, to avoid issue like in https://github.com/rectorphp/rector-src/pull/2029 use case, I think we can make it configurable with  `INLINE_PUBLIC` as well, with allow `protected` and `public` modified as far as not forbidden, with default to false, same like in `TypedPropertyRector`.

The goal is to make it work together, with then register to `php74` and/or `type-declaration` config set. Currently, the `TypedPropertyFromAssignsRector` is not registered in any config set.