### PR TITLE
[Php74] Allow change protected property of final class when property only in current class on TypedPropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/final_class_protected_property_only_in_current.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/final_class_protected_property_only_in_current.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+use Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\AbstractParentClass;
+
+final class FinalClassProtectedPropertyOnlyInCurrent extends AbstractParentClass
+{
+    /**
+     * @var string
+     */
+    protected $somePropertyOnlyInCurrent;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Fixture;
+
+use Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\AbstractParentClass;
+
+final class FinalClassProtectedPropertyOnlyInCurrent extends AbstractParentClass
+{
+    protected string $somePropertyOnlyInCurrent;
+}
+
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Source/AbstractParentClass.php
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Source/AbstractParentClass.php
@@ -6,5 +6,9 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source;
 
 abstract class AbstractParentClass
 {
-
+    /**
+     * @var string
+     * @Assert\Choice({"chalet", "apartment"})
+     */
+    protected $type;
 }

--- a/rules/Php74/Guard/MakePropertyTypedGuard.php
+++ b/rules/Php74/Guard/MakePropertyTypedGuard.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Php74\Guard;
 
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;

--- a/rules/Php74/Guard/MakePropertyTypedGuard.php
+++ b/rules/Php74/Guard/MakePropertyTypedGuard.php
@@ -83,10 +83,6 @@ final class MakePropertyTypedGuard
             return false;
         }
 
-        if (! $class->extends instanceof FullyQualified) {
-            return true;
-        }
-
         return $this->parentPropertyLookupGuard->isLegal($property);
     }
 }

--- a/rules/Php74/Guard/MakePropertyTypedGuard.php
+++ b/rules/Php74/Guard/MakePropertyTypedGuard.php
@@ -14,6 +14,7 @@ use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Privatization\Guard\ParentPropertyLookupGuard;
 
 final class MakePropertyTypedGuard
 {
@@ -21,7 +22,8 @@ final class MakePropertyTypedGuard
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly PropertyAnalyzer $propertyAnalyzer,
-        private readonly PropertyManipulator $propertyManipulator
+        private readonly PropertyManipulator $propertyManipulator,
+        private readonly ParentPropertyLookupGuard $parentPropertyLookupGuard
     ) {
     }
 
@@ -81,6 +83,10 @@ final class MakePropertyTypedGuard
             return false;
         }
 
-        return ! $class->extends instanceof FullyQualified;
+        if (! $class->extends instanceof FullyQualified) {
+            return true;
+        }
+
+        return $this->parentPropertyLookupGuard->isLegal($property);
     }
 }


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2152, using `ParentPropertyLookupGuard` from PR to allow change protected property of final class when property only in current class on TypedPropertyRector