### PR TITLE
[Php54] Add ArrayToShortArrayRector

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 411 Rules Overview
+# 412 Rules Overview
 
 <br>
 
@@ -32,7 +32,7 @@
 
 - [Php53](#php53) (3)
 
-- [Php54](#php54) (2)
+- [Php54](#php54) (3)
 
 - [Php55](#php55) (5)
 
@@ -4591,6 +4591,25 @@ Use ?: instead of ?, where useful
 <br>
 
 ## Php54
+
+### ArrayToShortArrayRector
+
+Array to short array
+
+- class: [`Rector\Php54\Rector\Array_\ArrayToShortArrayRector`](../rules/Php54/Rector/Array_/ArrayToShortArrayRector.php)
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        return array();
++        return [];
+     }
+ }
+```
+
+<br>
 
 ### RemoveReferenceFromCallRector
 

--- a/config/set/php54.php
+++ b/config/set/php54.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php54\Rector\Array_\ArrayToShortArrayRector;
 use Rector\Php54\Rector\Break_\RemoveZeroBreakContinueRector;
 use Rector\Php54\Rector\FuncCall\RemoveReferenceFromCallRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ArrayToShortArrayRector::class);
+
     $rectorConfig
         ->ruleWithConfiguration(RenameFunctionRector::class, [
             'mysqli_param_count' => 'mysqli_stmt_param_count',

--- a/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/ArrayToShortArrayRectorTest.php
+++ b/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/ArrayToShortArrayRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php54\Rector\Array_\ArrayToShortArrayRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ArrayToShortArrayRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/Fixture/fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\ArrayToShortArrayTest\Fixture;
+
+function emptyArray()
+{
+    return array();
+}
+
+function singleElementArray()
+{
+    return array(1);
+}
+
+function manyElementArray()
+{
+    return array(1, 'abc', true);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\ArrayToShortArrayTest\Fixture;
+
+function emptyArray()
+{
+    return [];
+}
+
+function singleElementArray()
+{
+    return [1];
+}
+
+function manyElementArray()
+{
+    return [1, 'abc', true];
+}
+
+?>

--- a/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/Fixture/skip_already_short_array.php.inc
+++ b/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/Fixture/skip_already_short_array.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\ArrayToShortArrayTest\Fixture;
+
+function emptyArray()
+{
+    return [];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\ArrayToShortArrayTest\Fixture;
+
+function emptyArray()
+{
+    return [];
+}
+
+?>

--- a/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/Fixture/skip_already_short_array.php.inc
+++ b/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/Fixture/skip_already_short_array.php.inc
@@ -8,14 +8,3 @@ function emptyArray()
 }
 
 ?>
------
-<?php
-
-namespace Rector\Tests\Php54\Rector\Array_\ArrayToShortArrayTest\Fixture;
-
-function emptyArray()
-{
-    return [];
-}
-
-?>

--- a/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/config/configured_rule.php
+++ b/rules-tests/Php54/Rector/Array_/ArrayToShortArrayRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php54\Rector\Array_\ArrayToShortArrayRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ArrayToShortArrayRector::class);
+};

--- a/rules/Php54/Rector/Array_/ArrayToShortArrayRector.php
+++ b/rules/Php54/Rector/Array_/ArrayToShortArrayRector.php
@@ -6,10 +6,9 @@ namespace Rector\Php54\Rector\Array_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
-use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\Rector\AbstractRector;
-use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -19,10 +18,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ArrayToShortArrayRector extends AbstractRector implements MinPhpVersionInterface
 {
-    public function __construct(private readonly CurrentFileProvider $currentFileProvider)
-    {
-    }
-
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::SHORT_ARRAY;
@@ -71,22 +66,12 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $file = $this->currentFileProvider->getFile();
-        if (! $file instanceof File) {
+        if ($node->getAttribute(AttributeKey::KIND) === Array_::KIND_SHORT) {
             return null;
         }
 
-        $oldTokens = $file->getOldTokens();
-        $startTokenPos = $node->getStartTokenPos();
-        if (! isset($oldTokens[$startTokenPos][1])) {
-            return null;
-        }
-
-        $arrayStart = $oldTokens[$startTokenPos][1];
-        if ($arrayStart === '[') {
-            return null;
-        }
-
-        return new Array_($node->items);
+        $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        $node->setAttribute(AttributeKey::KIND, Array_::KIND_SHORT);
+        return $node;
     }
 }

--- a/rules/Php54/Rector/Array_/ArrayToShortArrayRector.php
+++ b/rules/Php54/Rector/Array_/ArrayToShortArrayRector.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php54\Rector\Array_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use Rector\Core\Provider\CurrentFileProvider;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\Application\File;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Php54\Rector\Array_\ArrayToShortArrayRector\ArrayToShortArrayRectorTest
+ */
+final class ArrayToShortArrayRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(private readonly CurrentFileProvider $currentFileProvider)
+    {
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::SHORT_ARRAY;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Array to short array',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return array();
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return [];
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Array_::class];
+    }
+
+    /**
+     * @param Array_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $file = $this->currentFileProvider->getFile();
+        if (! $file instanceof File) {
+            return null;
+        }
+
+        $oldTokens = $file->getOldTokens();
+        $startTokenPos = $node->getStartTokenPos();
+        if (! isset($oldTokens[$startTokenPos][1])) {
+            return null;
+        }
+
+        $arrayStart = $oldTokens[$startTokenPos][1];
+        if ($arrayStart === '[') {
+            return null;
+        }
+
+        return new Array_($node->items);
+    }
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -52,6 +52,11 @@ final class PhpVersionFeature
     /**
      * @var int
      */
+    public const SHORT_ARRAY = PhpVersion::PHP_54;
+
+    /**
+     * @var int
+     */
     public const DATE_TIME_INTERFACE = PhpVersion::PHP_55;
 
     /**


### PR DESCRIPTION
Add a new rule to convert `array()` syntax to short array syntax, introduced in PHP 5.4.