### PR TITLE
[DeadCode] Skip has return reassign Coalesce Op on RemoveUnusedPrivatePropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_has_return_reassign_when_empty.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_has_return_reassign_when_empty.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+use stdClass;
+
+final class SkipHasReturnReassignWhenEmpty
+{
+    private array $data = [];
+
+    public function init(string $key, stdClass $stdClass): void
+    {
+        $this->data[$key] = $stdClass;
+    }
+
+    public function execute(string $key)
+    {
+        return $this->data[$key] ??= new stdClass();
+    }
+}

--- a/rules/Removing/NodeManipulator/ComplexNodeRemover.php
+++ b/rules/Removing/NodeManipulator/ComplexNodeRemover.php
@@ -46,11 +46,13 @@ final class ComplexNodeRemover
     ): bool {
         $propertyName = $this->nodeNameResolver->getName($property);
         $totalPropertyFetch = $this->propertyFetchAnalyzer->countLocalPropertyFetchName($class, $propertyName);
+        $expressions = [];
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($class->stmts, function (Node $node) use (
             $removeAssignSideEffect,
             $propertyName,
-            &$totalPropertyFetch
+            &$totalPropertyFetch,
+            &$expressions
         ): ?Node {
             // here should be checked all expr like stmts that can hold assign, e.f. if, foreach etc. etc.
             if (! $node instanceof Expression) {
@@ -93,8 +95,7 @@ final class ComplexNodeRemover
             }
 
             if ($totalPropertyFetch < $currentTotalPropertyFetch) {
-                $this->nodeRemover->removeNode($node);
-                return $node;
+                $expressions[] = $node;
             }
 
             return null;
@@ -107,6 +108,7 @@ final class ComplexNodeRemover
 
         $this->removeConstructorDependency($class, $propertyName);
 
+        $this->nodeRemover->removeNodes($expressions);
         $this->nodeRemover->removeNode($property);
 
         return true;


### PR DESCRIPTION
Given the following code:

```php
final class SkipHasReturnReassignWhenEmpty
{
    private array $data = [];

    public function init(string $key, stdClass $stdClass): void
    {
        $this->data[$key] = $stdClass;
    }

    public function execute(string $key)
    {
        return $this->data[$key] ??= new stdClass();
    }
}
```

Currently remove first assign:

```diff
     public function init(string $key, stdClass $stdClass): void
     {
-        $this->data[$key] = $stdClass;
```

which should be skipped. This PR try to fix it.