### PR TITLE
Fix @return on StaticDoctrineAnnotationParser::resolveAnnotationValue()

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
@@ -46,7 +46,7 @@ final class StaticDoctrineAnnotationParser
 
     /**
      * @see https://github.com/doctrine/annotations/blob/c66f06b7c83e9a2a7523351a9d5a4b55f885e574/lib/Doctrine/Common/Annotations/DocParser.php#L1215-L1224
-     * @return array<mixed>
+     * @return CurlyListNode|string|array<mixed>|ConstExprNode|DoctrineAnnotationTagValueNode
      */
     public function resolveAnnotationValue(
         BetterTokenIterator $tokenIterator


### PR DESCRIPTION
@TomasVotruba this is based on your comment at https://github.com/rectorphp/rector-src/pull/2555#issuecomment-1164467089

The original `@return` value on `StaticDoctrineAnnotationParser::resolveAnnotationValue()` is `array<mixed>`, that's why it keep to have value `array<mixed>` on downgrading. 

This PR fix to the correct `@return CurlyListNode|string|array<mixed>|ConstExprNode|DoctrineAnnotationTagValueNode` so on downgrading, it will be ok

