### PR TITLE
[CodeQuality] Handle empty stmts on RemoveAlwaysTrueConditionSetInConstructorRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector/Fixture/empty_stmts.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector/Fixture/empty_stmts.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\RemoveAlwaysTrueConditionSetInConstructorRector\Fixture;
+
+use stdClass;
+
+final class EmptyStmts
+{
+    private $value;
+
+    public function __construct(stdClass $value)
+    {
+        $this->value = $value;
+    }
+
+    public function go()
+    {
+        if ($this->value) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\RemoveAlwaysTrueConditionSetInConstructorRector\Fixture;
+
+use stdClass;
+
+final class EmptyStmts
+{
+    private $value;
+
+    public function __construct(stdClass $value)
+    {
+        $this->value = $value;
+    }
+
+    public function go()
+    {
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector.php
+++ b/rules/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector.php
@@ -92,17 +92,18 @@ CODE_SAMPLE
 
     /**
      * @param If_ $node
-     * @return Stmt[]|null
+     * @return null|If_|Stmt[]
      */
-    public function refactor(Node $node): ?array
+    public function refactor(Node $node): null|If_|array
     {
         $ifStmt = $this->matchTruableIf($node);
         if (! $ifStmt instanceof If_) {
             return null;
         }
 
-        if ($ifStmt->stmts === null) {
-            return null;
+        if ($ifStmt->stmts === []) {
+            $this->removeNode($ifStmt);
+            return $ifStmt;
         }
 
         return $ifStmt->stmts;


### PR DESCRIPTION
PR https://github.com/rectorphp/rector-src/pull/2280 cause on empty if stmts, it currently produce : 

```
There was 1 error:

1) Rector\Tests\CodeQuality\Rector\FunctionLike\RemoveAlwaysTrueConditionSetInConstructorRector\RemoveAlwaysTrueConditionSetInConstructorRectorTest::test with data set #7 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Array of nodes cannot be empty. Ensure "Rector\CodeQuality\Rector\FunctionLike\RemoveAlwaysTrueConditionSetInConstructorRector->refactor()" returns non-empty array for Nodes.

A) Return null for no change:

    return null;

B) Remove the Node:

    $this->removeNode($node);
    return $node;
```

This PR fix it.