### PR TITLE
Attempt to fix incorrect doctrine table attribute values on php 8.1

### DIFF
--- a/packages/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/packages/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -13,8 +13,6 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Use_;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
-use Rector\Core\Php\PhpVersionProvider;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\PhpAttribute\AnnotationToAttributeMapper;
 use Rector\PhpAttribute\AttributeArrayNameInliner;
@@ -28,21 +26,18 @@ final class PhpAttributeGroupFactory
     /**
      * @var array<string, string[]>>
      */
-    private array $unwrappedAnnotations = [];
+    private array $unwrappedAnnotations = [
+        'Doctrine\ORM\Mapping\Table' => ['indexes', 'uniqueConstraints'],
+        'Doctrine\ORM\Mapping\Entity' => ['uniqueConstraints'],
+    ];
 
     public function __construct(
         private readonly AnnotationToAttributeMapper $annotationToAttributeMapper,
         private readonly AttributeNameFactory $attributeNameFactory,
         private readonly NamedArgsFactory $namedArgsFactory,
         private readonly ExprParameterReflectionTypeCorrector $exprParameterReflectionTypeCorrector,
-        private readonly AttributeArrayNameInliner $attributeArrayNameInliner,
-        PhpVersionProvider $phpVersionProvider
+        private readonly AttributeArrayNameInliner $attributeArrayNameInliner
     ) {
-        // nested indexes supported only since PHP 8.1
-        if (! $phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::NEW_INITIALIZERS)) {
-            $this->unwrappedAnnotations['Doctrine\ORM\Mapping\Table'] = ['indexes', 'uniqueConstraints'];
-            $this->unwrappedAnnotations['Doctrine\ORM\Mapping\Entity'][] = 'uniqueConstraints';
-        }
     }
 
     public function createFromSimpleTag(AnnotationToAttribute $annotationToAttribute): AttributeGroup

--- a/packages/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/packages/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -26,7 +26,7 @@ final class PhpAttributeGroupFactory
     /**
      * @var array<string, string[]>>
      */
-    private array $unwrappedAnnotations = [
+    private const UNWRAPPED_ANNOTATIONS = [
         'Doctrine\ORM\Mapping\Table' => ['indexes', 'uniqueConstraints'],
         'Doctrine\ORM\Mapping\Entity' => ['uniqueConstraints'],
     ];
@@ -110,7 +110,7 @@ final class PhpAttributeGroupFactory
     private function removeUnwrappedItems(string $attributeClass, array $items): array
     {
         // unshift annotations that can be extracted
-        $unwrappeColumns = $this->unwrappedAnnotations[$attributeClass] ?? [];
+        $unwrappeColumns = self::UNWRAPPED_ANNOTATIONS[$attributeClass] ?? [];
         if ($unwrappeColumns === []) {
             return $items;
         }

--- a/packages/PhpAttribute/UnwrapableAnnotationAnalyzer.php
+++ b/packages/PhpAttribute/UnwrapableAnnotationAnalyzer.php
@@ -29,11 +29,6 @@ final class UnwrapableAnnotationAnalyzer
      */
     private array $annotationsToAttributes = [];
 
-    public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
-    ) {
-    }
-
     /**
      * @param AnnotationToAttribute[] $annotationsToAttributes
      */
@@ -47,11 +42,6 @@ final class UnwrapableAnnotationAnalyzer
      */
     public function areUnwrappable(array $doctrineAnnotationTagValueNodes): bool
     {
-        // the new in initilazers is handled directly
-        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::NEW_INITIALIZERS)) {
-            return false;
-        }
-
         foreach ($doctrineAnnotationTagValueNodes as $doctrineAnnotationTagValueNode) {
             $annotationClassName = $doctrineAnnotationTagValueNode->identifierTypeNode->getAttribute(
                 PhpDocAttributeKey::RESOLVED_CLASS

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp81/table_and_nested_index_and_uniqueconstraints.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp81/table_and_nested_index_and_uniqueconstraints.php.inc
@@ -23,7 +23,9 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\F
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Table(indexes: [new ORM\Index(name: 'search_idx', columns: ['name', 'c'])], uniqueConstraints: [new ORM\UniqueConstraint(name: 'name_idx', columns: ['name'])])]
+#[ORM\Table]
+#[ORM\Index(name: 'search_idx', columns: ['name', 'c'])]
+#[ORM\UniqueConstraint(name: 'name_idx', columns: ['name'])]
 class TableAndNestedIndex
 {
 }

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -250,6 +250,14 @@ CODE_SAMPLE
                 $shouldInlinedNested = true;
             }
 
+            // Inline nested annotations when they can/need to be unwrapped (doctrine @Table(index: [@Index(...)])
+            if ($nestedDoctrineAnnotationTagValueNodes !== []
+                && $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::NEW_INITIALIZERS)
+                && $this->unwrapableAnnotationAnalyzer->areUnwrappable($nestedDoctrineAnnotationTagValueNodes)
+            ) {
+                    $shouldInlinedNested = true;
+            }
+
             if (! $this->removableAnnotationAnalyzer->isRemovable($doctrineTagValueNode)) {
                 $doctrineTagAndAnnotationToAttributes[] = new DoctrineTagAndAnnotationToAttribute(
                     $doctrineTagValueNode,


### PR DESCRIPTION
Reverted some changes of #1850 as they resulted in incorrect doctrine `Table` attribute values on php 8.1 (`indexes` and `uniqueConstraints` can't be initialized inline) + some extra needed fixes

Fixes rectorphp/rector#7163 and partial fix of rectorphp/rector-doctrine#116 (point 1 and 2)

I've updated the failing test of rector-doctrine in rectorphp/rector-doctrine#118