### PR TITLE
[TypeDeclaration][Strict] Skip different type assigned different method on TypedPropertyFromStrictConstructorRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_different_type_assigned_different_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_different_type_assigned_different_method.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+class SkipDifferentTypeAssignedDifferentMethod
+{
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function reset(int $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_different_type_assigned_different_method2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_different_type_assigned_different_method2.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+class SkipDifferentTypeAssignedDifferentMethod2
+{
+    private $name;
+
+    public function __construct()
+    {
+        $this->name = 'test';
+    }
+
+    public function reset(int $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/ConstructorPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/ConstructorPropertyTypeInferer.php
@@ -107,8 +107,7 @@ final class ConstructorPropertyTypeInferer
         string $propertyName,
         ClassLike $classLike,
         ?Type $resolvedType
-    ): ?Type
-    {
+    ): ?Type {
         if (! $resolvedType instanceof Type) {
             return null;
         }


### PR DESCRIPTION
Skip the following code should be fixed on `TypedPropertyFromStrictConstructorRector`

```php
class SkipDifferentTypeAssignedDifferentMethod
{
    private $name;

    public function __construct(string $name)
    {
        $this->name = $name;
    }

    public function reset(int $name)
    {
        $this->name = $name;
    }
}
```

which handled by `TypedPropertyFromAssignsRector`

Fixes https://github.com/rectorphp/rector/issues/7113