### PR TITLE
[Core] Allow any Node passed to ReflectionResolver::resolveClassReflection()

### DIFF
--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -14,11 +14,8 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
-use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
@@ -70,9 +67,8 @@ final class ReflectionResolver
         return $this->reflectionProvider->getClass($className);
     }
 
-    public function resolveClassReflection(
-        ClassMethod|Property|ClassLike|New_|Function_|ClassConst|MethodCall|StaticCall|null $node
-    ): ?ClassReflection {
+    public function resolveClassReflection(?Node $node): ?ClassReflection
+    {
         if (! $node instanceof Node) {
             return null;
         }


### PR DESCRIPTION
To allow more usage like in rector-symfony:

https://github.com/rectorphp/rector-symfony/blob/642ada356ce00cc85cda1fcb30ef28081c2209e6/src/TypeAnalyzer/ControllerAnalyzer.php#L48-L60

```php
    public function isInsideController(Node $node): bool
    {
        $scope = $node->getAttribute(AttributeKey::SCOPE);

        // might be missing in a trait
        if (! $scope instanceof Scope) {
            return false;
        }

        $classReflection = $scope->getClassReflection();
        if (! $classReflection instanceof ClassReflection) {
            return false;
        }

        return $this->isControllerClassReflection($classReflection);
    }
```


to be cleaned up to:

```php

    public function isInsideController(Node $node): bool
    {
        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
        if (! $classReflection instanceof ClassReflection) {
            return false;
        }

        return $this->isControllerClassReflection($classReflection);
    }
```

