### PR TITLE
[DeadCode] Skip RemoveAlwaysTrueIfConditionRector on property use by @var docblock on Trait

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_property_by_var_doc_in_trait.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_property_by_var_doc_in_trait.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+trait SkipPropertyByVarDocInTrait
+{
+    /** @var Formatter|null */
+    private $formatter;
+
+    public function verify()
+    {
+        // if we don't have a formatter, make one
+        if (! isset($this->formatter)) {
+            // if no formatter, use the default
+            $this->formatter = new Formatter();
+        }
+
+        $this->formatter->format();
+    }
+}

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -115,7 +115,8 @@ CODE_SAMPLE
             $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($propertyFetch);
 
             if (! $classReflection instanceof ClassReflection) {
-                continue;
+                // cannot get parent Trait_ from Property Fetch
+                return true;
             }
 
             $propertyName = (string) $this->nodeNameResolver->getName($propertyFetch);


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2717, check to skip `@var` on Property for trait as well.