### PR TITLE
[Core] Improve UnreachableStmtAnalyzer: verify itself by recursive call

### DIFF
--- a/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
+++ b/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
@@ -4,30 +4,23 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
-use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class UnreachableStmtAnalyzer
 {
-    public function isStmtPHPStanUnreachable(Stmt $stmt): bool
+    public function isStmtPHPStanUnreachable(?Stmt $stmt): bool
     {
+        if (! $stmt instanceof Stmt) {
+            return false;
+        }
+
         if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
             // here the scope is never available for next stmt so we have nothing to refresh
             return true;
         }
 
-        $previousStmt = $stmt;
-        while ($previousStmt = $previousStmt->getAttribute(AttributeKey::PREVIOUS_NODE)) {
-            if (! $previousStmt instanceof Node) {
-                break;
-            }
-
-            if ($previousStmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
-                return true;
-            }
-        }
-
-        return false;
+        $previousStmt = $stmt->getAttribute(AttributeKey::PREVIOUS_NODE);
+        return $this->isStmtPHPStanUnreachable($previousStmt);
     }
 }


### PR DESCRIPTION
`PREVIOUS_NODE` of Stmt is always `Stmt` or `null`, so check against itself by recursively call its method.