### PR TITLE
Add failing test fixture for RemoveAlwaysTrueIfConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/f_docentete.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/f_docentete.php.inc
@@ -1,0 +1,103 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class FDocentete
+{
+    public function __construct(private string $doPiece)
+    {
+    }
+
+    public function getDoPiece(): ?string
+    {
+        return $this->doPiece;
+    }
+
+    public function setDoPiece(?string $doPiece): self
+    {
+        $this->doPiece = $doPiece;
+        return $this;
+    }
+}
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class GetFDocentetesController
+{
+    public static function test()
+    {
+        $fDoclignes = [
+            ['doPiece' => '1']
+        ];
+        $fDocentetes = [
+            new FDocentete('1'),
+            new FDocentete('2'),
+        ];
+        /** @var FDocentete $currentFDocentete */
+        $currentFDocentete = null;
+        foreach ($fDoclignes as $fDocligne) {
+            if (is_null($currentFDocentete) || $currentFDocentete->getDoPiece() !== $fDocligne['doPiece']) {
+                if (!is_null($currentFDocentete)) {
+                    echo 'I echo here';
+                }
+                $currentFDocentete = current(array_filter($fDocentetes, static fn(FDocentete $fDocentete) => $fDocentete->getDoPiece() === $fDocligne['doPiece']));
+            }
+        }
+    }
+}
+
+GetFDocentetesController::test();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class FDocentete
+{
+    public function __construct(private string $doPiece)
+    {
+    }
+
+    public function getDoPiece(): ?string
+    {
+        return $this->doPiece;
+    }
+
+    public function setDoPiece(?string $doPiece): self
+    {
+        $this->doPiece = $doPiece;
+        return $this;
+    }
+}
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class GetFDocentetesController
+{
+    public static function test()
+    {
+        $fDoclignes = [
+            ['doPiece' => '1']
+        ];
+        $fDocentetes = [
+            new FDocentete('1'),
+            new FDocentete('2'),
+        ];
+        /** @var FDocentete $currentFDocentete */
+        $currentFDocentete = null;
+        foreach ($fDoclignes as $fDocligne) {
+            if (is_null($currentFDocentete) || $currentFDocentete->getDoPiece() !== $fDocligne['doPiece']) {
+                if (!is_null($currentFDocentete)) {
+                    echo 'I echo here';
+                }
+                $currentFDocentete = current(array_filter($fDocentetes, static fn(FDocentete $fDocentete) => $fDocentete->getDoPiece() === $fDocligne['doPiece']));
+            }
+        }
+    }
+}
+
+GetFDocentetesController::test();
+
+?>


### PR DESCRIPTION
# Failing Test for RemoveAlwaysTrueIfConditionRector

Based on https://getrector.org/demo/52d9f84d-3203-44ee-9295-b7e2dc909b02

https://github.com/rectorphp/rector/issues/7440