### PR TITLE
Add failing test fixture for RemoveUnusedPrivateMethodParameterRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
+
+final class Foo {
+    private callable $callable;
+    public function setCallable(callable $callable) {
+        $this->callable = $callable;
+    }
+}
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        $foo = new Foo();
+        $foo->setCallable($this->test(...));
+    }
+    
+    private function test($foo, $bar) {}
+}
+
+$demo = new DemoFile();
+$demo->run();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
+
+// what is expected code?
+// should remain the same? delete part bellow ----- (included)
+
+?>


### PR DESCRIPTION
# Failing Test for RemoveUnusedPrivateMethodParameterRector

Based on https://getrector.org/demo/d8f5b669-6f89-4cdf-9a5f-bb3d77a443c1

refs https://github.com/rectorphp/rector/issues/7278