### PR TITLE
[Core] Remove clean comment on NodeComparator::isNodeEqual()

### DIFF
--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -7,7 +7,6 @@ namespace Rector\Core\PhpParser\Comparing;
 use PhpParser\Node;
 use Rector\Comments\CommentRemover;
 use Rector\Core\Contract\PhpParser\NodePrinterInterface;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class NodeComparator
 {
@@ -43,15 +42,7 @@ final class NodeComparator
      */
     public function isNodeEqual(Node $singleNode, array $availableNodes): bool
     {
-        // remove comments, only content is relevant
-        $singleNode = clone $singleNode;
-        $singleNode->setAttribute(AttributeKey::COMMENTS, null);
-
         foreach ($availableNodes as $availableNode) {
-            // remove comments, only content is relevant
-            $availableNode = clone $availableNode;
-            $availableNode->setAttribute(AttributeKey::COMMENTS, null);
-
             if ($this->areNodesEqual($singleNode, $availableNode)) {
                 return true;
             }


### PR DESCRIPTION
The `NodeComparator::isNodeEqual()` is consume `NodeComparator::areNodesEqual()` which already compare printing without comment, so clean up comment during comparison is not needed.