### PR TITLE
[Php56] Skip multiple catch with same variable on AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -44,7 +44,6 @@ use Rector\Core\Util\StringUtils;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\RemoveDeepChainMethodCallNodeVisitor;
-use Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture\readonly;
 use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Webmozart\Assert\Assert;

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
@@ -140,7 +141,7 @@ final class PHPStanNodeScopeResolver
 
             if ($node instanceof TryCatch) {
                 foreach ($node->catches as $catch) {
-                    $varName = $catch->var instanceof Expr\Variable
+                    $varName = $catch->var instanceof Variable
                         ? $this->nodeNameResolver->getName($catch->var)
                         : null;
                     $catchMutatingScope = $mutatingScope->enterCatch($catch->types, $varName);

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -138,6 +138,7 @@ final class PHPStanNodeScopeResolver
 
             if ($node instanceof TryCatch) {
                 foreach ($node->catches as $catch) {
+                    $mutatingScope = $mutatingScope->enterCatch($catch->types, $catch->var->name);
                     $this->processNodes($catch->stmts, $smartFileInfo, $mutatingScope);
                 }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -41,8 +41,10 @@ use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\StaticReflection\SourceLocator\ParentAttributeSourceLocator;
 use Rector\Core\StaticReflection\SourceLocator\RenamedClassesSourceLocator;
 use Rector\Core\Util\StringUtils;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\RemoveDeepChainMethodCallNodeVisitor;
+use Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture\readonly;
 use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Webmozart\Assert\Assert;
@@ -74,6 +76,7 @@ final class PHPStanNodeScopeResolver
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly RenamedClassesSourceLocator $renamedClassesSourceLocator,
         private readonly ParentAttributeSourceLocator $parentAttributeSourceLocator,
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -138,7 +141,10 @@ final class PHPStanNodeScopeResolver
 
             if ($node instanceof TryCatch) {
                 foreach ($node->catches as $catch) {
-                    $mutatingScope = $mutatingScope->enterCatch($catch->types, $catch->var->name);
+                    $varName = $catch->var instanceof Expr\Variable
+                        ? $this->nodeNameResolver->getName($catch->var)
+                        : null;
+                    $mutatingScope = $mutatingScope->enterCatch($catch->types, $varName);
                     $this->processNodes($catch->stmts, $smartFileInfo, $mutatingScope);
                 }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -143,8 +143,8 @@ final class PHPStanNodeScopeResolver
                     $varName = $catch->var instanceof Expr\Variable
                         ? $this->nodeNameResolver->getName($catch->var)
                         : null;
-                    $mutatingScope = $mutatingScope->enterCatch($catch->types, $varName);
-                    $this->processNodes($catch->stmts, $smartFileInfo, $mutatingScope);
+                    $catchMutatingScope = $mutatingScope->enterCatch($catch->types, $varName);
+                    $this->processNodes($catch->stmts, $smartFileInfo, $catchMutatingScope);
                 }
 
                 if ($node->finally instanceof Finally_) {

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_catch_use_variable.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_catch_use_variable.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class SkipCatchUseVariable
+{
+    public function run()
+    {
+        try {
+        } catch (\Exception $e) {
+            var_dump($e);
+        }
+    }
+
+    public function run2()
+    {
+        try {
+        } catch (\Exception $e) {
+            $e;
+        }
+    }
+
+    public function run3()
+    {
+        try {
+        } catch (\Exception $e) {
+            echo $e::class;
+        }
+    }
+}

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
@@ -24,7 +24,7 @@ class SkipMultipleCatchWithUseSameVariable
         }
     }
 
-    public function run2()
+    public function run3()
     {
         try {
         } catch (\Exception $e) {

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
@@ -23,4 +23,14 @@ class SkipMultipleCatchWithUseSameVariable
             $e;
         }
     }
+
+    public function run2()
+    {
+        try {
+        } catch (\Exception $e) {
+            echo $e::class;
+        } catch (\Throwable $e) {
+            echo $e::class;
+        }
+    }
 }

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
@@ -13,4 +13,14 @@ class SkipMultipleCatchWithUseSameVariable
             var_dump($e);
         }
     }
+
+    public function run2()
+    {
+        try {
+        } catch (\Exception $e) {
+            $e;
+        } catch (\Throwable $e) {
+            $e;
+        }
+    }
 }

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_multiple_catch_use_same_variable.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class SkipMultipleCatchWithUseSameVariable
+{
+    public function run()
+    {
+        try {
+        } catch (\Exception $e) {
+            var_dump($e);
+        } catch (\Throwable $e) {
+            var_dump($e);
+        }
+    }
+}

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -20,7 +20,6 @@ use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Case_;
-use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Function_;

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Php56\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
@@ -19,6 +20,7 @@ use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Case_;
+use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Function_;
@@ -70,6 +72,10 @@ final class UndefinedVariableResolver
 
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
             if (! $parentNode instanceof Node) {
+                return null;
+            }
+
+            if ($parentNode instanceof Arg) {
                 return null;
             }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Php56\NodeAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
@@ -71,10 +70,6 @@ final class UndefinedVariableResolver
 
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
             if (! $parentNode instanceof Node) {
-                return null;
-            }
-
-            if ($parentNode instanceof Arg) {
                 return null;
             }
 


### PR DESCRIPTION
Given the following code:

```php
class SkipMultipleCatchWithUseSameVariable
{
    public function run()
    {
        try {
        } catch (\Exception $e) {
            var_dump($e);
        } catch (\Throwable $e) {
            var_dump($e);
        }
    }
}
```

It cause result:

```diff
     public function run()
     {
+        $e = null;
```

which should be skipped.