### PR TITLE
[TypeDeclaration] Skip too deep level array on ArrayShapeFromConstantArrayReturnRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector/Fixture/skip_too_deep_level.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector/Fixture/skip_too_deep_level.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector\Fixture;
+
+final class SkipTooDeepLevel
+{
+    public function getDefaultContext(): array
+    {
+        return [
+             'foo' => [
+                 'bar' => [
+                    'baz' => 'bat',
+                 ],
+             ],
+        ];
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector.php
@@ -34,6 +34,11 @@ final class ArrayShapeFromConstantArrayReturnRector extends AbstractRector
      */
     private const SKIPPED_CHAR_REGEX = '#\W#u';
 
+    /**
+     * @var int
+     */
+    private const MAX_LEVEL = 3;
+
     public function __construct(
         private readonly ClassMethodReturnTypeResolver $classMethodReturnTypeResolver,
         private readonly PhpDocTypeChanger $phpDocTypeChanger
@@ -132,8 +137,12 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function shouldSkip(ConstantArrayType $constantArrayType): bool
+    private function shouldSkip(ConstantArrayType $constantArrayType, int $level = 1): bool
     {
+        if ($level === 3) {
+            return true;
+        }
+
         $keyType = $constantArrayType->getKeyType();
 
         // empty array
@@ -161,9 +170,11 @@ CODE_SAMPLE
             }
         }
 
+        ++$level;
+
         $itemType = $constantArrayType->getItemType();
         if ($itemType instanceof ConstantArrayType) {
-            return $this->shouldSkip($itemType);
+            return $this->shouldSkip($itemType, $level);
         }
 
         return false;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector.php
@@ -139,7 +139,7 @@ CODE_SAMPLE
 
     private function shouldSkip(ConstantArrayType $constantArrayType, int $level = 1): bool
     {
-        if ($level === 3) {
+        if ($level === self::MAX_LEVEL) {
             return true;
         }
 


### PR DESCRIPTION
I think 3 level array is too deep for array shape:

```php
final class SkipTooDeepLevel
{
    public function getDefaultContext(): array
    {
        return [
             'foo' => [
                 'bar' => [
                    'baz' => 'bat',
                 ],
             ],
        ];
    }
}
```

This PR skip it.