### PR TITLE
[Core] Ensure re-index node attributes (stmts, params, uses, args) on ChangedNodeScopeRefresher

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -82,11 +82,7 @@ final class ChangedNodeScopeRefresher
 
     private function reIndexNodeAttributes(Node $node): void
     {
-        if ($node instanceof StmtsAwareInterface && $node->stmts !== null) {
-            $node->stmts = array_values($node->stmts);
-        }
-
-        if ($node instanceof ClassLike) {
+        if ($node instanceof ClassLike || ($node instanceof StmtsAwareInterface && $node->stmts !== null)) {
             $node->stmts = array_values($node->stmts);
         }
 

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -8,7 +8,11 @@ use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\MutatingScope;
@@ -70,12 +74,32 @@ final class ChangedNodeScopeRefresher
             $node = new Property(0, [], [], null, [$attributeGroup]);
         }
 
+        $this->reIndexNodeAttributes($node);
+
+        $stmts = $this->resolveStmts($node);
+        $this->phpStanNodeScopeResolver->processNodes($stmts, $smartFileInfo, $mutatingScope);
+    }
+
+    private function reIndexNodeAttributes(Node $node): void
+    {
         if ($node instanceof StmtsAwareInterface && $node->stmts !== null) {
             $node->stmts = array_values($node->stmts);
         }
 
-        $stmts = $this->resolveStmts($node);
-        $this->phpStanNodeScopeResolver->processNodes($stmts, $smartFileInfo, $mutatingScope);
+        if ($node instanceof ClassLike) {
+            $node->stmts = array_values($node->stmts);
+        }
+
+        if ($node instanceof FunctionLike) {
+            $node->params = array_values($node->params);
+            if ($node instanceof Closure) {
+                $node->uses = array_values($node->uses);
+            }
+        }
+
+        if ($node instanceof CallLike) {
+            $node->args = array_values($node->args);
+        }
     }
 
     /**

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -10,10 +10,17 @@ use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\MutatingScope;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
@@ -82,18 +89,21 @@ final class ChangedNodeScopeRefresher
 
     private function reIndexNodeAttributes(Node $node): void
     {
-        if ($node instanceof ClassLike || ($node instanceof StmtsAwareInterface && $node->stmts !== null)) {
+        if (($node instanceof ClassLike || $node instanceof StmtsAwareInterface) && $node->stmts !== null) {
             $node->stmts = array_values($node->stmts);
         }
 
         if ($node instanceof FunctionLike) {
+            /** @var ClassMethod|Function_|Closure $node */
             $node->params = array_values($node->params);
+
             if ($node instanceof Closure) {
                 $node->uses = array_values($node->uses);
             }
         }
 
         if ($node instanceof CallLike) {
+            /** @var FuncCall|MethodCall|New_|NullsafeMethodCall|StaticCall $node */
             $node->args = array_values($node->args);
         }
     }


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2453, this PR ensure re-index node attributes (stmts, params, uses, args) on ClassLike, FunctionLike, CallLike