### PR TITLE
[Core] Apply auto set Scope from parent on AbstractScopeAwareRector

### DIFF
--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -41,9 +41,18 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
             $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
         }
 
-        if (! $scope instanceof Scope) {
-            $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
 
+        if (! $scope instanceof Scope && $parent instanceof Node) {
+            $parentScope = $parent->getAttribute(AttributeKey::SCOPE);
+
+            if ($parentScope instanceof Scope) {
+                $node->setAttribute(AttributeKey::SCOPE, $parentScope);
+                $scope = $parentScope;
+            }
+        }
+
+        if (! $scope instanceof Scope) {
             $errorMessage = sprintf(
                 'Scope not available on "%s" node with parent node of "%s", but is required by a refactorWithScope() method of "%s" rule. Fix scope refresh on changed nodes first',
                 $node::class,


### PR DESCRIPTION
This is to handle uncovered part like in PR:

- https://github.com/rectorphp/rector-src/pull/2709 

that reported by @leoloso 

which can happen again in the future, by verify:

- No Scope
- Parent Node has Scope

then, use parent Scope as its Node scope.