### PR TITLE
[Core] Remove unused PropertyManipulator::isInlineStmtWithConstructMethod()

### DIFF
--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -159,7 +159,6 @@ final class PropertyManipulator
         }
 
         $propertyFetches = $this->propertyFetchFinder->findPrivatePropertyFetches($propertyOrParam);
-        $propertyName = $this->nodeNameResolver->getName($propertyOrParam);
 
         foreach ($propertyFetches as $propertyFetch) {
             if ($this->isChangeableContext($propertyFetch)) {
@@ -167,6 +166,7 @@ final class PropertyManipulator
             }
 
             // skip for constructor? it is allowed to set value in constructor method
+            $propertyName = $this->nodeNameResolver->getName($propertyFetch);
             if ($this->constructorAssignDetector->isPropertyAssigned($classLike, $propertyName)) {
                 continue;
             }

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -226,27 +226,6 @@ final class PropertyManipulator
         return null;
     }
 
-    public function isInlineStmtWithConstructMethod(
-        PropertyFetch|StaticPropertyFetch $propertyFetch,
-        ?ClassMethod $classMethod
-    ): bool {
-        if (! $classMethod instanceof ClassMethod) {
-            return false;
-        }
-
-        if (! $this->nodeNameResolver->isName($classMethod->name, MethodName::CONSTRUCT)) {
-            return false;
-        }
-
-        $currentStmt = $propertyFetch->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        if (! $currentStmt instanceof Stmt) {
-            return false;
-        }
-
-        $parent = $currentStmt->getAttribute(AttributeKey::PARENT_NODE);
-        return $parent === $classMethod;
-    }
-
     private function isChangeableContext(PropertyFetch | StaticPropertyFetch $propertyFetch): bool
     {
         $parent = $propertyFetch->getAttribute(AttributeKey::PARENT_NODE);


### PR DESCRIPTION
use `ConstructorAssignDetector::isPropertyAssigned()` instead, verify check on `__construct()` only as readonly may silently unset in test class.