### PR TITLE
[PSR4] Handle invalid missing ; on NormalizeNamespaceByPSR4ComposerAutoloadRector with GroupUse

### DIFF
--- a/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/group_use_class.php.inc
+++ b/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/group_use_class.php.inc
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Foo\Bar\{ SomeLongClass as SomeClass };
 use Foo\Bar\{ SomeLongClass2 };
-class AliasedUsed
+class GroupUseClass
 {
     public function someMethod()
     {
@@ -25,7 +25,7 @@ namespace Rector\Tests\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4
 
 use Foo\Bar\{SomeLongClass as SomeClass};
 use Foo\Bar\{SomeLongClass2};
-class AliasedUsed
+class GroupUseClass
 {
     public function someMethod()
     {

--- a/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/group_use_with_alias.php.inc
+++ b/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/group_use_with_alias.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Foo\Bar\{ SomeLongClass as SomeClass };
+class AliasedUsed
+{
+    public function someMethod()
+    {
+        new SomeClass;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector\Fixture;
+
+use Foo\Bar\{SomeLongClass as SomeClass};
+class AliasedUsed
+{
+    public function someMethod()
+    {
+        new \Foo\Bar\SomeLongClass;
+    }
+}

--- a/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/group_use_with_alias.php.inc
+++ b/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/group_use_with_alias.php.inc
@@ -3,11 +3,17 @@
 declare(strict_types=1);
 
 use Foo\Bar\{ SomeLongClass as SomeClass };
+use Foo\Bar\{ SomeLongClass2 };
 class AliasedUsed
 {
     public function someMethod()
     {
         new SomeClass;
+    }
+
+    public function someMethod2()
+    {
+        new SomeLongClass2;
     }
 }
 
@@ -18,10 +24,16 @@ class AliasedUsed
 namespace Rector\Tests\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector\Fixture;
 
 use Foo\Bar\{SomeLongClass as SomeClass};
+use Foo\Bar\{SomeLongClass2};
 class AliasedUsed
 {
     public function someMethod()
     {
         new \Foo\Bar\SomeLongClass;
+    }
+
+    public function someMethod2()
+    {
+        new \Foo\Bar\SomeLongClass2;
     }
 }

--- a/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/use_class.php.inc
+++ b/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/Fixture/use_class.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Foo\Bar\SomeLongClass as SomeClass;
+use Foo\Bar\SomeLongClass2;
+class UseClass
+{
+    public function someMethod()
+    {
+        new SomeClass;
+    }
+
+    public function someMethod2()
+    {
+        new SomeLongClass2;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector\Fixture;
+
+use Foo\Bar\SomeLongClass as SomeClass;
+use Foo\Bar\SomeLongClass2;
+class UseClass
+{
+    public function someMethod()
+    {
+        new \Foo\Bar\SomeLongClass;
+    }
+
+    public function someMethod2()
+    {
+        new \Foo\Bar\SomeLongClass2;
+    }
+}

--- a/rules/PSR4/NodeManipulator/FullyQualifyStmtsAnalyzer.php
+++ b/rules/PSR4/NodeManipulator/FullyQualifyStmtsAnalyzer.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\GroupUse;
-use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
 use PHPStan\Reflection\Constant\RuntimeConstantReflection;
 use PHPStan\Reflection\ReflectionProvider;

--- a/rules/PSR4/NodeManipulator/FullyQualifyStmtsAnalyzer.php
+++ b/rules/PSR4/NodeManipulator/FullyQualifyStmtsAnalyzer.php
@@ -9,6 +9,9 @@ use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
 use PHPStan\Reflection\Constant\RuntimeConstantReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\Configuration\Option;
@@ -50,6 +53,16 @@ final class FullyQualifyStmtsAnalyzer
             }
 
             if ($this->isNativeConstant($node)) {
+                return null;
+            }
+
+            $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+            if ($parent instanceof GroupUse) {
+                $parent->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                return null;
+            }
+
+            if ($parent instanceof UseUse) {
                 return null;
             }
 


### PR DESCRIPTION
Given the following code:

```php
use Foo\Bar\{ SomeLongClass as SomeClass };
class GroupUseClass
{
    public function someMethod()
    {
        new SomeClass;
    }
}
```

it produce:

```diff
-use Foo\Bar\{ SomeLongClass as SomeClass };
+use \Foo\Bar\{ \SomeLongClass as SomeClass }
```

which :

- add `\` in name in group use
- remove `;`, that cause error:

```bash
Parse error: syntax error, unexpected fully qualified name "\SomeLongClass", expecting identifier or namespaced name or "function" or "const" in /in/qlefX on line 3
```

this PR try to fix it.