### PR TITLE
[Core] Handle Scope not available on DowngradeArrayIsListRector+DowngradePregUnmatchedAsNullConstantRector

### DIFF
--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -58,9 +58,9 @@ final class NodesToAddCollector implements NodeCollectorInterface
         if ($smartFileInfo instanceof SmartFileInfo) {
             $currentScope = $positionNode->getAttribute(AttributeKey::SCOPE);
             $this->changedNodeScopeRefresher->refresh($addedNode, $smartFileInfo, $currentScope);
+        } else {
+            $addedNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
         }
-
-        $addedNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
 
         $position = $this->resolveNearestStmtPosition($positionNode);
         $this->nodesToAddBefore[$position][] = $this->wrapToExpression($addedNode);

--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -18,7 +18,6 @@ use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Contract\Collector\NodeCollectorInterface;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class NodesToAddCollector implements NodeCollectorInterface
 {

--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -75,10 +75,12 @@ final class NodesToAddCollector implements NodeCollectorInterface
     public function addNodesAfterNode(array $addedNodes, Node $positionNode): void
     {
         $position = $this->resolveNearestStmtPosition($positionNode);
+        $currentScope = $positionNode->getAttribute(AttributeKey::SCOPE);
+
         foreach ($addedNodes as $addedNode) {
             // prevent fluent method weird indent
             $addedNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            $addedNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
+            $addedNode->setAttribute(AttributeKey::SCOPE, $currentScope);
 
             $this->nodesToAddAfter[$position][] = $this->wrapToExpression($addedNode);
         }
@@ -137,7 +139,6 @@ final class NodesToAddCollector implements NodeCollectorInterface
     public function addNodesBeforeNode(array $newNodes, Node $positionNode): void
     {
         foreach ($newNodes as $newNode) {
-            $newNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
             $this->addNodeBeforeNode($newNode, $positionNode, null);
         }
 

--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -49,7 +49,7 @@ final class NodesToAddCollector implements NodeCollectorInterface
     /**
      * @deprecated Return created nodes right in refactor() method to keep context instead.
      */
-    public function addNodeBeforeNode(Node $addedNode, Node $positionNode, ?SmartFileInfo $smartFileInfo = null): void
+    public function addNodeBeforeNode(Node $addedNode, Node $positionNode): void
     {
         if ($positionNode->getAttributes() === []) {
             $message = sprintf('Switch arguments in "%s()" method', __METHOD__);
@@ -130,7 +130,7 @@ final class NodesToAddCollector implements NodeCollectorInterface
     public function addNodesBeforeNode(array $newNodes, Node $positionNode): void
     {
         foreach ($newNodes as $newNode) {
-            $this->addNodeBeforeNode($newNode, $positionNode, null);
+            $this->addNodeBeforeNode($newNode, $positionNode);
         }
 
         $this->rectorChangeCollector->notifyNodeFileInfo($positionNode);

--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -74,15 +74,10 @@ final class NodesToAddCollector implements NodeCollectorInterface
      */
     public function addNodesAfterNode(array $addedNodes, Node $positionNode): void
     {
-        $position = $this->resolveNearestStmtPosition($positionNode);
-        $currentScope = $positionNode->getAttribute(AttributeKey::SCOPE);
-
         foreach ($addedNodes as $addedNode) {
             // prevent fluent method weird indent
             $addedNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            $addedNode->setAttribute(AttributeKey::SCOPE, $currentScope);
-
-            $this->nodesToAddAfter[$position][] = $this->wrapToExpression($addedNode);
+            $this->addNodeAfterNode($addedNode, $positionNode);
         }
 
         $this->rectorChangeCollector->notifyNodeFileInfo($positionNode);

--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -85,6 +85,11 @@ final class NodesToAddCollector implements NodeCollectorInterface
      */
     public function addNodeAfterNode(Node $addedNode, Node $positionNode): void
     {
+        if ($positionNode->getAttributes() === []) {
+            $message = sprintf('Switch arguments in "%s()" method', __METHOD__);
+            throw new ShouldNotHappenException($message);
+        }
+
         $this->refreshScope($addedNode, $positionNode);
 
         $position = $this->resolveNearestStmtPosition($positionNode);

--- a/packages/PostRector/Collector/NodesToAddCollector.php
+++ b/packages/PostRector/Collector/NodesToAddCollector.php
@@ -60,6 +60,8 @@ final class NodesToAddCollector implements NodeCollectorInterface
             $this->changedNodeScopeRefresher->refresh($addedNode, $smartFileInfo, $currentScope);
         }
 
+        $addedNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
+
         $position = $this->resolveNearestStmtPosition($positionNode);
         $this->nodesToAddBefore[$position][] = $this->wrapToExpression($addedNode);
 
@@ -76,6 +78,8 @@ final class NodesToAddCollector implements NodeCollectorInterface
         foreach ($addedNodes as $addedNode) {
             // prevent fluent method weird indent
             $addedNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $addedNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
+
             $this->nodesToAddAfter[$position][] = $this->wrapToExpression($addedNode);
         }
 
@@ -88,6 +92,8 @@ final class NodesToAddCollector implements NodeCollectorInterface
      */
     public function addNodeAfterNode(Node $addedNode, Node $positionNode): void
     {
+        $addedNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
+
         $position = $this->resolveNearestStmtPosition($positionNode);
         $this->nodesToAddAfter[$position][] = $this->wrapToExpression($addedNode);
 
@@ -131,6 +137,7 @@ final class NodesToAddCollector implements NodeCollectorInterface
     public function addNodesBeforeNode(array $newNodes, Node $positionNode): void
     {
         foreach ($newNodes as $newNode) {
+            $newNode->setAttribute(AttributeKey::SCOPE, $positionNode->getAttribute(AttributeKey::SCOPE));
             $this->addNodeBeforeNode($newNode, $positionNode, null);
         }
 

--- a/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
@@ -154,7 +154,7 @@ CODE_SAMPLE
         $assignVariable = $firstArg->value;
         $preAssign = new Assign($assignVariable, $array);
 
-        $this->nodesToAddCollector->addNodeBeforeNode($preAssign, $currentStmt, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($preAssign, $currentStmt);
 
         return $expr;
     }

--- a/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
+++ b/rules/DowngradePhp54/Rector/Closure/DowngradeThisInClosureRector.php
@@ -104,7 +104,7 @@ CODE_SAMPLE
 
         $expression = new Expression(new Assign($selfVariable, new Variable('this')));
 
-        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node);
 
         $this->traverseNodesWithCallable($node, static function (Node $subNode) use ($selfVariable): ?Closure {
             if (! $subNode instanceof Closure) {

--- a/rules/DowngradePhp54/Rector/MethodCall/DowngradeInstanceMethodCallRector.php
+++ b/rules/DowngradePhp54/Rector/MethodCall/DowngradeInstanceMethodCallRector.php
@@ -66,7 +66,7 @@ CODE_SAMPLE
         $variable = $this->namedVariableFactory->createVariable($node, 'object');
         $expression = new Expression(new Assign($variable, $node->var));
 
-        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node);
         $node->var = $variable;
         // necessary to remove useless parentheses
         $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);

--- a/rules/DowngradePhp56/Rector/FuncCall/DowngradeArrayFilterUseConstantRector.php
+++ b/rules/DowngradePhp56/Rector/FuncCall/DowngradeArrayFilterUseConstantRector.php
@@ -111,8 +111,7 @@ CODE_SAMPLE
 
         $this->nodesToAddCollector->addNodeBeforeNode(
             new Expression(new Assign($variable, new Array_([]))),
-            $funcCall,
-            $this->file->getSmartFileInfo()
+            $funcCall
         );
 
         /** @var ConstFetch $constant */
@@ -121,7 +120,7 @@ CODE_SAMPLE
             ? $this->applyArrayFilterUseKey($args, $closure, $variable)
             : $this->applyArrayFilterUseBoth($args, $closure, $variable);
 
-        $this->nodesToAddCollector->addNodeBeforeNode($foreach, $funcCall, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($foreach, $funcCall);
 
         return $variable;
     }

--- a/rules/DowngradePhp70/Rector/FuncCall/DowngradeDirnameLevelsRector.php
+++ b/rules/DowngradePhp70/Rector/FuncCall/DowngradeDirnameLevelsRector.php
@@ -131,7 +131,7 @@ CODE_SAMPLE
         $closure = $this->createClosure();
         $exprAssignClosure = $this->createExprAssign($funcVariable, $closure);
 
-        $this->nodesToAddCollector->addNodeBeforeNode($exprAssignClosure, $funcCall, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($exprAssignClosure, $funcCall);
 
         $funcCall->name = $funcVariable;
 

--- a/rules/DowngradePhp70/Rector/FuncCall/DowngradeSessionStartArrayOptionsRector.php
+++ b/rules/DowngradePhp70/Rector/FuncCall/DowngradeSessionStartArrayOptionsRector.php
@@ -87,11 +87,7 @@ CODE_SAMPLE
             $funcName = new Name('ini_set');
             $iniSet = new FuncCall($funcName, [new Arg($sessionKey), new Arg($option->value)]);
 
-            $this->nodesToAddCollector->addNodeBeforeNode(
-                new Expression($iniSet),
-                $node,
-                $this->file->getSmartFileInfo()
-            );
+            $this->nodesToAddCollector->addNodeBeforeNode(new Expression($iniSet), $node);
         }
 
         unset($node->args[0]);

--- a/rules/DowngradePhp70/Rector/MethodCall/DowngradeMethodCallOnCloneRector.php
+++ b/rules/DowngradePhp70/Rector/MethodCall/DowngradeMethodCallOnCloneRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
             $assign = new Assign($variable, $node->var);
         }
 
-        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($assign), $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($assign), $node);
         $node->var = $variable;
         $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
 

--- a/rules/DowngradePhp70/Rector/Spaceship/DowngradeSpaceshipRector.php
+++ b/rules/DowngradePhp70/Rector/Spaceship/DowngradeSpaceshipRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
         $assignVariable = $this->namedVariableFactory->createVariable($node, 'battleShipcompare');
 
         $assignExpression = $this->getAssignExpression($anonymousFunction, $assignVariable);
-        $this->nodesToAddCollector->addNodeBeforeNode($assignExpression, $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($assignExpression, $node);
 
         return new FuncCall($assignVariable, [new Arg($node->left), new Arg($node->right)]);
     }

--- a/rules/DowngradePhp71/Rector/StaticCall/DowngradeClosureFromCallableRector.php
+++ b/rules/DowngradePhp71/Rector/StaticCall/DowngradeClosureFromCallableRector.php
@@ -79,7 +79,7 @@ CODE_SAMPLE
         $tempVariable = $this->namedVariableFactory->createVariable($node, 'callable');
         $expression = new Expression(new Assign($tempVariable, $node->args[0]->value));
 
-        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node);
 
         $closure = new Closure();
         $closure->uses[] = new ClosureUse($tempVariable);

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -248,7 +248,7 @@ CODE_SAMPLE
     {
         if ($if->stmts !== []) {
             $firstStmt = $if->stmts[0];
-            $this->nodesToAddCollector->addNodeBeforeNode($funcCall, $firstStmt, $this->file->getSmartFileInfo());
+            $this->nodesToAddCollector->addNodeBeforeNode($funcCall, $firstStmt);
 
             return;
         }

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeStreamIsattyRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
         $variable = new Variable($this->variableNaming->createCountedValueName('streamIsatty', $scope));
         $assign = new Assign($variable, $function);
 
-        $this->nodesToAddCollector->addNodeBeforeNode($assign, $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($assign, $node);
 
         return new FuncCall($variable, $node->args);
     }

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -102,7 +102,7 @@ CODE_SAMPLE
         }
 
         $resetFuncCall = $this->nodeFactory->createFuncCall('reset', [$array]);
-        $this->nodesToAddCollector->addNodeBeforeNode($resetFuncCall, $funcCall, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($resetFuncCall, $funcCall);
 
         $funcCall->name = new Name('key');
         if ($originalArray !== $array) {
@@ -130,7 +130,7 @@ CODE_SAMPLE
         }
 
         $resetFuncCall = $this->nodeFactory->createFuncCall('end', [$array]);
-        $this->nodesToAddCollector->addNodeBeforeNode($resetFuncCall, $funcCall, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($resetFuncCall, $funcCall);
 
         $funcCall->name = new Name('key');
         if ($originalArray !== $array) {
@@ -142,11 +142,7 @@ CODE_SAMPLE
 
     private function addAssignNewVariable(FuncCall $funcCall, Expr $expr, Expr|Variable $variable): void
     {
-        $this->nodesToAddCollector->addNodeBeforeNode(
-            new Expression(new Assign($variable, $expr)),
-            $funcCall,
-            $this->file->getSmartFileInfo()
-        );
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression(new Assign($variable, $expr)), $funcCall);
     }
 
     private function resolveCastedArray(Expr $expr): Expr|Variable

--- a/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
+++ b/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
@@ -121,11 +121,7 @@ CODE_SAMPLE
             );
             // Assign the value to the variable
             $newVariable = new Variable($variableName);
-            $this->nodesToAddCollector->addNodeBeforeNode(
-                new Assign($newVariable, $allowableTagsParam),
-                $node,
-                $this->file->getSmartFileInfo()
-            );
+            $this->nodesToAddCollector->addNodeBeforeNode(new Assign($newVariable, $allowableTagsParam), $node);
 
             // Apply refactor on the variable
             $newExpr = $this->createIsArrayTernaryFromExpression($newVariable);

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionClassGetConstantsFilterRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionClassGetConstantsFilterRector.php
@@ -135,20 +135,12 @@ CODE_SAMPLE
             $variableReflectionClassConstants,
             new MethodCall($methodCall->var, 'getReflectionConstants')
         );
-        $this->nodesToAddCollector->addNodeBeforeNode(
-            new Expression($assign),
-            $methodCall,
-            $this->file->getSmartFileInfo()
-        );
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($assign), $methodCall);
 
         $result = $this->variableNaming->createCountedValueName('result', $scope);
         $variableResult = new Variable($result);
         $assignVariableResult = new Assign($variableResult, new Array_());
-        $this->nodesToAddCollector->addNodeBeforeNode(
-            new Expression($assignVariableResult),
-            $methodCall,
-            $this->file->getSmartFileInfo()
-        );
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($assignVariableResult), $methodCall);
 
         $ifs = [];
         $valueVariable = new Variable('value');
@@ -176,11 +168,7 @@ CODE_SAMPLE
             'array_walk',
             [$variableReflectionClassConstants, $closure]
         );
-        $this->nodesToAddCollector->addNodeBeforeNode(
-            new Expression($funcCall),
-            $methodCall,
-            $this->file->getSmartFileInfo()
-        );
+        $this->nodesToAddCollector->addNodeBeforeNode(new Expression($funcCall), $methodCall);
 
         return $variableResult;
     }

--- a/rules/DowngradePhp80/Rector/New_/DowngradeArbitraryExpressionsSupportRector.php
+++ b/rules/DowngradePhp80/Rector/New_/DowngradeArbitraryExpressionsSupportRector.php
@@ -96,7 +96,7 @@ CODE_SAMPLE
             $assign = new Assign($variable, $node->class);
         }
 
-        $this->nodesToAddCollector->addNodeBeforeNode($assign, $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($assign, $node);
         $node->class = $variable;
         return $node;
     }

--- a/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
+++ b/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
@@ -172,7 +172,7 @@ final class ArrayMergeFromArraySpreadFactory
         $newVariable = new Variable($variableName);
 
         $newVariableAssign = new Assign($newVariable, $arrayItem->value);
-        $this->nodesToAddCollector->addNodeBeforeNode($newVariableAssign, $array, $file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($newVariableAssign, $array);
 
         return $newVariable;
     }

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
         $function = $this->createClosure();
         $expression = new Expression(new Assign($variable, $function));
 
-        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node, $this->file->getSmartFileInfo());
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $node);
 
         return new FuncCall($variable, $node->args);
     }

--- a/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
+++ b/rules/EarlyReturn/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
@@ -141,11 +141,7 @@ CODE_SAMPLE
         Foreach_ $foreach
     ): Foreach_ {
         $this->removeNode($expression);
-        $this->nodesToAddCollector->addNodeBeforeNode(
-            new Return_($assign->expr),
-            $breaks[0],
-            $this->file->getSmartFileInfo()
-        );
+        $this->nodesToAddCollector->addNodeBeforeNode(new Return_($assign->expr), $breaks[0]);
         $this->removeNode($breaks[0]);
 
         $return->expr = $assignPreviousVariable->expr;

--- a/rules/Php70/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector.php
+++ b/rules/Php70/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector.php
@@ -107,11 +107,7 @@ final class NonVariableToVariableOnFunctionCallRector extends AbstractRector imp
                 continue;
             }
 
-            $this->nodesToAddCollector->addNodeBeforeNode(
-                $replacements->getAssign(),
-                $currentStmt,
-                $this->file->getSmartFileInfo()
-            );
+            $this->nodesToAddCollector->addNodeBeforeNode($replacements->getAssign(), $currentStmt);
 
             $node->args[$key]->value = $replacements->getVariable();
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -251,7 +251,7 @@ CODE_SAMPLE;
         $this->mirrorAttributes($originalAttributes, $node);
 
         $currentScope = $originalNode->getAttribute(AttributeKey::SCOPE);
-        $this->changedNodeScopeRefresher->refresh($node, $this->file->getSmartFileInfo(), $currentScope);
+        $this->changedNodeScopeRefresher->refresh($node, $currentScope, $this->file->getSmartFileInfo());
 
         $this->connectParentNodes($node);
 

--- a/tests/Issues/ScopeNotAvailable/FixtureDowngradePregUnmatched/preg_unmatched.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureDowngradePregUnmatched/preg_unmatched.php.inc
@@ -18,10 +18,10 @@ function test()
 {
         $match = ((\PREG_PATTERN_ORDER | \PREG_SET_ORDER) & $flags) ? 'preg_match_all' : 'preg_match';
         $match($regexp.'u', $this->string, $matches, $flags, $offset);
-            array_walk_recursive($matches, function (&$value) {
-                if ($value === '') {
-                    $value = null;
-               }
+        array_walk_recursive($matches, function (&$value) {
+            if ($value === '') {
+                $value = null;
+            }
         });
 }
 

--- a/tests/Issues/ScopeNotAvailable/FixtureDowngradePregUnmatched/preg_unmatched.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureDowngradePregUnmatched/preg_unmatched.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+
+function test()
+{
+        $match = ((\PREG_PATTERN_ORDER | \PREG_SET_ORDER) & $flags) ? 'preg_match_all' : 'preg_match';
+        $match($regexp.'u', $this->string, $matches, $flags | \PREG_UNMATCHED_AS_NULL, $offset);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+
+function test()
+{
+        $match = ((\PREG_PATTERN_ORDER | \PREG_SET_ORDER) & $flags) ? 'preg_match_all' : 'preg_match';
+        $match($regexp.'u', $this->string, $matches, $flags, $offset);
+            array_walk_recursive($matches, function (&$value) {
+                if ($value === '') {
+                    $value = null;
+               }
+        });
+}
+
+?>

--- a/tests/Issues/ScopeNotAvailable/PregUnmatchedTest.php
+++ b/tests/Issues/ScopeNotAvailable/PregUnmatchedTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class PregUnmatchedTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureDowngradePregUnmatched');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/callable_this_downgrade_preg_unmatched_configured_rule.php';
+    }
+}

--- a/tests/Issues/ScopeNotAvailable/config/callable_this_downgrade_preg_unmatched_configured_rule.php
+++ b/tests/Issues/ScopeNotAvailable/config/callable_this_downgrade_preg_unmatched_configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector;
+use Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([DowngradeArrayIsListRector::class, DowngradePregUnmatchedAsNullConstantRector::class]);
+};


### PR DESCRIPTION
Given the following code:

```php
function test()
{
        $match = ((\PREG_PATTERN_ORDER | \PREG_SET_ORDER) & $flags) ? 'preg_match_all' : 'preg_match';
        $match($regexp.'u', $this->string, $matches, $flags | \PREG_UNMATCHED_AS_NULL, $offset);
}
```

it currently make error:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\ScopeNotAvailable\PregUnmatchedTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Scope not available on "PhpParser\Node\Expr\FuncCall" node with parent node of "", but is required by a refactorWithScope() method of "Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector" rule. Fix scope refresh on changed nodes first
```

Applied rules:

```php
Rector\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector;
Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector;
```

Fixes https://github.com/rectorphp/rector/issues/7252