### PR TITLE
Add [file] + [rule] debug info on --debug + fix literal number downgrade type change to string

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -50,7 +50,7 @@ use Symplify\Skipper\Skipper\Skipper;
 abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorInterface
 {
     /**
-     * @var string[]
+     * @var array<AttributeKey:*>
      */
     private const ATTRIBUTES_TO_MIRROR = [
         AttributeKey::SCOPE,

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -51,7 +51,7 @@ use Symplify\Skipper\Skipper\Skipper;
 abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorInterface
 {
     /**
-     * @var array<AttributeKey::*>
+     * @var string[]
      */
     private const ATTRIBUTES_TO_MIRROR = [
         AttributeKey::SCOPE,

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -51,7 +51,7 @@ use Symplify\Skipper\Skipper\Skipper;
 abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorInterface
 {
     /**
-     * @var array<AttributeKey:*>
+     * @var array<AttributeKey::*>
      */
     private const ATTRIBUTES_TO_MIRROR = [
         AttributeKey::SCOPE,
@@ -450,9 +450,6 @@ CODE_SAMPLE;
         }
 
         $this->rectorOutputStyle->writeln('[file] ' . $this->file->getRelativeFilePath());
-
-        // prevent spamming with the same class over and over
-        // indented on purpose to improve log nesting under [refactoring]
         $this->rectorOutputStyle->writeln('[rule] ' . static::class);
         $this->rectorOutputStyle->newLine(1);
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -21,6 +21,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
 use Rector\Core\Application\ChangedNodeScopeRefresher;
 use Rector\Core\Configuration\CurrentNodeProvider;
+use Rector\Core\Console\Output\RectorOutputStyle;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Exclusion\ExclusionManager;
@@ -123,6 +124,8 @@ CODE_SAMPLE;
 
     private UnreachableStmtAnalyzer $unreachableStmtAnalyzer;
 
+    private RectorOutputStyle $rectorOutputStyle;
+
     #[Required]
     public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
@@ -145,7 +148,8 @@ CODE_SAMPLE;
         RectifiedAnalyzer $rectifiedAnalyzer,
         CreatedByRuleDecorator $createdByRuleDecorator,
         ChangedNodeScopeRefresher $changedNodeScopeRefresher,
-        UnreachableStmtAnalyzer $unreachableStmtAnalyzer
+        UnreachableStmtAnalyzer $unreachableStmtAnalyzer,
+        RectorOutputStyle $rectorOutputStyle,
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
         $this->nodesToAddCollector = $nodesToAddCollector;
@@ -168,6 +172,7 @@ CODE_SAMPLE;
         $this->createdByRuleDecorator = $createdByRuleDecorator;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
         $this->unreachableStmtAnalyzer = $unreachableStmtAnalyzer;
+        $this->rectorOutputStyle = $rectorOutputStyle;
     }
 
     /**
@@ -215,6 +220,8 @@ CODE_SAMPLE;
         $this->currentNodeProvider->setNode($node);
 
         $originalAttributes = $node->getAttributes();
+
+        $this->printDebugCurrentFileAndRule();
 
         $node = $this->refactor($node);
 
@@ -434,5 +441,19 @@ CODE_SAMPLE;
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new ParentConnectingVisitor());
         $nodeTraverser->traverse([$node]);
+    }
+
+    private function printDebugCurrentFileAndRule(): void
+    {
+        if (! $this->rectorOutputStyle->isDebug()) {
+            return;
+        }
+
+        $this->rectorOutputStyle->writeln('[file] ' . $this->file->getRelativeFilePath());
+
+        // prevent spamming with the same class over and over
+        // indented on purpose to improve log nesting under [refactoring]
+        $this->rectorOutputStyle->writeln('[rule] ' . static::class);
+        $this->rectorOutputStyle->newLine(1);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/symplify/symplify/runs/6405930856?check_suite_focus=true

---

As there are dozens of rule that can be applied on a file, the combination of both is always crutial for debugging.
Before we had only all files or all rules at the same time, making it hard to find the duo.

Now Rector will print both right next to each other so it's easier to find even in big logs:

![image](https://user-images.githubusercontent.com/924196/168091786-fb1d94a0-9b8e-46fc-b862-87286733ddc3.png)


Ref https://github.com/rectorphp/rector-src/pull/2292#issuecomment-1124652589