### PR TITLE
[DowngradePhp81] Handle no scope on DowngradeFirstClassCallableSyntaxRector inside ArrayItem

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
@@ -156,6 +157,10 @@ final class PHPStanNodeScopeResolver
 
             if ($node instanceof ArrayItem) {
                 $this->processArrayItem($node, $mutatingScope);
+            }
+
+            if ($node instanceof FuncCall && $node->name instanceof Expr) {
+                $node->name->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
             if ($node instanceof Assign) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -117,17 +117,14 @@ final class PHPStanNodeScopeResolver
                 $node instanceof Expression ||
                 $node instanceof Return_ ||
                 $node instanceof Assign ||
-                $node instanceof EnumCase
+                $node instanceof EnumCase ||
+                $node instanceof AssignOp
             ) && $node->expr instanceof Expr) {
                 $node->expr->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
             if ($node instanceof Ternary) {
                 $this->processTernary($node, $mutatingScope);
-            }
-
-            if ($node instanceof AssignOp) {
-                $node->expr->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
             if ($node instanceof BinaryOp) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -155,6 +155,10 @@ final class PHPStanNodeScopeResolver
             }
 
             if ($node instanceof ArrayItem) {
+                if ($node->key instanceof Expr) {
+                    $node->key->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+                }
+
                 $node->value->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -155,11 +155,7 @@ final class PHPStanNodeScopeResolver
             }
 
             if ($node instanceof ArrayItem) {
-                if ($node->key instanceof Expr) {
-                    $node->key->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-                }
-
-                $node->value->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+                $this->processArrayItem($node, $mutatingScope);
             }
 
             if ($node instanceof Assign) {
@@ -221,6 +217,15 @@ final class PHPStanNodeScopeResolver
         $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
         return $this->processNodesWithDependentFiles($smartFileInfo, $stmts, $scope, $nodeCallback);
+    }
+
+    private function processArrayItem(ArrayItem $arrayItem, MutatingScope $mutatingScope): void
+    {
+        if ($arrayItem->key instanceof Expr) {
+            $arrayItem->key->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+        }
+
+        $arrayItem->value->setAttribute(AttributeKey::SCOPE, $mutatingScope);
     }
 
     private function decorateTraitAttrGroups(Trait_ $trait, MutatingScope $mutatingScope): void

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -7,6 +7,7 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\BinaryOp;
@@ -151,6 +152,10 @@ final class PHPStanNodeScopeResolver
 
             if ($node instanceof TryCatch) {
                 $this->processTryCatch($node, $smartFileInfo, $mutatingScope);
+            }
+
+            if ($node instanceof ArrayItem) {
+                $node->value->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
             if ($node instanceof Assign) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -702,8 +702,3 @@ parameters:
             message: '#Method call return value that should be used, but is not#'
             path: src/PhpParser/Node/NodeFactory.php
             count: 1
-
-        -
-            message: '#Parameters should use "array\|Symplify\\SmartFileSystem\\SmartFileInfo\|PHPStan\\Analyser\\MutatingScope" types as the only types passed to this method#'
-            paths:
-                - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -702,3 +702,8 @@ parameters:
             message: '#Method call return value that should be used, but is not#'
             path: src/PhpParser/Node/NodeFactory.php
             count: 1
+
+        -
+            message: '#Parameters should use "array\|Symplify\\SmartFileSystem\\SmartFileInfo\|PHPStan\\Analyser\\MutatingScope" types as the only types passed to this method#'
+            paths:
+                - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -68,8 +68,12 @@ final class ChangedNodeScopeRefresher
             $mutatingScope = $this->scopeFactory->createFromFile($smartFileInfo);
         }
 
+        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+        if ($node instanceof Expr && ! $mutatingScope instanceof MutatingScope && $parent instanceof Node) {
+            $mutatingScope = $parent->getAttribute(AttributeKey::SCOPE);
+        }
+
         if (! $mutatingScope instanceof MutatingScope) {
-            $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
             $errorMessage = sprintf(
                 'Node "%s" with parent of "%s" is missing scope required for scope refresh.',
                 $node::class,

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -69,7 +69,7 @@ final class ChangedNodeScopeRefresher
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if ($node instanceof Expr && ! $mutatingScope instanceof MutatingScope && $parent instanceof Node) {
+        if (! $mutatingScope instanceof MutatingScope && $node instanceof Expr && $parent instanceof Node) {
             $mutatingScope = $parent->getAttribute(AttributeKey::SCOPE);
         }
 

--- a/tests/Issues/ScopeNotAvailable/FirstClassCallableTest.php
+++ b/tests/Issues/ScopeNotAvailable/FirstClassCallableTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class FirstClassCallableTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureFirstClassCallable');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/first_class_callable_configured_rule.php';
+    }
+}

--- a/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key.php.inc
@@ -2,12 +2,12 @@
 
 namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
-final class Fixture
+final class FirstClassCallableAsKey
 {
     public function getCallables(): array
     {
         return [
-            $this->opposite(...),
+            $this->opposite(...) => 'test',
         ];
     }
 }
@@ -18,12 +18,12 @@ final class Fixture
 
 namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
-final class Fixture
+final class FirstClassCallableAsKey
 {
     public function getCallables(): array
     {
         return [
-            \Closure::fromCallable([$this, 'opposite']),
+            \Closure::fromCallable([$this, 'opposite']) => 'test',
         ];
     }
 }

--- a/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key2.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+
+final class FirstClassCallableAsKey2
+{
+    public function getCallables(): array
+    {
+        return [
+            $this->opposite(...)() => 'test',
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+
+final class FirstClassCallableAsKey2
+{
+    public function getCallables(): array
+    {
+        return [
+            \Closure::fromCallable([$this, 'opposite'])() => 'test',
+        ];
+    }
+}
+
+?>

--- a/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+
+final class DemoFile
+{
+    public function getCallables(): array
+    {
+        return [
+            $this->opposite(...),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+
+final class DemoFile
+{
+    public function getCallables(): array
+    {
+        return [
+            \Closure::fromCallable([$this, 'opposite']),
+        ];
+    }
+}
+
+?>

--- a/tests/Issues/ScopeNotAvailable/config/first_class_callable_configured_rule.php
+++ b/tests/Issues/ScopeNotAvailable/config/first_class_callable_configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallableSyntaxRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeFirstClassCallableSyntaxRector::class);
+};


### PR DESCRIPTION
Given the following config:

```php
final class DemoFile
{
    public function getCallables(): array
    {
        return [
            $this->opposite(...),
        ];
    }
}
```

It currently produce:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\ScopeNotAvailable\FirstClassCallableTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\ShouldNotHappenException: Node "PhpParser\Node\Expr\StaticCall" with parent of "PhpParser\Node\Expr\ArrayItem" is missing scope required for scope refresh.
```

Fixes https://github.com/rectorphp/rector/issues/7314