### PR TITLE
[DeadCode] Skip Try { finally } assign and loop stmts on RemoveUnreachableStatementRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_try_finally_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_try_finally_assign.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipTryFinallyAssign
+{
+    public function setMultiple($values, $ttl = null): bool
+    {
+        try {
+
+        } finally {
+            $a = 1;
+        }
+
+        return $a;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_try_finally_loop.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_try_finally_loop.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipTryFinallyLoop
+{
+    public function setMultiple($values, $ttl = null): bool
+    {
+        try {
+
+        } finally {
+            while (ob_get_level() > $__outputLevel__) {
+                ob_end_clean();
+            }
+        }
+
+        return false;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/try_finally.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/try_finally.php.inc
@@ -8,7 +8,7 @@ class TryFinally
     public function setMultiple($values, $ttl = null): bool
     {
         try {
-            return true;
+            throw new Exception();
         } finally {
             echo 3;
         }
@@ -29,7 +29,7 @@ class TryFinally
     public function setMultiple($values, $ttl = null): bool
     {
         try {
-            return true;
+            throw new Exception();
         } finally {
             echo 3;
         }


### PR DESCRIPTION
Current fixture test is invalid as in try's catch, it not throw, so it must be by passed, ref https://github.com/rectorphp/rector-src/compare/skip-try-finally-not-throw?expand=1#diff-52dce884a27671c1c8b9ca18f5bde6ad72c71265439ee5a8c58be1b8cac73905

I updated the fixture and add more failing tests case for assign and loop in finally stmts 