### PR TITLE
[Core] Refactor CreatedByRuleDecorator to only set CREATED_BY_RULE on target Node when class is equals with Original Node

### DIFF
--- a/src/NodeDecorator/CreatedByRuleDecorator.php
+++ b/src/NodeDecorator/CreatedByRuleDecorator.php
@@ -19,7 +19,9 @@ final class CreatedByRuleDecorator
         }
 
         foreach ($node as $singleNode) {
-            $this->createByRule($singleNode, $rectorClass);
+            if ($singleNode::class === $originalNode::class) {
+                $this->createByRule($singleNode, $rectorClass);
+            }
         }
 
         $this->createByRule($originalNode, $rectorClass);


### PR DESCRIPTION
When the target Node class is not equals with original Node, the `CREATED_BY_RULE` attribute should not be applied to a new target Node as already different Node class.

This PR update to only set `CREATED_BY_RULE` attribute on target Node when the target Node class is equals with Original Node class.