### PR TITLE
[CodeQuality] Skip empty array push args and no 2nd arg on ChangeArrayPushToArrayAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector/Fixture/skip_empty_args.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector/Fixture/skip_empty_args.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector\Fixture;
+
+class SkipEmptyArgs
+{
+    public function run()
+    {
+        array_push();
+
+        echo 'test';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector/Fixture/skip_no_second_arg.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector/Fixture/skip_no_second_arg.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector\Fixture;
+
+class SkipNoSecondArg
+{
+    public function run(array $items)
+    {
+        array_push($items);
+    }
+}

--- a/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
@@ -70,8 +70,16 @@ CODE_SAMPLE
 
         $args = $funcCall->getArgs();
 
+        if ($args === []) {
+            return null;
+        }
+
         /** @var Arg $firstArg */
         $firstArg = array_shift($args);
+
+        if ($args === []) {
+            return null;
+        }
 
         $arrayDimFetch = new ArrayDimFetch($firstArg->value);
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/2265#discussion_r867471329 Empty array push args and no 2nd arg currently cause error:

```
There were 2 errors:

1) Rector\Tests\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector\ChangeArrayPushToArrayAssignRectorTest::test with data set #4 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Array of nodes cannot be empty. Ensure "Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector->refactor()" returns non-empty array for Nodes.

A) Return null for no change:

    return null;

B) Remove the Node:

    $this->removeNode($node);
    return $node;

/Users/samsonasik/www/rector-src/src/Rector/AbstractRector.php:214
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:200
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:91
/Users/samsonasik/www/rector-src/src/PhpParser/NodeTraverser/RectorNodeTraverser.php:33
/Users/samsonasik/www/rector-src/src/Application/FileProcessor.php:42
/Users/samsonasik/www/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:103
/Users/samsonasik/www/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:62
/Users/samsonasik/www/rector-src/src/Application/ApplicationFileProcessor.php:132
/Users/samsonasik/www/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:177
/Users/samsonasik/www/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:131
/Users/samsonasik/www/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:115
/Users/samsonasik/www/rector-src/rules-tests/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector/ChangeArrayPushToArrayAssignRectorTest.php:18

2) Rector\Tests\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector\ChangeArrayPushToArrayAssignRectorTest::test with data set #2 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Attempt to read property "value" on null

/Users/samsonasik/www/rector-src/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php:76
/Users/samsonasik/www/rector-src/src/Rector/AbstractRector.php:205
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:200
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:91
/Users/samsonasik/www/rector-src/src/PhpParser/NodeTraverser/RectorNodeTraverser.php:33
/Users/samsonasik/www/rector-src/src/Application/FileProcessor.php:42
/Users/samsonasik/www/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:103
/Users/samsonasik/www/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:62
/Users/samsonasik/www/rector-src/src/Application/ApplicationFileProcessor.php:132
/Users/samsonasik/www/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:177
/Users/samsonasik/www/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:131
/Users/samsonasik/www/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:115
/Users/samsonasik/www/rector-src/rules-tests/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector/ChangeArrayPushToArrayAssignRectorTest.php:18
```

it should be skipped.