### PR TITLE
[Php74] Skip static property filled by trait on TypedPropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/static_property_filled_by_trait.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/static_property_filled_by_trait.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+use Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\AnotherClass;
+use Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\FillerTrait;
+
+class StaticPropertyFilledByTrait
+{
+    use FillerTrait;
+
+    /**
+     * @var AnotherClass
+     */
+    private static $someStaticProperty;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Source/FillerTrait.php
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Source/FillerTrait.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source;
 
+use stdClass;
+
 trait FillerTrait
 {
-    public function process(AnotherClass $anotherClass)
+    public function process(stdClass $stdClass)
     {
-        $this->property = $anotherClass;
+        $this->property = $stdClass;
+    }
+
+    public function process2(stdClass $stdClass)
+    {
+        self::$someStaticProperty = $stdClass;
     }
 }

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -66,9 +66,10 @@ final class PropertyFetchAnalyzer
 
     public function containsLocalPropertyFetchName(Node $node, string $propertyName): bool
     {
-        return (bool) $this->betterNodeFinder->findFirst($node, function (Node $node) use ($propertyName): bool {
-            return $this->isLocalPropertyFetchName($node, $propertyName);
-        });
+        return (bool) $this->betterNodeFinder->findFirst(
+            $node,
+            fn (Node $node): bool => $this->isLocalPropertyFetchName($node, $propertyName)
+        );
     }
 
     public function isPropertyToSelf(PropertyFetch | StaticPropertyFetch $expr): bool

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -67,11 +67,7 @@ final class PropertyFetchAnalyzer
     public function containsLocalPropertyFetchName(Node $node, string $propertyName): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($node, function (Node $node) use ($propertyName): bool {
-            if (! $node instanceof PropertyFetch) {
-                return false;
-            }
-
-            return $this->nodeNameResolver->isName($node->name, $propertyName);
+            return $this->isLocalPropertyFetchName($node, $propertyName);
         });
     }
 


### PR DESCRIPTION
`TypedPropertyRector` currently only skip property filled by trait on `PropertyFetch`, but still process on `StaticPropertyFetch`, it should be skipped as well.