### PR TITLE
[Php74] Add support for string|false|null on RestoreDefaultNullToNullableTypePropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/string_false_null.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/string_false_null.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+class StringFalseNull
+{
+    public string|false|null $name;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+class StringFalseNull
+{
+    public string|false|null $name = null;
+}
+
+?>

--- a/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
+++ b/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
@@ -25,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemovePhpVersionIdCheckRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    private string | int | null $phpVersionConstraint;
+    private string | int | null $phpVersionConstraint = null;
 
     public function __construct(
         private readonly PhpVersionFactory $phpVersionFactory

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Rector\Php74\Rector\Property;
 
 use PhpParser\Node;
-use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -83,10 +83,6 @@ CODE_SAMPLE
             return true;
         }
 
-        if (! $this->nodeTypeResolver->isNullableType($property)) {
-            return true;
-        }
-
         if (count($property->props) > 1) {
             return true;
         }
@@ -108,6 +104,10 @@ CODE_SAMPLE
         // so it needs to has null default
         if (! $classLike instanceof Class_) {
             return false;
+        }
+
+        if (! $this->nodeTypeResolver->isNullableType($property)) {
+            return true;
         }
 
         return $this->constructorAssignDetector->isPropertyAssigned($classLike, $propertyName);

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -78,7 +79,11 @@ CODE_SAMPLE
 
     private function shouldSkip(Property $property): bool
     {
-        if (! $property->type instanceof NullableType) {
+        if ($property->type === null) {
+            return true;
+        }
+
+        if (! $this->nodeTypeResolver->isNullableType($property)) {
             return true;
         }
 


### PR DESCRIPTION
Given the following code:

```php
class StringFalseNull
{
    public string|false|null $name;
}
```

is currently skipped, which may cause error:

```
Fatal error: Uncaught Error: Typed property NullableStringDefaultString::$name must not be accessed before initialization
```

it should be added `null` default value:

```diff
-    public string|false|null $name;
+    public string|false|null $name = null;
```