### PR TITLE
Ability to yield files with names

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -102,6 +102,14 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
         return StaticFixtureFinder::yieldDirectoryExclusively($directory, $suffix);
     }
 
+    /**
+     * @return Iterator<string, array<int, SmartFileInfo>>
+     */
+    protected function yieldFilesWithPathnameFromDirectory(string $directory, string $suffix = '*.php.inc'): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectoryExclusivelyWithRelativePathname($directory, $suffix);
+    }
+
     protected function isWindows(): bool
     {
         return strncasecmp(PHP_OS, 'WIN', 3) === 0;


### PR DESCRIPTION
It's useful for PHPUnit with `--testdox` flag. See: https://twitter.com/_Codito_/status/1555212319088644097

I modified vendors in order to achieve that effect, currently there's no `AbstractRectorTestCase` method for yielding with keys required to display human-friendly set names.

⚠️ symplify/symplify#4292 required for proper return types.