### PR TITLE
[EarlyReturn] Skip ReturnEarlyIfVariableRector with @var doc

### DIFF
--- a/rules-tests/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector/Fixture/skip_with_var_doc.php.inc
+++ b/rules-tests/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector/Fixture/skip_with_var_doc.php.inc
@@ -7,7 +7,7 @@ final class SkipWithVarDoc
     public function run(int $value): int|string
     {
         if ($value === 50) {
-            /** @var string */
+            /** @var string $value */
             $value = execute();
         }
 

--- a/rules-tests/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector/Fixture/skip_with_var_doc.php.inc
+++ b/rules-tests/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector/Fixture/skip_with_var_doc.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector\Fixture;
+
+final class SkipWithVarDoc
+{
+    public function run(int $value): int|string
+    {
+        if ($value === 50) {
+            /** @var string */
+            $value = execute();
+        }
+
+        return $value;
+    }
+}

--- a/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
+++ b/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
@@ -109,14 +109,6 @@ CODE_SAMPLE
         return null;
     }
 
-    private function hasVarTag(Expression $expression): bool
-    {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($expression);
-        $varTagValueNode = $phpDocInfo->getVarTagValueNode();
-
-        return $varTagValueNode instanceof VarTagValueNode;
-    }
-
     private function matchOnlyIfStmtReturnExpr(Stmt $onlyIfStmt, Variable $returnVariable): Expr|null
     {
         if (! $onlyIfStmt instanceof Expression) {
@@ -127,7 +119,8 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->hasVarTag($onlyIfStmt)) {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($onlyIfStmt);
+        if ($phpDocInfo->getVarTagValueNode() instanceof VarTagValueNode) {
             return null;
         }
 

--- a/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
+++ b/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\NodeAnalyzer\VariableAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -108,6 +109,14 @@ CODE_SAMPLE
         return null;
     }
 
+    private function hasVarTag(Expression $expression): bool
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($expression);
+        $varTagValueNode = $phpDocInfo->getVarTagValueNode();
+
+        return $varTagValueNode instanceof VarTagValueNode;
+    }
+
     private function matchOnlyIfStmtReturnExpr(Stmt $onlyIfStmt, Variable $returnVariable): Expr|null
     {
         if (! $onlyIfStmt instanceof Expression) {
@@ -115,6 +124,10 @@ CODE_SAMPLE
         }
 
         if (! $onlyIfStmt->expr instanceof Assign) {
+            return null;
+        }
+
+        if ($this->hasVarTag($onlyIfStmt)) {
             return null;
         }
 


### PR DESCRIPTION
The following code should be skipped:

```php
final class SkipWithVarDoc
{
    public function run(int $value): int|string
    {
        if ($value === 50) {
            /** @var string $value */
            $value = execute();
        }

        return $value;
    }
}
```