### PR TITLE
[EarlyReturn] Skip ChangeAndIfToEarlyReturnRector in case of simple scalar return

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -3883,12 +3883,12 @@ Changes if && to early return
      {
 -        if ($car->hasWheels && $car->hasFuel) {
 -            return true;
-+        if (!$car->hasWheels) {
++        if (! $car->hasWheels) {
 +            return false;
          }
 
 -        return false;
-+        if (!$car->hasFuel) {
++        if (! $car->hasFuel) {
 +            return false;
 +        }
 +

--- a/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/skip_if_stmt_used_in_return.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/skip_if_stmt_used_in_return.php.inc
@@ -2,18 +2,16 @@
 
 namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
 
-class SkipIfStmtUsedInReturn
+final class SkipIfStmtUsedInReturn
 {
-    public function run()
+    public function run($otherValue)
     {
         $content = '';
 
-        if (1 === 1 && 2 === 2) {
+        if ($otherValue === 1 && $otherValue === 2) {
             $content = execute($content);
         }
 
         return $content . 'execute';
     }
 }
-
-?>

--- a/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/skip_simple_return.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/skip_simple_return.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+final class SkipSimpleReturn
+{
+    public function getEerrors($fileName)
+    {
+        if (is_string($fileName) && str_contains($fileName, 'vendor')) {
+            return [];
+        }
+
+        return ['some error'];
+    }
+}

--- a/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/skip_simple_return_of_bool.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector/Fixture/skip_simple_return_of_bool.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector\Fixture;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
+
+final class SkipSimpleReturnOfBool
+{
+    public function resolve(Expr $expr)
+    {
+        if ($expr instanceof String_ && $expr->value === '') {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
+++ b/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
@@ -16,8 +16,8 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 final class IfAndAnalyzer
 {
     public function __construct(
-        private BetterNodeFinder $betterNodeFinder,
-        private NodeComparator $nodeComparator,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly NodeComparator $nodeComparator,
     ) {
     }
 

--- a/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
+++ b/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\EarlyReturn\NodeAnalyzer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Return_;
+use Rector\Core\PhpParser\Comparing\NodeComparator;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+
+final class IfAndAnalyzer
+{
+    public function __construct(
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeComparator $nodeComparator,
+    ) {
+    }
+
+    public function isIfAndWithInstanceof(BooleanAnd $booleanAnd): bool
+    {
+        if (! $booleanAnd->left instanceof Instanceof_) {
+            return false;
+        }
+
+        // only one instanceof check
+        return ! $booleanAnd->right instanceof Instanceof_;
+    }
+
+    public function isIfStmtExprUsedInNextReturn(If_ $if, Return_ $return): bool
+    {
+        if (! $return->expr instanceof Expr) {
+            return false;
+        }
+
+        $ifExprs = $this->betterNodeFinder->findInstanceOf($if->stmts, Expr::class);
+        foreach ($ifExprs as $ifExpr) {
+            $isExprFoundInReturn = (bool) $this->betterNodeFinder->findFirst(
+                $return->expr,
+                fn (Node $node): bool => $this->nodeComparator->areNodesEqual($node, $ifExpr)
+            );
+            if ($isExprFoundInReturn) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/rules/EarlyReturn/NodeAnalyzer/SimpleScalarAnalyzer.php
+++ b/rules/EarlyReturn/NodeAnalyzer/SimpleScalarAnalyzer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\EarlyReturn\NodeAnalyzer;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+
+final class SimpleScalarAnalyzer
+{
+    public function isSimpleScalar(Expr $expr): bool
+    {
+        // empty array
+        if ($expr instanceof Array_ && $expr->items === []) {
+            return true;
+        }
+
+        // empty string
+        return $expr instanceof String_ && $expr->value === '';
+    }
+}

--- a/src/NodeManipulator/IfManipulator.php
+++ b/src/NodeManipulator/IfManipulator.php
@@ -250,7 +250,7 @@ final class IfManipulator
             return false;
         }
 
-        return ! (bool) $if->elseifs;
+        return $if->elseifs === [];
     }
 
     public function createIfNegation(Expr $expr, Return_ $return): If_
@@ -259,9 +259,9 @@ final class IfManipulator
         return $this->createIfStmt($expr, $return);
     }
 
-    public function createIfStmt(Expr $expr, Stmt $stmt): If_
+    public function createIfStmt(Expr $condExpr, Stmt $stmt): If_
     {
-        return new If_($expr, [
+        return new If_($condExpr, [
             'stmts' => [$stmt],
         ]);
     }


### PR DESCRIPTION
Avoid these  changes https://github.com/symplify/symplify/pull/4363/commits/aff42ce6bb63264c5e81be26963b010e2efe91c2

They do not bring much value and make code harder to read.