### PR TITLE
[Core] Add ReflectionResolver::resolveClassReflectionSourceObject() method

### DIFF
--- a/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
@@ -129,7 +129,7 @@ CODE_SAMPLE
         MethodCallRenameInterface $methodCallRename
     ): bool {
         if (! $node instanceof ClassMethod) {
-            $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+            $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
 
             if (! $classReflection instanceof ClassReflection) {
                 return false;


### PR DESCRIPTION
Added `ReflectionResolver::resolveClassReflectionSourceObject()` method that lookup the object caller of the `StaticCall, New_, or MethodCall`.

The original `resolveClassReflection()` will remain lookup of its consumer, so:

```php
function isInsideController(StaticCall $staticCall)
{
    $classReflection = $this->reflectionResolver->resolveClassReflection($staticCall);
    if (! $classReflection instanceof ClassReflection) {
        return false;
    }

    return $classReflection->getName() === 'Controller';
}
```

which work on the following class:

```php
class Controller
{
    public function foo()
    {
          Foo::bar();
    }
}
```

which got `Controller` object instead of `Foo`.

To get `Foo` ClassReflection, use `resolveClassReflectionSourceObject()` instead.