### PR TITLE
Update the branch alias for dev-main

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -16,7 +16,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.12-dev"
+            "dev-main": "0.13-dev"
         }
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,7 @@
         },
         "enable-patching": true,
         "branch-alias": {
-            "dev-main": "0.12-dev"
+            "dev-main": "0.13-dev"
         }
     },
     "config": {


### PR DESCRIPTION
Else `^0.13@dev` will not install dev-main only `0.13.0` (currently).