### PR TITLE
[Core] Handle Scope not available on CallableThisArrayToAnonymousFunctionRector+CountArrayToEmptyArrayComparisonRector

### DIFF
--- a/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
@@ -144,6 +144,7 @@ CODE_SAMPLE
         if (($node instanceof Identical || $node instanceof NotIdentical) && $node->right instanceof LNumber && $node->right->value === 0) {
             $this->removeNode($funcCall);
             $node->right = new Array_([]);
+            $node->right->setAttribute(AttributeKey::SCOPE, $funcCall->getAttribute(AttributeKey::SCOPE));
 
             return $expr;
         }
@@ -151,6 +152,7 @@ CODE_SAMPLE
         if (($node instanceof Identical || $node instanceof NotIdentical) && $node->left instanceof LNumber && $node->left->value === 0) {
             $this->removeNode($funcCall);
             $node->left = new Array_([]);
+            $node->left->setAttribute(AttributeKey::SCOPE, $funcCall->getAttribute(AttributeKey::SCOPE));
 
             return $expr;
         }

--- a/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
@@ -144,7 +144,7 @@ CODE_SAMPLE
         if (($node instanceof Identical || $node instanceof NotIdentical) && $node->right instanceof LNumber && $node->right->value === 0) {
             $this->removeNode($funcCall);
             $node->right = new Array_([]);
-            $node->right->setAttribute(AttributeKey::SCOPE, $funcCall->getAttribute(AttributeKey::SCOPE));
+            $node->right->setAttribute(AttributeKey::SCOPE, $node->getAttribute(AttributeKey::SCOPE));
 
             return $expr;
         }
@@ -152,7 +152,7 @@ CODE_SAMPLE
         if (($node instanceof Identical || $node instanceof NotIdentical) && $node->left instanceof LNumber && $node->left->value === 0) {
             $this->removeNode($funcCall);
             $node->left = new Array_([]);
-            $node->left->setAttribute(AttributeKey::SCOPE, $funcCall->getAttribute(AttributeKey::SCOPE));
+            $node->left->setAttribute(AttributeKey::SCOPE, $node->getAttribute(AttributeKey::SCOPE));
 
             return $expr;
         }

--- a/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
+++ b/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+
+class CountArray
+{
+    public function decode(string $hash): array
+    {
+        return [];
+    }
+
+    public function decodeOne(string $hash): ?int
+    {
+        $values = $this->decode($hash);
+        if (count($values) === 0) {
+            return null;
+        }
+
+        return $values[0];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+
+class CountArray
+{
+    public function decode(string $hash): array
+    {
+        return [];
+    }
+
+    public function decodeOne(string $hash): ?int
+    {
+        $values = $this->decode($hash);
+        if ($values === []) {
+            return null;
+        }
+
+        return $values[0];
+    }
+}
+
+?>

--- a/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
+++ b/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
@@ -45,3 +45,4 @@ class CountArray
 }
 
 ?>
+

--- a/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
+++ b/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
@@ -45,4 +45,3 @@ class CountArray
 }
 
 ?>
-


### PR DESCRIPTION
Given the following code:

```php
class CountArray
{
    public function decode(string $hash): array
    {
        return [];
    }

    public function decodeOne(string $hash): ?int
    {
        $values = $this->decode($hash);
        if (count($values) === 0) {
            return null;
        }

        return $values[0];
    }
}
```

It cause error:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\ScopeNotAvailable\CallableThisTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Scope not available on "PhpParser\Node\Expr\Array_" node with parent node of "", but is required by a refactorWithScope() method of "Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector" rule. Fix scope refresh on changed nodes first
```

Applied rules:

```php
Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
```

Fixes https://github.com/rectorphp/rector/issues/7251