### PR TITLE
[TypeDeclaration] Skip parent in vendor on ReturnTypeDeclarationRector

### DIFF
--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -21,6 +21,7 @@ use Rector\Core\Reflection\ReflectionResolver;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 
 final class ClassMethodReturnTypeOverrideGuard
 {
@@ -37,7 +38,8 @@ final class ClassMethodReturnTypeOverrideGuard
         private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly AstResolver $astResolver,
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
     ) {
     }
 
@@ -55,6 +57,10 @@ final class ClassMethodReturnTypeOverrideGuard
 
         $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
         if (! $classReflection instanceof ClassReflection) {
+            return true;
+        }
+
+        if (! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed($classMethod)) {
             return true;
         }
 

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_parent_in_vendor_no_return_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_parent_in_vendor_no_return_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source\vendor\ExternalParentNoReturnType;
+use stdClass;
+
+final class SkipParentInVendorNoReturnType extends ExternalParentNoReturnType
+{
+    public function run()
+    {
+        return new stdClass;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/vendor/ExternalParentNoReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/vendor/ExternalParentNoReturnType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Source\vendor;
+
+use stdClass;
+
+class ExternalParentNoReturnType
+{
+    public function run()
+    {
+        return new stdClass;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7207

Handled with `ParentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed()` with check like the following:

```
         *
         *     - both in /vendor/ -> allowed
         *     - one of them in /vendor/ -> not allowed
         *     - both not in /vendor/ -> allowed
```

https://3v4l.org/Rc0RF#v8.0.13