### PR TITLE
[DowngradePhp80] Add Static Call Support on DowngradeMatchToSwitchRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/static_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/static_call.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class SomeStaticCall
+{
+    public static function output($value)
+    {
+        echo $value;
+    }
+
+    public function run($statusCode)
+    {
+        self::output(match ($statusCode) {
+            200, 300 => null,
+            400 => 'not found',
+            default => 'unknown status code',
+        });
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class SomeStaticCall
+{
+    public static function output($value)
+    {
+        echo $value;
+    }
+
+    public function run($statusCode)
+    {
+        switch ($statusCode) {
+            case 200:
+            case 300:
+                self::output(null);
+                break;
+            case 400:
+                self::output('not found');
+                break;
+            default:
+                self::output('unknown status code');
+                break;
+        }
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -6,7 +6,6 @@ namespace Rector\DowngradePhp80\Rector\Expression;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
@@ -166,7 +165,7 @@ CODE_SAMPLE
         } elseif ($node->expr instanceof Match_) {
             $stmts[] = new Expression($matchArm->body);
             $stmts[] = new Break_();
-        } elseif ($node->expr instanceof CallLike)  {
+        } elseif ($node->expr instanceof CallLike) {
             /** @var FuncCall|MethodCall|New_|NullsafeMethodCall|StaticCall $call */
             $call = clone $node->expr;
             $call->args = [new Arg($matchArm->body)];

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp80\Rector\Expression;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
@@ -154,16 +155,16 @@ CODE_SAMPLE
         } elseif ($node instanceof Echo_) {
             $stmts[] = new Echo_([$matchArm->body]);
             $stmts[] = new Break_();
-        } elseif ($node->expr instanceof CallLike) {
-            $call = clone $node->expr;
-            $call->args = [new Arg($matchArm->body)];
-            $stmts[] = new Expression($call);
-            $stmts[] = new Break_();
         } elseif ($node->expr instanceof Assign) {
             $stmts[] = new Expression(new Assign($node->expr->var, $matchArm->body));
             $stmts[] = new Break_();
         } elseif ($node->expr instanceof Match_) {
             $stmts[] = new Expression($matchArm->body);
+            $stmts[] = new Break_();
+        } elseif ($node->expr instanceof Expr)  {
+            $call = clone $node->expr;
+            $call->args = [new Arg($matchArm->body)];
+            $stmts[] = new Expression($call);
             $stmts[] = new Break_();
         }
 

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -10,7 +10,12 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\MatchArm;
 use PhpParser\Node\Stmt;
@@ -161,7 +166,8 @@ CODE_SAMPLE
         } elseif ($node->expr instanceof Match_) {
             $stmts[] = new Expression($matchArm->body);
             $stmts[] = new Break_();
-        } elseif ($node->expr instanceof Expr)  {
+        } elseif ($node->expr instanceof CallLike)  {
+            /** @var FuncCall|MethodCall|New_|NullsafeMethodCall|StaticCall $call */
             $call = clone $node->expr;
             $call->args = [new Arg($matchArm->body)];
             $stmts[] = new Expression($call);

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -156,7 +156,7 @@ CODE_SAMPLE
         } elseif ($node instanceof Echo_) {
             $stmts[] = new Echo_([$matchArm->body]);
             $stmts[] = new Break_();
-        } else if ($node->expr instanceof MethodCall || $node->expr instanceof FuncCall) {
+        } else if ($node->expr instanceof CallLike) {
             $call = clone $node->expr;
             $call->args = [new Arg($matchArm->body)];
             $stmts[] = new Expression($call);

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -9,9 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\MatchArm;
 use PhpParser\Node\Stmt;
@@ -156,7 +154,7 @@ CODE_SAMPLE
         } elseif ($node instanceof Echo_) {
             $stmts[] = new Echo_([$matchArm->body]);
             $stmts[] = new Break_();
-        } else if ($node->expr instanceof CallLike) {
+        } elseif ($node->expr instanceof CallLike) {
             $call = clone $node->expr;
             $call->args = [new Arg($matchArm->body)];
             $stmts[] = new Expression($call);


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2173 by @jrstanley, this PR add static call support as well.