### PR TITLE
[Php81] Fix crash on redis->set() on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/redis_set.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/redis_set.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+class RedisSet
+{
+    public function __construct(
+        private \Redis $redis,
+        private int $ttl
+    ) {
+    }
+
+    public function save(): void
+    {
+        $this->redis->set(
+            'key',
+            'value',
+            $this->ttl
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+class RedisSet
+{
+    public function __construct(
+        private readonly \Redis $redis,
+        private readonly int $ttl
+    ) {
+    }
+
+    public function save(): void
+    {
+        $this->redis->set(
+            'key',
+            'value',
+            $this->ttl
+        );
+    }
+}
+
+?>

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -306,7 +306,11 @@ final class PropertyManipulator
             return false;
         }
 
-        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($functionLikeReflection->getVariants());
+        $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+            $node->getAttribute(AttributeKey::SCOPE),
+            $node->getArgs(),
+            $functionLikeReflection->getVariants()
+        );
         foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
             if ($parameterReflection->passedByReference()->yes()) {
                 return true;

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -25,6 +25,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
 use PhpParser\Node\Stmt\Unset_;
+use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
@@ -306,8 +307,13 @@ final class PropertyManipulator
             return false;
         }
 
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return false;
+        }
+
         $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-            $node->getAttribute(AttributeKey::SCOPE),
+            $scope,
             $node->getArgs(),
             $functionLikeReflection->getVariants()
         );


### PR DESCRIPTION
it currently crash:

```bash

There was 1 error:
1) Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\ReadOnlyPropertyRectorTest::test with data set #6 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
PHPStan\ShouldNotHappenException: Multiple variants - use selectFromArgs() instead.
phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ParametersAcceptorSelector.php:45
/home/runner/work/rector-src/rector-src/src/NodeManipulator/PropertyManipulator.php:309
```

Fixes https://github.com/rectorphp/rector/issues/7237
