### PR TITLE
Move Nette extension from the core to the community

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -20,12 +20,11 @@ jobs:
             fail-fast: false
             matrix:
                 repository_name:
-                    # must be repository name, e.g. https://github.com/rectorphp/rector-nette
+                    # must be repository name, e.g. https://github.com/rectorphp/rector-symfony
                     - rectorphp/rector-symfony
                     - rectorphp/rector-phpunit
                     - rectorphp/rector-doctrine
                     - rectorphp/rector-laravel
-                    - rectorphp/rector-nette
                     - rectorphp/rector-cakephp
                     - rectorphp/rector-phpoffice
                     - rectorphp/rector-downgrade-php

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "rector/rector-downgrade-php": "dev-main",
         "rector/rector-generator": "dev-main",
         "rector/rector-laravel": "dev-main",
-        "rector/rector-nette": "dev-main",
         "rector/rector-phpoffice": "dev-main",
         "rector/rector-phpunit": "dev-main",
         "rector/rector-symfony": "dev-main",

--- a/dev-docs/packages_ci_status.md
+++ b/dev-docs/packages_ci_status.md
@@ -12,12 +12,6 @@
 * ![](https://github.com/rectorphp/phpstan-rules/actions/workflows/tests.yaml/badge.svg)
 * ![](https://github.com/rectorphp/phpstan-rules/actions/workflows/code_analysis.yaml/badge.svg)
 
-## Nette
-
-* https://github.com/rectorphp/rector-nette
-* ![](https://github.com/rectorphp/rector-nette/actions/workflows/tests.yaml/badge.svg)
-* ![](https://github.com/rectorphp/rector-nette/actions/workflows/code_analysis.yaml/badge.svg)
-
 ## Symfony
 
 * https://github.com/rectorphp/rector-symfony

--- a/rector.php
+++ b/rector.php
@@ -7,7 +7,6 @@ use Rector\CodingStyle\Rector\ClassMethod\ReturnArrayClassMethodToYieldRector;
 use Rector\CodingStyle\Rector\MethodCall\PreferThisOrSelfMethodCallRector;
 use Rector\CodingStyle\ValueObject\ReturnArrayClassMethodToYield;
 use Rector\Config\RectorConfig;
-use Rector\Nette\Set\NetteSetList;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
@@ -23,7 +22,6 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::TYPE_DECLARATION,
         SetList::EARLY_RETURN,
         SetList::TYPE_DECLARATION_STRICT,
-        NetteSetList::NETTE_CODE_QUALITY,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
         SetList::CODING_STYLE,
     ]);


### PR DESCRIPTION
In past year, there's been a big boom of community-maintained Rector rules:

* https://github.com/sabbelasichon/typo3-rector
* https://github.com/craftcms/rector
* https://github.com/FriendsOfShopware/shopware-rector
* https://github.com/sulu/sulu-rector

<br>

This trend is **healthy and positive** for Rector ecosystem for various reason:

* the community around framework/project is much more motivated to grow  :heavy_check_mark: 
* the community has better know-how of news and features, that are comming in next version  :heavy_check_mark: 
* they have their own way of coding related to the framework-way, that should be separated from Rector core way of coding  :heavy_check_mark: 
* they need specific dependencies  :heavy_check_mark: 
* it can allow us to focus on Rector core and extends support for native PHP features   :heavy_check_mark: 

<br>

Saying that, the Nette extension would deserve such growth.

We discussed with @lulco to take over the Nette Rector rules and make develop further :muscle: 

The original rector-nette repository can be now found at: https://github.com/efabrica-team/rector-nette


<br>

The only change for end-user is that to required Nette package, it must be added via composer:

```bash
composer require <...>/rector-nette --dev
```

That's it :slightly_smiling_face: 