### PR TITLE
[Scoper] Replace manual register Symplify\SmartFileSystem\SmartFileInfo with require scoper-autoload

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -15,7 +15,7 @@ spl_autoload_register(function (string $class): void {
     if (strpos($class, 'RectorPrefix') === 0 || strpos($class, 'Rector\\') === 0) {
         if ($composerAutoloader === null) {
             // prefixed version autoload
-            $composerAutoloader = require __DIR__ . '/vendor/autoload.php';
+            $composerAutoloader = require_once __DIR__ . '/vendor/autoload.php';
         }
 
         // some weird collision with PHPStan custom rule tests

--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -22,13 +22,7 @@ spl_autoload_register(function (string $class): void {
         if (! is_int($composerAutoloader)) {
             $composerAutoloader->loadClass($class);
         }
-    }
 
-    // aliased by php-scoper, that's why its missing
-    if ($class === 'Symplify\SmartFileSystem\SmartFileInfo') {
-        $filePath = __DIR__ . '/vendor/symplify/smart-file-system/src/SmartFileInfo.php';
-        if (file_exists($filePath)) {
-            require $filePath;
-        }
+        require_once __DIR__ . '/vendor/scoper-autoload.php';
     }
 });


### PR DESCRIPTION
@TomasVotruba @ondrejmirtes continue of https://github.com/rectorphp/rector-src/pull/2256, replace manual register `Symplify\SmartFileSystem\SmartFileInfo` to bootstrap.php with : 

```
require_once __DIR__ . '/vendor/scoper-autoload.php';
```

I tried locally with `laminas/laminas-servicemanager-migration` on running tests and it seems working ok.