### PR TITLE
[DeadCode] Skip from non typed param on RemoveUnreachableStatementRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_from_non_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_from_non_typed_param.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * @param stdClass|array $item
+ */
+function SkipFromNonTypedParam($item)
+{
+    if ($item instanceof stdClass) {
+        return 1;
+    }
+
+    if (is_array($item)) {
+        return 2;
+    }
+
+    throw new InvalidArgumentException();
+}
+
+?>


### PR DESCRIPTION
Given the following code should be skipped since the value is from param but typed:

```php
/**
 * @param stdClass|array $item
 */
function SkipFromNonTypedParam($item)
{
    if ($item instanceof stdClass) {
        return 1;
    }

    if (is_array($item)) {
        return 2;
    }

    throw new InvalidArgumentException();
}
```

It currently remove the `throw`:

```diff
-
-    throw new InvalidArgumentException();
```

which invalid.