### PR TITLE
[TypeDeclaration] Skip generic on ReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/generic_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/generic_return.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+class AbstractController 
+{
+    private readonly UseCaseBusInterface $useCaseBus;
+
+    /**
+     * @template T
+     *
+     * @param UseCaseInterface<T> $useCase
+     *
+     * @return T
+     */
+    protected function execute(UseCaseInterface $useCase): mixed
+    {
+        return $this->useCaseBus->execute($useCase);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_generic.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_generic.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-class AbstractController 
+class SkipGeneric
 {
     private readonly UseCaseBusInterface $useCaseBus;
 

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_generic.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_generic.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\Fixture;
+
 class SkipGeneric
 {
     private readonly UseCaseBusInterface $useCaseBus;

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -21,6 +21,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\StaticTypeMapper\ValueObject\Type\NonExistingObjectType;
 use Rector\TypeDeclaration\PhpDocParser\NonInformativeReturnTagRemover;
 use Rector\TypeDeclaration\PhpParserTypeAnalyzer;
 use Rector\TypeDeclaration\TypeAlreadyAddedChecker\ReturnTypeAlreadyAddedChecker;
@@ -109,7 +110,7 @@ CODE_SAMPLE
             [ReturnTypeDeclarationReturnTypeInfererTypeInferer::class]
         );
 
-        if ($inferedReturnType instanceof MixedType) {
+        if ($inferedReturnType instanceof MixedType || $inferedReturnType instanceof NonExistingObjectType) {
             return null;
         }
 


### PR DESCRIPTION
It detected as NonExistingObjectType

Closes #2454 
Fixes https://github.com/rectorphp/rector/issues/721