### PR TITLE
Fix/early return inline constructor default 7319

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/do_not_change_has_before_if.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/do_not_change_has_before_if.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class DonotChangeHasBeforeIf
+{
+    private $name;
+    private $age;
+    private $gender;
+
+    public function __construct(bool $initName = true)
+    {
+        $this->age = 20;
+
+        if (!$initName) {
+            $this->gender = 'M';
+
+            return;
+        }
+
+        $this->name = 'John';
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class DonotChangeHasBeforeIf
+{
+    private $name;
+    private $age = 20;
+    private $gender;
+
+    public function __construct(bool $initName = true)
+    {
+        if (!$initName) {
+            $this->gender = 'M';
+
+            return;
+        }
+
+        $this->name = 'John';
+    }
+}
+?>

--- a/rules/CodeQuality/NodeAnalyzer/ConstructorPropertyDefaultExprResolver.php
+++ b/rules/CodeQuality/NodeAnalyzer/ConstructorPropertyDefaultExprResolver.php
@@ -34,7 +34,7 @@ final class ConstructorPropertyDefaultExprResolver
 
         foreach ($stmts as $stmt) {
             if (! $stmt instanceof Expression) {
-                continue;
+                break;
             }
 
             $nestedStmt = $stmt->expr;


### PR DESCRIPTION
This PR should fix https://github.com/rectorphp/rector/issues/7319 by searching a "return stmt" if a "if stmt" is found.