### PR TITLE
[Core][DeadCode] Remove ClassMethodManipulator->isPropertyPromotion()

### DIFF
--- a/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDeadConstructorRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\NodeAnalyzer\ParamAnalyzer;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
@@ -20,7 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveDeadConstructorRector extends AbstractRector
 {
     public function __construct(
-        private readonly ClassMethodManipulator $classMethodManipulator
+        private readonly ClassMethodManipulator $classMethodManipulator,
+        private readonly ParamAnalyzer $paramAnalyzer
     ) {
     }
 
@@ -91,7 +93,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->classMethodManipulator->isPropertyPromotion($classMethod)) {
+        if ($this->paramAnalyzer->hasPropertyPromotion($classMethod->params)) {
             return true;
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\NodeAnalyzer\ParamAnalyzer;
 use Rector\Core\NodeManipulator\ClassMethodManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
@@ -22,7 +23,8 @@ final class RemoveEmptyClassMethodRector extends AbstractRector
 {
     public function __construct(
         private readonly ClassMethodManipulator $classMethodManipulator,
-        private readonly ControllerClassMethodManipulator $controllerClassMethodManipulator
+        private readonly ControllerClassMethodManipulator $controllerClassMethodManipulator,
+        private readonly ParamAnalyzer $paramAnalyzer
     ) {
     }
 
@@ -121,7 +123,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->classMethodManipulator->isPropertyPromotion($classMethod)) {
+        if ($this->paramAnalyzer->hasPropertyPromotion($classMethod->params)) {
             return true;
         }
 

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -105,18 +105,6 @@ final class ClassMethodManipulator
         return $paramName;
     }
 
-    public function isPropertyPromotion(ClassMethod $classMethod): bool
-    {
-        foreach ($classMethod->params as $param) {
-            /** @var Param $param */
-            if ($param->flags !== 0) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /**
      * @param string[] $possibleNames
      */


### PR DESCRIPTION
- The functionality `ClassMethodManipulator->isPropertyPromotion()` is duplicated with `ParamAnalyzer->hasPropertyPromotion()`
- The `isPropertyPromotion()` make assumption that the ClassMethod use all property promotion, while actually, it only check if one of parameters is a property promotion, so I think `hasPropertyPromotion()` is more make sense instead of `isPropertyPromotion`