### PR TITLE
[TypeDeclaration] Skip modified type between assign and return on ReturnTypeFromStrictNewArrayRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/skip_modified_type_between_assign_and_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/skip_modified_type_between_assign_and_return.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class SkipModifiedTypeBetweenAssignAndReturn
+{
+    public function run()
+    {
+        $values = [];
+
+        $this->settings($values);
+
+        return $values;
+    }
+
+    private function settings(&$values)
+    {
+        $values = 1;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -122,6 +122,12 @@ CODE_SAMPLE
             return null;
         }
 
+        $returnType = $this->nodeTypeResolver->getType($onlyReturn->expr);
+
+        if (! $returnType instanceof ArrayType) {
+            return null;
+        }
+
         if (! $this->nodeNameResolver->areNamesEqual($onlyReturn->expr, $variable)) {
             return null;
         }


### PR DESCRIPTION
Same with https://github.com/rectorphp/rector-src/pull/2650, the following code should be skipped:

```php
final class SkipModifiedTypeBetweenAssignAndReturn
{
    public function run()
    {
        $values = [];

        $this->settings($values);

        return $values;
    }

    private function settings(&$values)
    {
        $values = 1;
    }
}
```