### PR TITLE
[Php81] Skip modified by trait on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_multiple_assign.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_multiple_assign.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Source\ModifiedByTrait;
+
+final class SkipModifiedByTrait
+{
+    use ModifiedByTrait;
+
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function execute()
+    {
+        $this->modify();
+    }
+}

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Source/ModifiedByTrait.php
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Source/ModifiedByTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Source;
+
+trait ModifiedByTrait
+{
+    public function modify()
+    {
+        $this->name = 'modified';
+    }
+}


### PR DESCRIPTION
When property modified by trait, it should be skipped.