### PR TITLE
Update packages-tests github action to use latest phpdoc-parser

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -47,9 +47,7 @@ jobs:
 
             # test with current commit in a pull-request
             -
-                run: |
-                    composer require phpstan/phpdoc-parser:1.5.* --no-update
-                    composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
+                run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
                 if: ${{ github.event_name == 'pull_request' }}
 
             -   run: composer install --ansi

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "phpstan/phpstan": "^1.7.10"
+        "phpstan/phpstan": "^1.7.12"
     },
     "autoload": {
         "files": [

--- a/rules/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector.php
+++ b/rules/CodeQuality/Rector/Array_/ArrayThisCallToThisMethodCallRector.php
@@ -120,8 +120,8 @@ CODE_SAMPLE
             return new MethodCall(new Variable('this'), $arrayCallable->getMethod());
         }
 
-        $methodReflection = $classReflection->getNativeMethod($arrayCallable->getMethod());
-        return $this->nodeFactory->createClosureFromMethodReflection($methodReflection);
+        $extendedMethodReflection = $classReflection->getNativeMethod($arrayCallable->getMethod());
+        return $this->nodeFactory->createClosureFromMethodReflection($extendedMethodReflection);
     }
 
     private function isAssignedToNetteMagicOnProperty(Array_ $array): bool

--- a/rules/DeadCode/Comparator/CurrentAndParentClassMethodComparator.php
+++ b/rules/DeadCode/Comparator/CurrentAndParentClassMethodComparator.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\VariadicPlaceholder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\Exception\ShouldNotHappenException;
@@ -138,26 +138,26 @@ final class CurrentAndParentClassMethodComparator
             throw new ShouldNotHappenException();
         }
 
-        $parentMethodReflection = $classReflection->getMethod($methodName, $scope);
+        $extendedMethodReflection = $classReflection->getMethod($methodName, $scope);
 
         // 3rd party code
-        if (! $parentMethodReflection->isPrivate() && ! $parentMethodReflection->isPublic() && $classMethod->isPublic()) {
+        if (! $extendedMethodReflection->isPrivate() && ! $extendedMethodReflection->isPublic() && $classMethod->isPublic()) {
             return true;
         }
 
-        if ($parentMethodReflection->isInternal()->yes()) {
+        if ($extendedMethodReflection->isInternal()->yes()) {
             // we can't know for certain so we assume its a override with purpose
             return true;
         }
 
-        return $this->areParameterDefaultsDifferent($classMethod, $parentMethodReflection);
+        return $this->areParameterDefaultsDifferent($classMethod, $extendedMethodReflection);
     }
 
     private function areParameterDefaultsDifferent(
         ClassMethod $classMethod,
-        MethodReflection $methodReflection
+        ExtendedMethodReflection $extendedMethodReflection
     ): bool {
-        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($extendedMethodReflection->getVariants());
 
         foreach ($parametersAcceptor->getParameters() as $key => $parameterReflection) {
             if (! isset($classMethod->params[$key])) {


### PR DESCRIPTION
it was temporary pin to use phpstan/phpdoc-parser:1.5.* to fix github action packages tests. This PR remove it to allow use latest phpdoc-parser.