### PR TITLE
[Core] Remove loop on FilesFinder::findInDirectoriesAndFiles()

### DIFF
--- a/packages/Caching/UnchangedFilesFilter.php
+++ b/packages/Caching/UnchangedFilesFilter.php
@@ -15,18 +15,18 @@ final class UnchangedFilesFilter
     }
 
     /**
-     * @param SmartFileInfo[]|string[] $fileInfosOrPaths
+     * @param SmartFileInfo[]|string[] $fileInfos
      * @return SmartFileInfo[]
      */
-    public function filterAndJoinWithDependentFileInfos(array $fileInfosOrPaths): array
+    public function filterAndJoinWithDependentFileInfos(array $fileInfos): array
     {
         $changedFileInfos = [];
         $dependentFileInfos = [];
 
-        foreach ($fileInfosOrPaths as $fileInfoOrPath) {
-            $fileInfo = is_string($fileInfoOrPath)
-                ? new SmartFileInfo($fileInfoOrPath)
-                : $fileInfoOrPath;
+        foreach ($fileInfos as $fileInfo) {
+            if (is_string($fileInfo)) {
+                $fileInfo = new SmartFileInfo($fileInfo);
+            }
 
             if (! $this->changedFilesDetector->hasFileChanged($fileInfo)) {
                 continue;

--- a/packages/Caching/UnchangedFilesFilter.php
+++ b/packages/Caching/UnchangedFilesFilter.php
@@ -23,21 +23,21 @@ final class UnchangedFilesFilter
         $changedFileInfos = [];
         $dependentFileInfos = [];
 
-        foreach ($fileInfosOrPaths as $fileInfo) {
-            $fileInfo = is_string($fileInfo)
-                ? new SmartFileInfo($fileInfo)
-                : $fileInfo;
+        foreach ($fileInfosOrPaths as $fileInfoOrPath) {
+            $fileInfoOrPath = is_string($fileInfoOrPath)
+                ? new SmartFileInfo($fileInfoOrPath)
+                : $fileInfoOrPath;
 
-            if (! $this->changedFilesDetector->hasFileChanged($fileInfo)) {
+            if (! $this->changedFilesDetector->hasFileChanged($fileInfoOrPath)) {
                 continue;
             }
 
-            $changedFileInfos[] = $fileInfo;
-            $this->changedFilesDetector->invalidateFile($fileInfo);
+            $changedFileInfos[] = $fileInfoOrPath;
+            $this->changedFilesDetector->invalidateFile($fileInfoOrPath);
 
             $dependentFileInfos = array_merge(
                 $dependentFileInfos,
-                $this->changedFilesDetector->getDependentFileInfos($fileInfo)
+                $this->changedFilesDetector->getDependentFileInfos($fileInfoOrPath)
             );
         }
 

--- a/packages/Caching/UnchangedFilesFilter.php
+++ b/packages/Caching/UnchangedFilesFilter.php
@@ -24,20 +24,20 @@ final class UnchangedFilesFilter
         $dependentFileInfos = [];
 
         foreach ($fileInfosOrPaths as $fileInfoOrPath) {
-            $fileInfoOrPath = is_string($fileInfoOrPath)
+            $fileInfo = is_string($fileInfoOrPath)
                 ? new SmartFileInfo($fileInfoOrPath)
                 : $fileInfoOrPath;
 
-            if (! $this->changedFilesDetector->hasFileChanged($fileInfoOrPath)) {
+            if (! $this->changedFilesDetector->hasFileChanged($fileInfo)) {
                 continue;
             }
 
-            $changedFileInfos[] = $fileInfoOrPath;
-            $this->changedFilesDetector->invalidateFile($fileInfoOrPath);
+            $changedFileInfos[] = $fileInfo;
+            $this->changedFilesDetector->invalidateFile($fileInfo);
 
             $dependentFileInfos = array_merge(
                 $dependentFileInfos,
-                $this->changedFilesDetector->getDependentFileInfos($fileInfoOrPath)
+                $this->changedFilesDetector->getDependentFileInfos($fileInfo)
             );
         }
 

--- a/packages/Caching/UnchangedFilesFilter.php
+++ b/packages/Caching/UnchangedFilesFilter.php
@@ -15,15 +15,19 @@ final class UnchangedFilesFilter
     }
 
     /**
-     * @param SmartFileInfo[] $fileInfos
+     * @param SmartFileInfo[]|string[] $fileInfosOrPaths
      * @return SmartFileInfo[]
      */
-    public function filterAndJoinWithDependentFileInfos(array $fileInfos): array
+    public function filterAndJoinWithDependentFileInfos(array $fileInfosOrPaths): array
     {
         $changedFileInfos = [];
         $dependentFileInfos = [];
 
-        foreach ($fileInfos as $fileInfo) {
+        foreach ($fileInfosOrPaths as $fileInfo) {
+            $fileInfo = is_string($fileInfo)
+                ? new SmartFileInfo($fileInfo)
+                : $fileInfo;
+
             if (! $this->changedFilesDetector->hasFileChanged($fileInfo)) {
                 continue;
             }

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -55,12 +55,7 @@ final class FilesFinder
 
         $directories = $this->fileSystemFilter->filterDirectories($filesAndDirectories);
 
-        $smartFileInfos = [];
-        foreach ($filePaths as $filePath) {
-            $smartFileInfos[] = new SmartFileInfo($filePath);
-        }
-
-        $smartFileInfos = $this->unchangedFilesFilter->filterAndJoinWithDependentFileInfos($smartFileInfos);
+        $smartFileInfos = $this->unchangedFilesFilter->filterAndJoinWithDependentFileInfos($filePaths);
 
         return array_merge($smartFileInfos, $this->findInDirectories($directories, $suffixes));
     }


### PR DESCRIPTION
Add ability to pass array of string as file paths on `UnchangedFilesFilter::filterAndJoinWithDependentFileInfos()`, so no need loop to create `SmartFileInfo` instance on `FilesFinder-> findInDirectoriesAndFiles()`