### PR TITLE
[Scoped] Remove Php71 comment reference on config-downgrade

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -53,9 +53,7 @@ final class DowngradeRectorConfig
         'vendor/cweagans/*',
         'nette/caching/src/Bridges/*',
 
-        // This class has an issue for PHP 7.1:
-        // https://github.com/rectorphp/rector/issues/4816#issuecomment-743209526
-        // It doesn't happen often, and Rector doesn't use it, so then
+        // Rector doesn't use it, so then
         // we simply skip downgrading this class
         'vendor/symfony/dependency-injection/ExpressionLanguage.php',
         'vendor/symfony/dependency-injection/ExpressionLanguageProvider.php',


### PR DESCRIPTION
Current scoped rector is downgraded to php 7.2 instead of 7.1 so comment for php 7.1 can be removed, updated to only information that the class is not downgaded as not used.