### PR TITLE
Add failing test fixture for RemoveDataProviderTestPrefixRector

### DIFF
--- a/rules-tests/PHPUnit/Rector/Class_/RemoveDataProviderTestPrefixRector/Fixture/base_class.php.inc
+++ b/rules-tests/PHPUnit/Rector/Class_/RemoveDataProviderTestPrefixRector/Fixture/base_class.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
+
+class BaseClass extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider testProvideData()
+     */
+    public function test()
+    {
+        $nothing = 5;
+    }
+
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
+
+class ChildClass extends BaseClass
+{
+
+    public function testProvideData()
+    {
+        return ['123'];
+    }
+    
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
+
+class BaseClass extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test()
+    {
+        $nothing = 5;
+    }
+
+}
+
+namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
+
+class ChildClass extends BaseClass
+{
+
+    public function provideData()
+    {
+        return ['123'];
+    }
+    
+}
+
+?>

--- a/rules-tests/PHPUnit/Rector/Class_/RemoveDataProviderTestPrefixRector/Fixture/base_class.php.inc
+++ b/rules-tests/PHPUnit/Rector/Class_/RemoveDataProviderTestPrefixRector/Fixture/base_class.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
 
-class BaseClass extends \PHPUnit\Framework\TestCase
+abstract class BaseClass extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider testProvideData()
@@ -13,8 +13,6 @@ class BaseClass extends \PHPUnit\Framework\TestCase
     }
 
 }
-
-namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
 
 class ChildClass extends BaseClass
 {
@@ -32,7 +30,7 @@ class ChildClass extends BaseClass
 
 namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
 
-class BaseClass extends \PHPUnit\Framework\TestCase
+abstract class BaseClass extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideData()
@@ -43,8 +41,6 @@ class BaseClass extends \PHPUnit\Framework\TestCase
     }
 
 }
-
-namespace Rector\Tests\PHPUnit\Rector\Class_\RemoveDataProviderTestPrefixRector\Fixture;
 
 class ChildClass extends BaseClass
 {


### PR DESCRIPTION
# Failing Test for RemoveDataProviderTestPrefixRector

Based on https://getrector.org/demo/637e1142-1cb1-4f9d-9a21-67776e0219ff

In reference to issue #85: https://github.com/rectorphp/rector-phpunit/issues/85