### PR TITLE
[VendorPatch] Register nikic-php-parser-lib-phpparser-node-stmt-namespace-php into vendor-patches list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,8 @@
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-foreach-php.patch",
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-if-php.patch",
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-case-php.patch",
-                "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-elseif-php.patch"
+                "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-elseif-php.patch",
+                "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-namespace-php.patch"
             ],
             "symfony/dependency-injection": [
                 "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch",

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/keep_function_after_return_no_namespace.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/keep_function_after_return_no_namespace.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+calledFunction();
+return;
+
+function calledFunction()
+{
+    define("SOMETHING",true);
+}

--- a/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector.php
@@ -68,7 +68,7 @@ CODE_SAMPLE
         }
 
         $originalStmts = $node->stmts;
-        $cleanedStmts = $this->processCleanUpUnreachabelStmts($node->stmts);
+        $cleanedStmts = $this->processCleanUpUnreachabelStmts($node, $node->stmts);
 
         if ($cleanedStmts === $originalStmts) {
             return null;
@@ -82,7 +82,7 @@ CODE_SAMPLE
      * @param Stmt[] $stmts
      * @return Stmt[]
      */
-    private function processCleanUpUnreachabelStmts(array $stmts): array
+    private function processCleanUpUnreachabelStmts(StmtsAwareInterface $stmtsAware, array $stmts): array
     {
         foreach ($stmts as $key => $stmt) {
             if (! isset($stmts[$key - 1])) {
@@ -93,7 +93,7 @@ CODE_SAMPLE
 
             // unset...
 
-            if ($this->terminatedNodeAnalyzer->isAlwaysTerminated($previousStmt, $stmt)) {
+            if ($this->terminatedNodeAnalyzer->isAlwaysTerminated($stmtsAware, $previousStmt, $stmt)) {
                 array_splice($stmts, $key);
                 return $stmts;
             }

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -22,7 +22,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
@@ -101,7 +100,7 @@ final class ChangedNodeScopeRefresher
 
     private function reIndexNodeAttributes(Node $node): void
     {
-        if (($node instanceof Namespace_ || $node instanceof ClassLike || $node instanceof StmtsAwareInterface) && $node->stmts !== null) {
+        if (($node instanceof ClassLike || $node instanceof StmtsAwareInterface) && $node->stmts !== null) {
             $node->stmts = array_values($node->stmts);
         }
 

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -56,7 +56,7 @@ final class TerminatedNodeAnalyzer
             return false;
         }
 
-        if (($stmtsAware instanceof FileWithoutNamespace || $stmtsAware instanceof Namespace_) && $currentStmt instanceof ClassLike || $currentStmt instanceof Function_) {
+        if (($stmtsAware instanceof FileWithoutNamespace || $stmtsAware instanceof Namespace_) && ($currentStmt instanceof ClassLike || $currentStmt instanceof Function_)) {
             return false;
         }
 

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -9,19 +9,24 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Finally_;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Goto_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Label;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\TryCatch;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 
 final class TerminatedNodeAnalyzer
 {
@@ -45,9 +50,13 @@ final class TerminatedNodeAnalyzer
      */
     private const ALLOWED_CONTINUE_CURRENT_STMTS = [InlineHTML::class, Nop::class];
 
-    public function isAlwaysTerminated(Stmt $node, Stmt $currentStmt): bool
+    public function isAlwaysTerminated(StmtsAwareInterface $stmtsAware, Stmt $node, Stmt $currentStmt): bool
     {
         if (in_array($currentStmt::class, self::ALLOWED_CONTINUE_CURRENT_STMTS, true)) {
+            return false;
+        }
+
+        if (($stmtsAware instanceof FileWithoutNamespace || $stmtsAware instanceof Namespace_) && $currentStmt instanceof ClassLike || $currentStmt instanceof Function_) {
             return false;
         }
 


### PR DESCRIPTION
@TomasVotruba this is to cover after `patches/nikic-php-parser-lib-phpparser-node-stmt-namespace-php.patch` added to vendor-patches : 

- https://github.com/rectorphp/vendor-patches/pull/2

wait until https://github.com/rectorphp/vendor-patches/pull/2 merged first.