### PR TITLE
[Php80] Preserve int key defined not start from 0 on AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\DiscriminatorMap({ "1" = "CostDetailEntity" })
+ */
+class PreserveIntKeyDefined
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\DiscriminatorMap([1 => 'CostDetailEntity'])]
+class PreserveIntKeyDefined
+{
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -36,6 +36,7 @@ return static function (RectorConfig $rectorConfig): void {
             new AnnotationToAttribute('Doctrine\ORM\Mapping\UniqueConstraint'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumns'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumn'),
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\DiscriminatorMap'),
 
             // validation
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\All'),


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7345