### PR TITLE
[PHP 8.0] Keep quoted string with doublecolon in AnnotationToAttributeRector

### DIFF
--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
@@ -24,11 +24,6 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     protected bool $hasChanged = false;
 
     /**
-     * @var mixed[]
-     */
-    private array $originalValues = [];
-
-    /**
      * @param array<string|int, mixed> $values Must be public so node traverser can go through them
      */
     public function __construct(
@@ -36,7 +31,6 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
         protected ?string $originalContent = null,
         protected ?string $silentKey = null
     ) {
-        $this->originalValues = $values;
     }
 
     public function removeValue(string $key): void
@@ -145,7 +139,12 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
             if (is_int($key) && $this->silentKey !== null) {
                 $explicitKeysValues[$this->silentKey] = $valueWithoutQuotes;
             } else {
-                $explicitKeysValues[$this->removeQuotes($key)] = $valueWithoutQuotes;
+                // to keep constant keys strings if quoted
+                if (is_string($key) && ! str_contains($key, '::')) {
+                    $key = $this->removeQuotes($key);
+                }
+
+                $explicitKeysValues[$key] = $valueWithoutQuotes;
             }
         }
 
@@ -155,14 +154,6 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     public function markAsChanged(): void
     {
         $this->hasChanged = true;
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getOriginalValues(): array
-    {
-        return $this->originalValues;
     }
 
     /**

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/ClassConstFetchAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/ClassConstFetchAnnotationToAttributeMapper.php
@@ -19,7 +19,12 @@ final class ClassConstFetchAnnotationToAttributeMapper implements AnnotationToAt
             return false;
         }
 
-        return str_contains($value, '::');
+        if (! str_contains($value, '::')) {
+            return false;
+        }
+
+        // is quoted? skip it
+        return ! str_starts_with($value, '"');
     }
 
     /**

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/StringAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/StringAnnotationToAttributeMapper.php
@@ -50,6 +50,10 @@ final class StringAnnotationToAttributeMapper implements AnnotationToAttributeMa
             $kind = String_::KIND_SINGLE_QUOTED;
         }
 
+        if (str_starts_with($value, '"') && str_ends_with($value, '"')) {
+            $value = trim($value, '"');
+        }
+
         return new String_($value, [
             AttributeKey::KIND => $kind,
         ]);

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/constant_as_array_key.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/constant_as_array_key.php.inc
@@ -9,7 +9,8 @@ use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Constant
  * @GenericAnnotation(
  *     itemOperations={
  *         "get" = {
-               ConstantReference::FIRST_NAME = true
+ *              ConstantReference::FIRST_NAME = true,
+ *              'some::string' = 'some-value'
  *         }
  *     }
  * )
@@ -17,7 +18,7 @@ use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Constant
 final class DemoClass {
 }
 ?>
------
+    -----
 <?php
 
 namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
@@ -25,7 +26,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\ConstantReference;
 
-#[GenericAnnotation(itemOperations: ['get' => [ConstantReference::FIRST_NAME => true]])]
+#[GenericAnnotation(itemOperations: ['get' => [ConstantReference::FIRST_NAME => true, 'some-string' => 'some-value']])]
 final class DemoClass
 {
 }

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/constant_as_array_key.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/constant_as_array_key.php.inc
@@ -6,19 +6,17 @@ use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericA
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\ConstantReference;
 
 /**
- * @GenericAnnotation(
- *     itemOperations={
- *         "get" = {
- *              ConstantReference::FIRST_NAME = true,
- *              'some::string' = 'some-value'
- *         }
- *     }
- * )
+ * @GenericAnnotation({
+ *     ConstantReference::FIRST_NAME = true,
+ *     "some::string" = "some-value"
+ * })
  */
-final class DemoClass {
+final class ConstantAsArrayKey
+{
 }
+
 ?>
-    -----
+-----
 <?php
 
 namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
@@ -26,8 +24,9 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\ConstantReference;
 
-#[GenericAnnotation(itemOperations: ['get' => [ConstantReference::FIRST_NAME => true, 'some-string' => 'some-value']])]
-final class DemoClass
+#[GenericAnnotation([ConstantReference::FIRST_NAME => true, 'some::string' => 'some-value'])]
+final class ConstantAsArrayKey
 {
 }
+
 ?>


### PR DESCRIPTION
* Closes https://github.com/rectorphp/rector-src/pull/2780
* Fixes https://github.com/rectorphp/rector/issues/7387