### PR TITLE
added failling test

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/foreach_non-empty.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/foreach_non-empty.php.inc
@@ -4,12 +4,12 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeR
 
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Source\ExternalList;
 
-final class ForeachNumeric
+final class ForeachNonEmpty
 {
     public function run(): array
     {
         $map = [];
-        foreach (ExternalList::getArrayOfNumericStrings() as $externalValue) {
+        foreach (ExternalList::getArrayOfNonEmptyStrings() as $externalValue) {
             $map[$externalValue] = 100;
         }
         return $map;
@@ -22,15 +22,15 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeR
 
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Source\ExternalList;
 
-final class ForeachNumeric
+final class ForeachNonEmpty
 {
     /**
-     * @return array<numeric-string, int>
+     * @return array<non-empty-string, int>
      */
     public function run(): array
     {
         $map = [];
-        foreach (ExternalList::getArrayOfNumericStrings() as $externalValue) {
+        foreach (ExternalList::getArrayOfNonEmptyStrings() as $externalValue) {
             $map[$externalValue] = 100;
         }
         return $map;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/foreach_numeric.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/foreach_numeric.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Source\ExternalList;
+
+final class ForeachNumeric
+{
+    public function run(): array
+    {
+        $map = [];
+        foreach (ExternalList::NUMERIC_VALUES as $externalValue) {
+            $map[$externalValue] = 100;
+        }
+        return $map;
+    }
+}
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector\Source\ExternalList;
+
+final class ForeachNumeric
+{
+    /**
+     * @return array<numeric-string, int>
+     */
+    public function run(): array
+    {
+        $map = [];
+        foreach (ExternalList::NUMERIC_VALUES as $externalValue) {
+            $map[$externalValue] = 100;
+        }
+        return $map;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Source/ExternalList.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddArrayReturnDocTypeRector/Source/ExternalList.php
@@ -11,4 +11,24 @@ final class ExternalList
     public const SECOND = 'second';
 
     public const VALUES = [self::FIRST, self::SECOND];
+
+    /**
+     * @var non-empty-string[]
+     */
+    static public function getArrayOfNonEmptyStrings() {
+        $a = [];
+        $a[] = self::FIRST;
+        $a[] = self::SECOND;
+        return $a;
+    }
+
+    /**
+     * @var numeric-string[]
+     */
+    static public function getArrayOfNumericStrings() {
+        $a = [];
+        $a[] = 1;
+        $a[] = 2;
+        return $a;
+    }
 }


### PR DESCRIPTION
I have the feeling rector should provide more specialized string types when these are known

----

I came to the conlusion as I reviewd the source of [PHPStanStaticTypeMapper](https://github.com/rectorphp/rector-src/blob/3f3fc412140becdc86cc43a6ef87b5be495c9444/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php#L32-L55) and was wondering whether it is missing some more specialized string types like `AccessoryNonEmptyStringType`.

turns out the broken tests do not related to `PHPStanStaticTypeMapper` and I have no idea how to fix them :-/.
maybe someone else can work on a fix