### PR TITLE
[DowngradePhp80] Alternative Apply PHPStan 1.7.x-dev compatible for PhpParameterReflection

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "phpstan/phpstan": "^1.6.8 || <1.7"
+        "phpstan/phpstan": "^1.6.8"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nikic/php-parser": "^4.13.2",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.5.1",
-        "phpstan/phpstan": "^1.6.8 || <1.7",
+        "phpstan/phpstan": "^1.6.8",
         "phpstan/phpstan-phpunit": "^1.0",
         "psr/log": "^2.0",
         "react/child-process": "^0.6.4",

--- a/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
@@ -94,27 +94,26 @@ final class NamedToUnnamedArgs
                 $reflectionParameter = $functionLikeReflection->getParameters()[$i];
                 $isPassedByReference = $reflectionParameter->isPassedByReference();
                 $isVariadic = $reflectionParameter->isVariadic();
-                $defaultValueType = $this->defaultParameterValueResolver->resolveDefaultValueConstantType($reflectionParameter);
+                $defaultValueType = $this->defaultParameterValueResolver->resolveDefaultValueConstantType(
+                    $reflectionParameter
+                );
                 $defaultValue = $this->defaultParameterValueResolver->resolveValueFromType($defaultValueType);
             } else {
                 /** @var ParameterReflection|PhpParameterReflection $parameterReflection */
                 $parameterReflection = $parameters[$i];
-                $isPassedByReference  = $parameterReflection->passedByReference()->yes();
+                $isPassedByReference = $parameterReflection->passedByReference()
+                    ->yes();
                 $isVariadic = $parameterReflection->isVariadic();
-                $defaultValue = $this->defaultParameterValueResolver->resolveFromParameterReflection($parameterReflection);
+                $defaultValue = $this->defaultParameterValueResolver->resolveFromParameterReflection(
+                    $parameterReflection
+                );
             }
 
             if (! $defaultValue instanceof Expr) {
                 continue;
             }
 
-            $unnamedArgs[$i] = new Arg(
-                $defaultValue,
-                $isPassedByReference,
-                $isVariadic,
-                [],
-                null
-            );
+            $unnamedArgs[$i] = new Arg($defaultValue, $isPassedByReference, $isVariadic, [], null);
         }
 
         return $unnamedArgs;

--- a/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
@@ -90,28 +90,28 @@ final class NamedToUnnamedArgs
                 continue;
             }
 
-            /** @var ParameterReflection|PhpParameterReflection $parameterReflection */
             if ($functionLikeReflection instanceof ReflectionFunction) {
-                // @todo since PHPStan 1.7.* add new InitializerExprTypeResolver() service as 1st arg - https://github.com/phpstan/phpstan-src/commit/c8b3926f005d008178d6d8c62aaca0200a6359a2#diff-ce65c81a2653b1f53bc416082582e248f629d65c066440d9c4edc5005d16af32
-                $parameterReflection = new PhpParameterReflection(
-                    $functionLikeReflection->getParameters()[$i],
-                    null,
-                    null
-                );
+                $reflectionParameter = $functionLikeReflection->getParameters()[$i];
+                $isPassedByReference = $reflectionParameter->isPassedByReference();
+                $isVariadic = $reflectionParameter->isVariadic();
+                $defaultValueType = $this->defaultParameterValueResolver->resolveDefaultValueConstantType($reflectionParameter);
+                $defaultValue = $this->defaultParameterValueResolver->resolveValueFromType($defaultValueType);
             } else {
+                /** @var ParameterReflection|PhpParameterReflection $parameterReflection */
                 $parameterReflection = $parameters[$i];
+                $isPassedByReference  = $parameterReflection->passedByReference()->yes();
+                $isVariadic = $parameterReflection->isVariadic();
+                $defaultValue = $this->defaultParameterValueResolver->resolveFromParameterReflection($parameterReflection);
             }
 
-            $defaultValue = $this->defaultParameterValueResolver->resolveFromParameterReflection($parameterReflection);
             if (! $defaultValue instanceof Expr) {
                 continue;
             }
 
             $unnamedArgs[$i] = new Arg(
                 $defaultValue,
-                $parameterReflection->passedByReference()
-                    ->yes(),
-                $parameterReflection->isVariadic(),
+                $isPassedByReference,
+                $isVariadic,
                 [],
                 null
             );


### PR DESCRIPTION
Alternative of PR https://github.com/rectorphp/rector-src/pull/2336 for compatible code with PHPStan 1.7.x-dev with just consume the native functionality when exists, copy get type of default value as needed. 

so no need to manual instance of `PhpParameterReflection` object creation.

Closes https://github.com/rectorphp/rector-src/pull/2336