### PR TITLE
[DeadCode] Improve RemoveUnreachableStatementRector performance by return after array_splice early

### DIFF
--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -120,10 +120,7 @@ CODE_SAMPLE
      */
     private function processCleanUpUnreachabelStmts(array $stmts): array
     {
-        $cleanedStmts = [];
         foreach ($stmts as $key => $stmt) {
-            $cleanedStmts[] = $stmt;
-
             if (! isset($stmts[$key - 1])) {
                 continue;
             }
@@ -135,8 +132,8 @@ CODE_SAMPLE
             $previousStmt = $stmts[$key - 1];
 
             if ($this->shouldRemove($previousStmt, $stmt)) {
-                array_pop($cleanedStmts);
-                return $cleanedStmts;
+                array_splice($stmts, $key);
+                return $stmts;
             }
         }
 

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -120,8 +120,14 @@ CODE_SAMPLE
      */
     private function processCleanUpUnreachabelStmts(array $stmts): array
     {
-        $originalStmts = $stmts;
+        $isRemoved = false;
+
         foreach ($stmts as $key => $stmt) {
+            if ($isRemoved) {
+                unset($stmts[$key]);
+                continue;
+            }
+
             if (! isset($stmts[$key - 1])) {
                 continue;
             }
@@ -132,18 +138,15 @@ CODE_SAMPLE
 
             $previousStmt = $stmts[$key - 1];
 
-            if ($this->shouldRemove($previousStmt, $stmt)) {
-                unset($stmts[$key]);
-                break;
+            if (! $this->shouldRemove($previousStmt, $stmt)) {
+                continue;
             }
+
+            unset($stmts[$key]);
+            $isRemoved = true;
         }
 
-        if ($originalStmts === $stmts) {
-            return $originalStmts;
-        }
-
-        $stmts = array_values($stmts);
-        return $this->processCleanUpUnreachabelStmts($stmts);
+        return $stmts;
     }
 
     private function shouldRemove(Stmt $previousStmt, Stmt $currentStmt): bool

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -120,13 +120,9 @@ CODE_SAMPLE
      */
     private function processCleanUpUnreachabelStmts(array $stmts): array
     {
-        $isRemoved = false;
-
+        $cleanedStmts = [];
         foreach ($stmts as $key => $stmt) {
-            if ($isRemoved) {
-                unset($stmts[$key]);
-                continue;
-            }
+            $cleanedStmts[] = $stmt;
 
             if (! isset($stmts[$key - 1])) {
                 continue;
@@ -138,12 +134,10 @@ CODE_SAMPLE
 
             $previousStmt = $stmts[$key - 1];
 
-            if (! $this->shouldRemove($previousStmt, $stmt)) {
-                continue;
+            if ($this->shouldRemove($previousStmt, $stmt)) {
+                array_pop($cleanedStmts);
+                return $cleanedStmts;
             }
-
-            unset($stmts[$key]);
-            $isRemoved = true;
         }
 
         return $stmts;


### PR DESCRIPTION
on loop, when we found a key that start to be removed, we return early after array_splice the stmts.