### PR TITLE
[Config] Do not enable parallel by default on Windows

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -61,7 +61,10 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->autoloadPaths([]);
     $rectorConfig->bootstrapFiles([]);
-    $rectorConfig->parallel(seconds: 120, maxNumberOfProcess: 16, jobSize: 20);
+
+    if (PHP_OS_FAMILY !== 'Windows') {
+        $rectorConfig->parallel(seconds: 120, maxNumberOfProcess: 16, jobSize: 20);
+    }
 
     $rectorConfig->disableImportNames();
     $rectorConfig->importShortClasses();


### PR DESCRIPTION
It seems there are various issues reported that parallel has issue running on Windows. Until we get reproducible repository for it, I think we should not make parallel enabled by default on Windows OS.