### PR TITLE
`RenameVariableToMatchNewTypeRector` renames inside foreach loop

### DIFF
--- a/rules-tests/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector/Fixture/within_foreach_loop.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector/Fixture/within_foreach_loop.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector\Source\DreamSearch;
+
+final class MyForeachCommand
+{
+    protected function execute(): void
+    {
+        foreach (range(1, 2) as $i) {
+            $search = new DreamSearch();
+            $search->reachIt();
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector\Source\DreamSearch;
+
+final class MyForeachCommand
+{
+    protected function execute(): void
+    {
+        foreach (range(1, 2) as $i) {
+            $dreamSearch = new DreamSearch();
+            $dreamSearch->reachIt();
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
I've tried to make a minimal reproduceable fixture, but every time I run phpunit it won't fail. Don't know why. 
Using the online demo it does (not - as expected) work: https://getrector.org/demo/d1772e18-4e4f-4f34-899e-b2fec96ce721

refs https://github.com/rectorphp/rector/issues/7381

Anything I misunderstood?
@samsonasik this time a crossed "Allow edits by maintainers" ;-)