### PR TITLE
[DogFood] Skip call(configure) on UpgradeRectorConfigRector

### DIFF
--- a/rules-tests/DogFood/Rector/Closure/UpgradeRectorConfigRector/Fixture/skip_call_configure.php.inc
+++ b/rules-tests/DogFood/Rector/Closure/UpgradeRectorConfigRector/Fixture/skip_call_configure.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DogFood\Rector\Closure\UpgradeRectorConfigRector\Fixture;
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $services = $rectorConfig->services();
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            'old_2' => 'new_2',
+        ]])
+        ->call('configure', [[
+            'old_4' => 'new_4',
+        ]]);
+
+    $rectorConfig->import(__DIR__ . '/first_config.php');
+    $rectorConfig->import(__DIR__ . '/second_config.php');
+};

--- a/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
+++ b/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
@@ -6,7 +6,6 @@ namespace Rector\DogFood\Rector\Closure;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
@@ -186,16 +185,6 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function isFoundFluentServiceCall(Node $node): bool
-    {
-        if (! $node instanceof MethodCall) {
-            return false;
-        }
-
-        $chains = $this->fluentChainMethodCallNodeAnalyzer->collectMethodCallNamesInChain($node);
-        return count($chains) > 1;
-    }
-
     public function updateClosureParam(Closure $closure): void
     {
         $param = $closure->params[0];
@@ -227,6 +216,16 @@ CODE_SAMPLE
         }
 
         return $this->isNames($paramType, [self::CONTAINER_CONFIGURATOR_CLASS, self::RECTOR_CONFIG_CLASS]);
+    }
+
+    private function isFoundFluentServiceCall(Node $node): bool
+    {
+        if (! $node instanceof MethodCall) {
+            return false;
+        }
+
+        $chains = $this->fluentChainMethodCallNodeAnalyzer->collectMethodCallNamesInChain($node);
+        return count($chains) > 1;
     }
 
     /**


### PR DESCRIPTION
Given the following code:

```php
<?php

namespace Rector\Tests\DogFood\Rector\Closure\UpgradeRectorConfigRector\Fixture;

use Rector\Config\RectorConfig;
use Rector\Renaming\Rector\Name\RenameClassRector;

return static function (RectorConfig $rectorConfig): void {
    $services = $rectorConfig->services();
    $services->set(RenameClassRector::class)
        ->call('configure', [[
            'old_2' => 'new_2',
        ]])
        ->call('configure', [[
            'old_4' => 'new_4',
        ]]);

    $rectorConfig->import(__DIR__ . '/first_config.php');
    $rectorConfig->import(__DIR__ . '/second_config.php');
};
```

Currently produce:

```diff
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $services = $rectorConfig->services();
-    $services->set(RenameClassRector::class)
+    $rectorConfig->rule(RenameClassRector::class)
         ->call('configure', [[
             'old_2' => 'new_2',
         ]])
```

which invalid, and even changed, the array deep should be removed as `->call('configure')` remove first key array, so I think it should be skipped, and because it possibly called multiple times. `->call()->call()` as above example.