### PR TITLE
Add failing test for JMS AccessType

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/JMS/annotation_to_attribute_access_type.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/JMS/annotation_to_attribute_access_type.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\JMS;
+
+use JMS\Serializer\Annotation as JMS;
+
+/**
+ * @JMS\AccessType("public_method")
+ */
+class MyClass
+{
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\JMS;
+
+use JMS\Serializer\Annotation as JMS;
+
+#[JMS\AccessType(type: 'public_method')]
+class MyClass
+{
+}
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -36,6 +36,9 @@ return static function (RectorConfig $rectorConfig): void {
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\All'),
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Length'),
 
+            // JMS
+            new AnnotationToAttribute('JMS\Serializer\Annotation\AccessType'),
+
             // test for alias used
             new AnnotationToAttribute(
                 'Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\UseAlias\TestSmth'


### PR DESCRIPTION
Hi there!

This adds a failing Test for the JMS Serializer [AccessType](https://github.com/schmittjoh/serializer/blob/91652cc27bfe53f5d9b929dee10639e611f9ade4/src/Annotation/AccessType.php).

The Test seem to fail because of two reasons:
1. The named parameter `type` is on the second position in AccessType, but the Annotation is transformed to the Attribute `#[JMS\AccessType('public_method')]` (note the missing `type` name). The first Parameter is an array `$values`.
2. The [SetList](https://github.com/rectorphp/rector-symfony/blob/main/config/sets/jms/annotations-to-attributes.php) for JMS Serializer lives in [rector-symfony](https://github.com/rectorphp/rector-symfony) (maybe this is the better target for this test?). I added it here, because the [guide](https://github.com/rectorphp/rector/blob/main/docs/how_to_add_test_for_rector_rule.md) said it should be targeted at the Rule (which is AnnotationToAttribute).

Would be happy for some directions how to proceed. :)
Thanks