### PR TITLE
[DeadCode] Handle collection of Case_ on RemoveUnreachableStatementRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_switch_case_collection.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_switch_case_collection.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedSwitchCaseCollection
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+            case 'b':
+                return 'AB';
+            default:
+                return 'C';
+        }
+
+        echo 'never executed';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedSwitchCaseCollection
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+            case 'b':
+                return 'AB';
+            default:
+                return 'C';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_switch_case_empty_stmt.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_switch_case_empty_stmt.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipSwitchCaseEmptyStmt
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+        }
+
+        echo 'executed';
+    }
+}
+

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -91,9 +91,13 @@ final class TerminatedNodeAnalyzer
         }
 
         $hasDefault = false;
-        foreach ($switch->cases as $case) {
+        foreach ($switch->cases as $key => $case) {
             if (! $case->cond instanceof Expr) {
                 $hasDefault = true;
+            }
+
+            if ($case->stmts === [] && isset($switch->cases[$key + 1])) {
+                continue;
             }
 
             if (! $this->isTerminatedInLastStmts($case->stmts, $node)) {


### PR DESCRIPTION
Given the following code:

```php
class AlwaysTerminatedSwitchCaseCollection
{
    public function run($a)
    {
        switch ($a) {
            case 'a':
            case 'b':
                return 'AB';
            default:
                return 'C';
        }

        echo 'never executed';
    }
}
```

should remove: 

```diff
-        echo 'never executed';
```