### PR TITLE
[Core] Apply Scope Refresh on Enum_

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
@@ -61,7 +61,7 @@ final class TestModifyReprintTest extends AbstractTestCase
         // this will extended tokens of first node
         $doctrineAnnotationTagValueNode->changeValue('methods', new CurlyListNode(['"GET"', '"HEAD"']));
 
-        $expectedDocContent = trim($inputFileInfoAndExpected->getExpected());
+        $expectedDocContent = trim((string) $inputFileInfoAndExpected->getExpected());
 
         $printedPhpDocInfo = $this->printPhpDocInfoToString($phpDocInfo);
         $this->assertSame($expectedDocContent, $printedPhpDocInfo);

--- a/packages-tests/Comments/CommentRemover/CommentRemoverTest.php
+++ b/packages-tests/Comments/CommentRemover/CommentRemoverTest.php
@@ -46,7 +46,7 @@ final class CommentRemoverTest extends AbstractTestCase
         $fileContent = $this->nodePrinter->print($nodesWithoutComments);
         $fileContent = trim($fileContent);
 
-        $expectedContent = trim($fileInfoToLocalInputAndExpected->getExpected());
+        $expectedContent = trim((string) $fileInfoToLocalInputAndExpected->getExpected());
 
         $this->assertSame($fileContent, $expectedContent, $smartFileInfo->getRelativeFilePathFromCwd());
 

--- a/packages/Parallel/Command/WorkerCommandLineFactory.php
+++ b/packages/Parallel/Command/WorkerCommandLineFactory.php
@@ -61,7 +61,7 @@ final class WorkerCommandLineFactory
                 break;
             }
 
-            $workerCommandArray[] = escapeshellarg($arg);
+            $workerCommandArray[] = escapeshellarg((string) $arg);
         }
 
         $workerCommandArray[] = $workerCommandName;
@@ -110,7 +110,7 @@ final class WorkerCommandLineFactory
              *
              * tested in macOS and Ubuntu (github action)
              */
-            $workerCommandArray[] = escapeshellarg($input->getOption(Option::CONFIG));
+            $workerCommandArray[] = escapeshellarg((string) $input->getOption(Option::CONFIG));
         }
 
         return implode(' ', $workerCommandArray);

--- a/rules-tests/Php81/Rector/Class_/ConstantListClassToEnumRector/Fixture/enum_no_namespace.php.inc
+++ b/rules-tests/Php81/Rector/Class_/ConstantListClassToEnumRector/Fixture/enum_no_namespace.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+class EnumNoNamespace
+{
+    public const LEFT = 'left';
+
+    public const RIGHT = 'right';
+}
+
+?>
+-----
+<?php
+
+enum EnumNoNamespace : string
+{
+    case LEFT = 'left';
+    case RIGHT = 'right';
+}
+
+?>

--- a/rules/Naming/Naming/PropertyNaming.php
+++ b/rules/Naming/Naming/PropertyNaming.php
@@ -64,7 +64,7 @@ final class PropertyNaming
             return null;
         }
 
-        $originalName = lcfirst($matches['root_name']);
+        $originalName = lcfirst((string) $matches['root_name']);
 
         return new ExpectedName($originalName, $this->rectorNamingInflector->singularize($originalName));
     }
@@ -123,11 +123,7 @@ final class PropertyNaming
         }
 
         $className = $this->resolveClassName($objectType);
-        if (str_contains($className, '\\')) {
-            $shortClassName = (string) Strings::after($className, '\\', -1);
-        } else {
-            $shortClassName = $className;
-        }
+        $shortClassName = str_contains($className, '\\') ? (string) Strings::after($className, '\\', -1) : $className;
 
         $variableName = $this->removeInterfaceSuffixPrefix($shortClassName, 'interface');
         $variableName = $this->removeInterfaceSuffixPrefix($variableName, 'abstract');

--- a/rules/Php81/NodeFactory/EnumFactory.php
+++ b/rules/Php81/NodeFactory/EnumFactory.php
@@ -31,6 +31,7 @@ final class EnumFactory
     {
         $shortClassName = $this->nodeNameResolver->getShortName($class);
         $enum = new Enum_($shortClassName);
+        $enum->namespacedName = $class->namespacedName;
 
         $constants = $class->getConstants();
 

--- a/rules/Php81/NodeFactory/EnumFactory.php
+++ b/rules/Php81/NodeFactory/EnumFactory.php
@@ -54,6 +54,7 @@ final class EnumFactory
     {
         $shortClassName = $this->nodeNameResolver->getShortName($class);
         $enum = new Enum_($shortClassName);
+        $enum->namespacedName = $class->namespacedName;
 
         // constant to cases
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);

--- a/src/Application/VersionResolver.php
+++ b/src/Application/VersionResolver.php
@@ -56,7 +56,7 @@ final class VersionResolver
             );
         }
 
-        $version = trim($commitHashExecOutput[0]);
+        $version = trim((string) $commitHashExecOutput[0]);
         return trim($version, '"');
     }
 
@@ -69,6 +69,6 @@ final class VersionResolver
             );
         }
 
-        return new DateTime(trim($output[0]));
+        return new DateTime(trim((string) $output[0]));
     }
 }

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Namespace_;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 
@@ -23,7 +22,6 @@ final class ScopeAnalyzer
         Namespace_::class,
         FileWithoutNamespace::class,
         Identifier::class,
-        Enum_::class,
         Param::class,
         Arg::class,
     ];


### PR DESCRIPTION
Handled with remove `Enum_` from `ScopeAnalyzer::NO_SCOPE_NODES` constant:

https://github.com/rectorphp/rector-src/pull/2549/files#diff-3d7ebdca094b191b83bd9cad50291e953fa15cd8c645563821329200c2bb1901

and register namespacedName on EnumFactory 

https://github.com/rectorphp/rector-src/pull/2549/files#diff-65af61c68c6a1e907d31bd97cfd13b02bbab31772ccedd7b6883dbc287bd0abd

