### PR TITLE
[Core] Use existing findParentType() on BetterNodeFinder::findParentByTypes()

### DIFF
--- a/packages/BetterPhpDocParser/Comment/CommentsMerger.php
+++ b/packages/BetterPhpDocParser/Comment/CommentsMerger.php
@@ -80,7 +80,7 @@ final class CommentsMerger
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($node, function (Node $node) use (
             &$childrenComments
-        ) {
+        ): void {
             $comments = $node->getComments();
 
             if ($comments !== []) {

--- a/rules/CodeQuality/NodeManipulator/ClassMethodParameterTypeManipulator.php
+++ b/rules/CodeQuality/NodeManipulator/ClassMethodParameterTypeManipulator.php
@@ -110,7 +110,7 @@ final class ClassMethodParameterTypeManipulator
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classMethod->stmts, function (Node $node) use (
             $param,
             $methodsReturningClassInstance
-        ) {
+        ): void {
             if (! $node instanceof MethodCall) {
                 return null;
             }

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -112,7 +112,7 @@ final class ShortNameResolver
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, function (Node $node) use (
             &$shortNamesToFullyQualifiedNames
-        ) {
+        ): void {
             // class name is used!
             if ($node instanceof ClassLike && $node->name instanceof Identifier) {
                 $fullyQualifiedName = $this->nodeNameResolver->getName($node);
@@ -161,7 +161,7 @@ final class ShortNameResolver
         $shortNames = [];
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, function (Node $node) use (
             &$shortNames
-        ) {
+        ): void {
             // speed up for nodes that are
             $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
             if (! $phpDocInfo instanceof PhpDocInfo) {
@@ -172,7 +172,7 @@ final class ShortNameResolver
             $phpDocNodeTraverser->traverseWithCallable(
                 $phpDocInfo->getPhpDocNode(),
                 '',
-                function ($node) use (&$shortNames) {
+                function ($node) use (&$shortNames): void {
                     if ($node instanceof PhpDocTagNode) {
                         $shortName = trim($node->name, '@');
                         if (StringUtils::isMatch($shortName, self::BIG_LETTER_START_REGEX)) {

--- a/rules/CodingStyle/ClassNameImport/UseImportsTraverser.php
+++ b/rules/CodingStyle/ClassNameImport/UseImportsTraverser.php
@@ -47,7 +47,7 @@ final class UseImportsTraverser
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, function (Node $node) use (
             $callable,
             $desiredType
-        ) {
+        ): void {
             if ($node instanceof Use_) {
                 // only import uses
                 if ($node->type !== $desiredType) {

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -148,7 +148,7 @@ CODE_SAMPLE
         $this->traverseNodesWithCallable($catch->stmts, function (Node $node) use (
             $oldVariableName,
             $newVariableName
-        ) {
+        ): void {
             if (! $node instanceof Variable) {
                 return null;
             }

--- a/rules/CodingStyle/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
+++ b/rules/CodingStyle/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
     private function collectPropertyNamesWithMissingDefaultArray(Class_ $class): array
     {
         $propertyNames = [];
-        $this->traverseNodesWithCallable($class, function (Node $node) use (&$propertyNames) {
+        $this->traverseNodesWithCallable($class, function (Node $node) use (&$propertyNames): void {
             if (! $node instanceof PropertyProperty) {
                 return null;
             }

--- a/rules/DeadCode/NodeCollector/ModifiedVariableNamesCollector.php
+++ b/rules/DeadCode/NodeCollector/ModifiedVariableNamesCollector.php
@@ -42,7 +42,7 @@ final class ModifiedVariableNamesCollector
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmt, function (Node $node) use (
             &$variableNames
-        ) {
+        ): void {
             if (! $node instanceof Arg) {
                 return null;
             }
@@ -71,7 +71,7 @@ final class ModifiedVariableNamesCollector
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmt, function (Node $node) use (
             &$modifiedVariableNames
-        ) {
+        ): void {
             if (! $node instanceof Assign) {
                 return null;
             }

--- a/rules/DowngradePhp56/Rector/FuncCall/DowngradeArrayFilterUseConstantRector.php
+++ b/rules/DowngradePhp56/Rector/FuncCall/DowngradeArrayFilterUseConstantRector.php
@@ -143,7 +143,7 @@ CODE_SAMPLE
             $key,
             $value,
             &$stmts
-        ) {
+        ): void {
             if (! $subNode instanceof Stmt) {
                 return null;
             }
@@ -188,7 +188,7 @@ CODE_SAMPLE
             $key,
             $arrayValue,
             &$stmts
-        ) {
+        ): void {
             if (! $subNode instanceof Stmt) {
                 return null;
             }

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -78,7 +78,7 @@ final class TokenManipulator
         // replace "$content = $token;" → "$content = $token->text;"
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, function (Node $node) use (
             $singleTokenExpr
-        ) {
+        ): void {
             if (! $node instanceof Assign) {
                 return null;
             }
@@ -177,7 +177,7 @@ final class TokenManipulator
     {
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, function (Node $node) use (
             $singleTokenVariable
-        ) {
+        ): void {
             if (! $node instanceof FuncCall) {
                 return null;
             }

--- a/rules/Php80/PhpDoc/PhpDocNodeFinder.php
+++ b/rules/Php80/PhpDoc/PhpDocNodeFinder.php
@@ -19,7 +19,10 @@ final class PhpDocNodeFinder
         $foundNodes = [];
 
         $phpDocNodeTraverser = new PhpDocNodeTraverser();
-        $phpDocNodeTraverser->traverseWithCallable($node, '', function (Node $node) use (&$foundNodes, $nodeType) {
+        $phpDocNodeTraverser->traverseWithCallable($node, '', function (Node $node) use (
+            &$foundNodes,
+            $nodeType
+        ): void {
             if (! is_a($node, $nodeType, true)) {
                 return null;
             }

--- a/rules/Php80/Rector/Class_/StringableForToStringRector.php
+++ b/rules/Php80/Rector/Class_/StringableForToStringRector.php
@@ -144,7 +144,7 @@ CODE_SAMPLE
             return;
         }
 
-        $this->traverseNodesWithCallable((array) $toStringClassMethod->stmts, function (Node $subNode) {
+        $this->traverseNodesWithCallable((array) $toStringClassMethod->stmts, function (Node $subNode): void {
             if (! $subNode instanceof Return_) {
                 return null;
             }

--- a/rules/Php80/Rector/FuncCall/TokenGetAllToObjectRector.php
+++ b/rules/Php80/Rector/FuncCall/TokenGetAllToObjectRector.php
@@ -155,7 +155,7 @@ CODE_SAMPLE
             return;
         }
 
-        $this->traverseNodesWithCallable($tokensForeach, function (Node $node) use ($singleToken) {
+        $this->traverseNodesWithCallable($tokensForeach, function (Node $node) use ($singleToken): void {
             $this->tokenManipulator->refactorArrayToken([$node], $singleToken);
             $this->tokenManipulator->refactorNonArrayToken([$node], $singleToken);
             $this->tokenManipulator->refactorTokenIsKind([$node], $singleToken);

--- a/rules/Privatization/Rector/Class_/ChangeGlobalVariablesToPropertiesRector.php
+++ b/rules/Privatization/Rector/Class_/ChangeGlobalVariablesToPropertiesRector.php
@@ -110,7 +110,7 @@ CODE_SAMPLE
     {
         $this->globalVariableNames = [];
 
-        $this->traverseNodesWithCallable($classMethod, function (Node $node) use ($class) {
+        $this->traverseNodesWithCallable($classMethod, function (Node $node) use ($class): void {
             if ($node instanceof Global_) {
                 $this->refactorGlobal($class, $node);
                 return NodeTraverser::DONT_TRAVERSE_CHILDREN;

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -386,7 +386,7 @@ final class ClassRenamer
 
     private function changeNameToFullyQualifiedName(ClassLike $classLike): void
     {
-        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classLike, function (Node $node) {
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classLike, function (Node $node): void {
             if (! $node instanceof FullyQualified) {
                 return null;
             }

--- a/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
+++ b/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
         $this->traverseNodesWithCallable($class->stmts, function (Node $node) use (
             $onlyPropertyProperty,
             &$isIdenticalOrNotIdenticalToNull
-        ) {
+        ): void {
             $matchedPropertyFetchName = $this->matchPropertyFetchNameComparedToNull($node);
             if ($matchedPropertyFetchName === null) {
                 return null;
@@ -155,7 +155,7 @@ CODE_SAMPLE
         $this->traverseNodesWithCallable($class->stmts, function (Node $node) use (
             $onlyPropertyProperty,
             &$isBooleanNot
-        ) {
+        ): void {
             if (! $node instanceof BooleanNot) {
                 return null;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -172,7 +172,7 @@ CODE_SAMPLE
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $newParamType,
-            function (Node $node) {
+            function (Node $node): void {
                 // original attributes have to removed to avoid tokens crashing from origin positions
                 $node->setAttributes([]);
                 return null;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector.php
@@ -117,7 +117,7 @@ CODE_SAMPLE
             $paramType = $parentParam->type;
 
             // original attributes have to removed to avoid tokens crashing from origin positions
-            $this->traverseNodesWithCallable($paramType, function (Node $node) {
+            $this->traverseNodesWithCallable($paramType, function (Node $node): void {
                 $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
                 return null;
             });

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -46,7 +46,7 @@ final class AssignToPropertyTypeInferer
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classLike->stmts, function (Node $node) use (
             $propertyName,
             &$assignedExprTypes
-        ) {
+        ): void {
             if (! $node instanceof Assign) {
                 return null;
             }

--- a/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/PropertyNodeParamTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ParamTypeInferer/PropertyNodeParamTypeInferer.php
@@ -54,7 +54,7 @@ final class PropertyNodeParamTypeInferer implements ParamTypeInfererInterface
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classMethod, function (Node $node) use (
             $paramName,
             &$propertyStaticTypes
-        ) {
+        ): void {
             if (! $node instanceof Assign) {
                 return null;
             }

--- a/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
+++ b/src/DependencyInjection/Loader/Configurator/RectorServiceConfigurator.php
@@ -24,7 +24,7 @@ final class RectorServiceConfigurator extends ServiceConfigurator
         $this->ensureClassIsConfigurable($this->id);
 
         // decorate with value object inliner so Symfony understands, see https://getrector.org/blog/2020/09/07/how-to-inline-value-object-in-symfony-php-config
-        array_walk_recursive($configuration, function (&$value) {
+        array_walk_recursive($configuration, function (&$value): void {
             if (is_object($value)) {
                 $value = ValueObjectInliner::inline($value);
             }

--- a/src/NodeManipulator/ArrayDestructVariableFilter.php
+++ b/src/NodeManipulator/ArrayDestructVariableFilter.php
@@ -31,7 +31,7 @@ final class ArrayDestructVariableFilter
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classMethod, function (Node $node) use (
             &$arrayDestructionCreatedVariables
-        ) {
+        ): void {
             if (! $node instanceof Assign) {
                 return null;
             }

--- a/src/NodeManipulator/Dependency/DependencyClassMethodDecorator.php
+++ b/src/NodeManipulator/Dependency/DependencyClassMethodDecorator.php
@@ -98,7 +98,7 @@ final class DependencyClassMethodDecorator
         $cleanParams = $this->promotedPropertyParamCleaner->cleanFromFlags($params);
 
         // remove deep attributes to avoid bugs with nested tokens re-print
-        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($cleanParams, function (Node $node) {
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($cleanParams, function (Node $node): void {
             $node->setAttributes([]);
             return null;
         });

--- a/src/NodeManipulator/FunctionLikeManipulator.php
+++ b/src/NodeManipulator/FunctionLikeManipulator.php
@@ -34,7 +34,7 @@ final class FunctionLikeManipulator
         $returnedLocalPropertyNames = [];
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($functionLike, function (Node $node) use (
             &$returnedLocalPropertyNames
-        ) {
+        ): void {
             if (! $node instanceof Return_) {
                 return null;
             }

--- a/src/NodeManipulator/PropertyFetchAssignManipulator.php
+++ b/src/NodeManipulator/PropertyFetchAssignManipulator.php
@@ -82,7 +82,7 @@ final class PropertyFetchAssignManipulator
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($node, function (Node $node) use (
             $paramName,
             &$propertyNames
-        ) {
+        ): void {
             if (! $node instanceof Assign) {
                 return null;
             }

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -42,7 +42,7 @@ final class StmtsManipulator
     {
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $classMethod->stmts,
-            function (Node $node) use (&$stmts) {
+            function (Node $node) use (&$stmts): void {
                 foreach ($stmts as $key => $assign) {
                     if (! $this->nodeComparator->areNodesEqual($node, $assign)) {
                         continue;

--- a/src/NodeManipulator/VariableManipulator.php
+++ b/src/NodeManipulator/VariableManipulator.php
@@ -54,7 +54,7 @@ final class VariableManipulator
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $classMethod->getStmts(),
-            function (Node $node) use (&$assignsOfArrayToVariable, $currentClass, $currentClassName) {
+            function (Node $node) use (&$assignsOfArrayToVariable, $currentClass, $currentClassName): void {
                 if (! $node instanceof Assign) {
                     return null;
                 }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -55,15 +55,13 @@ final class BetterNodeFinder
     {
         Assert::allIsAOf($types, Node::class);
 
-        while ($currentNode = $currentNode->getAttribute(AttributeKey::PARENT_NODE)) {
-            if (! $currentNode instanceof Node) {
-                return null;
-            }
-
-            foreach ($types as $type) {
-                if (is_a($currentNode, $type, true)) {
-                    return $currentNode;
-                }
+        foreach ($types as $type) {
+            /**
+             * @var class-string<T> $type
+             */
+            $parent = $this->findParentType($currentNode, $type);
+            if ($parent instanceof Node) {
+                return $parent;
             }
         }
 


### PR DESCRIPTION
There is already `BetterNodeFinder::findParentType()`, on multi types, we can re-use existing `findParentType()`.