### PR TITLE
normalize index brace

### DIFF
--- a/build/target-repository/e2e/parse-php7-code/src/Foo.php
+++ b/build/target-repository/e2e/parse-php7-code/src/Foo.php
@@ -7,6 +7,6 @@ class Foo
     public function __construct()
     {
         $bar = 'baz';
-        print $bar{2};
+        print $bar[2];
     }
 }


### PR DESCRIPTION
Array index should always be written by using square braces.