### PR TITLE
[Core][Php80] Register FileWithoutNamespace into StmtsAwareInterface so ChangeSwitchToMatchRector can work without namespace

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/no_namespace.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/no_namespace.php.inc
@@ -4,11 +4,11 @@ $data = 'value';
 
 switch ($data) {
         case Lexer::T_DELETE:
-            $statement = $this->DeleteStatement();
+            $statement = deleteStatement();
             break;
 
         default:
-            $statement = $this->syntaxError('SELECT, UPDATE or DELETE');
+            $statement = syntaxError('SELECT, UPDATE or DELETE');
             break;
 }
 
@@ -21,8 +21,8 @@ echo $statement;
 $data = 'value';
 
 $statement = match ($data) {
-    Lexer::T_DELETE => $this->DeleteStatement(),
-    default => $this->syntaxError('SELECT, UPDATE or DELETE'),
+    Lexer::T_DELETE => deleteStatement(),
+    default => syntaxError('SELECT, UPDATE or DELETE'),
 };
 
 echo $statement;

--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/no_namespace.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/no_namespace.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+$data = 'value';
+
 switch ($data) {
         case Lexer::T_DELETE:
             $statement = $this->DeleteStatement();
@@ -15,6 +17,8 @@ echo $statement;
 ?>
 -----
 <?php
+
+$data = 'value';
 
 $statement = match ($data) {
     Lexer::T_DELETE => $this->DeleteStatement(),

--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/no_namespace.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/no_namespace.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+switch ($data) {
+        case Lexer::T_DELETE:
+            $statement = $this->DeleteStatement();
+            break;
+
+        default:
+            $statement = $this->syntaxError('SELECT, UPDATE or DELETE');
+            break;
+}
+
+echo $statement;
+
+?>
+-----
+<?php
+
+$statement = match ($data) {
+    Lexer::T_DELETE => $this->DeleteStatement(),
+    default => $this->syntaxError('SELECT, UPDATE or DELETE'),
+};
+
+echo $statement;
+
+?>

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -102,7 +102,7 @@ final class ChangedNodeScopeRefresher
 
     private function reIndexNodeAttributes(Node $node): void
     {
-        if (($node instanceof FileWithoutNamespace || $node instanceof Namespace_ || $node instanceof ClassLike || $node instanceof StmtsAwareInterface) && $node->stmts !== null) {
+        if (($node instanceof Namespace_ || $node instanceof ClassLike || $node instanceof StmtsAwareInterface) && $node->stmts !== null) {
             $node->stmts = array_values($node->stmts);
         }
 

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -30,7 +30,6 @@ use PHPStan\Analyser\MutatingScope;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Node\AttributeKey;

--- a/src/PhpParser/Node/CustomNode/FileWithoutNamespace.php
+++ b/src/PhpParser/Node/CustomNode/FileWithoutNamespace.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Rector\Core\PhpParser\Node\CustomNode;
 
 use PhpParser\Node\Stmt;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 
 /**
  * Inspired by https://github.com/phpstan/phpstan-src/commit/ed81c3ad0b9877e6122c79b4afda9d10f3994092
  */
-final class FileWithoutNamespace extends Stmt
+final class FileWithoutNamespace extends Stmt implements StmtsAwareInterface
 {
     /**
      * @param Stmt[] $stmts


### PR DESCRIPTION
Since refactor `ChangeSwitchToMatchRector` to  use `StmtsAwareInterface`: 

- https://github.com/rectorphp/rector-src/pull/2801

, it no longer works without namespace, so this PR adds `FileWithoutNamespace` to `StmtsAwareInterface`