### PR TITLE
[DX] Move UnionTypeFactory from DowngradePhp72 to NodeTypeResolver packages

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Type/UnionTypeFactory.php
+++ b/packages/NodeTypeResolver/PHPStan/Type/UnionTypeFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\DowngradePhp72;
+namespace Rector\NodeTypeResolver\PHPStan\Type;
 
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;

--- a/rules/CodeQuality/NodeManipulator/ClassMethodParameterTypeManipulator.php
+++ b/rules/CodeQuality/NodeManipulator/ClassMethodParameterTypeManipulator.php
@@ -21,10 +21,10 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ParamAnalyzer;
-use Rector\DowngradePhp72\UnionTypeFactory;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\NodeTypeResolver\PHPStan\Type\UnionTypeFactory;
 use Symplify\Astral\NodeTraverser\SimpleCallableNodeTraverser;
 
 final class ClassMethodParameterTypeManipulator

--- a/rules/CodeQuality/NodeManipulator/ClassMethodReturnTypeManipulator.php
+++ b/rules/CodeQuality/NodeManipulator/ClassMethodReturnTypeManipulator.php
@@ -13,8 +13,8 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\DowngradePhp72\UnionTypeFactory;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\NodeTypeResolver\PHPStan\Type\UnionTypeFactory;
 
 final class ClassMethodReturnTypeManipulator
 {


### PR DESCRIPTION
The `UnionTypeFactory` is never used in `DowngradePhp*` rules, so it need to be moved to separate place.

This PR move it to `NodeTypeResolver` packages to avoid notice:

```bash
 * Rector\DowngradePhp72\UnionTypeFactory
src/DowngradePhp72/UnionTypeFactory.php

 [ERROR] Found 1 unused classes. Check them, remove them or correct the command.
```

when moving to [rector-downgrade-php](https://github.com/rectorphp/rector-downgrade-php) package https://github.com/rectorphp/rector-downgrade-php/runs/7068212829?check_suite_focus=true