### PR TITLE
[Core] Handle Previous Stmt not Stmt on UnreachableStmtAnalyzer

### DIFF
--- a/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
+++ b/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
@@ -26,7 +26,7 @@ final class UnreachableStmtAnalyzer
         }
 
         $previousStmt = $stmt->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($previousStmt instanceof Node && ! $stmt instanceof Stmt) {
+        if ($previousStmt instanceof Node && ! $previousStmt instanceof Stmt) {
             return true;
         }
 

--- a/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
+++ b/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
@@ -27,7 +27,7 @@ final class UnreachableStmtAnalyzer
 
         $previousStmt = $stmt->getAttribute(AttributeKey::PREVIOUS_NODE);
         if (! $previousStmt instanceof Node) {
-            return $this->isStmtPHPStanUnreachable($previousStmt);
+            return false;
         }
 
         if ($previousStmt instanceof Stmt) {

--- a/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
+++ b/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
@@ -26,10 +26,12 @@ final class UnreachableStmtAnalyzer
         }
 
         $previousStmt = $stmt->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($previousStmt instanceof Node && ! $previousStmt instanceof Stmt) {
-            return true;
+        if (! $previousStmt instanceof Node) {
+            return $this->isStmtPHPStanUnreachable($previousStmt);
         }
-
-        return $this->isStmtPHPStanUnreachable($previousStmt);
+        if ($previousStmt instanceof Stmt) {
+            return $this->isStmtPHPStanUnreachable($previousStmt);
+        }
+        return true;
     }
 }

--- a/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
+++ b/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
@@ -29,9 +29,11 @@ final class UnreachableStmtAnalyzer
         if (! $previousStmt instanceof Node) {
             return $this->isStmtPHPStanUnreachable($previousStmt);
         }
+
         if ($previousStmt instanceof Stmt) {
             return $this->isStmtPHPStanUnreachable($previousStmt);
         }
+
         return true;
     }
 }

--- a/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
+++ b/src/NodeAnalyzer/UnreachableStmtAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
+use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -25,6 +26,10 @@ final class UnreachableStmtAnalyzer
         }
 
         $previousStmt = $stmt->getAttribute(AttributeKey::PREVIOUS_NODE);
+        if ($previousStmt instanceof Node && ! $stmt instanceof Stmt) {
+            return true;
+        }
+
         return $this->isStmtPHPStanUnreachable($previousStmt);
     }
 }


### PR DESCRIPTION
When previous of Stmt is a Node, but not an Stmt, it means unreachable. I can't reproduce it in tests, but it should handle use case like in https://github.com/rectorphp/rector/issues/7182.

Fixes https://github.com/rectorphp/rector/issues/7182