### PR TITLE
[DowngradePhp81] Handle crash parent Arg is missing scope on DowngradeFirstClassCallableSyntaxRector

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -100,7 +100,6 @@ final class PHPStanNodeScopeResolver
             &$nodeCallback,
             $isScopeRefreshing
         ): void {
-
             if ($node instanceof Arg) {
                 $node->value->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Name;
@@ -99,6 +100,11 @@ final class PHPStanNodeScopeResolver
             &$nodeCallback,
             $isScopeRefreshing
         ): void {
+
+            if ($node instanceof Arg) {
+                $node->value->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+            }
+
             if ($node instanceof Foreach_) {
                 // decorate value as well
                 $node->valueVar->setAttribute(AttributeKey::SCOPE, $mutatingScope);

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector/Fixture/func_call_in_arg.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector/Fixture/func_call_in_arg.php.inc
@@ -31,8 +31,7 @@ class SomeClass
     public function run(string $file)
     {
         try {
-            $validateSchema = \Closure::fromCallable(array($this, 'validateSchema'));
-            $dom = XmlUtils::loadFile($file, $validateSchema);
+            $dom = XmlUtils::loadFile($file, \Closure::fromCallable([$this, 'validateSchema']));
         } catch (Exception) {}
     }
 

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector/Fixture/func_call_in_arg.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector/Fixture/func_call_in_arg.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallabl
 use Exception;
 use Symfony\Component\Config\Util\XmlUtils;
 
-class SomeClass
+class FuncCallInArg
 {
     public function run(string $file)
     {
@@ -26,7 +26,7 @@ namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallabl
 use Exception;
 use Symfony\Component\Config\Util\XmlUtils;
 
-class SomeClass
+class FuncCallInArg
 {
     public function run(string $file)
     {

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector/Fixture/func_call_in_arg.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector/Fixture/func_call_in_arg.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallableSyntaxRector\Fixture;
+
+use Exception;
+use Symfony\Component\Config\Util\XmlUtils;
+
+class SomeClass
+{
+    public function run(string $file)
+    {
+        try {
+            $dom = XmlUtils::loadFile($file, $this->validateSchema(...));
+        } catch (Exception) {}
+    }
+
+    private function validateSchema(...$args) {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallableSyntaxRector\Fixture;
+
+use Exception;
+use Symfony\Component\Config\Util\XmlUtils;
+
+class SomeClass
+{
+    public function run(string $file)
+    {
+        try {
+            $validateSchema = \Closure::fromCallable(array($this, 'validateSchema'));
+            $dom = XmlUtils::loadFile($file, $validateSchema);
+        } catch (Exception) {}
+    }
+
+    private function validateSchema(...$args) {}
+}
+
+?>


### PR DESCRIPTION
Given the following code:

```php
use Exception;
use Symfony\Component\Config\Util\XmlUtils;

class SomeClass
{
    public function run(string $file)
    {
        try {
            $validateSchema = \Closure::fromCallable(array($this, 'validateSchema'));
            $dom = XmlUtils::loadFile($file, $validateSchema);
        } catch (Exception) {}
    }

    private function validateSchema(...$args) {}
}
```

currently cause crash:

```bash
There was 1 error:

1) Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallableSyntaxRector\DowngradeFirstClassCallableSyntaxRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Node "PhpParser\Node\Expr\StaticCall" with parent of "PhpParser\Node\Arg" is missing scope required for scope refresh.
```

ref https://github.com/rectorphp/rector/issues/7193