### PR TITLE
[PHPStan] Fix PHPStan notice on MultiDirnameRector

### DIFF
--- a/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
@@ -71,14 +71,14 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
         return $node;
     }
 
-    private function shouldSkip(): bool
-    {
-        return $this->nestingLevel < 2;
-    }
-
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::DIRNAME_LEVELS;
+    }
+
+    private function shouldSkip(): bool
+    {
+        return $this->nestingLevel < 2;
     }
 
     private function matchNestedDirnameFuncCall(FuncCall $funcCall): ?FuncCall

--- a/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/Php70/Rector/FuncCall/MultiDirnameRector.php
@@ -61,7 +61,7 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
         }
 
         // nothing to improve
-        if ($this->nestingLevel < 2) {
+        if ($this->shouldSkip()) {
             return null;
         }
 
@@ -69,6 +69,11 @@ final class MultiDirnameRector extends AbstractRector implements MinPhpVersionIn
         $node->args[1] = new Arg(new LNumber($this->nestingLevel));
 
         return $node;
+    }
+
+    private function shouldSkip(): bool
+    {
+        return $this->nestingLevel < 2;
     }
 
     public function provideMinPhpVersion(): int


### PR DESCRIPTION
It seems latest `PHPStan` https://github.com/phpstan/phpstan/releases/tag/1.7.15 make error:

```bash
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  rules/Php70/Rector/FuncCall/MultiDirnameRector.php:64
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Comparison operation "<" between 0 and 2 is always true#'
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  rules/Php70/Rector/FuncCall/MultiDirnameRector.php:68
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Unreachable statement \- code above always terminates#'
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

It is due to`MultiDirnameRector` which `PropertyFetch` is filled by other method.  I rolled back the rolled back the code enhancement of `MultiDirnameRector` to solve it.