### PR TITLE
[CodingStyle] Skip comment after @var on InlineSimplePropertyAnnotationRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector/Fixture/EmptyConfig/comment_after_var.php.inc
+++ b/rules-tests/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector/Fixture/EmptyConfig/comment_after_var.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Property\InlineSimplePropertyAnnotationRector\Fixture\EmptyConfig;
+
+final class SkipCommentAfterVar
+{
+    /**
+     * @var string[]
+     *
+     * some comment
+     */
+    private const POSSIBLE_DELIMITERS = ['#', '~', '/'];
+}

--- a/rules-tests/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector/Fixture/EmptyConfig/comment_after_var.php.inc
+++ b/rules-tests/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector/Fixture/EmptyConfig/comment_after_var.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\CodingStyle\Rector\Property\InlineSimplePropertyAnnotatio
 final class SkipCommentAfterVar
 {
     /**
-     * @var string[]
+     * @phpstan-var string[]
      *
      * some comment
      */

--- a/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
+++ b/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
@@ -123,6 +123,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (count($phpDocInfo->getPhpDocNode()->children) > 1) {
+            return null;
+        }
+
         // Creating new node is the only way to enforce the "singleLined" property AFAIK
         $newPhpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
         $newPhpDocInfo->makeSingleLined();


### PR DESCRIPTION
@dorrogeray This PR fix issue like in https://github.com/rectorphp/rector-src/pull/2072/files/3f788294918b1def03b74a15f0acab58d7c9e1cd#diff-eba629d378e644f5b16b35c4544953d32fddc8e3bdbcff7eeeadb1d0c3dce893

