### PR TITLE
[Core] Move parent instanceof Node check on BetterNodeFinder::findParentType() inside do { } while condition

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -88,7 +88,9 @@ final class BetterNodeFinder
             if (is_a($parent, $type, true)) {
                 return $parent;
             }
-        } while ($parent = $parent->getAttribute(AttributeKey::PARENT_NODE));
+
+            $parent = $parent->getAttribute(AttributeKey::PARENT_NODE);
+        } while ($parent instanceof Node);
 
         return null;
     }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -88,10 +88,6 @@ final class BetterNodeFinder
             if (is_a($parent, $type, true)) {
                 return $parent;
             }
-
-            if (! $parent instanceof Node) {
-                return null;
-            }
         } while ($parent = $parent->getAttribute(AttributeKey::PARENT_NODE));
 
         return null;


### PR DESCRIPTION
The instanceof Node already exists before `do {} while`, updated to use type control on `while`