### PR TITLE
[Naming][TypeDeclaration] Handle RenameVariableToMatchMethodCallReturnTypeRector + AddVoidReturnTypeWhereNoReturnRector

### DIFF
--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -138,11 +138,18 @@ CODE_SAMPLE
                     return false;
                 }
 
+                $passedNodeOriginalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+                $usedNodeOriginalNode = $callNode->getAttribute(AttributeKey::ORIGINAL_NODE);
+
+                if (! $passedNodeOriginalNode instanceof Node || ! $usedNodeOriginalNode instanceof Node) {
+                    return false;
+                }
+
                 /** @var FuncCall|StaticCall|MethodCall $node */
-                $passedNode = clone $node;
+                $passedNode = clone $passedNodeOriginalNode;
 
                 /** @var FuncCall|StaticCall|MethodCall $callNode */
-                $usedNode = clone $callNode;
+                $usedNode = clone $usedNodeOriginalNode;
 
                 /** @var FuncCall|StaticCall|MethodCall $passedNode */
                 $passedNode->args = [];

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -142,14 +142,17 @@ CODE_SAMPLE
 
                 $usedNodeOriginalNode = $callNode->getAttribute(AttributeKey::ORIGINAL_NODE);
 
-                if (! $usedNodeOriginalNode instanceof CallLike) {
+                if (! $usedNodeOriginalNode instanceof Node) {
+                    return false;
+                }
+
+                if (! in_array($usedNodeOriginalNode::class, [FuncCall::class, StaticCall::class, MethodCall::class], true)) {
                     return false;
                 }
 
                 /** @var FuncCall|StaticCall|MethodCall $node */
                 $passedNode = clone $node;
 
-                /** @var FuncCall|StaticCall|MethodCall $callNode */
                 $usedNode = clone $usedNodeOriginalNode;
 
                 /** @var FuncCall|StaticCall|MethodCall $passedNode */

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -144,11 +144,7 @@ CODE_SAMPLE
                     return false;
                 }
 
-                if (! in_array(
-                    $usedNodeOriginalNode::class,
-                    [FuncCall::class, StaticCall::class, MethodCall::class],
-                    true
-                )) {
+                if ($usedNodeOriginalNode::class !== $callNode::class) {
                     return false;
                 }
 

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -145,6 +145,7 @@ CODE_SAMPLE
                 if (! $passedNodeOriginalNode instanceof CallLike) {
                     return false;
                 }
+
                 if (! $usedNodeOriginalNode instanceof CallLike) {
                     return false;
                 }

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -26,6 +26,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\RenameVariableToMatchMethodCallReturnTypeRectorTest
@@ -146,16 +147,12 @@ CODE_SAMPLE
                     return false;
                 }
 
-                /** @var FuncCall|StaticCall|MethodCall $node */
+                Assert::isAnyOf($passedNodeOriginalNode, [FuncCall::class, StaticCall::class, MethodCall::class]);
+                Assert::isAnyOf($usedNodeOriginalNode, [FuncCall::class, StaticCall::class, MethodCall::class]);
+
                 $passedNode = clone $passedNodeOriginalNode;
-
-                /** @var FuncCall|StaticCall|MethodCall $callNode */
                 $usedNode = clone $usedNodeOriginalNode;
-
-                /** @var FuncCall|StaticCall|MethodCall $passedNode */
                 $passedNode->args = [];
-
-                /** @var FuncCall|StaticCall|MethodCall $usedNode */
                 $usedNode->args = [];
 
                 return $this->nodeComparator->areNodesEqual($passedNode, $usedNode);

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -140,22 +140,22 @@ CODE_SAMPLE
                     return false;
                 }
 
-                $passedNodeOriginalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
                 $usedNodeOriginalNode = $callNode->getAttribute(AttributeKey::ORIGINAL_NODE);
-                if (! $passedNodeOriginalNode instanceof CallLike) {
-                    return false;
-                }
 
                 if (! $usedNodeOriginalNode instanceof CallLike) {
                     return false;
                 }
 
-                Assert::isAnyOf($passedNodeOriginalNode, [FuncCall::class, StaticCall::class, MethodCall::class]);
-                Assert::isAnyOf($usedNodeOriginalNode, [FuncCall::class, StaticCall::class, MethodCall::class]);
+                /** @var FuncCall|StaticCall|MethodCall $node */
+                $passedNode = clone $node;
 
-                $passedNode = clone $passedNodeOriginalNode;
+                /** @var FuncCall|StaticCall|MethodCall $callNode */
                 $usedNode = clone $usedNodeOriginalNode;
+
+                /** @var FuncCall|StaticCall|MethodCall $passedNode */
                 $passedNode->args = [];
+
+                /** @var FuncCall|StaticCall|MethodCall $usedNode */
                 $usedNode->args = [];
 
                 return $this->nodeComparator->areNodesEqual($passedNode, $usedNode);

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -142,8 +142,10 @@ CODE_SAMPLE
 
                 $passedNodeOriginalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
                 $usedNodeOriginalNode = $callNode->getAttribute(AttributeKey::ORIGINAL_NODE);
-
-                if (! $passedNodeOriginalNode instanceof CallLike || ! $usedNodeOriginalNode instanceof CallLike) {
+                if (! $passedNodeOriginalNode instanceof CallLike) {
+                    return false;
+                }
+                if (! $usedNodeOriginalNode instanceof CallLike) {
                     return false;
                 }
 

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -6,7 +6,6 @@ namespace Rector\Naming\Rector\Assign;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -26,7 +25,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\RenameVariableToMatchMethodCallReturnTypeRectorTest
@@ -146,7 +144,11 @@ CODE_SAMPLE
                     return false;
                 }
 
-                if (! in_array($usedNodeOriginalNode::class, [FuncCall::class, StaticCall::class, MethodCall::class], true)) {
+                if (! in_array(
+                    $usedNodeOriginalNode::class,
+                    [FuncCall::class, StaticCall::class, MethodCall::class],
+                    true
+                )) {
                     return false;
                 }
 

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -6,6 +6,7 @@ namespace Rector\Naming\Rector\Assign;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -141,7 +142,7 @@ CODE_SAMPLE
                 $passedNodeOriginalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
                 $usedNodeOriginalNode = $callNode->getAttribute(AttributeKey::ORIGINAL_NODE);
 
-                if (! $passedNodeOriginalNode instanceof Node || ! $usedNodeOriginalNode instanceof Node) {
+                if (! $passedNodeOriginalNode instanceof CallLike || ! $usedNodeOriginalNode instanceof CallLike) {
                     return false;
                 }
 

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -151,6 +151,7 @@ CODE_SAMPLE
                 /** @var FuncCall|StaticCall|MethodCall $node */
                 $passedNode = clone $node;
 
+                /** @var FuncCall|StaticCall|MethodCall $usedNodeOriginalNode */
                 $usedNode = clone $usedNodeOriginalNode;
 
                 /** @var FuncCall|StaticCall|MethodCall $passedNode */

--- a/tests/Issues/Issue7112/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7112/Fixture/fixture.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7112\Fixture;
+
+class Fixture
+{
+    public function something($callback = null): self
+    {
+        return $this;
+    }
+
+    public function run(): void
+    {
+        $model = $this->something()->value();
+        $model = $this->something(
+            function ($query) {
+                return $query;
+            }
+        )->value();
+    }
+
+    private function value(): string
+    {
+        return 'anything';
+    }
+}

--- a/tests/Issues/Issue7112/RuleCombinationShouldNotAddVoidReturnTypeWhereReturnExistsRectorTest.php
+++ b/tests/Issues/Issue7112/RuleCombinationShouldNotAddVoidReturnTypeWhereReturnExistsRectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue7112;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7112
+ */
+final class RuleCombinationShouldNotAddVoidReturnTypeWhereReturnExistsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue7112/config/configured_rule.php
+++ b/tests/Issues/Issue7112/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $services = $rectorConfig->services();
+    $services->set(RenameVariableToMatchMethodCallReturnTypeRector::class);
+    $services->set(AddVoidReturnTypeWhereNoReturnRector::class);
+};


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/2079 
Fixes https://github.com/rectorphp/rector/issues/7112