### PR TITLE
[Core] AbstractScopeAwareRector is ready to be used in custom rules 🎉 🎉 🎉 

### DIFF
--- a/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
@@ -61,7 +61,7 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
         }
 
         // nothing to improve
-        if ($this->shouldSkip()) {
+        if ($this->nestingLevel < 2) {
             return null;
         }
 
@@ -74,11 +74,6 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::DIRNAME_LEVELS;
-    }
-
-    private function shouldSkip(): bool
-    {
-        return $this->nestingLevel < 2;
     }
 
     private function matchNestedDirnameFuncCall(FuncCall $funcCall): ?FuncCall

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -10,10 +10,6 @@ use Rector\Core\Contract\Rector\ScopeAwarePhpRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
-/**
- * @internal Currently in experimental testing for core Rector rules. So we can verify if this feature is useful or not.
- * Do not use outside in custom rules. Go for AbstractRector instead.
- */
 abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeAwarePhpRectorInterface
 {
     /**


### PR DESCRIPTION
I think `AbstractScopeAwareRector` is now ready to be used in custom rector rule, as the next of `UnreachableStatementNode` is correctly has `Scope` now, so on this PR, I remove the `@internal` note comment .

By this, the tweak of `PropertyFetch` filled outside method which make read after `$this->nestingLevel < 2` got `UnreachableStatementNode` on `MultiDirnameRector` at PR:

-  https://github.com/rectorphp/rector-src/pull/2488 

can be rolled back as it no longer error on running rectify:

```bash
bin/rector process rules/Php70/Rector/FuncCall/MultiDirnameRector.php --dry-run --clear-cache     
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                                                                                                                             
```

🎉 🎉 🎉