### PR TITLE
[CodeQuality][DeadCode] Handle SimplifyUselessVariableRector+RemoveOverriddenValuesRector

### DIFF
--- a/rules/DeadCode/Rector/FunctionLike/RemoveOverriddenValuesRector.php
+++ b/rules/DeadCode/Rector/FunctionLike/RemoveOverriddenValuesRector.php
@@ -6,10 +6,8 @@ namespace Rector\DeadCode\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\NodeCollector\NodeByTypeAndPositionCollector;

--- a/rules/DeadCode/Rector/FunctionLike/RemoveOverriddenValuesRector.php
+++ b/rules/DeadCode/Rector/FunctionLike/RemoveOverriddenValuesRector.php
@@ -6,8 +6,10 @@ namespace Rector\DeadCode\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\NodeCollector\NodeByTypeAndPositionCollector;
@@ -107,7 +109,7 @@ CODE_SAMPLE
      */
     private function resolveAssignedVariables(FunctionLike $functionLike): array
     {
-        return $this->betterNodeFinder->find($functionLike, function (Node $node): bool {
+        return $this->betterNodeFinder->find($functionLike, function (Node $node) use ($functionLike): bool {
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
             if (! $parentNode instanceof Assign) {
                 return false;
@@ -135,6 +137,11 @@ CODE_SAMPLE
 
             // simple variable only
             if (! is_string($node->name)) {
+                return false;
+            }
+
+            $parentFunctionLike = $this->betterNodeFinder->findParentType($node, FunctionLike::class);
+            if ($parentFunctionLike !== $functionLike) {
                 return false;
             }
 

--- a/tests/Issues/UselessVariableOverride/Fixture/fixture.php.inc
+++ b/tests/Issues/UselessVariableOverride/Fixture/fixture.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\UselessVariableOverride\Fixture;
+
+class Fixture
+{
+    public function formatPlaces($geotools, $places): array
+    {
+        $features = \array_map(function (array $placeResource) use (
+            $geotools
+        ) {
+            $distances = \array_map(static function (CoordinateInterface $coordinate) use ($geotools) {
+                return $geotools->distance()->flat();
+            }, []);
+
+            return new Feature($distances);
+        }, $places);
+
+        return $features;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\UselessVariableOverride\Fixture;
+
+class Fixture
+{
+    public function formatPlaces($geotools, $places): array
+    {
+        return \array_map(function (array $placeResource) use (
+            $geotools
+        ) {
+            $distances = \array_map(static function (CoordinateInterface $coordinate) use ($geotools) {
+                return $geotools->distance()->flat();
+            }, []);
+
+            return new Feature($distances);
+        }, $places);
+    }
+}
+
+?>

--- a/tests/Issues/UselessVariableOverride/UselessVariableOverrideTest.php
+++ b/tests/Issues/UselessVariableOverride/UselessVariableOverrideTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\UselessVariableOverride;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class UselessVariableOverrideTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/UselessVariableOverride/config/configured_rule.php
+++ b/tests/Issues/UselessVariableOverride/config/configured_rule.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\Config\RectorConfig;
 
+use Rector\DeadCode\Rector\FunctionLike\RemoveOverriddenValuesRector;
+
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(\Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector::class);
-    $rectorConfig->rule(\Rector\DeadCode\Rector\FunctionLike\RemoveOverriddenValuesRector::class);
+    $rectorConfig->rule(SimplifyUselessVariableRector::class);
+    $rectorConfig->rule(RemoveOverriddenValuesRector::class);
 };

--- a/tests/Issues/UselessVariableOverride/config/configured_rule.php
+++ b/tests/Issues/UselessVariableOverride/config/configured_rule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\Config\RectorConfig;
-
 use Rector\DeadCode\Rector\FunctionLike\RemoveOverriddenValuesRector;
 
 return static function (RectorConfig $rectorConfig): void {

--- a/tests/Issues/UselessVariableOverride/config/configured_rule.php
+++ b/tests/Issues/UselessVariableOverride/config/configured_rule.php
@@ -1,0 +1,8 @@
+<?php
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(\Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector::class);
+    $rectorConfig->rule(\Rector\DeadCode\Rector\FunctionLike\RemoveOverriddenValuesRector::class);
+};

--- a/tests/Issues/UselessVariableOverride/config/configured_rule.php
+++ b/tests/Issues/UselessVariableOverride/config/configured_rule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {


### PR DESCRIPTION
Given the following code:

```php
class Fixture
{
    public function formatPlaces($geotools, $places): array
    {
        $features = \array_map(function (array $placeResource) use (
            $geotools
        ) {
            $distances = \array_map(static function (CoordinateInterface $coordinate) use ($geotools) {
                return $geotools->distance()->flat();
            }, []);

            return new Feature($distances);
        }, $places);

        return $features;
    }
}
```

It produce:

```diff
-            $distances = \array_map(static function (CoordinateInterface $coordinate) use ($geotools) {
-                return $geotools->distance()->flat();
-            }, []);
-
             return new Feature($distances);
```

which variable `$distances` inside `array_map()` is removed, while used in next statement. This PR try to fix it.

Fixes https://github.com/rectorphp/rector/issues/7156