### PR TITLE
Add failing test fixture for UnSpreadOperatorRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/extends.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/extends.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\UnSpreadOperatorRector\Fixture;
+
+class A
+{
+    /** @noRector UnSpreadOperatorRector */
+    public static function make(... $arguments): static
+    {
+        return new static();
+    }
+}
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\UnSpreadOperatorRector\Fixture;
+
+final class B extends A
+{
+    public static function make(... $arguments): static
+    {
+        return new static();
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for UnSpreadOperatorRector

Based on https://getrector.org/demo/f83cf736-ff98-4bc4-86a8-4611c8dd8804

(where A - a class from dependency that you can't change)