### PR TITLE
[Core] Fix bootstrap stubs load on PHP 7.2 when vendor/ excluded via skip()

### DIFF
--- a/build/target-repository/.github/workflows/e2e_php72.yaml
+++ b/build/target-repository/.github/workflows/e2e_php72.yaml
@@ -1,6 +1,3 @@
-# This workflow runs system tests: Use the Rector application from the source
-# checkout to process "fixture" projects in tests/system-tests
-# to see if those can be processed successfully
 name: End to End tests on PHP 7.2
 
 on:

--- a/build/target-repository/.github/workflows/e2e_php72.yaml
+++ b/build/target-repository/.github/workflows/e2e_php72.yaml
@@ -1,0 +1,36 @@
+# This workflow runs system tests: Use the Rector application from the source
+# checkout to process "fixture" projects in tests/system-tests
+# to see if those can be processed successfully
+name: End to End tests on PHP 7.2
+
+on:
+    pull_request: null
+    push:
+        branches:
+            - main
+
+jobs:
+    end_to_end_on_php72:
+        runs-on: ubuntu-latest
+
+        name: End to end test - PHP 7.2 with load ReflectionUnionType stub
+
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "7.2"
+                    coverage: none
+
+            # wait for deploy to packagist
+            -   run: sleep 70
+
+            -
+                run: composer install --ansi
+                working-directory: e2e/reflection-union-php72
+
+            -
+                run: vendor/bin/rector process --ansi
+                working-directory: e2e/reflection-union-php72
+

--- a/build/target-repository/.github/workflows/e2e_php72.yaml
+++ b/build/target-repository/.github/workflows/e2e_php72.yaml
@@ -30,4 +30,3 @@ jobs:
             -
                 run: vendor/bin/rector process --ansi
                 working-directory: e2e/reflection-union-php72
-

--- a/build/target-repository/e2e/reflection-union-php72/composer.json
+++ b/build/target-repository/e2e/reflection-union-php72/composer.json
@@ -1,0 +1,11 @@
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "require": {
+        "php": "7.2.*",
+        "rector/rector": "dev-main"
+    }
+}

--- a/build/target-repository/e2e/reflection-union-php72/rector.php
+++ b/build/target-repository/e2e/reflection-union-php72/rector.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src'
+    ]);
+
+    $rectorConfig->skip([
+        __DIR__ . '/vendor',
+    ]);
+};

--- a/build/target-repository/e2e/reflection-union-php72/src/foo.php
+++ b/build/target-repository/e2e/reflection-union-php72/src/foo.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+class Foo {
+
+    /**
+     * @param \DateTime|\DateTimeImmutable $date
+     * @return string
+     */
+    public function bar($date) {
+        return $date->format('C');
+    }
+}

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Core\Autoloading;
 
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\FileSystem\FilesFinder;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Throwable;
 use Webmozart\Assert\Assert;
@@ -57,7 +56,7 @@ final class BootstrapFilesIncluder
             return;
         }
 
-        $dir   = new RecursiveDirectoryIterator($stubsRectorDirectory, RecursiveDirectoryIterator::SKIP_DOTS);
+        $dir = new RecursiveDirectoryIterator($stubsRectorDirectory, RecursiveDirectoryIterator::SKIP_DOTS);
         $stubs = new RecursiveIteratorIterator($dir);
 
         foreach ($stubs as $stub) {

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\Core\Autoloading;
 
-use SplFileInfo;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Exception\ShouldNotHappenException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use SplFileInfo;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Throwable;
 use Webmozart\Assert\Assert;

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Autoloading;
 
+use SplFileInfo;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Exception\ShouldNotHappenException;
 use RecursiveDirectoryIterator;
@@ -57,6 +58,7 @@ final class BootstrapFilesIncluder
         }
 
         $dir = new RecursiveDirectoryIterator($stubsRectorDirectory, RecursiveDirectoryIterator::SKIP_DOTS);
+        /** @var SplFileInfo[] $stubs */
         $stubs = new RecursiveIteratorIterator($dir);
 
         foreach ($stubs as $stub) {

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Core\Autoloading;
 
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\FileSystem\FilesFinder;
@@ -14,8 +16,7 @@ use Webmozart\Assert\Assert;
 final class BootstrapFilesIncluder
 {
     public function __construct(
-        private readonly ParameterProvider $parameterProvider,
-        private readonly FilesFinder $filesFinder
+        private readonly ParameterProvider $parameterProvider
     ) {
     }
 
@@ -56,9 +57,11 @@ final class BootstrapFilesIncluder
             return;
         }
 
-        $stubs = $this->filesFinder->findInDirectoriesAndFiles([$stubsRectorDirectory], ['php']);
+        $dir   = new RecursiveDirectoryIterator($stubsRectorDirectory, RecursiveDirectoryIterator::SKIP_DOTS);
+        $stubs = new RecursiveIteratorIterator($dir);
+
         foreach ($stubs as $stub) {
-            require_once $stub->getRealPath();
+            require_once $stub;
         }
     }
 }

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -60,7 +60,7 @@ final class BootstrapFilesIncluder
         $stubs = new RecursiveIteratorIterator($dir);
 
         foreach ($stubs as $stub) {
-            require_once $stub;
+            require_once $stub->getRealPath();
         }
     }
 }


### PR DESCRIPTION
@TomasVotruba this is to fix issue that only happen in PHP 7.2, which can make error:

```bash
"Child process error: PHP Fatal error:  Class 'ReflectionUnionType' not found
```

while working on PHP 7.3 and PHP 7.4. Reproduced repository : 

https://github.com/Micr0mega/rector-issue-7196/runs/6651988104?check_suite_focus=true#step:5:10
         
/cc @Micr0mega

Fixes https://github.com/rectorphp/rector/issues/7196