### PR TITLE
[Core] Make BetterNodeFinder::findFirstPrevious() consistent with findFirstNext()

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -275,13 +275,12 @@ final class BetterNodeFinder
     public function findFirstPrevious(
         Node $node,
         callable $filter,
-        bool $lookupParent = true,
-        bool $stopOnFunctionLike = true
+        bool $lookupParent = true
     ): ?Node {
         // move to previous Node
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
         if ($previousStatement instanceof Node) {
-            $foundNode = $this->findFirst([$previousStatement], $filter);
+            $foundNode = $this->findFirst([$previousStatement], $filter, $lookupParent);
 
             // we found what we need
             if ($foundNode instanceof Node) {
@@ -296,12 +295,12 @@ final class BetterNodeFinder
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if ($stopOnFunctionLike && $parent instanceof FunctionLike) {
+        if ($parent instanceof FunctionLike) {
             return null;
         }
 
         if ($parent instanceof Node) {
-            return $this->findFirstPrevious($parent, $filter);
+            return $this->findFirstPrevious($parent, $filter, $lookupParent);
         }
 
         return null;

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -272,11 +272,7 @@ final class BetterNodeFinder
     /**
      * @param callable(Node $node): bool $filter
      */
-    public function findFirstPrevious(
-        Node $node,
-        callable $filter,
-        bool $lookupParent = true
-    ): ?Node {
+    public function findFirstPrevious(Node $node, callable $filter, bool $lookupParent = true): ?Node {
         // move to previous Node
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
         if ($previousStatement instanceof Node) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -272,7 +272,8 @@ final class BetterNodeFinder
     /**
      * @param callable(Node $node): bool $filter
      */
-    public function findFirstPrevious(Node $node, callable $filter, bool $lookupParent = true): ?Node {
+    public function findFirstPrevious(Node $node, callable $filter, bool $lookupParent = true): ?Node
+    {
         // move to previous Node
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
         if ($previousStatement instanceof Node) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -277,14 +277,14 @@ final class BetterNodeFinder
         // move to previous Node
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
         if ($previousStatement instanceof Node) {
-            $foundNode = $this->findFirst([$previousStatement], $filter, $lookupParent);
+            $foundNode = $this->findFirst([$previousStatement], $filter);
 
             // we found what we need
             if ($foundNode instanceof Node) {
                 return $foundNode;
             }
 
-            return $this->findFirstPrevious($previousStatement, $filter);
+            return $this->findFirstPrevious($previousStatement, $filter, $lookupParent);
         }
 
         if (! $lookupParent) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -275,16 +275,16 @@ final class BetterNodeFinder
     public function findFirstPrevious(Node $node, callable $filter, bool $lookupParent = true): ?Node
     {
         // move to previous Node
-        $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($previousStatement instanceof Node) {
-            $foundNode = $this->findFirst([$previousStatement], $filter);
+        $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
+        if ($previousNode instanceof Node) {
+            $foundNode = $this->findFirst($previousNode, $filter);
 
             // we found what we need
             if ($foundNode instanceof Node) {
                 return $foundNode;
             }
 
-            return $this->findFirstPrevious($previousStatement, $filter, $lookupParent);
+            return $this->findFirstPrevious($previousNode, $filter, $lookupParent);
         }
 
         if (! $lookupParent) {


### PR DESCRIPTION
Make BetterNodeFinder::findFirstPrevious() consistent with findFirstNext() to stop when parent is `FunctionLike`, while keep the `lookupParent` flag to allow search only previuos node without parent lookup as used as that used on out of scope check, ref:

https://github.com/rectorphp/rector-src/pull/2213/files#diff-ea07b1de509e261e6de1548878c862f091e6e41d08c88c2b3b5547b6d72f7c18L152

The `stopOnFunctionLike` flag is not used in code yet in method calls, we can enable it only when used in the future. 

This PR will stop on parent is FunctionLike by default and ensure `lookupParent` flag bring in recursive call.