### PR TITLE
[Php71] Skip CountOnNullRector on view files

### DIFF
--- a/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\MixedType;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeTypeResolver\NodeTypeCorrector\PregMatchTypeCorrector;
@@ -64,7 +65,7 @@ final class CountableTypeAnalyzer
                 : $this->nodeTypeResolver->getType($node->class);
 
             $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
-            if (! $classLike instanceof ClassLike && ! $type instanceof ObjectType) {
+            if (! $classLike instanceof ClassLike && $type instanceof MixedType) {
                 return true;
             }
         }
@@ -73,7 +74,7 @@ final class CountableTypeAnalyzer
             $type = $this->nodeTypeResolver->getType($node);
 
             $functionLike = $this->betterNodeFinder->findParentType($node, FunctionLike::class);
-            if (! $functionLike instanceof FunctionLike && ! $type instanceof ObjectType) {
+            if (! $functionLike instanceof FunctionLike && $type instanceof MixedType) {
                 return true;
             }
         }

--- a/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
@@ -50,8 +50,10 @@ final class CountableTypeAnalyzer
         }
 
         if ($node instanceof Variable) {
+            $type = $this->nodeTypeResolver->getType($node);
+
             $functionLike = $this->betterNodeFinder->findParentType($node, FunctionLike::class);
-            if (! $functionLike instanceof FunctionLike) {
+            if (! $functionLike instanceof FunctionLike && ! $type instanceof \PHPStan\Type\ObjectType) {
                 return true;
             }
         }

--- a/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
@@ -44,7 +44,7 @@ final class CountableTypeAnalyzer
                 : $this->nodeTypeResolver->getType($node->class);
 
             $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
-            if (! $classLike instanceof ClassLike && ! $type instanceof \PHPStan\Type\ObjectType) {
+            if (! $classLike instanceof ClassLike && ! $type instanceof ObjectType) {
                 return true;
             }
         }
@@ -53,7 +53,7 @@ final class CountableTypeAnalyzer
             $type = $this->nodeTypeResolver->getType($node);
 
             $functionLike = $this->betterNodeFinder->findParentType($node, FunctionLike::class);
-            if (! $functionLike instanceof FunctionLike && ! $type instanceof \PHPStan\Type\ObjectType) {
+            if (! $functionLike instanceof FunctionLike && ! $type instanceof ObjectType) {
                 return true;
             }
         }

--- a/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/CountableTypeAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\TypeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassLike;
@@ -38,8 +39,12 @@ final class CountableTypeAnalyzer
     public function isCountableType(Node $node): bool
     {
         if ($this->propertyFetchAnalyzer->isPropertyFetch($node)) {
+            $type = $node instanceof PropertyFetch
+                ? $this->nodeTypeResolver->getType($node->var)
+                : $this->nodeTypeResolver->getType($node->class);
+
             $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
-            if (! $classLike instanceof ClassLike) {
+            if (! $classLike instanceof ClassLike && ! $type instanceof \PHPStan\Type\ObjectType) {
                 return true;
             }
         }

--- a/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_property_fetch_on_view.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_property_fetch_on_view.php.inc
@@ -1,0 +1,3 @@
+<?php
+echo 'Found' . count($this->data);
+?>

--- a/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_variable_on_view.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/CountOnNullRector/Fixture/skip_variable_on_view.php.inc
@@ -1,0 +1,3 @@
+<?php
+echo 'Found' . count($data);
+?>


### PR DESCRIPTION
Most common usage for view that use data from controller can use the following code:

```
 echo 'Found' . count($this->data);
```

which can be skipped.