### PR TITLE
[Php70] Handle crash on EregToPregMatchRector

### DIFF
--- a/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/fixture5.php.inc
+++ b/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/fixture5.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\FuncCall\EregToPregMatchRector\Fixture;
+
+function eregToPregMatch5()
+{
+    ereg_replace('[^0-9.-]', ' ', 'le 09.78-95 65/02');
+
+}
+
+?>
+    -----
+<?php
+
+namespace Rector\Tests\Php70\Rector\FuncCall\EregToPregMatchRector\Fixture;
+
+function eregToPregMatch5()
+{
+    preg_replace('/[^0-9.-]/', ' ', 'le 09.78-95 65/02');
+
+}
+
+?>

--- a/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/fixture5.php.inc
+++ b/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/fixture5.php.inc
@@ -9,14 +9,14 @@ function eregToPregMatch5()
 }
 
 ?>
-    -----
+-----
 <?php
 
 namespace Rector\Tests\Php70\Rector\FuncCall\EregToPregMatchRector\Fixture;
 
 function eregToPregMatch5()
 {
-    preg_replace('/[^0-9.-]/', ' ', 'le 09.78-95 65/02');
+    preg_replace('#[^0-9\.\-]#m', ' ', 'le 09.78-95 65/02');
 
 }
 

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -247,7 +247,7 @@ final class EregToPcreTransformer
 
                 if ($i < $l && $s[$i] === '-') {
                     $b = $s[++$i];
-                    ++$i;
+
                     if ($b === ']') {
                         $cls .= $this->_ere2pcre_escape($a) . '\-';
                         break;
@@ -257,6 +257,8 @@ final class EregToPcreTransformer
                     }
 
                     $cls .= $this->_ere2pcre_escape($a) . '-' . $this->_ere2pcre_escape($b);
+
+                    ++$i;
                 } else {
                     $cls .= $this->_ere2pcre_escape($a);
                 }


### PR DESCRIPTION
Given the following code:

```php
ereg_replace('[^0-9.-]', ' ', 'le 09.78-95 65/02');
```

It cause error:

```bash
"System error: ""[" does not have a matching "]"" 
```

This PR fix it.

Closes #2459 
Fixes https://github.com/rectorphp/rector/issues/7217

