### PR TITLE
[Scoped] Rollback Symplify\SmartFileSystem\SmartFileInfo require at bootstrap.php

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -23,4 +23,12 @@ spl_autoload_register(function (string $class): void {
             $composerAutoloader->loadClass($class);
         }
     }
+
+    // aliased by php-scoper, that's why its missing
+    if ($class === 'Symplify\SmartFileSystem\SmartFileInfo') {
+        $filePath = __DIR__ . '/vendor/symplify/smart-file-system/src/SmartFileInfo.php';
+        if (file_exists($filePath)) {
+            require $filePath;
+        }
+    }
 });


### PR DESCRIPTION
ref https://github.com/rectorphp/rector-src/pull/2253#issuecomment-1120210378 that cause error when used in `laminas-servicemanager-migration`

```
➜  laminas-servicemanager-migration git:(0.6.x) ✗ vendor/bin/phpunit 
PHPUnit 9.5.20 #StandWithUkraine

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

EEEEE                                                               5 / 5 (100%)

Time: 00:00.005, Memory: 8.00 MB

There were 5 errors:

1) Error
The data provider specified for LaminasTest\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector\AutoImportRenameUseTest::test is invalid.
Error: Class "Symplify\SmartFileSystem\SmartFileInfo" not found
/Users/samsonasik/www/laminas-servicemanager-migration/vendor/rector/rector/vendor/symplify/easy-testing/src/DataProvider/StaticFixtureFinder.php:59
```