### PR TITLE
final public method for abstract class

### DIFF
--- a/src/Console/Command/AbstractProcessCommand.php
+++ b/src/Console/Command/AbstractProcessCommand.php
@@ -17,7 +17,7 @@ abstract class AbstractProcessCommand extends Command
     protected ConfigurationFactory $configurationFactory;
 
     #[Required]
-    public function autowire(ConfigurationFactory $configurationFactory): void
+    final public function autowire(ConfigurationFactory $configurationFactory): void
     {
         $this->configurationFactory = $configurationFactory;
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE;
     private RectorOutputStyle $rectorOutputStyle;
 
     #[Required]
-    public function autowire(
+    final public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
         NodesToAddCollector $nodesToAddCollector,
         NodeRemover $nodeRemover,
@@ -170,7 +170,7 @@ CODE_SAMPLE;
     /**
      * @return Node[]|null
      */
-    public function beforeTraverse(array $nodes): ?array
+    final public function beforeTraverse(array $nodes): ?array
     {
         // workaround for file around refactor()
         $file = $this->currentFileProvider->getFile();
@@ -276,7 +276,7 @@ CODE_SAMPLE;
      * Replacing nodes in leaveNode() method avoids infinite recursion
      * see"infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
      */
-    public function leaveNode(Node $node)
+    final public function leaveNode(Node $node)
     {
         $objectHash = spl_object_hash($node);
 

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -23,7 +23,7 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
      * Process Node of matched type with its PHPStan scope
      * @return Node|Node[]|null
      */
-    public function refactor(Node $node)
+    final public function refactor(Node $node)
     {
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         if (! $scope instanceof Scope) {


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.