### PR TITLE
AddReturnTypeDeclarationBasedOnParentClassMethodRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/AddReturnTypeDeclarationBasedOnParentClassMethodRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/AddReturnTypeDeclarationBasedOnParentClassMethodRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AddReturnTypeDeclarationBasedOnParentClassMethodRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_class.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithReturnType;
+
+class MyClass extends SomeClassWithReturnType
+{
+    public function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithReturnType;
+
+class MyClass extends SomeClassWithReturnType
+{
+    public function run(): int
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_class_mixed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_class_mixed.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithReturnMixed;
+
+class MyClass extends SomeClassWithReturnMixed
+{
+    public function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithReturnMixed;
+
+class MyClass extends SomeClassWithReturnMixed
+{
+    public function run(): mixed
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_class_no_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_class_no_type.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithoutReturnType;
+
+class MyClass extends SomeClassWithoutReturnType
+{
+    public function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithoutReturnType;
+
+class MyClass extends SomeClassWithoutReturnType
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_interface.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/extended_interface.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeInterfaceWithReturnType;
+
+abstract class MyClass implements SomeInterfaceWithReturnType
+{
+    public function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeInterfaceWithReturnType;
+
+abstract class MyClass implements SomeInterfaceWithReturnType
+{
+    public function run(): string
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_narrowed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_narrowed.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithReturnMixed;
+
+class MyClass extends SomeClassWithReturnMixed
+{
+    public function run(): string
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithReturnMixed.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithReturnMixed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
+
+class SomeClassWithReturnMixed
+{
+    public function run(): mixed
+    {
+      return 5;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithReturnType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
+
+class SomeClassWithReturnType
+{
+    public function run(): int
+    {
+      return 5;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithoutReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithoutReturnType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
+
+class SomeClassWithoutReturnType
+{
+    public function run()
+    {
+      return 5;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeInterfaceWithReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeInterfaceWithReturnType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
+
+interface SomeInterfaceWithReturnType
+{
+    public function run(): string;
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddReturnTypeDeclarationBasedOnParentClassMethodRector::class);
+
+    $rectorConfig->phpVersion(PhpVersionFeature::MIXED_TYPE);
+};

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Rector\Core\Php\PhpVersionProvider;
+use Rector\Core\PhpParser\AstResolver;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/lsp_errors
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\AddReturnTypeDeclarationBasedOnParentClassMethodRectorTest
+ */
+final class AddReturnTypeDeclarationBasedOnParentClassMethodRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private readonly AstResolver $astResolver,
+        private readonly PhpVersionProvider $phpVersionProvider,
+    ) {
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::FATAL_ERROR_ON_INCOMPATIBLE_METHOD_SIGNATURE;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add missing return type declaration based on parent class method', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class A
+{
+    public function execute(): int
+    {
+    }
+}
+
+class B extends A{
+    public function execute()
+    {
+    }
+}
+CODE_SAMPLE
+,
+                <<<'CODE_SAMPLE'
+class A
+{
+    public function execute(): int
+    {
+    }
+}
+
+class B extends A{
+    public function execute(): int
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->nodeNameResolver->isName($node, MethodName::CONSTRUCT)) {
+            return null;
+        }
+
+        $parentMethodReflection = $this->parentClassMethodTypeOverrideGuard->getParentClassMethod($node);
+        if (! $parentMethodReflection instanceof MethodReflection) {
+            return null;
+        }
+
+        $parentClassMethod = $this->astResolver->resolveClassMethodFromMethodReflection($parentMethodReflection);
+
+        if (! $parentClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        if ($parentClassMethod->isPrivate()) {
+            return null;
+        }
+
+        $parentClassMethodReturnType = $parentClassMethod->getReturnType();
+        if ($parentClassMethodReturnType === null) {
+            return null;
+        }
+
+        $parentClassMethodReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType(
+            $parentClassMethodReturnType
+        );
+
+        return $this->processClassMethodReturnType($node, $parentClassMethodReturnType);
+    }
+
+    private function processClassMethodReturnType(ClassMethod $classMethod, Type $parentType): ?ClassMethod
+    {
+        if ($parentType instanceof MixedType) {
+            $class = $classMethod->getAttribute(AttributeKey::PARENT_NODE);
+            if (! $class instanceof Class_) {
+                return null;
+            }
+
+            $className = (string) $this->nodeNameResolver->getName($class);
+            $currentObjectType = new ObjectType($className);
+            if (! $parentType->equals($currentObjectType) && $classMethod->returnType !== null) {
+                return null;
+            }
+        }
+
+        if ($parentType instanceof MixedType && ! $this->phpVersionProvider->isAtLeastPhpVersion(
+            PhpVersionFeature::MIXED_TYPE
+        )) {
+            return null;
+        }
+
+        // already set and sub type or equal → no change
+        if ($this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange($classMethod, $parentType)) {
+            return null;
+        }
+
+        $classMethod->returnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+            $parentType,
+            TypeKind::RETURN
+        );
+
+        return $classMethod;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
@@ -16,9 +16,9 @@ use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
@@ -36,8 +36,8 @@ final class AddReturnTypeDeclarationRector extends AbstractRector implements Con
     private bool $hasChanged = false;
 
     public function __construct(
-        private readonly TypeComparator $typeComparator,
         private readonly PhpVersionProvider $phpVersionProvider,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
     ) {
     }
 
@@ -142,27 +142,12 @@ CODE_SAMPLE
         }
 
         // already set and sub type or equal → no change
-        if ($this->shouldSkipType($classMethod, $newType)) {
+        if ($this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange($classMethod, $newType)) {
             return;
         }
 
         $classMethod->returnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($newType, TypeKind::RETURN);
 
         $this->hasChanged = true;
-    }
-
-    private function shouldSkipType(ClassMethod $classMethod, Type $newType): bool
-    {
-        if ($classMethod->returnType === null) {
-            return false;
-        }
-
-        $currentReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
-
-        if ($this->typeComparator->isSubtype($currentReturnType, $newType)) {
-            return true;
-        }
-
-        return $this->typeComparator->areTypesEqual($currentReturnType, $newType);
     }
 }


### PR DESCRIPTION
First draft that adds return type only by first parent/interface found with that method. In future I will try to change it to detect correct intersection type that will satisfy all parents/interfaces.

It is heavily based on AddReturnTypeDeclaration and AddParamBasedOnParentClassMethodRector.

There were some duplicated code with existing rule so I moved it to service but not sure if it is correct place. Structure of services used in rules is quite confusing to me - is there any design guide for that?

I think this roule could also be added to some existing sets but not sure to which. It is quite universal rule that detects issues that would cause Fatal error.

Tests included and after PR #2660 by @samsonasik it works perfectly with interfaces too.

@TomasVotruba Let me know if you want something solved differently.