### PR TITLE
[Php70] Refactor MultiDirnameRector by moving nestingLevel check to separate method

### DIFF
--- a/full_build.sh
+++ b/full_build.sh
@@ -35,7 +35,13 @@ sh build/build-rector-scoped.sh rector-build rector-prefixed-downgraded
 
 # verify syntax valid in php 7.2
 composer global require php-parallel-lint/php-parallel-lint
-~/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/contracts/Cache --exclude rector-prefixed-downgraded/vendor/symfony/contracts/HttpClient/Test
+
+if test -z ${PHP72_BIN_PATH+y}; then
+    ~/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/contracts/Cache --exclude rector-prefixed-downgraded/vendor/symfony/contracts/HttpClient/Test;
+else
+    echo "verify syntax with parallel lint";
+    $PHP72_BIN_PATH ~/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/contracts/Cache --exclude rector-prefixed-downgraded/vendor/symfony/contracts/HttpClient/Test;
+fi
 
 # Check php 7.2 can be used locally with PHP72_BIN_PATH env
 # rector-prefixed-downgraded check

--- a/full_build.sh
+++ b/full_build.sh
@@ -39,7 +39,7 @@ composer global require php-parallel-lint/php-parallel-lint
 if test -z ${PHP72_BIN_PATH+y}; then
     ~/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/contracts/Cache --exclude rector-prefixed-downgraded/vendor/symfony/contracts/HttpClient/Test;
 else
-    echo "verify syntax with parallel lint";
+    echo "verify syntax valid in php 7.2 with specify PHP72_BIN_PATH env";
     $PHP72_BIN_PATH ~/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/contracts/Cache --exclude rector-prefixed-downgraded/vendor/symfony/contracts/HttpClient/Test;
 fi
 

--- a/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
@@ -61,14 +61,19 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
         }
 
         // nothing to improve
-        if ($this->nestingLevel < 2) {
-            return $activeFuncCallNode;
+        if ($this->shouldSkip()) {
+            return null;
         }
 
         $node->args[0] = $lastFuncCallNode->args[0];
         $node->args[1] = new Arg(new LNumber($this->nestingLevel));
 
         return $node;
+    }
+
+    private function shouldSkip(): bool
+    {
+        return $this->nestingLevel < 2;
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
@@ -71,14 +71,14 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
         return $node;
     }
 
-    private function shouldSkip(): bool
-    {
-        return $this->nestingLevel < 2;
-    }
-
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::DIRNAME_LEVELS;
+    }
+
+    private function shouldSkip(): bool
+    {
+        return $this->nestingLevel < 2;
     }
 
     private function matchNestedDirnameFuncCall(FuncCall $funcCall): ?FuncCall


### PR DESCRIPTION
Cherry pick https://github.com/rectorphp/rector-src/pull/2487 part of removing instanceof `AbstractScopeAwareRector` check effort on multiple rules applied in Node -> File on `RectifiedAnalyzer` which if the following check removed:

https://github.com/rectorphp/rector-src/blob/ef4267ebf048e96aa600823d92e92d5b6abd7c5f/src/ProcessAnalyzer/RectifiedAnalyzer.php#L63-L66

make error:

```bash
bin/rector process rules/Php70/Rector/FuncCall/MultiDirnameRector.php --dry-run --clear-cache     
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [ERROR] Could not process "rules/Php70/Rector/FuncCall/MultiDirnameRector.php" file, due to:                           
         "System error: "Scope not available on "PhpParser\Node\Expr\Assign" node with parent node of                   
         "PhpParser\Node\Stmt\Expression", but is required by a refactorWithScope() method of                           
         "Rector\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector" rule. Fix scope refresh on   
         changed nodes first"                                                                                           
         Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new". On 
         line: 36       
```

It got error seems due to direct check on `$this->nestingLevel` variable directly, moving to separate method seems solve it.

The check on `RectifiedAnalyzer` still needed due to removing the check still cause error on scoped build https://github.com/rectorphp/rector-src/pull/2487#issuecomment-1154057146
