### PR TITLE
[Fix] Make UnionTypesRector and ReturnAnnotationIncorrectNullableRector skip chaotic methods

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -248,6 +248,7 @@ parameters:
             message: '#Class cognitive complexity is \d+, keep it under \d+#'
             paths:
                 - packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+                - rules/Php80/Rector/FunctionLike/UnionTypesRector.php
 
         -
             message: '#Property with protected modifier is not allowed\. Use interface contract method instead#'

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_chaotic_methods.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_chaotic_methods.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+final class SkipAnnotationsOnChaoticMethods extends NodeVisitorAbstract
+{
+    /**
+     * @return Node|null
+     */
+    public function enterNode(Node $node): ?Node
+    {
+        return $node;
+    }
+}
+

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_removing_mixed_array.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_removing_mixed_array.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+class SkipRemovingMixedReturnType
+{
+    /**
+     * @return mixed[]
+     */
+    private function x(): array
+    {
+        return [];
+    }
+}

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_removing_mixed_array_or_null.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_removing_mixed_array_or_null.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+class SkipRemovingNullableMixedReturnType
+{
+    /**
+     * @return mixed[]|null
+     */
+    private function x(bool $returnNull): ?array
+    {
+        return $returnNull ? null : [];
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-chaotic-methods.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector/Fixture/skip-chaotic-methods.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnAnnotationIncorrectNullableRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+final class SkipAnnotationsOnChaoticMethods extends NodeVisitorAbstract
+{
+    /**
+     * @return Node
+     */
+    public function enterNode(Node $node): ?Node
+    {
+        return $node;
+    }
+}
+

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -14,6 +14,7 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\DeadCode\TypeNodeAnalyzer\GenericTypeNodeAnalyzer;
+use Rector\DeadCode\TypeNodeAnalyzer\MixedArrayTypeNodeAnalyzer;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 
 final class DeadReturnTagValueNodeAnalyzer
@@ -22,6 +23,7 @@ final class DeadReturnTagValueNodeAnalyzer
         private readonly TypeComparator $typeComparator,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer,
+        private readonly MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer,
     ) {
     }
 
@@ -54,6 +56,10 @@ final class DeadReturnTagValueNodeAnalyzer
         }
 
         if ($this->genericTypeNodeAnalyzer->hasGenericType($returnTagValueNode->type)) {
+            return false;
+        }
+
+        if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($returnTagValueNode->type)) {
             return false;
         }
 

--- a/rules/DeadCode/TypeNodeAnalyzer/MixedArrayTypeNodeAnalyzer.php
+++ b/rules/DeadCode/TypeNodeAnalyzer/MixedArrayTypeNodeAnalyzer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\TypeNodeAnalyzer;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
+
+final class MixedArrayTypeNodeAnalyzer
+{
+    public function hasMixedArrayType(UnionTypeNode $unionTypeNode): bool
+    {
+        $types = $unionTypeNode->types;
+
+        foreach ($types as $type) {
+            if ($type instanceof SpacingAwareArrayTypeNode) {
+                $typeNode = $type->type;
+                if (! $typeNode instanceof IdentifierTypeNode) {
+                    continue;
+                }
+
+                if ($typeNode->name === 'mixed') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
+++ b/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
@@ -28,6 +28,7 @@ use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeAnalyzer;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodParamVendorLockResolver;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -43,6 +44,7 @@ final class UnionTypesRector extends AbstractRector implements MinPhpVersionInte
         private readonly ReturnTagRemover $returnTagRemover,
         private readonly ParamTagRemover $paramTagRemover,
         private readonly ClassMethodParamVendorLockResolver $classMethodParamVendorLockResolver,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
         private readonly UnionTypeAnalyzer $unionTypeAnalyzer,
         private readonly TypeFactory $typeFactory
     ) {
@@ -94,6 +96,10 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $this->hasChanged = false;
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
+            return null;
+        }
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
@@ -14,6 +14,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\Guard\PhpDocNestedAnnotationGuard;
 use Rector\TypeDeclaration\Helper\PhpDocNullableTypeHelper;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -25,6 +26,7 @@ final class ReturnAnnotationIncorrectNullableRector extends AbstractRector
     public function __construct(
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly PhpDocNullableTypeHelper $phpDocNullableTypeHelper,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
         private readonly PhpDocNestedAnnotationGuard $phpDocNestedAnnotationGuard
     ) {
     }
@@ -75,11 +77,15 @@ CODE_SAMPLE
     }
 
     /**
-     * @param ClassMethod $node
+     * @param ClassMethod|Function_ $node
      */
     public function refactor(Node $node): ?Node
     {
         $returnType = $node->getReturnType();
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
+            return null;
+        }
 
         if ($returnType === null) {
             return null;

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -62,7 +62,7 @@ final class ValueResolver
     }
 
     /**
-     * @return mixed|null
+     * @phpstan-return mixed|null
      */
     public function getValue(Expr $expr, bool $resolvedClassReference = false)
     {
@@ -215,7 +215,7 @@ final class ValueResolver
     }
 
     /**
-     * @return mixed[]
+     * @phpstan-return mixed[]|null
      */
     private function extractConstantArrayTypeValue(ConstantArrayType $constantArrayType): ?array
     {

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -62,7 +62,7 @@ final class ValueResolver
     }
 
     /**
-     * @phpstan-return mixed|null
+     * @return mixed|null
      */
     public function getValue(Expr $expr, bool $resolvedClassReference = false)
     {
@@ -215,7 +215,7 @@ final class ValueResolver
     }
 
     /**
-     * @phpstan-return mixed[]|null
+     * @return mixed[]|null
      */
     private function extractConstantArrayTypeValue(ConstantArrayType $constantArrayType): ?array
     {


### PR DESCRIPTION
If you add the `VarAnnotationIncorrectNullableRector` and `ReturnAnnotationIncorrectNullableRector` rules to strict-declaration set and run rector, it should produce the expected output.