### PR TITLE
use arrow functions

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -72,9 +72,7 @@ return [
 
     'patchers' => [
         // fix short import bug, @see https://github.com/rectorphp/rector-scoper-017/blob/23f3256a6f5a18483d6eb4659d69ba117501e2e3/vendor/nikic/php-parser/lib/PhpParser/Builder/Declaration.php#L6
-        function (string $filePath, string $prefix, string $content): string {
-            return str_replace(sprintf('use %s\PhpParser;', $prefix), 'use PhpParser;', $content);
-        },
+        fn (string $filePath, string $prefix, string $content): string => str_replace(sprintf('use %s\PhpParser;', $prefix), 'use PhpParser;', $content),
 
         function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'src/Application/VersionResolver.php')) {


### PR DESCRIPTION
Anonymous functions with one-liner return statement must use arrow functions.