### PR TITLE
Fix doctrine join table annotation to attribute rector

### DIFF
--- a/packages/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/packages/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -29,6 +29,7 @@ final class PhpAttributeGroupFactory
     private const UNWRAPPED_ANNOTATIONS = [
         'Doctrine\ORM\Mapping\Table' => ['indexes', 'uniqueConstraints'],
         'Doctrine\ORM\Mapping\Entity' => ['uniqueConstraints'],
+        'Doctrine\ORM\Mapping\JoinTable' => ['joinColumns', 'inverseJoinColumns'],
     ];
 
     public function __construct(

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/manytomany_with_jointable.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/manytomany_with_jointable.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ManyToManyWithJoinTable
+{
+    /**
+     * @ORM\ManyToMany(targetEntity="App\Entity\Example", inversedBy="backLink")
+     * @ORM\JoinTable(name="table_name",
+     *     joinColumns={@ORM\JoinColumn(name="origin_id", referencedColumnName="id")},
+     *     inverseJoinColumns={@ORM\JoinColumn(name="target_id", referencedColumnName="id")}
+     * )
+     */
+    private $collection;
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Doctrine;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ManyToManyWithJoinTable
+{
+    #[ORM\ManyToMany(targetEntity: 'App\Entity\Example', inversedBy: 'backLink')]
+    #[ORM\JoinTable(name: 'table_name')]
+    #[ORM\JoinColumn(name: 'origin_id', referencedColumnName: 'id')]
+    #[ORM\InverseJoinColumn(name: 'target_id', referencedColumnName: 'id')]
+    private $collection;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp81/manytomany_with_jointable.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp81/manytomany_with_jointable.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\FixturePhp81;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ManyToManyWithJoinTable
+{
+    /**
+     * @ORM\ManyToMany(targetEntity="App\Entity\Example", inversedBy="backLink")
+     * @ORM\JoinTable(name="table_name",
+     *     joinColumns={@ORM\JoinColumn(name="origin_id", referencedColumnName="id")},
+     *     inverseJoinColumns={@ORM\JoinColumn(name="target_id", referencedColumnName="id")}
+     * )
+     */
+    private $collection;
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\FixturePhp81;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ManyToManyWithJoinTable
+{
+    #[ORM\ManyToMany(targetEntity: 'App\Entity\Example', inversedBy: 'backLink')]
+    #[ORM\JoinTable(name: 'table_name')]
+    #[ORM\JoinColumn(name: 'origin_id', referencedColumnName: 'id')]
+    #[ORM\InverseJoinColumn(name: 'target_id', referencedColumnName: 'id')]
+    private $collection;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/auto_import.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/auto_import.php
@@ -15,11 +15,17 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersionFeature::NEW_INITIALIZERS - 1);
 
     $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
-        new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity'),
-        new AnnotationToAttribute('Doctrine\ORM\Mapping\Id'),
-        new AnnotationToAttribute('Doctrine\ORM\Mapping\Column'),
         new AnnotationToAttribute('Symfony\Component\Validator\Constraints\NotBlank'),
         new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Length'),
         new AnnotationToAttribute(Apple::class, AppleAttribute::class),
+
+        // doctrine
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Id'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Column'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\ManyToMany'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumns'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinTable'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumn'),
     ]);
 };

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -35,6 +35,7 @@ return static function (RectorConfig $rectorConfig): void {
             new AnnotationToAttribute('Doctrine\ORM\Mapping\Index'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\UniqueConstraint'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumns'),
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinTable'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumn'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\DiscriminatorMap'),
 

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/nested_attributes_php81.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/nested_attributes_php81.php
@@ -22,8 +22,15 @@ return static function (RectorConfig $rectorConfig): void {
             new AnnotationToAttribute(NotNull::class),
             new AnnotationToAttribute(NotNumber::class),
             new AnnotationToAttribute(GenericAnnotation::class),
+
+            // doctrine
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity'),
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\ManyToMany'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\Table'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\Index'),
             new AnnotationToAttribute('Doctrine\ORM\Mapping\UniqueConstraint'),
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumns'),
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinTable'),
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumn'),
         ]);
 };


### PR DESCRIPTION
Start on fix for rectorphp/rector#7346 and rectorphp/rector-doctrine#116 (point 3)

@samsonasik the only thing i'm struggling with is the conversion of 
```inverseJoinColumns={@ORM\JoinColumn(name="target_id", referencedColumnName="id")}``` 
to 
```#[ORM\InverseJoinColumn(name: 'target_id', referencedColumnName: 'id')]``` 
because it is not converting the annotation one to one to the attribute.

So I will need some help to fix this