### PR TITLE
Fix Scalar_Encapsed node as dynamic in `ExprAnalyzer::isDynamicExpr()`

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_string_interpolation.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_string_interpolation.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class SkipComplexAssign
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = "interpolated {$name}";
+    }
+}

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -13,6 +13,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
+use PhpParser\Node\Scalar\Encapsed;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\NodeManipulator\ArrayManipulator;
@@ -68,7 +69,8 @@ final class ExprAnalyzer
     {
         if (! $expr instanceof Array_) {
             if ($expr instanceof Scalar) {
-                return false;
+                // string interpolation is true, otherwise false
+                return $expr instanceof Encapsed;
             }
 
             return ! $this->isAllowedConstFetchOrClassConstFetch($expr);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7168