### PR TITLE
[DeadCode] Handle crash on indirect parent BinaryOp on RemoveDuplicatedInstanceOfRector

### DIFF
--- a/rules-tests/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector/Fixture/skip_in_arg.php.inc
+++ b/rules-tests/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector/Fixture/skip_in_arg.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\BinaryOp\RemoveDuplicatedInstanceOfRector\Fixture;
+
+class SkipInArg
+{
+    public function run($a)
+    {
+        $a
+            && $this->execute(
+                    $a instanceof stdClass ? 'a' : 'b',
+                    $a instanceof stdClass ? 'a' : 'b'
+                );
+    }
+
+    private function execute(...$args) {}
+}

--- a/rules-tests/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector/Fixture/skip_indirect_parent_binary_op.php.inc
+++ b/rules-tests/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector/Fixture/skip_indirect_parent_binary_op.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DeadCode\Rector\BinaryOp\RemoveDuplicatedInstanceOfRector\Fixture;
 
-class SkipInArg
+class SkipIndirectParentBinaryOp
 {
     public function run($a)
     {

--- a/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
+++ b/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\Instanceof_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\NodeAnalyzer\InstanceOfUniqueKeyResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -87,8 +88,9 @@ CODE_SAMPLE
 
         $uniqueInstanceOfKeys = [];
         foreach ($instanceOfs as $instanceOf) {
-            $isInArg = (bool) $this->betterNodeFinder->findParentType($instanceOf, Arg::class);
-            if ($isInArg) {
+            $instanceOfParentNode = $instanceOf->getAttribute(AttributeKey::PARENT_NODE);
+
+            if (! $instanceOfParentNode instanceof BinaryOp) {
                 continue;
             }
 

--- a/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
+++ b/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\BinaryOp;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\Instanceof_;
 use Rector\Core\Rector\AbstractRector;
@@ -86,6 +87,11 @@ CODE_SAMPLE
 
         $uniqueInstanceOfKeys = [];
         foreach ($instanceOfs as $instanceOf) {
+            $isInArg = (bool) $this->betterNodeFinder->findParentType($instanceOf, Arg::class);
+            if ($isInArg) {
+                continue;
+            }
+
             $uniqueKey = $this->instanceOfUniqueKeyResolver->resolve($instanceOf);
             if ($uniqueKey === null) {
                 continue;

--- a/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
+++ b/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\BinaryOp;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\Instanceof_;
 use Rector\Core\Rector\AbstractRector;

--- a/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
+++ b/rules/DeadCode/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
@@ -83,16 +83,17 @@ CODE_SAMPLE
         $duplicatedInstanceOfs = [];
 
         /** @var Instanceof_[] $instanceOfs */
-        $instanceOfs = $this->betterNodeFinder->findInstanceOf($binaryOp, Instanceof_::class);
+        $instanceOfs = $this->betterNodeFinder->find($binaryOp, static function (Node $subNode): bool {
+            if (! $subNode instanceof Instanceof_) {
+                return false;
+            }
+
+            $parentNode = $subNode->getAttribute(AttributeKey::PARENT_NODE);
+            return $parentNode instanceof BinaryOp;
+        });
 
         $uniqueInstanceOfKeys = [];
         foreach ($instanceOfs as $instanceOf) {
-            $instanceOfParentNode = $instanceOf->getAttribute(AttributeKey::PARENT_NODE);
-
-            if (! $instanceOfParentNode instanceof BinaryOp) {
-                continue;
-            }
-
             $uniqueKey = $this->instanceOfUniqueKeyResolver->resolve($instanceOf);
             if ($uniqueKey === null) {
                 continue;


### PR DESCRIPTION
Given the following code:

```php
class SkipIndirectParentBinaryOp
{
    public function run($a)
    {
        $a
            && $this->execute(
                    $a instanceof stdClass ? 'a' : 'b',
                    $a instanceof stdClass ? 'a' : 'b'
                );
    }

    private function execute(...$args) {}
}
```

It currently crash:

```bash
There was 1 error:

1) Rector\Tests\DeadCode\Rector\BinaryOp\RemoveDuplicatedInstanceOfRector\RemoveDuplicatedInstanceOfRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
LogicException: leaveNode() returned invalid value of type integer

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:168
```

it should be skipped instead.

Fixes https://github.com/rectorphp/rector/issues/7290