### PR TITLE
Fixture class name fix on original `@inheritDoc` without curly 

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/skip_inherit_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/skip_inherit_doc.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeR
 
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Source\ParentClassWithDefinedReturnSecond;
 
-class SkipCurlyInheritDoc extends ParentClassWithDefinedReturnSecond
+class SkipInheritDoc extends ParentClassWithDefinedReturnSecond
 {
     /**
      * @inheritdoc


### PR DESCRIPTION
Fixture class name fix on original `@inheritDoc` without curly on https://github.com/rectorphp/rector-src/pull/2359