### PR TITLE
[EarlyReturn] Mirror comment on ReturnEarlyIfVariableRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector/Fixture/mirror_comment.php.inc
+++ b/rules-tests/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector/Fixture/mirror_comment.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector\Fixture;
+
+final class MirrorComment
+{
+    public function run($value)
+    {
+        if ($value === 50) {
+            // some comment
+            $value = 100;
+        }
+
+        return $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector\Fixture;
+
+final class MirrorComment
+{
+    public function run($value)
+    {
+        if ($value === 50) {
+            // some comment
+            return 100;
+        }
+
+        return $value;
+    }
+}
+
+?>

--- a/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
+++ b/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
@@ -99,6 +99,8 @@ CODE_SAMPLE
                 }
 
                 $if->stmts[0] = new Return_($assignedExpr);
+                $this->mirrorComments($if->stmts[0], $onlyIfStmt);
+
                 return $node;
             }
         }

--- a/src/NodeAnalyzer/VariableAnalyzer.php
+++ b/src/NodeAnalyzer/VariableAnalyzer.php
@@ -60,7 +60,7 @@ final class VariableAnalyzer
         return (bool) $this->betterNodeFinder->findFirstPrevious($variable, function (Node $subNode) use (
             $variable
         ): bool {
-            if ($this->isParamRefrenced($subNode, $variable)) {
+            if ($this->isParamReferenced($subNode, $variable)) {
                 return true;
             }
 
@@ -101,7 +101,7 @@ final class VariableAnalyzer
         return $parentParentNode instanceof Static_;
     }
 
-    private function isParamRefrenced(Node $node, Variable $variable): bool
+    private function isParamReferenced(Node $node, Variable $variable): bool
     {
         if (! $node instanceof Param) {
             return false;


### PR DESCRIPTION
The comment in re-assign variable should be kept and used in return node.