### PR TITLE
[DeadCode] Handle combine RemoveAlwaysTrueIfConditionRector + RemoveDeadConstructorRector

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\Core\ProcessAnalyzer;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\RectorInterface;
+use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\RectifiedNode;
@@ -23,6 +24,10 @@ final class RectifiedAnalyzer
      * @var array<string, RectifiedNode|null>
      */
     private array $previousFileWithNodes = [];
+
+    public function __construct(private readonly NodeComparator $nodeComparator)
+    {
+    }
 
     public function verify(RectorInterface $rector, Node $node, File $currentFile): ?RectifiedNode
     {
@@ -47,8 +52,10 @@ final class RectifiedAnalyzer
 
     private function shouldContinue(RectifiedNode $rectifiedNode, RectorInterface $rector, Node $node): bool
     {
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
         if ($rectifiedNode->getRectorClass() === $rector::class && $rectifiedNode->getNode() === $node) {
-            return false;
+            // allow to revisit the Node if Node is changed
+            return ! $this->nodeComparator->areNodesEqual($originalNode, $node);
         }
 
         if ($rector instanceof AbstractScopeAwareRector) {
@@ -56,7 +63,6 @@ final class RectifiedAnalyzer
             return $scope instanceof Scope;
         }
 
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
         if ($originalNode instanceof Node) {
             return true;
         }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -54,7 +54,9 @@ final class RectifiedAnalyzer
     {
         $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
         if ($rectifiedNode->getRectorClass() === $rector::class && $rectifiedNode->getNode() === $node) {
-            // allow to revisit the Node if Node is changed
+            /**
+             * allow to revisit the Node with same Rector rule if Node is changed by other rule
+             */
             return ! $this->nodeComparator->areNodesEqual($originalNode, $node);
         }
 

--- a/tests/Issues/AlwaysTrueIfInDeadConstructor/AlwaysTrueIfInDeadConstructorTest.php
+++ b/tests/Issues/AlwaysTrueIfInDeadConstructor/AlwaysTrueIfInDeadConstructorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\AlwaysTrueIfInDeadConstructor;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AlwaysTrueIfInDeadConstructorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/AlwaysTrueIfInDeadConstructor/Fixture/fixture.php.inc
+++ b/tests/Issues/AlwaysTrueIfInDeadConstructor/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\AlwaysTrueIfInDeadConstructor\Fixture;
+
+final class Fixture
+{
+    public function __construct()
+    {
+        if (1 === 1) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\AlwaysTrueIfInDeadConstructor\Fixture;
+
+final class Fixture
+{
+}
+
+?>

--- a/tests/Issues/AlwaysTrueIfInDeadConstructor/config/configured_rule.php
+++ b/tests/Issues/AlwaysTrueIfInDeadConstructor/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveDeadConstructorRector;
+use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveAlwaysTrueIfConditionRector::class);
+    $rectorConfig->rule(RemoveDeadConstructorRector::class);
+};

--- a/tests/Issues/IssueReturnBeforeElseIf/Fixture/complex_if_cond_or_without_elseif.php.inc
+++ b/tests/Issues/IssueReturnBeforeElseIf/Fixture/complex_if_cond_or_without_elseif.php.inc
@@ -28,10 +28,7 @@ class ComplexIfCondOrWithoutElseIf
 {
     public function run($a, $b, $c)
     {
-        if ($a && false === $b) {
-            return 'a';
-        }
-        if (! $c) {
+        if (($a && false === $b) || ! $c) {
             return 'a';
         }
         return 'b';

--- a/tests/Issues/IssueReturnBeforeElseIf/Fixture/complex_if_cond_or_without_elseif.php.inc
+++ b/tests/Issues/IssueReturnBeforeElseIf/Fixture/complex_if_cond_or_without_elseif.php.inc
@@ -28,7 +28,10 @@ class ComplexIfCondOrWithoutElseIf
 {
     public function run($a, $b, $c)
     {
-        if (($a && false === $b) || ! $c) {
+        if ($a && false === $b) {
+            return 'a';
+        }
+        if (! $c) {
             return 'a';
         }
         return 'b';


### PR DESCRIPTION
Given the following code:

```php
final class Fixture
{
    public function __construct()
    {
        if (1 === 1) {
        }
    }
}
```

it currently only remove the `if`, while empty `__construct()` after `if` removed is still exists so it require double run rector.

```diff
     public function __construct()
     {
-        if (1 === 1) {
-        }
     }
```

to remove dead constructor. This PR try to apply it so the dead constructor also removed.

Applied rules:

```php
Rector\DeadCode\Rector\ClassMethod\RemoveDeadConstructorRector;
Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
```