### PR TITLE
[Core] Remove Current Statement check on RectifiedAnalyzer, use Original Node instead

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -55,14 +55,13 @@ final class RectifiedAnalyzer
         }
 
         $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-
-        if (! $originalNode instanceof Node) {
-            $startTokenPos = $node->getStartTokenPos();
-            $endTokenPos = $node->getEndTokenPos();
-
-            return $startTokenPos < 0 || $endTokenPos < 0;
+        if ($originalNode instanceof Node) {
+            return true;
         }
 
-        return true;
+        $startTokenPos = $node->getStartTokenPos();
+        $endTokenPos = $node->getEndTokenPos();
+
+        return $startTokenPos < 0 || $endTokenPos < 0;
     }
 }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -54,14 +54,14 @@ final class RectifiedAnalyzer
             return true;
         }
 
-        $stmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        if ($stmt instanceof Stmt) {
-            return true;
-        }
-
         $startTokenPos = $node->getStartTokenPos();
         $endTokenPos = $node->getEndTokenPos();
 
-        return $startTokenPos < 0 || $endTokenPos < 0;
+        if ($startTokenPos < 0 || $endTokenPos < 0) {
+            return true;
+        }
+
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+        return $originalNode instanceof Node;
     }
 }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -54,16 +54,15 @@ final class RectifiedAnalyzer
             return true;
         }
 
-        $startTokenPos = $node->getStartTokenPos();
-        $endTokenPos = $node->getEndTokenPos();
-        if ($startTokenPos < 0) {
-            return true;
-        }
-        if ($endTokenPos < 0) {
-            return true;
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+
+        if (! $originalNode instanceof Node) {
+            $startTokenPos = $node->getStartTokenPos();
+            $endTokenPos = $node->getEndTokenPos();
+
+            return $startTokenPos < 0 || $endTokenPos < 0;
         }
 
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-        return $originalNode instanceof Node;
+        return true;
     }
 }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -56,8 +56,10 @@ final class RectifiedAnalyzer
 
         $startTokenPos = $node->getStartTokenPos();
         $endTokenPos = $node->getEndTokenPos();
-
-        if ($startTokenPos < 0 || $endTokenPos < 0) {
+        if ($startTokenPos < 0) {
+            return true;
+        }
+        if ($endTokenPos < 0) {
             return true;
         }
 


### PR DESCRIPTION
Remove check against `AttributeKey::CURRENT_STATEMENT` on `RectifiedAnalyzer`, use `AttributeKey::ORIGINAL_NODE` instead.