### PR TITLE
[CodingStyle] Ensure node changed when return $node on SymplifyQuoteEscapeRector

### DIFF
--- a/rules/CodingStyle/Rector/String_/SymplifyQuoteEscapeRector.php
+++ b/rules/CodingStyle/Rector/String_/SymplifyQuoteEscapeRector.php
@@ -68,11 +68,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?String_
     {
-        $hasChangedSingleQuoted = null;
-        $hasChangedDoubleQuoted = null;
         $doubleQuoteCount = substr_count($node->value, '"');
         $singleQuoteCount = substr_count($node->value, "'");
         $kind = $node->getAttribute(AttributeKey::KIND);
+        $hasChangedSingleQuoted = false;
+        $hasChangedDoubleQuoted = false;
 
         if ($kind === String_::KIND_SINGLE_QUOTED) {
             $hasChangedSingleQuoted = $this->processSingleQuoted($node, $doubleQuoteCount, $singleQuoteCount);


### PR DESCRIPTION
**Before** `SymplifyQuoteEscapeRector` show in "applied rules" even the rule is not applied

```diff
bin/rector process src/Console
 9/9 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) src/Console/ConsoleApplication.php:19

 final class ConsoleApplication extends Application
 {
-    private $b;
     /**
      * @var string
      */
    ----------- end diff -----------

Applied rules:
 * SymplifyQuoteEscapeRector
 * RemoveUnusedPrivatePropertyRector
```

**After** only display other rule that applied 

```diff
bin/rector process src/Console                                                   
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) src/Console/ConsoleApplication.php:19

    ---------- begin diff ----------
@@ @@

 final class ConsoleApplication extends Application
 {
-    private $b;
-
     /**
      * @var string
      */
    ----------- end diff -----------

Applied rules:
 * RemoveUnusedPrivatePropertyRector
```