### PR TITLE
[Core] Move check CREATED_BY_RULE attribute from AbstractRector into RectifiedAnalyzer

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -15,6 +15,8 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  * This service verify if the Node already rectified with same Rector rule before current Rector rule with condition
  *
  *        Same Rector Rule <-> Same Node <-> Same File
+ *
+ *  For both non-consecutive or consecutive order.
  */
 final class RectifiedAnalyzer
 {
@@ -29,17 +31,24 @@ final class RectifiedAnalyzer
 
     public function verify(AbstractRector $rector, Node $node, File $currentFile): ?RectifiedNode
     {
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+        $rectorClass = $rector::class;
+
+        if ($this->hasCreatedByRule($rectorClass, $node, $originalNode)) {
+            return new RectifiedNode($rectorClass, $node);
+        }
+
         $smartFileInfo = $currentFile->getSmartFileInfo();
         $realPath = $smartFileInfo->getRealPath();
 
         if (! isset($this->previousFileWithNodes[$realPath])) {
-            $this->previousFileWithNodes[$realPath] = new RectifiedNode($rector::class, $node);
+            $this->previousFileWithNodes[$realPath] = new RectifiedNode($rectorClass, $node);
             return null;
         }
 
         /** @var RectifiedNode $rectifiedNode */
         $rectifiedNode = $this->previousFileWithNodes[$realPath];
-        if ($this->shouldContinue($rectifiedNode, $rector, $node)) {
+        if ($this->shouldContinue($rectifiedNode, $rectorClass, $node, $originalNode)) {
             return null;
         }
 
@@ -48,10 +57,21 @@ final class RectifiedAnalyzer
         return $rectifiedNode;
     }
 
-    private function shouldContinue(RectifiedNode $rectifiedNode, AbstractRector $rector, Node $node): bool
+    private function hasCreatedByRule(string $rectorClass, Node $node, ?Node $originalNode): bool
     {
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-        if ($rectifiedNode->getRectorClass() === $rector::class && $rectifiedNode->getNode() === $node) {
+        $originalNode ??= $node;
+        $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
+        return in_array($rectorClass, $createdByRule, true);
+    }
+
+    private function shouldContinue(
+        RectifiedNode $rectifiedNode,
+        string $rectorClass,
+        Node $node,
+        ?Node $originalNode
+    ): bool
+    {
+        if ($rectifiedNode->getRectorClass() === $rectorClass && $rectifiedNode->getNode() === $node) {
             /**
              * allow to revisit the Node with same Rector rule if Node is changed by other rule
              */

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -69,8 +69,7 @@ final class RectifiedAnalyzer
         string $rectorClass,
         Node $node,
         ?Node $originalNode
-    ): bool
-    {
+    ): bool {
         if ($rectifiedNode->getRectorClass() === $rectorClass && $rectifiedNode->getNode() === $node) {
             /**
              * allow to revisit the Node with same Rector rule if Node is changed by other rule

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -185,14 +185,6 @@ CODE_SAMPLE;
             return null;
         }
 
-        /** @var Node $originalNode */
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE) ?? clone $node;
-        $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-
-        if (in_array(static::class, $createdByRule, true)) {
-            return null;
-        }
-
         $this->currentRectorProvider->changeCurrentRector($this);
         // for PHP doc info factory and change notifier
         $this->currentNodeProvider->setNode($node);
@@ -210,6 +202,9 @@ CODE_SAMPLE;
             $errorMessage = sprintf(self::EMPTY_NODE_ARRAY_MESSAGE, static::class);
             throw new ShouldNotHappenException($errorMessage);
         }
+
+        /** @var Node $originalNode */
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE) ?? $node;
 
         /** @var Node[]|Node $refactoredNode */
         $this->createdByRuleDecorator->decorate($refactoredNode, $originalNode, static::class);


### PR DESCRIPTION
Background
----------

Currently, we still have 2 sides check for infinite loop apply rule check for:

```
Same Rector Rule <-> Same Node <-> Same File
```

**1. for non-consecutive order, checked in AbstractRector with verify:**

```php
$createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];

if (in_array(static::class, $createdByRule, true)) {
    return null;
}
```

**2. for consecutive order, checked in `RectifiedAnalyzer` service**

Refactor
--------

This PR refactor to move the check early from `AbstractRector` into `RectifiedAnalyzer` service so we have single service to verify the infinite loop apply rule.
