### PR TITLE
Fix const fetch node

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
@@ -6,6 +6,7 @@ namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
 use PhpParser\Node\Name;
+use PhpParser\Node\Expr\ConstFetch;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\NullType;
@@ -53,6 +54,6 @@ final class NullTypeMapper implements TypeMapperInterface
             return null;
         }
 
-        return new Name('null');
+        return new ConstFetch(new Name('null'));
     }
 }


### PR DESCRIPTION
I updated my rector set against the newest version and a test is always failing.

```
Undefined property: PhpParser\Node\Name::$name

phar:///Users/shyim/Code/shopware-rector/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/ArgumentsNormalizer.php:58
phar:///Users/shyim/Code/shopware-rector/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/ArgumentsNormalizer.php:40
phar:///Users/shyim/Code/shopware-rector/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:2277
phar:///Users/shyim/Code/shopware-rector/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:1999
phar:///Users/shyim/Code/shopware-rector/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:512
phar:///Users/shyim/Code/shopware-rector/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:296
/Users/shyim/Code/shopware-rector/vendor/rector/rector/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:213
/Users/shyim/Code/shopware-rector/vendor/rector/rector/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:204
```

It looks like the null node is wrong crafted. After changing it to constfetch like php-parse it shows for a parsed file. It works again


```
array(
    0: Stmt_Expression(
        expr: Expr_FuncCall(
            name: Name(
                parts: array(
                    0: test
                )
            )
            args: array(
                0: Arg(
                    name: null
                    value: Expr_ConstFetch(
                        name: Name(
                            parts: array(
                                0: null
                            )
                        )
                    )
                    byRef: false
                    unpack: false
                )
            )
        )
    )
)
```