### PR TITLE
[Scoper] Remove PHPStanStubLoader->loadStubs() call on config-downgrade

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -3,11 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Stubs\PHPStanStubLoader;
 use Rector\Set\ValueObject\DowngradeLevelSetList;
-
-$phpStanStubLoader = new PHPStanStubLoader();
-$phpStanStubLoader->loadStubs();
 
 require_once  __DIR__ . '/../target-repository/stubs-rector/PHPUnit/Framework/TestCase.php';
 require_once  __DIR__ . '/../../stubs/Composer/EventDispatcher/EventSubscriberInterface.php';

--- a/full_build.sh
+++ b/full_build.sh
@@ -74,3 +74,5 @@ cd ..
 
 rm -rf rector-prefixed-downgraded
 rm -rf rector-build
+
+git checkout src/functions


### PR DESCRIPTION
It already called on RectorContainerFactory->createFromConfigs()