### PR TITLE
[DX] Add note warning about using old config

### DIFF
--- a/config/parameters.php
+++ b/config/parameters.php
@@ -29,7 +29,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // FQN class importing
     $rectorConfig->disableImportNames();
-    $parameters->set(Option::IMPORT_SHORT_CLASSES, true);
+    $rectorConfig->importShortClasses();
 
     $parameters->set(Option::NESTED_CHAIN_METHOD_CALL_LIMIT, 60);
 

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -69,6 +69,18 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::AUTO_IMPORT_NAMES, true);
     }
 
+    public function importShortClasses(): void
+    {
+        $parameters = $this->parameters();
+        $parameters->set(Option::IMPORT_SHORT_CLASSES, true);
+    }
+
+    public function disableImportShortClasses(): void
+    {
+        $parameters = $this->parameters();
+        $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+    }
+
     public function disableImportNames(): void
     {
         $parameters = $this->parameters();

--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/config/not_import_short_classes.php
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/config/not_import_short_classes.php
@@ -3,12 +3,11 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Configuration\Option;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $parameters = $rectorConfig->parameters();
     $rectorConfig->importNames();
-    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+    $rectorConfig->disableImportShortClasses();
+
     $rectorConfig->rule(RenameClassRector::class);
 };

--- a/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
+++ b/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
@@ -36,6 +36,7 @@ final class UpgradeRectorConfigRector extends AbstractRector
         Option::SKIP => 'skip',
         Option::AUTOLOAD_PATHS => 'autoloadPaths',
         Option::BOOTSTRAP_FILES => 'bootstrapFiles',
+        Option::IMPORT_SHORT_CLASSES => 'importShortClasses',
         Option::AUTO_IMPORT_NAMES => 'importNames',
         Option::PARALLEL => 'parallel',
         Option::PHPSTAN_FOR_RECTOR_PATH => 'phpstanConfig',

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\MethodCall;
@@ -158,14 +159,6 @@ CODE_SAMPLE
         } elseif ($node instanceof Echo_) {
             $stmts[] = new Echo_([$matchArm->body]);
             $stmts[] = new Break_();
-<<<<<<< HEAD
-=======
-        } elseif ($node->expr instanceof MethodCall || $node->expr instanceof FuncCall) {
-            $call = clone $node->expr;
-            $call->args = [new Arg($matchArm->body)];
-            $stmts[] = new Expression($call);
-            $stmts[] = new Break_();
->>>>>>> 8b793b3348... fix cs
         } elseif ($node->expr instanceof Assign) {
             $stmts[] = new Expression(new Assign($node->expr->var, $matchArm->body));
             $stmts[] = new Break_();

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\MethodCall;
@@ -159,6 +158,14 @@ CODE_SAMPLE
         } elseif ($node instanceof Echo_) {
             $stmts[] = new Echo_([$matchArm->body]);
             $stmts[] = new Break_();
+<<<<<<< HEAD
+=======
+        } elseif ($node->expr instanceof MethodCall || $node->expr instanceof FuncCall) {
+            $call = clone $node->expr;
+            $call->args = [new Arg($matchArm->body)];
+            $stmts[] = new Expression($call);
+            $stmts[] = new Break_();
+>>>>>>> 8b793b3348... fix cs
         } elseif ($node->expr instanceof Assign) {
             $stmts[] = new Expression(new Assign($node->expr->var, $matchArm->body));
             $stmts[] = new Break_();

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -61,6 +61,7 @@ final class Option
     public const AUTO_IMPORT_NAMES = 'auto_import_names';
 
     /**
+     * @deprecated Use @see \Rector\Config\RectorConfig::importShortClasses() instead
      * @var string
      */
     public const IMPORT_SHORT_CLASSES = 'import_short_classes';

--- a/src/DependencyInjection/RectorContainerFactory.php
+++ b/src/DependencyInjection/RectorContainerFactory.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Rector\Core\DependencyInjection;
 
+use Nette\Utils\FileSystem;
 use Psr\Container\ContainerInterface;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Core\Kernel\RectorKernel;
 use Rector\Core\Stubs\PHPStanStubLoader;
 use Rector\Core\ValueObject\Bootstrap\BootstrapConfigs;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class RectorContainerFactory
 {
@@ -17,7 +19,25 @@ final class RectorContainerFactory
         $container = $this->createFromConfigs($bootstrapConfigs->getConfigFiles());
 
         $mainConfigFile = $bootstrapConfigs->getMainConfigFile();
+
         if ($mainConfigFile !== null) {
+            // warning about old syntax before RectorConfig
+            $fileContents = FileSystem::read($mainConfigFile);
+            if (str_contains($fileContents, 'ContainerConfigurator $containerConfigurator')) {
+                /** @var SymfonyStyle $symfonyStyle */
+                $symfonyStyle = $container->get(SymfonyStyle::class);
+
+                // @todo add link to blog post after release
+                $warningMessage = sprintf(
+                    'Your "%s" config is using old syntax with "ContainerConfigurator".%sPlease upgrade to "RectorConfig" that allows better autocomplete and future standard.',
+                    $mainConfigFile,
+                    PHP_EOL,
+                );
+                $symfonyStyle->warning($warningMessage);
+                // to make message noticable
+                sleep(1);
+            }
+
             /** @var ChangedFilesDetector $changedFilesDetector */
             $changedFilesDetector = $container->get(ChangedFilesDetector::class);
             $changedFilesDetector->setFirstResolvedConfigFileInfo($mainConfigFile);


### PR DESCRIPTION
To remove direct  dependency on Symfony container that might cause some conflicts now. 
The only way to avoid those, we have to move away from usage of `ContainerConfigurator` - https://github.com/rectorphp/rector-src/pull/2104

But we can't remove the class just like that, as Rector would crash without any note. 
We prefer to take a safer path - first upgrade the `rector.php` configs to `RectorConfig`. 

To help spread the message, when you run Rector with container configurator, you'll get a warning message:

![image](https://user-images.githubusercontent.com/924196/165359835-1e0714e5-bf3c-4d7b-adfd-b872adc82e81.png)

This helps informing users about a new way to configure Rector. In future release this will be risen to an error message (but uccess) code with longer time to spot, to make sure the upgrade is done before the class removal.
