### PR TITLE
[Core] Remove $className parameter on AstResolver::resolveClassFromClassReflection()

### DIFF
--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -88,13 +88,11 @@ final class FamilyRelationsAnalyzer
         $kindPropertyFetch = $this->getKindPropertyFetch($property);
 
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
-            $ancestorClassName = $ancestorClassReflection->getName();
-
             if ($ancestorClassReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;
             }
 
-            $class = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection, $ancestorClassName);
+            $class = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection);
             if (! $class instanceof Class_) {
                 continue;
             }

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -33,8 +33,7 @@ final class ClassConstManipulator
         $className = (string) $this->nodeNameResolver->getName($class);
         foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
             $ancestorClass = $this->astResolver->resolveClassFromClassReflection(
-                $ancestorClassReflection,
-                $ancestorClassReflection->getName()
+                $ancestorClassReflection
             );
 
             if (! $ancestorClass instanceof ClassLike) {

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -32,9 +32,7 @@ final class ClassConstManipulator
 
         $className = (string) $this->nodeNameResolver->getName($class);
         foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
-            $ancestorClass = $this->astResolver->resolveClassFromClassReflection(
-                $ancestorClassReflection
-            );
+            $ancestorClass = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection);
 
             if (! $ancestorClass instanceof ClassLike) {
                 continue;

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -76,7 +76,7 @@ final class AstResolver
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        return $this->resolveClassFromClassReflection($classReflection, $className);
+        return $this->resolveClassFromClassReflection($classReflection);
     }
 
     public function resolveClassFromObjectType(
@@ -209,10 +209,9 @@ final class AstResolver
     }
 
     public function resolveClassFromClassReflection(
-        ClassReflection $classReflection,
-        string $className
+        ClassReflection $classReflection
     ): Trait_ | Class_ | Interface_ | Enum_ | null {
-        return $this->classLikeAstResolver->resolveClassFromClassReflection($classReflection, $className);
+        return $this->classLikeAstResolver->resolveClassFromClassReflection($classReflection);
     }
 
     /**

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\ValueObject\Application\File;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Symplify\Astral\PhpParser\SmartPhpParser;
 
 final class ClassLikeAstResolver
@@ -27,12 +28,12 @@ final class ClassLikeAstResolver
     public function __construct(
         private readonly SmartPhpParser $smartPhpParser,
         private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 
     public function resolveClassFromClassReflection(
-        ClassReflection $classReflection,
-        string $className
+        ClassReflection $classReflection
     ): Trait_ | Class_ | Interface_ | Enum_ | null {
         if ($classReflection->isBuiltin()) {
             return null;
@@ -63,7 +64,7 @@ final class ClassLikeAstResolver
 
         $reflectionClassName = $classReflection->getName();
         foreach ($classLikes as $classLike) {
-            if ($reflectionClassName !== $className) {
+            if (! $this->nodeNameResolver->isName($classLike, $reflectionClassName)) {
                 continue;
             }
 

--- a/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
@@ -47,8 +47,8 @@ final class ParentAttributeSourceLocator implements SourceLocator
             $identifierName
         )) {
             $classReflection = $this->reflectionProvider->getClass($identifierName);
-            $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
 
+            $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
             if ($class === null) {
                 return null;
             }

--- a/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
@@ -47,8 +47,8 @@ final class ParentAttributeSourceLocator implements SourceLocator
             $identifierName
         )) {
             $classReflection = $this->reflectionProvider->getClass($identifierName);
+            $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
 
-            $class = $this->astResolver->resolveClassFromClassReflection($classReflection, $identifierName);
             if ($class === null) {
                 return null;
             }


### PR DESCRIPTION
The 2nd `$className` parameter used always is value of 1st parameter classname, so it can be removed, no need to include it.