### PR TITLE
[DeadCode] Refactor RemoveUnreachableStatementRector to check previuos stmt against Throw_,Exit_,Return_,TryCatch_

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_from_non_typed_param.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_from_non_typed_param.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * @param stdClass|array $item
+ */
+function SkipFromNonTypedParam($item)
+{
+    if ($item instanceof stdClass) {
+        return 1;
+    }
+
+    if (is_array($item)) {
+        return 2;
+    }
+
+    throw new InvalidArgumentException();
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_try_finally_only_comment.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_try_finally_only_comment.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipTryFinallyOnlyCommentStmt
+{
+    public function setMultiple($values, $ttl = null): bool
+    {
+        try {
+            return true;
+        } finally {
+            // only comment
+        }
+
+        return false;
+    }
+}

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -18,6 +18,7 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\TryCatch;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -131,6 +132,11 @@ CODE_SAMPLE
             return true;
         }
 
-        return $previousStmt instanceof TryCatch && $previousStmt->finally instanceof Finally_ && $previousStmt->finally->stmts !== [];
+        return $previousStmt instanceof TryCatch && $previousStmt->finally instanceof Finally_ && $this->cleanNop($previousStmt->finally->stmts) !== [];
+    }
+
+    private function cleanNop(array $stmts): array
+    {
+        return array_filter($stmts, fn (Stmt $stmt): bool => ! $stmt instanceof Nop);
     }
 }

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -6,20 +6,18 @@ namespace Rector\DeadCode\Rector\Stmt;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Exit_;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
+use PhpParser\Node\Stmt\TryCatch;
 use Rector\Core\Rector\AbstractRector;
-use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -30,10 +28,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveUnreachableStatementRector extends AbstractRector
 {
-    public function __construct(private readonly SideEffectNodeDetector $sideEffectNodeDetector)
-    {
-    }
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove unreachable statements', [
@@ -76,113 +70,63 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $stmts = $node->stmts;
-
-        $isPassedTheUnreachable = false;
-        $toBeRemovedKeys = [];
-
-        foreach ($stmts as $key => $stmt) {
-            if ($this->shouldSkipNode($stmt)) {
-                continue;
-            }
-
-            if ($this->isUnreachable($stmt)) {
-                $isPassedTheUnreachable = true;
-            }
-
-            if ($this->isAfterMarkTestSkippedMethodCall($stmt)) {
-                // keep for test case temporary ignored
-                break;
-            }
-
-            if (! $isPassedTheUnreachable) {
-                continue;
-            }
-
-            $toBeRemovedKeys[] = $key;
-        }
-
-        if ($toBeRemovedKeys === []) {
+        if ($node->stmts === null) {
             return null;
         }
 
-        $start = reset($toBeRemovedKeys);
-        if (! isset($stmts[$start - 1])) {
+        $originalStmts = $node->stmts;
+        $cleanedStmts = $this->processRemoveStmt($node->stmts);
+
+        if ($cleanedStmts === $originalStmts) {
             return null;
         }
 
-        $previousFirstUnreachable = $stmts[$start - 1];
-        if (in_array($previousFirstUnreachable::class, [Throw_::class, Return_::class, Exit_::class], true)) {
-            return $this->processCleanUpUnreachabelStmts($node, $toBeRemovedKeys);
-        }
-
-        // check previous side effect can check against start jump key - 2
-        // as previously already checked as reachable part
-        if (! $this->hasPreviousSideEffect($start - 2, $stmts)) {
-            return $this->processCleanUpUnreachabelStmts($node, $toBeRemovedKeys);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param Stmt[] $stmts
-     */
-    private function hasPreviousSideEffect(int $start, array $stmts): bool
-    {
-        for ($key = $start; $key > 0; --$key) {
-            $previousStmt = $stmts[$key];
-            $hasSideEffect = (bool) $this->betterNodeFinder->findFirst(
-                $previousStmt,
-                fn (Node $node): bool => $this->sideEffectNodeDetector->detectCallExpr($node)
-            );
-
-            if ($hasSideEffect) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param int[] $toBeRemovedKeys
-     */
-    private function processCleanUpUnreachabelStmts(Foreach_|FunctionLike|Else_|If_ $node, array $toBeRemovedKeys): Node
-    {
-        foreach ($toBeRemovedKeys as $toBeRemovedKey) {
-            unset($node->stmts[$toBeRemovedKey]);
-        }
-
+        $node->stmts = $cleanedStmts;
         return $node;
     }
 
-    private function shouldSkipNode(Stmt $stmt): bool
-    {
-        return $stmt instanceof Nop;
-    }
-
-    private function isUnreachable(Stmt $stmt): bool
-    {
-        $isUnreachable = $stmt->getAttribute(AttributeKey::IS_UNREACHABLE);
-
-        return $isUnreachable === true;
-    }
-
     /**
-     * Keep content after markTestSkipped(), intentional temporary
+     * @param Stmt $stmts
+     * @return Stmt[]|null
      */
-    private function isAfterMarkTestSkippedMethodCall(Stmt $stmt): bool
+    private function processRemovestmt(array $stmts): ?array
     {
-        if (! $stmt instanceof Expression) {
-            return false;
+        $originalStmts = $stmts;
+        foreach ($stmts as $key => $stmt) {
+            if (! isset($stmts[$key - 1])) {
+                continue;
+            }
+
+            if ($stmt instanceof Nop) {
+                continue;
+            }
+
+            $previousStmt = $stmts[$key - 1];
+            if ($previousStmt instanceof Throw_) {
+                unset($stmts[$key]);
+                break;
+            }
+
+            if ($previousStmt instanceof Expression && $previousStmt->expr instanceof Exit_) {
+                unset($stmts[$key]);
+                break;
+            }
+
+            if ($previousStmt instanceof Return_) {
+                unset($stmts[$key]);
+                break;
+            }
+
+            if ($previousStmt instanceof TryCatch && $previousStmt->finally instanceof Finally_ && $previousStmt->finally->stmts !== []) {
+                unset($stmts[$key]);
+                break;
+            }
         }
 
-        $expr = $stmt->expr;
-        if ($expr instanceof MethodCall || $expr instanceof StaticCall) {
-            return $this->isNames($expr->name, ['markTestSkipped', 'markTestIncomplete']);
+        if ($originalStmts === $stmts) {
+            return $originalStmts;
         }
 
-        return false;
+        return $this->processRemovestmt(array_values($stmts));
     }
 }

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
         }
 
         $originalStmts = $node->stmts;
-        $cleanedStmts = $this->processRemoveStmt($node->stmts);
+        $cleanedStmts = $this->processCleanUpUnreachabelStmts($node->stmts);
 
         if ($cleanedStmts === $originalStmts) {
             return null;
@@ -89,7 +89,7 @@ CODE_SAMPLE
      * @param Stmt[] $stmts
      * @return Stmt[]
      */
-    private function processRemoveStmt(array $stmts): array
+    private function processCleanUpUnreachabelStmts(array $stmts): array
     {
         $originalStmts = $stmts;
         foreach ($stmts as $key => $stmt) {
@@ -114,7 +114,7 @@ CODE_SAMPLE
         }
 
         $stmts = array_values($stmts);
-        return $this->processRemoveStmt($stmts);
+        return $this->processCleanUpUnreachabelStmts($stmts);
     }
 
     private function shouldRemove(Stmt $previousStmt): bool

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -18,7 +18,6 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\TryCatch;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -132,9 +131,15 @@ CODE_SAMPLE
             return true;
         }
 
-        return $previousStmt instanceof TryCatch && $previousStmt->finally instanceof Finally_ && $this->cleanNop($previousStmt->finally->stmts) !== [];
+        return $previousStmt instanceof TryCatch && $previousStmt->finally instanceof Finally_ && $this->cleanNop(
+            $previousStmt->finally->stmts
+        ) !== [];
     }
 
+    /**
+     * @param Stmt[] $stmts
+     * @return Stmt[]
+     */
     private function cleanNop(array $stmts): array
     {
         return array_filter($stmts, fn (Stmt $stmt): bool => ! $stmt instanceof Nop);


### PR DESCRIPTION
Hi @TomasVotruba ,

It seems we can't rely on `AttributeKey::IS_UNREACHABLE` attribute from PHPStan, I tried already in my own libraries, eg: https://github.com/samsonasik/ForceHttpsModule at it cause invalid result too with current `dev-main`

Here is refactor PR of RemoveUnreachableStatementRector which loop stmts, check against previous stmt are:

```
Throw_,
Exit_,
Return_,
TryCatch_ with finally has stmt
```

so that's must a valid unreachable stmt.

Closes https://github.com/rectorphp/rector-src/pull/2132 
