### PR TITLE
[Test] Remove PHPStanStubLoader::loadStubs() and require constants in tests bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../src/constants.php';
-
 // make local php-parser a priority to avoid conflict
 require_once __DIR__ . '/../preload.php';
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Stubs\PHPStanStubLoader;
-
 require_once __DIR__ . '/../src/constants.php';
 
 // make local php-parser a priority to avoid conflict
@@ -15,6 +13,3 @@ error_reporting(E_ALL ^ E_DEPRECATED);
 
 // performance boost
 gc_disable();
-
-$phpStanStubLoader = new PHPStanStubLoader();
-$phpStanStubLoader->loadStubs();


### PR DESCRIPTION
since we are running test in php 8.1