### PR TITLE
[DowngradePhp80] Apply PHPStan 1.7.x-dev compatible for PhpParameterReflection

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "phpstan/phpstan": "^1.6.8 || <1.7"
+        "phpstan/phpstan": "^1.6.8"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nikic/php-parser": "^4.13.2",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.5.1",
-        "phpstan/phpstan": "^1.6.8 || <1.7",
+        "phpstan/phpstan": "^1.6.8",
         "phpstan/phpstan-phpunit": "^1.0",
         "psr/log": "^2.0",
         "react/child-process": "^0.6.4",

--- a/config/services-rules.php
+++ b/config/services-rules.php
@@ -24,5 +24,6 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/../rules/*/Contract/*',
             __DIR__ . '/../rules/*/Exception/*',
             __DIR__ . '/../rules/*/Enum/*',
+            __DIR__ . '/../rules/DowngradePhp80/Reflection/SimplePhpParameterReflection.php',
         ]);
 };

--- a/config/services.php
+++ b/config/services.php
@@ -74,6 +74,7 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/../src/PhpParser/ValueObject',
             __DIR__ . '/../src/functions',
             __DIR__ . '/../src/constants.php',
+
         ]);
 
     $services->alias(Application::class, ConsoleApplication::class);

--- a/config/services.php
+++ b/config/services.php
@@ -74,7 +74,6 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/../src/PhpParser/ValueObject',
             __DIR__ . '/../src/functions',
             __DIR__ . '/../src/constants.php',
-
         ]);
 
     $services->alias(Application::class, ConsoleApplication::class);

--- a/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\Php\PhpParameterReflection;
 use Rector\DowngradePhp80\Reflection\DefaultParameterValueResolver;
+use Rector\DowngradePhp80\Reflection\SimplePhpParameterReflection;
 use Rector\NodeNameResolver\NodeNameResolver;
 use ReflectionFunction;
 
@@ -19,7 +20,7 @@ final class NamedToUnnamedArgs
 {
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly DefaultParameterValueResolver $defaultParameterValueResolver,
+        private readonly DefaultParameterValueResolver $defaultParameterValueResolver
     ) {
     }
 
@@ -92,12 +93,7 @@ final class NamedToUnnamedArgs
 
             /** @var ParameterReflection|PhpParameterReflection $parameterReflection */
             if ($functionLikeReflection instanceof ReflectionFunction) {
-                // @todo since PHPStan 1.7.* add new InitializerExprTypeResolver() service as 1st arg - https://github.com/phpstan/phpstan-src/commit/c8b3926f005d008178d6d8c62aaca0200a6359a2#diff-ce65c81a2653b1f53bc416082582e248f629d65c066440d9c4edc5005d16af32
-                $parameterReflection = new PhpParameterReflection(
-                    $functionLikeReflection->getParameters()[$i],
-                    null,
-                    null
-                );
+                $parameterReflection = new SimplePhpParameterReflection($functionLikeReflection, $i);
             } else {
                 $parameterReflection = $parameters[$i];
             }

--- a/rules/DowngradePhp80/Reflection/SimplePhpParameterReflection.php
+++ b/rules/DowngradePhp80/Reflection/SimplePhpParameterReflection.php
@@ -33,7 +33,8 @@ final class SimplePhpParameterReflection implements ParameterReflection
     }
 
     /**
-     * getType() is never used yet
+     * getType() is never used yet and the implementation require PHPStan $phpDocType services injection
+     * @see https://github.com/phpstan/phpstan-src/blob/92420cd4b190b57d1ba8bf9e800eb97c8c0ee2f2/src/Reflection/Php/PhpParameterReflection.php#L24
      */
     public function getType(): Type
     {

--- a/rules/DowngradePhp80/Reflection/SimplePhpParameterReflection.php
+++ b/rules/DowngradePhp80/Reflection/SimplePhpParameterReflection.php
@@ -33,7 +33,7 @@ final class SimplePhpParameterReflection implements ParameterReflection
     }
 
     /**
-     * getType() is never used yet and the implementation require PHPStan $phpDocType services injection
+     * getType() is never used yet on manual object creation, and the implementation require PHPStan $phpDocType services injection
      * @see https://github.com/phpstan/phpstan-src/blob/92420cd4b190b57d1ba8bf9e800eb97c8c0ee2f2/src/Reflection/Php/PhpParameterReflection.php#L24
      */
     public function getType(): Type

--- a/rules/DowngradePhp80/Reflection/SimplePhpParameterReflection.php
+++ b/rules/DowngradePhp80/Reflection/SimplePhpParameterReflection.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Reflection;
+
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\ConstantTypeHelper;
+use PHPStan\Type\Type;
+use Rector\Core\Exception\NotImplementedYetException;
+use ReflectionFunction;
+use ReflectionParameter;
+use Throwable;
+
+final class SimplePhpParameterReflection implements ParameterReflection
+{
+    private readonly ReflectionParameter $parameter;
+
+    public function __construct(ReflectionFunction $reflectionFunction, int $position)
+    {
+        $this->parameter = $reflectionFunction->getParameters()[$position];
+    }
+
+    public function getName(): string
+    {
+        return $this->parameter->getName();
+    }
+
+    public function isOptional(): bool
+    {
+        return $this->parameter->isOptional();
+    }
+
+    /**
+     * getType() is never used yet
+     */
+    public function getType(): Type
+    {
+        throw new NotImplementedYetException();
+    }
+
+    public function passedByReference(): PassedByReference
+    {
+        return $this->parameter->isPassedByReference()
+            ? PassedByReference::createCreatesNewVariable()
+            : PassedByReference::createNo();
+    }
+
+    public function isVariadic(): bool
+    {
+        return $this->parameter->isVariadic();
+    }
+
+    public function getDefaultValue(): ?Type
+    {
+        try {
+            if ($this->parameter->isDefaultValueAvailable()) {
+                $defaultValue = $this->parameter->getDefaultValue();
+                return ConstantTypeHelper::getTypeFromValue($defaultValue);
+            }
+        } catch (Throwable) {
+            return null;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Apply PHPStan 1.7.x-dev compatible for PhpParameterReflection on manual object creation on `NamedToUnnamedArgs` by create new class named: `SimplePhpParameterReflection` with only provide:

- native `ReflectionFunction` php object
- position parameter

by above, adapt the original  `PhpParameterReflection` on PHPStan 1.6 which only provide information that only used in next of its usage of the manual object creation.

ref https://github.com/rectorphp/rector/issues/7161
Closes https://github.com/rectorphp/rector-src/pull/2337