### PR TITLE
[Parallel] Display stack trace on --debug on parallel

### DIFF
--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -99,11 +99,12 @@ final class WorkerRunner
                     ++$systemErrorsCount;
 
                     $errorMessage = sprintf('System error: "%s"', $throwable->getMessage()) . PHP_EOL;
-                    $errorMessage .= 'Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new';
-                    $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
 
                     if ($this->rectorConsoleOutputStyle->isDebug()) {
-                        $systemErrors[] = new SystemError($throwable->getTraceAsString(), $filePath, $throwable->getLine());
+                        $systemErrors[] = new SystemError($errorMessage . PHP_EOL . 'Stack trace:' . PHP_EOL . $throwable->getTraceAsString(), $filePath, $throwable->getLine());
+                    } else {
+                        $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
+                        $errorMessage .= 'Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new';
                     }
                 }
             }

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -97,15 +97,7 @@ final class WorkerRunner
                     );
                 } catch (Throwable $throwable) {
                     ++$systemErrorsCount;
-
-                    $errorMessage = sprintf('System error: "%s"', $throwable->getMessage()) . PHP_EOL;
-
-                    if ($this->rectorConsoleOutputStyle->isDebug()) {
-                        $systemErrors[] = new SystemError($errorMessage . PHP_EOL . 'Stack trace:' . PHP_EOL . $throwable->getTraceAsString(), $filePath, $throwable->getLine());
-                    } else {
-                        $errorMessage .= 'Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new';
-                        $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
-                    }
+                    $systemErrors = $this->collectSystemErrors($systemErrors, $throwable, $filePath);
                 }
             }
 
@@ -124,5 +116,28 @@ final class WorkerRunner
         });
 
         $decoder->on(ReactEvent::ERROR, $handleErrorCallback);
+    }
+
+    /**
+     * @param SystemError[] $systemErrors
+     * @return SystemError[]
+     */
+    private function collectSystemErrors(array $systemErrors, Throwable $throwable, string $filePath): array
+    {
+        $errorMessage = sprintf('System error: "%s"', $throwable->getMessage()) . PHP_EOL;
+
+        if ($this->rectorConsoleOutputStyle->isDebug()) {
+            $systemErrors[] = new SystemError(
+                $errorMessage . PHP_EOL . 'Stack trace:' . PHP_EOL . $throwable->getTraceAsString(),
+                $filePath,
+                $throwable->getLine()
+            );
+            return $systemErrors;
+        }
+
+        $errorMessage .= 'Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new';
+        $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
+
+        return $systemErrors;
     }
 }

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -8,6 +8,7 @@ use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
 use PHPStan\Analyser\NodeScopeResolver;
 use Rector\Core\Application\FileProcessor\PhpFileProcessor;
+use Rector\Core\Console\Style\RectorConsoleOutputStyle;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\StaticReflection\DynamicSourceLocatorDecorator;
 use Rector\Core\ValueObject\Application\File;
@@ -34,6 +35,7 @@ final class WorkerRunner
         private readonly PhpFileProcessor $phpFileProcessor,
         private readonly NodeScopeResolver $nodeScopeResolver,
         private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator,
+        private readonly RectorConsoleOutputStyle $rectorConsoleOutputStyle
     ) {
     }
 
@@ -99,6 +101,10 @@ final class WorkerRunner
                     $errorMessage = sprintf('System error: "%s"', $throwable->getMessage()) . PHP_EOL;
                     $errorMessage .= 'Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new';
                     $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
+
+                    if ($this->rectorConsoleOutputStyle->isDebug()) {
+                        $systemErrors[] = new SystemError($throwable->getTraceAsString(), $filePath, $throwable->getLine());
+                    }
                 }
             }
 

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -103,8 +103,8 @@ final class WorkerRunner
                     if ($this->rectorConsoleOutputStyle->isDebug()) {
                         $systemErrors[] = new SystemError($errorMessage . PHP_EOL . 'Stack trace:' . PHP_EOL . $throwable->getTraceAsString(), $filePath, $throwable->getLine());
                     } else {
-                        $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
                         $errorMessage .= 'Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new';
+                        $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7254

**Before**

```bash
[file] src/Config/Loader/ConfigureCallMergingLoaderFactory.php
[rule] Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector
                                                                                                                        
 [ERROR] Could not process "src/Config/Loader/ConfigureCallMergingLoaderFactory.php" file, due to:                      
         "System error: "Look at "Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector::refactor()":111"   
         Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new". On 
         line: 111         
```

**After**

```bash
[file] src/Config/Loader/ConfigureCallMergingLoaderFactory.php
[rule] Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector

[ERROR] Could not process "src/Config/Loader/ConfigureCallMergingLoaderFactory.php" file, due to:                      
         "System error: "Look at "Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector::refactor()":111"   
                                                                                                                        
         Stack trace:                                                                                                   
         #0 src/Rector/AbstractRector.php(218):                                                                         
         Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector->refactor(Object(PhpParser\Node\Stmt\Class_))
         #1 vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(200):                                               
         Rector\Core\Rector\AbstractRector->enterNode(Object(PhpParser\Node\Stmt\Class_))                               
         #2 vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array) 
         #3 vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223):                                               
         PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))                                  
         #4 vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(91): PhpParser\NodeTraverser->traverseArray(Array)  
         #5 src/PhpParser/NodeTraverser/RectorNodeTraverser.php(33): PhpParser\NodeTraverser->traverse(Array)           
         #6 src/Application/FileProcessor.php(42): Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser->traverse(Array)
         #7 src/Application/FileProcessor/PhpFileProcessor.php(103):                                                    
         Rector\Core\Application\FileProcessor->refactor(Object(Rector\Core\ValueObject\Application\File),              
         Object(Rector\Core\ValueObject\Configuration))                                                                 
         #8 src/Application/FileProcessor/PhpFileProcessor.php(62):                                                     
         Rector\Core\Application\FileProcessor\PhpFileProcessor->refactorNodesWithRectors(Object(Rector\Core\ValueObject\Applica
         tion\File), Object(Rector\Core\ValueObject\Configuration))                                                     
         #9 packages/Parallel/WorkerRunner.php(92):                                                                     
         Rector\Core\Application\FileProcessor\PhpFileProcessor->process(Object(Rector\Core\ValueObject\Application\File),
         Object(Rector\Core\ValueObject\Configuration))                                                                 
         #10 vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123):                                       
         Rector\Parallel\WorkerRunner->Rector\Parallel\{closure}(Array)                                                 
         #11 vendor/clue/ndjson-react/src/Decoder.php(131): Evenement\EventEmitter->emit('data', Array)                 
         #12 vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123): Clue\React\NDJson\Decoder->handleData(Array)
         #13 vendor/react/stream/src/Util.php(71): Evenement\EventEmitter->emit('data', Array)                          
         #14 vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123):                                       
         React\Stream\Util::React\Stream\{closure}('{"action":"main...')                                                
         #15 vendor/react/stream/src/DuplexResourceStream.php(196): Evenement\EventEmitter->emit('data', Array)         
         #16 vendor/react/event-loop/src/StreamSelectLoop.php(246): React\Stream\DuplexResourceStream->handleData(Resource id
         #3325)                                                                                                         
         #17 vendor/react/event-loop/src/StreamSelectLoop.php(213):                                                     
         React\EventLoop\StreamSelectLoop->waitForStreamActivity(NULL)                                                  
         #18 src/Console/Command/WorkerCommand.php(66): React\EventLoop\StreamSelectLoop->run()                         
         #19 vendor/symfony/console/Command/Command.php(308):                                                           
         Rector\Core\Console\Command\WorkerCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput),          
         Object(Symfony\Component\Console\Output\ConsoleOutput))                                                        
         #20 vendor/symfony/console/Application.php(998):                                                               
         Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput),              
         Object(Symfony\Component\Console\Output\ConsoleOutput))                                                        
         #21 vendor/symfony/console/Application.php(299):                                                               
         Symfony\Component\Console\Application->doRunCommand(Object(Rector\Core\Console\Command\WorkerCommand),         
         Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))     
         #22 src/Console/ConsoleApplication.php(58):                                                                    
         Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput),                
         Object(Symfony\Component\Console\Output\ConsoleOutput))                                                        
         #23 vendor/symfony/console/Application.php(171):                                                               
         Rector\Core\Console\ConsoleApplication->doRun(Object(Symfony\Component\Console\Input\ArgvInput),               
         Object(Symfony\Component\Console\Output\ConsoleOutput))                                                        
         #24 bin/rector.php(159): Symfony\Component\Console\Application->run()                                          
         #25 bin/rector(4): require_once('/Users/samsonas...')                                                          
         #26 {main}". On line: 111                                                                                      
                                                              
```