### PR TITLE
[Php72] Handle crash on PreInc usage on CreateFunctionToAnonymousFunctionRector

### DIFF
--- a/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/use_increment.php.inc
+++ b/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/use_increment.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
+
+class UseIncrement
+{
+    private array $_quoteIdentifierCallbacks = array();
+    private int $_qiCallbacksCount = 0;
+
+    public function getQuoteIdentifierCallback($adapter)
+    {
+        $callback = create_function('$v', 'return Mage::helper(\'customgrid/collection\')->callQuoteIdentifier($v, '.++$this->_qiCallbacksCount.');');
+    }
+
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
+
+class UseIncrement
+{
+    private array $_quoteIdentifierCallbacks = array();
+    private int $_qiCallbacksCount = 0;
+
+    public function getQuoteIdentifierCallback($adapter)
+    {
+        $callback = function ($v) {
+            return Mage::helper('customgrid/collection')->callQuoteIdentifier($v, ++$this->_qiCallbacksCount);
+        };
+    }
+
+}
+
+?>

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -85,6 +85,7 @@ final class InlineCodeParser
         if ($expr instanceof Concat) {
             return $this->stringify($expr->left) . $this->stringify($expr->right);
         }
+
         return $this->nodePrinter->print($expr);
     }
 }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -91,7 +91,7 @@ final class InlineCodeParser
             return $this->stringify($expr->left) . $this->stringify($expr->right);
         }
 
-        if ($expr instanceof Variable || $expr instanceof PropertyFetch || $expr instanceof StaticPropertyFetch) {
+        if ($expr instanceof Expr) {
             return $this->nodePrinter->print($expr);
         }
 

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -7,15 +7,10 @@ namespace Rector\Core\PhpParser\Parser;
 use Nette\Utils\Strings;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
-use PhpParser\Parser;
 use Rector\Core\Contract\PhpParser\NodePrinterInterface;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Util\StringUtils;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 use Symplify\SmartFileSystem\SmartFileSystem;
@@ -90,11 +85,6 @@ final class InlineCodeParser
         if ($expr instanceof Concat) {
             return $this->stringify($expr->left) . $this->stringify($expr->right);
         }
-
-        if ($expr instanceof Expr) {
-            return $this->nodePrinter->print($expr);
-        }
-
-        throw new ShouldNotHappenException($expr::class . ' ' . __METHOD__);
+        return $this->nodePrinter->print($expr);
     }
 }


### PR DESCRIPTION
Given the following code:

```bash
class UseIncrement
{
    private array $_quoteIdentifierCallbacks = array();
    private int $_qiCallbacksCount = 0;

    public function getQuoteIdentifierCallback($adapter)
    {
         $callback = create_function('$v', 'return Mage::helper(\'customgrid/collection\')->callQuoteIdentifier($v, '.++$this->_qiCallbacksCount.');');
    }

}
```

It currently make crash:

```bash
There was 1 error:

1) Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\CreateFunctionToAnonymousFunctionRectorTest::test with data set #3 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: PhpParser\Node\Expr\PreInc Rector\Core\PhpParser\Parser\InlineCodeParser::stringify
```

This PR try to fix it .

Fixes https://github.com/rectorphp/rector/issues/7216