### PR TITLE
[EarlyReturn] Handle crash on assign in if else before on RemoveAlwaysElseRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/assign_in_if_else_before.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/assign_in_if_else_before.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+
 function dummy($can_order_products, $offset, $limit)
 {
     if (!empty($can_order_products)) {
@@ -19,7 +21,7 @@ function dummy($can_order_products, $offset, $limit)
             return $can_order_products;
         }
     }
-    
+
     return false;
 }
 
@@ -28,9 +30,6 @@ function dummy($can_order_products, $offset, $limit)
 <?php
 
 namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
-
-// what is expected code?
-// should remain the same? delete part bellow ----- (included)
 
 function dummy($can_order_products, $offset, $limit)
 {
@@ -44,14 +43,14 @@ function dummy($can_order_products, $offset, $limit)
 
             if (!empty($can_order_products)) {
                 return $can_order_products;
+            } else {
+                return false;
             }
-            
-            return false;
+        } else {
+            return $can_order_products;
         }
-        
-        return $can_order_products;
     }
-    
+
     return false;
 }
 

--- a/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/assign_in_if_else_before.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/assign_in_if_else_before.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
 
-function dummy($can_order_products, $offset, $limit)
+function assignInIfElseBefore($can_order_products, $offset, $limit)
 {
     if (!empty($can_order_products)) {
         if (!empty($limit)) {
@@ -31,7 +31,7 @@ function dummy($can_order_products, $offset, $limit)
 
 namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
 
-function dummy($can_order_products, $offset, $limit)
+function assignInIfElseBefore($can_order_products, $offset, $limit)
 {
     if (!empty($can_order_products)) {
         if (!empty($limit)) {

--- a/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/assign_in_if_else_before.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/assign_in_if_else_before.php.inc
@@ -43,12 +43,10 @@ function dummy($can_order_products, $offset, $limit)
 
             if (!empty($can_order_products)) {
                 return $can_order_products;
-            } else {
-                return false;
             }
-        } else {
-            return $can_order_products;
+            return false;
         }
+        return $can_order_products;
     }
 
     return false;

--- a/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/demo_fixture.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/demo_fixture.php.inc
@@ -1,0 +1,58 @@
+<?php
+
+function dummy($can_order_products, $offset, $limit)
+{
+    if (!empty($can_order_products)) {
+        if (!empty($limit)) {
+            if (!empty($offset)) {
+                $can_order_products = array_slice($can_order_products, $offset, $limit);
+            } else {
+                $can_order_products = array_slice($can_order_products, 0, $limit);
+            }
+
+            if (!empty($can_order_products)) {
+                return $can_order_products;
+            } else {
+                return false;
+            }
+        } else {
+            return $can_order_products;
+        }
+    }
+    
+    return false;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+
+// what is expected code?
+// should remain the same? delete part bellow ----- (included)
+
+function dummy($can_order_products, $offset, $limit)
+{
+    if (!empty($can_order_products)) {
+        if (!empty($limit)) {
+            if (!empty($offset)) {
+                $can_order_products = array_slice($can_order_products, $offset, $limit);
+            } else {
+                $can_order_products = array_slice($can_order_products, 0, $limit);
+            }
+
+            if (!empty($can_order_products)) {
+                return $can_order_products;
+            }
+            
+            return false;
+        }
+        
+        return $can_order_products;
+    }
+    
+    return false;
+}
+
+?>

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -135,8 +135,7 @@ CODE_SAMPLE
         $lastStmt = end($node->stmts);
 
         if ($lastStmt instanceof If_ && $lastStmt->else instanceof Else_) {
-            $next = $lastStmt->else->getAttribute(AttributeKey::NEXT_NODE);
-            return $next instanceof Stmt;
+            return $this->doesLastStatementBreakFlow($lastStmt);
         }
 
         return ! ($lastStmt instanceof Return_

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -6,6 +6,7 @@ namespace Rector\EarlyReturn\Rector\If_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Exit_;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
@@ -14,6 +15,7 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -133,7 +135,8 @@ CODE_SAMPLE
         $lastStmt = end($node->stmts);
 
         if ($lastStmt instanceof If_ && $lastStmt->else instanceof Else_) {
-            return false;
+            $next = $lastStmt->else->getAttribute(AttributeKey::NEXT_NODE);
+            return $next instanceof Stmt;
         }
 
         return ! ($lastStmt instanceof Return_

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -131,6 +132,10 @@ CODE_SAMPLE
     private function doesLastStatementBreakFlow(If_ | ElseIf_ $node): bool
     {
         $lastStmt = end($node->stmts);
+
+        if ($lastStmt instanceof If_ && $lastStmt->else instanceof Else_) {
+            return false;
+        }
 
         return ! ($lastStmt instanceof Return_
             || $lastStmt instanceof Throw_

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -6,7 +6,6 @@ namespace Rector\EarlyReturn\Rector\If_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Exit_;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
@@ -15,7 +14,6 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/2821 Fixes https://github.com/rectorphp/rector/issues/7412

Given the following code:

```php
function assignInIfElseBefore($can_order_products, $offset, $limit)
{
    if (!empty($can_order_products)) {
        if (!empty($limit)) {
            if (!empty($offset)) {
                $can_order_products = array_slice($can_order_products, $offset, $limit);
            } else {
                $can_order_products = array_slice($can_order_products, 0, $limit);
            }

            if (!empty($can_order_products)) {
                return $can_order_products;
            } else {
                return false;
            }
        } else {
            return $can_order_products;
        }
    }

    return false;
}
```

It currently produce error:

```bash
There was 1 failure:

1) Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\RemoveAlwaysElseRectorTest::test with data set #4 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
assert($itemStartPos >= 0 && $itemEndPos >= 0 && $itemStartPos >= $pos) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:759
```