### PR TITLE
[Core] Improve PropertyFetchAnalyzer::PropertyFetchAnalyzer() to check against Variable and Name

### DIFF
--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -38,7 +39,7 @@ final class PropertyFetchAnalyzer
     public function isLocalPropertyFetch(Node $node): bool
     {
         if ($node instanceof PropertyFetch) {
-            if ($node->var instanceof MethodCall) {
+            if (! $node->var instanceof Variable) {
                 return false;
             }
 
@@ -46,6 +47,10 @@ final class PropertyFetchAnalyzer
         }
 
         if ($node instanceof StaticPropertyFetch) {
+            if (! $node->class instanceof Name) {
+                return false;
+            }
+
             return $this->nodeNameResolver->isName($node->class, ObjectReference::SELF()->getValue());
         }
 


### PR DESCRIPTION
- check against `Variable` node for `this` value on PropertyFetch
- check against `Name` node for `self` value on StaticPropertyFetch
