### PR TITLE
[DX] Remove "--working-dir" option as not compatible with parallel run, better handle via CI working-dir options

### DIFF
--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -82,11 +82,6 @@ final class Option
     public const CLEAR_CACHE = 'clear-cache';
 
     /**
-     * @var string
-     */
-    public const WORKING_DIR = 'working-dir';
-
-    /**
      * @deprecated Use @see \Rector\Config\RectorConfig::parallel() instead
      * @var string
      */

--- a/src/Console/ConsoleApplication.php
+++ b/src/Console/ConsoleApplication.php
@@ -9,7 +9,6 @@ use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\Core\Application\VersionResolver;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Console\Command\ProcessCommand;
-use Rector\Core\Exception\Configuration\InvalidConfigurationException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -48,18 +47,6 @@ final class ConsoleApplication extends Application
 
         $shouldFollowByNewline = false;
 
-        // switch working dir
-        $newWorkDir = $this->getNewWorkingDir($input);
-        if ($newWorkDir !== '') {
-            $oldWorkingDir = getcwd();
-            chdir($newWorkDir);
-
-            if ($output->isDebug()) {
-                $message = sprintf('Changed working directory from "%s" to "%s"', $oldWorkingDir, getcwd());
-                $output->writeln($message);
-            }
-        }
-
         // skip in this case, since generate content must be clear from meta-info
         if ($this->shouldPrintMetaInformation($input)) {
             $output->writeln($this->getLongVersion());
@@ -81,17 +68,6 @@ final class ConsoleApplication extends Application
         $this->addCustomOptions($defaultInputDefinition);
 
         return $defaultInputDefinition;
-    }
-
-    private function getNewWorkingDir(InputInterface $input): string
-    {
-        $workingDir = $input->getParameterOption('--working-dir');
-        if (is_string($workingDir) && ! is_dir($workingDir)) {
-            $errorMessage = sprintf('Invalid working directory specified, "%s" does not exist.', $workingDir);
-            throw new InvalidConfigurationException($errorMessage);
-        }
-
-        return (string) $workingDir;
     }
 
     private function shouldPrintMetaInformation(InputInterface $input): bool
@@ -148,13 +124,6 @@ final class ConsoleApplication extends Application
             null,
             InputOption::VALUE_NONE,
             'Clear cache'
-        ));
-
-        $inputDefinition->addOption(new InputOption(
-            Option::WORKING_DIR,
-            null,
-            InputOption::VALUE_REQUIRED,
-            'If specified, use the given directory as working directory.'
         ));
     }
 


### PR DESCRIPTION
Added in https://github.com/rectorphp/rector-src/commit/4a13ed538729b6f7e98ac31de91b294d1b18ec93

## The Troubles

This option should help to move Rector to directory, where project is located. This is very helpful in case of downgrades, where Retcor is typically located outside the project in parent directory.

The issue is, Rector is running in parallel and is passing `--working-dir` just partially. The nested worker command does not have exact informatin about it's parent script, and is misslocated.

That leads to errors like this:

![image](https://user-images.githubusercontent.com/924196/170883771-36e0d288-a254-4d65-b8fa-0835509801ed.png)

To fix this behavior, we have to move from juggling directory instead Rector to direct paths and CI support.

<br>



## How to upgrade?

Instead of using `--working-dir` options, use exact paths to downgrade and add `-a` with autoload option for `vendor/autoload.php`, see:

* https://github.com/symplify/symplify/commit/237eef8cf6dafda9f8de502cbaeb1a476f481051

Another option is to make use of `working-dir` in Github Actions: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun