### PR TITLE
Re-add guard check AbstractScopeAwareRector on RectifiedAnalyzer

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
+use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
+use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\RectifiedNode;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -60,6 +62,11 @@ final class RectifiedAnalyzer
 
         if ($originalNode instanceof Node) {
             return true;
+        }
+
+        if ($rector instanceof AbstractScopeAwareRector) {
+            $scope = $node->getAttribute(AttributeKey::SCOPE);
+            return $scope instanceof Scope;
         }
 
         $startTokenPos = $node->getStartTokenPos();


### PR DESCRIPTION
The UnreachableNode patch on https://github.com/rectorphp/rector-src/pull/2495 cause downgrade scoped bug:

```bash
[file] vendor/nette/neon/src/Neon/Parser.php
[rule] Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector
                                                                                                                        
 [ERROR] Could not process "vendor/nette/neon/src/Neon/Parser.php" file, due to:                                        
         "System error: "Scope not available on "PhpParser\Node\Expr\FuncCall" node with parent node of                 
         "PhpParser\Node\Expr\BinaryOp\Greater", but is required by a refactorWithScope() method of                     
         "Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector" rule. Fix scope refresh on changed nodes    
         first"                                                                                                         
         Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new". On 
         line: 45  
```

This PR re-open the guard so we can check in next iteration.