### PR TITLE
final public method for abstract class

### DIFF
--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
@@ -39,7 +39,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
         $this->originalValues = $values;
     }
 
-    public function removeValue(string $key): void
+    final public function removeValue(string $key): void
     {
         $quotedKey = '"' . $key . '"';
 
@@ -58,7 +58,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     /**
      * @return mixed[]
      */
-    public function getValues(): array
+    final public function getValues(): array
     {
         return $this->values;
     }
@@ -66,7 +66,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     /**
      * @return mixed|Node|null
      */
-    public function getValue(string | int $key)
+    final public function getValue(string | int $key)
     {
         // to allow false as default
         if (! array_key_exists($key, $this->values)) {
@@ -79,7 +79,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     /**
      * @param mixed $value
      */
-    public function changeValue(string $key, $value): void
+    final public function changeValue(string $key, $value): void
     {
         // is quoted?
         if (isset($this->values[$key]) && is_string($this->values[$key]) && StringUtils::isMatch(
@@ -98,7 +98,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     /**
      * @return mixed|null
      */
-    public function getValueWithoutQuotes(string | int $key)
+    final public function getValueWithoutQuotes(string | int $key)
     {
         $value = $this->getValue($key);
         if ($value === null) {
@@ -111,7 +111,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     /**
      * @param mixed $value
      */
-    public function changeSilentValue($value): void
+    final public function changeSilentValue($value): void
     {
         // is quoted?
         if (StringUtils::isMatch($this->values[0], self::UNQUOTED_VALUE_REGEX)) {
@@ -128,7 +128,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     /**
      * @return mixed|null
      */
-    public function getSilentValue()
+    final public function getSilentValue()
     {
         $value = $this->values[0] ?? null;
         if ($value === null) {
@@ -142,7 +142,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
      * Useful for attributes
      * @return array<int|string, mixed>
      */
-    public function getValuesWithExplicitSilentAndWithoutQuotes(): array
+    final public function getValuesWithExplicitSilentAndWithoutQuotes(): array
     {
         $explicitKeysValues = [];
 
@@ -158,7 +158,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
         return $explicitKeysValues;
     }
 
-    public function markAsChanged(): void
+    final public function markAsChanged(): void
     {
         $this->hasChanged = true;
     }
@@ -166,7 +166,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     /**
      * @return mixed[]
      */
-    public function getOriginalValues(): array
+    final public function getOriginalValues(): array
     {
         return $this->originalValues;
     }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDelegatingParentCallRector/Source/ParentController.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDelegatingParentCallRector/Source/ParentController.php
@@ -9,7 +9,7 @@ abstract class ParentController
     private $isExperiment = false;
 
 
-    public function response()
+    final public function response()
     {
         if ($this->isExperiment === true) {
             return $this->responseNew();

--- a/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Source/Ormion.php
+++ b/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Source/Ormion.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Php71\Rector\FuncCall\RemoveExtraParametersRector\Source;
 
 abstract class Ormion
 {
-    public static function delete()
+    final public static function delete()
     {
     }
 }

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Source/FillerAbstract.php
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Source/FillerAbstract.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source;
 
 abstract class FillerAbstract
 {
-    public function process(AnotherClass $anotherClass)
+    final public function process(AnotherClass $anotherClass)
     {
         $this->property = $anotherClass;
     }

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Source/SomeContractClass.php
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Source/SomeContractClass.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Source;
 
 abstract class SomeContractClass
 {
-    public function run($param)
+    final public function run($param)
     {
     }
 }

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Source/AbstractClassWithProtectedProperty.php
@@ -11,17 +11,17 @@ abstract class AbstractClassWithProtectedProperty
      */
     protected $value = 1000;
 
-    public function run()
+    final public function run()
     {
         static::$valueStatic = 1000;
     }
 
-    public function run2()
+    final public function run2()
     {
         self::$valueStatic2 = 1000;
     }
 
-    public function run3()
+    final public function run3()
     {
         \Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture\KeepParentStaticProtectedUsedByParent::$valueStatic3 = 1000;
     }

--- a/rules-tests/Transform/Rector/FuncCall/FuncCallToMethodCallRector/Source/NullableTranslatorProvider.php
+++ b/rules-tests/Transform/Rector/FuncCall/FuncCallToMethodCallRector/Source/NullableTranslatorProvider.php
@@ -8,7 +8,7 @@ abstract class NullableTranslatorProvider
 {
     private $translator;
 
-    public function getTranslator(): ?SomeTranslator
+    final public function getTranslator(): ?SomeTranslator
     {
         return $this->translator;
     }

--- a/rules-tests/Transform/Rector/FuncCall/FuncCallToMethodCallRector/Source/TranslatorProvider.php
+++ b/rules-tests/Transform/Rector/FuncCall/FuncCallToMethodCallRector/Source/TranslatorProvider.php
@@ -8,7 +8,7 @@ abstract class TranslatorProvider
 {
     private $translator;
 
-    public function getTranslator(): SomeTranslator
+    final public function getTranslator(): SomeTranslator
     {
         return $this->translator;
     }

--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/ClassWithFileSystemMethod.php
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/ClassWithFileSystemMethod.php
@@ -8,7 +8,7 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 
 abstract class ClassWithFileSystemMethod
 {
-    public function getSmartFileSystem(): SmartFileSystem
+    final public function getSmartFileSystem(): SmartFileSystem
     {
         return new SmartFileSystem();
     }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Source/ParentClassWithDefinedReturnSecond.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Source/ParentClassWithDefinedReturnSecond.php
@@ -9,7 +9,7 @@ abstract class ParentClassWithDefinedReturnSecond
     /**
      * @return mixed[]
      */
-    public function getData()
+    final public function getData()
     {
         return ['...'];
     }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector/Source/ParentMethodWithUnion.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector/Source/ParentMethodWithUnion.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByParentCallT
 
 abstract class ParentMethodWithUnion
 {
-    public function getById(int|string $id)
+    final public function getById(int|string $id)
     {
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector/Source/AbstractClassWithoutParamType.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ParamTypeDeclarationRector/Source/AbstractClassWithoutParamType.php
@@ -5,7 +5,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationR
 
 abstract class AbstractClassWithoutParamType
 {
-    public function getReferenceDate($entity): \DateTime
+    final public function getReferenceDate($entity): \DateTime
     {
     }
 }

--- a/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
+++ b/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
@@ -23,7 +23,7 @@ abstract class AbstractFalsyScalarRuleFixerRector extends AbstractRector impleme
     /**
      * @param mixed[] $configuration
      */
-    public function configure(array $configuration): void
+    final public function configure(array $configuration): void
     {
         $treatAsNonEmpty = $configuration[self::TREAT_AS_NON_EMPTY] ?? (bool) current($configuration);
         Assert::boolean($treatAsNonEmpty);

--- a/src/Console/Command/AbstractProcessCommand.php
+++ b/src/Console/Command/AbstractProcessCommand.php
@@ -17,7 +17,7 @@ abstract class AbstractProcessCommand extends Command
     protected ConfigurationFactory $configurationFactory;
 
     #[Required]
-    public function autowire(ConfigurationFactory $configurationFactory): void
+    final public function autowire(ConfigurationFactory $configurationFactory): void
     {
         $this->configurationFactory = $configurationFactory;
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE;
     private RectorOutputStyle $rectorOutputStyle;
 
     #[Required]
-    public function autowire(
+    final public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
         NodesToAddCollector $nodesToAddCollector,
         NodeRemover $nodeRemover,
@@ -170,7 +170,7 @@ CODE_SAMPLE;
     /**
      * @return Node[]|null
      */
-    public function beforeTraverse(array $nodes): ?array
+    final public function beforeTraverse(array $nodes): ?array
     {
         // workaround for file around refactor()
         $file = $this->currentFileProvider->getFile();
@@ -276,7 +276,7 @@ CODE_SAMPLE;
      * Replacing nodes in leaveNode() method avoids infinite recursion
      * see"infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
      */
-    public function leaveNode(Node $node)
+    final public function leaveNode(Node $node)
     {
         $objectHash = spl_object_hash($node);
 

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -23,7 +23,7 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
      * Process Node of matched type with its PHPStan scope
      * @return Node|Node[]|null
      */
-    public function refactor(Node $node)
+    final public function refactor(Node $node)
     {
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         if (! $scope instanceof Scope) {

--- a/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -14,15 +14,15 @@ if (class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')
 
 abstract class AbstractController
 {
-    public function getDoctrine(): ManagerRegistry
+    final public function getDoctrine(): ManagerRegistry
     {
     }
 
-    public function render($templateName, $params = []): Response
+    final public function render($templateName, $params = []): Response
     {
     }
 
-    public function redirectToRoute($routeName): RedirectResponse
+    final public function redirectToRoute($routeName): RedirectResponse
     {
     }
 }


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.