### PR TITLE
[DeadCode] Handle always terminated Switch_ on RemoveUnreachableStatementRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_switch.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_switch.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedSwitch
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+                return 'A';
+            default:
+                return 'B';
+        }
+
+        echo 'never executed';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedSwitch
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+                return 'A';
+            default:
+                return 'B';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_assign_only_in_switch.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_assign_only_in_switch.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipAssignOnlyInSwitch
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+                $result = 'A';
+                break;
+        }
+
+        echo 'executed';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_no_case_in_switch.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_no_case_in_switch.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipNoCaseInSwitch
+{
+    public function run($a)
+    {
+        switch ($a) {
+        }
+
+        echo 'executed';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_switch_no_default.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_switch_no_default.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipSwitchNoDefault
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+                return 'A';
+            case 'b':
+                return 'B';
+        }
+
+        echo 'executed';
+    }
+}
+

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -6,8 +6,6 @@ namespace Rector\DeadCode\Rector\Stmt;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\InlineHTML;
-use PhpParser\Node\Stmt\Nop;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\NodeAnalyzer\TerminatedNodeAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -91,29 +89,16 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($stmt instanceof Nop) {
-                continue;
-            }
-
             $previousStmt = $stmts[$key - 1];
 
             // unset...
 
-            if ($this->shouldRemove($previousStmt, $stmt)) {
+            if ($this->terminatedNodeAnalyzer->isAlwaysTerminated($previousStmt, $stmt)) {
                 array_splice($stmts, $key);
                 return $stmts;
             }
         }
 
         return $stmts;
-    }
-
-    private function shouldRemove(Stmt $previousStmt, Stmt $currentStmt): bool
-    {
-        if ($currentStmt instanceof InlineHTML) {
-            return false;
-        }
-
-        return $this->terminatedNodeAnalyzer->isAlwaysTerminated($previousStmt, $currentStmt);
     }
 }

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -5,19 +5,9 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\Stmt;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\Break_;
-use PhpParser\Node\Stmt\Continue_;
-use PhpParser\Node\Stmt\Expression;
-use PhpParser\Node\Stmt\Goto_;
-use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\InlineHTML;
-use PhpParser\Node\Stmt\Label;
 use PhpParser\Node\Stmt\Nop;
-use PhpParser\Node\Stmt\Return_;
-use PhpParser\Node\Stmt\Throw_;
-use PhpParser\Node\Stmt\TryCatch;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\NodeAnalyzer\TerminatedNodeAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -124,30 +114,6 @@ CODE_SAMPLE
             return false;
         }
 
-        if ($previousStmt instanceof Throw_) {
-            return true;
-        }
-
-        if ($previousStmt instanceof Expression && $previousStmt->expr instanceof Exit_) {
-            return true;
-        }
-
-        if ($previousStmt instanceof Goto_ && $currentStmt instanceof Label) {
-            return false;
-        }
-
-        if (in_array($previousStmt::class, [Return_::class, Break_::class, Continue_::class, Goto_::class], true)) {
-            return true;
-        }
-
-        if ($previousStmt instanceof TryCatch) {
-            return $this->terminatedNodeAnalyzer->isAlwaysTerminated($previousStmt);
-        }
-
-        if ($previousStmt instanceof If_) {
-            return $this->terminatedNodeAnalyzer->isAlwaysTerminated($previousStmt);
-        }
-
-        return false;
+        return $this->terminatedNodeAnalyzer->isAlwaysTerminated($previousStmt, $currentStmt);
     }
 }

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -24,6 +24,7 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use PHPStan\Analyser\MutatingScope;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
@@ -132,6 +133,10 @@ final class ChangedNodeScopeRefresher
 
         if ($node instanceof TryCatch) {
             $node->catches = array_values($node->catches);
+        }
+
+        if ($node instanceof Switch_) {
+            $node->cases = array_values($node->cases);
         }
     }
 

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -7,11 +7,16 @@ namespace Rector\Core\NodeAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Finally_;
+use PhpParser\Node\Stmt\Goto_;
 use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Label;
 use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\TryCatch;
 
@@ -22,26 +27,85 @@ final class TerminatedNodeAnalyzer
      */
     private const TERMINATED_NODES = [Return_::class, Throw_::class];
 
-    public function isAlwaysTerminated(TryCatch|If_ $node): bool
+    /**
+     * @var array<class-string<Node>>
+     */
+    private const TERMINABLE_NODES = [Throw_::class, Return_::class, Break_::class, Continue_::class];
+
+    /**
+     * @var array<class-string<Node>>
+     */
+    private const TERMINABLE_NODES_BY_ITS_STMTS = [TryCatch::class, If_::class, Switch_::class];
+
+    public function isAlwaysTerminated(TryCatch|If_|Switch_|Node $node, Node $currentStmt): bool
     {
-        if ($node instanceof TryCatch) {
-            if ($node->finally instanceof Finally_ && $this->isTerminated($node->finally->stmts)) {
-                return true;
-            }
-
-            foreach ($node->catches as $catch) {
-                if (! $this->isTerminated($catch->stmts)) {
-                    return false;
-                }
-            }
-
-            return $this->isTerminated($node->stmts);
+        if (! in_array($node::class, self::TERMINABLE_NODES_BY_ITS_STMTS, true)) {
+            return $this->isTerminatedNode($node, $currentStmt);
         }
 
-        return $this->isTerminatedIf($node);
+        if ($node instanceof TryCatch) {
+            return $this->isTerminatedInLastStmtsTryCatch($node, $currentStmt);
+        }
+
+        if ($node instanceof If_) {
+            return $this->isTerminatedInLastStmtsIf($node, $currentStmt);
+        }
+
+        /** @var Switch_ $node */
+        return $this->isTerminatedInLastStmtsSwitch($node, $currentStmt);
     }
 
-    private function isTerminatedIf(If_ $if): bool
+    private function isTerminatedNode(Node $previousNode, Node $currentStmt): bool
+    {
+        if (in_array($previousNode::class, self::TERMINABLE_NODES, true)) {
+            return true;
+        }
+
+        if ($previousNode instanceof Expression && $previousNode->expr instanceof Exit_) {
+            return true;
+        }
+
+        if ($previousNode instanceof Goto_) {
+            return ! $currentStmt instanceof Label;
+        }
+
+        return false;
+    }
+
+    private function isTerminatedInLastStmtsSwitch(Switch_ $switch, Node $node): bool
+    {
+        if ($switch->cases === []) {
+            return false;
+        }
+
+        foreach ($switch->cases as $case) {
+            if (! $this->isTerminatedInLastStmts($case->stmts, $node)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isTerminatedInLastStmtsTryCatch(TryCatch $tryCatch, Node $node): bool
+    {
+        if ($tryCatch->finally instanceof Finally_ && $this->isTerminatedInLastStmts(
+            $tryCatch->finally->stmts,
+            $node
+        )) {
+            return true;
+        }
+
+        foreach ($tryCatch->catches as $catch) {
+            if (! $this->isTerminatedInLastStmts($catch->stmts, $node)) {
+                return false;
+            }
+        }
+
+        return $this->isTerminatedInLastStmts($tryCatch->stmts, $node);
+    }
+
+    private function isTerminatedInLastStmtsIf(If_ $if, Node $node): bool
     {
         // Without ElseIf_[] and Else_, after If_ is possibly executable
         if ($if->elseifs === [] && ! $if->else instanceof Else_) {
@@ -49,12 +113,12 @@ final class TerminatedNodeAnalyzer
         }
 
         foreach ($if->elseifs as $elseIf) {
-            if (! $this->isTerminated($elseIf->stmts)) {
+            if (! $this->isTerminatedInLastStmts($elseIf->stmts, $node)) {
                 return false;
             }
         }
 
-        if (! $this->isTerminated($if->stmts)) {
+        if (! $this->isTerminatedInLastStmts($if->stmts, $node)) {
             return false;
         }
 
@@ -62,13 +126,13 @@ final class TerminatedNodeAnalyzer
             return false;
         }
 
-        return $this->isTerminated($if->else->stmts);
+        return $this->isTerminatedInLastStmts($if->else->stmts, $node);
     }
 
     /**
      * @param Stmt[] $stmts
      */
-    private function isTerminated(array $stmts): bool
+    private function isTerminatedInLastStmts(array $stmts, Node $node): bool
     {
         if ($stmts === []) {
             return false;
@@ -76,6 +140,10 @@ final class TerminatedNodeAnalyzer
 
         $lastKey = array_key_last($stmts);
         $lastNode = $stmts[$lastKey];
+
+        if (isset($stmts[$lastKey - 1]) && $this->isTerminatedNode($stmts[$lastKey - 1], $node)) {
+            return false;
+        }
 
         if ($lastNode instanceof Expression) {
             return $lastNode->expr instanceof Exit_;

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
@@ -78,13 +79,18 @@ final class TerminatedNodeAnalyzer
             return false;
         }
 
+        $hasDefault = false;
         foreach ($switch->cases as $case) {
+            if (! $case->cond instanceof Expr) {
+                $hasDefault = true;
+            }
+
             if (! $this->isTerminatedInLastStmts($case->stmts, $node)) {
                 return false;
             }
         }
 
-        return true;
+        return $hasDefault;
     }
 
     private function isTerminatedInLastStmtsTryCatch(TryCatch $tryCatch, Node $node): bool

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -15,7 +15,9 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\Goto_;
 use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Label;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\Throw_;
@@ -38,8 +40,17 @@ final class TerminatedNodeAnalyzer
      */
     private const TERMINABLE_NODES_BY_ITS_STMTS = [TryCatch::class, If_::class, Switch_::class];
 
+    /**
+     * @var array<class-string<Node>>
+     */
+    private const ALLOWED_CONTINUE_CURRENT_STMTS = [InlineHTML::class, Nop::class];
+
     public function isAlwaysTerminated(TryCatch|If_|Switch_|Node $node, Node $currentStmt): bool
     {
+        if (in_array($currentStmt::class, self::ALLOWED_CONTINUE_CURRENT_STMTS, true)) {
+            return false;
+        }
+
         if (! in_array($node::class, self::TERMINABLE_NODES_BY_ITS_STMTS, true)) {
             return $this->isTerminatedNode($node, $currentStmt);
         }


### PR DESCRIPTION
Given the following code:

```php
class AlwaysTerminatedSwitch
{
    public function run($a)
    {
        switch ($a) {
            case 'a':
                return 'A';
            default:
                return 'B';
        }

        echo 'never executed';
    }
}
```

should remove:

```diff
-        echo 'never executed';
```