### PR TITLE
Add failing test fixture for AddArrayParamDocTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayParamDocTypeRector/Fixture/skip_union_function_parameter.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayParamDocTypeRector/Fixture/skip_union_function_parameter.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayParamDocTypeRector\Fixture;
+
+final class SkipUnionFunctionParameter
+{
+    private stdClass $value;
+    
+    public function setValue(stdClass|string $value): self {
+        $this->value = $value;
+        
+        return $this;
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for AddArrayParamDocTypeRector

Based on https://getrector.org/demo/1a74550e-9652-4fb8-8d85-5692d126a36a

refs https://github.com/rectorphp/rector/issues/7123