### PR TITLE
[DX] Instead of smart-file-system wrapper, use filesystem helpers directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "phpstan/phpstan-strict-rules": "^1.3",
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "phpunit/phpunit": "^9.5.21",
-        "rector/phpstan-rules": "^0.5.15",
+        "rector/phpstan-rules": "^0.6",
         "spatie/enum": "^3.13",
         "tracy/tracy": "^2.9.4",
         "symfony/process": "^6.1",

--- a/config/config.php
+++ b/config/config.php
@@ -44,6 +44,7 @@ use Rector\PSR4\Contract\PSR4AutoloadNamespaceMatcherInterface;
 use Rector\Utils\Command\MissingInSetCommand;
 use Symfony\Component\Console\Application;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use Symfony\Component\Filesystem\Filesystem;
 use Symplify\EasyParallel\ValueObject\EasyParallelConfig;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\PackageBuilder\Php\TypeChecker;
@@ -118,6 +119,8 @@ return static function (RectorConfig $rectorConfig): void {
 
     // parallel
     $services->set(ParametersMerger::class);
+
+    $services->set(Filesystem::class);
 
     // use faster in-memory cache in CI.
     // CI always starts from scratch, therefore IO intensive caching is not worth it

--- a/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfo/PhpDocInfoTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfo/PhpDocInfoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 
+use Nette\Utils\FileSystem;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\Nop;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
@@ -13,15 +14,12 @@ use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockTagReplacer;
 use Rector\StaticTypeMapper\ValueObject\Type\NonExistingObjectType;
 use Rector\Testing\PHPUnit\AbstractTestCase;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class PhpDocInfoTest extends AbstractTestCase
 {
     private PhpDocInfo $phpDocInfo;
 
     private PhpDocInfoPrinter $phpDocInfoPrinter;
-
-    private SmartFileSystem $smartFileSystem;
 
     private DocBlockTagReplacer $docBlockTagReplacer;
 
@@ -30,7 +28,6 @@ final class PhpDocInfoTest extends AbstractTestCase
         $this->boot();
 
         $this->phpDocInfoPrinter = $this->getService(PhpDocInfoPrinter::class);
-        $this->smartFileSystem = $this->getService(SmartFileSystem::class);
         $this->docBlockTagReplacer = $this->getService(DocBlockTagReplacer::class);
 
         $this->phpDocInfo = $this->createPhpDocInfoFromFile(__DIR__ . '/Source/doc.txt');
@@ -78,7 +75,7 @@ final class PhpDocInfoTest extends AbstractTestCase
     private function createPhpDocInfoFromFile(string $path): ?PhpDocInfo
     {
         $phpDocInfoFactory = $this->getService(PhpDocInfoFactory::class);
-        $phpDocContent = $this->smartFileSystem->readFile($path);
+        $phpDocContent = FileSystem::read($path);
 
         $nop = new Nop();
         $nop->setDocComment(new Doc($phpDocContent));

--- a/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/DoctrineTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/DoctrineTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Tests\BetterPhpDocParser\PhpDocInfo\PhpDocInfoPrinter;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Tests\BetterPhpDocParser\PhpDocInfo\PhpDocInfoPrinter\Source\Doctrine\CaseSensitive;
@@ -19,7 +20,7 @@ final class DoctrineTest extends AbstractPhpDocInfoPrinterTest
      */
     public function testClass(string $docFilePath, Node $node): void
     {
-        $docComment = $this->smartFileSystem->readFile($docFilePath);
+        $docComment = FileSystem::read($docFilePath);
         $phpDocInfo = $this->createPhpDocInfoFromDocCommentAndNode($docComment, $node);
 
         $fileInfo = new SmartFileInfo($docFilePath);

--- a/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/MultilineTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/MultilineTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Tests\BetterPhpDocParser\PhpDocInfo\PhpDocInfoPrinter;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use PhpParser\BuilderFactory;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
@@ -24,7 +25,7 @@ final class MultilineTest extends AbstractPhpDocInfoPrinterTest
      */
     public function test(string $docFilePath, Node $node): void
     {
-        $docComment = $this->smartFileSystem->readFile($docFilePath);
+        $docComment = FileSystem::read($docFilePath);
         $phpDocInfo = $this->createPhpDocInfoFromDocCommentAndNode($docComment, $node);
 
         $fileInfo = new SmartFileInfo($docFilePath);

--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Tests\BetterPhpDocParser\PhpDocParser\TagValueNodeReprint;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -17,7 +18,6 @@ use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\EasyTesting\FixtureSplitter\TrioFixtureSplitter;
 use Symplify\EasyTesting\ValueObject\FixtureSplit\TrioContent;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class TagValueNodeReprintTest extends AbstractTestCase
 {
@@ -114,8 +114,7 @@ final class TagValueNodeReprintTest extends AbstractTestCase
         $temporaryFileName = sys_get_temp_dir() . '/rector/tests/' . $fixturefileInfo->getRelativePathname();
         $firstValue = $trioContent->getFirstValue();
 
-        $smartFileSystem = new SmartFileSystem();
-        $smartFileSystem->dumpFile($temporaryFileName, $firstValue);
+        FileSystem::write($temporaryFileName, $firstValue);
 
         return new SmartFileInfo($temporaryFileName);
     }

--- a/packages/Caching/CacheFactory.php
+++ b/packages/Caching/CacheFactory.php
@@ -7,14 +7,14 @@ namespace Rector\Caching;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
 use Rector\Core\Configuration\Option;
+use Symfony\Component\Filesystem\Filesystem;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class CacheFactory
 {
     public function __construct(
         private readonly ParameterProvider $parameterProvider,
-        private readonly SmartFileSystem $smartFileSystem
+        private readonly Filesystem $fileSystem
     ) {
     }
 
@@ -29,11 +29,11 @@ final class CacheFactory
 
         if ($cacheClass === FileCacheStorage::class) {
             // ensure cache directory exists
-            if (! $this->smartFileSystem->exists($cacheDirectory)) {
-                $this->smartFileSystem->mkdir($cacheDirectory);
+            if (! $this->fileSystem->exists($cacheDirectory)) {
+                $this->fileSystem->mkdir($cacheDirectory);
             }
 
-            $fileCacheStorage = new FileCacheStorage($cacheDirectory, $this->smartFileSystem);
+            $fileCacheStorage = new FileCacheStorage($cacheDirectory, $this->fileSystem);
             return new Cache($fileCacheStorage);
         }
 

--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -21,7 +21,7 @@ final class FileCacheStorage implements CacheStorageInterface
 {
     public function __construct(
         private string $directory,
-        private SmartFileSystem $smartFileSystem
+        private \Symfony\Component\Filesystem\Filesystem $filesystem
     ) {
     }
 
@@ -51,8 +51,8 @@ final class FileCacheStorage implements CacheStorageInterface
     public function save(string $key, string $variableKey, mixed $data): void
     {
         $cacheFilePaths = $this->getCacheFilePaths($key);
-        $this->smartFileSystem->mkdir($cacheFilePaths->getFirstDirectory());
-        $this->smartFileSystem->mkdir($cacheFilePaths->getSecondDirectory());
+        $this->filesystem-> mkdir($cacheFilePaths->getFirstDirectory());
+        $this->filesystem->mkdir($cacheFilePaths->getSecondDirectory());
 
         $path = $cacheFilePaths->getFilePath();
 
@@ -92,22 +92,22 @@ final class FileCacheStorage implements CacheStorageInterface
 
     public function clear(): void
     {
-        $this->smartFileSystem->remove($this->directory);
+        $this->filesystem->remove($this->directory);
     }
 
     private function processRemoveCacheFilePath(CacheFilePaths $cacheFilePaths): void
     {
         $filePath = $cacheFilePaths->getFilePath();
-        if (! $this->smartFileSystem->exists($filePath)) {
+        if (! $this->filesystem->exists($filePath)) {
             return;
         }
 
-        $this->smartFileSystem->remove($filePath);
+        $this->filesystem->remove($filePath);
     }
 
     private function processRemoveEmptyDirectory(string $directory): void
     {
-        if (! $this->smartFileSystem->exists($directory)) {
+        if (! $this->filesystem->exists($directory)) {
             return;
         }
 
@@ -115,7 +115,7 @@ final class FileCacheStorage implements CacheStorageInterface
             return;
         }
 
-        $this->smartFileSystem->remove($directory);
+        $this->filesystem->remove($directory);
     }
 
     private function isNotEmptyDirectory(string $directory): bool

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -736,3 +736,6 @@ parameters:
         -
             message: '#Creating new PHPStan\\Parser\\(CachedParser|SimpleParser) is not covered by backward compatibility promise\. The class might change in a minor PHPStan version#'
             path: packages/PhpDocParser/PhpParser/SmartPhpParserFactory.php
+
+        # allowed
+        - '#Instead of "Symfony\\Component\\Filesystem\\Filesystem" class/interface use "Symplify\\SmartFileSystem\\SmartFileSystem"#'

--- a/rules-tests/PSR4/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/FileWithoutNamespaceTest.php
+++ b/rules-tests/PSR4/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/FileWithoutNamespaceTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Rector\Tests\PSR4\Rector\Namespace_\MultipleClassFileToPsr4ClassesRector;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use Rector\FileSystemRector\ValueObject\AddedFileWithContent;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\EasyTesting\StaticFixtureSplitter;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class FileWithoutNamespaceTest extends AbstractRectorTestCase
 {
@@ -43,16 +43,14 @@ final class FileWithoutNamespaceTest extends AbstractRectorTestCase
      */
     public function provideData(): Iterator
     {
-        $smartFileSystem = new SmartFileSystem();
-
         $filePathsWithContents = [
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/SkipWithoutNamespace.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/SkipWithoutNamespace.php')
+                FileSystem::read(__DIR__ . '/Expected/SkipWithoutNamespace.php')
             ),
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/JustTwoExceptionWithoutNamespace.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/JustTwoExceptionWithoutNamespace.php')
+                FileSystem::read(__DIR__ . '/Expected/JustTwoExceptionWithoutNamespace.php')
             ),
         ];
 

--- a/rules-tests/PSR4/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/MultipleClassFileToPsr4ClassesRectorTest.php
+++ b/rules-tests/PSR4/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/MultipleClassFileToPsr4ClassesRectorTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Rector\Tests\PSR4\Rector\Namespace_\MultipleClassFileToPsr4ClassesRector;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use Rector\FileSystemRector\ValueObject\AddedFileWithContent;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\EasyTesting\StaticFixtureSplitter;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class MultipleClassFileToPsr4ClassesRectorTest extends AbstractRectorTestCase
 {
@@ -42,17 +42,15 @@ final class MultipleClassFileToPsr4ClassesRectorTest extends AbstractRectorTestC
      */
     public function provideData(): Iterator
     {
-        $smartFileSystem = new SmartFileSystem();
-
         // source: https://github.com/nette/utils/blob/798f8c1626a8e0e23116d90e588532725cce7d0e/src/Utils/exceptions.php
         $filePathsWithContents = [
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/RegexpException.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/RegexpException.php')
+                FileSystem::read(__DIR__ . '/Expected/RegexpException.php')
             ),
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/UnknownImageFileException.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/UnknownImageFileException.php')
+                FileSystem::read(__DIR__ . '/Expected/UnknownImageFileException.php')
             ),
         ];
         yield [new SmartFileInfo(__DIR__ . '/Fixture/nette_exceptions.php.inc'), $filePathsWithContents];
@@ -60,15 +58,15 @@ final class MultipleClassFileToPsr4ClassesRectorTest extends AbstractRectorTestC
         $filePathsWithContents = [
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/MyTrait.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/MyTrait.php')
+                FileSystem::read(__DIR__ . '/Expected/MyTrait.php')
             ),
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/ClassTraitAndInterface.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/ClassTraitAndInterface.php')
+                FileSystem::read(__DIR__ . '/Expected/ClassTraitAndInterface.php')
             ),
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/MyInterface.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/MyInterface.php')
+                FileSystem::read(__DIR__ . '/Expected/MyInterface.php')
             ),
         ];
 
@@ -77,7 +75,7 @@ final class MultipleClassFileToPsr4ClassesRectorTest extends AbstractRectorTestC
         $filePathsWithContents = [
             new AddedFileWithContent(
                 $this->getFixtureTempDirectory() . '/ClassMatchesFilenameException.php',
-                $smartFileSystem->readFile(__DIR__ . '/Expected/ClassMatchesFilenameException.php')
+                FileSystem::read(__DIR__ . '/Expected/ClassMatchesFilenameException.php')
             ),
         ];
 

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -18,6 +18,7 @@ use Rector\Core\ValueObjectFactory\Application\FileFactory;
 use Rector\Parallel\Application\ParallelFileProcessor;
 use Rector\Parallel\ValueObject\Bridge;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symplify\EasyParallel\CpuCoreCountProvider;
 use Symplify\EasyParallel\Exception\ParallelShouldNotHappenException;
 use Symplify\EasyParallel\FileSystem\FilePathNormalizer;
@@ -25,7 +26,6 @@ use Symplify\EasyParallel\ScheduleFactory;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\PackageBuilder\Yaml\ParametersMerger;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 use Webmozart\Assert\Assert;
 
 final class ApplicationFileProcessor
@@ -44,7 +44,7 @@ final class ApplicationFileProcessor
      * @param FileProcessorInterface[] $fileProcessors
      */
     public function __construct(
-        private readonly SmartFileSystem $smartFileSystem,
+        private readonly Filesystem $filesytem,
         private readonly FileDiffFileDecorator $fileDiffFileDecorator,
         private readonly RemovedAndAddedFilesProcessor $removedAndAddedFilesProcessor,
         private readonly OutputStyleInterface $rectorOutputStyle,
@@ -164,8 +164,8 @@ final class ApplicationFileProcessor
     {
         $smartFileInfo = $file->getSmartFileInfo();
 
-        $this->smartFileSystem->dumpFile($smartFileInfo->getPathname(), $file->getFileContent());
-        $this->smartFileSystem->chmod($smartFileInfo->getRealPath(), $smartFileInfo->getPerms());
+        $this->filesytem->dumpFile($smartFileInfo->getPathname(), $file->getFileContent());
+        $this->filesytem->chmod($smartFileInfo->getRealPath(), $smartFileInfo->getPerms());
     }
 
     /**

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -44,7 +44,7 @@ final class ApplicationFileProcessor
      * @param FileProcessorInterface[] $fileProcessors
      */
     public function __construct(
-        private readonly Filesystem $filesytem,
+        private readonly Filesystem $filesystem,
         private readonly FileDiffFileDecorator $fileDiffFileDecorator,
         private readonly RemovedAndAddedFilesProcessor $removedAndAddedFilesProcessor,
         private readonly OutputStyleInterface $rectorOutputStyle,
@@ -164,8 +164,8 @@ final class ApplicationFileProcessor
     {
         $smartFileInfo = $file->getSmartFileInfo();
 
-        $this->filesytem->dumpFile($smartFileInfo->getPathname(), $file->getFileContent());
-        $this->filesytem->chmod($smartFileInfo->getRealPath(), $smartFileInfo->getPerms());
+        $this->filesystem->dumpFile($smartFileInfo->getPathname(), $file->getFileContent());
+        $this->filesystem->chmod($smartFileInfo->getRealPath(), $smartFileInfo->getPerms());
     }
 
     /**

--- a/src/Application/FileSystem/RemovedAndAddedFilesProcessor.php
+++ b/src/Application/FileSystem/RemovedAndAddedFilesProcessor.php
@@ -7,7 +7,7 @@ namespace Rector\Core\Application\FileSystem;
 use Rector\Core\Contract\Console\OutputStyleInterface;
 use Rector\Core\PhpParser\Printer\NodesWithFileDestinationPrinter;
 use Rector\Core\ValueObject\Configuration;
-use Symplify\SmartFileSystem\SmartFileSystem;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Adds and removes scheduled file
@@ -15,7 +15,7 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 final class RemovedAndAddedFilesProcessor
 {
     public function __construct(
-        private readonly SmartFileSystem $smartFileSystem,
+        private readonly Filesystem $filesystem,
         private readonly NodesWithFileDestinationPrinter $nodesWithFileDestinationPrinter,
         private readonly RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
         private readonly OutputStyleInterface $rectorOutputStyle
@@ -42,7 +42,7 @@ final class RemovedAndAddedFilesProcessor
             } else {
                 $message = sprintf('File "%s" was removed', $relativePath);
                 $this->rectorOutputStyle->warning($message);
-                $this->smartFileSystem->remove($removedFile->getPathname());
+                $this->filesystem->remove($removedFile->getPathname());
             }
         }
     }
@@ -54,7 +54,7 @@ final class RemovedAndAddedFilesProcessor
                 $message = sprintf('File "%s" will be added', $addedFileWithContent->getFilePath());
                 $this->rectorOutputStyle->note($message);
             } else {
-                $this->smartFileSystem->dumpFile(
+                $this->filesystem->dumpFile(
                     $addedFileWithContent->getFilePath(),
                     $addedFileWithContent->getFileContent()
                 );
@@ -75,7 +75,7 @@ final class RemovedAndAddedFilesProcessor
                 $message = sprintf('File "%s" will be added', $addedFileWithNode->getFilePath());
                 $this->rectorOutputStyle->note($message);
             } else {
-                $this->smartFileSystem->dumpFile($addedFileWithNode->getFilePath(), $fileContent);
+                $this->filesystem->dumpFile($addedFileWithNode->getFilePath(), $fileContent);
                 $message = sprintf('File "%s" was added', $addedFileWithNode->getFilePath());
                 $this->rectorOutputStyle->note($message);
             }
@@ -95,8 +95,8 @@ final class RemovedAndAddedFilesProcessor
                 );
                 $this->rectorOutputStyle->note($message);
             } else {
-                $this->smartFileSystem->dumpFile($movedFile->getNewFilePath(), $fileContent);
-                $this->smartFileSystem->remove($movedFile->getFilePath());
+                $this->filesystem->dumpFile($movedFile->getNewFilePath(), $fileContent);
+                $this->filesystem->remove($movedFile->getFilePath());
 
                 $message = sprintf(
                     'File "%s" was moved to "%s"',

--- a/src/Autoloading/AdditionalAutoloader.php
+++ b/src/Autoloading/AdditionalAutoloader.php
@@ -8,7 +8,7 @@ use Rector\Core\Configuration\Option;
 use Rector\Core\StaticReflection\DynamicSourceLocatorDecorator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use Symplify\SmartFileSystem\FileSystemGuard;
+use Webmozart\Assert\Assert;
 
 /**
  * Should it pass autoload files/directories to PHPStan analyzer?
@@ -16,7 +16,6 @@ use Symplify\SmartFileSystem\FileSystemGuard;
 final class AdditionalAutoloader
 {
     public function __construct(
-        private readonly FileSystemGuard $fileSystemGuard,
         private readonly ParameterProvider $parameterProvider,
         private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator
     ) {
@@ -34,7 +33,8 @@ final class AdditionalAutoloader
             return;
         }
 
-        $this->fileSystemGuard->ensureFileExists($autoloadFile, 'Extra autoload');
+        Assert::fileExists($autoloadFile, sprintf('Extra autoload file %s was not found', $autoloadFile));
+
         require_once $autoloadFile;
     }
 

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Console\Command;
 
+use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Contract\Console\OutputStyleInterface;
@@ -68,7 +69,7 @@ final class InitCommand extends Command
             $fullPHPVersion = (string) $this->phpVersionProvider->provide();
             $phpVersion = Strings::substring($fullPHPVersion, 0, 1) . Strings::substring($fullPHPVersion, 2, 1);
 
-            $fileContent = $this->smartFileSystem->readFile($rectorRootFilePath);
+            $fileContent = FileSystem::read($rectorRootFilePath);
             $fileContent = str_replace(
                 'LevelSetList::UP_TO_PHP_XY',
                 'LevelSetList::UP_TO_PHP_' . $phpVersion,

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class InitCommand extends Command
 {
@@ -24,7 +23,7 @@ final class InitCommand extends Command
     private const TEMPLATE_PATH = __DIR__ . '/../../../templates/rector.php.dist';
 
     public function __construct(
-        private readonly SmartFileSystem $smartFileSystem,
+        private readonly \Symfony\Component\Filesystem\Filesystem $filesystem,
         private readonly OutputStyleInterface $rectorOutputStyle,
         private readonly PhpVersionProvider $phpVersionProvider,
         private readonly SymfonyStyle $symfonyStyle
@@ -60,11 +59,11 @@ final class InitCommand extends Command
 
         $rectorRootFilePath = getcwd() . '/rector.php';
 
-        $doesFileExist = $this->smartFileSystem->exists($rectorRootFilePath);
+        $doesFileExist = $this->filesystem->exists($rectorRootFilePath);
         if ($doesFileExist) {
             $this->rectorOutputStyle->warning('Config file "rector.php" already exists');
         } else {
-            $this->smartFileSystem->copy(self::TEMPLATE_PATH, $rectorRootFilePath);
+            $this->filesystem->copy(self::TEMPLATE_PATH, $rectorRootFilePath);
 
             $fullPHPVersion = (string) $this->phpVersionProvider->provide();
             $phpVersion = Strings::substring($fullPHPVersion, 0, 1) . Strings::substring($fullPHPVersion, 2, 1);
@@ -75,7 +74,7 @@ final class InitCommand extends Command
                 'LevelSetList::UP_TO_PHP_' . $phpVersion,
                 $fileContent
             );
-            $this->smartFileSystem->dumpFile($rectorRootFilePath, $fileContent);
+            $this->filesystem->dumpFile($rectorRootFilePath, $fileContent);
 
             $this->rectorOutputStyle->success('"rector.php" config file was added');
         }

--- a/src/FileSystem/FilePathHelper.php
+++ b/src/FileSystem/FilePathHelper.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\Core\FileSystem;
 
-use Symplify\SmartFileSystem\SmartFileSystem;
+use Symfony\Component\Filesystem\Filesystem;
 
 final class FilePathHelper
 {
     public function __construct(
-        private readonly SmartFileSystem $smartFileSystem,
+        private readonly Filesystem $filesystem,
     ) {
     }
 
@@ -17,7 +17,7 @@ final class FilePathHelper
     {
         $normalizedFileRealPath = $this->normalizePath($fileRealPath);
 
-        $relativeFilePath = $this->smartFileSystem->makePathRelative(
+        $relativeFilePath = $this->filesystem->makePathRelative(
             $normalizedFileRealPath,
             (string) realpath(getcwd())
         );

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\Parser;
 
+use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
@@ -13,7 +14,6 @@ use PhpParser\Node\Stmt;
 use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\Util\StringUtils;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class InlineCodeParser
 {
@@ -57,7 +57,6 @@ final class InlineCodeParser
         private readonly NodePrinterInterface $nodePrinter,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly SimplePhpParser $simplePhpParser,
-        private readonly SmartFileSystem $smartFileSystem
     ) {
     }
 
@@ -68,7 +67,7 @@ final class InlineCodeParser
     {
         // to cover files too
         if (is_file($content)) {
-            $content = $this->smartFileSystem->readFile($content);
+            $content = FileSystem::read($content);
         }
 
         // wrap code so php-parser can interpret it

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -15,7 +15,8 @@ final class SimplePhpParser
 {
     private readonly Parser $phpParser;
 
-    public function __construct() {
+    public function __construct()
+    {
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);
     }

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -4,20 +4,18 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\Parser;
 
+use Nette\Utils\FileSystem;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class SimplePhpParser
 {
     private readonly Parser $phpParser;
 
-    public function __construct(
-        private readonly SmartFileSystem $smartFileSystem,
-    ) {
+    public function __construct() {
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);
     }
@@ -27,7 +25,7 @@ final class SimplePhpParser
      */
     public function parseFile(string $filePath): array
     {
-        $fileContent = $this->smartFileSystem->readFile($filePath);
+        $fileContent = FileSystem::read($filePath);
         return $this->parseString($fileContent);
     }
 

--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -9,8 +9,8 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\ValueObject\Application\File;
+use Symfony\Component\Filesystem\Filesystem;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 /**
  * @see \Rector\Core\Tests\PhpParser\Printer\FormatPerservingPrinterTest
@@ -19,7 +19,7 @@ final class FormatPerservingPrinter
 {
     public function __construct(
         private readonly BetterStandardPrinter $betterStandardPrinter,
-        private readonly SmartFileSystem $smartFileSystem
+        private readonly Filesystem $filesystem
     ) {
     }
 
@@ -32,8 +32,8 @@ final class FormatPerservingPrinter
     {
         $newContent = $this->betterStandardPrinter->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
 
-        $this->smartFileSystem->dumpFile($fileInfo->getRealPath(), $newContent);
-        $this->smartFileSystem->chmod($fileInfo->getRealPath(), $fileInfo->getPerms());
+        $this->filesystem->dumpFile($fileInfo->getRealPath(), $newContent);
+        $this->filesystem->chmod($fileInfo->getRealPath(), $fileInfo->getPerms());
 
         return $newContent;
     }

--- a/tests/Issues/PhpTagsAddedToBlade/PhpTagsAddedToBladeTest.php
+++ b/tests/Issues/PhpTagsAddedToBlade/PhpTagsAddedToBladeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\PhpTagsAddedToBlade;
 
+use Nette\Utils\FileSystem;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\Core\Application\ApplicationFileProcessor;
 use Rector\Core\ValueObject\Application\File;
@@ -12,7 +13,6 @@ use Rector\Parallel\ValueObject\Bridge;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class PhpTagsAddedToBladeTest extends AbstractRectorTestCase
 {
@@ -48,8 +48,7 @@ final class PhpTagsAddedToBladeTest extends AbstractRectorTestCase
         $this->assertStringEqualsFile($expectedFileInfo->getRealPath(), $inputFileInfo->getContents());
 
         // restore original file
-        $smartFileSystem = new SmartFileSystem();
-        $smartFileSystem->dumpFile($inputFileInfo->getRealPath(), $inputFileInfoContent);
+        FileSystem::write($inputFileInfo->getRealPath(), $inputFileInfoContent);
     }
 
     public function provideConfigFilePath(): string

--- a/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
+++ b/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\PhpParser\Printer;
 
+use Nette\Utils\FileSystem;
 use Rector\Core\PhpParser\Printer\FormatPerservingPrinter;
 use Rector\Testing\PHPUnit\AbstractTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class FormatPerservingPrinterTest extends AbstractTestCase
 {
@@ -18,18 +18,15 @@ final class FormatPerservingPrinterTest extends AbstractTestCase
 
     private FormatPerservingPrinter $formatPerservingPrinter;
 
-    private SmartFileSystem $smartFileSystem;
-
     protected function setUp(): void
     {
         $this->boot();
         $this->formatPerservingPrinter = $this->getService(FormatPerservingPrinter::class);
-        $this->smartFileSystem = $this->getService(SmartFileSystem::class);
     }
 
     protected function tearDown(): void
     {
-        $this->smartFileSystem->remove(__DIR__ . '/Fixture');
+        FileSystem::delete(__DIR__ . '/Fixture');
     }
 
     public function testFileModeIsPreserved(): void


### PR DESCRIPTION
Next step to lower the complexity, by using classes we already have here :+1: 