### PR TITLE
[Core][DeadCode] Skip remove Node as Stmt when has @phpstan-ignore-next-line on DeadCode rules

### DIFF
--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\NodeRemoval;
 
 use PhpParser\Comment;
-use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
@@ -21,7 +20,6 @@ use Rector\ChangesReporting\Collector\RectorChangeCollector;
 use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Logging\CurrentRectorProvider;
-use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Collector\NodesToRemoveCollector;
 
@@ -44,9 +42,7 @@ final class NodeRemover
             return;
         }
 
-        $currentRector = $this->currentRectorProvider->getCurrentRector();
-        if ($node instanceof Stmt && $currentRector instanceof PhpRectorInterface && str_starts_with($currentRector::class, 'Rector\DeadCode')) {
-
+        if ($this->shouldCheckPHPStanIgnoreNextLine($node)) {
             /**
              * Check single line comment,eg:
              *
@@ -162,5 +158,14 @@ final class NodeRemover
         $this->rectorChangeCollector->notifyNodeFileInfo($class->implements[$key]);
 
         unset($class->implements[$key]);
+    }
+
+    private function shouldCheckPHPStanIgnoreNextLine(Node $node): bool
+    {
+        $currentRector = $this->currentRectorProvider->getCurrentRector();
+        return $node instanceof Stmt && $currentRector instanceof PhpRectorInterface && str_starts_with(
+            $currentRector::class,
+            'Rector\DeadCode'
+        );
     }
 }

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -18,7 +18,10 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\ChangesReporting\Collector\RectorChangeCollector;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\Logging\CurrentRectorProvider;
+use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Collector\NodesToRemoveCollector;
 
@@ -27,7 +30,8 @@ final class NodeRemover
     public function __construct(
         private readonly NodesToRemoveCollector $nodesToRemoveCollector,
         private readonly RectorChangeCollector $rectorChangeCollector,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly CurrentRectorProvider $currentRectorProvider
     ) {
     }
 
@@ -40,7 +44,9 @@ final class NodeRemover
             return;
         }
 
-        if ($node instanceof Stmt) {
+        $currentRector = $this->currentRectorProvider->getCurrentRector();
+        if ($node instanceof Stmt && $currentRector instanceof PhpRectorInterface && ! str_contains($currentRector::class, 'Downgrade')) {
+
             /**
              * Check single line comment,eg:
              *

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -51,9 +51,11 @@ final class NodeRemover
                 if (! $comment instanceof Doc) {
                     continue;
                 }
+
                 if ($comment->getText() !== '// @phpstan-ignore-next-line') {
                     continue;
                 }
+
                 return;
             }
 

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeRemoval;
 
+use PhpParser\Comment;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
@@ -48,15 +49,13 @@ final class NodeRemover
             $comments = $node->getAttribute(AttributeKey::COMMENTS) ?? [];
 
             foreach ($comments as $comment) {
-                if (! $comment instanceof Doc) {
+                if (! $comment instanceof Comment) {
                     continue;
                 }
 
-                if ($comment->getText() !== '// @phpstan-ignore-next-line') {
-                    continue;
+                if ($comment->getText() === '// @phpstan-ignore-next-line') {
+                    return;
                 }
-
-                return;
             }
 
             # Check multi lines comments, eg:

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -48,9 +48,13 @@ final class NodeRemover
             $comments = $node->getAttribute(AttributeKey::COMMENTS) ?? [];
 
             foreach ($comments as $comment) {
-                if ($comment instanceof Doc && $comment->getText() === '// @phpstan-ignore-next-line') {
-                    return;
+                if (! $comment instanceof Doc) {
+                    continue;
                 }
+                if ($comment->getText() !== '// @phpstan-ignore-next-line') {
+                    continue;
+                }
+                return;
             }
 
             # Check multi lines comments, eg:

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -45,7 +45,7 @@ final class NodeRemover
         }
 
         $currentRector = $this->currentRectorProvider->getCurrentRector();
-        if ($node instanceof Stmt && $currentRector instanceof PhpRectorInterface && ! str_contains($currentRector::class, 'Downgrade')) {
+        if ($node instanceof Stmt && $currentRector instanceof PhpRectorInterface && str_starts_with($currentRector::class, 'Rector\DeadCode')) {
 
             /**
              * Check single line comment,eg:

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeRemoval;
 
+use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
@@ -47,7 +48,7 @@ final class NodeRemover
             $comments = $node->getAttribute(AttributeKey::COMMENTS) ?? [];
 
             foreach ($comments as $comment) {
-                if ($comment->getText() === '// @phpstan-ignore-next-line') {
+                if ($comment instanceof Doc && $comment->getText() === '// @phpstan-ignore-next-line') {
                     return;
                 }
             }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_use_phpstan_ignore_next_line.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_use_phpstan_ignore_next_line.php.inc
@@ -12,7 +12,7 @@ final class SkipUsePhpstanIgnoreNextLine
     /**
      * @phpstan-ignore-next-line
      */
-    public function run()
+    public function run2()
     {
     }
 }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_use_phpstan_ignore_next_line.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_use_phpstan_ignore_next_line.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+final class SkipUsePhpstanIgnoreNextLine
+{
+    // @phpstan-ignore-next-line
+    public function run()
+    {
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     */
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp70/Rector/Declare_/DowngradeStrictTypeDeclarationRector/Fixture/with_phpstan_ignore_next_line.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/Declare_/DowngradeStrictTypeDeclarationRector/Fixture/with_phpstan_ignore_next_line.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\Declare_\DowngradeStrictTypeDeclarationRector\Fixture;
+
+// @phpstan-ignore-next-line
+declare(strict_types=1);
+
+class Fixture
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\Declare_\DowngradeStrictTypeDeclarationRector\Fixture;
+
+class Fixture
+{
+}
+
+?>


### PR DESCRIPTION
Rector is based on phpstan, so if phpstan mark the statement as ignored to be check, I think the stmt should not be removed, eg:

```php
final class SkipUsePhpstanIgnoreNextLine
{
    // @phpstan-ignore-next-line
    public function run()
    {
    }

    /**
     * @phpstan-ignore-next-line
     */
    public function run2()
    {
    }
}
```

with applied rule : `RemoveEmptyClassMethodRector`, it should be skipped.