### PR TITLE
[CodeQuality][CodingStyle] Handle crash assert($subStartPos >= 0 && $subEndPos >= 0) on combination CodeQuality and CodingStyle rules

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -53,8 +53,11 @@ final class RectifiedAnalyzer
             return null;
         }
 
-        // re-set to refill next
-        $this->previousFileWithNodes[$realPath] = null;
+        if ($this->previousFileWithNodes[$realPath]->getNode() === $node) {
+            // re-set to refill next
+            $this->previousFileWithNodes[$realPath] = null;
+        }
+
         return $rectifiedNode;
     }
 

--- a/tests/Issues/Issue7306/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7306/Fixture/fixture.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7306\Fixture;
+
+class Fixture
+{
+    public function method1(int $value): void
+    {
+        if ($value) {
+            // do something
+        }
+    }
+    public function method2(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7306\Fixture;
+
+class Fixture
+{
+    public function method1(int $value): void
+    {
+        if ($value !== 0) {
+            // do something
+        }
+    }
+
+    public function method2(): void
+    {
+    }
+}
+
+?>

--- a/tests/Issues/Issue7306/RuleCombinationShouldNotSimplifyIfNotNullReturnTest.php
+++ b/tests/Issues/Issue7306/RuleCombinationShouldNotSimplifyIfNotNullReturnTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue7306;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7306
+ */
+final class RuleCombinationShouldNotSimplifyIfNotNullReturnTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue7306/config/configured_rule.php
+++ b/tests/Issues/Issue7306/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
+use Rector\CodeQuality\Rector\If_\SimplifyIfNotNullReturnRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        SimplifyIfNotNullReturnRector::class,
+        ExplicitBoolCompareRector::class,
+        NewlineAfterStatementRector::class,
+    ]);
+};

--- a/tests/Issues/Issue7306/config/configured_rule.php
+++ b/tests/Issues/Issue7306/config/configured_rule.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Rector\Config\RectorConfig;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfNotNullReturnRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([


### PR DESCRIPTION
Closes #2705 Fixes https://github.com/rectorphp/rector/issues/7306