### PR TITLE
[CodingStyle] Add StaticArrowFunctionRector

### DIFF
--- a/config/set/coding-style.php
+++ b/config/set/coding-style.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
 use Rector\CodingStyle\Rector\Assign\PHPStormVarAnnotationRector;
 use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
@@ -67,5 +68,6 @@ return static function (RectorConfig $rectorConfig): void {
         MakeInheritedMethodVisibilitySameAsParentRector::class,
         CallUserFuncArrayToVariadicRector::class,
         VersionCompareFuncCallToConstantRector::class,
+        StaticArrowFunctionRector::class,
     ]);
 };

--- a/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/Fixture/fixture.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector\Fixture;
+
+fn(): string => 'test';
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector\Fixture;
+
+static fn(): string => 'test';
+
+?>

--- a/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/Fixture/skip_already_static.php.inc
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/Fixture/skip_already_static.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector\Fixture;
+
+static fn(): string => 'test';

--- a/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/Fixture/skip_with_this.php.inc
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/Fixture/skip_with_this.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector\Fixture;
+
+class SkipWithThis
+{
+    private $data = 'data';
+
+    public function run()
+    {
+        fn(): string => $this->data;
+    }
+}

--- a/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/StaticArrowFunctionRectorTest.php
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/StaticArrowFunctionRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class StaticArrowFunctionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/config/configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(StaticArrowFunctionRector::class);
+};

--- a/rules/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector.php
+++ b/rules/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector.php
@@ -47,20 +47,23 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($node->static) {
-            return null;
-        }
-
-        $hasThisCall = (bool) $this->betterNodeFinder->findFirst(
-            $node->expr,
-            static fn (Node $subNode): bool => $subNode instanceof Variable && $subNode->name === 'this'
-        );
-
-        if ($hasThisCall) {
+        if ($this->shouldSkip($node)) {
             return null;
         }
 
         $node->static = true;
         return $node;
+    }
+
+    private function shouldSkip(ArrowFunction $arrowFunction): bool
+    {
+        if ($arrowFunction->static) {
+            return true;
+        }
+
+        return (bool) $this->betterNodeFinder->findFirst(
+            $arrowFunction->expr,
+            static fn (Node $subNode): bool => $subNode instanceof Variable && $subNode->name === 'this'
+        );
     }
 }

--- a/rules/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector.php
+++ b/rules/CodingStyle/Rector/ArrowFunction/StaticArrowFunctionRector.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\ArrowFunction;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Variable;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector\StaticArrowFunctionRectorTest
+ */
+final class StaticArrowFunctionRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes ArrowFunction to be static when possible',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+fn (): string => 'test';
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+static fn (): string => 'test';
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ArrowFunction::class];
+    }
+
+    /**
+     * @param ArrowFunction $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->static) {
+            return null;
+        }
+
+        $hasThisCall = (bool) $this->betterNodeFinder->findFirst(
+            $node->expr,
+            static fn (Node $subNode): bool => $subNode instanceof Variable && $subNode->name === 'this'
+        );
+
+        if ($hasThisCall) {
+            return null;
+        }
+
+        $node->static = true;
+        return $node;
+    }
+}


### PR DESCRIPTION
Add `StaticArrowFunctionRector` to apply `static` to `ArrowFunction` when possible.