### PR TITLE
[CodeQuality] Do not duplicate Expr on SimplifyIfElseToTernaryRector+SimplifyUselessVariableRector+CompleteDynamicPropertiesRector

### DIFF
--- a/tests/Issues/SimplifyVariableIfElseTernary/Fixture/do_not_duplicated_expr.php.inc
+++ b/tests/Issues/SimplifyVariableIfElseTernary/Fixture/do_not_duplicated_expr.php.inc
@@ -6,7 +6,8 @@ namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
 
 final class DoNotDuplicateExpr
 {
-    function test($foo, $bar) {
+    function test($foo, $bar)
+    {
         if ($foo > 0) {
             $baz = 'a';
         } else {
@@ -27,7 +28,8 @@ namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
 
 final class DoNotDuplicateExpr
 {
-    function test($foo, $bar) {
+    function test($foo, $bar)
+    {
         return $foo > 0 ? 'a' : 'b';
     }
 }

--- a/tests/Issues/SimplifyVariableIfElseTernary/Fixture/do_not_duplicated_expr.php.inc
+++ b/tests/Issues/SimplifyVariableIfElseTernary/Fixture/do_not_duplicated_expr.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
+
+final class DoNotDuplicateExpr
+{
+    function test($foo, $bar) {
+        if ($foo > 0) {
+            $baz = 'a';
+        } else {
+            $baz = 'b';
+        }
+
+        return $baz;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
+
+final class DoNotDuplicateExpr
+{
+    function test($foo, $bar) {
+        return $foo > 0 ? 'a' : 'b';
+    }
+}
+
+?>

--- a/tests/Issues/SimplifyVariableIfElseTernary/SimplifyVariableIfElseTernaryTest.php
+++ b/tests/Issues/SimplifyVariableIfElseTernary/SimplifyVariableIfElseTernaryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SimplifyVariableIfElseTernaryTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/SimplifyVariableIfElseTernary/config/configured_rule.php
+++ b/tests/Issues/SimplifyVariableIfElseTernary/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        SimplifyIfElseToTernaryRector::class,
+        SimplifyUselessVariableRector::class,
+        CompleteDynamicPropertiesRector::class,
+    ]);
+};


### PR DESCRIPTION
Given the following code:

```php
final class DoNotDuplicateExpr
{
    function test($foo, $bar) {
        if ($foo > 0) {
            $baz = 'a';
        } else {
            $baz = 'b';
        }

        return $baz;
    }
}
```

it currently produce:

```diff
+        $baz = $foo > 0 ? 'a' : 'b';
+
         return $foo > 0 ? 'a' : 'b';
```

this PR try to fix it. Fixes https://github.com/rectorphp/rector/issues/7165