### PR TITLE
[Core] Fix phpstan/phpdoc-parser whitespace on ^1.6.0 by set requireWhitespaceBeforeDescription to true

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -47,9 +47,7 @@ jobs:
 
             # test with current commit in a pull-request
             -
-                run: |
-                    composer require phpstan/phpdoc-parser:1.5.* --no-update
-                    composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
+                run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
                 if: ${{ github.event_name == 'pull_request' }}
 
             -   run: composer install --ansi

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "nette/utils": "^3.2.7",
         "nikic/php-parser": "^4.14.0",
         "ondram/ci-detector": "^4.1",
-        "phpstan/phpdoc-parser": "1.5.*",
+        "phpstan/phpdoc-parser": "^1.6.0",
         "phpstan/phpstan": "^1.7.10",
         "phpstan/phpstan-phpunit": "^1.1",
         "react/child-process": "^0.6.4",

--- a/packages/BetterPhpDocParser/PhpDocNodeMapper.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeMapper.php
@@ -14,7 +14,7 @@ use Symplify\Astral\PhpDocParser\PhpDocNodeVisitor\ParentConnectingPhpDocNodeVis
 
 /**
  * @see \Rector\Tests\BetterPhpDocParser\PhpDocNodeMapperTest
- */
+ * @see \Rector\Tests\BetterPhpDocParser\PhpDocNodeMapperTest*/
 final class PhpDocNodeMapper
 {
     /**

--- a/packages/BetterPhpDocParser/PhpDocParser/BetterPhpDocParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/BetterPhpDocParser.php
@@ -40,7 +40,7 @@ final class BetterPhpDocParser extends PhpDocParser
         private readonly array $phpDocNodeDecorators,
         private readonly PrivatesCaller $privatesCaller = new PrivatesCaller(),
     ) {
-        parent::__construct($typeParser, $constExprParser);
+        parent::__construct($typeParser, $constExprParser, true);
     }
 
     public function parse(TokenIterator $tokenIterator): PhpDocNode

--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
@@ -10,7 +10,7 @@ use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 
 /**
  * @see \Rector\Tests\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParserTest
- */
+ * @see \Rector\Tests\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParserTest*/
 final class ArrayParser
 {
     public function __construct(

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -14,7 +14,7 @@ use Symplify\SmartFileSystem\SmartFileInfo;
  * Inspired by https://github.com/symplify/symplify/pull/90/files#diff-72041b2e1029a08930e13d79d298ef11
  *
  * @see \Rector\Tests\Caching\Detector\ChangedFilesDetectorTest
- */
+ * @see \Rector\Tests\Caching\Detector\ChangedFilesDetectorTest*/
 final class ChangedFilesDetector
 {
     public function __construct(

--- a/packages/ChangesReporting/Annotation/AnnotationExtractor.php
+++ b/packages/ChangesReporting/Annotation/AnnotationExtractor.php
@@ -10,7 +10,7 @@ use ReflectionClass;
 
 /**
  * @see \Rector\Tests\ChangesReporting\Annotation\AnnotationExtractorTest
- */
+ * @see \Rector\Tests\ChangesReporting\Annotation\AnnotationExtractorTest*/
 final class AnnotationExtractor
 {
     /**

--- a/packages/NodeCollector/BinaryOpConditionsCollector.php
+++ b/packages/NodeCollector/BinaryOpConditionsCollector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Expr\BinaryOp;
 
 /**
  * @see \Rector\Tests\NodeCollector\BinaryOpConditionsCollectorTest
- */
+ * @see \Rector\Tests\NodeCollector\BinaryOpConditionsCollectorTest*/
 final class BinaryOpConditionsCollector
 {
     /**

--- a/packages/NodeCollector/BinaryOpTreeRootLocator.php
+++ b/packages/NodeCollector/BinaryOpTreeRootLocator.php
@@ -11,7 +11,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * @see \Rector\Tests\NodeCollector\BinaryOpTreeRootLocatorTest
- */
+ * @see \Rector\Tests\NodeCollector\BinaryOpTreeRootLocatorTest*/
 final class BinaryOpTreeRootLocator
 {
     /**

--- a/packages/NodeNameResolver/Regex/RegexPatternDetector.php
+++ b/packages/NodeNameResolver/Regex/RegexPatternDetector.php
@@ -11,8 +11,7 @@ final class RegexPatternDetector
     /**
      * @var string[]
      *
-     * This prevents miss matching like "aMethoda"
-     */
+     * This prevents miss matching like "aMethoda"*/
     private const POSSIBLE_DELIMITERS = ['#', '~', '/'];
 
     public function isRegexPattern(string $name): bool

--- a/packages/NodeTypeResolver/TypeComparator/ArrayTypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/ArrayTypeComparator.php
@@ -14,7 +14,7 @@ use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeCommonTypeNarrower;
 
 /**
  * @see \Rector\Tests\NodeTypeResolver\TypeComparator\ArrayTypeComparatorTest
- */
+ * @see \Rector\Tests\NodeTypeResolver\TypeComparator\ArrayTypeComparatorTest*/
 final class ArrayTypeComparator
 {
     public function __construct(

--- a/packages/NodeTypeResolver/TypeComparator/ScalarTypeComparator.php
+++ b/packages/NodeTypeResolver/TypeComparator/ScalarTypeComparator.php
@@ -13,7 +13,7 @@ use PHPStan\Type\Type;
 
 /**
  * @see \Rector\Tests\NodeTypeResolver\TypeComparator\ScalarTypeComparatorTest
- */
+ * @see \Rector\Tests\NodeTypeResolver\TypeComparator\ScalarTypeComparatorTest*/
 final class ScalarTypeComparator
 {
     public function areEqualScalar(Type $firstType, Type $secondType): bool

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
@@ -35,6 +35,7 @@ use Symfony\Contracts\Service\Attribute\Required;
  * @see \Rector\Tests\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapperTest
  *
  * @implements TypeMapperInterface<ArrayType>
+ * @see \Rector\Tests\PHPStanStaticTypeMapper\TypeMapper\ArrayTypeMapperTest
  */
 final class ArrayTypeMapper implements TypeMapperInterface
 {

--- a/packages/PhpAttribute/UseAliasNameMatcher.php
+++ b/packages/PhpAttribute/UseAliasNameMatcher.php
@@ -12,7 +12,7 @@ use Rector\PhpAttribute\ValueObject\UseAliasMetadata;
 
 /**
  * @see \Rector\Tests\PhpAttribute\UseAliasNameMatcherTest
- */
+ * @see \Rector\Tests\PhpAttribute\UseAliasNameMatcherTest*/
 final class UseAliasNameMatcher
 {
     /**

--- a/packages/StaticTypeMapper/PhpDoc/PhpDocTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDoc/PhpDocTypeMapper.php
@@ -13,7 +13,7 @@ use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 
 /**
  * @see \Rector\Tests\StaticTypeMapper\PhpDoc\PhpDocTypeMapperTest
- */
+ * @see \Rector\Tests\StaticTypeMapper\PhpDoc\PhpDocTypeMapperTest*/
 final class PhpDocTypeMapper
 {
     /**

--- a/rules/DowngradePhp71/Rector/ClassConst/DowngradeClassConstantVisibilityRector.php
+++ b/rules/DowngradePhp71/Rector/ClassConst/DowngradeClassConstantVisibilityRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://wiki.php.net/rfc/class_const_visibility
  *
  * @see \Rector\Tests\DowngradePhp71\Rector\ClassConst\DowngradeClassConstantVisibilityRectorTest
- */
+ * @see \Rector\Tests\DowngradePhp71\Rector\ClassConst\DowngradeClassConstantVisibilityRectorTest*/
 final class DowngradeClassConstantVisibilityRector extends AbstractRector
 {
     public function __construct(

--- a/rules/Naming/Naming/PropertyNaming.php
+++ b/rules/Naming/Naming/PropertyNaming.php
@@ -25,7 +25,7 @@ use Rector\StaticTypeMapper\ValueObject\Type\SelfObjectType;
  * @todo merge with very similar logic in
  * @see VariableNaming
  * @see \Rector\Tests\Naming\Naming\PropertyNamingTest
- */
+ * @see \Rector\Tests\Naming\Naming\PropertyNamingTest*/
 final class PropertyNaming
 {
     /**
@@ -123,11 +123,7 @@ final class PropertyNaming
         }
 
         $className = $this->resolveClassName($objectType);
-        if (str_contains($className, '\\')) {
-            $shortClassName = (string) Strings::after($className, '\\', -1);
-        } else {
-            $shortClassName = $className;
-        }
+        $shortClassName = str_contains($className, '\\') ? (string) Strings::after($className, '\\', -1) : $className;
 
         $variableName = $this->removeInterfaceSuffixPrefix($shortClassName, 'interface');
         $variableName = $this->removeInterfaceSuffixPrefix($variableName, 'abstract');

--- a/rules/PSR4/Composer/PSR4NamespaceMatcher.php
+++ b/rules/PSR4/Composer/PSR4NamespaceMatcher.php
@@ -12,7 +12,7 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
  * @see \Rector\Tests\PSR4\Composer\PSR4NamespaceMatcherTest
- */
+ * @see \Rector\Tests\PSR4\Composer\PSR4NamespaceMatcherTest*/
 final class PSR4NamespaceMatcher implements PSR4AutoloadNamespaceMatcherInterface
 {
     public function __construct(

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -11,7 +11,7 @@ use Rector\Php70\Exception\InvalidEregException;
  * @changelog https://gist.github.com/lifthrasiir/704754/7e486f43e62fd1c9d3669330c251f8ca4a59a3f8
  *
  * @see \Rector\Tests\Php70\EregToPcreTransformerTest
- */
+ * @see \Rector\Tests\Php70\EregToPcreTransformerTest*/
 final class EregToPcreTransformer
 {
     /**

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -14,7 +14,7 @@ use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Privatization\NodeManipulator\VisibilityManipulatorTest
- */
+ * @see \Rector\Tests\Privatization\NodeManipulator\VisibilityManipulatorTest*/
 final class VisibilityManipulator
 {
     public function hasVisibility(Class_ | ClassMethod | Property | ClassConst | Param $node, int $visibility): bool

--- a/rules/TypeDeclaration/TypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeNormalizer.php
@@ -20,7 +20,7 @@ use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
 
 /**
  * @see \Rector\Tests\TypeDeclaration\TypeNormalizerTest
- */
+ * @see \Rector\Tests\TypeDeclaration\TypeNormalizerTest*/
 final class TypeNormalizer
 {
     /**

--- a/src/Application/VersionResolver.php
+++ b/src/Application/VersionResolver.php
@@ -12,7 +12,7 @@ use Rector\Core\Exception\VersionException;
  * See https://github.com/composer/composer/blob/6587715d0f8cae0cd39073b3bc5f018d0e6b84fe/src/Composer/Compiler.php#L208
  *
  * @see \Rector\Core\Tests\Application\VersionResolverTest
- */
+ * @see \Rector\Core\Tests\Application\VersionResolverTest*/
 final class VersionResolver
 {
     /**

--- a/src/Exclusion/ExclusionManager.php
+++ b/src/Exclusion/ExclusionManager.php
@@ -19,7 +19,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * @see \Rector\Core\Tests\Exclusion\ExclusionManagerTest
- */
+ * @see \Rector\Core\Tests\Exclusion\ExclusionManagerTest*/
 final class ExclusionManager
 {
     /**

--- a/src/NodeManipulator/ClassInsertManipulator.php
+++ b/src/NodeManipulator/ClassInsertManipulator.php
@@ -66,8 +66,7 @@ final class ClassInsertManipulator
     }
 
     /**
-     * @internal Use PropertyAdder service instead
-     */
+     * @internal Use PropertyAdder service instead*/
     public function addPropertyToClass(Class_ $class, string $name, ?Type $type): void
     {
         $existingProperty = $class->getProperty($name);

--- a/src/Php/PhpVersionProvider.php
+++ b/src/Php/PhpVersionProvider.php
@@ -15,7 +15,7 @@ use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 /**
  * @see \Rector\Core\Tests\Php\PhpVersionProviderTest
- */
+ * @see \Rector\Core\Tests\Php\PhpVersionProviderTest*/
 final class PhpVersionProvider
 {
     /**

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -67,7 +67,7 @@ use Symplify\Astral\ValueObject\NodeBuilder\PropertyBuilder;
 
 /**
  * @see \Rector\Core\Tests\PhpParser\Node\NodeFactoryTest
- */
+ * @see \Rector\Core\Tests\PhpParser\Node\NodeFactoryTest*/
 final class NodeFactory
 {
     /**

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -28,7 +28,7 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 
 /**
  * @see \Rector\Core\Tests\PhpParser\Node\Value\ValueResolverTest
- */
+ * @see \Rector\Core\Tests\PhpParser\Node\Value\ValueResolverTest*/
 final class ValueResolver
 {
     private ?ConstExprEvaluator $constExprEvaluator = null;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -37,6 +37,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  * @see \Rector\Core\Tests\PhpParser\Printer\BetterStandardPrinterTest
  *
  * @property array<string, array{string, bool, string, null}> $insertionMap
+ * @see \Rector\Core\Tests\PhpParser\Printer\BetterStandardPrinterTest
  */
 final class BetterStandardPrinter extends Standard implements NodePrinterInterface
 {

--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -14,7 +14,7 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 
 /**
  * @see \Rector\Core\Tests\PhpParser\Printer\FormatPerservingPrinterTest
- */
+ * @see \Rector\Core\Tests\PhpParser\Printer\FormatPerservingPrinterTest*/
 final class FormatPerservingPrinter
 {
     public function __construct(

--- a/src/Validation/RectorAssert.php
+++ b/src/Validation/RectorAssert.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * @see \Rector\Core\Tests\Validation\RectorAssertTest
- */
+ * @see \Rector\Core\Tests\Validation\RectorAssertTest*/
 final class RectorAssert
 {
     /**

--- a/tests/PhpParser/Node/Value/ValueResolverTest.php
+++ b/tests/PhpParser/Node/Value/ValueResolverTest.php
@@ -24,8 +24,7 @@ final class ValueResolverTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider dataProvider
-     */
+     * @dataProvider dataProvider*/
     public function test(Expr $expr, string | bool | int | float | null $expectedValue): void
     {
         $resolvedValue = $this->valueResolver->getValue($expr);


### PR DESCRIPTION
@TomasVotruba I found it, it needs to be set to true.