### PR TITLE
Apply ParametersAcceptorSelectorVariantsWrapper::select() take 2

### DIFF
--- a/packages/NodeTypeResolver/MethodParameterTypeResolver.php
+++ b/packages/NodeTypeResolver/MethodParameterTypeResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver;
 
-use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;

--- a/packages/NodeTypeResolver/MethodParameterTypeResolver.php
+++ b/packages/NodeTypeResolver/MethodParameterTypeResolver.php
@@ -62,7 +62,7 @@ final class MethodParameterTypeResolver
 
         $parameterTypes = [];
 
-        if (! $node instanceof StaticCall) {
+        if ($node instanceof ClassMethod) {
             $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
         } else {
             $scope = $node->getAttribute(AttributeKey::SCOPE);

--- a/packages/NodeTypeResolver/MethodParameterTypeResolver.php
+++ b/packages/NodeTypeResolver/MethodParameterTypeResolver.php
@@ -63,7 +63,7 @@ final class MethodParameterTypeResolver
 
         $parameterTypes = [];
 
-        if (! $node instanceof CallLike) {
+        if (! $node instanceof StaticCall) {
             $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
         } else {
             $scope = $node->getAttribute(AttributeKey::SCOPE);

--- a/packages/NodeTypeResolver/MethodParameterTypeResolver.php
+++ b/packages/NodeTypeResolver/MethodParameterTypeResolver.php
@@ -55,8 +55,7 @@ final class MethodParameterTypeResolver
     private function provideParameterTypesFromMethodReflection(
         MethodReflection $methodReflection,
         ClassMethod|StaticCall $node
-    ): array
-    {
+    ): array {
         if ($methodReflection instanceof NativeMethodReflection) {
             // method "getParameters()" does not exist there
             return [];

--- a/packages/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
@@ -89,8 +89,7 @@ final class StaticCallMethodCallTypeResolver implements NodeTypeResolverInterfac
         StaticCall|MethodCall $node,
         string $methodName,
         Scope $scope
-    ): Type
-    {
+    ): Type {
         if (! $this->reflectionProvider->hasClass($referencedClass)) {
             return new MixedType();
         }

--- a/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
@@ -98,7 +98,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $expectedArgOrParamOrder = $this->resolveExpectedArgParamOrderIfDifferent($classMethodReflection);
+        $expectedArgOrParamOrder = $this->resolveExpectedArgParamOrderIfDifferent($classMethodReflection, $classMethod);
         if ($expectedArgOrParamOrder === null) {
             return null;
         }
@@ -162,13 +162,13 @@ CODE_SAMPLE
      */
     private function resolveExpectedArgParamOrderIfDifferent(
         MethodReflection $methodReflection,
-        New_|MethodCall|null $node = null
+        New_|MethodCall|ClassMethod $node
     ): ?array {
         if ($this->vendorLocationDetector->detectMethodReflection($methodReflection)) {
             return null;
         }
 
-        if (! $node instanceof CallLike) {
+        if ($node instanceof ClassMethod) {
             $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
         } else {
             $scope = $node->getAttribute(AttributeKey::SCOPE);

--- a/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
@@ -163,8 +163,7 @@ CODE_SAMPLE
     private function resolveExpectedArgParamOrderIfDifferent(
         MethodReflection $methodReflection,
         New_|MethodCall|null $node = null
-    ): ?array
-    {
+    ): ?array {
         if ($this->vendorLocationDetector->detectMethodReflection($methodReflection)) {
             return null;
         }

--- a/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\ClassMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\ClassMethod;


### PR DESCRIPTION
continue https://github.com/rectorphp/rector-src/pull/2632 to ensure use selectFromArgs() for multi variants for `CallLike`, also Fixes https://github.com/rectorphp/rector/issues/7297