### PR TITLE
[Php74] Use ConstructorAssignDetector on RestoreDefaultNullToNullableTypePropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/change_trait.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/change_trait.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+trait ChangeTrait
+{
+    public ?string $name;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+trait ChangeTrait
+{
+    public ?string $name = null;
+}
+
+?>


### PR DESCRIPTION
There is already `ConstructorAssignDetector` detection for filled by `__constuct()` or `setUp()`, so it change to use the service, also add fixture for change trait, as trait can be used in multiple context, so we don't know if it is filled by `construct()` or `setUp()`, which nullable better to have null default value in trait.