### PR TITLE
[DeadCode] Skip object shape pseudo-type in RemoveNonExistingVarAnnotationRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep.php.inc
@@ -14,6 +14,9 @@ class Keep
         /** @var int $trainings */
         $trainings = $this->getAnotherData();
 
+        /** @var object{foo: string} $foo */
+        $foo = json_decode('["foo": "bar"]', false);
+
         return $trainings;
     }
 }

--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep.php.inc
@@ -15,7 +15,7 @@ class Keep
         $trainings = $this->getAnotherData();
 
         /** @var object{foo: string} $foo */
-        $foo = json_decode('["foo": "bar"]', false);
+        $foo = json_decode('{"foo": "bar"}', false);
 
         return $trainings;
     }

--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep.php.inc
@@ -14,9 +14,6 @@ class Keep
         /** @var int $trainings */
         $trainings = $this->getAnotherData();
 
-        /** @var object{foo: string} $foo */
-        $foo = json_decode('{"foo": "bar"}', false);
-
         return $trainings;
     }
 }

--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep_object_shape.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/keep_object_shape.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector\Fixture;
+
+final class KeepObjectShape
+{
+    public function get()
+    {
+        /** @var object{foo: string} $foo */
+        $foo = json_decode('{"foo": "bar"}', false);
+    }
+}

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\While_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\NodeAnalyzer\ExprUsedInNodeAnalyzer;
 use Symplify\PackageBuilder\Php\TypeChecker;
@@ -108,6 +109,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isObjectShapePseudoType($varTagValueNode)) {
+            return null;
+        }
+
         $variableName = ltrim($varTagValueNode->variableName, '$');
         if ($this->hasVariableName($node, $variableName)) {
             return null;
@@ -170,5 +175,26 @@ CODE_SAMPLE
 
             return $this->isName($node, $variableName);
         });
+    }
+
+    /**
+     * This is a hack,
+     * that waits on phpdoc-parser to get merged - https://github.com/phpstan/phpdoc-parser/pull/145
+     */
+    private function isObjectShapePseudoType(VarTagValueNode $varTagValueNode): bool
+    {
+        if (! $varTagValueNode->type instanceof IdentifierTypeNode) {
+            return false;
+        }
+
+        if ($varTagValueNode->type->name !== 'object') {
+            return false;
+        }
+
+        if (! str_starts_with($varTagValueNode->description, '{')) {
+            return false;
+        }
+
+        return str_contains($varTagValueNode->description, '}');
     }
 }


### PR DESCRIPTION
* Closes https://github.com/rectorphp/rector-src/pull/2797
* Fixes https://github.com/rectorphp/rector/issues/7393