### PR TITLE
[Php80] Rollback preserve int key defined not start from 0 Fixture on AnnotationToAttributeRector

### DIFF
--- a/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
@@ -45,26 +45,26 @@ final class CurlyListNodeAnnotationToAttributeMapper implements AnnotationToAttr
         $valuesWithExplicitSilent = $value->getValues();
         $loop = -1;
 
-        foreach ($valuesWithExplicitSilent as $key => $singleValue) {
-            $valueExpr = $this->annotationToAttributeMapper->map($singleValue);
+        foreach ($valuesWithExplicitSilent as $valueWithExplicitSilent) {
+            $valueExpr = $this->annotationToAttributeMapper->map($valueWithExplicitSilent);
 
             // remove node
             if ($valueExpr === DocTagNodeState::REMOVE_ARRAY) {
                 continue;
             }
 
-            if (! is_int($key)) {
-                $keyExpr = $this->annotationToAttributeMapper->map($key);
-                Assert::isInstanceOf($keyExpr, Expr::class);
-            } else {
-                ++$loop;
+            ++$loop;
 
-                $keyExpr = $loop !== $key
-                    ? new LNumber($key)
+            $keyExpr = $loop !== $valueWithExplicitSilent->key && is_numeric($valueWithExplicitSilent->key)
+                    ? new LNumber((int) $valueWithExplicitSilent->key)
                     : null;
-            }
 
-            $arrayItems[] = new ArrayItem($valueExpr, $keyExpr);
+            if ($valueExpr instanceof ArrayItem && $keyExpr instanceof LNumber) {
+                $valueExpr->key = $keyExpr;
+                $arrayItems[] = $valueExpr;
+            } else {
+                $arrayItems[] = new ArrayItem($valueExpr, $keyExpr);
+            }
         }
 
         return new Array_($arrayItems);

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
@@ -40,11 +40,11 @@ final class CurlyListNodeAnnotationToAttributeMapper implements AnnotationToAttr
     public function map($value): Array_
     {
         $arrayItems = [];
-        $valuesWithExplicitSilent = $value->getValues();
+        $arrayItemNodes = $value->getValues();
         $loop = -1;
 
-        foreach ($valuesWithExplicitSilent as $valueWithExplicitSilent) {
-            $valueExpr = $this->annotationToAttributeMapper->map($valueWithExplicitSilent);
+        foreach ($arrayItemNodes as $arrayItemNode) {
+            $valueExpr = $this->annotationToAttributeMapper->map($arrayItemNode);
 
             // remove node
             if ($valueExpr === DocTagNodeState::REMOVE_ARRAY) {
@@ -53,8 +53,8 @@ final class CurlyListNodeAnnotationToAttributeMapper implements AnnotationToAttr
 
             ++$loop;
 
-            $keyExpr = $loop !== $valueWithExplicitSilent->key && is_numeric($valueWithExplicitSilent->key)
-                    ? new LNumber((int) $valueWithExplicitSilent->key)
+            $keyExpr = $loop !== $arrayItemNode->key && is_numeric($arrayItemNode->key)
+                    ? new LNumber((int) $arrayItemNode->key)
                     : null;
 
             if ($valueExpr instanceof ArrayItem && $keyExpr instanceof LNumber) {

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PhpAttribute\AnnotationToAttributeMapper;
 
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\LNumber;
@@ -13,7 +12,6 @@ use Rector\PhpAttribute\AnnotationToAttributeMapper;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
 use Rector\PhpAttribute\Enum\DocTagNodeState;
 use Symfony\Contracts\Service\Attribute\Required;
-use Webmozart\Assert\Assert;
 
 /**
  * @implements AnnotationToAttributeMapperInterface<CurlyListNode>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\D
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\DiscriminatorMap([1 => 'CostDetailEntity'])]
+#[ORM\DiscriminatorMap(['1' => 'CostDetailEntity'])]
 class PreserveIntKeyDefined
 {
 }

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
@@ -5,10 +5,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\D
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\DiscriminatorMap({
- *     "cost" = "CostEntity",
- *     "product" = "ProductEntity",
- * })
+ * @ORM\DiscriminatorMap({ "1" = "CostDetailEntity" })
  */
 class PreserveIntKeyDefined
 {
@@ -22,7 +19,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\D
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\DiscriminatorMap(['cost' => 'CostEntity', 'product' => 'ProductEntity'])]
+#[ORM\DiscriminatorMap([1 => 'CostDetailEntity'])]
 class PreserveIntKeyDefined
 {
 }

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\D
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\DiscriminatorMap(['1' => 'CostDetailEntity'])]
+#[ORM\DiscriminatorMap([1 => 'CostDetailEntity'])]
 class PreserveIntKeyDefined
 {
 }


### PR DESCRIPTION
Int key "1" unordered key defined is valid in Doctrine\ORM\Mapping\DiscriminatorMap per issue  

- https://github.com/rectorphp/rector/issues/7345

that was resolved at:

- https://github.com/rectorphp/rector-src/pull/2735

It changed to string in latest PR:

- https://github.com/rectorphp/rector-src/pull/2786

This PR rollback the transformation fixture for integer unorder key fixture to avoid regression.