### PR TITLE
[Feature] Add ReturnAnnotationIncorrectNullableRector for fixing incorrect null type in @return

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 508 Rules Overview
+# 510 Rules Overview
 
 <br>
 
@@ -86,9 +86,9 @@
 
 - [Strict](#strict) (5)
 
-- [Transform](#transform) (35)
+- [Transform](#transform) (36)
 
-- [TypeDeclaration](#typedeclaration) (24)
+- [TypeDeclaration](#typedeclaration) (25)
 
 - [Visibility](#visibility) (3)
 
@@ -10195,6 +10195,43 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
 <br>
 
+### FileGetContentsAndJsonDecodeToStaticCallRector
+
+Merge 2 function calls to static call
+
+:wrench: **configure it!**
+
+- class: [`Rector\Transform\Rector\FunctionLike\FileGetContentsAndJsonDecodeToStaticCallRector`](../rules/Transform/Rector/FunctionLike/FileGetContentsAndJsonDecodeToStaticCallRector.php)
+
+```php
+use Rector\Transform\Rector\FunctionLike\FileGetContentsAndJsonDecodeToStaticCallRector;
+use Rector\Transform\ValueObject\StaticCallRecipe;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(FileGetContentsAndJsonDecodeToStaticCallRector::class)
+        ->configure([new StaticCallRecipe('FileLoader', 'loadJson')]);
+};
+```
+
+↓
+
+```diff
+ final class SomeClass
+ {
+     public function load($filePath)
+     {
+-        $fileGetContents = file_get_contents($filePath);
+-        return json_decode($fileGetContents, true);
++        return FileLoader::loadJson($filePath);
+     }
+ }
+```
+
+<br>
+
 ### FuncCallToConstFetchRector
 
 Changes use of function calls to use constants
@@ -11696,6 +11733,28 @@ Add `@var` to properties that are missing it
      public function run()
      {
          $this->value = 123;
+     }
+ }
+```
+
+<br>
+
+### ReturnAnnotationIncorrectNullableRector
+
+Add or remove null type from `@return` phpdoc typehint based on php return type declaration
+
+- class: [`Rector\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector`](../rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php)
+
+```diff
+ final class SomeClass
+ {
+     /**
+-     * @return \DateTime[]
++     * @return \DateTime[]|null
+      */
+     public function getDateTimes(): ?array
+     {
+         return $this->dateTimes;
      }
  }
 ```

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-already-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-already-includes-null.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationAlreadyIncludesNull
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-complex.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-complex.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationComplex
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationComplex
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country,
+     * })
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null-on-scalar.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null-on-scalar.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
 
-final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+final class ReturnAnnotationIncorrectlyIncludesNullOnScalar
 {
     /**
      * @return string|null
@@ -18,7 +18,7 @@ final class ParamAnnotationIncorrectlyIncludesNullOnScalar
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
 
-final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+final class ReturnAnnotationIncorrectlyIncludesNullOnScalar
 {
     /**
      * @return string

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null-on-scalar.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null-on-scalar.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @return string|null
+     */
+    public function getDateTimes(): array
+    {
+        return $this->text;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ParamAnnotationIncorrectlyIncludesNullOnScalar
+{
+    /**
+     * @return string
+     */
+    public function getDateTimes(): array
+    {
+        return $this->text;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-generic-syntax.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @return array<int,\DateTime>
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithGenericSyntax
+{
+    /**
+     * Rector automatically transforms generic int-keyed simple arrays to the [] notation
+     * @see \Rector\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapper::isIntegerKeyAndNonNestedArray
+     *
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-nested-generic-syntax.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null-with-nested-generic-syntax.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @return array<int, array<string, \DateTime>>
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNullWithNestedGenericSyntax
+{
+    /**
+     * @return array<int, array<string, \DateTime>>|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-is-missing-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNull
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnAnnotationIsMissingNull
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-on-function-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-on-function-incorrectly-includes-null.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+/**
+ * @return \DateTime[]|null
+ */
+function getDateTimes(): array
+{
+    return [new \DateTime()];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+/**
+ * @return \DateTime[]
+ */
+function getDateTimes(): array
+{
+    return [new \DateTime()];
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-on-function-is-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-annotation-on-function-is-missing-null.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+/**
+ * @return \DateTime[]
+ */
+function getDateTimes(int $i): ?array
+{
+    return $i > 0 ? [new \DateTime()] : null;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+/**
+ * @return \DateTime[]|null
+ */
+function getDateTimes(int $i): ?array
+{
+    return $i > 0 ? [new \DateTime()] : null;
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-incorrectly-includes-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-incorrectly-includes-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]|null
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationIncorrectlyIncludesNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-missing-null.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/return-union-annotation-missing-null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationMissingNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class ReturnUnionAnnotationMissingNull
+{
+    /**
+     * @return \DateTime[]|\DateTimeImmutable[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-broken-return-annotation.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-broken-return-annotation.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipBrokenReturnAnnotation
+{
+    /** @return # */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-complex-on-phpdoc-parser-failure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-complex-on-phpdoc-parser-failure.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationComplexOnPhpdocParserFailure
+{
+    /**
+     * @Serializer\VirtualProperty
+     * @Serializer\Type("array<DateTime>")
+     * @Assert\All({
+     *     @Assert\NotBlank,
+     *     @AppAssert\Country
+     * })
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-no-type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-no-type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationWhenMethodHasNoReturnType
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes()
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-non-nullable-type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-when-property-has-non-nullable-type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationWhenPropertyHasNonNullableType
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-return-annotation-with-generic-syntax-when-null-is-not-missing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+final class SkipReturnAnnotationWithGenericSyntaxWhenNullIsNotMissing
+{
+    /**
+     * @return  array<int,\DateTime>|null $dateTimes
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/ReturnAnnotationIncorrectNullableRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/ReturnAnnotationIncorrectNullableRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ReturnAnnotationIncorrectNullableRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/config/config.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/config/config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector;
+
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ReturnAnnotationIncorrectNullableRector::class);
+};

--- a/rules/TypeDeclaration/Guard/PhpDocNestedAnnotationGuard.php
+++ b/rules/TypeDeclaration/Guard/PhpDocNestedAnnotationGuard.php
@@ -6,7 +6,7 @@ namespace Rector\TypeDeclaration\Guard;
 
 use Nette\Utils\Strings;
 use PhpParser\Comment\Doc;
-use PhpParser\Node\Stmt\Property;
+use PhpParser\Node;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -28,14 +28,14 @@ final class PhpDocNestedAnnotationGuard
      * Check if rector accidentally skipped annotation during parsing which it should not have (this bug is likely related to parsing of annotations
      * in phpstan / rector)
      */
-    public function isPhpDocCommentCorrectlyParsed(Property $property): bool
+    public function isPhpDocCommentCorrectlyParsed(Node $node): bool
     {
-        $comments = $property->getAttribute(AttributeKey::COMMENTS, []);
+        $comments = $node->getAttribute(AttributeKey::COMMENTS, []);
         if ((is_countable($comments) ? count($comments) : 0) !== 1) {
             return true;
         }
 
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         /** @var Doc $phpDoc */
         $phpDoc = $comments[0];

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Guard\PhpDocNestedAnnotationGuard;
+use Rector\TypeDeclaration\Helper\PhpDocNullableTypeHelper;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\ReturnAnnotationIncorrectNullableRectorTest
+ */
+final class ReturnAnnotationIncorrectNullableRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private readonly PhpDocNullableTypeHelper $phpDocNullableTypeHelper,
+        private readonly PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add or remove null type from @return phpdoc typehint based on php return type declaration',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @return \DateTime[]|null
+     */
+    public function getDateTimes(): ?array
+    {
+        return $this->dateTimes;
+    }
+}
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $returnType = $node->getReturnType();
+
+        if ($returnType === null) {
+            return null;
+        }
+
+        if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
+            return null;
+        }
+
+        if (! $this->phpDocNestedAnnotationGuard->isPhpDocCommentCorrectlyParsed($node)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return null;
+        }
+
+        $phpStanDocTypeNode = $returnTagValueNode->type;
+        $phpParserType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnType);
+        $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($phpStanDocTypeNode, $node);
+
+        $updatedPhpDocType = $this->phpDocNullableTypeHelper->resolveUpdatedPhpDocTypeFromPhpDocTypeAndPhpParserType(
+            $docType,
+            $phpParserType
+        );
+
+        if (! $updatedPhpDocType instanceof Type) {
+            return null;
+        }
+
+        $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $updatedPhpDocType);
+
+        if (! $phpDocInfo->hasChanged()) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
@@ -70,7 +71,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class];
+        return [ClassMethod::class, Function_::class];
     }
 
     /**


### PR DESCRIPTION
Extracted PR from https://github.com/rectorphp/rector-src/pull/2049

Added new **ReturnAnnotationIncorrectNullableRector** which adds or removes `null` type from `@return` phpdoc typehint based on php return type declaration