### PR TITLE
Use phpstan/phpdoc-parser 1.5.* to avoid space removal

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -47,7 +47,9 @@ jobs:
 
             # test with current commit in a pull-request
             -
-                run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
+                run: |
+                    composer require phpstan/phpdoc-parser:1.5.* --no-update
+                    composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
                 if: ${{ github.event_name == 'pull_request' }}
 
             -   run: composer install --ansi

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "nette/utils": "^3.2.7",
         "nikic/php-parser": "^4.14.0",
         "ondram/ci-detector": "^4.1",
-        "phpstan/phpdoc-parser": "^1.5.1",
+        "phpstan/phpdoc-parser": "1.5.*",
         "phpstan/phpstan": "^1.7.10",
         "phpstan/phpstan-phpunit": "^1.1",
         "react/child-process": "^0.6.4",


### PR DESCRIPTION
phpdoc-parser 1.6.0 seems cause invalid content:

```diff
 final class CallbackWithCuryBraces
 {
     /**
-     * @Assert\Choice(callback={"Some\Other\Random\Class_", "getChoices"})
-     */
+     * @Assert\Choice(callback={"Some\Other\Random\Class_", "getChoices"})*/
```

This PR pin to `"phpstan/phpdoc-parser": "1.5.*"`