### PR TITLE
[TypeDeclaration] Skip return property not exists by ClassReflection on ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_return_property_never_exists.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_return_property_never_exists.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+final class SkipReturnPropertyNotAutoloaded extends NotAutoloadedClass
+{
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/SetterNodeReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/SetterNodeReturnTypeInfererTypeInferer.php
@@ -52,6 +52,10 @@ final class SetterNodeReturnTypeInfererTypeInferer implements ReturnTypeInfererI
 
         $types = [];
         foreach ($returnedPropertyNames as $returnedPropertyName) {
+            if (! $classReflection->hasProperty($returnedPropertyName)) {
+                continue;
+            }
+
             $propertyReflection = $classReflection->getProperty($returnedPropertyName, $scope);
             if (! $propertyReflection instanceof PhpPropertyReflection) {
                 continue;


### PR DESCRIPTION
Given the following code which property not detected as possibly from not autoloaded parent class:

```php
final class SkipReturnPropertyNotAutoloaded extends NotAutoloadedClass
{
    public function getName(): string
    {
        return $this->name;
    }
}
```

should be skipped instead of crash:

```
There was 1 error:

There was 1 error:

1) Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\ReturnTypeDeclarationRectorTest::test with data set #52 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
PHPStan\Reflection\MissingPropertyFromReflectionException: Property $name was not found in reflection of class Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture\SkipReturnPropertyNotAutoloaded.
```

Fixes https://github.com/rectorphp/rector/issues/7127