### PR TITLE
[DeadCode] Register more Stmt Nodes on RemoveUnreachableStatementRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_case.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_case.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SomeCase
+{
+    public function run()
+    {
+        switch ($a) {
+            case 'a':
+                return 'A';
+                break;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SomeCase
+{
+    public function run()
+    {
+        switch ($a) {
+            case 'a':
+                return 'A';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_catch.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_catch.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+use RuntimeException;
+
+class SomeCatch
+{
+    public function run()
+    {
+        try {
+
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMesssage());
+            echo 'test';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+use RuntimeException;
+
+class SomeCatch
+{
+    public function run()
+    {
+        try {
+
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMesssage());
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_do.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_do.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeDo
+{
+    public function run()
+    {
+        $i = 1;
+        do {
+            throw new Exception();
+            echo 'test';
+        } while (++$i < 10);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeDo
+{
+    public function run()
+    {
+        $i = 1;
+        do {
+            throw new Exception();
+        } while (++$i < 10);
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_else_if.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_else_if.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeElseIf
+{
+    public function run()
+    {
+        if (rand(0, 1)) {
+
+        } elseif (rand(0, 1)) {
+            throw new Exception();
+            echo 'test';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeElseIf
+{
+    public function run()
+    {
+        if (rand(0, 1)) {
+
+        } elseif (rand(0, 1)) {
+            throw new Exception();
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_finally.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_finally.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+use RuntimeException;
+
+class SomeFinally
+{
+    public function run()
+    {
+        try {
+
+        } finally {
+            throw new RuntimeException();
+            echo 'test';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+use RuntimeException;
+
+class SomeFinally
+{
+    public function run()
+    {
+        try {
+
+        } finally {
+            throw new RuntimeException();
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_for.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_for.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeFor
+{
+    public function run()
+    {
+        for ($i = 1; $i<10;++$i) {
+            throw new Exception();
+            echo 'test';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeFor
+{
+    public function run()
+    {
+        for ($i = 1; $i<10;++$i) {
+            throw new Exception();
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_try.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_try.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use RuntimeException;
+
+class SomeTry
+{
+    public function run()
+    {
+        try {
+            throw new RuntimeException();
+            echo 'test';
+        } finally {
+
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use RuntimeException;
+
+class SomeTry
+{
+    public function run()
+    {
+        try {
+            throw new RuntimeException();
+        } finally {
+
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_while.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/some_while.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeWhile
+{
+    public function run()
+    {
+        while (++$i < 10) {
+            throw new Exception();
+            echo 'test';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SomeWhile
+{
+    public function run()
+    {
+        while (++$i < 10) {
+            throw new Exception();
+        }
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\Stmt;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
@@ -17,6 +19,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
@@ -74,7 +77,9 @@ CODE_SAMPLE
             Foreach_::class,
             Do_::class,
             While_::class,
-            FunctionLike::class,
+            ClassMethod::class,
+            Function_::class,
+            Closure::class,
             If_::class,
             ElseIf_::class,
             Else_::class,
@@ -86,7 +91,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Foreach_|FunctionLike|Else_|If_ $node
+     * @param For_|Foreach_|Do_|While_|ClassMethod|Function_|Closure|If_|ElseIf_|Else_|Case_|TryCatch|Catch_|Finally_ $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -79,6 +79,7 @@ CODE_SAMPLE
             ElseIf_::class,
             Else_::class,
             Case_::class,
+            TryCatch::class,
             Catch_::class,
             Finally_::class,
         ];

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -7,7 +7,6 @@ namespace Rector\DeadCode\Rector\Stmt;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Exit_;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Catch_;

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -8,15 +8,21 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Case_;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
+use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Finally_;
+use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\Node\Stmt\While_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -63,7 +69,19 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Foreach_::class, FunctionLike::class, Else_::class, If_::class];
+        return [
+            For_::class,
+            Foreach_::class,
+            Do_::class,
+            While_::class,
+            FunctionLike::class,
+            If_::class,
+            ElseIf_::class,
+            Else_::class,
+            Case_::class,
+            Catch_::class,
+            Finally_::class,
+        ];
     }
 
     /**


### PR DESCRIPTION
since `RemoveUnreachableStatementRector` check exactly previous stmt on loop, it can be applied to more Nodes which has stmt property:

```php
            For_::class,
            Foreach_::class,
            Do_::class,
            While_::class,
            ClassMethod::class,
            Function_::class,
            Closure::class,
            If_::class,
            ElseIf_::class,
            Else_::class,
            Case_::class,
            TryCatch::class,
            Catch_::class,
            Finally_::class,
```