### PR TITLE
[Php74] Add class-string to string support on TypedPropertyRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -42,6 +42,13 @@ final class PhpDocTypeChanger
         ArrayShapeNode::class,
     ];
 
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_IDENTIFIER_TYPENODE_TYPES = [
+        'class-string',
+    ];
+
     public function __construct(
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly TypeComparator $typeComparator,
@@ -163,7 +170,15 @@ final class PhpDocTypeChanger
             }
         }
 
-        return in_array($typeNode::class, self::ALLOWED_TYPES, true);
+        if (in_array($typeNode::class, self::ALLOWED_TYPES, true)) {
+            return true;
+        }
+
+        if (! $typeNode instanceof \PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode) {
+            return false;
+        }
+
+        return in_array((string) $typeNode, self::ALLOWED_IDENTIFIER_TYPENODE_TYPES, true);
     }
 
     public function copyPropertyDocToParam(Property $property, Param $param): void

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -45,9 +45,7 @@ final class PhpDocTypeChanger
     /**
      * @var string[]
      */
-    private const ALLOWED_IDENTIFIER_TYPENODE_TYPES = [
-        'class-string',
-    ];
+    private const ALLOWED_IDENTIFIER_TYPENODE_TYPES = ['class-string'];
 
     public function __construct(
         private readonly StaticTypeMapper $staticTypeMapper,

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\MixedType;
@@ -172,7 +173,7 @@ final class PhpDocTypeChanger
             return true;
         }
 
-        if (! $typeNode instanceof \PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode) {
+        if (! $typeNode instanceof IdentifierTypeNode) {
             return false;
         }
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
@@ -6,6 +6,7 @@ namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
@@ -60,7 +61,7 @@ final class ClassStringTypeMapper implements TypeMapperInterface
      */
     public function mapToPhpParserNode(Type $type, TypeKind $typeKind): ?Node
     {
-        return null;
+        return new Name('string');
     }
 
     #[Required]

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
-use PHPStan\Type\ClassStringType;
-use PHPStan\Type\Generic\GenericClassStringType;
 use PhpParser\Node;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
@@ -15,7 +13,9 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType as PhpParserUnionType;
 use PhpParser\NodeAbstract;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
@@ -238,11 +238,7 @@ final class UnionTypeMapper implements TypeMapperInterface
     private function processResolveCompatibleStringCandidates(UnionType $unionType): ?Name
     {
         foreach ($unionType->getTypes() as $type) {
-            if (! in_array(
-                $type::class,
-                [ClassStringType::class, GenericClassStringType::class],
-                true
-            )) {
+            if (! in_array($type::class, [ClassStringType::class, GenericClassStringType::class], true)) {
                 return null;
             }
         }

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/class_string_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/class_string_type.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ClassStringType
+{
+    /**
+     * @var class-string
+     */
+    private $property = 'stdClass';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ClassStringType
+{
+    /**
+     * @var class-string
+     */
+    private string $property = 'stdClass';
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/class_string_type_no_default.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/class_string_type_no_default.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ClassStringTypeNoDefault
+{
+    /**
+     * @var class-string
+     */
+    private $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class ClassStringTypeNoDefault
+{
+    /**
+     * @var class-string
+     */
+    private string $property;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/no_condition_union_nullable.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/no_condition_union_nullable.php.inc
@@ -25,7 +25,7 @@ use Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\ReturnString;
 
 class NoConditionUnionNullable
 {
-    private ?string $nullOrString = null;
+    private ?string $nullOrString;
 
     public function __construct(?ReturnString $returnString = null)
     {

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/nullable_class_string.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/nullable_class_string.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class NullableClassString
+{
+    /**
+     * @var class-string|null
+     */
+    private $property;
+
+    public function run(): ?string
+    {
+        return $this->property;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class NullableClassString
+{
+    /**
+     * @var class-string|null
+     */
+    private ?string $property = null;
+
+    public function run(): ?string
+    {
+        return $this->property;
+    }
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/stdclass_type_filled_null_in_teardown.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/stdclass_type_filled_null_in_teardown.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-final class ArrayTypeFilledDefaultNullInTearDownTest extends TestCase
+final class StdClassTypeFilledNullInTearDownTest extends TestCase
 {
     /**
      * @var stdClass
@@ -32,9 +32,9 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-final class ArrayTypeFilledDefaultNullInTearDownTest extends TestCase
+final class StdClassTypeFilledNullInTearDownTest extends TestCase
 {
-    private ?\stdClass $property = null;
+    private ?\stdClass $property;
 
     protected function setUp(): void
     {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/nullable_class_string.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/nullable_class_string.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class NullableClassString
+{
+    /**
+     * @var class-string
+     */
+    private $property;
+
+    public function fill()
+    {
+        $this->property = 'stdClass';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class NullableClassString
+{
+    /**
+     * @var class-string
+     */
+    private ?string $property = null;
+
+    public function fill()
+    {
+        $this->property = 'stdClass';
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/has_method_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureInlinePublic/has_method_type.php.inc
@@ -24,10 +24,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsR
 
 final class HasMethodType
 {
-    /**
-     * @var class-string|object|null
-     */
-    public $obj;
+    public string|object|null $obj = null;
 
     public function loader($obj)
     {

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -38,6 +38,10 @@ final class VarTagRemover
             return;
         }
 
+        if ($this->phpDocTypeChanger->isAllowed($varTagValueNode->type)) {
+            return;
+        }
+
         $phpDocInfo->removeByType(VarTagValueNode::class);
     }
 

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -15,7 +15,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
-use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
@@ -62,7 +61,6 @@ final class TypedPropertyRector extends AbstractRector implements AllowEmptyConf
         private readonly VendorLockResolver $vendorLockResolver,
         private readonly DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
         private readonly VarTagRemover $varTagRemover,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer,
         private readonly ObjectTypeAnalyzer $objectTypeAnalyzer,
         private readonly MakePropertyTypedGuard $makePropertyTypedGuard,

--- a/src/NodeManipulator/BinaryOpManipulator.php
+++ b/src/NodeManipulator/BinaryOpManipulator.php
@@ -30,8 +30,8 @@ final class BinaryOpManipulator
      */
     public function matchFirstAndSecondConditionNode(
         BinaryOp $binaryOp,
-        $firstCondition,
-        $secondCondition
+        callable|string $firstCondition,
+        callable|string $secondCondition
     ): ?TwoNodeMatch {
         $this->validateCondition($firstCondition);
         $this->validateCondition($secondCondition);
@@ -114,7 +114,7 @@ final class BinaryOpManipulator
     /**
      * @param callable(Node $firstNode, Node $secondNode=): bool|class-string<Node> $firstCondition
      */
-    private function validateCondition($firstCondition): void
+    private function validateCondition(callable|string $firstCondition): void
     {
         if (is_callable($firstCondition)) {
             return;
@@ -131,7 +131,7 @@ final class BinaryOpManipulator
      * @param callable(Node $firstNode, Node $secondNode=): bool|class-string<Node> $condition
      * @return callable(Node $firstNode, Node $secondNode=): bool
      */
-    private function normalizeCondition($condition): callable
+    private function normalizeCondition(callable|string $condition): callable
     {
         if (is_callable($condition)) {
             return $condition;


### PR DESCRIPTION
Given the following code:

```php
final class ClassStringType
{
    /**
     * @var class-string
     */
    private $property = 'stdClass';
}
```

should changed to:

```diff
     /**
      * @var class-string
      */
-    private $property = 'stdClass';
+    private string $property = 'stdClass';
```

this PR try to add its support.