### PR TITLE
[FamilyTree] Use parent->hasNativeMethod() on ClassChildAnalyzer->resolveParentClassMethods()

### DIFF
--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -92,7 +92,7 @@ final class ClassChildAnalyzer
         $parentClassMethods = [];
         $parents = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
         foreach ($parents as $parent) {
-            if (! $parent->hasMethod($methodName)) {
+            if (! $parent->hasNativeMethod($methodName)) {
                 continue;
             }
 


### PR DESCRIPTION
@hirenkeraliya this should solve https://github.com/rectorphp/rector/issues/7181 as next check is : 

```php
$methodReflection = $parent->getNativeMethod($methodName);
```

which the `has()` check should be check against `NativeMethod()` instead of `Method()`.

Fixes https://github.com/rectorphp/rector/issues/7181