### PR TITLE
[Php80] Validate ArrayItem on CurlyListNodeAnnotationToAttributeMapper

### DIFF
--- a/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
@@ -61,12 +61,13 @@ final class CurlyListNodeAnnotationToAttributeMapper implements AnnotationToAttr
 
             ++$loop;
 
-            if ($loop === (int) $arrayItemNode->key) {
+            $arrayItemNodeKey = (int) $arrayItemNode->key;
+            if ($loop === $arrayItemNodeKey) {
                 $arrayItems[] = $valueExpr;
                 continue;
             }
 
-            $valueExpr->key = new LNumber((int) $arrayItemNode->key);
+            $valueExpr->key = new LNumber($arrayItemNodeKey);
             $arrayItems[] = $valueExpr;
         }
 

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
@@ -53,7 +53,6 @@ final class CurlyListNodeAnnotationToAttributeMapper implements AnnotationToAttr
                 continue;
             }
 
-            Assert::isInstanceOf($arrayItemNode, ArrayItemNode::class);
             Assert::isInstanceOf($valueExpr, ArrayItem::class);
 
             if (! is_numeric($arrayItemNode->key)) {

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/CurlyListNodeAnnotationToAttributeMapper.php
@@ -7,7 +7,6 @@ namespace Rector\PhpAttribute\AnnotationToAttributeMapper;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\LNumber;
-use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
 use Rector\PhpAttribute\AnnotationToAttributeMapper;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2811:

- ensure that mapped values are `ArrayItem` to catch possible bug early.
- always cast to (int) first before compare key value for numeric data as key is quoted.
- no need to include ArrayItem inside ArrayItem, just add it into the array