### PR TITLE
[DX] Update super old configure to RectorConfig

### DIFF
--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -49,8 +49,8 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractTestCas
             __DIR__ . '/config/main_config_with_own_value.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
-                'old_4' => 'new_4',
                 'old_3' => 'new_3',
+                'old_4' => 'new_4',
             ],
         ];
 

--- a/tests/DependencyInjection/config/first_config.php
+++ b/tests/DependencyInjection/config/first_config.php
@@ -6,9 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $services = $rectorConfig->services();
-    $services->set(RenameClassRector::class)
-        ->configure([
-            'old_1' => 'new_1',
-        ]);
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'old_1' => 'new_1',
+    ]);
 };

--- a/tests/DependencyInjection/config/main_config_with_override_value.php
+++ b/tests/DependencyInjection/config/main_config_with_override_value.php
@@ -6,14 +6,10 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $services = $rectorConfig->services();
-    $services->set(RenameClassRector::class)
-        ->call('configure', [[
-            'old_2' => 'new_2',
-        ]])
-        ->call('configure', [[
-            'old_4' => 'new_4',
-        ]]);
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'old_2' => 'new_2',
+        'old_4' => 'new_4',
+    ]);
 
     $rectorConfig->import(__DIR__ . '/first_config.php');
     $rectorConfig->import(__DIR__ . '/second_config.php');

--- a/tests/DependencyInjection/config/main_config_with_own_value.php
+++ b/tests/DependencyInjection/config/main_config_with_own_value.php
@@ -6,14 +6,10 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $services = $rectorConfig->services();
-    $services->set(RenameClassRector::class)
-        ->call('configure', [[
-            'old_3' => 'new_3',
-        ]])
-        ->call('configure', [[
-            'old_4' => 'new_4',
-        ]]);
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'old_3' => 'new_3',
+        'old_4' => 'new_4',
+    ]);
 
     $rectorConfig->import(__DIR__ . '/first_config.php');
     $rectorConfig->import(__DIR__ . '/second_config.php');

--- a/tests/DependencyInjection/config/one_set_with_own_rename.php
+++ b/tests/DependencyInjection/config/one_set_with_own_rename.php
@@ -9,9 +9,7 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(PHPUnitSetList::PHPUNIT_60);
 
-    $services = $rectorConfig->services();
-    $services->set(RenameClassRector::class)
-        ->configure([
-            'Old' => 'New',
-        ]);
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Old' => 'New',
+    ]);
 };

--- a/tests/DependencyInjection/config/second_config.php
+++ b/tests/DependencyInjection/config/second_config.php
@@ -6,10 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $services = $rectorConfig->services();
-    $services->set(RenameClassRector::class)
-        ->call('configure', [[
-            'old_2' => 'new_2',
-        ],
-        ]);
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'old_2' => 'new_2',
+    ]);
 };

--- a/tests/DependencyInjection/config/two_sets_with_own_rename.php
+++ b/tests/DependencyInjection/config/two_sets_with_own_rename.php
@@ -11,9 +11,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(PHPUnitSetList::PHPUNIT_60);
     $rectorConfig->import(TwigSetList::TWIG_20);
 
-    $services = $rectorConfig->services();
-    $services->set(RenameClassRector::class)
-        ->call('configure', [[
-            'Old' => 'New',
-        ]]);
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Old' => 'New',
+    ]);
 };


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/2119

The `configure` call is super old syntax, that is now replaced with `RectorConfig`