### PR TITLE
DowngradeMatchToSwitchRector adds Method and Function call support

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/anonymous_function_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/anonymous_function_call.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class AnonymousFunctionCall
+{
+    public function run($statusCode)
+    {
+        $output = function($value) {
+            echo $value;
+        };
+
+        $output(match ($statusCode) {
+            200, 300 => null,
+            400 => 'not found',
+            default => 'unknown status code',
+        });
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class AnonymousFunctionCall
+{
+    public function run($statusCode)
+    {
+        $output = function($value) {
+            echo $value;
+        };
+
+        switch ($statusCode) {
+            case 200:
+            case 300:
+                $output(null);
+                break;
+            case 400:
+                $output('not found');
+                break;
+            default:
+                $output('unknown status code');
+                break;
+        }
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/function_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/function_call.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+function output($value)
+{
+    echo $value;
+}
+
+class FunctionCall
+{
+    public function run($statusCode)
+    {
+        output(match ($statusCode) {
+            200, 300 => null,
+            400 => 'not found',
+            default => 'unknown status code',
+        });
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+function output($value)
+{
+    echo $value;
+}
+
+class FunctionCall
+{
+    public function run($statusCode)
+    {
+        switch ($statusCode) {
+            case 200:
+            case 300:
+                output(null);
+                break;
+            case 400:
+                output('not found');
+                break;
+            default:
+                output('unknown status code');
+                break;
+        }
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/method_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/method_call.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class ClassFunctionCall
+{
+    public function output($value)
+    {
+        echo $value;
+    }
+
+    public function run($statusCode)
+    {
+        $this->output(match ($statusCode) {
+            200, 300 => null,
+            400 => 'not found',
+            default => 'unknown status code',
+        });
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class ClassFunctionCall
+{
+    public function output($value)
+    {
+        echo $value;
+    }
+
+    public function run($statusCode)
+    {
+        switch ($statusCode) {
+            case 200:
+            case 300:
+                $this->output(null);
+                break;
+            case 400:
+                $this->output('not found');
+                break;
+            default:
+                $this->output('unknown status code');
+                break;
+        }
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\Expression;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\MatchArm;
 use PhpParser\Node\Stmt;
@@ -152,10 +156,13 @@ CODE_SAMPLE
         } elseif ($node instanceof Echo_) {
             $stmts[] = new Echo_([$matchArm->body]);
             $stmts[] = new Break_();
+        } else if ($node->expr instanceof MethodCall || $node->expr instanceof FuncCall) {
+            $call = clone $node->expr;
+            $call->args = [new Arg($matchArm->body)];
+            $stmts[] = new Expression($call);
+            $stmts[] = new Break_();
         } elseif ($node->expr instanceof Assign) {
-            /** @var Assign $assign */
-            $assign = $node->expr;
-            $stmts[] = new Expression(new Assign($assign->var, $matchArm->body));
+            $stmts[] = new Expression(new Assign($node->expr->var, $matchArm->body));
             $stmts[] = new Break_();
         } elseif ($node->expr instanceof Match_) {
             $stmts[] = new Expression($matchArm->body);


### PR DESCRIPTION
## DowngradeMatchToSwitchRector: Adds Tests and Support for Match return value use in Method and Function calls

Failing example demos:
- `$this->output(match...);` [Rector Demo](https://getrector.org/demo/a7465ba6-3e1f-4be1-8028-6268e71438eb) | [3v4l demo](https://3v4l.org/cqYHA)
- `$output(match...);` [Rector Demo](https://getrector.org/demo/bcb53155-687b-470a-a239-25dd6907cb4e) | [3v4l demo](https://3v4l.org/HVTKo)
- `output(match...);` [Rector Demo](https://getrector.org/demo/42f95e36-b093-4fdd-8441-1622f535924d) | [3v4l demo](https://3v4l.org/PslmI)

Three new test fixtures are introduced and are now passing.