### PR TITLE
Fix test to only resolve to known classes

### DIFF
--- a/tests/Issues/DoNotReplaceUnknownClasses/Fixture/skip_unknown_target_entity.php.inc
+++ b/tests/Issues/DoNotReplaceUnknownClasses/Fixture/skip_unknown_target_entity.php.inc
@@ -9,7 +9,7 @@ use My\Namespace\UsedUnknownClass;
 final class SkipUnknownTargetEntity
 {
     /**
-     * @ORM\ManyToOne(targetEntity=\My\Namespace\UsedUnknownClass::class)
+     * @ORM\ManyToOne(targetEntity=UsedUnknownClass)
      */
     private readonly ?Collection $items;
 }


### PR DESCRIPTION
This test now fails once https://github.com/rectorphp/rector-doctrine/pull/112 gets merged. Prior to this PR, the test merely reflected the status quo (see my comment in https://github.com/rectorphp/rector-src/pull/2319#discussion_r886302409 ). So this corrects the test that an unknown target entity is untouched.