### PR TITLE
[Core] Add $seconds, $maxNumberOfProcess, and $jobSize parameters to RectorConfig::parallel() method

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -48,9 +48,6 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL, false);
     }
 
-    /**
-     * @param array<string, int> $criteria
-     */
     public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20): void
     {
         $parameters = $this->parameters();

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -48,11 +48,17 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL, false);
     }
 
-    public function parallel(int $seconds = 120): void
+    /**
+     * @param array<string, int> $criteria
+     */
+    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
+
         $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
+        $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $maxNumberOfProcess);
+        $parameters->set(Option::PARALLEL_JOB_SIZE, $jobSize);
     }
 
     /**

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -54,6 +54,12 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL, true);
     }
 
+    public function parallelTimoutInSeconds(int $seconds): void
+    {
+        $parameters = $this->parameters();
+        $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
+    }
+
     /**
      * @param array<int|string, mixed> $criteria
      */

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -48,16 +48,14 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL, false);
     }
 
-    public function parallel(): void
+    public function parallel(int $seconds = 120): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
-    }
 
-    public function parallelTimoutInSeconds(int $seconds): void
-    {
-        $parameters = $this->parameters();
-        $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
+        if (is_int($seconds)) {
+            $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
+        }
     }
 
     /**

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -52,10 +52,7 @@ final class RectorConfig extends ContainerConfigurator
     {
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
-
-        if (is_int($seconds)) {
-            $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
-        }
+        $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
     }
 
     /**

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -186,11 +186,13 @@ final class Option
     public const PARALLEL_PORT = 'port';
 
     /**
+     * @deprecated Use @see \Rector\Config\RectorConfig::parallel() instead with pass int $jobSize parameter
      * @var string
      */
     public const PARALLEL_JOB_SIZE = 'parallel-job-size';
 
     /**
+     * @deprecated Use @see \Rector\Config\RectorConfig::parallel() instead with pass int $maxNumberOfProcess parameter
      * @var string
      */
     public const PARALLEL_MAX_NUMBER_OF_PROCESSES = 'parallel-max-number-of-processes';

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -196,6 +196,7 @@ final class Option
     public const PARALLEL_MAX_NUMBER_OF_PROCESSES = 'parallel-max-number-of-processes';
 
     /**
+     * @deprecated Use @see \Rector\Config\RectorConfig::parallelTimoutInSeconds() instead
      * @var string
      */
     public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -196,7 +196,7 @@ final class Option
     public const PARALLEL_MAX_NUMBER_OF_PROCESSES = 'parallel-max-number-of-processes';
 
     /**
-     * @deprecated Use @see \Rector\Config\RectorConfig::parallelTimoutInSeconds() instead
+     * @deprecated Use @see \Rector\Config\RectorConfig::parallel() instead with pass int $seconds parameter
      * @var string
      */
     public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';


### PR DESCRIPTION
to handle use Option directly to increase parallel timeout like this https://github.com/codeigniter4/CodeIgniter4/pull/5931/commits/346c83ff7693520be63d5293e978645c571461fc#diff-d933a2ad57daa43419b483d3f1ddedaec7aa44933007fead9f9437390f596f4a