### PR TITLE
[Core] Merge BetterNodeFinder findFirstPreviousOfNode() with findFirstPrevious()

### DIFF
--- a/rules/CodeQuality/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector.php
@@ -120,7 +120,7 @@ CODE_SAMPLE
 
     private function findPreviousAssignToArrayKeys(FuncCall $funcCall, Expr $expr): null|Node|FunctionLike
     {
-        return $this->betterNodeFinder->findFirstPreviousOfNode($funcCall, function (Node $node) use ($expr): bool {
+        return $this->betterNodeFinder->findFirstPrevious($funcCall, function (Node $node) use ($expr): bool {
             // breaking out of scope
             if ($node instanceof FunctionLike) {
                 return true;

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -128,7 +128,7 @@ CODE_SAMPLE
         }
 
         $newVariable = new Variable($newVariableName);
-        $isFoundInPrevious = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+        $isFoundInPrevious = (bool) $this->betterNodeFinder->findFirstPrevious(
             $node,
             fn (Node $n): bool => $this->nodeComparator->areNodesEqual($n, $newVariable)
         );

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -185,7 +185,7 @@ CODE_SAMPLE
 
     private function isUsedInPreviousNode(Variable $variable): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+        return (bool) $this->betterNodeFinder->findFirstPrevious(
             $variable,
             fn (Node $node): bool => $this->usedVariableNameAnalyzer->isVariableNamed($node, $variable)
         );
@@ -214,7 +214,7 @@ CODE_SAMPLE
             return false;
         }
 
-        $previousAssign = $this->betterNodeFinder->findFirstPreviousOfNode(
+        $previousAssign = $this->betterNodeFinder->findFirstPrevious(
             $assign,
             fn (Node $node): bool => $node instanceof Assign && $this->usedVariableNameAnalyzer->isVariableNamed(
                 $node->var,

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -159,7 +159,7 @@ CODE_SAMPLE
         }
 
         $variable = $instanceof->expr;
-        $isReassign = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+        $isReassign = (bool) $this->betterNodeFinder->findFirstPrevious(
             $instanceof,
             fn (Node $subNode): bool => $subNode instanceof Assign && $this->nodeComparator->areNodesEqual(
                 $subNode->var,

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -141,7 +141,7 @@ CODE_SAMPLE
             return false;
         }
 
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($node, function (Node $subNode): bool {
+        return (bool) $this->betterNodeFinder->findFirstPrevious($node, function (Node $subNode): bool {
             if (! $subNode instanceof FuncCall) {
                 return false;
             }

--- a/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
+++ b/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
@@ -91,7 +91,7 @@ final class UselessIfCondBeforeForeachDetector
 
     private function fromPreviousParam(Expr $expr): ?Node
     {
-        return $this->betterNodeFinder->findFirstPreviousOfNode($expr, function (Node $node) use ($expr): bool {
+        return $this->betterNodeFinder->findFirstPrevious($expr, function (Node $node) use ($expr): bool {
             if (! $node instanceof Param) {
                 return false;
             }

--- a/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
+++ b/rules/DogFood/Rector/Closure/UpgradeRectorConfigRector.php
@@ -147,7 +147,7 @@ CODE_SAMPLE
                         return null;
                     }
 
-                    $isPossiblyServiceDefinition = (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+                    $isPossiblyServiceDefinition = (bool) $this->betterNodeFinder->findFirstPrevious(
                         $node,
                         fn (Node $node): bool => $this->isFoundFluentServiceCall($node)
                     );

--- a/rules/DowngradePhp72/NodeAnalyzer/RegexFuncAnalyzer.php
+++ b/rules/DowngradePhp72/NodeAnalyzer/RegexFuncAnalyzer.php
@@ -42,7 +42,7 @@ final class RegexFuncAnalyzer
         }
 
         /** @var Assign|null $assignExprVariable */
-        $assignExprVariable = $this->betterNodeFinder->findFirstPreviousOfNode($funcCall, function (Node $node) use (
+        $assignExprVariable = $this->betterNodeFinder->findFirstPrevious($funcCall, function (Node $node) use (
             $variable
         ): bool {
             if (! $node instanceof Assign) {

--- a/rules/DowngradePhp72/NodeManipulator/JsonConstCleaner.php
+++ b/rules/DowngradePhp72/NodeManipulator/JsonConstCleaner.php
@@ -40,7 +40,7 @@ final class JsonConstCleaner
      */
     private function hasDefinedCheck(ConstFetch|BitwiseOr $node, array $constants): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+        return (bool) $this->betterNodeFinder->findFirstPrevious(
             $node,
             function (Node $subNode) use ($constants): bool {
                 if (! $subNode instanceof FuncCall) {

--- a/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
+++ b/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
 
         $assignVariable = $assign->var;
         /** @var Expr $variablePrevious */
-        $variablePrevious = $this->betterNodeFinder->findFirstPreviousOfNode($node, function (Node $node) use (
+        $variablePrevious = $this->betterNodeFinder->findFirstPrevious($node, function (Node $node) use (
             $assignVariable
         ): bool {
             $parent = $node->getAttribute(AttributeKey::PARENT_NODE);

--- a/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
+++ b/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
@@ -117,7 +117,7 @@ CODE_SAMPLE
 
     private function hasNamespaceInPreviousNamespace(Namespace_ $namespace): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode(
+        return (bool) $this->betterNodeFinder->findFirstPrevious(
             $namespace,
             fn (Node $node): bool => $node instanceof Namespace_
         );

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -171,7 +171,7 @@ final class UndefinedVariableResolver
 
     private function isAfterSwitchCaseWithParentCase(Variable $variable): bool
     {
-        $previousSwitch = $this->betterNodeFinder->findFirstPreviousOfNode(
+        $previousSwitch = $this->betterNodeFinder->findFirstPrevious(
             $variable,
             fn (Node $subNode): bool => $subNode instanceof Switch_
         );
@@ -197,7 +197,7 @@ final class UndefinedVariableResolver
 
     private function hasPreviousCheckedWithIsset(Variable $variable): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($variable, function (Node $subNode) use (
+        return (bool) $this->betterNodeFinder->findFirstPrevious($variable, function (Node $subNode) use (
             $variable
         ): bool {
             if (! $subNode instanceof Isset_) {
@@ -217,7 +217,7 @@ final class UndefinedVariableResolver
 
     private function hasPreviousCheckedWithEmpty(Variable $variable): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($variable, function (Node $subNode) use (
+        return (bool) $this->betterNodeFinder->findFirstPrevious($variable, function (Node $subNode) use (
             $variable
         ): bool {
             if (! $subNode instanceof Empty_) {

--- a/rules/Php80/NodeManipulator/ResourceReturnToObject.php
+++ b/rules/Php80/NodeManipulator/ResourceReturnToObject.php
@@ -121,7 +121,7 @@ final class ResourceReturnToObject
         array $collectionFunctionToReturnObject
     ): ?FullyQualifiedObjectType {
         $objectInstanceCheck = null;
-        $assign = $this->betterNodeFinder->findFirstPreviousOfNode($funcCall, function (Node $subNode) use (
+        $assign = $this->betterNodeFinder->findFirstPrevious($funcCall, function (Node $subNode) use (
             &$objectInstanceCheck,
             $expr,
             $collectionFunctionToReturnObject

--- a/rules/Php80/Rector/Switch_/ChangeSwitchToMatchRector.php
+++ b/rules/Php80/Rector/Switch_/ChangeSwitchToMatchRector.php
@@ -143,7 +143,7 @@ CODE_SAMPLE
 
     private function changeToAssign(Switch_ $switch, Match_ $match, Expr $assignExpr): Assign
     {
-        $prevInitializedAssign = $this->betterNodeFinder->findFirstPreviousOfNode(
+        $prevInitializedAssign = $this->betterNodeFinder->findFirstPrevious(
             $switch,
             fn (Node $node): bool => $node instanceof Assign && $this->nodeComparator->areNodesEqual(
                 $node->var,

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -202,7 +202,7 @@ CODE_SAMPLE
 
     private function isCastedReassign(Expr $expr): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($expr, function (Node $subNode) use (
+        return (bool) $this->betterNodeFinder->findFirstPrevious($expr, function (Node $subNode) use (
             $expr
         ): bool {
             if (! $subNode instanceof Assign) {

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -202,9 +202,7 @@ CODE_SAMPLE
 
     private function isCastedReassign(Expr $expr): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPrevious($expr, function (Node $subNode) use (
-            $expr
-        ): bool {
+        return (bool) $this->betterNodeFinder->findFirstPrevious($expr, function (Node $subNode) use ($expr): bool {
             if (! $subNode instanceof Assign) {
                 return false;
             }

--- a/rules/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector.php
+++ b/rules/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector.php
@@ -253,7 +253,7 @@ CODE_SAMPLE
         }
 
         // skip values in another constants
-        $parentConst = $this->scopeAwareNodeFinder->findParentType($string, [ClassConst::class]);
+        $parentConst = $this->betterNodeFinder->findParentType($string, ClassConst::class);
         if ($parentConst !== null) {
             return true;
         }

--- a/rules/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector.php
+++ b/rules/Privatization/Rector/Class_/RepeatedLiteralToClassConstantRector.php
@@ -15,7 +15,6 @@ use Rector\Core\NodeManipulator\ClassInsertManipulator;
 use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Util\StaticRectorStrings;
-use Rector\NodeNestingScope\NodeFinder\ScopeAwareNodeFinder;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -52,8 +51,7 @@ final class RepeatedLiteralToClassConstantRector extends AbstractRector
 
     public function __construct(
         private readonly ClassInsertManipulator $classInsertManipulator,
-        private readonly ReservedKeywordAnalyzer $reservedKeywordAnalyzer,
-        private readonly ScopeAwareNodeFinder $scopeAwareNodeFinder
+        private readonly ReservedKeywordAnalyzer $reservedKeywordAnalyzer
     ) {
     }
 

--- a/src/NodeAnalyzer/CallAnalyzer.php
+++ b/src/NodeAnalyzer/CallAnalyzer.php
@@ -81,7 +81,7 @@ final class CallAnalyzer
             return true;
         }
 
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($expr, function (Node $node) use ($expr): bool {
+        return (bool) $this->betterNodeFinder->findFirstPrevious($expr, function (Node $node) use ($expr): bool {
             if (! $node instanceof Assign) {
                 return false;
             }

--- a/src/NodeAnalyzer/VariableAnalyzer.php
+++ b/src/NodeAnalyzer/VariableAnalyzer.php
@@ -28,7 +28,7 @@ final class VariableAnalyzer
             return true;
         }
 
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($variable, function (Node $node) use (
+        return (bool) $this->betterNodeFinder->findFirstPrevious($variable, function (Node $node) use (
             $variable
         ): bool {
             if (! in_array($node::class, [Static_::class, Global_::class], true)) {
@@ -56,7 +56,7 @@ final class VariableAnalyzer
 
     public function isUsedByReference(Variable $variable): bool
     {
-        return (bool) $this->betterNodeFinder->findFirstPreviousOfNode($variable, function (Node $subNode) use (
+        return (bool) $this->betterNodeFinder->findFirstPrevious($variable, function (Node $subNode) use (
             $variable
         ): bool {
             if (! $subNode instanceof Variable) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -272,7 +272,12 @@ final class BetterNodeFinder
     /**
      * @param callable(Node $node): bool $filter
      */
-    public function findFirstPrevious(Node $node, callable $filter, bool $lookupParent = true, bool $stopOnFunctionLike = true): ?Node
+    public function findFirstPrevious(
+        Node $node,
+        callable $filter,
+        bool $lookupParent = true,
+        bool $stopOnFunctionLike = true
+    ): ?Node
     {
         // move to previous Node
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -277,8 +277,7 @@ final class BetterNodeFinder
         callable $filter,
         bool $lookupParent = true,
         bool $stopOnFunctionLike = true
-    ): ?Node
-    {
+    ): ?Node {
         // move to previous Node
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
         if ($previousStatement instanceof Node) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -272,18 +272,19 @@ final class BetterNodeFinder
     /**
      * @param callable(Node $node): bool $filter
      */
-    public function findFirstPreviousOfNode(Node $node, callable $filter, bool $lookupParent = true): ?Node
+    public function findFirstPrevious(Node $node, callable $filter, bool $lookupParent = true, bool $stopOnFunctionLike = true): ?Node
     {
-        // move to previous expression
+        // move to previous Node
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($previousStatement !== null) {
+        if ($previousStatement instanceof Node) {
             $foundNode = $this->findFirst([$previousStatement], $filter);
+
             // we found what we need
-            if ($foundNode !== null) {
+            if ($foundNode instanceof Node) {
                 return $foundNode;
             }
 
-            return $this->findFirstPreviousOfNode($previousStatement, $filter);
+            return $this->findFirstPrevious($previousStatement, $filter);
         }
 
         if (! $lookupParent) {
@@ -291,54 +292,12 @@ final class BetterNodeFinder
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if ($parent instanceof FunctionLike) {
+        if ($stopOnFunctionLike && $parent instanceof FunctionLike) {
             return null;
         }
 
         if ($parent instanceof Node) {
-            return $this->findFirstPreviousOfNode($parent, $filter);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param callable(Node $node): bool $filter
-     */
-    public function findFirstPrevious(Node $node, callable $filter): ?Node
-    {
-        $currentStmt = $this->resolveCurrentStatement($node);
-
-        // current Stmt not an Stmt may caused by Node already removed
-        if (! $currentStmt instanceof Stmt) {
-            return null;
-        }
-
-        $foundInCurrentStmt = $this->findFirst($currentStmt, $filter);
-
-        if ($foundInCurrentStmt instanceof Node) {
-            return $foundInCurrentStmt;
-        }
-
-        // previous Stmt of Stmt must be Stmt if found
-        $previousStatement = $currentStmt->getAttribute(AttributeKey::PREVIOUS_NODE);
-
-        if ($previousStatement instanceof Stmt) {
-            return $this->findFirstPrevious($previousStatement, $filter);
-        }
-
-        $parent = $currentStmt->getAttribute(AttributeKey::PARENT_NODE);
-
-        // Last Node? Node not found
-        if (! $parent instanceof Stmt) {
-            return null;
-        }
-
-        // previous Stmt of Stmt must be Stmt if found
-        $previousStatement = $parent->getAttribute(AttributeKey::PREVIOUS_NODE);
-
-        if ($previousStatement instanceof Stmt) {
-            return $this->findFirstPrevious($previousStatement, $filter);
+            return $this->findFirstPrevious($parent, $filter);
         }
 
         return null;


### PR DESCRIPTION
There are 2 methods for find first previous node:

- `findFirstPrevious()` lookup previous node, start with current statement, which on the first execution, it always hit current Node, which if we search same Node it will always found.
- `findFirstPreviousOfNode()` lookup previous node only, if not found, then find the parent's previous.

This PR merge `findFirstPreviousOfNode()` into `findFirstPrevious()` with enhancement:

- keep flag `$lookupParent` to allow to stop when previous Node is null when defined as false (default true)
- add flag `stopOnFunctionLike` to allow stop searching back when parent is hit `FunctionLike` when defined as true (default true)