### PR TITLE
array syntax

### DIFF
--- a/stubs/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/stubs/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -33,5 +33,5 @@ interface UrlGeneratorInterface
      */
     const NETWORK_PATH = 'network';
 
-    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH);
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH);
 }

--- a/stubs/Symfony/Component/Routing/Router.php
+++ b/stubs/Symfony/Component/Routing/Router.php
@@ -15,7 +15,7 @@ class Router implements RouterInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
         return $this->getGenerator()->generate($name, $parameters, $referenceType);
     }


### PR DESCRIPTION
PHP arrays should be declared using the configured syntax.