### PR TITLE
self static accessor

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Source/StaticFactory.php
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Source/StaticFactory.php
@@ -10,6 +10,6 @@ final class StaticFactory
 
     public static function now()
     {
-        return new static();
+        return new self();
     }
 }


### PR DESCRIPTION
Inside a final class or anonymous class self should be preferred to static.