### PR TITLE
[TypeDeclaration] Skip string type override nullable string return on AddReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/Fixture/skip_implements_nullablestring_already_has_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/Fixture/skip_implements_nullablestring_already_has_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Source\FormTypeInterface;
+
+final class MyFormType implements FormTypeInterface
+{
+    public function getParent(): string
+    {
+        return 'foo';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/Source/FormTypeInterface.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/Source/FormTypeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Source;
+
+interface FormTypeInterface
+{
+    /**
+     * @return string|null
+     */
+    public function getParent();
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use PHPStan\Type\MixedType;
-use PHPStan\Type\VoidType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
+use PHPStan\Type\VoidType;
 use Rector\Config\RectorConfig;
 use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture\ReturnOfStatic;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 use PHPStan\Type\MixedType;
 use PHPStan\Type\VoidType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
 use Rector\Config\RectorConfig;
 use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture\ReturnOfStatic;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture\ReturnTheMixed;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Source\DataTransformerInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Source\FormTypeInterface;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Source\PHPUnitTestCase;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 
 return static function (RectorConfig $rectorConfig): void {
+    $nullableStringType = new UnionType([new NullType(), new StringType()]);
+
     $rectorConfig
         ->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
             new AddReturnTypeDeclaration(PHPUnitTestCase::class, 'tearDown', new VoidType()),
@@ -24,5 +30,6 @@ return static function (RectorConfig $rectorConfig): void {
                 new SimpleStaticType(ReturnOfStatic::class)
             ),
             new AddReturnTypeDeclaration(DataTransformerInterface::class, 'transform', new MixedType()),
+            new AddReturnTypeDeclaration(FormTypeInterface::class, 'getParent', $nullableStringType),
         ]);
 };

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
@@ -144,6 +144,11 @@ CODE_SAMPLE
         // already set → no change
         if ($classMethod->returnType !== null) {
             $currentReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
+
+            if ($this->typeComparator->isSubtype($currentReturnType, $newType)) {
+                return;
+            }
+
             if ($this->typeComparator->areTypesEqual($currentReturnType, $newType)) {
                 return;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
@@ -141,22 +141,29 @@ CODE_SAMPLE
             return;
         }
 
-        // already set → no change
-        if ($classMethod->returnType !== null) {
-            $currentReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
-
-            if ($this->typeComparator->isSubtype($currentReturnType, $newType)) {
-                return;
-            }
-
-            if ($this->typeComparator->areTypesEqual($currentReturnType, $newType)) {
-                return;
-            }
+        // already set and sub type or equal → no change
+        if ($this->shouldSkipType($classMethod, $newType)) {
+            return;
         }
 
         $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($newType, TypeKind::RETURN);
         $classMethod->returnType = $returnTypeNode;
 
         $this->hasChanged = true;
+    }
+
+    private function shouldSkipType(ClassMethod $classMethod, Type $newType): bool
+    {
+        if ($classMethod->returnType === null) {
+            return false;
+        }
+
+        $currentReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
+
+        if ($this->typeComparator->isSubtype($currentReturnType, $newType)) {
+            return true;
+        }
+
+        return $this->typeComparator->areTypesEqual($currentReturnType, $newType);
     }
 }


### PR DESCRIPTION
Closes #2557 
Fixes https://github.com/rectorphp/rector/issues/7253