### PR TITLE
Do not process static methods from Enum class.

### DIFF
--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/fully_qualified_class_name.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/fully_qualified_class_name.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
+
+final class FullyQualifiedClassName
+{
+    public function run($value)
+    {
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST();
+        $compare2 = MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
+
+final class FullyQualifiedClassName
+{
+    public function run($value)
+    {
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+        $compare2 = MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_enum_static_method_call.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_enum_static_method_call.php.inc
@@ -8,6 +8,8 @@ final class StaticEnumStaticMethodCall
 {
     public function run($value)
     {
+        SomeEnum::from($value)->getKey();
+        SomeEnum::from($value)->getValue();
         $compare = SomeEnum::from($value);
         $compare = SomeEnum::values();
         $compare = SomeEnum::keys();

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_enum_static_method_call.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_enum_static_method_call.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class StaticEnumStaticMethodCall
+{
+    public function run($value)
+    {
+        $compare = SomeEnum::from($value);
+        $compare = SomeEnum::values();
+        $compare = SomeEnum::keys();
+        $compare = SomeEnum::isValid($value);
+        $compare = SomeEnum::search($value);
+        $compare = SomeEnum::toArray();
+        SomeEnum::assertValidValue($value);
+    }
+}

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/static_method_call.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/static_method_call.php.inc
@@ -24,7 +24,7 @@ final class StaticMethodCall
 {
     public function run($value)
     {
-        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+        $compare = SomeEnum::USED_TO_BE_CONST;
     }
 }
 

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_constant.php.inc
@@ -24,7 +24,7 @@ final class UsageOfConstant
 {
     public function run($value)
     {
-        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::VALUE->getKey();
+        $compare = SomeEnum::VALUE->getKey();
     }
 }
 

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_value.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_value.php.inc
@@ -4,11 +4,11 @@ namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRecto
 
 use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
 
-final class UsageOfConstantValue
+final class UsageOfGetValue
 {
     public function run($value)
     {
-        $compare = SomeEnum::VALUE()->getValue();
+        $enum = SomeEnum::USED_TO_BE_CONST()->getValue();
     }
 }
 
@@ -20,11 +20,11 @@ namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRecto
 
 use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
 
-final class UsageOfConstantValue
+final class UsageOfGetValue
 {
     public function run($value)
     {
-        $compare = SomeEnum::VALUE->getValue();
+        $enum = SomeEnum::USED_TO_BE_CONST->value;
     }
 }
 

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -74,10 +75,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $className = $node->class->getAttribute(AttributeKey::ORIGINAL_NAME)->toCodeString();
-        if (! is_string($className)) {
+        $originalName = $node->class->getAttribute(AttributeKey::ORIGINAL_NAME);
+        if (! $originalName instanceof Name) {
             return null;
         }
+
+        $className = $originalName->toCodeString();
 
         return $this->nodeFactory->createShortClassConstFetch($className, $enumCaseName);
     }
@@ -94,10 +97,13 @@ CODE_SAMPLE
         }
 
         $staticCall = $methodCall->var;
-        $className = $staticCall->class->getAttribute(AttributeKey::ORIGINAL_NAME)->toCodeString();
-        if ($className === null) {
+
+        $originalName = $staticCall->class->getAttribute(AttributeKey::ORIGINAL_NAME);
+        if (! $originalName instanceof Name) {
             return null;
         }
+
+        $className = $originalName->toCodeString();
 
         $enumCaseName = $this->getName($staticCall->name);
         if ($enumCaseName === null) {
@@ -114,10 +120,12 @@ CODE_SAMPLE
         }
 
         $staticCall = $methodCall->var;
-        $className = $staticCall->class->getAttribute(AttributeKey::ORIGINAL_NAME)->toCodeString();
-        if ($className === null) {
+        $originalName = $staticCall->class->getAttribute(AttributeKey::ORIGINAL_NAME);
+        if (! $originalName instanceof Name) {
             return null;
         }
+
+        $className = $originalName->toCodeString();
 
         $enumCaseName = $this->getName($staticCall->name);
         if ($enumCaseName === null) {

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -63,7 +63,7 @@ CODE_SAMPLE
         }
 
         $enumCaseName = $this->getName($node->name);
-        if ($enumCaseName === null || in_array($enumCaseName, self::ENUM_METHODS, true)) {
+        if ($enumCaseName === null || $this->shouldOmitEnumCase($enumCaseName)) {
             return null;
         }
 
@@ -106,7 +106,7 @@ CODE_SAMPLE
         $className = $originalName->toCodeString();
 
         $enumCaseName = $this->getName($staticCall->name);
-        if ($enumCaseName === null) {
+        if ($enumCaseName === null || $this->shouldOmitEnumCase($enumCaseName)) {
             return null;
         }
 
@@ -128,7 +128,7 @@ CODE_SAMPLE
         $className = $originalName->toCodeString();
 
         $enumCaseName = $this->getName($staticCall->name);
-        if ($enumCaseName === null) {
+        if ($enumCaseName === null || $this->shouldOmitEnumCase($enumCaseName)) {
             return null;
         }
 
@@ -152,5 +152,10 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function shouldOmitEnumCase(string $enumCaseName): bool
+    {
+        return in_array($enumCaseName, self::ENUM_METHODS, true);
     }
 }


### PR DESCRIPTION
Keep original qualified names of the classes.