### PR TITLE
Add new Annotation to attribute fixture : Symfony security

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/symfony_security.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/symfony_security.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Symfony;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+final class SymfonySecurity
+{
+    /**
+     * @Security("is_granted(constant('\\Rector\\Tests\\Php80\\Rector\\Class_\\AnnotationToAttributeRector\\Source\\ConstantReference::FIRST_NAME'))")
+     */
+    public function action ()
+    {
+    }
+}
+
+?>
+    -----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Symfony;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+final class SymfonySecurity
+{
+    #[Security("is_granted(constant('\\\Rector\\\Tests\\\Php80\\\Rector\\\Class_\\\AnnotationToAttributeRector\\\Source\\\ConstantReference::FIRST_NAME'))")]
+    public function action ()
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Annotation To Attribute for Symfony, `@Security` + `constant(FQN)`
see issue :  [230](https://github.com/rectorphp/rector-symfony/issues/230)