### PR TITLE
[AutoImport] Handle auto import crash on docblock @SuppressWarnings(PHPMD.ElseExpression) inside anonymous class

### DIFF
--- a/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/AutoImportTest.php
+++ b/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/AutoImportTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\Closure\StaticClosureRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AutoImportTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureAutoImport');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/auto_import_configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/FixtureAutoImport/anonymous_class_suppress_warning_doc.php.inc
+++ b/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/FixtureAutoImport/anonymous_class_suppress_warning_doc.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Closure\StaticClosureRector\FixtureAutoImport;
+
+return new class {
+    /**
+     * Run the migrations.
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
+    public function up(): void
+    {
+        Schema::create('tagging_tagged', function (Blueprint $table) : void {
+            $table->engine = 'InnoDB';
+        });
+    }
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Closure\StaticClosureRector\FixtureAutoImport;
+
+return new class {
+    /**
+     * Run the migrations.
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
+    public function up(): void
+    {
+        Schema::create('tagging_tagged', static function (Blueprint $table) : void {
+            $table->engine = 'InnoDB';
+        });
+    }
+};
+
+?>

--- a/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/FixtureAutoImport/anonymous_class_without_supress_warning.php.inc
+++ b/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/FixtureAutoImport/anonymous_class_without_supress_warning.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Closure\StaticClosureRector\FixtureAutoImport;
+
+return new class {
+    public function up(): void
+    {
+        \Some\Framework\Db\FullyQualified\Schema::create('tagging_tagged', function (Blueprint $table) : void {
+            $table->engine = 'InnoDB';
+        });
+    }
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Closure\StaticClosureRector\FixtureAutoImport;
+
+use Some\Framework\Db\FullyQualified\Schema;
+return new class {
+    public function up(): void
+    {
+        Schema::create('tagging_tagged', static function (Blueprint $table) : void {
+            $table->engine = 'InnoDB';
+        });
+    }
+};
+
+?>

--- a/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/config/auto_import_configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/config/auto_import_configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+    $rectorConfig->rule(StaticClosureRector::class);
+};

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -228,7 +228,9 @@ final class ShortNameResolver
         foreach ($shortNames as $shortName) {
             $stmtsMatchedName = $this->useImportNameMatcher->matchNameWithStmts($shortName, $stmts);
 
-            if ($reflectionClass instanceof ReflectionClass && ! $this->classAnalyzer->isAnonymousClassName($reflectionClass->getShortName())) {
+            if ($reflectionClass instanceof ReflectionClass && ! $this->classAnalyzer->isAnonymousClassName(
+                $reflectionClass->getShortName()
+            )) {
                 $fullyQualifiedName = Reflection::expandClassName($shortName, $reflectionClass);
             } elseif (is_string($stmtsMatchedName)) {
                 $fullyQualifiedName = $stmtsMatchedName;

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -17,6 +17,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\CodingStyle\NodeAnalyzer\UseImportNameMatcher;
+use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Util\StringUtils;
 use Rector\Core\ValueObject\Application\File;
@@ -51,6 +52,7 @@ final class ShortNameResolver
         private readonly ReflectionProvider $reflectionProvider,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly UseImportNameMatcher $useImportNameMatcher,
+        private readonly ClassAnalyzer $classAnalyzer
     ) {
     }
 
@@ -226,7 +228,7 @@ final class ShortNameResolver
         foreach ($shortNames as $shortName) {
             $stmtsMatchedName = $this->useImportNameMatcher->matchNameWithStmts($shortName, $stmts);
 
-            if ($reflectionClass instanceof ReflectionClass) {
+            if ($reflectionClass instanceof ReflectionClass && ! $this->classAnalyzer->isAnonymousClassName($reflectionClass->getShortName())) {
                 $fullyQualifiedName = Reflection::expandClassName($shortName, $reflectionClass);
             } elseif (is_string($stmtsMatchedName)) {
                 $fullyQualifiedName = $stmtsMatchedName;

--- a/src/NodeAnalyzer/ClassAnalyzer.php
+++ b/src/NodeAnalyzer/ClassAnalyzer.php
@@ -24,6 +24,11 @@ final class ClassAnalyzer
     ) {
     }
 
+    public function isAnonymousClassName(string $className): bool
+    {
+        return StringUtils::isMatch($className, self::ANONYMOUS_CLASS_REGEX);
+    }
+
     public function isAnonymousClass(Node $node): bool
     {
         if (! $node instanceof Class_) {


### PR DESCRIPTION
Given the following code : 

```php
return new class {
    /**
     * Run the migrations.
     *
     * @SuppressWarnings(PHPMD.ElseExpression)
     */
    public function up(): void
    {
        Schema::create('tagging_tagged', function (Blueprint $table) : void {
            $table->engine = 'InnoDB';
        });
    }
};
```

It currently produce error:

```bash
There was 1 error:

1) Rector\Tests\CodingStyle\Rector\Closure\StaticClosureRector\AutoImportTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Undefined array key "AnonymousClass11f5dd862c2eabeab7ceede0c3d39eca"

/Users/samsonasik/www/rector-src/vendor/nette/utils/src/Utils/Reflection.php:311
/Users/samsonasik/www/rector-src/vendor/nette/utils/src/Utils/Reflection.php:279
/Users/samsonasik/www/rector-src/rules/CodingStyle/ClassNameImport/ShortNameResolver.php:232
```

Fixes https://github.com/rectorphp/rector/issues/7398