### PR TITLE
[TypeDeclaration] Directly use ParametersAcceptorSelector::selectFromArgs() on AlwaysStrictScalarExprAnalyzer

### DIFF
--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -101,11 +101,7 @@ final class AlwaysStrictScalarExprAnalyzer
         $variants = $functionReflection->getVariants();
         $scope = $funcCall->getAttribute(AttributeKey::SCOPE);
 
-        $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-            $scope,
-            $funcCall->getArgs(),
-            $variants
-        );
+        $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $funcCall->getArgs(), $variants);
 
         return $parametersAcceptor->getReturnType();
     }

--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\MagicConst;
 use PhpParser\Node\Scalar\MagicConst\Line;
 use PhpParser\Node\Scalar\String_;
-use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
@@ -100,20 +99,13 @@ final class AlwaysStrictScalarExprAnalyzer
         }
 
         $variants = $functionReflection->getVariants();
-        if (count($variants) > 1) {
-            $scope = $funcCall->getAttribute(AttributeKey::SCOPE);
-            if ($scope instanceof Scope) {
-                $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
-                    $scope,
-                    $funcCall->getArgs(),
-                    $variants
-                );
-            } else {
-                return null;
-            }
-        } else {
-            $parametersAcceptor = ParametersAcceptorSelector::selectSingle($variants);
-        }
+        $scope = $funcCall->getAttribute(AttributeKey::SCOPE);
+
+        $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $funcCall->getArgs(),
+            $variants
+        );
 
         return $parametersAcceptor->getReturnType();
     }


### PR DESCRIPTION
I think check variants count is not needed.