### PR TITLE
Add failing test for grouped imports in UseImportsResolver

### DIFF
--- a/rules-tests/Naming/Naming/UseImportsResolver/Fixture/group_use.php.inc
+++ b/rules-tests/Naming/Naming/UseImportsResolver/Fixture/group_use.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Naming\Naming\UseImportsResolver\Fixture;
+
+use Rector\Tests\Naming\Naming\UseImportsResolver\Source\OtherClass;
+use Rector\Tests\Naming\Naming\UseImportsResolver\Source\{FirstClass, SecondClass};
+
+class MyGroupUse1
+{
+    private FirstClass $firstClass;
+    private SecondClass $secondClass;
+    private OtherClass $otherClass;
+}

--- a/rules-tests/Naming/Naming/UseImportsResolver/Fixture/group_use_aliased.php.inc
+++ b/rules-tests/Naming/Naming/UseImportsResolver/Fixture/group_use_aliased.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Naming\Naming\UseImportsResolver\Fixture;
+
+# Valid import for reference
+use Rector\Tests\Naming\Naming\UseImportsResolver\Source\OtherClass;
+use Rector\Tests\Naming\Naming\UseImportsResolver\Source\{FirstClass as ClassA, SecondClass as ClassB};
+
+class MyGroupUse2
+{
+    private ClassA $firstClass;
+    private ClassB $secondClass;
+    private OtherClass $otherClass;
+}

--- a/rules-tests/Naming/Naming/UseImportsResolver/Source/FirstClass.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/Source/FirstClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Naming\Naming\UseImportsResolver\Source;
+
+class FirstClass
+{
+
+}

--- a/rules-tests/Naming/Naming/UseImportsResolver/Source/OtherClass.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/Source/OtherClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Naming\Naming\UseImportsResolver\Source;
+
+class OtherClass
+{
+
+}

--- a/rules-tests/Naming/Naming/UseImportsResolver/Source/SecondClass.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/Source/SecondClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Naming\Naming\UseImportsResolver\Source;
+
+class SecondClass
+{
+
+}

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Naming\Naming\UseImportsResolver;
+
+use Iterator;
+use PhpParser\Node\Stmt\Property;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Naming\Naming\UseImportsResolver;
+use Rector\Testing\PHPUnit\AbstractTestCase;
+use Rector\Testing\TestingParser\TestingParser;
+use Rector\Tests\Naming\Naming\UseImportsResolver\Source\FirstClass;
+use Rector\Tests\Naming\Naming\UseImportsResolver\Source\SecondClass;
+use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+class UseImportsResolverTest extends AbstractTestCase
+{
+    private UseImportsResolver $useImportsResolver;
+
+    private TestingParser $testingParser;
+
+    private BetterNodeFinder $nodeFinder;
+
+    protected function setUp(): void
+    {
+        $this->boot();
+        $this->useImportsResolver = $this->getService(UseImportsResolver::class);
+        $this->testingParser = $this->getService(TestingParser::class);
+        $this->nodeFinder = $this->getService(BetterNodeFinder::class);
+    }
+
+    /**
+     * @dataProvider provideData()
+     */
+    public function testUsesFromProperty(SmartFileInfo $file): void
+    {
+        $nodes = $this->testingParser->parseFileToDecoratedNodes($file->getRelativeFilePath());
+
+        $firstProperty = $this->nodeFinder->findFirstInstanceOf($nodes, Property::class);
+        $resolvedUses = $this->useImportsResolver->resolveForNode($firstProperty);
+
+        $stringUses = array_map(fn ($use) => $use->uses[0]->name->toString(), $resolvedUses);
+
+        $this->assertContains(FirstClass::class, $stringUses);
+        $this->assertContains(SecondClass::class, $stringUses);
+    }
+
+    public function provideData(): Iterator
+    {
+        $directory = __DIR__ . '/Fixture';
+        return StaticFixtureFinder::yieldDirectoryExclusively($directory);
+    }
+}


### PR DESCRIPTION
This adds a failing test for [7150](https://github.com/rectorphp/rector/issues/7150).

I am not 100% sure if this test would work when the functionality got implemented. But at least it is a start.