### PR TITLE
[DeadCode] Add TagRemovalGuard for re-use code check that @param/@return allowed to be removed

### DIFF
--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc;
 
-use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\BetterPhpDocParser\ValueObject\PhpDoc\VariadicAwareParamTagValueNode;
-use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
-use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
-use Rector\DeadCode\TypeNodeAnalyzer\GenericTypeNodeAnalyzer;
-use Rector\DeadCode\TypeNodeAnalyzer\MixedArrayTypeNodeAnalyzer;
+use Rector\DeadCode\PhpDoc\Guard\TagRemovalGuard;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 
@@ -29,8 +18,7 @@ final class DeadParamTagValueNodeAnalyzer
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly TypeComparator $typeComparator,
-        private readonly GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer,
-        private readonly MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer
+        private readonly TagRemovalGuard $tagRemovalGuard
     ) {
     }
 
@@ -57,87 +45,7 @@ final class DeadParamTagValueNodeAnalyzer
             return false;
         }
 
-        if (in_array($paramTagValueNode->type::class, PhpDocTypeChanger::ALLOWED_TYPES, true)) {
-            return false;
-        }
-
-        if (! $paramTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
-            return $this->isEmptyDescription($paramTagValueNode, $param->type);
-        }
-
-        if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($paramTagValueNode->type)) {
-            return false;
-        }
-
-        if (! $this->genericTypeNodeAnalyzer->hasGenericType($paramTagValueNode->type)) {
-            return $this->isEmptyDescription($paramTagValueNode, $param->type);
-        }
-
-        return false;
-    }
-
-    private function isEmptyDescription(ParamTagValueNode $paramTagValueNode, Node $node): bool
-    {
-        if ($paramTagValueNode->description !== '') {
-            return false;
-        }
-
-        $parent = $paramTagValueNode->getAttribute(PhpDocAttributeKey::PARENT);
-        if (! $parent instanceof PhpDocTagNode) {
-            return true;
-        }
-
-        $parent = $parent->getAttribute(PhpDocAttributeKey::PARENT);
-        if (! $parent instanceof PhpDocNode) {
-            return true;
-        }
-
-        $children = $parent->children;
-
-        foreach ($children as $key => $child) {
-            if ($child instanceof PhpDocTagNode && $node instanceof FullyQualified) {
-                return $this->isUnionIdentifier($child);
-            }
-
-            if (! $this->isTextNextline($key, $child)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private function isTextNextline(int $key, PhpDocChildNode $phpDocChildNode): bool
-    {
-        if ($key < 1) {
-            return true;
-        }
-
-        if (! $phpDocChildNode instanceof PhpDocTextNode) {
-            return true;
-        }
-
-        return (string) $phpDocChildNode === '';
-    }
-
-    private function isUnionIdentifier(PhpDocTagNode $phpDocTagNode): bool
-    {
-        if (! $phpDocTagNode->value instanceof VariadicAwareParamTagValueNode) {
-            return true;
-        }
-
-        if (! $phpDocTagNode->value->type instanceof BracketsAwareUnionTypeNode) {
-            return true;
-        }
-
-        $types = $phpDocTagNode->value->type->types;
-        foreach ($types as $type) {
-            if ($type instanceof IdentifierTypeNode) {
-                return false;
-            }
-        }
-
-        return true;
+        return $this->tagRemovalGuard->isLegal($paramTagValueNode, $param->type);
     }
 
     private function matchParamByName(string $desiredParamName, FunctionLike $functionLike): ?Param

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -8,13 +8,9 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
-use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\DeadCode\TypeNodeAnalyzer\GenericTypeNodeAnalyzer;
-use Rector\DeadCode\TypeNodeAnalyzer\MixedArrayTypeNodeAnalyzer;
+use Rector\DeadCode\PhpDoc\Guard\TagRemovalGuard;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 
 final class DeadReturnTagValueNodeAnalyzer
@@ -22,8 +18,7 @@ final class DeadReturnTagValueNodeAnalyzer
     public function __construct(
         private readonly TypeComparator $typeComparator,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer,
-        private readonly MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer,
+        private readonly TagRemovalGuard $tagRemovalGuard
     ) {
     }
 
@@ -47,44 +42,6 @@ final class DeadReturnTagValueNodeAnalyzer
             return false;
         }
 
-        if (in_array($returnTagValueNode->type::class, PhpDocTypeChanger::ALLOWED_TYPES, true)) {
-            return false;
-        }
-
-        if (! $returnTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
-            return $returnTagValueNode->description === '';
-        }
-
-        if ($this->genericTypeNodeAnalyzer->hasGenericType($returnTagValueNode->type)) {
-            return false;
-        }
-
-        if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($returnTagValueNode->type)) {
-            return false;
-        }
-
-        if ($this->hasTruePseudoType($returnTagValueNode->type)) {
-            return false;
-        }
-
-        return $returnTagValueNode->description === '';
-    }
-
-    private function hasTruePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
-    {
-        $unionTypes = $bracketsAwareUnionTypeNode->types;
-
-        foreach ($unionTypes as $unionType) {
-            if (! $unionType instanceof IdentifierTypeNode) {
-                continue;
-            }
-
-            $name = strtolower((string) $unionType);
-            if ($name === 'true') {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->tagRemovalGuard->isLegal($returnTagValueNode, $returnType);
     }
 }

--- a/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\DeadCode\PhpDoc;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\Type\UnionType;
+use Rector\DeadCode\PhpDoc\Guard\TagRemovalGuard;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
@@ -15,6 +16,7 @@ final class DeadVarTagValueNodeAnalyzer
     public function __construct(
         private readonly TypeComparator $typeComparator,
         private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly TagRemovalGuard $tagRemovalGuard
     ) {
     }
 
@@ -40,6 +42,6 @@ final class DeadVarTagValueNodeAnalyzer
             return false;
         }
 
-        return $varTagValueNode->description === '';
+        return $this->tagRemovalGuard->isLegal($varTagValueNode, $property->type);
     }
 }

--- a/rules/DeadCode/PhpDoc/Guard/TagRemovalGuard.php
+++ b/rules/DeadCode/PhpDoc/Guard/TagRemovalGuard.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\PhpDoc\Guard;
+
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\BetterPhpDocParser\ValueObject\PhpDoc\VariadicAwareParamTagValueNode;
+use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
+use Rector\DeadCode\TypeNodeAnalyzer\GenericTypeNodeAnalyzer;
+use Rector\DeadCode\TypeNodeAnalyzer\MixedArrayTypeNodeAnalyzer;
+
+final class TagRemovalGuard
+{
+    public function __construct(
+        private readonly MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer,
+        private readonly GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer
+    ) {
+    }
+
+    public function isLegal(ParamTagValueNode|ReturnTagValueNode $tagValueNode, Node $node): bool
+    {
+        if (in_array($tagValueNode->type::class, PhpDocTypeChanger::ALLOWED_TYPES, true)) {
+            return false;
+        }
+
+        if (! $tagValueNode->type instanceof BracketsAwareUnionTypeNode) {
+            return $this->isEmptyDescription($tagValueNode, $node);
+        }
+
+        if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($tagValueNode->type)) {
+            return false;
+        }
+
+        if ($this->hasTruePseudoType($tagValueNode->type)) {
+            return false;
+        }
+
+        if ($this->genericTypeNodeAnalyzer->hasGenericType($tagValueNode->type)) {
+            return false;
+        }
+
+        return $this->isEmptyDescription($tagValueNode, $node);
+    }
+
+    private function hasTruePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
+    {
+        $unionTypes = $bracketsAwareUnionTypeNode->types;
+
+        foreach ($unionTypes as $unionType) {
+            if (! $unionType instanceof IdentifierTypeNode) {
+                continue;
+            }
+
+            $name = strtolower((string) $unionType);
+            if ($name === 'true') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isEmptyDescription(ParamTagValueNode|ReturnTagValueNode $tagValueNode, Node $node): bool
+    {
+        if ($tagValueNode->description !== '') {
+            return false;
+        }
+
+        $parent = $tagValueNode->getAttribute(PhpDocAttributeKey::PARENT);
+        if (! $parent instanceof PhpDocTagNode) {
+            return true;
+        }
+
+        $parent = $parent->getAttribute(PhpDocAttributeKey::PARENT);
+        if (! $parent instanceof PhpDocNode) {
+            return true;
+        }
+
+        $children = $parent->children;
+
+        foreach ($children as $key => $child) {
+            if ($child instanceof PhpDocTagNode && $node instanceof FullyQualified) {
+                return $this->isUnionIdentifier($child);
+            }
+
+            if (! $this->isTextNextline($key, $child)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isUnionIdentifier(PhpDocTagNode $phpDocTagNode): bool
+    {
+        if (! $phpDocTagNode->value instanceof VariadicAwareParamTagValueNode) {
+            return true;
+        }
+
+        if (! $phpDocTagNode->value->type instanceof BracketsAwareUnionTypeNode) {
+            return true;
+        }
+
+        $types = $phpDocTagNode->value->type->types;
+        foreach ($types as $type) {
+            if ($type instanceof IdentifierTypeNode) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isTextNextline(int $key, PhpDocChildNode $phpDocChildNode): bool
+    {
+        if ($key < 1) {
+            return true;
+        }
+
+        if (! $phpDocChildNode instanceof PhpDocTextNode) {
+            return true;
+        }
+
+        return (string) $phpDocChildNode === '';
+    }
+}

--- a/rules/DeadCode/PhpDoc/Guard/TagRemovalGuard.php
+++ b/rules/DeadCode/PhpDoc/Guard/TagRemovalGuard.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\VariadicAwareParamTagValueNode;
@@ -28,7 +29,7 @@ final class TagRemovalGuard
     ) {
     }
 
-    public function isLegal(ParamTagValueNode|ReturnTagValueNode $tagValueNode, Node $node): bool
+    public function isLegal(ParamTagValueNode|ReturnTagValueNode|VarTagValueNode $tagValueNode, Node $node): bool
     {
         if (in_array($tagValueNode->type::class, PhpDocTypeChanger::ALLOWED_TYPES, true)) {
             return false;


### PR DESCRIPTION
Reduce duplicating check on param/return check that may overlapped by creating a new service: `TagRemovalGuard`