### PR TITLE
[Php56] Ensure return null on empty variable initialization after check with existing stmts on AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
+++ b/rules/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
@@ -103,6 +103,11 @@ CODE_SAMPLE
         }
 
         $variablesInitiation = $this->collectVariablesInitiation($undefinedVariableNames, $node->stmts);
+
+        if ($variablesInitiation === []) {
+            return null;
+        }
+
         $node->stmts = array_merge($variablesInitiation, $node->stmts);
 
         return $node;


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2721, ensure return null when no result on collecting variable initialization after verified with existing sttmts.