### PR TITLE
[Naming] Skip used in arrow function args on RenameVariableToMatchMethodCallReturnTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/skip_variable_used_in_arrow_function_args.php.inc
+++ b/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/skip_variable_used_in_arrow_function_args.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallRetur
 
 use Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Source\FastRunner;
 
-class SkipVariableUsedInArrowFunctionParam
+class SkipVariableUsedInArrowFunctionArgs
 {
     public function run()
     {

--- a/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/skip_variable_used_in_arrow_function_param.php.inc
+++ b/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/skip_variable_used_in_arrow_function_param.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Source\FastRunner;
+
+class SkipVariableUsedInArrowFunctionParam
+{
+    public function run()
+    {
+        $a = $this->getFastRunner(fn (FastRunner $a) => $a->run());
+        $a->exit();
+    }
+
+    public function getFastRunner(callable $c): FastRunner
+    {
+        return new FastRunner();
+    }
+}

--- a/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Source/FastRunner.php
+++ b/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Source/FastRunner.php
@@ -6,5 +6,8 @@ namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallRetur
 
 final class FastRunner
 {
-
+    public function run()
+    {
+        return $this;
+    }
 }

--- a/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
+++ b/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Naming\Matcher;
 
+use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
@@ -41,6 +42,16 @@ final class VariableAndCallAssignMatcher
 
         $functionLike = $this->getFunctionLike($assign);
         if (! $functionLike instanceof FunctionLike) {
+            return null;
+        }
+
+        $isVariableFoundInCall = (bool) $this->betterNodeFinder->findFirst(
+            $call->getArgs(),
+            fn (Node $subNode): bool =>
+                $subNode instanceof Variable && $this->nodeNameResolver->isName($subNode, $variableName)
+        );
+
+        if ($isVariableFoundInCall) {
             return null;
         }
 

--- a/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
+++ b/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
@@ -45,13 +45,13 @@ final class VariableAndCallAssignMatcher
             return null;
         }
 
-        $isVariableFoundInCall = (bool) $this->betterNodeFinder->findFirst(
+        $isVariableFoundInCallArgs = (bool) $this->betterNodeFinder->findFirst(
             $call->getArgs(),
             fn (Node $subNode): bool =>
                 $subNode instanceof Variable && $this->nodeNameResolver->isName($subNode, $variableName)
         );
 
-        if ($isVariableFoundInCall) {
+        if ($isVariableFoundInCallArgs) {
             return null;
         }
 


### PR DESCRIPTION
Given the following code:

```php
class SkipVariableUsedInArrowFunctionArgs
{
    public function run()
    {
        $a = $this->getFastRunner(fn (FastRunner $a) => $a->run());
        $a->exit();
    }

    public function getFastRunner(callable $c): FastRunner
    {
        return new FastRunner();
    }
}
```

it produce:

```diff
-        $a = $this->getFastRunner(fn (FastRunner $a) => $a->run());
-        $a->exit();
+        $fastRunner = $this->getFastRunner(fn (FastRunner $a) => $fastRunner->run());
+        $fastRunner->exit();
```

which should be skipped as the `$fastRunner->run()` should keep using `$a->run()` instead.

Fixes https://github.com/rectorphp/rector/issues/7266