### PR TITLE
[DeadCode] Allow return Nop Stmts (comments) on RemoveAlwaysTrueIfConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/nop_stmt.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/nop_stmt.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class NopStmt
+{
+    public function run()
+    {
+        if (true === true) {
+            // some comment
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class NopStmt
+{
+    public function run()
+    {
+        // some comment
+
+    }
+}
+
+?>

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -240,9 +240,7 @@ CODE_SAMPLE;
             $this->nodesToReturn[$originalNodeHash] = $node;
 
             $firstNodeKey = array_key_first($node);
-            if (! $node[$firstNodeKey] instanceof Nop) {
-                $this->mirrorComments($node[$firstNodeKey], $originalNode);
-            }
+            $this->mirrorComments($node[$firstNodeKey], $originalNode);
 
             // will be replaced in leaveNode() the original node must be passed
             return $originalNode;
@@ -328,6 +326,10 @@ CODE_SAMPLE;
 
     protected function mirrorComments(Node $newNode, Node $oldNode): void
     {
+        if ($newNode instanceof Nop) {
+            return;
+        }
+
         $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO));
         $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\NodeVisitorAbstract;
@@ -239,7 +240,9 @@ CODE_SAMPLE;
             $this->nodesToReturn[$originalNodeHash] = $node;
 
             $firstNodeKey = array_key_first($node);
-            $this->mirrorComments($node[$firstNodeKey], $originalNode);
+            if (! $node[$firstNodeKey] instanceof Nop) {
+                $this->mirrorComments($node[$firstNodeKey], $originalNode);
+            }
 
             // will be replaced in leaveNode() the original node must be passed
             return $originalNode;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -326,12 +326,10 @@ CODE_SAMPLE;
 
     protected function mirrorComments(Node $newNode, Node $oldNode): void
     {
-        if ($newNode instanceof Nop) {
-            return;
-        }
-
         $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO));
-        $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
+        if (! $newNode instanceof Nop) {
+            $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
+        }
     }
 
     /**


### PR DESCRIPTION
Given the following code:

```php
class NopStmt
{
    public function run()
    {
        if (true === true) {
            // some comment
        }
    }
}
```

The `// some comment` comment is removed:

```diff
-        if (true === true) {
-            // some comment
-        }
+
```

which as `RemoveAlwaysTrueIfConditionRector` returns stmts if not empty, it should be return [`Nop`] as is. 