### PR TITLE
[DowngradePhp80] Add in arrow function in return support on DowngradeMatchToSwitchRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/array_item_keyed_assigned.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/array_item_keyed_assigned.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class ArrayItemKeyedAssigned
+{
+    public function run($statusCode)
+    {
+        $value = [
+            'result' => match ($statusCode) {
+                200, 300 => null,
+                400 => 'not found',
+                default => 'unknown status code',
+            },
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+class ArrayItemKeyedAssigned
+{
+    public function run($statusCode)
+    {
+        $value = [
+            'result' => (function () use ($statusCode) {
+                switch ($statusCode) {
+                    case 200:
+                    case 300:
+                        return null;
+                    case 400:
+                        return 'not found';
+                    default:
+                        return 'unknown status code';
+                }
+            })(),
+        ];
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/in_arrow_function_as_invokable.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/in_arrow_function_as_invokable.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class InArrowFunctionAsInvokable
+{
+    public function run($value)
+    {
+        (static fn (mixed $default): mixed => match (true) {
+                is_string($default) => sprintf('"%s"', $default),
+                default => $default,
+            })($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class InArrowFunctionAsInvokable
+{
+    public function run($value)
+    {
+        (static function (mixed $default) : mixed {
+            switch (true) {
+                case is_string($default):
+                    return sprintf('"%s"', $default);
+                default:
+                    return $default;
+            }
+        })($value);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/in_arrow_function_in_expression.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/in_arrow_function_in_expression.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class InArrowFunctionInExpression
+{
+    public function run($value)
+    {
+        static fn (mixed $default): mixed => match (true) {
+                is_string($default) => sprintf('"%s"', $default),
+                default => $default,
+            };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class InArrowFunctionInExpression
+{
+    public function run($value)
+    {
+        static function (mixed $default) : mixed {
+            switch (true) {
+                case is_string($default):
+                    return sprintf('"%s"', $default);
+                default:
+                    return $default;
+            }
+        };
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/in_arrow_function_in_return.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/in_arrow_function_in_return.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class InArrowFunctionInReturn
+{
+    public function run($value)
+    {
+        return static fn (mixed $default): mixed => match (true) {
+                is_string($default) => sprintf('"%s"', $default),
+                default => $default,
+            };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class InArrowFunctionInReturn
+{
+    public function run($value)
+    {
+        return static function (mixed $default) : mixed {
+            switch (true) {
+                case is_string($default):
+                    return sprintf('"%s"', $default);
+                default:
+                    return $default;
+            }
+        };
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -129,8 +129,7 @@ CODE_SAMPLE
         ArrowFunction $arrowFunction,
         Match_ $match,
         Echo_|Expression|Return_ $node
-    ): Echo_|Expression|Return_|null
-    {
+    ): Echo_|Expression|Return_|null {
         $parentOfParentMatch = $arrowFunction->getAttribute(AttributeKey::PARENT_NODE);
 
         if (! $parentOfParentMatch instanceof Node) {

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
 
         $stmts = [new Return_($match)];
         $originalParentMatch = $arrowFunction;
-        $arrowFunction = $this->anonymousFunctionFactory->create(
+        $anonymousFunction = $this->anonymousFunctionFactory->create(
             $arrowFunction->params,
             $stmts,
             $arrowFunction->returnType,
@@ -146,17 +146,17 @@ CODE_SAMPLE
         );
 
         if ($parentOfParentMatch instanceof Arg && $parentOfParentMatch->value === $originalParentMatch) {
-            $parentOfParentMatch->value = $arrowFunction;
+            $parentOfParentMatch->value = $anonymousFunction;
             return $node;
         }
 
         if (($parentOfParentMatch instanceof Assign || $parentOfParentMatch instanceof Expression || $parentOfParentMatch instanceof Return_) && $parentOfParentMatch->expr === $originalParentMatch) {
-            $parentOfParentMatch->expr = $arrowFunction;
+            $parentOfParentMatch->expr = $anonymousFunction;
             return $node;
         }
 
         if ($parentOfParentMatch instanceof FuncCall && $parentOfParentMatch->name === $originalParentMatch) {
-            $parentOfParentMatch->name = $arrowFunction;
+            $parentOfParentMatch->name = $anonymousFunction;
             return $node;
         }
 

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -166,7 +166,8 @@ CODE_SAMPLE
      * @param MatchArm[] $matchArms
      * @return Case_[]
      */
-    private function createSwitchCasesFromMatchArms(Echo_ | Expression | Return_ $node, array $matchArms): array {
+    private function createSwitchCasesFromMatchArms(Echo_ | Expression | Return_ $node, array $matchArms): array
+    {
         $switchCases = [];
 
         foreach ($matchArms as $matchArm) {

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
 
         /**
          * Yes, Pass Match_ object itself to Return_
-         * Let the Rule revisit the Match_ the ArrowFunction converted to Closure_
+         * Let the Rule revisit the Match_ after the ArrowFunction converted to Closure_
          */
         $stmts = [new Return_($match)];
         $closure = $this->anonymousFunctionFactory->create(

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -136,6 +136,10 @@ CODE_SAMPLE
             return null;
         }
 
+        /**
+         * Yes, Pass Match_ object itself to Return_
+         * Let the Rule revisit the Match_ the ArrowFunction converted to Closure_
+         */
         $stmts = [new Return_($match)];
         $closure = $this->anonymousFunctionFactory->create(
             $arrowFunction->params,

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\MethodCall;
@@ -214,7 +215,10 @@ CODE_SAMPLE
     {
         $stmts = [];
 
-        if ($matchArm->body instanceof Throw_) {
+        $hasParentArrayItem = (bool) $this->betterNodeFinder->findParentType($matchArm, ArrayItem::class);
+        if ($hasParentArrayItem) {
+            $stmts[] = new Return_($matchArm->body);
+        } elseif ($matchArm->body instanceof Throw_) {
             $stmts[] = new Expression($matchArm->body);
         } elseif ($node instanceof ArrayItem || $node instanceof Return_) {
             $stmts[] = new Return_($matchArm->body);

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -137,7 +137,6 @@ CODE_SAMPLE
         }
 
         $stmts = [new Return_($match)];
-        $originalParentMatch = $arrowFunction;
         $closure = $this->anonymousFunctionFactory->create(
             $arrowFunction->params,
             $stmts,
@@ -145,17 +144,17 @@ CODE_SAMPLE
             $arrowFunction->static
         );
 
-        if ($parentOfParentMatch instanceof Arg && $parentOfParentMatch->value === $originalParentMatch) {
+        if ($parentOfParentMatch instanceof Arg && $parentOfParentMatch->value === $arrowFunction) {
             $parentOfParentMatch->value = $closure;
             return $node;
         }
 
-        if (($parentOfParentMatch instanceof Assign || $parentOfParentMatch instanceof Expression || $parentOfParentMatch instanceof Return_) && $parentOfParentMatch->expr === $originalParentMatch) {
+        if (($parentOfParentMatch instanceof Assign || $parentOfParentMatch instanceof Expression || $parentOfParentMatch instanceof Return_) && $parentOfParentMatch->expr === $arrowFunction) {
             $parentOfParentMatch->expr = $closure;
             return $node;
         }
 
-        if ($parentOfParentMatch instanceof FuncCall && $parentOfParentMatch->name === $originalParentMatch) {
+        if ($parentOfParentMatch instanceof FuncCall && $parentOfParentMatch->name === $arrowFunction) {
             $parentOfParentMatch->name = $closure;
             return $node;
         }

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
 
         $stmts = [new Return_($match)];
         $originalParentMatch = $arrowFunction;
-        $anonymousFunction = $this->anonymousFunctionFactory->create(
+        $closure = $this->anonymousFunctionFactory->create(
             $arrowFunction->params,
             $stmts,
             $arrowFunction->returnType,
@@ -146,17 +146,17 @@ CODE_SAMPLE
         );
 
         if ($parentOfParentMatch instanceof Arg && $parentOfParentMatch->value === $originalParentMatch) {
-            $parentOfParentMatch->value = $anonymousFunction;
+            $parentOfParentMatch->value = $closure;
             return $node;
         }
 
         if (($parentOfParentMatch instanceof Assign || $parentOfParentMatch instanceof Expression || $parentOfParentMatch instanceof Return_) && $parentOfParentMatch->expr === $originalParentMatch) {
-            $parentOfParentMatch->expr = $anonymousFunction;
+            $parentOfParentMatch->expr = $closure;
             return $node;
         }
 
         if ($parentOfParentMatch instanceof FuncCall && $parentOfParentMatch->name === $originalParentMatch) {
-            $parentOfParentMatch->name = $anonymousFunction;
+            $parentOfParentMatch->name = $closure;
             return $node;
         }
 

--- a/tests/Issues/Issue6708/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6708/Fixture/fixture.php.inc
@@ -32,9 +32,9 @@ class Fixture
 
     public function run($operation)
     {
-        $item2Unpacked = $this->getArray();
         switch ($operation) {
             case 'fruits':
+                $item2Unpacked = $this->getArray();
                 return array_merge(['banana', 'orange'], $item2Unpacked);
         }
     }

--- a/tests/Issues/Issue6708/Fixture/fixture3.php.inc
+++ b/tests/Issues/Issue6708/Fixture/fixture3.php.inc
@@ -33,13 +33,13 @@ class Fixture3
 
     public function run($operation)
     {
-        $item2Unpacked = $this->getFirstArray();
-        $item3Unpacked = $this->getSecondArray();
         switch ($operation) {
             case 'fruits':
+                $item2Unpacked = $this->getFirstArray();
                 return array_merge(['banana', 'orange'], is_array($item2Unpacked) ? $item2Unpacked : iterator_to_array($item2Unpacked));
             case 'veggies':
-                return array_merge(['tomato', 'lettuce'], is_array($item3Unpacked) ? $item3Unpacked : iterator_to_array($item3Unpacked));
+                $item2Unpacked = $this->getSecondArray();
+                return array_merge(['tomato', 'lettuce'], is_array($item2Unpacked) ? $item2Unpacked : iterator_to_array($item2Unpacked));
         }
     }
 }


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2330, this PR add support for downgrade inside arrow function in direct return, eg:

```php
final class InArrowFunctionInReturn
{
    public function run($value)
    {
        return static fn (mixed $default): mixed => match (true) {
                is_string($default) => sprintf('"%s"', $default),
                default => $default,
            };
    }
}
```

which currently still skipped.