### PR TITLE
[Php56] Skip already initialized on next Stmt on AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -227,7 +227,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                 $composedTokenIterator->isCurrentTokenType(
                     Lexer::TOKEN_CLOSE_CURLY_BRACKET,
                     Lexer::TOKEN_CLOSE_PARENTHESES
-                // sometimes it gets mixed int    ")
+                    // sometimes it gets mixed int    ")
                 ) || \str_contains($composedTokenIterator->currentTokenValue(), ')')) {
                 ++$closeBracketCount;
             }

--- a/packages/NodeTypeResolver/TypeAnalyzer/MethodTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/MethodTypeAnalyzer.php
@@ -37,8 +37,8 @@ final class MethodTypeAnalyzer
     private function isMethodName(MethodCall $methodCall, string $expectedName): bool
     {
         if (
-        $methodCall->name instanceof Identifier
-        && $this->areMethodNamesEqual($methodCall->name->toString(), $expectedName)
+            $methodCall->name instanceof Identifier
+            && $this->areMethodNamesEqual($methodCall->name->toString(), $expectedName)
         ) {
             return true;
         }

--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -43,7 +43,7 @@ function (OriginalClass $someClass)
 {
 }
 CODE_SAMPLE
-            ,
+                ,
                 <<<'CODE_SAMPLE'
 function (RenamedClass $someClass)
 {

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -79,7 +79,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 use App\AnotherClass;
 

--- a/packages/PostRector/Rector/NodeRemovingPostRector.php
+++ b/packages/PostRector/Rector/NodeRemovingPostRector.php
@@ -103,7 +103,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-                        ,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/packages/PostRector/Rector/PropertyAddingPostRector.php
+++ b/packages/PostRector/Rector/PropertyAddingPostRector.php
@@ -65,7 +65,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-                        ,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -105,7 +105,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-                        ,
+                    ,
                     <<<'CODE_SAMPLE'
 use App\AnotherClass;
 

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_already_initialized_next.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_already_initialized_next.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class SkipAlreadyInitializedNext
+{
+    public function run()
+    {
+        $a = null;
+        $b = null;
+
+        if (rand(0, 1)) {
+            $a = 5;
+            $b = 2;
+        } else if (rand(0,1)) {
+            unset($a);
+            unset($b);
+        }
+
+        echo $a;
+        echo $b;
+    }
+}

--- a/rules/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector.php
+++ b/rules/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector.php
@@ -44,7 +44,7 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 version_compare(PHP_VERSION, '5.6', 'ge');
 CODE_SAMPLE
-            ,
+                ,
                 [new ReplaceFuncCallArgumentDefaultValue('version_compare', 2, 'gte', 'ge',)]
             ),
         ]);

--- a/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
+++ b/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
@@ -37,7 +37,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
@@ -47,7 +47,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [new RemoveMethodCallParam('Caller', 'process', 1)]
             ),
         ]);

--- a/rules/CodeQuality/Rector/Assign/SplitListAssignToSeparateLineRector.php
+++ b/rules/CodeQuality/Rector/Assign/SplitListAssignToSeparateLineRector.php
@@ -36,7 +36,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
+++ b/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
@@ -45,7 +45,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
+++ b/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
@@ -44,7 +44,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
@@ -44,7 +44,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodeQuality/Rector/FuncCall/AddPregQuoteDelimiterRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/AddPregQuoteDelimiterRector.php
@@ -33,7 +33,7 @@ final class AddPregQuoteDelimiterRector extends AbstractRector
                 <<<'CODE_SAMPLE'
 '#' . preg_quote('name') . '#';
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 '#' . preg_quote('name', '#') . '#';
 CODE_SAMPLE

--- a/rules/CodeQuality/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector.php
@@ -33,7 +33,7 @@ function run($packageName, $values)
     return in_array($packageName, $keys, true);
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 function run($packageName, $values)
 {

--- a/rules/CodeQuality/Rector/FuncCall/ArrayMergeOfNonArraysToSimpleArrayRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ArrayMergeOfNonArraysToSimpleArrayRector.php
@@ -40,7 +40,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
@@ -31,7 +31,7 @@ final class ChangeArrayPushToArrayAssignRector extends AbstractRector
 $items = [];
 array_push($items, $item);
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 $items = [];
 $items[] = $item;

--- a/rules/CodeQuality/Rector/FuncCall/IntvalToTypeCastRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/IntvalToTypeCastRector.php
@@ -34,7 +34,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -50,7 +50,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodeQuality/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
+++ b/rules/CodeQuality/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
@@ -36,7 +36,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -117,7 +117,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [
                     self::DELIMITER => '#',
                 ]

--- a/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/CountArrayToEmptyArrayComparisonRector.php
@@ -39,7 +39,7 @@ count($array) === 0;
 count($array) > 0;
 ! count($array);
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 $array === [];
 $array !== [];

--- a/rules/CodingStyle/Rector/Property/AddFalseDefaultToBoolPropertyRector.php
+++ b/rules/CodingStyle/Rector/Property/AddFalseDefaultToBoolPropertyRector.php
@@ -39,7 +39,7 @@ class SomeClass
     private $isDisabled;
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
+++ b/rules/CodingStyle/Rector/Property/InlineSimplePropertyAnnotationRector.php
@@ -62,7 +62,7 @@ final class SomeClass
     private ?array $dateTimes;
 }
 CODE_SAMPLE
-,
+                    ,
                     ['var', 'phpstan-var'],
                 ),
             ]

--- a/rules/CodingStyle/Rector/Use_/SeparateMultiUseImportsRector.php
+++ b/rules/CodingStyle/Rector/Use_/SeparateMultiUseImportsRector.php
@@ -30,7 +30,7 @@ class SomeClass
     use SomeTrait, AnotherTrait;
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 use A;
 use B;

--- a/rules/Composer/Rector/RemovePackageComposerRector.php
+++ b/rules/Composer/Rector/RemovePackageComposerRector.php
@@ -38,12 +38,12 @@ final class RemovePackageComposerRector implements ComposerRectorInterface
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 <<<'CODE_SAMPLE'
 {
 }
 CODE_SAMPLE
-            ,
+                ,
                 ['symfony/console']
             ),
         ]);

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -58,7 +58,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/DeadCode/Rector/ClassConst/RemoveUnusedPrivateClassConstantRector.php
+++ b/rules/DeadCode/Rector/ClassConst/RemoveUnusedPrivateClassConstantRector.php
@@ -40,7 +40,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
+++ b/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
@@ -44,13 +44,13 @@ final class SomeClass
 {
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
 }
 CODE_SAMPLE
-,
+                ,
                 ['method'],
             ),
         ]);

--- a/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
+++ b/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
@@ -76,7 +76,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -86,7 +86,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     [PhpVersion::PHP_80]
                 ),
             ],

--- a/rules/DeadCode/Rector/FunctionLike/RemoveDuplicatedIfReturnRector.php
+++ b/rules/DeadCode/Rector/FunctionLike/RemoveDuplicatedIfReturnRector.php
@@ -63,7 +63,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
@@ -51,7 +51,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector.php
+++ b/rules/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector.php
@@ -41,7 +41,7 @@ if (version_compare(PHP_VERSION, '7.2', '<')) {
     return 'is PHP 7.2+';
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 // current PHP: 7.2
 return 'is PHP 7.2+';

--- a/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
@@ -63,7 +63,7 @@ class SomeClass
 {
 }
 CODE_SAMPLE
-,
+                ,
                 [
                     self::REMOVE_ASSIGN_SIDE_EFFECT => true,
                 ]

--- a/rules/DeadCode/Rector/Ternary/TernaryToBooleanOrFalseToBooleanAndRector.php
+++ b/rules/DeadCode/Rector/Ternary/TernaryToBooleanOrFalseToBooleanAndRector.php
@@ -35,7 +35,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -37,7 +37,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/EarlyReturn/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector.php
+++ b/rules/EarlyReturn/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector.php
@@ -53,7 +53,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/EarlyReturn/Rector/If_/ChangeIfElseValueAssignToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeIfElseValueAssignToEarlyReturnRector.php
@@ -50,7 +50,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -41,7 +41,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/MysqlToMysqli/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
+++ b/rules/MysqlToMysqli/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
@@ -93,7 +93,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -61,7 +61,7 @@ public function getRunner(): Runner
 }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
+++ b/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
@@ -49,7 +49,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
+++ b/rules/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
@@ -42,7 +42,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -73,7 +73,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 ['ClassName', 'AnotherClassName'],
             ),
         ]);

--- a/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
+++ b/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
@@ -92,6 +92,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->stmts === null) {
+            return null;
+        }
+
         $undefinedVariableNames = $this->undefinedVariableResolver->resolve($node);
 
         if ($undefinedVariableNames === []) {
@@ -100,12 +104,20 @@ CODE_SAMPLE
 
         $variablesInitiation = [];
         foreach ($undefinedVariableNames as $undefinedVariableName) {
-            $value = $this->isArray($undefinedVariableName, (array) $node->stmts)
+            $value = $this->isArray($undefinedVariableName, $node->stmts)
                 ? new Array_([])
                 : $this->nodeFactory->createNull();
 
             $assign = new Assign(new Variable($undefinedVariableName), $value);
-            $variablesInitiation[] = new Expression($assign);
+            $expresssion = new Expression($assign);
+
+            foreach ($node->stmts as $stmt) {
+                if ($this->nodeComparator->areNodesEqual($expresssion, $stmt)) {
+                    continue 2;
+                }
+            }
+
+            $variablesInitiation[] = $expresssion;
         }
 
         $node->stmts = array_merge($variablesInitiation, (array) $node->stmts);

--- a/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
+++ b/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
@@ -102,16 +102,30 @@ CODE_SAMPLE
             return null;
         }
 
+        $variablesInitiation = $this->collectVariablesInitiation($undefinedVariableNames, $node->stmts);
+        $node->stmts = array_merge($variablesInitiation, $node->stmts);
+
+        return $node;
+    }
+
+    /**
+     * @param string[] $undefinedVariableNames
+     * @param Stmt[] $stmts
+     * @return Expression[]
+     */
+    private function collectVariablesInitiation(array $undefinedVariableNames, array $stmts): array
+    {
         $variablesInitiation = [];
+
         foreach ($undefinedVariableNames as $undefinedVariableName) {
-            $value = $this->isArray($undefinedVariableName, $node->stmts)
+            $value = $this->isArray($undefinedVariableName, $stmts)
                 ? new Array_([])
                 : $this->nodeFactory->createNull();
 
             $assign = new Assign(new Variable($undefinedVariableName), $value);
             $expresssion = new Expression($assign);
 
-            foreach ($node->stmts as $stmt) {
+            foreach ($stmts as $stmt) {
                 if ($this->nodeComparator->areNodesEqual($expresssion, $stmt)) {
                     continue 2;
                 }
@@ -120,9 +134,7 @@ CODE_SAMPLE
             $variablesInitiation[] = $expresssion;
         }
 
-        $node->stmts = array_merge($variablesInitiation, $node->stmts);
-
-        return $node;
+        return $variablesInitiation;
     }
 
     /**

--- a/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
+++ b/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
@@ -120,7 +120,7 @@ CODE_SAMPLE
             $variablesInitiation[] = $expresssion;
         }
 
-        $node->stmts = array_merge($variablesInitiation, (array) $node->stmts);
+        $node->stmts = array_merge($variablesInitiation, $node->stmts);
 
         return $node;
     }

--- a/rules/Php71/Rector/Name/ReservedObjectRector.php
+++ b/rules/Php71/Rector/Name/ReservedObjectRector.php
@@ -45,13 +45,13 @@ class Object
 {
 }
 CODE_SAMPLE
-                                ,
+                    ,
                     <<<'CODE_SAMPLE'
 class SmartObject
 {
 }
 CODE_SAMPLE
-                            ,
+                    ,
                     [
                         'ReservedObject' => 'SmartObject',
                         'Object' => 'AnotherSmartObject',

--- a/rules/Php74/Rector/MethodCall/ChangeReflectionTypeToStringToGetNameRector.php
+++ b/rules/Php74/Rector/MethodCall/ChangeReflectionTypeToStringToGetNameRector.php
@@ -66,7 +66,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -35,7 +35,7 @@ class SomeClass
     public ?string $name;
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php74/Rector/Property/TypedPropertyRector.php
+++ b/rules/Php74/Rector/Property/TypedPropertyRector.php
@@ -95,7 +95,7 @@ final class SomeClass
     private bool $isDone = false;
 }
 CODE_SAMPLE
-                ,
+                    ,
                     [
                         self::INLINE_PUBLIC => false,
                     ]

--- a/rules/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
+++ b/rules/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
@@ -41,7 +41,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -61,7 +61,7 @@ class B extends A{
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class A
 {

--- a/rules/Php80/Rector/ClassMethod/FinalPrivateToPrivateVisibilityRector.php
+++ b/rules/Php80/Rector/ClassMethod/FinalPrivateToPrivateVisibilityRector.php
@@ -41,7 +41,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/ClassMethod/SetStateToStaticRector.php
+++ b/rules/Php80/Rector/ClassMethod/SetStateToStaticRector.php
@@ -41,7 +41,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -65,7 +65,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/Class_/StringableForToStringRector.php
+++ b/rules/Php80/Rector/Class_/StringableForToStringRector.php
@@ -63,7 +63,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass implements Stringable
 {

--- a/rules/Php80/Rector/FuncCall/ClassOnObjectRector.php
+++ b/rules/Php80/Rector/FuncCall/ClassOnObjectRector.php
@@ -37,7 +37,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/FuncCall/Php8ResourceReturnToObjectRector.php
+++ b/rules/Php80/Rector/FuncCall/Php8ResourceReturnToObjectRector.php
@@ -111,7 +111,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/FuncCall/TokenGetAllToObjectRector.php
+++ b/rules/Php80/Rector/FuncCall/TokenGetAllToObjectRector.php
@@ -65,7 +65,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
+++ b/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
@@ -54,7 +54,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
+++ b/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
@@ -68,7 +68,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/Identical/StrEndsWithRector.php
+++ b/rules/Php80/Rector/Identical/StrEndsWithRector.php
@@ -57,7 +57,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/Identical/StrStartsWithRector.php
+++ b/rules/Php80/Rector/Identical/StrStartsWithRector.php
@@ -55,7 +55,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/NotIdentical/StrContainsRector.php
+++ b/rules/Php80/Rector/NotIdentical/StrContainsRector.php
@@ -48,7 +48,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php80/Rector/Ternary/GetDebugTypeRector.php
+++ b/rules/Php80/Rector/Ternary/GetDebugTypeRector.php
@@ -41,7 +41,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -295,7 +295,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Php81/Rector/FuncCall/Php81ResourceReturnToObjectRector.php
+++ b/rules/Php81/Rector/FuncCall/Php81ResourceReturnToObjectRector.php
@@ -76,7 +76,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
+++ b/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
@@ -40,7 +40,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/Privatization/Rector/Class_/ChangeGlobalVariablesToPropertiesRector.php
+++ b/rules/Privatization/Rector/Class_/ChangeGlobalVariablesToPropertiesRector.php
@@ -57,7 +57,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
@@ -58,7 +58,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector.php
+++ b/rules/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector.php
@@ -42,7 +42,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Privatization/Rector/MethodCall/ReplaceStringWithClassConstantRector.php
+++ b/rules/Privatization/Rector/MethodCall/ReplaceStringWithClassConstantRector.php
@@ -44,7 +44,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -54,7 +54,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [new ReplaceStringWithClassConstant('SomeClass', 'call', 0, 'Placeholder')]
             ),
         ]);

--- a/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector.php
@@ -53,7 +53,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -34,7 +34,7 @@ final class SomeClass
     protected $value;
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
+++ b/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
@@ -42,7 +42,7 @@ class SomeClass
 {
 }
 CODE_SAMPLE
-,
+                ,
                 ['TraitNameToRemove']
             ),
         ]);

--- a/rules/Renaming/Rector/String_/RenameStringRector.php
+++ b/rules/Renaming/Rector/String_/RenameStringRector.php
@@ -37,7 +37,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -47,7 +47,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [
                     'ROLE_PREVIOUS_ADMIN' => 'IS_IMPERSONATOR',
                 ]

--- a/rules/Restoration/Rector/Class_/RemoveFinalFromEntityRector.php
+++ b/rules/Restoration/Rector/Class_/RemoveFinalFromEntityRector.php
@@ -35,7 +35,7 @@ final class SomeClass
 {
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 use Doctrine\ORM\Mapping as ORM;
 

--- a/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
+++ b/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
@@ -40,7 +40,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector.php
+++ b/rules/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector.php
@@ -48,7 +48,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {

--- a/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
+++ b/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
@@ -43,7 +43,7 @@ final class SomeEmptyArray
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeEmptyArray
 {

--- a/rules/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector.php
+++ b/rules/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector.php
@@ -49,7 +49,7 @@ final class NegatedString
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 <<<'CODE_SAMPLE'
 final class NegatedString
 {

--- a/rules/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector.php
+++ b/rules/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector.php
@@ -44,7 +44,7 @@ final class ArrayCompare
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 <<<'CODE_SAMPLE'
 final class ArrayCompare
 {
@@ -54,7 +54,7 @@ final class ArrayCompare
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 [
                     self::TREAT_AS_NON_EMPTY => false,
                 ]

--- a/rules/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector.php
+++ b/rules/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector.php
@@ -45,7 +45,7 @@ final class ShortTernaryArray
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 <<<'CODE_SAMPLE'
 final class ShortTernaryArray
 {

--- a/rules/Transform/Rector/Assign/DimFetchAssignToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/DimFetchAssignToMethodCallRector.php
@@ -46,7 +46,7 @@ class RouterFactory
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 use Nette\Application\Routers\RouteList;
 
@@ -59,7 +59,7 @@ class RouterFactory
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     [
                         new DimFetchAssignToMethodCall(
                             'Nette\Application\Routers\RouteList',

--- a/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
+++ b/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
@@ -39,7 +39,7 @@ class SomeClass
     public $name;
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\DBAL\Types\Types;
@@ -50,7 +50,7 @@ class SomeClass
     public $name;
 }
 CODE_SAMPLE
-,
+                ,
                 [
                     new AttributeKeyToClassConstFetch('Doctrine\ORM\Mapping\Column', 'type', 'Doctrine\DBAL\Types\Types', [
                         'string' => 'STRING',

--- a/rules/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector.php
+++ b/rules/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector.php
@@ -48,7 +48,7 @@ class SomeClass implements ArrayAccess
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass implements ArrayAccess
 {
@@ -58,7 +58,7 @@ class SomeClass implements ArrayAccess
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 [
                     'ArrayAccess' => ['offsetGet'],
                 ]

--- a/rules/Transform/Rector/Class_/AddAllowDynamicPropertiesAttributeRector.php
+++ b/rules/Transform/Rector/Class_/AddAllowDynamicPropertiesAttributeRector.php
@@ -56,7 +56,7 @@ class SomeObject {
     public string $someProperty = 'hello world';
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 namespace Example\Domain;
 
@@ -65,7 +65,7 @@ class SomeObject {
     public string $someProperty = 'hello world';
 }
 CODE_SAMPLE
-,
+                ,
                 ['Example\*'],
             ),
         ]);

--- a/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
+++ b/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
@@ -39,14 +39,14 @@ class SomeClass
     use SomeTrait;
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass implements SomeInterface
 {
     use SomeTrait;
 }
 CODE_SAMPLE
-            ,
+                ,
                 [
                     'SomeTrait' => 'SomeInterface',
                 ]

--- a/rules/Transform/Rector/Class_/RemoveAllowDynamicPropertiesAttributeRector.php
+++ b/rules/Transform/Rector/Class_/RemoveAllowDynamicPropertiesAttributeRector.php
@@ -47,7 +47,7 @@ class SomeObject {
     public string $someProperty = 'hello world';
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 namespace Example\Domain;
 
@@ -55,7 +55,7 @@ class SomeObject {
     public string $someProperty = 'hello world';
 }
 CODE_SAMPLE
-,
+                ,
                 ['Example\*']
             ),
         ]);

--- a/rules/Transform/Rector/FuncCall/FuncCallToNewRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToNewRector.php
@@ -47,7 +47,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [
                     'collection' => ['Collection'],
                 ]

--- a/rules/Transform/Rector/FunctionLike/FileGetContentsAndJsonDecodeToStaticCallRector.php
+++ b/rules/Transform/Rector/FunctionLike/FileGetContentsAndJsonDecodeToStaticCallRector.php
@@ -41,7 +41,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
@@ -51,7 +51,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [new StaticCallRecipe('FileLoader', 'loadJson')]
             ),
         ]);

--- a/rules/Transform/Rector/MethodCall/MethodCallToStaticCallRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToStaticCallRector.php
@@ -43,7 +43,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
@@ -60,7 +60,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [new MethodCallToStaticCall('AnotherDependency', 'process', 'StaticCaller', 'anotherMethod')]
             ),
         ]);

--- a/rules/Transform/Rector/New_/NewArgToMethodCallRector.php
+++ b/rules/Transform/Rector/New_/NewArgToMethodCallRector.php
@@ -40,7 +40,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -51,7 +51,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [new NewArgToMethodCall('Dotenv', true, 'usePutenv')]
             ),
         ]);

--- a/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
@@ -50,7 +50,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 use Symplify\SmartFileSystem\SmartFileSystem;
 
@@ -72,7 +72,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 [
                     new StaticCallToMethodCall(
                         'Nette\Utils\FileSystem',

--- a/rules/Transform/Rector/StaticCall/StaticCallToNewRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToNewRector.php
@@ -40,7 +40,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -50,7 +50,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [new StaticCallToNew('JsonResponse', 'create')]
             ),
         ]);

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -54,7 +54,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -63,7 +63,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 [new AddParamTypeDeclaration('SomeClass', 'process', 0, new StringType())]
             ),
         ]);

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
@@ -59,7 +59,7 @@ class B extends A{
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class A
 {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ArrayShapeFromConstantArrayReturnRector.php
@@ -55,7 +55,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -66,7 +66,7 @@ final class UseDependency
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 class SomeTypedService
 {

--- a/rules/TypeDeclaration/Rector/Property/AddPropertyTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/Property/AddPropertyTypeDeclarationRector.php
@@ -52,7 +52,7 @@ class SomeClass extends ParentClass
     public string $name;
 }
 CODE_SAMPLE
-,
+                ,
                 $configuration
             ),
         ]);

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -88,7 +88,7 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                ,
                 [
                     self::INLINE_PUBLIC => false,
                 ]

--- a/rules/Visibility/Rector/ClassConst/ChangeConstantVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassConst/ChangeConstantVisibilityRector.php
@@ -47,7 +47,7 @@ class MyClass extends FrameworkClass
     public const SOME_CONSTANT = 1;
 }
 CODE_SAMPLE
-                                ,
+                    ,
                     <<<'CODE_SAMPLE'
 class FrameworkClass
 {
@@ -59,7 +59,7 @@ class MyClass extends FrameworkClass
     protected const SOME_CONSTANT = 1;
 }
 CODE_SAMPLE
-                                ,
+                    ,
                     [new ChangeConstantVisibility('ParentObject', 'SOME_CONSTANT', Visibility::PROTECTED)]
                 ),
             ]

--- a/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassMethod/ChangeMethodVisibilityRector.php
@@ -54,7 +54,7 @@ class MyClass extends FrameworkClass
     }
 }
 CODE_SAMPLE
-                                ,
+                    ,
                     <<<'CODE_SAMPLE'
 class FrameworkClass
 {

--- a/src/NonPhpFile/Rector/RenameClassNonPhpRector.php
+++ b/src/NonPhpFile/Rector/RenameClassNonPhpRector.php
@@ -50,12 +50,12 @@ final class RenameClassNonPhpRector implements NonPhpRectorInterface, Configurab
 services:
     - SomeOldClass
 CODE_SAMPLE
-                ,
+                    ,
                     <<<'CODE_SAMPLE'
 services:
     - SomeNewClass
 CODE_SAMPLE
-                ,
+                    ,
                     [
                         'SomeOldClass' => 'SomeNewClass',
                     ]


### PR DESCRIPTION
Given the following code should be skipped:


```php
<?php

namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;

class SkipAlreadyInitializedNext
{
    public function run()
    {
        $a = null;
        $b = null;

        if (rand(0, 1)) {
            $a = 5;
            $b = 2;
        } else if (rand(0,1)) {
            unset($a);
            unset($b);
        }

        echo $a;
        echo $b;
    }
}

```

Fixes https://github.com/rectorphp/rector/issues/7327