### PR TITLE
[TypeDeclaration] Using ConstructorAssignDetector on TypedPropertyFromStrictConstructorRector

### DIFF
--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
@@ -33,7 +32,6 @@ final class TypedPropertyFromStrictConstructorRector extends AbstractRector
         private readonly VarTagRemover $varTagRemover,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly PropertyFetchFinder $propertyFetchFinder,
-        private readonly PropertyManipulator $propertyManipulator,
         private readonly ConstructorAssignDetector $constructorAssignDetector
     ) {
     }

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -18,6 +18,7 @@ use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer\ConstructorPropertyTypeInferer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -32,7 +33,8 @@ final class TypedPropertyFromStrictConstructorRector extends AbstractRector
         private readonly VarTagRemover $varTagRemover,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly PropertyFetchFinder $propertyFetchFinder,
-        private readonly PropertyManipulator $propertyManipulator
+        private readonly PropertyManipulator $propertyManipulator,
+        private readonly ConstructorAssignDetector $constructorAssignDetector
     ) {
     }
 
@@ -147,7 +149,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $this->propertyManipulator->isInlineStmtWithConstructMethod($propertyFetch, $classMethod)) {
+            if (! $this->constructorAssignDetector->isPropertyAssigned($class, $propertyName)) {
                 return false;
             }
         }

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -6,14 +6,11 @@ namespace Rector\TypeDeclaration\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\Core\Rector\AbstractRector;
-use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -31,7 +28,6 @@ final class TypedPropertyFromStrictConstructorRector extends AbstractRector
         private readonly ConstructorPropertyTypeInferer $constructorPropertyTypeInferer,
         private readonly VarTagRemover $varTagRemover,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly PropertyFetchFinder $propertyFetchFinder,
         private readonly ConstructorAssignDetector $constructorAssignDetector
     ) {
     }
@@ -81,6 +77,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        $property = null;
         if ($node->type !== null) {
             return null;
         }
@@ -117,8 +114,9 @@ CODE_SAMPLE
         }
 
         $node->type = $propertyTypeNode;
+        $propertyName = $this->nodeNameResolver->getName($property);
 
-        if ($this->isDefaultToBeNull($node, $classLike)) {
+        if ($this->constructorAssignDetector->isPropertyAssigned($classLike, $propertyName)) {
             $node->props[0]->default = null;
         }
 
@@ -130,28 +128,5 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::TYPED_PROPERTIES;
-    }
-
-    private function isDefaultToBeNull(Property $property, Class_ $class): bool
-    {
-        $propertyName = $this->nodeNameResolver->getName($property);
-        $propertyFetches = $this->propertyFetchFinder->findLocalPropertyFetchesByName($class, $propertyName);
-
-        foreach ($propertyFetches as $propertyFetch) {
-            $classMethod = $this->betterNodeFinder->findParentType($propertyFetch, ClassMethod::class);
-            if (! $classMethod instanceof ClassMethod) {
-                continue;
-            }
-
-            if (! $this->nodeNameResolver->isName($classMethod, MethodName::CONSTRUCT)) {
-                continue;
-            }
-
-            if (! $this->constructorAssignDetector->isPropertyAssigned($class, $propertyName)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -77,7 +77,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $property = null;
         if ($node->type !== null) {
             return null;
         }
@@ -114,7 +113,7 @@ CODE_SAMPLE
         }
 
         $node->type = $propertyTypeNode;
-        $propertyName = $this->nodeNameResolver->getName($property);
+        $propertyName = $this->nodeNameResolver->getName($node);
 
         if ($this->constructorAssignDetector->isPropertyAssigned($classLike, $propertyName)) {
             $node->props[0]->default = null;


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2054, `ConstructorAssignDetector` can be used.