### PR TITLE
[DogFood] Skip services variable used as service load/defaults definition on UpgradeRectorConfigRector

### DIFF
--- a/rules-tests/DogFood/Rector/Closure/UpgradeRectorConfigRector/Fixture/skip_service_used.php.inc
+++ b/rules-tests/DogFood/Rector/Closure/UpgradeRectorConfigRector/Fixture/skip_service_used.php.inc
@@ -13,5 +13,14 @@ return static function (RectorConfig $rectorConfig): void {
         ->autowire()
         ->autoconfigure();
 
+    $services->load('Rector\\', __DIR__ . '/../rules')
+        ->exclude([
+            __DIR__ . '/../rules/*/ValueObject/*',
+            __DIR__ . '/../rules/*/Rector/*',
+            __DIR__ . '/../rules/*/Contract/*',
+            __DIR__ . '/../rules/*/Exception/*',
+            __DIR__ . '/../rules/*/Enum/*',
+        ]);
+
     $services->set(UpgradeRectorConfigRector::class);
 };

--- a/rules-tests/DogFood/Rector/Closure/UpgradeRectorConfigRector/Fixture/skip_service_used.php.inc
+++ b/rules-tests/DogFood/Rector/Closure/UpgradeRectorConfigRector/Fixture/skip_service_used.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DogFood\Rector\Closure\UpgradeRectorConfigRector\Fixture;
+
+use Rector\Config\RectorConfig;
+use Rector\DogFood\Rector\Closure\UpgradeRectorConfigRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $services = $rectorConfig->services();
+
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->set(UpgradeRectorConfigRector::class);
+};

--- a/rules/DogFood/NodeManipulator/ContainerConfiguratorEmptyAssignRemover.php
+++ b/rules/DogFood/NodeManipulator/ContainerConfiguratorEmptyAssignRemover.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DogFood\NodeManipulator;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
@@ -27,7 +28,16 @@ final class ContainerConfiguratorEmptyAssignRemover
                 continue;
             }
 
-            if ($this->exprUsedInNextNodeAnalyzer->isUsed($closure->stmts[$key]->expr->var)) {
+            /** @var Expression $expression */
+            $expression = $closure->stmts[$key];
+
+            /** @var Assign $assign */
+            $assign = $expression->expr;
+
+            /** @var Expr $var */
+            $var = $assign->var;
+
+            if ($this->exprUsedInNextNodeAnalyzer->isUsed($var)) {
                 continue;
             }
 

--- a/rules/DogFood/NodeManipulator/ContainerConfiguratorEmptyAssignRemover.php
+++ b/rules/DogFood/NodeManipulator/ContainerConfiguratorEmptyAssignRemover.php
@@ -9,12 +9,14 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use Rector\DeadCode\NodeAnalyzer\ExprUsedInNextNodeAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 
 final class ContainerConfiguratorEmptyAssignRemover
 {
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver,
+        private readonly ExprUsedInNextNodeAnalyzer $exprUsedInNextNodeAnalyzer
     ) {
     }
 
@@ -22,6 +24,10 @@ final class ContainerConfiguratorEmptyAssignRemover
     {
         foreach ($closure->getStmts() as $key => $stmt) {
             if (! $this->isHelperAssign($stmt)) {
+                continue;
+            }
+
+            if ($this->exprUsedInNextNodeAnalyzer->isUsed($closure->stmts[$key]->expr->var)) {
                 continue;
             }
 

--- a/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
+++ b/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
@@ -143,7 +143,7 @@ CODE_SAMPLE
                 $nodeVarType = $this->nodeTypeResolver->getType($node->var);
 
                 if ($nodeVarType instanceof FullyQualifiedObjectType && $nodeVarType->getClassName() === self::SERVICE_CONFIGURATOR_CLASS) {
-                    $ispossiblyServiceDefinition = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+                    $isPossiblyServiceDefinition = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
                         $node,
                         function (Node $node): bool {
                             if (! $node instanceof MethodCall) {
@@ -155,7 +155,7 @@ CODE_SAMPLE
                         }
                     );
 
-                    if ($ispossiblyServiceDefinition) {
+                    if ($isPossiblyServiceDefinition) {
                         return null;
                     }
                 }

--- a/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
+++ b/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
@@ -6,6 +6,7 @@ namespace Rector\DogFood\Rector\Closure;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
@@ -15,9 +16,11 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Defluent\NodeAnalyzer\FluentChainMethodCallNodeAnalyzer;
 use Rector\DogFood\NodeAnalyzer\ContainerConfiguratorCallAnalyzer;
 use Rector\DogFood\NodeManipulator\ContainerConfiguratorEmptyAssignRemover;
 use Rector\DogFood\NodeManipulator\ContainerConfiguratorImportsMerger;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -60,10 +63,16 @@ final class UpgradeRectorConfigRector extends AbstractRector
      */
     private const CONTAINER_CONFIGURATOR_CLASS = 'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator';
 
+    /**
+     * @var string
+     */
+    private const SERVICE_CONFIGURATOR_CLASS = 'Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator';
+
     public function __construct(
         private readonly ContainerConfiguratorCallAnalyzer $containerConfiguratorCallAnalyzer,
         private readonly ContainerConfiguratorEmptyAssignRemover $containerConfiguratorEmptyAssignRemover,
-        private readonly ContainerConfiguratorImportsMerger $containerConfiguratorImportsMerger
+        private readonly ContainerConfiguratorImportsMerger $containerConfiguratorImportsMerger,
+        private readonly FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer
     ) {
     }
 
@@ -131,6 +140,26 @@ CODE_SAMPLE
 
             // 2. call on rule
             if ($node instanceof MethodCall) {
+                $nodeVarType = $this->nodeTypeResolver->getType($node->var);
+
+                if ($nodeVarType instanceof FullyQualifiedObjectType && $nodeVarType->getClassName() === self::SERVICE_CONFIGURATOR_CLASS) {
+                    $ispossiblyServiceDefinition = $this->betterNodeFinder->findFirstPreviousOfNode(
+                        $node,
+                        function (Node $node): bool {
+                        if (! $node instanceof MethodCall) {
+                            return false;
+                        }
+
+                        $methodCall = $this->fluentChainMethodCallNodeAnalyzer->resolveRootMethodCall($node);
+                        return $methodCall instanceof Expr;
+                    }
+                    );
+
+                    if ($ispossiblyServiceDefinition !== null) {
+                        return null;
+                    }
+                }
+
                 if ($this->containerConfiguratorCallAnalyzer->isMethodCallWithServicesSetConfiguredRectorRule($node)) {
                     return $this->refactorConfigureRuleMethodCall($node);
                 }

--- a/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
+++ b/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
@@ -143,19 +143,19 @@ CODE_SAMPLE
                 $nodeVarType = $this->nodeTypeResolver->getType($node->var);
 
                 if ($nodeVarType instanceof FullyQualifiedObjectType && $nodeVarType->getClassName() === self::SERVICE_CONFIGURATOR_CLASS) {
-                    $ispossiblyServiceDefinition = $this->betterNodeFinder->findFirstPreviousOfNode(
+                    $ispossiblyServiceDefinition = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
                         $node,
                         function (Node $node): bool {
-                        if (! $node instanceof MethodCall) {
-                            return false;
-                        }
+                            if (! $node instanceof MethodCall) {
+                                return false;
+                            }
 
-                        $methodCall = $this->fluentChainMethodCallNodeAnalyzer->resolveRootMethodCall($node);
-                        return $methodCall instanceof Expr;
-                    }
+                            $methodCall = $this->fluentChainMethodCallNodeAnalyzer->resolveRootMethodCall($node);
+                            return $methodCall instanceof Expr;
+                        }
                     );
 
-                    if ($ispossiblyServiceDefinition !== null) {
+                    if ($ispossiblyServiceDefinition) {
                         return null;
                     }
                 }


### PR DESCRIPTION
when services variable used, it currently still remove it and it:

```php
<?php

namespace Rector\Tests\DogFood\Rector\Closure\UpgradeRectorConfigRector\Fixture;

use Rector\Config\RectorConfig;
use Rector\DogFood\Rector\Closure\UpgradeRectorConfigRector;

return static function (RectorConfig $rectorConfig): void {
    $services = $rectorConfig->services();

    $services->defaults()
        ->public()
        ->autowire()
        ->autoconfigure();

    $services->load('Rector\\', __DIR__ . '/../rules')
        ->exclude([
            __DIR__ . '/../rules/*/ValueObject/*',
            __DIR__ . '/../rules/*/Rector/*',
            __DIR__ . '/../rules/*/Contract/*',
            __DIR__ . '/../rules/*/Exception/*',
            __DIR__ . '/../rules/*/Enum/*',
        ]);

    $services->set(UpgradeRectorConfigRector::class);
};
```

transform to:

```diff
-    $services = $rectorConfig->services();
-
     $services->defaults()
         ->public()
         ->autowire()
         ->autoconfigure();
 
-    $services->set(UpgradeRectorConfigRector::class);
+    $rectorConfig->rule(UpgradeRectorConfigRector::class);
```

which services definition removed, which cause error. This use case is mostly for service definition, which should be skipped as even kept, the transforming to `->rule()` may cause error like :

```
 [ERROR] Expected an instance of this class or to this class among his parents                                          
         Rector\Core\Contract\Rector\RectorInterface. Got: string in                                                    
         /Users/samsonasik/www/rector-symfony/config/config.php (which is being imported from                           
         "/Users/samsonasik/www/rector-symfony/rector.php").      
```

ref https://github.com/rectorphp/rector-laravel/pull/43