### PR TITLE
[Core] Refactor RectifiedAnalyzer: early check against AbstractScopeAwareRector instead of Original node

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -51,21 +51,17 @@ final class RectifiedAnalyzer
             return false;
         }
 
+        if ($rector instanceof AbstractScopeAwareRector) {
+            $scope = $node->getAttribute(AttributeKey::SCOPE);
+            return $scope instanceof Scope;
+        }
+
         $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
         if ($originalNode instanceof Node) {
             return true;
         }
 
         $startTokenPos = $node->getStartTokenPos();
-        if ($startTokenPos >= 0) {
-            return false;
-        }
-
-        if (! $rector instanceof AbstractScopeAwareRector) {
-            return true;
-        }
-
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-        return $scope instanceof Scope;
+        return $startTokenPos < 0;
     }
 }


### PR DESCRIPTION
When multi rules applied to a file for verify:

```
Same Rector Rule <-> Same Node <-> Same File
```

This PR verify if previous rector class is not equals and previous node is not equals, then check early if passed rule extends `AbstractScopeAwareRector`, if yes, check if it has `Scope` early so it will be stopped when no Scope even original node attribute value  exists.