### PR TITLE
[Core] Apply auto fallback to use Scope from File when Node both doesnot has parent Node and Scope

### DIFF
--- a/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
@@ -144,7 +144,6 @@ CODE_SAMPLE
         if (($node instanceof Identical || $node instanceof NotIdentical) && $node->right instanceof LNumber && $node->right->value === 0) {
             $this->removeNode($funcCall);
             $node->right = new Array_([]);
-            $node->right->setAttribute(AttributeKey::SCOPE, $node->getAttribute(AttributeKey::SCOPE));
 
             return $expr;
         }
@@ -152,7 +151,6 @@ CODE_SAMPLE
         if (($node instanceof Identical || $node instanceof NotIdentical) && $node->left instanceof LNumber && $node->left->value === 0) {
             $this->removeNode($funcCall);
             $node->left = new Array_([]);
-            $node->left->setAttribute(AttributeKey::SCOPE, $node->getAttribute(AttributeKey::SCOPE));
 
             return $expr;
         }

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -9,10 +9,8 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\Namespace_;
 use PHPStan\Analyser\MutatingScope;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class ScopeAnalyzer
 {
@@ -20,11 +18,6 @@ final class ScopeAnalyzer
      * @var array<class-string<Node>>
      */
     private const NO_SCOPE_NODES = [Name::class, Identifier::class, Param::class, Arg::class];
-
-    /**
-     * @var array<class-string<Stmt>>
-     */
-    private const RESOLVABLE_FROM_FILE_NODES = [Namespace_::class, FileWithoutNamespace::class];
 
     public function hasScope(Node $node): bool
     {
@@ -43,6 +36,7 @@ final class ScopeAnalyzer
             return false;
         }
 
-        return in_array($node::class, self::RESOLVABLE_FROM_FILE_NODES, true);
+        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+        return ! $parent instanceof Node;
     }
 }

--- a/src/NodeManipulator/ClassInsertManipulator.php
+++ b/src/NodeManipulator/ClassInsertManipulator.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Stmt\TraitUse;
 use PHPStan\Type\Type;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\ValueObject\PropertyMetadata;
 
 final class ClassInsertManipulator
@@ -32,9 +31,6 @@ final class ClassInsertManipulator
 
     public function addAsFirstMethod(Class_ $class, Property | ClassConst | ClassMethod $stmt): void
     {
-        $scope = $class->getAttribute(AttributeKey::SCOPE);
-        $stmt->setAttribute(AttributeKey::SCOPE, $scope);
-
         if ($this->isSuccessToInsertBeforeFirstMethod($class, $stmt)) {
             return;
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -24,6 +24,7 @@ use Rector\Core\Contract\Rector\PhpRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Exclusion\ExclusionManager;
 use Rector\Core\Logging\CurrentRectorProvider;
+use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -98,6 +99,8 @@ CODE_SAMPLE;
 
     protected ChangedNodeScopeRefresher $changedNodeScopeRefresher;
 
+    protected ScopeAnalyzer $scopeAnalyzer;
+
     protected ScopeFactory $scopeFactory;
 
     private SimpleCallableNodeTraverser $simpleCallableNodeTraverser;
@@ -146,6 +149,7 @@ CODE_SAMPLE;
         CreatedByRuleDecorator $createdByRuleDecorator,
         ChangedNodeScopeRefresher $changedNodeScopeRefresher,
         RectorOutputStyle $rectorOutputStyle,
+        ScopeAnalyzer $scopeAnalyzer,
         ScopeFactory $scopeFactory
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
@@ -169,6 +173,7 @@ CODE_SAMPLE;
         $this->createdByRuleDecorator = $createdByRuleDecorator;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
         $this->rectorOutputStyle = $rectorOutputStyle;
+        $this->scopeAnalyzer = $scopeAnalyzer;
         $this->scopeFactory = $scopeFactory;
     }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -37,6 +37,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeRemoval\NodeRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 use Rector\PostRector\Collector\NodesToAddCollector;
 use Rector\PostRector\Collector\NodesToRemoveCollector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -120,6 +121,8 @@ CODE_SAMPLE;
 
     private RectorOutputStyle $rectorOutputStyle;
 
+    protected ScopeFactory $scopeFactory;
+
     #[Required]
     public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
@@ -142,7 +145,8 @@ CODE_SAMPLE;
         RectifiedAnalyzer $rectifiedAnalyzer,
         CreatedByRuleDecorator $createdByRuleDecorator,
         ChangedNodeScopeRefresher $changedNodeScopeRefresher,
-        RectorOutputStyle $rectorOutputStyle
+        RectorOutputStyle $rectorOutputStyle,
+        ScopeFactory $scopeFactory
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
         $this->nodesToAddCollector = $nodesToAddCollector;
@@ -165,6 +169,7 @@ CODE_SAMPLE;
         $this->createdByRuleDecorator = $createdByRuleDecorator;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
         $this->rectorOutputStyle = $rectorOutputStyle;
+        $this->scopeFactory = $scopeFactory;
     }
 
     /**

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -98,6 +98,8 @@ CODE_SAMPLE;
 
     protected ChangedNodeScopeRefresher $changedNodeScopeRefresher;
 
+    protected ScopeFactory $scopeFactory;
+
     private SimpleCallableNodeTraverser $simpleCallableNodeTraverser;
 
     private ExclusionManager $exclusionManager;
@@ -120,8 +122,6 @@ CODE_SAMPLE;
     private CreatedByRuleDecorator $createdByRuleDecorator;
 
     private RectorOutputStyle $rectorOutputStyle;
-
-    protected ScopeFactory $scopeFactory;
 
     #[Required]
     public function autowire(

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\ScopeAwarePhpRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeAwarePhpRectorInterface
@@ -21,13 +20,11 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
     {
         $scope = $node->getAttribute(AttributeKey::SCOPE);
 
-        if (! $scope instanceof Scope) {
-            $scopeAnalyzer = new ScopeAnalyzer();
-            if ($scopeAnalyzer->isScopeResolvableFromFile($node, $scope)) {
-                $smartFileInfo = $this->file->getSmartFileInfo();
-                $scope = $this->scopeFactory->createFromFile($smartFileInfo);
-                $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
-            }
+        if ($this->scopeAnalyzer->isScopeResolvableFromFile($node, $scope)) {
+            $smartFileInfo = $this->file->getSmartFileInfo();
+            $scope = $this->scopeFactory->createFromFile($smartFileInfo);
+
+            $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
         }
 
         if (! $scope instanceof Scope) {


### PR DESCRIPTION
Error for Scope not exists with `node with parent node of ""` for empty parent can happen in many places, eg, on rule that apply the following condition:

**1. Add more statement to Node:**

```php
$class->stmts[] = $stmt;
```

which the `$stmt` doesn't has `parent` attribute yet like in PR:

- https://github.com/rectorphp/rector-src/pull/2396

**2. Return Node that not modified:**

```php
$node->right = new Array_();

return $expr;
```

which returned `Node` is different Node than modified like in PR:

- https://github.com/rectorphp/rector-src/pull/2552

The `Scope` was was manually added via patch in the individual rules itself like:

```php
$scope = $class->getAttribute(AttributeKey::SCOPE);
$stmt->setAttribute(AttributeKey::SCOPE, $scope);
```

**OR**

```php
$node->right->setAttribute(AttributeKey::SCOPE, $node->getAttribute(AttributeKey::SCOPE));
```

which can happen again anytime in the future, so we need to manually patch in the rules.

**This PR update:**

- `ScopeAnalyzer::isScopeResolvableFromFile()` to verify if Node doesn't has Scope, and doesn't has parent Node ~> mark as resolvable from File.
- Update `AbstractScopeAwareRector::refactor()` to refresh `Scope` when `Scope` can't be found in the visited `Node`, then check if it is resolvableFromFile, if yes, refresh in the fly.

So no more manual update if the Node doesn't has Scope, and doesn't has parent Node.