### PR TITLE
[Core] Rollback ParameterProvider autowire into AbstractRector

### DIFF
--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -52,7 +52,8 @@ final class ClassRenamer
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockClassRenamer $docBlockClassRenamer,
         private readonly ReflectionProvider $reflectionProvider,
-        private readonly NodeRemover $nodeRemover
+        private readonly NodeRemover $nodeRemover,
+        private readonly ParameterProvider $parameterProvider
     ) {
     }
 

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -52,8 +52,7 @@ final class ClassRenamer
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockClassRenamer $docBlockClassRenamer,
         private readonly ReflectionProvider $reflectionProvider,
-        private readonly NodeRemover $nodeRemover,
-        private readonly ParameterProvider $parameterProvider
+        private readonly NodeRemover $nodeRemover
     ) {
     }
 

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -19,7 +19,6 @@ use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Renaming\NodeManipulator\ClassRenamer;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -31,8 +31,7 @@ final class RenameClassRector extends AbstractRector implements ConfigurableRect
 {
     public function __construct(
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
-        private readonly ClassRenamer $classRenamer,
-        private readonly ParameterProvider $parameterProvider,
+        private readonly ClassRenamer $classRenamer
     ) {
     }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -40,6 +40,7 @@ use Rector\PostRector\Collector\NodesToRemoveCollector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symfony\Contracts\Service\Attribute\Required;
 use Symplify\Astral\NodeTraverser\SimpleCallableNodeTraverser;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\Skipper\Skipper\Skipper;
 
 /**
@@ -80,6 +81,8 @@ CODE_SAMPLE;
     protected NodeNameResolver $nodeNameResolver;
 
     protected NodeTypeResolver $nodeTypeResolver;
+
+    protected ParameterProvider $parameterProvider;
 
     protected PhpVersionProvider $phpVersionProvider;
 
@@ -137,6 +140,7 @@ CODE_SAMPLE;
         PhpVersionProvider $phpVersionProvider,
         ExclusionManager $exclusionManager,
         StaticTypeMapper $staticTypeMapper,
+        ParameterProvider $parameterProvider,
         CurrentRectorProvider $currentRectorProvider,
         CurrentNodeProvider $currentNodeProvider,
         Skipper $skipper,
@@ -158,6 +162,7 @@ CODE_SAMPLE;
         $this->phpVersionProvider = $phpVersionProvider;
         $this->exclusionManager = $exclusionManager;
         $this->staticTypeMapper = $staticTypeMapper;
+        $this->parameterProvider = $parameterProvider;
         $this->currentRectorProvider = $currentRectorProvider;
         $this->currentNodeProvider = $currentNodeProvider;
         $this->skipper = $skipper;

--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -21,8 +21,6 @@ final class StaticEasyPrefixer
         'Helmich\TypoScriptParser\Parser\Traverser\Traverser',
         // for usage in packages/Testing/PHPUnit/PlatformAgnosticAssertions.php
         'PHPUnit\Framework\Constraint\IsEqual',
-        // used to get parameter value from custom rule
-        'Symplify\PackageBuilder\Parameter\ParameterProvider',
     ];
 
     /**


### PR DESCRIPTION
The ParameterProvider service was removed from autowire at PR:

- https://github.com/rectorphp/rector-src/pull/2038

which since 0.12.21, it cause error on custom rules that using it, so it make error:

```
1) LaminasTest\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector\AutoImportRenameUseTest::test with data set #0 (RectorPrefix20220418\Symplify\SmartFileSystem\SmartFileInfo Object (...))
Undefined property: Laminas\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector::$parameterProvider
```

Register `ParameterProvider` to unprefix scoper is not a solution as it cause another error:

```
 Cannot autowire service "Laminas\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector": argument "$parameterProvider" of method "__construct()" references class "Symplify\PackageBuilder\Parameter\ParameterProvider" but no such service exists.
```

Requiring symplify/package-builder is not a solution since it require php 8.0, while the custom rule that use it using php 7.4, ref https://github.com/laminas/laminas-servicemanager-migration/runs/6066032581?check_suite_focus=true

The possible solution I found is by rollback it to `AbstractRector` property with autowire.

This PR fix it.

Fixes https://github.com/rectorphp/rector/issues/7117