### PR TITLE
[PHP 8.1] Extend MyCLabsMethodCallToEnumConstRector with getValue() and static call

### DIFF
--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_magic_calls.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_magic_calls.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class SkipMagicCalls
+{
+    public function run($value, $magicMethod)
+    {
+        $compare = SomeEnum::$magicMethod();
+    }
+}

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/static_method_call.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/static_method_call.php.inc
@@ -8,7 +8,7 @@ final class StaticMethodCall
 {
     public function run($value)
     {
-        $compare = SomeEnum::VALUE();
+        $compare = SomeEnum::USED_TO_BE_CONST();
     }
 }
 
@@ -24,7 +24,7 @@ final class StaticMethodCall
 {
     public function run($value)
     {
-        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE;
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
     }
 }
 

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/static_method_call.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/static_method_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class StaticMethodCall
+{
+    public function run($value)
+    {
+        $compare = SomeEnum::VALUE();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class StaticMethodCall
+{
+    public function run($value)
+    {
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE;
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant.php.inc
@@ -24,7 +24,7 @@ final class UsageOfConstant
 {
     public function run($value)
     {
-        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE;
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE->getKey();
     }
 }
 

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant_value.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant_value.php.inc
@@ -24,7 +24,7 @@ final class UsageOfConstantValue
 {
     public function run($value)
     {
-        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE->value;
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE->getValue();
     }
 }
 

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant_value.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant_value.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class UsageOfConstantValue
+{
+    public function run($value)
+    {
+        $compare = SomeEnum::VALUE()->getValue();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class UsageOfConstantValue
+{
+    public function run($value)
+    {
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE->value;
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Source/SomeEnum.php
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Source/SomeEnum.php
@@ -7,9 +7,9 @@ namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRecto
 use MyCLabs\Enum\Enum;
 
 /**
- * @method SomeEnum VALUE()
+ * @method SomeEnum USED_TO_BE_CONST()
  */
 final class SomeEnum extends Enum
 {
-    const VALUE = 'value';
+    const USED_TO_BE_CONST = 'value';
 }


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/7240

@OskarStark For next issue, create a failing test fixture directly in `MyCLabsMethodCallToEnumConstRector`.

It seeps up the whole issue-PR cycle significantly :wink: 