### PR TITLE
[Scoped] Register ParameterProvider to Excluded class on Scoped version

### DIFF
--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -21,6 +21,8 @@ final class StaticEasyPrefixer
         'Helmich\TypoScriptParser\Parser\Traverser\Traverser',
         // for usage in packages/Testing/PHPUnit/PlatformAgnosticAssertions.php
         'PHPUnit\Framework\Constraint\IsEqual',
+        // used to get parameter value from custom rule
+        'Symplify\PackageBuilder\Parameter\ParameterProvider',
     ];
 
     /**


### PR DESCRIPTION
Since `ParameterProvider` is no longer exists in `AbstractRector`, getting parameter value no longer doable via `ParameterProvider` as the class is prefixed, and `symplify/package-builder` itself already require php 8.

To solve it is by make `Symplify\PackageBuilder\Parameter\ParameterProvider` available when called with register into Excluded class so user can inject to the `__construct()` of the custom rule.

Fixes https://github.com/rectorphp/rector/issues/7117