### PR TITLE
[CodeQuality] Replace static with self for private constants

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 512 Rules Overview
+# 513 Rules Overview
 
 <br>
 
@@ -6,7 +6,7 @@
 
 - [Arguments](#arguments) (5)
 
-- [CodeQuality](#codequality) (72)
+- [CodeQuality](#codequality) (73)
 
 - [CodingStyle](#codingstyle) (35)
 
@@ -621,6 +621,25 @@ Change multiple null compares to ?? queue
 -
 -        return null;
 +        return $this->orderItem ?? $this->orderItemUnit;
+     }
+ }
+```
+
+<br>
+
+### ConvertStaticPrivateConstantToSelfRector
+
+Replaces static::* access to private constants with self::*
+
+- class: [`Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector`](../rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php)
+
+```diff
+ class Foo {
+     private const BAR = 'bar';
+     public function run()
+     {
+-        $bar = static::BAR;
++        $bar = self::BAR;
      }
  }
 ```

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/ConvertStaticPrivateConstantToSelfRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/ConvertStaticPrivateConstantToSelfRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ConvertStaticPrivateConstantToSelfRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/constants-from-other-classes-are-not-changed.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/constants-from-other-classes-are-not-changed.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+final class Foo
+{
+    public function run(): void
+    {
+        echo \DateTimeInterface::ATOM;
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/other-visibilities-are-not-changed.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/other-visibilities-are-not-changed.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+final class Foo
+{
+    protected const BAR = 1;
+    public const BAZ = 1;
+    public function run(): void
+    {
+        echo static::BAR;
+        echo static::BAZ;
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/private-constant-with-self-will-not-be-changed.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/private-constant-with-self-will-not-be-changed.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+final class Foo
+{
+    private const BAR = 1;
+    public function baz(): void
+    {
+        echo self::BAR;
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/private-constant-with-static-should-use-self.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/private-constant-with-static-should-use-self.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+final class Foo
+{
+    private const BAR = 1;
+    public function baz(): void
+    {
+        echo static::BAR;
+    }
+}
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+final class Foo
+{
+    private const BAR = 1;
+    public function baz(): void
+    {
+        echo self::BAR;
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/config/config.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/config/config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector::class);
+};

--- a/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\ClassConstFetch;
+
+use Exception;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Error;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\ConvertStaticPrivateConstantToSelfRectorTest
+ * @see https://3v4l.org/8Y0ba
+ * @see https://phpstan.org/r/11d4c850-1a40-4fae-b665-291f96104d11
+ */
+final class ConvertStaticPrivateConstantToSelfRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replaces static::* access to private constants with self::*',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class Foo {
+    private const BAR = 'bar';
+    public function run()
+    {
+        $bar = static::BAR;
+    }
+}
+CODE_SAMPLE
+,
+                    <<<'CODE_SAMPLE'
+class Foo {
+    private const BAR = 'bar';
+    public function run()
+    {
+        $bar = self::BAR;
+    }
+}
+CODE_SAMPLE
+,
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassConstFetch::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\ClassConstFetch $node
+     *
+     * @return \PhpParser\Node|null
+     */
+    public function refactor(Node $node)
+    {
+        if (! $this->isUsingStatic($node)) {
+            return null;
+        }
+
+        if (! $this->isPrivateConstant($node)) {
+            return null;
+        }
+
+        return new ClassConstFetch(new Name('self'), $node->name,);
+    }
+
+    private function isUsingStatic(ClassConstFetch $node): bool
+    {
+        if (! $node->class instanceof Name) {
+            return false;
+        }
+
+        return $node->class->getFirst() === 'static';
+    }
+
+    private function isPrivateConstant(ClassConstFetch $node): bool
+    {
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return false;
+        }
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+        $constantName = $node->name;
+        if ($constantName instanceof Error) {
+            return false;
+        }
+        try {
+            $constantReflection = $classReflection->getConstant($constantName->toString());
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return $constantReflection->isPrivate();
+    }
+}


### PR DESCRIPTION
I wasn't able to find a rule like this and we use this in our project, have a look at the problem here:
 * https://3v4l.org/8Y0ba
 * https://phpstan.org/r/11d4c850-1a40-4fae-b665-291f96104d11