### PR TITLE
[Core] Clean up ScopeAnalyzer: Enum_ is has Scope

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -690,3 +690,11 @@ parameters:
         -
             message: '#New objects with "\$fullyQualifiedObjectType" name are overridden\. This can lead to unwanted bugs, please pick a different name to avoid it#'
             path: packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+
+        -
+            message: '#Comparison operation "<" between 0 and 2 is always true#'
+            path: rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+
+        -
+            message: '#Unreachable statement \- code above always terminates#'
+            path: rules/Php70/Rector/FuncCall/MultiDirnameRector.php

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Namespace_;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 
@@ -23,7 +22,6 @@ final class ScopeAnalyzer
         Namespace_::class,
         FileWithoutNamespace::class,
         Identifier::class,
-        Enum_::class,
         Param::class,
         Arg::class,
     ];


### PR DESCRIPTION
`Enum_` is has Scope so can be refreshed, so can be removed from list of Node that doesn't has `Scope` as filled at 

https://github.com/rectorphp/rector-src/blob/945889cfb4c6e84efe3496cc5a45c9b2583764cb/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php#L204-L207