### PR TITLE
[Php80][TypeDeclaration] Handle UnionTypesRector+AddArrayReturnDocTypeRector on auto import FullyQualified doc

### DIFF
--- a/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
+++ b/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Privatization\TypeManipulator;
 
-use PHPStan\Reflection\ClassReflection;
 use PhpParser\Node;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;

--- a/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
+++ b/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
@@ -46,7 +46,7 @@ final class NormalizeTypeToRespectArrayScalarType
         return $type;
     }
 
-    private function resolveArrayType(ArrayType $arrayType): ArrayType|MixedType
+    private function resolveArrayType(ArrayType $arrayType): ArrayType
     {
         $itemType = $arrayType->getItemType();
         if (! $itemType instanceof IntersectionType) {
@@ -63,10 +63,11 @@ final class NormalizeTypeToRespectArrayScalarType
         }
 
         if ($types === []) {
-            return new MixedType();
+            $arrayItemType = new MixedType();
+        } else {
+            $arrayItemType = count($types) === 1 ? array_pop($types) : new IntersectionType($types);
         }
 
-        $arrayItemType = count($types) === 1 ? array_pop($types) : new IntersectionType($types);
         return new ArrayType($arrayType->getKeyType(), $arrayItemType);
     }
 

--- a/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
+++ b/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
@@ -59,6 +59,10 @@ final class NormalizeTypeToRespectArrayScalarType
                 continue;
             }
 
+            if ($itemTypeType instanceof ArrayType) {
+                continue;
+            }
+
             unset($types[$key]);
         }
 

--- a/tests/Issues/UnionArrayAutoImport/Fixture/fixture.php.inc
+++ b/tests/Issues/UnionArrayAutoImport/Fixture/fixture.php.inc
@@ -1,0 +1,60 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\UnionArrayAutoImport\Fixture;
+
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+
+final class Fixture
+{
+    /**
+     * @param Stmt[] $stmts
+     */
+    public function run(array $stmts): array
+    {
+        $expressions = [];
+
+        foreach ($stmts as $stmt) {
+            if (! $stmt instanceof Expression) {
+                break;
+            }
+
+            $expressions[] = $stmt;
+        }
+
+        return $expressions;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\UnionArrayAutoImport\Fixture;
+
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+
+final class Fixture
+{
+    /**
+     * @param Stmt[] $stmts
+     * @return Expression[]
+     */
+    public function run(array $stmts): array
+    {
+        $expressions = [];
+
+        foreach ($stmts as $stmt) {
+            if (! $stmt instanceof Expression) {
+                break;
+            }
+
+            $expressions[] = $stmt;
+        }
+
+        return $expressions;
+    }
+}
+
+?>

--- a/tests/Issues/UnionArrayAutoImport/UnionArrayAutoImportTest.php
+++ b/tests/Issues/UnionArrayAutoImport/UnionArrayAutoImportTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\UnionArrayAutoImport;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class UnionArrayAutoImportTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/UnionArrayAutoImport/config/configured_rule.php
+++ b/tests/Issues/UnionArrayAutoImport/config/configured_rule.php
@@ -7,9 +7,6 @@ use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
-        UnionTypesRector::class,
-        AddArrayReturnDocTypeRector::class,
-    ]);
+    $rectorConfig->rules([UnionTypesRector::class, AddArrayReturnDocTypeRector::class]);
     $rectorConfig->importNames();
 };

--- a/tests/Issues/UnionArrayAutoImport/config/configured_rule.php
+++ b/tests/Issues/UnionArrayAutoImport/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        UnionTypesRector::class,
+        AddArrayReturnDocTypeRector::class,
+    ]);
+    $rectorConfig->importNames();
+};


### PR DESCRIPTION
Given the following code:

```php
use PhpParser\Node\Stmt;
use PhpParser\Node\Stmt\Expression;

final class Fixture
{
    /**
     * @param Stmt[] $stmts
     */
    public function run(array $stmts): array
    {
        $expressions = [];

        foreach ($stmts as $stmt) {
            if (! $stmt instanceof Expression) {
                break;
            }

            $expressions[] = $stmt;
        }

        return $expressions;
    }
}
```

It currently got output:

```diff
+     * @return \Expression&Stmt[]
```

which should be:

```diff
-     * @return \Expression&Stmt[]
+     * @return Expression[]
```

Applied rules:

```
Rector\Php80\Rector\FunctionLike\UnionTypesRector
Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector
```

Fixes https://github.com/rectorphp/rector/issues/7340
