### PR TITLE
Add failing test fixture for ForeachItemsAssignToEmptyArrayToAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_traversable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_traversable.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRector\Fixture;
+
+class SkipTraversable
+{
+    public function run()
+    {
+        $items = [];
+        foreach ($this->getTraversable() as $item) {
+            $items[] = $item;
+        }
+    }
+
+    private function getTraversable(): iterable
+    {
+        yield 123;
+    }
+}


### PR DESCRIPTION
# Failing Test for ForeachItemsAssignToEmptyArrayToAssignRector

Based on https://getrector.org/demo/8b7aa594-cfa5-4308-ade5-98d9f47f5c9c

Ref https://github.com/rectorphp/rector/issues/7350