### PR TITLE
[Core] Fix message configure rule error on EmptyConfigurableRectorChecker

### DIFF
--- a/src/Validation/EmptyConfigurableRectorChecker.php
+++ b/src/Validation/EmptyConfigurableRectorChecker.php
@@ -26,7 +26,7 @@ final class EmptyConfigurableRectorChecker
         $this->reportWarningMessage($emptyConfigurableRectorClasses);
 
         $solutionMessage = sprintf(
-            'Do you want to run them?%sConfigure them in `rector.php` with "...->configure(...);"',
+            'Do you want to run them?%sConfigure them in `rector.php` with "...$rectorConfig->ruleWithConfiguration(...);"',
             PHP_EOL
         );
         $this->rectorOutputStyle->note($solutionMessage);


### PR DESCRIPTION
The `configure()` is now use `ruleWithConfiguration()` with `$rectorConfig`