### PR TITLE
[Scoped] Add back SmartFileInfo to bootstrap.php

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -23,4 +23,11 @@ spl_autoload_register(function (string $class): void {
             $composerAutoloader->loadClass($class);
         }
     }
+
+    if ($class === 'Symplify\SmartFileSystem\SmartFileInfo') {
+        $filePath = __DIR__ . '/vendor/symplify/smart-file-system/src/SmartFileInfo.php';
+        if (file_exists($filePath)) {
+            require_once $filePath;
+        }
+    }
 });

--- a/scoper.php
+++ b/scoper.php
@@ -79,7 +79,7 @@ return [
         ),
 
         // unprefixed SmartFileInfo - needed in AbstractTestCase
-        fn (string $filePath, string $prefix, string $content): string => Strings::replace(
+        static fn (string $filePath, string $prefix, string $content): string => Strings::replace(
             $content,
             '#' . $prefix . '\\\\Symplify\\\\SmartFileSystem\\\\SmartFileInfo#',
             'Symplify\SmartFileSystem\SmartFileInfo'


### PR DESCRIPTION
@TomasVotruba the commit https://github.com/rectorphp/rector-src/commit/c579c2873c4511eb29e337a12b62cadd3978f1e7 cause error in latest dev-main when used, eg:

```
git clone https://github.com/laminas/laminas-servicemanager-migration.git
cd laminas-servicemanager-migration
composer require rector/rector:dev-main#dbb408c5c92269e97d3aea0755ae01545e7aa59a
vendor/bin/phpunit
```

with error:

```
➜  laminas-servicemanager-migration git:(0.16.x) ✗ vendor/bin/phpunit
PHPUnit 9.5.23 #StandWithUkraine

EEEEE                                                               5 / 5 (100%)

Time: 00:00.003, Memory: 8.00 MB

There were 5 errors:

1) Error
The data provider specified for LaminasTest\ServiceManager\Migration\Rector\Class_\ImplementsFactoryInterfaceToPsrFactoryRector\AutoImportRenameUseTest::test is invalid.
Error: Class "Symplify\SmartFileSystem\SmartFileInfo" not found
/Users/samsonasik/www/laminas-servicemanager-migration/vendor/rector/rector/vendor/symplify/easy-testing/src/DataProvider/StaticFixtureFinder.php:59
```

This add back `SmartFileInfo` require to bootstrap.php to resolve it, update to use require_once to ensure no double require.

Fixes https://github.com/rectorphp/rector/issues/7433