### PR TITLE
[Core] Remove is_string() check on glob loop data

### DIFF
--- a/src/FileSystem/FilesystemTweaker.php
+++ b/src/FileSystem/FilesystemTweaker.php
@@ -74,18 +74,9 @@ final class FilesystemTweaker
      */
     private function foundInGlob(string $path): array
     {
-        $foundPaths = [];
         /** @var string[] $paths */
         $paths = (array) glob($path);
 
-        foreach ($paths as $path) {
-            if (! file_exists($path)) {
-                continue;
-            }
-
-            $foundPaths[] = $path;
-        }
-
-        return $foundPaths;
+        return array_filter($paths, fn (string $path): bool => file_exists($path));
     }
 }

--- a/src/FileSystem/FilesystemTweaker.php
+++ b/src/FileSystem/FilesystemTweaker.php
@@ -67,10 +67,6 @@ final class FilesystemTweaker
         $foundDirectories = [];
 
         foreach ((array) glob($directory, GLOB_ONLYDIR) as $foundDirectory) {
-            if (! is_string($foundDirectory)) {
-                continue;
-            }
-
             $foundDirectories[] = $foundDirectory;
         }
 
@@ -85,10 +81,6 @@ final class FilesystemTweaker
         $foundPaths = [];
 
         foreach ((array) glob($path) as $foundPath) {
-            if (! is_string($foundPath)) {
-                continue;
-            }
-
             if (! file_exists($foundPath)) {
                 continue;
             }

--- a/src/FileSystem/FilesystemTweaker.php
+++ b/src/FileSystem/FilesystemTweaker.php
@@ -42,7 +42,7 @@ final class FilesystemTweaker
      *
      * @param string[] $paths
      *
-     * @return string[]
+     * @return string[]|bool[]
      */
     public function resolveWithFnmatch(array $paths): array
     {
@@ -64,12 +64,8 @@ final class FilesystemTweaker
      */
     private function findDirectoriesInGlob(string $directory): array
     {
-        $foundDirectories = [];
-
-        foreach ((array) glob($directory, GLOB_ONLYDIR) as $foundDirectory) {
-            $foundDirectories[] = $foundDirectory;
-        }
-
+        /** @var string[] $foundDirectories */
+        $foundDirectories = (array) glob($directory, GLOB_ONLYDIR);
         return $foundDirectories;
     }
 
@@ -79,13 +75,15 @@ final class FilesystemTweaker
     private function foundInGlob(string $path): array
     {
         $foundPaths = [];
+        /** @var string[] $paths */
+        $paths = (array) glob($path);
 
-        foreach ((array) glob($path) as $foundPath) {
-            if (! file_exists($foundPath)) {
+        foreach ($paths as $path) {
+            if (! file_exists($path)) {
                 continue;
             }
 
-            $foundPaths[] = $foundPath;
+            $foundPaths[] = $path;
         }
 
         return $foundPaths;

--- a/src/FileSystem/FilesystemTweaker.php
+++ b/src/FileSystem/FilesystemTweaker.php
@@ -42,7 +42,7 @@ final class FilesystemTweaker
      *
      * @param string[] $paths
      *
-     * @return string[]|bool[]
+     * @return string[]
      */
     public function resolveWithFnmatch(array $paths): array
     {


### PR DESCRIPTION
`glob()` is return `false` or `array` of string. If it already casted to array, there is no need to check against `is_string()` inside the loop, ref https://3v4l.org/HXlaX