### PR TITLE
Rename doTestFileInfo to assertTestFileInfo

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -103,7 +103,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
     }
 
     /**
-     * @deprecated The doTestFileInfois deprecated use assertTestFileInfo instead.
+     * @deprecated The doTestFileInfo is deprecated use assertTestFileInfo instead.
      */
     protected function doTestFileInfo(SmartFileInfo $fixtureFileInfo, bool $allowMatches = true): void
     {

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -102,7 +102,15 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
         return strncasecmp(PHP_OS, 'WIN', 3) === 0;
     }
 
+    /**
+     * @deprecated The doTestFileInfois deprecated use assertTestFileInfo instead.
+     */
     protected function doTestFileInfo(SmartFileInfo $fixtureFileInfo, bool $allowMatches = true): void
+    {
+        $this->assertTestFileInfo($$ixtureFileInfo, $allowMatches);
+    }
+
+    protected function assertTestFileInfo(SmartFileInfo $fixtureFileInfo, bool $allowMatches = true): void
     {
         $inputFileInfoAndExpectedFileInfo = StaticFixtureSplitter::splitFileInfoToLocalInputAndExpectedFileInfos(
             $fixtureFileInfo


### PR DESCRIPTION
Rector does else add `@doesNotPerformAssertions` when using PHPUnit:

```php
PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
PHPUnitSetList::PHPUNIT_91,
```

Method with `assert*` does not fall into this rule and so the `@doesNotPerformAssertions` will not longer added.

![Bildschirmfoto 2022-05-12 um 17 20 28](https://user-images.githubusercontent.com/1698337/168110249-3bd4b312-7918-4434-916e-c410f68e7f5d.png)
