### PR TITLE
[DeadCode] Skip used in compact() on RemoveUnusedConstructorParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/skip_used_in_compact.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/skip_used_in_compact.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class SkipUsedInCompact
+{
+    public $data;
+
+    public function __construct($hey, $man)
+    {
+        $this->data = compact('hey', 'man');
+    }
+}

--- a/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
+++ b/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
@@ -6,12 +6,12 @@ namespace Rector\DeadCode\NodeCollector;
 
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\Core\NodeManipulator\ClassMethodManipulator;
+use Rector\Core\NodeAnalyzer\ParamAnalyzer;
 
 final class UnusedParameterResolver
 {
     public function __construct(
-        private readonly ClassMethodManipulator $classMethodManipulator
+        private readonly ParamAnalyzer $paramAnalyzer
     ) {
     }
 
@@ -30,7 +30,7 @@ final class UnusedParameterResolver
                 continue;
             }
 
-            if ($this->classMethodManipulator->isParameterUsedInClassMethod($param, $classMethod)) {
+            if ($this->paramAnalyzer->isParamUsedInClassMethod($classMethod, $param)) {
                 continue;
             }
 

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -50,7 +50,7 @@ final class ParamAnalyzer
                 return false;
             }
 
-            $arguments = $this->funcCallManipulator->extractArgumentsFromCompactFuncCall($node);
+            $arguments = $this->funcCallManipulator->extractArgumentsFromCompactFuncCalls([$node]);
             return $this->nodeNameResolver->isNames($param, $arguments);
         });
     }

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -43,20 +43,27 @@ final class ParamAnalyzer
             }
 
             if ($node instanceof Closure) {
-                foreach ($node->uses as $use) {
-                    if ($this->nodeComparator->areNodesEqual($use->var, $param->var)) {
-                        return true;
-                    }
-                }
+                return $this->isVariableInClosureUses($node, $param->var);
             }
 
             if (! $this->nodeNameResolver->isName($node, 'compact')) {
                 return false;
             }
 
-            $arguments = $this->funcCallManipulator->extractArgumentsFromCompactFuncCalls([$node]);
+            $arguments = $this->funcCallManipulator->extractArgumentsFromCompactFuncCall($node);
             return $this->nodeNameResolver->isNames($param, $arguments);
         });
+    }
+
+    private function isVariableInClosureUses(Closure $closure, Variable $variable): bool
+    {
+        foreach ($closure->uses as $use) {
+            if ($this->nodeComparator->areNodesEqual($use->var, $variable)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -7,20 +7,25 @@ namespace Rector\Core\NodeAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\NodeManipulator\FuncCallManipulator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
+use Rector\NodeNameResolver\NodeNameResolver;
 
 final class ParamAnalyzer
 {
     public function __construct(
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly NodeComparator $nodeComparator,
-        private readonly ValueResolver $valueResolver
+        private readonly ValueResolver $valueResolver,
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly FuncCallManipulator $funcCallManipulator
     ) {
     }
 
@@ -29,7 +34,7 @@ final class ParamAnalyzer
         return (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped($classMethod, function (Node $node) use (
             $param
         ): bool {
-            if (! $node instanceof Variable && ! $node instanceof Closure) {
+            if (! $node instanceof Variable && ! $node instanceof Closure && ! $node instanceof FuncCall) {
                 return false;
             }
 
@@ -37,13 +42,20 @@ final class ParamAnalyzer
                 return $this->nodeComparator->areNodesEqual($node, $param->var);
             }
 
-            foreach ($node->uses as $use) {
-                if ($this->nodeComparator->areNodesEqual($use->var, $param->var)) {
-                    return true;
+            if ($node instanceof Closure) {
+                foreach ($node->uses as $use) {
+                    if ($this->nodeComparator->areNodesEqual($use->var, $param->var)) {
+                        return true;
+                    }
                 }
             }
 
-            return false;
+            if (! $this->nodeNameResolver->isName($node, 'compact')) {
+                return false;
+            }
+
+            $arguments = $this->funcCallManipulator->extractArgumentsFromCompactFuncCalls([$node]);
+            return $this->nodeNameResolver->isNames($param, $arguments);
         });
     }
 

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -55,17 +55,6 @@ final class ParamAnalyzer
         });
     }
 
-    private function isVariableInClosureUses(Closure $closure, Variable $variable): bool
-    {
-        foreach ($closure->uses as $use) {
-            if ($this->nodeComparator->areNodesEqual($use->var, $variable)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /**
      * @param Param[] $params
      */
@@ -96,5 +85,16 @@ final class ParamAnalyzer
     public function hasDefaultNull(Param $param): bool
     {
         return $param->default instanceof ConstFetch && $this->valueResolver->isNull($param->default);
+    }
+
+    private function isVariableInClosureUses(Closure $closure, Variable $variable): bool
+    {
+        foreach ($closure->uses as $use) {
+            if ($this->nodeComparator->areNodesEqual($use->var, $variable)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\NodeManipulator;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
@@ -14,7 +13,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\MethodName;
@@ -27,35 +25,8 @@ final class ClassMethodManipulator
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly NodeComparator $nodeComparator,
-        private readonly FuncCallManipulator $funcCallManipulator,
         private readonly ReflectionResolver $reflectionResolver
     ) {
-    }
-
-    public function isParameterUsedInClassMethod(Param $param, ClassMethod $classMethod): bool
-    {
-        $isUsedDirectly = (bool) $this->betterNodeFinder->findFirst(
-            (array) $classMethod->stmts,
-            fn (Node $node): bool => $this->nodeComparator->areNodesEqual($node, $param->var)
-        );
-
-        if ($isUsedDirectly) {
-            return true;
-        }
-
-        /** @var FuncCall[] $compactFuncCalls */
-        $compactFuncCalls = $this->betterNodeFinder->find((array) $classMethod->stmts, function (Node $node): bool {
-            if (! $node instanceof FuncCall) {
-                return false;
-            }
-
-            return $this->nodeNameResolver->isName($node, 'compact');
-        });
-
-        $arguments = $this->funcCallManipulator->extractArgumentsFromCompactFuncCalls($compactFuncCalls);
-
-        return $this->nodeNameResolver->isNames($param, $arguments);
     }
 
     public function isNamedConstructor(ClassMethod $classMethod): bool

--- a/src/NodeManipulator/FuncCallManipulator.php
+++ b/src/NodeManipulator/FuncCallManipulator.php
@@ -16,22 +16,25 @@ final class FuncCallManipulator
     }
 
     /**
+     * @param FuncCall[] $compactFuncCalls
      * @return string[]
      */
-    public function extractArgumentsFromCompactFuncCall(FuncCall $funcCall): array
+    public function extractArgumentsFromCompactFuncCalls(array $compactFuncCalls): array
     {
         $arguments = [];
-        foreach ($funcCall->args as $arg) {
-            if (! $arg instanceof Arg) {
-                continue;
-            }
+        foreach ($compactFuncCalls as $compactFuncCall) {
+            foreach ($compactFuncCall->args as $arg) {
+                if (! $arg instanceof Arg) {
+                    continue;
+                }
 
-            $value = $this->valueResolver->getValue($arg->value);
-            if ($value === null) {
-                continue;
-            }
+                $value = $this->valueResolver->getValue($arg->value);
+                if ($value === null) {
+                    continue;
+                }
 
-            $arguments[] = $value;
+                $arguments[] = $value;
+            }
         }
 
         return $arguments;

--- a/src/NodeManipulator/FuncCallManipulator.php
+++ b/src/NodeManipulator/FuncCallManipulator.php
@@ -16,25 +16,22 @@ final class FuncCallManipulator
     }
 
     /**
-     * @param FuncCall[] $compactFuncCalls
      * @return string[]
      */
-    public function extractArgumentsFromCompactFuncCalls(array $compactFuncCalls): array
+    public function extractArgumentsFromCompactFuncCall(FuncCall $funcCall): array
     {
         $arguments = [];
-        foreach ($compactFuncCalls as $compactFuncCall) {
-            foreach ($compactFuncCall->args as $arg) {
-                if (! $arg instanceof Arg) {
-                    continue;
-                }
-
-                $value = $this->valueResolver->getValue($arg->value);
-                if ($value === null) {
-                    continue;
-                }
-
-                $arguments[] = $value;
+        foreach ($funcCall->args as $arg) {
+            if (! $arg instanceof Arg) {
+                continue;
             }
+
+            $value = $this->valueResolver->getValue($arg->value);
+            if ($value === null) {
+                continue;
+            }
+
+            $arguments[] = $value;
         }
 
         return $arguments;


### PR DESCRIPTION
The following code should be skipped:

```php
final class SkipUsedInCompact
{
    public $data;

    public function __construct($hey, $man)
    {
        $this->data = compact('hey', 'man');
    }
}
```

ref https://3v4l.org/DMSih