### PR TITLE
[Core] Direct assign visitors property data on RectorNodeTraverser

### DIFF
--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -45,7 +45,11 @@ final class RectorNodeTraverser extends NodeTraverser
         }
 
         // filer out by version
-        $this->visitors = array_merge($this->visitors, $this->phpVersionedFilter->filter($this->phpRectors));
+        $activePhpRectors = $this->phpVersionedFilter->filter($this->phpRectors);
+        $this->visitors = $this->visitors === []
+            ? $activePhpRectors
+            : array_merge($this->visitors, $activePhpRectors);
+
         $this->areNodeVisitorsPrepared = true;
     }
 }

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\NodeTraverser;
 
-use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Rector\VersionBonding\PhpVersionedFilter;
@@ -46,11 +45,7 @@ final class RectorNodeTraverser extends NodeTraverser
         }
 
         // filer out by version
-        $activePhpRectors = $this->phpVersionedFilter->filter($this->phpRectors);
-        foreach ($activePhpRectors as $activePhpRector) {
-            $this->addVisitor($activePhpRector);
-        }
-
+        $this->visitors = array_merge($this->visitors, $this->phpVersionedFilter->filter($this->phpRectors));
         $this->areNodeVisitorsPrepared = true;
     }
 }

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\NodeTraverser;
 
+use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Rector\VersionBonding\PhpVersionedFilter;


### PR DESCRIPTION
- Using direct assign visitors property data on RectorNodeTraverser instead of loop and and add as the property is protected and can be filled directly.
- Using `array_merge()` to be safe if the value is initialized somewhere.