### PR TITLE
[Lumen] Create Lumen RoutesStringMiddlewareToArrayRector

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -22,6 +22,8 @@
 
 - [EarlyReturn](#earlyreturn) (11)
 
+- [Lumen](#lumen) (1)
+
 - [MysqlToMysqli](#mysqltomysqli) (4)
 
 - [Naming](#naming) (6)
@@ -4172,6 +4174,23 @@ Changes Single return of || to early returns
 +        return (bool) $this->somethingElse();
      }
  }
+```
+
+<br>
+
+## Lumen
+
+### RoutesStringMiddlewareToArrayRector
+
+Changes middlewares from rule definitions from string to array notation.
+
+- class: [`Rector\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector`](../rules/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector.php)
+
+```diff
+-$router->get('/user', ['middleware => 'test']);
+-$router->post('/user', ['middleware => 'test|authentication']);
++$router->get('/user', ['middleware => ['test']]);
++$router->post('/user', ['middleware => ['test', 'authentication']]);
 ```
 
 <br>

--- a/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/group_method_middleware_not_an_array.php.inc
+++ b/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/group_method_middleware_not_an_array.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->group(['middleware' => 'auth'], function () use ($router) {
+    $router->get('/', 'HomeController@home');
+});
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->group(['middleware' => ['auth']], function () use ($router) {
+    $router->get('/', 'HomeController@home');
+});
+
+?>

--- a/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/routes_method_middleware_not_an_array.php.inc
+++ b/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/routes_method_middleware_not_an_array.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->get('/', ['uses' => 'HomeController@home', 'middleware' => 'auth']);
+$router->post('/', ['uses' => 'HomeController@home', 'middleware' => 'auth']);
+$router->put('/', ['uses' => 'HomeController@home', 'middleware' => 'auth']);
+$router->delete('/', ['uses' => 'HomeController@home', 'middleware' => 'auth']);
+$router->options('/', ['uses' => 'HomeController@home', 'middleware' => 'auth']);
+$router->patch('/', ['uses' => 'HomeController@home', 'middleware' => 'auth']);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->get('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->post('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->put('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->delete('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->options('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->patch('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+
+?>

--- a/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/routes_method_middleware_string_array_notation.php.inc
+++ b/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/routes_method_middleware_string_array_notation.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->group(['middleware' => 'first|second'], function () use ($router) {
+    $router->get('/', ['uses' => 'HomeController@home', 'middleware' => 'third|fourth']);
+});
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->group(['middleware' => ['first', 'second']], function () use ($router) {
+    $router->get('/', ['uses' => 'HomeController@home', 'middleware' => ['third', 'fourth']]);
+});
+
+?>

--- a/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/skip_group_method_middleware_an_array.php.inc
+++ b/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/skip_group_method_middleware_an_array.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->group(['middleware' => ['auth']], function () use ($router) {
+    $router->get('/', 'HomeController@home');
+});
+
+?>

--- a/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/skip_routes_method_middleware_an_array.php.inc
+++ b/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/Fixture/skip_routes_method_middleware_an_array.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\Fixture;
+
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->get('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->post('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->put('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->delete('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->options('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+$router->patch('/', ['uses' => 'HomeController@home', 'middleware' => ['auth']]);
+
+?>

--- a/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/RoutesStringMiddlewareToArrayRectorTest.php
+++ b/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/RoutesStringMiddlewareToArrayRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RoutesStringMiddlewareToArrayRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/config/configured_rule.php
+++ b/rules-tests/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RoutesStringMiddlewareToArrayRector::class);
+};

--- a/rules/Lumen/NodeAnalyzer/LumenRouteRegisteringMethodAnalyzer.php
+++ b/rules/Lumen/NodeAnalyzer/LumenRouteRegisteringMethodAnalyzer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Lumen\NodeAnalyzer;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Type\ObjectType;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+
+final class LumenRouteRegisteringMethodAnalyzer
+{
+    public function __construct(
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver
+    ) {
+    }
+
+    public function isLumenRoutingClass(MethodCall $methodCall): bool
+    {
+        return $this->nodeTypeResolver->isObjectType($methodCall->var, new ObjectType('Laravel\Lumen\Routing\Router'));
+    }
+
+    public function isRoutesRegisterGroup(\PhpParser\Node\Identifier|\PhpParser\Node\Expr $name): bool
+    {
+        return $this->nodeNameResolver->isName($name, 'group');
+    }
+
+    public function isRoutesRegisterRoute(\PhpParser\Node\Identifier|\PhpParser\Node\Expr $name): bool
+    {
+        return $this->nodeNameResolver->isNames($name, ['delete', 'get', 'options', 'patch', 'post', 'put']);
+    }
+}

--- a/rules/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector.php
+++ b/rules/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Lumen\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Core\NodeManipulator\ArrayManipulator;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Lumen\NodeAnalyzer\LumenRouteRegisteringMethodAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Lumen\Rector\MethodCall\RoutesStringMiddlewareToArrayRector\RoutesStringMiddlewareToArrayRectorTest
+ */
+final class RoutesStringMiddlewareToArrayRector extends AbstractRector
+{
+    public function __construct(
+        private ArrayManipulator $arrayManipulator,
+        private LumenRouteRegisteringMethodAnalyzer $lumenRouteRegisteringMethodAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes middlewares from rule definitions from string to array notation.',
+            [new CodeSample(<<<'CODE_SAMPLE'
+$router->get('/user', ['middleware => 'test']);
+$router->post('/user', ['middleware => 'test|authentication']);
+CODE_SAMPLE
+            , <<<'CODE_SAMPLE'
+$router->get('/user', ['middleware => ['test']]);
+$router->post('/user', ['middleware => ['test', 'authentication']]);
+CODE_SAMPLE)]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof MethodCall) {
+            return null;
+        }
+
+        if (! $this->lumenRouteRegisteringMethodAnalyzer->isLumenRoutingClass($node)) {
+            return null;
+        }
+
+        $attributes = $this->getRouterMethodAttributes($node);
+        if ($attributes === null) {
+            return null;
+        }
+
+        $middleware = $this->findItemInArrayByKeyAndUnset($attributes, 'middleware');
+        if ($middleware === null) {
+            return null;
+        }
+
+        /** @var Node\Scalar\String_|Node\Expr\Array_ $middlewareValue */
+        $middlewareValue = $middleware->value;
+        if ($middlewareValue instanceof Node\Expr\Array_) {
+            return null;
+        }
+
+        /** @var string $middlewareString */
+        $middlewareString = $middlewareValue->value;
+        $splitMiddleware = explode('|', $middlewareString);
+
+        $newMiddlewareArray = new Node\Expr\Array_([]);
+        foreach ($splitMiddleware as $item) {
+            $newMiddlewareArray->items[] = new ArrayItem(new Node\Scalar\String_($item));
+        }
+
+        $this->replaceItemInArrayByKey(
+            $attributes,
+            new ArrayItem($newMiddlewareArray, new Node\Scalar\String_('middleware')),
+            'middleware'
+        );
+
+        return $node;
+    }
+
+    private function getRouterMethodAttributes(MethodCall $node): ?Node\Expr\Array_
+    {
+        $attributes = null;
+        if ($this->lumenRouteRegisteringMethodAnalyzer->isRoutesRegisterGroup($node->name)) {
+            $attributes = $node->getArgs()[0]
+                ->value;
+        }
+
+        if ($this->lumenRouteRegisteringMethodAnalyzer->isRoutesRegisterRoute($node->name)) {
+            $attributes = $node->getArgs()[1]
+                ->value;
+        }
+
+        if (! $attributes instanceof Node\Expr\Array_) {
+            return null;
+        }
+
+        return $attributes;
+    }
+
+    private function findItemInArrayByKeyAndUnset(Array_ $array, string $keyName): ?ArrayItem
+    {
+        foreach ($array->items as $i => $item) {
+            if ($item === null) {
+                continue;
+            }
+            if (! $this->arrayManipulator->hasKeyName($item, $keyName)) {
+                continue;
+            }
+            $removedArrayItem = $array->items[$i];
+            if (! $removedArrayItem instanceof ArrayItem) {
+                continue;
+            }
+            return $item;
+        }
+        return null;
+    }
+
+    private function replaceItemInArrayByKey(Array_ $array, ArrayItem $newItem, string $keyName): void
+    {
+        foreach ($array->items as $i => $item) {
+            if ($item === null) {
+                continue;
+            }
+            if (! $this->arrayManipulator->hasKeyName($item, $keyName)) {
+                continue;
+            }
+            if (! $array->items[$i] instanceof ArrayItem) {
+                continue;
+            }
+
+            $array->items[$i] = $newItem;
+        }
+    }
+}

--- a/rules/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector.php
+++ b/rules/Lumen/Rector/MethodCall/RoutesStringMiddlewareToArrayRector.php
@@ -63,7 +63,7 @@ CODE_SAMPLE)]
             return null;
         }
 
-        $middleware = $this->findItemInArrayByKeyAndUnset($attributes, 'middleware');
+        $middleware = $this->findItemInArrayByKey($attributes, 'middleware');
         if ($middleware === null) {
             return null;
         }
@@ -112,7 +112,7 @@ CODE_SAMPLE)]
         return $attributes;
     }
 
-    private function findItemInArrayByKeyAndUnset(Array_ $array, string $keyName): ?ArrayItem
+    private function findItemInArrayByKey(Array_ $array, string $keyName): ?ArrayItem
     {
         foreach ($array->items as $i => $item) {
             if ($item === null) {
@@ -121,8 +121,8 @@ CODE_SAMPLE)]
             if (! $this->arrayManipulator->hasKeyName($item, $keyName)) {
                 continue;
             }
-            $removedArrayItem = $array->items[$i];
-            if (! $removedArrayItem instanceof ArrayItem) {
+            $foundArrayItem = $array->items[$i];
+            if (! $foundArrayItem instanceof ArrayItem) {
                 continue;
             }
             return $item;


### PR DESCRIPTION
I see that all framework-related Rectors were moved to the outside packages. I do not see package for Lumen specifically so that's why I created this rule in the main rector-src so if you wish you can later extract it. 