### PR TITLE
[Doctrine][Nette][TypeDeclaration] Handle add __construct with no Scope on InitializeDefaultEntityCollectionRector+RenderMethodParamToTypeDeclarationRector

### DIFF
--- a/rules/TypeDeclaration/NodeAnalyzer/ControllerRenderMethodAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ControllerRenderMethodAnalyzer.php
@@ -21,8 +21,12 @@ final class ControllerRenderMethodAnalyzer
     ) {
     }
 
-    public function isRenderMethod(ClassMethod $classMethod, Scope $scope): bool
+    public function isRenderMethod(ClassMethod $classMethod, ?Scope $scope): bool
     {
+        if (! $scope instanceof Scope) {
+            return false;
+        }
+
         // nette one?
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {

--- a/tests/Issues/AddConstructMethodNoScope/AddConstructMethodNoScopeTest.php
+++ b/tests/Issues/AddConstructMethodNoScope/AddConstructMethodNoScopeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AnnotationImport;
+namespace Rector\Core\Tests\Issues\AddConstructMethodNoScope;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/tests/Issues/AddConstructMethodNoScope/AddConstructMethodNoScopeTest.php
+++ b/tests/Issues/AddConstructMethodNoScope/AddConstructMethodNoScopeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\AnnotationImport;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7134
+ */
+final class AddConstructMethodNoScopeTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/AddConstructMethodNoScope/Fixture/add_constructor_method_no_scope.php.inc
+++ b/tests/Issues/AddConstructMethodNoScope/Fixture/add_constructor_method_no_scope.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Core\Tests\Issues\AddConstructMethodNoScope\Fixture;
+
 use App\Entity\Sage\FDocligne;
 use App\Repository\Sage\FDocenteteRepository;
 use Doctrine\Common\Collections\Collection;
@@ -17,6 +19,8 @@ class FDocentete
 ?>
 -----
 <?php
+
+namespace Rector\Core\Tests\Issues\AddConstructMethodNoScope\Fixture;
 
 use App\Entity\Sage\FDocligne;
 use App\Repository\Sage\FDocenteteRepository;

--- a/tests/Issues/AddConstructMethodNoScope/Fixture/add_constructor_method_no_scope.php.inc
+++ b/tests/Issues/AddConstructMethodNoScope/Fixture/add_constructor_method_no_scope.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+use App\Entity\Sage\FDocligne;
+use App\Repository\Sage\FDocenteteRepository;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table]
+#[ORM\Entity(repositoryClass: FDocenteteRepository::class, readOnly: true)]
+class FDocentete
+{
+    #[ORM\OneToMany(mappedBy: 'doPiece', targetEntity: FDocligne::class)]
+    #[ORM\JoinColumn(referencedColumnName: 'DO_Piece')]
+    private ?Collection $fDoclignes = null;
+}
+
+?>
+-----
+<?php
+
+use App\Entity\Sage\FDocligne;
+use App\Repository\Sage\FDocenteteRepository;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table]
+#[ORM\Entity(repositoryClass: FDocenteteRepository::class, readOnly: true)]
+class FDocentete
+{
+    #[ORM\OneToMany(mappedBy: 'doPiece', targetEntity: FDocligne::class)]
+    #[ORM\JoinColumn(referencedColumnName: 'DO_Piece')]
+    private ?Collection $fDoclignes = null;
+    public function __construct()
+    {
+        $this->fDoclignes = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+}
+
+?>

--- a/tests/Issues/AddConstructMethodNoScope/config/configured_rule.php
+++ b/tests/Issues/AddConstructMethodNoScope/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Rector\Class_\InitializeDefaultEntityCollectionRector;
+use Rector\Nette\Rector\ClassMethod\RenderMethodParamToTypeDeclarationRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(InitializeDefaultEntityCollectionRector::class);
+    $rectorConfig->rule(RenderMethodParamToTypeDeclarationRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
<?php

namespace App\Entity\Test;

use App\Entity\Sage\FDocligne;
use App\Repository\Sage\FDocenteteRepository;
use Doctrine\Common\Collections\Collection;
use Doctrine\ORM\Mapping as ORM;

#[ORM\Table]
#[ORM\Entity(repositoryClass: FDocenteteRepository::class, readOnly: true)]
class FDocentete
{
    #[ORM\OneToMany(mappedBy: 'doPiece', targetEntity: FDocligne::class)]
    #[ORM\JoinColumn(referencedColumnName: 'DO_Piece')]
    private ?Collection $fDoclignes = null;
}
```

Currently produce:

```


There was 1 error:

1) Rector\Core\Tests\Issues\AnnotationImport\AddConstructMethodNoScopeTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
TypeError: Rector\TypeDeclaration\NodeAnalyzer\ControllerRenderMethodAnalyzer::isRenderMethod(): Argument #2 ($scope) must be of type PHPStan\Analyser\Scope, null given, called in /Users/samsonasik/www/rector-src/vendor/rector/rector-nette/src/Rector/ClassMethod/RenderMethodParamToTypeDeclarationRector.php on line 88
```

Applied rules:

```php
Rector\Doctrine\Rector\Class_\InitializeDefaultEntityCollectionRector;
Rector\Nette\Rector\ClassMethod\RenderMethodParamToTypeDeclarationRector;
```

This PR fix it. Fixes https://github.com/rectorphp/rector/issues/7134