### PR TITLE
[Php55] Handle crash on no quote in backslash on PregReplaceEModifierRector

### DIFF
--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_back_reference.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_back_reference.php.inc
@@ -10,6 +10,7 @@ class NoQuoteInBackReference
 
         echo preg_replace('~(-159)~e', 'chr(\\1)', $str);
         echo preg_replace('~(-159)~e', "chr(\\1)", $str);
+        echo preg_replace('~(-159)~e', 'chr("\\1")', $str);
     }
 }
 
@@ -25,6 +26,9 @@ class NoQuoteInBackReference
     {
         $str = '-159';
 
+        echo preg_replace_callback('~(-159)~', function ($matches) {
+            return chr($matches[1]);
+        }, $str);
         echo preg_replace_callback('~(-159)~', function ($matches) {
             return chr($matches[1]);
         }, $str);

--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_back_reference.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_back_reference.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\Fixture;
 
-class NoQuoteInBackslash
+class NoQuoteInBackReference
 {
     public function run($str)
     {
@@ -19,7 +19,7 @@ class NoQuoteInBackslash
 
 namespace Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\Fixture;
 
-class NoQuoteInBackslash
+class NoQuoteInBackReference
 {
     public function run($str)
     {

--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_backslash.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_backslash.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\Fixture;
+
+class NoQuoteInBackslash
+{
+    public function run($str)
+    {
+        $str = preg_replace('~&#([0-9]+);~e', 'chr(\\1)', $str);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\Fixture;
+
+class NoQuoteInBackslash
+{
+    public function run($str)
+    {
+        $str = preg_replace_callback('~&#([0-9]+);~', function ($matches) {
+            return chr($matches[1]);
+        }, $str);
+    }
+}
+
+?>

--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_backslash.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/no_quote_in_backslash.php.inc
@@ -6,7 +6,10 @@ class NoQuoteInBackslash
 {
     public function run($str)
     {
-        $str = preg_replace('~&#([0-9]+);~e', 'chr(\\1)', $str);
+        $str = '-159';
+
+        echo preg_replace('~(-159)~e', 'chr(\\1)', $str);
+        echo preg_replace('~(-159)~e', "chr(\\1)", $str);
     }
 }
 
@@ -20,7 +23,12 @@ class NoQuoteInBackslash
 {
     public function run($str)
     {
-        $str = preg_replace_callback('~&#([0-9]+);~', function ($matches) {
+        $str = '-159';
+
+        echo preg_replace_callback('~(-159)~', function ($matches) {
+            return chr($matches[1]);
+        }, $str);
+        echo preg_replace_callback('~(-159)~', function ($matches) {
             return chr($matches[1]);
         }, $str);
     }


### PR DESCRIPTION
Given the following code:

```php
echo preg_replace('~(-159)~e', 'chr(\\1)', $str);
```

it currently produce error:

```bash
There was 1 error:

1) Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\PregReplaceEModifierRectorTest::test with data set #6 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
PhpParser\Error: Syntax error, unexpected T_NS_SEPARATOR on line 1
```

Fixes https://github.com/rectorphp/rector/issues/7312