### PR TITLE
[Doc] Typo fix; autoimportNames -> importNames

### DIFF
--- a/build/target-repository/docs/auto_import_names.md
+++ b/build/target-repository/docs/auto_import_names.md
@@ -16,7 +16,7 @@ Rector works with all class names as fully qualified by default, so it knows the
 To import FQN like these, configure `rector.php` with:
 
 ```php
-$rectorConfig->autoImportNames();
+$rectorConfig->importNames();
 ```
 
 <br>


### PR DESCRIPTION
Documentation typo fix. There is no `autoImportNames()` method, it should be `importNames()`.