### PR TITLE
`RenameParamToMatchTypeRector` renames param in arrow function

### DIFF
--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/static-arrow-function.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/static-arrow-function.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\SingleSomeClass;
+
+class MyStaticAnonymousFunction
+{
+    public function run(): void
+    {
+        $function = static fn (SingleSomeClass $class): bool => true;
+        $function(new SingleSomeClass());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\SingleSomeClass;
+
+class MyStaticAnonymousFunction
+{
+    public function run(): void
+    {
+        $function = static fn (SingleSomeClass $singleSomeClass): bool => true;
+        $function(new SingleSomeClass());
+    }
+}
+
+?>


### PR DESCRIPTION
refs https://github.com/rectorphp/rector/issues/7382