### PR TITLE
[Php80] Skip default no stmt next is case on ChangeSwitchToMatchRector

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_default_no_stmt_next_case.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_default_no_stmt_next_case.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class SkipDefaultNoStmtNextCase
+{
+    public function run($value)
+    {
+        switch ($value) {
+            default:
+            case 1:
+                $a = 1;
+                return $a;
+        }
+    }
+}

--- a/rules/Php80/NodeResolver/SwitchExprsResolver.php
+++ b/rules/Php80/NodeResolver/SwitchExprsResolver.php
@@ -101,6 +101,11 @@ final class SwitchExprsResolver
                 return;
             }
 
+            // current default has no stmt? keep as is as rely to next case
+            if ($case->stmts === []) {
+                return;
+            }
+
             for ($loop = $key - 1; $loop >= 0; --$loop) {
                 if ($switch->cases[$loop]->stmts !== []) {
                     break;

--- a/rules/Php80/NodeResolver/SwitchExprsResolver.php
+++ b/rules/Php80/NodeResolver/SwitchExprsResolver.php
@@ -22,12 +22,14 @@ final class SwitchExprsResolver
      */
     public function resolve(Switch_ $switch): array
     {
+        $newSwitch = clone $switch;
+
         $condAndExpr = [];
         $collectionEmptyCasesCond = [];
 
-        $this->moveDefaultCaseToLast($switch);
+        $this->moveDefaultCaseToLast($newSwitch);
 
-        foreach ($switch->cases as $key => $case) {
+        foreach ($newSwitch->cases as $key => $case) {
             assert(is_int($key));
 
             if (! $this->isValidCase($case)) {
@@ -39,7 +41,7 @@ final class SwitchExprsResolver
             }
         }
 
-        foreach ($switch->cases as $key => $case) {
+        foreach ($newSwitch->cases as $key => $case) {
             if ($case->stmts === []) {
                 continue;
             }


### PR DESCRIPTION
Given code should be skipped:

```php
class SkipDefaultNoStmtNextCase
{
    public function run($value)
    {
        switch ($value) {
            default:
            case 1:
                $a = 1;
                return $a;
        }
    }
}
```

instead of moving default to last which make invalid result, ref https://getrector.org/demo/468ad5e2-d3d1-4ef1-b037-dcf7d0a967db

Fixes https://github.com/rectorphp/rector/issues/7338