### PR TITLE
[Php81] Skip Doctrine ORM MappedSuperClass attribute on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity_mapped_superclass.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity_mapped_superclass.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\MappedSuperclass]
+abstract class Oi
+{
+    #[ORM\Column(type: 'string')]
+    #[ORM\Id]
+    private string $id;
+
+    public function __construct(string $id) {
+        $this->id = $id;
+    }
+}

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity_mapped_superclass.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_entity_mapped_superclass.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]
-abstract class Oi
+abstract class SkipEntityMappedSuperClass
 {
     #[ORM\Column(type: 'string')]
     #[ORM\Id]

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -60,6 +60,7 @@ final class PropertyManipulator
     private const ALLOWED_NOT_READONLY_ANNOTATION_CLASS_OR_ATTRIBUTES = [
         'Doctrine\ORM\Mapping\Entity',
         'Doctrine\ORM\Mapping\Table',
+        'Doctrine\ORM\Mapping\MappedSuperclass',
     ];
 
     /**


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7317