### PR TITLE
[Core] Ensure clone $node before remove comment on NodeComparator::printWithoutComments()

### DIFF
--- a/packages/Comments/CommentRemover.php
+++ b/packages/Comments/CommentRemover.php
@@ -29,8 +29,8 @@ final class CommentRemover
         $nodes = $node instanceof Node
             ? [$node]
             : $node;
-        $copiedNodes = array_map(fn (Node $node): Node => clone $node, $nodes);
+        $clonedNodes = array_map(fn (Node $node): Node => clone $node, $nodes);
 
-        return $this->commentRemovingNodeTraverser->traverse($copiedNodes);
+        return $this->commentRemovingNodeTraverser->traverse($clonedNodes);
     }
 }

--- a/packages/Comments/CommentRemover.php
+++ b/packages/Comments/CommentRemover.php
@@ -26,9 +26,11 @@ final class CommentRemover
             return null;
         }
 
-        $copiedNodes = $node;
+        $nodes = $node instanceof Node
+            ? [$node]
+            : $node;
+        $copiedNodes = array_map(fn (Node $node): Node => clone $node, $nodes);
 
-        $nodes = is_array($copiedNodes) ? $copiedNodes : [$copiedNodes];
-        return $this->commentRemovingNodeTraverser->traverse($nodes);
+        return $this->commentRemovingNodeTraverser->traverse($copiedNodes);
     }
 }

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -22,8 +22,8 @@ final class NodeComparator
      */
     public function printWithoutComments(Node | array | null $node): string
     {
-        $nodeWithCommentRemoved = $this->commentRemover->removeFromNode($node);
-        $content = $this->nodePrinter->print($nodeWithCommentRemoved);
+        $nodeWithoutComment = $this->commentRemover->removeFromNode($node);
+        $content = $this->nodePrinter->print($nodeWithoutComment);
 
         return trim($content);
     }

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -22,9 +22,7 @@ final class NodeComparator
      */
     public function printWithoutComments(Node | array | null $node): string
     {
-        $nodeWithoutComment = $this->commentRemover->removeFromNode($node);
-        $content = $this->nodePrinter->print($nodeWithoutComment);
-
+        $content = $this->nodePrinter->print($this->commentRemover->removeFromNode($node));
         return trim($content);
     }
 

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -22,8 +22,8 @@ final class NodeComparator
      */
     public function printWithoutComments(Node | array | null $node): string
     {
-        $node = $this->commentRemover->removeFromNode($node);
-        $content = $this->nodePrinter->print($node);
+        $nodeWithCommentRemoved = $this->commentRemover->removeFromNode($node);
+        $content = $this->nodePrinter->print($nodeWithCommentRemoved);
 
         return trim($content);
     }


### PR DESCRIPTION
The `NodeComparator::printWithoutComments()` which used by `NodeComparator::areNodesEqual()` is calling `CommentRemover::removeFromNode()` which copies Node before remove the comments to be used for printing compare.

This PR use cloned object instead of copied object.

This is to avoid possible docblock removed during comparison that handled at PR use case:

- https://github.com/rectorphp/rector-src/pull/2439

which previously comparing `Namespace_` Node cause docblock inside the `Namespace_` removed because of using of : 

```php
$this->nodeComparator->areNodesEqual($originalNode, $namespace)
```