### PR TITLE
Remove uses nodes attribute - part #3

### DIFF
--- a/rules/TypeDeclaration/PHPStan/Type/ObjectTypeSpecifier.php
+++ b/rules/TypeDeclaration/PHPStan/Type/ObjectTypeSpecifier.php
@@ -25,6 +25,7 @@ use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -37,7 +38,8 @@ use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 final class ObjectTypeSpecifier
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly UseImportsResolver $useImportsResolver,
     ) {
     }
 
@@ -46,18 +48,19 @@ final class ObjectTypeSpecifier
         ObjectType $objectType,
         Scope|null $scope
     ): TypeWithClassName | UnionType | MixedType {
-        /** @var Use_[]|null $uses */
-        $uses = $node->getAttribute(AttributeKey::USE_NODES);
-        if ($uses === null) {
+        $uses = $this->useImportsResolver->resolveForNode($node);
+
+        // no imports to narrow the type to
+        if ($uses === []) {
             return $objectType;
         }
 
-        $aliasedObjectType = $this->matchAliasedObjectType($node, $objectType);
+        $aliasedObjectType = $this->matchAliasedObjectType($node, $objectType, $uses);
         if ($aliasedObjectType !== null) {
             return $aliasedObjectType;
         }
 
-        $shortenedObjectType = $this->matchShortenedObjectType($node, $objectType);
+        $shortenedObjectType = $this->matchShortenedObjectType($objectType, $uses);
         if ($shortenedObjectType !== null) {
             return $shortenedObjectType;
         }
@@ -91,11 +94,12 @@ final class ObjectTypeSpecifier
         return new NonExistingObjectType($className);
     }
 
-    private function matchAliasedObjectType(Node $node, ObjectType $objectType): ?AliasedObjectType
+    /**
+     * @param Use_[] $uses
+     */
+    private function matchAliasedObjectType(Node $node, ObjectType $objectType, array $uses): ?AliasedObjectType
     {
-        /** @var Use_[]|null $uses */
-        $uses = $node->getAttribute(AttributeKey::USE_NODES);
-        if ($uses === null) {
+        if ($uses === []) {
             return null;
         }
 
@@ -154,13 +158,14 @@ final class ObjectTypeSpecifier
         return null;
     }
 
+    /**
+     * @param Use_[] $uses
+     */
     private function matchShortenedObjectType(
-        Node $node,
-        ObjectType $objectType
+        ObjectType $objectType,
+        array $uses
     ): ShortenedObjectType|ShortenedGenericObjectType|null {
-        /** @var Use_[]|null $uses */
-        $uses = $node->getAttribute(AttributeKey::USE_NODES);
-        if ($uses === null) {
+        if ($uses === []) {
             return null;
         }
 

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\Application;
 
 use Rector\ChangesReporting\Collector\AffectedFilesCollector;
+use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
 use Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser;
 use Rector\Core\PhpParser\Parser\RectorParser;
 use Rector\Core\ValueObject\Application\File;
@@ -17,7 +18,8 @@ final class FileProcessor
         private readonly AffectedFilesCollector $affectedFilesCollector,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly RectorParser $rectorParser,
-        private readonly RectorNodeTraverser $rectorNodeTraverser
+        private readonly RectorNodeTraverser $rectorNodeTraverser,
+        private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser,
     ) {
     }
 
@@ -36,7 +38,9 @@ final class FileProcessor
 
     public function refactor(File $file, Configuration $configuration): void
     {
-        $newStmts = $this->rectorNodeTraverser->traverse($file->getNewStmts());
+        $newStmts = $this->fileWithoutNamespaceNodeTraverser->traverse($file->getNewStmts());
+        $newStmts = $this->rectorNodeTraverser->traverse($newStmts);
+
         $file->changeNewStmts($newStmts);
 
         $this->affectedFilesCollector->removeFromList($file);

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -5,12 +5,8 @@ declare(strict_types=1);
 namespace Rector\Core\PhpParser\NodeTraverser;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Namespace_;
-use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\VersionBonding\PhpVersionedFilter;
 
 final class RectorNodeTraverser extends NodeTraverser
@@ -22,7 +18,6 @@ final class RectorNodeTraverser extends NodeTraverser
      */
     public function __construct(
         private readonly array $phpRectors,
-        private readonly NodeFinder $nodeFinder,
         private readonly PhpVersionedFilter $phpVersionedFilter
     ) {
     }
@@ -35,20 +30,7 @@ final class RectorNodeTraverser extends NodeTraverser
     public function traverse(array $nodes): array
     {
         $this->prepareNodeVisitors();
-
-        $hasNamespace = (bool) $this->nodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
-        if (! $hasNamespace && $nodes !== []) {
-            $fileWithoutNamespace = new FileWithoutNamespace($nodes);
-            foreach ($nodes as $node) {
-                $node->setAttribute(AttributeKey::PARENT_NODE, $fileWithoutNamespace);
-            }
-
-            $nodesToTraverse = [$fileWithoutNamespace];
-        } else {
-            $nodesToTraverse = $nodes;
-        }
-
-        return parent::traverse($nodesToTraverse);
+        return parent::traverse($nodes);
     }
 
     /**


### PR DESCRIPTION
- remove USE_NODES from ObjectTypeSpecifier
- move FileWithoutNamespaceNodeTraverser outside RectorNodeTraverser
