### PR TITLE
[Core] Ensure parent is Node on AbstractScopeAwareRector

### DIFF
--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -29,7 +29,7 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
             $errorMessage = sprintf(
                 'Scope not available on "%s" node with parent node of "%s", but is required by a refactorWithScope() method of "%s" rule. Fix scope refresh on changed nodes first',
                 $node::class,
-                $parent::class,
+                $parent instanceof Node ? $parent::class : null,
                 static::class,
             );
 


### PR DESCRIPTION
To handle instanceof check like in `ChangedNodeScopeRefresher`:

https://github.com/rectorphp/rector-src/blob/96400215b55a957bd5d5af2b8195af9bdb83c2ca/src/Application/ChangedNodeScopeRefresher.php#L56

I was got error `::class` on null error when debugging on PR

- https://github.com/rectorphp/rector-src/pull/2312