### PR TITLE
Add failing test fixture for RestoreDefaultNullToNullableTypeProperty…

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/demo_fixture.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/demo_fixture.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Traits;
+
+use App\Entity\Attachment;
+use Doctrine\Common\Collections\Collection;
+
+trait AttachmentEntity
+{
+    /** @var Collection<int, Attachment> */
+    private Collection $attachments;
+
+    public function getAttachments() : Collection
+    {
+        return $this->attachments;
+    }
+
+    public function addAttachment(Attachment $attachment) : static
+    {
+        $this->attachments[] = $attachment;
+
+        return $this;
+    }
+
+    public function removeAttachment(Attachment $attachment) : static
+    {
+        $this->attachments->removeElement($attachment);
+
+        return $this;
+    }
+
+    public function setAttachments(Collection $attachments) : static
+    {
+        $this->attachments = $attachments;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
`private Collection $attachments;` is not nullable, but Rector adds ` = null`

# Failing Test for RestoreDefaultNullToNullableTypePropertyRector

Based on https://getrector.org/demo/f8e97f26-045e-466e-b130-9852a931de22