### PR TITLE
[Scoped] Wait 2 minutes before build when create a tag

### DIFF
--- a/.github/workflows/alternate_build_scoped_rector.yaml
+++ b/.github/workflows/alternate_build_scoped_rector.yaml
@@ -22,6 +22,14 @@ jobs:
         timeout-minutes: 20
 
         steps:
+            # sometime, when 2 or more consecutive PRs merged, the checkout rectorphp/rector-src is overlapped
+            # and reverting other commit change
+            # this should not happen on create a tag, so wait first
+            -
+                name: "Wait before checkout rectorphp/rector-src on create a tag"
+                if: "startsWith(github.ref, 'refs/tags/')"
+                run: sleep 120
+
             -
                 uses: actions/checkout@v3
                 with:


### PR DESCRIPTION
build scoped sometime overlapped when 2-more consecutive PR merged. This mirror previous handling on build scope workflow to keep it behaviour so overlapped commit can be avoided when create a tag.