### PR TITLE
[Core] Make ScopeAnalyzer::resolveScope() always return MutatingScope

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -31,7 +31,6 @@ use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
@@ -61,27 +60,6 @@ final class ChangedNodeScopeRefresher
         }
 
         $mutatingScope = $this->scopeAnalyzer->resolveScope($node, $smartFileInfo, $mutatingScope);
-
-        if (! $mutatingScope instanceof MutatingScope) {
-            /**
-             * @var Node $parentNode
-             *
-             * $parentNode is always a Node when $mutatingScope is null, as checked in previous
-             *
-             *      $this->scopeAnalyzer->resolveScope()
-             *
-             *  which verify if no parent and no scope, it resolve Scope from File
-             */
-            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-
-            $errorMessage = sprintf(
-                'Node "%s" with parent of "%s" is missing scope required for scope refresh.',
-                $node::class,
-                $parentNode::class
-            );
-
-            throw new ShouldNotHappenException($errorMessage);
-        }
 
         // note from flight: when we traverse ClassMethod, the scope must be already in Class_, otherwise it crashes
         // so we need to somehow get a parent scope that is already in the same place the $node is

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -40,7 +40,7 @@ final class ScopeAnalyzer
         Node $node,
         SmartFileInfo $smartFileInfo,
         ?MutatingScope $mutatingScope = null
-    ): ?MutatingScope {
+    ): MutatingScope {
         if ($mutatingScope instanceof MutatingScope) {
             return $mutatingScope;
         }
@@ -56,6 +56,13 @@ final class ScopeAnalyzer
 
         /** @var MutatingScope|null $parentScope */
         $parentScope = $parentNode->getAttribute(AttributeKey::SCOPE);
-        return $parentScope;
+        if ($parentScope instanceof MutatingScope) {
+            return $parentScope;
+        }
+
+        $scope = $this->scopeFactory->createFromFile($smartFileInfo);
+        $parentNode->setAttribute(AttributeKey::SCOPE, $scope);
+
+        return $scope;
     }
 }

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -36,7 +36,7 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
             $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
         }
 
-         /** @var MutatingScope $scope */
+        /** @var MutatingScope $scope */
         return $this->refactorWithScope($node, $scope);
     }
 }

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -6,9 +6,7 @@ namespace Rector\Core\Rector;
 
 use PhpParser\Node;
 use PHPStan\Analyser\MutatingScope;
-use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\ScopeAwarePhpRectorInterface;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -35,34 +33,10 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
         if (! $scope instanceof MutatingScope) {
             $smartFileInfo = $this->file->getSmartFileInfo();
             $scope = $this->scopeAnalyzer->resolveScope($node, $smartFileInfo);
-
-            if ($scope instanceof MutatingScope) {
-                $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
-            }
+            $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
         }
 
-        if (! $scope instanceof Scope) {
-            /**
-             * @var Node $parentNode
-             *
-             * $parentNode is always a Node when $mutatingScope is null, as checked in previous
-             *
-             *      $this->scopeAnalyzer->resolveScope()
-             *
-             *  which verify if no parent and no scope, it resolve Scope from File
-             */
-            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-
-            $errorMessage = sprintf(
-                'Scope not available on "%s" node with parent node of "%s", but is required by a refactorWithScope() method of "%s" rule. Fix scope refresh on changed nodes first',
-                $node::class,
-                $parentNode::class,
-                static::class,
-            );
-
-            throw new ShouldNotHappenException($errorMessage);
-        }
-
+         /** @var MutatingScope $scope */
         return $this->refactorWithScope($node, $scope);
     }
 }

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -36,7 +36,6 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
             $this->changedNodeScopeRefresher->refresh($node, $scope, $smartFileInfo);
         }
 
-        /** @var MutatingScope $scope */
         return $this->refactorWithScope($node, $scope);
     }
 }


### PR DESCRIPTION
Background
----------

Previously, we can get `null` Scope when Node:

- not has Scope 
- parent Node is Node 
- parent Node is Scope-able 

Then we get Exception:

```
'Node "%s" with parent of "%s" is missing scope required for scope refresh.`
```

Refactor
--------

Apply fallback to use :

```php
$scope = $this->scopeFactory->createFromFile($smartFileInfo);
$parentNode->setAttribute(AttributeKey::SCOPE, $scope);

return $scope;
```

as fill parent Node Scope with it, and then return its Scope value, next rule call on the node will always get Scope due to parent filled with the scope first in previous apply and as it already refreshed, same Node will use the Scope applied in refresh call.

Benefit
-------

- Reduce maintenance check of parent that require Scope to be filled in `PHPStanNodeScopeResolver`.
- Reduce line of codes.