### PR TITLE
[PHP 8.2] Skip readonly class on property without type in ReadOnlyClassRector

### DIFF
--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/skip_missing_promoted_property_type.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/skip_missing_promoted_property_type.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final class SkipMissingPromotedPropertyType
+{
+    public function __construct(
+        private readonly $promotedProperty
+    ) {
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/skip_missing_property_type.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/skip_missing_property_type.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final class SkipMissingPropertyType
+{
+   private readonly $property;
+}

--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/skip_static_properties.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/skip_static_properties.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final class SkipStaticProperties
+{
+   private static string $property;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/924196/171163102-27733f22-dc5a-4323-be2f-0ccfc460b337.png)

See https://wiki.php.net/rfc/readonly_classes#restrictions