### PR TITLE
[PHPStan] Clean up ignore errors for narrow public

### DIFF
--- a/packages/NodeCollector/BinaryOpTreeRootLocator.php
+++ b/packages/NodeCollector/BinaryOpTreeRootLocator.php
@@ -20,6 +20,7 @@ final class BinaryOpTreeRootLocator
      *
      * This is useful in conjunction with BinaryOpConditionsCollector, which expects such tree.
      *
+     * @api
      * @param class-string<BinaryOp> $binaryOpClass
      */
     public function findOperationRoot(Expr $expr, string $binaryOpClass): Expr

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -382,7 +382,6 @@ parameters:
                 - src/*/*Processor.php
                 - rules/Composer/Application/FileProcessor/ComposerFileProcessor.php
                 - src/Contract/Processor/FileProcessorInterface.php
-                - packages/Parallel/Application/ParallelFileProcessor.php
                 - packages/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
 
         # skipped on purpose, as ctor overrie
@@ -673,13 +672,6 @@ parameters:
                 - src/ValueObject/StaticNonPhpFileSuffixes.php
                 - tests/FileSystem/FilesFinder/FilesFinderTest.php
 
-        -
-            message: '#Parameters should use "PhpParser\\Node\\Expr\\BinaryOp\|string" types as the only types passed to this method#'
-            path: packages/NodeCollector/BinaryOpTreeRootLocator.php
-        -
-            message: '#Parameters should use "string\|PhpParser\\Node\\Expr\\Variable" types as the only types passed to this method#'
-            path: src/PhpParser/Node/NodeFactory.php
-
         # union booleans
         - '#Method Rector\\Strict\\NodeFactory\\ExactCompareFactory\:\:createTruthyFromUnionType\(\) should return PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\BooleanNot\|PhpParser\\Node\\Expr\\Instanceof_\|null but returns PhpParser\\Node\\Expr\\BinaryOp\\BooleanAnd\|PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\Instanceof_\|null#'
         - '#Parameter \#1 \$compareExprs of method Rector\\Strict\\NodeFactory\\ExactCompareFactory\:\:resolveTruthyExpr\(\) expects array<PhpParser\\Node\\Expr\\BinaryOp\\BooleanAnd\|PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\Instanceof_\|null>, array<PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\BooleanNot\|PhpParser\\Node\\Expr\\Instanceof_\|null> given#'
@@ -708,5 +700,3 @@ parameters:
             message: '#Method call return value that should be used, but is not#'
             path: src/PhpParser/Node/NodeFactory.php
             count: 1
-
-        # @todo resolve later

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -149,6 +149,9 @@ final class NodeFactory
         return $this->createPropertyAssignmentWithExpr($propertyName, $variable);
     }
 
+    /**
+     * @api
+     */
     public function createPropertyAssignmentWithExpr(string $propertyName, Expr $expr): Assign
     {
         $propertyFetch = $this->createPropertyFetch(self::THIS, $propertyName);


### PR DESCRIPTION
Both of the following methods are used in vendor so they can be marked as `@api`:

- `BinaryOpTreeRootLocator::findOperationRoot()`
- `NodeFactory::createPropertyAssignmentWithExpr()`