### PR TITLE
[Experiment][Core] Remove AbstractScopeAwareRector check on RectifiedAnalyzer

### DIFF
--- a/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
@@ -60,15 +60,15 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
             $lastFuncCallNode = $activeFuncCallNode;
         }
 
-        // nothing to improve
-        if ($this->nestingLevel < 2) {
-            return $activeFuncCallNode;
+        if ($this->nestingLevel >= 2) {
+            $node->args[0] = $lastFuncCallNode->args[0];
+            $node->args[1] = new Arg(new LNumber($this->nestingLevel));
+
+            return $node;
         }
 
-        $node->args[0] = $lastFuncCallNode->args[0];
-        $node->args[1] = new Arg(new LNumber($this->nestingLevel));
-
-        return $node;
+        // nothing to improve
+        return null;
     }
 
     public function provideMinPhpVersion(): int

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
-use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\RectifiedNode;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -58,11 +56,6 @@ final class RectifiedAnalyzer
              * allow to revisit the Node with same Rector rule if Node is changed by other rule
              */
             return ! $this->nodeComparator->areNodesEqual($originalNode, $node);
-        }
-
-        if ($rector instanceof AbstractScopeAwareRector) {
-            $scope = $node->getAttribute(AttributeKey::SCOPE);
-            return $scope instanceof Scope;
         }
 
         if ($originalNode instanceof Node) {


### PR DESCRIPTION
Currently, there is still check: 

https://github.com/rectorphp/rector-src/blob/ef4267ebf048e96aa600823d92e92d5b6abd7c5f/src/ProcessAnalyzer/RectifiedAnalyzer.php#L63-L66

in `RectifiedAnalyzer` service for multiple rules applied to a file which make `Scope` gone, running it in the current src, will got error:

```bash
bin/rector process rules/Php70/Rector/FuncCall/MultiDirnameRector.php --dry-run --clear-cache     
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [ERROR] Could not process "rules/Php70/Rector/FuncCall/MultiDirnameRector.php" file, due to:                           
         "System error: "Scope not available on "PhpParser\Node\Expr\Assign" node with parent node of                   
         "PhpParser\Node\Stmt\Expression", but is required by a refactorWithScope() method of                           
         "Rector\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector" rule. Fix scope refresh on   
         changed nodes first"                                                                                           
         Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new". On 
         line: 36       
```

ref https://github.com/rectorphp/rector-src/runs/6864215117?check_suite_focus=true#step:6:16

This PR try to fix it.