### PR TITLE
Add failing test fixture for FormBuilderSetDataMapperRector

### DIFF
--- a/rules-tests/Symfony/Rector/MethodCall/FormBuilderSetDataMapperRector/Fixture/skip_this_data_mapper.php.inc
+++ b/rules-tests/Symfony/Rector/MethodCall/FormBuilderSetDataMapperRector/Fixture/skip_this_data_mapper.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+namespace Rector\Tests\Symfony\Rector\MethodCall\FormBuilderSetDataMapperRector\Fixture;
+
+final class SkipThisDataMapper extends AbstractType implements DataMapperInterface
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email')
+            ->setDataMapper($this);
+    }
+}


### PR DESCRIPTION
Related to https://github.com/rectorphp/rector/issues/7233

# Failing Test for FormBuilderSetDataMapperRector

Based on https://getrector.org/demo/3d11ee3d-0763-4be0-a942-a8797391d9ae