### PR TITLE
[Core] Move Scope Resolver to ScopeAnalyzer

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -134,7 +134,7 @@ final class ChangedNodeScopeRefresher
     }
 
     /**
-     * @return Stmt[]|Expression[]
+     * @return Stmt[]
      */
     private function resolveStmts(Node $node): array
     {

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -11,6 +11,8 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PHPStan\Analyser\MutatingScope;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ScopeAnalyzer
 {
@@ -18,6 +20,10 @@ final class ScopeAnalyzer
      * @var array<class-string<Node>>
      */
     private const NO_SCOPE_NODES = [Name::class, Identifier::class, Param::class, Arg::class];
+
+    public function __construct(private readonly ScopeFactory $scopeFactory)
+    {
+    }
 
     public function hasScope(Node $node): bool
     {
@@ -30,17 +36,27 @@ final class ScopeAnalyzer
         return true;
     }
 
-    public function isScopeResolvableFromFile(Node $node, ?MutatingScope $mutatingScope): bool
+    public function resolveScope(
+        Node $node,
+        SmartFileInfo $smartFileInfo,
+        ?MutatingScope $mutatingScope = null
+    ): ?MutatingScope
     {
         if ($mutatingScope instanceof MutatingScope) {
-            return false;
+            return $mutatingScope;
         }
 
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
         if (! $parentNode instanceof Node) {
-            return true;
+            return $this->scopeFactory->createFromFile($smartFileInfo);
         }
 
-        return ! $this->hasScope($parentNode);
+        if (! $this->hasScope($parentNode)) {
+            return $this->scopeFactory->createFromFile($smartFileInfo);
+        }
+
+        /** @var MutatingScope|null $parentScope */
+        $parentScope = $parentNode->getAttribute(AttributeKey::SCOPE);
+        return $parentScope;
     }
 }

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -40,8 +40,7 @@ final class ScopeAnalyzer
         Node $node,
         SmartFileInfo $smartFileInfo,
         ?MutatingScope $mutatingScope = null
-    ): ?MutatingScope
-    {
+    ): ?MutatingScope {
         if ($mutatingScope instanceof MutatingScope) {
             return $mutatingScope;
         }

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -35,6 +35,10 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
         if (! $scope instanceof MutatingScope) {
             $smartFileInfo = $this->file->getSmartFileInfo();
             $scope = $this->scopeAnalyzer->resolveScope($node, $smartFileInfo);
+
+            if ($scope instanceof MutatingScope) {
+                $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
+            }
         }
 
         if (! $scope instanceof Scope) {

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -11,20 +11,16 @@ use Rector\Core\Contract\Rector\ScopeAwarePhpRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 use Symfony\Contracts\Service\Attribute\Required;
 
 abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeAwarePhpRectorInterface
 {
     private ScopeAnalyzer $scopeAnalyzer;
 
-    private ScopeFactory $scopeFactory;
-
     #[Required]
-    public function autowireAbstractScopeAwareRector(ScopeAnalyzer $scopeAnalyzer, ScopeFactory $scopeFactory): void
+    public function autowireAbstractScopeAwareRector(ScopeAnalyzer $scopeAnalyzer): void
     {
         $this->scopeAnalyzer = $scopeAnalyzer;
-        $this->scopeFactory = $scopeFactory;
     }
 
     /**
@@ -36,20 +32,27 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
         /** @var MutatingScope|null $scope */
         $scope = $node->getAttribute(AttributeKey::SCOPE);
 
-        if ($this->scopeAnalyzer->isScopeResolvableFromFile($node, $scope)) {
+        if (! $scope instanceof MutatingScope) {
             $smartFileInfo = $this->file->getSmartFileInfo();
-            $scope = $this->scopeFactory->createFromFile($smartFileInfo);
-
-            $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
+            $scope = $this->scopeAnalyzer->resolveScope($node, $smartFileInfo);
         }
 
         if (! $scope instanceof Scope) {
+            /**
+             * @var Node $parentNode
+             *
+             * $parentNode is always a Node when $mutatingScope is null, as checked in previous
+             *
+             *      $this->scopeAnalyzer->resolveScope()
+             *
+             *  which verify if no parent and no scope, it resolve Scope from File
+             */
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
             $errorMessage = sprintf(
                 'Scope not available on "%s" node with parent node of "%s", but is required by a refactorWithScope() method of "%s" rule. Fix scope refresh on changed nodes first',
                 $node::class,
-                $parentNode instanceof Node ? $parentNode::class : 'unknown node',
+                $parentNode::class,
                 static::class,
             );
 


### PR DESCRIPTION
Background
----------

Previously, we apply various checks when no Scope:

- No parent -> resolve Scope from File 
- parent is not Scoppable (Arg, Name, Identifier, Param): -> resolve from File
- fallback to parent Scope

in multiple checks steps.

Refactor
--------

This PR move the above check to single location: `ScopeAnalyzer`, if on last fallback to parent Scope still has no Scope, we will got the Exception which parent Node already Node, which no need to verify $parentNode is Node in exception message as already checked in previous check.

```php
/**
 * @var Node $parentNode
 *
 * $parentNode is always a Node when $mutatingScope is null, as checked in previous
 *
 *      $this->scopeAnalyzer->resolveScope()
 *
 *  which verify if no parent and no scope, it resolve Scope from File
 */
$parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);

$errorMessage = sprintf(
    'Scope not available on "%s" node with parent node of "%s", but is required by a refactorWithScope() method of "%s" rule. Fix scope refresh on changed nodes first',
    $node::class,
    $parentNode::class,
    static::class,
);
```