### PR TITLE
[Core] Add BetterNodeFinder::findFirstInlinedPrevious()

### DIFF
--- a/rules/Php80/Rector/Switch_/ChangeSwitchToMatchRector.php
+++ b/rules/Php80/Rector/Switch_/ChangeSwitchToMatchRector.php
@@ -143,13 +143,12 @@ CODE_SAMPLE
 
     private function changeToAssign(Switch_ $switch, Match_ $match, Expr $assignExpr): Assign
     {
-        $prevInitializedAssign = $this->betterNodeFinder->findFirstPrevious(
+        $prevInitializedAssign = $this->betterNodeFinder->findFirstInlinedPrevious(
             $switch,
             fn (Node $node): bool => $node instanceof Assign && $this->nodeComparator->areNodesEqual(
                 $node->var,
                 $assignExpr
-            ),
-            false
+            )
         );
 
         $assign = new Assign($assignExpr, $match);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -269,6 +269,9 @@ final class BetterNodeFinder
         });
     }
 
+    /**
+     * @param callable(Node $node): bool $filter
+     */
     public function findFirstInlinedPrevious(Node $node, callable $filter): ?Node
     {
         $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -270,7 +270,7 @@ final class BetterNodeFinder
     }
 
     /**
-     * Only search in prevous Node/Stmt
+     * Only search in previous Node/Stmt
      *
      * @param callable(Node $node): bool $filter
      */
@@ -292,7 +292,7 @@ final class BetterNodeFinder
     }
 
     /**
-     * Search in prevous Node/Stmt, when no Node found, lookup previous Stmt of Parent Node
+     * Search in previous Node/Stmt, when no Node found, lookup previous Stmt of Parent Node
      *
      * @param callable(Node $node): bool $filter
      */

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -269,26 +269,33 @@ final class BetterNodeFinder
         });
     }
 
+    public function findFirstInlinedPrevious(Node $node, callable $filter): ?Node
+    {
+        $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
+        if (! $previousNode instanceof Node) {
+            return null;
+        }
+
+        $foundNode = $this->findFirst($previousNode, $filter);
+
+        // we found what we need
+        if ($foundNode instanceof Node) {
+            return $foundNode;
+        }
+
+        return $this->findFirstInlinedPrevious($previousNode, $filter);
+    }
+
     /**
      * @param callable(Node $node): bool $filter
      */
-    public function findFirstPrevious(Node $node, callable $filter, bool $lookupParent = true): ?Node
+    public function findFirstPrevious(Node $node, callable $filter): ?Node
     {
-        // move to previous Node
-        $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($previousNode instanceof Node) {
-            $foundNode = $this->findFirst($previousNode, $filter);
+        $foundNode = $this->findFirstInlinedPrevious($node, $filter);
 
-            // we found what we need
-            if ($foundNode instanceof Node) {
-                return $foundNode;
-            }
-
-            return $this->findFirstPrevious($previousNode, $filter, $lookupParent);
-        }
-
-        if (! $lookupParent) {
-            return null;
+        // we found what we need
+        if ($foundNode instanceof Node) {
+            return $foundNode;
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
@@ -297,7 +304,7 @@ final class BetterNodeFinder
         }
 
         if ($parent instanceof Node) {
-            return $this->findFirstPrevious($parent, $filter, $lookupParent);
+            return $this->findFirstPrevious($parent, $filter);
         }
 
         return null;

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -270,6 +270,8 @@ final class BetterNodeFinder
     }
 
     /**
+     * Only search in prevous Node/Stmt
+     *
      * @param callable(Node $node): bool $filter
      */
     public function findFirstInlinedPrevious(Node $node, callable $filter): ?Node
@@ -290,6 +292,8 @@ final class BetterNodeFinder
     }
 
     /**
+     * Search in prevous Node/Stmt, when no Node found, lookup previous Stmt of Parent Node
+     *
      * @param callable(Node $node): bool $filter
      */
     public function findFirstPrevious(Node $node, callable $filter): ?Node


### PR DESCRIPTION
Previously, we use `lookupParent` flag to check if we are going to search up to previous of parent node. 

This PR add new method: `findFirstInlinedPrevious()` that specifically only search in previous node, and stop when not found in last previous node/no previous node and remove `lookupParent` flag.

The usage is on `ChangeSwitchToMatchRector::changeToAssign()` https://github.com/rectorphp/rector-src/pull/2238/files#diff-ea07b1de509e261e6de1548878c862f091e6e41d08c88c2b3b5547b6d72f7c18

The origin `BetterNodeFinder::findFirstPrevious()` will lookup parent when not found in last previous node/no previous node.