### PR TITLE
[NodeTypeResolver] Refactor ParametersAcceptorSelectorVariantsWrapper to pass CallLike instead of Arg

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan;
 
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\CallLike;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
@@ -22,11 +21,7 @@ final class ParametersAcceptorSelectorVariantsWrapper
         $variants = $reflection->getVariants();
 
         return count($variants) > 1
-            ? ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $callLike->getArgs(),
-                $variants
-            )
+            ? ParametersAcceptorSelector::selectFromArgs($scope, $callLike->getArgs(), $variants)
             : ParametersAcceptorSelector::selectSingle($variants);
     }
 }

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\CallLike;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
@@ -13,18 +14,19 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 
 final class ParametersAcceptorSelectorVariantsWrapper
 {
-    /**
-     * @param Arg[] $args
-     */
     public static function select(
         FunctionReflection|MethodReflection $reflection,
-        array $args,
+        CallLike $callLike,
         Scope $scope
     ): ParametersAcceptor {
         $variants = $reflection->getVariants();
 
         return count($variants) > 1
-            ? ParametersAcceptorSelector::selectFromArgs($scope, $args, $variants)
+            ? ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $callLike->getArgs(),
+                $variants
+            )
             : ParametersAcceptorSelector::selectSingle($variants);
     }
 }

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -476,7 +476,7 @@ CODE_SAMPLE
 
         $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select(
             $functionReflection,
-            $funcCall->getArgs(),
+            $funcCall,
             $scope
         );
         $functionName = $this->nodeNameResolver->getName($funcCall);

--- a/rules/TypeDeclaration/NodeTypeAnalyzer/CallTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeTypeAnalyzer/CallTypeAnalyzer.php
@@ -37,7 +37,7 @@ final class CallTypeAnalyzer
 
         $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select(
             $methodReflection,
-            $call->getArgs(),
+            $call,
             $scope
         );
 

--- a/rules/TypeDeclaration/NodeTypeAnalyzer/CallTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeTypeAnalyzer/CallTypeAnalyzer.php
@@ -35,11 +35,7 @@ final class CallTypeAnalyzer
             return [];
         }
 
-        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select(
-            $methodReflection,
-            $call,
-            $scope
-        );
+        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($methodReflection, $call, $scope);
 
         $parameterTypes = [];
 

--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -106,7 +106,7 @@ final class AlwaysStrictScalarExprAnalyzer
 
         $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select(
             $functionReflection,
-            $funcCall->getArgs(),
+            $funcCall,
             $scope
         );
 

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -314,7 +314,7 @@ final class PropertyManipulator
 
         $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select(
             $functionLikeReflection,
-            $node->getArgs(),
+            $node,
             $scope
         );
         foreach ($parametersAcceptor->getParameters() as $parameterReflection) {


### PR DESCRIPTION
This is to ensure only pass `CallLike` to 2nd param on `ParametersAcceptorSelectorVariantsWrapper::select()`, which can :

- [x] improve performance as no need to call `->getArgs()` when only 1 variants
- [x] if there is a bug on `->getArgs()` call, eg: on  first class callable syntax, we can tweak in a single `ParametersAcceptorSelectorVariantsWrapper::select()` location instead of per its usage.