### PR TITLE
[Php74] Add class-string not filled by __construct to be to nullable string on TypedPropertyRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
+++ b/packages/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeAnalyzer.php
@@ -6,8 +6,10 @@ namespace Rector\PHPStanStaticTypeMapper\TypeAnalyzer;
 
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\NullType;
@@ -147,5 +149,17 @@ final class UnionTypeAnalyzer
         }
 
         return false;
+    }
+
+    public function mapGenericToClassStringType(UnionType $unionType): UnionType
+    {
+        $types = $unionType->getTypes();
+        foreach ($types as $key => $type) {
+            if ($type instanceof GenericClassStringType) {
+                $types[$key] = new ClassStringType();
+            }
+        }
+
+        return new UnionType($types);
     }
 }

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/nullable_class_string_on_fill_by_non_construct.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/nullable_class_string_on_fill_by_non_construct.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 
-final class NullableClassString
+final class NullableClassStringOnFillByNonConstruct
 {
     /**
      * @var class-string
@@ -21,7 +21,7 @@ final class NullableClassString
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
 
-final class NullableClassString
+final class NullableClassStringOnFillByNonConstruct
 {
     /**
      * @var class-string

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/nullable_class_string_on_fill_by_non_construct.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/nullable_class_string_on_fill_by_non_construct.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class NullableClassString
+{
+    /**
+     * @var class-string
+     */
+    private $property;
+
+    public function fill()
+    {
+        $this->property = 'stdClass';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+final class NullableClassString
+{
+    /**
+     * @var class-string
+     */
+    private ?string $property = null;
+
+    public function fill()
+    {
+        $this->property = 'stdClass';
+    }
+}
+
+?>


### PR DESCRIPTION
Continue on https://github.com/rectorphp/rector-src/pull/2120#issuecomment-1105820169 for class-string not filled by __construct to be nullable on TypedPropertyRector, which previously skipped and need to be handled by `TypedPropertyFromAssignsRector`.

This PR add its support to `TypedPropertyRector`