### PR TITLE
Add failing test fixture for NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/non_empty_string_are_preserved.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/non_empty_string_are_preserved.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class DemoFile
+{
+    public function foo(string $bar): array
+    {
+        mb_strlen("foo:{$bar}:");
+
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for NullToStrictStringFuncCallArgRector

Based on https://getrector.org/demo/b778fb29-98e6-4992-b4fa-b14a0be26429

In this case, the first argument of the mb_strlen function cannot be something else than a string, so the cast to string is useless