### PR TITLE
[CodingStyle] Add Future note comment to not register to coding-style config set when ecs with PhpdocLineSpanFixer used

### DIFF
--- a/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
+++ b/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
@@ -18,7 +18,11 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\Tests\CodingStyle\Rector\Property\InlineSimplePropertyAnnotationRector\InlineSimplePropertyAnnotationRectorTest
  *
- * Future note: do not register to coding-style config set as it will always conflict with ecs use of \PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer
+ * rector-src dev note:
+ *
+ *      Do not register to coding-style config/set/coding-style.php set
+ *      as it will always conflict with ECS use of \PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer
+ *      so rectify CI will always rolled back the change
  */
 final class InlineSimplePropertyAnnotationRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface
 {

--- a/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
+++ b/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
@@ -17,6 +17,8 @@ use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\CodingStyle\Rector\Property\InlineSimplePropertyAnnotationRector\InlineSimplePropertyAnnotationRectorTest
+ *
+ * Future note: do not register to coding-style config set as it will always conflict with ecs use of \PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer
  */
 final class InlineSimplePropertyAnnotationRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface
 {


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/2072#issuecomment-1099464586