### PR TITLE
[Php73] Skip escaped Dash on RegexDashEscapeRector

### DIFF
--- a/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/skip_double_escape_word_fixture.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/skip_double_escape_word_fixture.php.inc
@@ -9,5 +9,4 @@ class SkipDoubleEscapeWord
     }
 }
 
-
 ?>

--- a/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/skip_double_escape_word_fixture.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/skip_double_escape_word_fixture.php.inc
@@ -1,0 +1,13 @@
+<?php
+namespace Rector\Tests\Php73\Rector\FuncCall\RegexDashEscapeRector\Fixture;
+
+class SkipDoubleEscapeWord
+{
+    public function run(string $string)
+    {
+        preg_match('/[\-\w]/', $string);
+    }
+}
+
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/slashes.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/slashes.php.inc
@@ -11,17 +11,3 @@ class Slashes
 }
 
 ?>
------
-<?php
-
-namespace Rector\Tests\Php73\Rector\FuncCall\RegexDashEscapeRector\Fixture;
-
-class Slashes
-{
-    public function run()
-    {
-        preg_match('#[\\-\d]$#', 'test');
-    }
-}
-
-?>

--- a/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
@@ -40,7 +40,7 @@ final class RegexDashEscapeRector extends AbstractRector implements MinPhpVersio
 
     /**
      * @var string
-     * @see https://regex101.com/r/TBVme9/8
+     * @see https://regex101.com/r/TBVme9/9
      */
     private const RIGHT_HAND_UNESCAPED_DASH_REGEX = '#(?<!\[)(?<!\\\\)-(\\\\(w|s|d)[.*]?)\]#i';
 

--- a/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
@@ -42,7 +42,7 @@ final class RegexDashEscapeRector extends AbstractRector implements MinPhpVersio
      * @var string
      * @see https://regex101.com/r/TBVme9/8
      */
-    private const RIGHT_HAND_UNESCAPED_DASH_REGEX = '#(?<!\[)-(\\\\(w|s|d)[.*]?)\]#i';
+    private const RIGHT_HAND_UNESCAPED_DASH_REGEX = '#(?<!\[)(?<!\\\\)-(\\\\(w|s|d)[.*]?)\]#i';
 
     private bool $hasChanged = false;
 


### PR DESCRIPTION
# Failing Test for RegexDashEscapeRector

Based on https://getrector.org/demo/f7c15ce4-8dbe-4f79-bd1e-88c7a9d10c3c

Fixes https://github.com/rectorphp/rector/issues/7356