### PR TITLE
[fix] Skip doc-types in ReturnStrictTypeAnalyzer

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_false_report_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_false_report_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SkipFalseReportType
+{
+    public function isBoolean()
+    {
+        return $this->fakedTypes();
+    }
+
+    /**
+     * @return bool
+     */
+    private function fakedTypes()
+    {
+        return 100;
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Return_;
+use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Type\MixedType;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -65,7 +66,13 @@ final class ReturnStrictTypeAnalyzer
         }
 
         $parametersAcceptor = $methodReflection->getVariants()[0];
-        $returnType = $parametersAcceptor->getReturnType();
+        if ($parametersAcceptor instanceof FunctionVariantWithPhpDocs) {
+            // native return type is needed, as docblock can be false
+            $returnType = $parametersAcceptor->getNativeReturnType();
+        } else {
+            $returnType = $parametersAcceptor->getReturnType();
+        }
+
         if ($returnType instanceof MixedType) {
             return null;
         }


### PR DESCRIPTION
- add breaking fixture
- [fix] Skip doc-types in ReturnStrictTypeAnalyzer
