### PR TITLE
Fix performance issue

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -84,6 +84,7 @@ final class PHPStanNodeScopeResolver
         private readonly ParentAttributeSourceLocator $parentAttributeSourceLocator,
         private readonly NodeNameResolver $nodeNameResolver
     ) {
+        $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
     }
 
     /**
@@ -215,8 +216,6 @@ final class PHPStanNodeScopeResolver
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
         };
-
-        $this->decoratePHPStanNodeScopeResolverWithRenamedClassSourceLocator($this->nodeScopeResolver);
 
         return $this->processNodesWithDependentFiles($smartFileInfo, $stmts, $scope, $nodeCallback);
     }


### PR DESCRIPTION
I faced with performance issue on my project. When I run `rector process` on big number of files it takes a lot of time. I profiled this command and found that NodeScopeResolver is decorated on each node processing. As result there is a huge staketrace:
![Screenshot_1](https://user-images.githubusercontent.com/2588533/185200466-159e2af3-35f7-4473-8411-4c9ce87cd24a.png)

I moved decoration to constructor to do it once and it boost performance a lot.