### PR TITLE
Remove exclude Symfony ContainerConfigurator from scoping

### DIFF
--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -10,8 +10,6 @@ final class StaticEasyPrefixer
      * @var string[]
      */
     public const EXCLUDED_CLASSES = [
-        // part of public interface of configs.php
-        'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
         // for SmartFileInfo
         'Symplify\SmartFileSystem\SmartFileInfo',
         // for ComposerJson because it is part of the public API. I.e. ComposerRectorInterface


### PR DESCRIPTION
With the to introducing of the `RectorConfig` class it is not longer needed to exclude this ContainerConfigurator class from scoping. I run still sometimes into issue where my own `ContainerConfigurator` is loaded before rector and so get an error like [here](https://github.com/rectorphp/rector/issues/6837). With the new `RectorConfig` it is not longer required to expose / exclude this class for scoping.

As this is a bc break it maybe can only be merged for `0.13.x` or `1.0` release.