### PR TITLE
[DowngradePhp80] Fixture for DowngradeMatchToSwitchRector `match` having `true` subject expression

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/true_subject_expression.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/true_subject_expression.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class TrueSubjectExpression
+{
+    public function run($statusCode)
+    {
+        $result = match (true) {
+            ($statusCode >= 200 && $statusCode < 300) => 'success',
+            in_array($statusCode, range(400, 499)) => 'client error',
+            default => 'unknown status code',
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class TrueSubjectExpression
+{
+    public function run($statusCode)
+    {
+        switch (true) {
+            case $statusCode >= 200 && $statusCode < 300:
+                $result = 'success';
+                break;
+            case in_array($statusCode, range(400, 499)):
+                $result = 'client error';
+                break;
+            default:
+                $result = 'unknown status code';
+                break;
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
I was checking to make sure that the `DowngradeMatchToSwitchRector` supported cases where the subject expression is true `match(true) { ... }` and the match arms contained the expression to evaluate.

The tests are already passing for this (great!), however I thought it would be worthwhile adding the test in any event to ensure this continues to work in the future?