### PR TITLE
Use yieldDirectoryExclusivelyWithRelativePathname to allow filter by filename

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -94,7 +94,12 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
      */
     protected function yieldFilesFromDirectory(string $directory, string $suffix = '*.php.inc'): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusivelyWithRelativePathname($directory, $suffix);
+        $counter = 0;
+        foreach (\RectorPrefix20220523\Symplify\EasyTesting\DataProvider\StaticFixtureFinder::yieldDirectoryExclusivelyWithRelativePathname($directory, $suffix) as $name => $parameters) {
+            yield '#' . $counter . ' ' . $name => $parameters;
+
+            ++$counter;
+        }
     }
 
     protected function isWindows(): bool

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -94,7 +94,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
      */
     protected function yieldFilesFromDirectory(string $directory, string $suffix = '*.php.inc'): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively($directory, $suffix);
+        return StaticFixtureFinder::yieldDirectoryExclusivelyWithRelativePathname($directory, $suffix);
     }
 
     protected function isWindows(): bool

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -95,7 +95,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
     protected function yieldFilesFromDirectory(string $directory, string $suffix = '*.php.inc'): Iterator
     {
         $counter = 0;
-        foreach (\RectorPrefix20220523\Symplify\EasyTesting\DataProvider\StaticFixtureFinder::yieldDirectoryExclusivelyWithRelativePathname($directory, $suffix) as $name => $parameters) {
+        foreach (StaticFixtureFinder::yieldDirectoryExclusivelyWithRelativePathname($directory, $suffix) as $name => $parameters) {
             yield '#' . $counter . ' ' . $name => $parameters;
 
             ++$counter;


### PR DESCRIPTION
This way it is possible to use e.g.:

```php
vendor/bin/phpunit --filter="user_get_user_name_to_get_user_identifier.php.inc"
```