### PR TITLE
[Privatization] Add ParentPropertyLookupGuard service

### DIFF
--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_not_autoloaded.php.inc
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/keep_parent_not_autoloaded.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture;
+
+final class KeepParentNotAutoloaded extends NotAutoloadedParent
+{
+    protected $value = 100;
+}

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -135,7 +135,7 @@ CODE_SAMPLE
 
     private function isOverrideAbstractMethod(ClassMethod $classMethod): bool
     {
-        $classReflection = $this->reflectionResolver->resolveClassReflectionFromClassMethod($classMethod);
+        $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
         $methodName = $this->nodeNameResolver->getName($classMethod);
 
         return $classReflection instanceof ClassReflection && $this->classChildAnalyzer->hasAbstractParentClassMethod(

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -39,7 +39,7 @@ final class ParentPropertyLookupGuard
         }
 
         if ($class->extends === null) {
-            return false;
+            return true;
         }
 
         $classReflection = $this->reflectionResolver->resolveClassReflection($property);

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Privatization\Guard;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ClassReflection;
+use Rector\Core\Enum\ObjectReference;
+use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
+use Rector\Core\PhpParser\AstResolver;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\Reflection\ReflectionResolver;
+use Rector\NodeNameResolver\NodeNameResolver;
+
+final class ParentPropertyLookupGuard
+{
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private readonly AstResolver $astResolver
+    ) {
+    }
+
+    public function isLegal(Property $property): bool
+    {
+        $class = $this->betterNodeFinder->findParentType($property, Class_::class);
+
+        if (! $class instanceof Class_) {
+            return false;
+        }
+
+        if ($class->extends === null) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionResolver->resolveClassReflection($property);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        $propertyName = $this->nodeNameResolver->getName($property);
+        $className = $classReflection->getName();
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasProperty($propertyName)) {
+                return false;
+            }
+
+            if ($this->isFoundInParentClassMethods($parentClassReflection, $propertyName, $className)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isFoundInParentClassMethods(
+        ClassReflection $parentClassReflection,
+        string $propertyName,
+        string $className
+    ): bool {
+        $classLike = $this->astResolver->resolveClassFromName($parentClassReflection->getName());
+        if (! $classLike instanceof Class_) {
+            return false;
+        }
+
+        $methods = $classLike->getMethods();
+        foreach ($methods as $method) {
+            $isFound = $this->isFoundInMethodStmts((array) $method->stmts, $propertyName, $className);
+            if ($isFound) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function isFoundInMethodStmts(array $stmts, string $propertyName, string $className): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst($stmts, function (Node $subNode) use (
+            $propertyName,
+            $className
+        ): bool {
+            if (! $this->propertyFetchAnalyzer->isPropertyFetch($subNode)) {
+                return false;
+            }
+
+            /** @var PropertyFetch|StaticPropertyFetch $subNode */
+            if ($subNode instanceof PropertyFetch) {
+                if (! $subNode->var instanceof Variable) {
+                    return false;
+                }
+
+                if (! $this->nodeNameResolver->isName($subNode->var, 'this')) {
+                    return false;
+                }
+
+                return $this->nodeNameResolver->isName($subNode, $propertyName);
+            }
+
+            if (! $this->nodeNameResolver->isNames(
+                $subNode->class,
+                [ObjectReference::SELF()->getValue(), ObjectReference::STATIC()->getValue(), $className]
+            )) {
+                return false;
+            }
+
+            return $this->nodeNameResolver->isName($subNode->name, $propertyName);
+        });
+    }
+}

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -50,12 +50,19 @@ final class ParentPropertyLookupGuard
         $propertyName = $this->nodeNameResolver->getName($property);
         $className = $classReflection->getName();
 
-        foreach ($classReflection->getParents() as $parentClassReflection) {
-            if ($parentClassReflection->hasProperty($propertyName)) {
+        $parents = $classReflection->getParents();
+
+        // parent class not autoloaded
+        if ($parents === []) {
+            return false;
+        }
+
+        foreach ($parents as $parent) {
+            if ($parent->hasProperty($propertyName)) {
                 return false;
             }
 
-            if ($this->isFoundInParentClassMethods($parentClassReflection, $propertyName, $className)) {
+            if ($this->isFoundInParentClassMethods($parent, $propertyName, $className)) {
                 return false;
             }
         }

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -71,11 +71,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($classLike->extends === null) {
-            $this->visibilityManipulator->makePrivate($node);
-            return $node;
-        }
-
         if (! $this->parentPropertyLookupGuard->isLegal($node)) {
             return null;
         }

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -5,20 +5,10 @@ declare(strict_types=1);
 namespace Rector\Privatization\Rector\Property;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ClassReflection;
-use Rector\Core\Enum\ObjectReference;
-use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
-use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Privatization\Guard\ParentPropertyLookupGuard;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -30,8 +20,7 @@ final class PrivatizeFinalClassPropertyRector extends AbstractRector
 {
     public function __construct(
         private readonly VisibilityManipulator $visibilityManipulator,
-        private readonly AstResolver $astResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private readonly ParentPropertyLookupGuard $parentPropertyLookupGuard
     ) {
     }
 
@@ -87,7 +76,7 @@ CODE_SAMPLE
             return $node;
         }
 
-        if ($this->isPropertyVisibilityGuardedByParent($node, $classLike)) {
+        if (! $this->parentPropertyLookupGuard->isLegal($node)) {
             return null;
         }
 
@@ -103,91 +92,5 @@ CODE_SAMPLE
         }
 
         return ! $property->isProtected();
-    }
-
-    private function isPropertyVisibilityGuardedByParent(Property $property, Class_ $class): bool
-    {
-        if ($class->extends === null) {
-            return false;
-        }
-
-        /** @var Scope $scope */
-        $scope = $property->getAttribute(AttributeKey::SCOPE);
-
-        /** @var ClassReflection $classReflection */
-        $classReflection = $scope->getClassReflection();
-
-        $propertyName = $this->getName($property);
-        $className = (string) $this->nodeNameResolver->getName($class);
-
-        foreach ($classReflection->getParents() as $parentClassReflection) {
-            if ($parentClassReflection->hasProperty($propertyName)) {
-                return true;
-            }
-
-            if ($this->isFoundInParentClassMethods($parentClassReflection, $propertyName, $className)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isFoundInParentClassMethods(
-        ClassReflection $parentClassReflection,
-        string $propertyName,
-        string $className
-    ): bool {
-        $classLike = $this->astResolver->resolveClassFromName($parentClassReflection->getName());
-        if (! $classLike instanceof ClassLike) {
-            return false;
-        }
-
-        $methods = $classLike->getMethods();
-        foreach ($methods as $method) {
-            $isFound = $this->isFoundInMethodStmts((array) $method->stmts, $propertyName, $className);
-            if ($isFound) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param Stmt[] $stmts
-     */
-    private function isFoundInMethodStmts(array $stmts, string $propertyName, string $className): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst($stmts, function (Node $subNode) use (
-            $propertyName,
-            $className
-        ): bool {
-            if (! $this->propertyFetchAnalyzer->isPropertyFetch($subNode)) {
-                return false;
-            }
-
-            /** @var PropertyFetch|StaticPropertyFetch $subNode */
-            if ($subNode instanceof PropertyFetch) {
-                if (! $subNode->var instanceof Variable) {
-                    return false;
-                }
-
-                if (! $this->nodeNameResolver->isName($subNode->var, 'this')) {
-                    return false;
-                }
-
-                return $this->nodeNameResolver->isName($subNode, $propertyName);
-            }
-
-            if (! $this->nodeNameResolver->isNames(
-                $subNode->class,
-                [ObjectReference::SELF()->getValue(), ObjectReference::STATIC()->getValue(), $className]
-            )) {
-                return false;
-            }
-
-            return $this->nodeNameResolver->isName($subNode->name, $propertyName);
-        });
     }
 }

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
@@ -55,7 +56,7 @@ final class ReflectionResolver
         return $this->reflectionProvider->getClass($className);
     }
 
-    public function resolveClassReflectionFromClassMethod(ClassMethod $classMethod): ?ClassReflection
+    public function resolveClassReflection(ClassMethod|Property $classMethod): ?ClassReflection
     {
         $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
 


### PR DESCRIPTION
Add `ParentPropertyLookupGuard` service that can be re-used by other rules that validate that property is in parent and/or used by parent.

This can be used to validate final class with protected property with extends, and parent doesn't has property or doesn't use it, eg: in `TypedPropertyRector`, but that can be separate PR.