### PR TITLE
rollback guard

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
+use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
+use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\RectifiedNode;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -56,6 +58,11 @@ final class RectifiedAnalyzer
              * allow to revisit the Node with same Rector rule if Node is changed by other rule
              */
             return ! $this->nodeComparator->areNodesEqual($originalNode, $node);
+        }
+
+        if ($rector instanceof AbstractScopeAwareRector) {
+            $scope = $node->getAttribute(AttributeKey::SCOPE);
+            return $scope instanceof Scope;
         }
 
         if ($originalNode instanceof Node) {


### PR DESCRIPTION
PR https://github.com/rectorphp/rector-src/pull/2523 cause downgrade failure:

```bash
[ERROR] Could not process                                                      
         "rector-build/vendor/symfony/contracts/Service/ServiceLocatorTrait.php"
         file, due to:                                                          
         "System error: "Scope not available on "PhpParser\Node\Expr\FuncCall"  
         node with parent node of "PhpParser\Node\Stmt\Return_", but is required
         by a refactorWithScope() method of                                     
         "Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector"     
         rule. Fix scope refresh on changed nodes first"                        
         Run Rector with "--debug" option and post the report here:             
        [ https://github.com/rectorphp/rector/i](https://github.com/rectorphp/rector/issues/new)
ssues/new". On line: 43
```

rollback guard in `RectifiedAnalyzer` to check in next iteration.