### PR TITLE
[DeadCode][PHPUnit] handle crash on RemoveJustPropertyFetchForAssignRector+SimplifyForeachInstanceOfRector

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\MutatingScope;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\Core\NodeAnalyzer\UnreachableStmtAnalyzer;
@@ -67,6 +68,10 @@ final class ChangedNodeScopeRefresher
             // we'll have to fake-traverse 2 layers up, as PHPStan skips Scope for AttributeGroups and consequently Attributes
             $attributeGroup = new AttributeGroup([$node]);
             $node = new Property(0, [], [], null, [$attributeGroup]);
+        }
+
+        if ($node instanceof StmtsAwareInterface && $node->stmts !== null) {
+            $node->stmts = array_values($node->stmts);
         }
 
         $stmts = $this->resolveStmts($node);

--- a/tests/Issues/UndefinedStmtIndex/Fixture/fixture.php.inc
+++ b/tests/Issues/UndefinedStmtIndex/Fixture/fixture.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\UndefinedStmtIndex\Fixture;
+
+class Fixture
+{
+    public function fetchIdentities(array $data, array $identities)
+    {
+        $mappedUsers = [];
+        foreach ($identities as $id) {
+            $array = $mappedUsers[$id->user_id]->identities;
+            $array[] = $id;
+            $mappedUsers[$id->user_id]->identities = $array;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\UndefinedStmtIndex\Fixture;
+
+class Fixture
+{
+    public function fetchIdentities(array $data, array $identities)
+    {
+        $mappedUsers = [];
+        foreach ($identities as $id) {
+            $mappedUsers[$id->user_id]->identities[] = $id;
+        }
+    }
+}
+
+?>

--- a/tests/Issues/UndefinedStmtIndex/UndefinedStmtIndexTest.php
+++ b/tests/Issues/UndefinedStmtIndex/UndefinedStmtIndexTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\UndefinedStmtIndex;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class UndefinedStmtIndexTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/UndefinedStmtIndex/config/configured_rule.php
+++ b/tests/Issues/UndefinedStmtIndex/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\StmtsAwareInterface\RemoveJustPropertyFetchForAssignRector;
+use Rector\PHPUnit\Rector\Foreach_\SimplifyForeachInstanceOfRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveJustPropertyFetchForAssignRector::class);
+    $rectorConfig->rule(SimplifyForeachInstanceOfRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
class Fixture
{
    public function fetchIdentities(array $data, array $identities)
    {
        $mappedUsers = [];
        foreach ($identities as $id) {
            $array = $mappedUsers[$id->user_id]->identities;
            $array[] = $id;
            $mappedUsers[$id->user_id]->identities = $array;
        }
    }
}
```

it currently make crash:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\UndefinedStmtIndex\UndefinedStmtIndexTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Undefined array key 0

/Users/samsonasik/www/rector-src/src/NodeManipulator/ForeachManipulator.php:22
```

Applied rules:

```
Rector\DeadCode\Rector\StmtsAwareInterface\RemoveJustPropertyFetchForAssignRector;
Rector\PHPUnit\Rector\Foreach_\SimplifyForeachInstanceOfRector;
```

Fixes https://github.com/rectorphp/rector/issues/7219
Fixes https://github.com/rectorphp/rector/issues/7211