### PR TITLE
Fix class not found from Easy-Testing package

### DIFF
--- a/packages/Testing/Fixture/FixtureFileFinder.php
+++ b/packages/Testing/Fixture/FixtureFileFinder.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Rector\Testing\Fixture;
 
 use Iterator;
+use Nette\Utils\Strings;
+use Rector\Core\Exception\ShouldNotHappenException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SmartFileSystem\Exception\FileNotFoundException;
 
 final class FixtureFileFinder
 {
@@ -37,5 +40,70 @@ final class FixtureFileFinder
 
         $fileInfos = iterator_to_array($finder);
         return array_values($fileInfos);
+    }
+
+    /**
+     * @return Iterator<array<int, SmartFileInfo>>
+     */
+    public static function yieldDirectoryExclusively(string $directory, string $suffix = '*.php.inc'): Iterator
+    {
+        $fileInfos = self::findFilesInDirectoryExclusively($directory, $suffix);
+
+        return self::yieldFileInfos($fileInfos);
+    }
+
+    private static function ensureNoOtherFileName(string $directory, string $suffix): void
+    {
+        $finder = Finder::create()->in($directory)
+            ->files()
+            ->notName($suffix);
+
+        /** @var SplFileInfo[] $fileInfos */
+        $fileInfos = iterator_to_array($finder->getIterator());
+
+        $relativeFilePaths = [];
+        foreach ($fileInfos as $fileInfo) {
+            $relativeFilePaths[] = Strings::substring($fileInfo->getRealPath(), strlen(getcwd()) + 1);
+        }
+
+        if ($relativeFilePaths === []) {
+            return;
+        }
+
+        throw new ShouldNotHappenException(sprintf(
+            'Files "%s" have invalid suffix, use "%s" suffix instead',
+            implode('", ', $relativeFilePaths),
+            $suffix
+        ));
+    }
+
+    /**
+     * @return SplFileInfo[]
+     */
+    private static function findFilesInDirectoryExclusively(string $directory, string $suffix): array
+    {
+        self::ensureNoOtherFileName($directory, $suffix);
+
+        $finder = Finder::create()->in($directory)
+            ->files()
+            ->name($suffix);
+
+        $fileInfos = iterator_to_array($finder->getIterator());
+        return array_values($fileInfos);
+    }
+
+    /**
+     * @param SplFileInfo[] $fileInfos
+     * @return Iterator<array<int, SmartFileInfo>>
+     */
+    private static function yieldFileInfos(array $fileInfos): Iterator
+    {
+        foreach ($fileInfos as $fileInfo) {
+            try {
+                $smartFileInfo = new SmartFileInfo($fileInfo->getRealPath());
+                yield [$smartFileInfo];
+            } catch (FileNotFoundException) {
+            }
+        }
     }
 }

--- a/packages/Testing/Fixture/FixtureFileUpdater.php
+++ b/packages/Testing/Fixture/FixtureFileUpdater.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Testing\Fixture;
+
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SmartFileSystem\SmartFileSystem;
+
+/**
+ * @api
+ */
+final class FixtureFileUpdater
+{
+    public static function updateFixtureContent(
+        SmartFileInfo|string $originalFileInfo,
+        string $changedContent,
+        SmartFileInfo $fixtureFileInfo
+    ): void {
+        if (! getenv('UPDATE_TESTS') && ! getenv('UT')) {
+            return;
+        }
+
+        $newOriginalContent = self::resolveNewFixtureContent($originalFileInfo, $changedContent);
+
+        self::getSmartFileSystem()
+            ->dumpFile($fixtureFileInfo->getRealPath(), $newOriginalContent);
+    }
+
+    public static function updateExpectedFixtureContent(
+        string $newOriginalContent,
+        SmartFileInfo $expectedFixtureFileInfo
+    ): void {
+        if (! getenv('UPDATE_TESTS') && ! getenv('UT')) {
+            return;
+        }
+
+        self::getSmartFileSystem()
+            ->dumpFile($expectedFixtureFileInfo->getRealPath(), $newOriginalContent);
+    }
+
+    private static function getSmartFileSystem(): SmartFileSystem
+    {
+        return new SmartFileSystem();
+    }
+
+    private static function resolveNewFixtureContent(
+        SmartFileInfo|string $originalFileInfo,
+        string $changedContent
+    ): string {
+        if ($originalFileInfo instanceof SmartFileInfo) {
+            $originalContent = $originalFileInfo->getContents();
+        } else {
+            $originalContent = $originalFileInfo;
+        }
+
+        if ($originalContent === $changedContent) {
+            return $originalContent;
+        }
+
+        return $originalContent . '-----' . PHP_EOL . $changedContent;
+    }
+}

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -23,7 +23,6 @@ use Rector\Testing\Fixture\FixtureSplitter;
 use Rector\Testing\Fixture\FixtureTempFileDumper;
 use Rector\Testing\PHPUnit\Behavior\MovingFilesTrait;
 use SplFileInfo;
-use Symplify\EasyTesting\DataProvider\StaticFixtureUpdater;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
@@ -180,7 +179,6 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
                 throw $expectationFailedException;
             }
 
-            StaticFixtureUpdater::updateFixtureContent($originalFileInfo, $changedContent, $fixtureFileInfo);
             $contents = $expectedFileInfo->getContents();
 
             // make sure we don't get a diff in which every line is different (because of differences in EOL)

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -19,6 +19,7 @@ use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
 use Rector\Testing\Contract\RectorTestInterface;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\Fixture\FixtureFileUpdater;
 use Rector\Testing\Fixture\FixtureSplitter;
 use Rector\Testing\Fixture\FixtureTempFileDumper;
 use Rector\Testing\PHPUnit\Behavior\MovingFilesTrait;
@@ -178,6 +179,8 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
             if (! $allowMatches) {
                 throw $expectationFailedException;
             }
+
+            FixtureFileUpdater::updateFixtureContent($originalFileInfo, $changedContent, $fixtureFileInfo);
 
             $contents = $expectedFileInfo->getContents();
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -739,3 +739,7 @@ parameters:
 
         # used in abstract test case
         - '#Class constant "SPLIT_LINE_REGEX" is never used#'
+
+        -
+            message: '#Only booleans are allowed in a negated boolean, string\|false given#'
+            path: packages/Testing/Fixture/FixtureFileUpdater.php

--- a/rules-tests/Composer/Rector/AddPackageToRequireComposerRector/AddPackageToRequireComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/AddPackageToRequireComposerRector/AddPackageToRequireComposerRectorTest.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Composer\Rector\AddPackageToRequireComposerRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AddPackageToRequireComposerRectorTest extends AbstractRectorTestCase
@@ -21,7 +21,7 @@ final class AddPackageToRequireComposerRectorTest extends AbstractRectorTestCase
 
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
     }
 
     public function provideConfigFilePath(): string

--- a/rules-tests/Composer/Rector/AddPackageToRequireComposerRector/AddPackageToRequireComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/AddPackageToRequireComposerRector/AddPackageToRequireComposerRectorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Tests\Composer\Rector\AddPackageToRequireComposerRector;
 
 use Iterator;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AddPackageToRequireComposerRectorTest extends AbstractRectorTestCase

--- a/rules-tests/Composer/Rector/AddPackageToRequireDevComposerRector/AddPackageToRequireDevComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/AddPackageToRequireDevComposerRector/AddPackageToRequireDevComposerRectorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Tests\Composer\Rector\AddPackageToRequireDevComposerRector;
 
 use Iterator;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AddPackageToRequireDevComposerRectorTest extends AbstractRectorTestCase

--- a/rules-tests/Composer/Rector/AddPackageToRequireDevComposerRector/AddPackageToRequireDevComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/AddPackageToRequireDevComposerRector/AddPackageToRequireDevComposerRectorTest.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Composer\Rector\AddPackageToRequireDevComposerRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AddPackageToRequireDevComposerRectorTest extends AbstractRectorTestCase
@@ -21,7 +21,7 @@ final class AddPackageToRequireDevComposerRectorTest extends AbstractRectorTestC
 
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
     }
 
     public function provideConfigFilePath(): string

--- a/rules-tests/Composer/Rector/ChangePackageVersionComposerRector/ChangePackageVersionComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/ChangePackageVersionComposerRector/ChangePackageVersionComposerRectorTest.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Composer\Rector\ChangePackageVersionComposerRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ChangePackageVersionComposerRectorTest extends AbstractRectorTestCase
@@ -21,7 +21,7 @@ final class ChangePackageVersionComposerRectorTest extends AbstractRectorTestCas
 
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
     }
 
     public function provideConfigFilePath(): string

--- a/rules-tests/Composer/Rector/ChangePackageVersionComposerRector/ChangePackageVersionComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/ChangePackageVersionComposerRector/ChangePackageVersionComposerRectorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Tests\Composer\Rector\ChangePackageVersionComposerRector;
 
 use Iterator;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ChangePackageVersionComposerRectorTest extends AbstractRectorTestCase

--- a/rules-tests/Composer/Rector/CombinationComposerRector/CombinationComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/CombinationComposerRector/CombinationComposerRectorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Tests\Composer\Rector\CombinationComposerRector;
 
 use Iterator;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class CombinationComposerRectorTest extends AbstractRectorTestCase

--- a/rules-tests/Composer/Rector/CombinationComposerRector/CombinationComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/CombinationComposerRector/CombinationComposerRectorTest.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Composer\Rector\CombinationComposerRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class CombinationComposerRectorTest extends AbstractRectorTestCase
@@ -21,7 +21,7 @@ final class CombinationComposerRectorTest extends AbstractRectorTestCase
 
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
     }
 
     public function provideConfigFilePath(): string

--- a/rules-tests/Composer/Rector/RemovePackageComposerRector/RemovePackageComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/RemovePackageComposerRector/RemovePackageComposerRectorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Tests\Composer\Rector\RemovePackageComposerRector;
 
 use Iterator;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class RemovePackageComposerRectorTest extends AbstractRectorTestCase

--- a/rules-tests/Composer/Rector/RemovePackageComposerRector/RemovePackageComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/RemovePackageComposerRector/RemovePackageComposerRectorTest.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Composer\Rector\RemovePackageComposerRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class RemovePackageComposerRectorTest extends AbstractRectorTestCase
@@ -21,7 +21,7 @@ final class RemovePackageComposerRectorTest extends AbstractRectorTestCase
 
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
     }
 
     public function provideConfigFilePath(): string

--- a/rules-tests/Composer/Rector/ReplacePackageAndVersionComposerRector/ReplacePackageAndVersionComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/ReplacePackageAndVersionComposerRector/ReplacePackageAndVersionComposerRectorTest.php
@@ -6,7 +6,7 @@ namespace Rector\Tests\Composer\Rector\ReplacePackageAndVersionComposerRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ReplacePackageAndVersionComposerRectorTest extends AbstractRectorTestCase
@@ -21,7 +21,7 @@ final class ReplacePackageAndVersionComposerRectorTest extends AbstractRectorTes
 
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
     }
 
     public function provideConfigFilePath(): string

--- a/rules-tests/Composer/Rector/ReplacePackageAndVersionComposerRector/ReplacePackageAndVersionComposerRectorTest.php
+++ b/rules-tests/Composer/Rector/ReplacePackageAndVersionComposerRector/ReplacePackageAndVersionComposerRectorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Tests\Composer\Rector\ReplacePackageAndVersionComposerRector;
 
 use Iterator;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ReplacePackageAndVersionComposerRectorTest extends AbstractRectorTestCase

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -9,11 +9,11 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Use_;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Naming\Naming\UseImportsResolver;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Rector\Testing\PHPUnit\AbstractTestCase;
 use Rector\Testing\TestingParser\TestingParser;
 use Rector\Tests\Naming\Naming\UseImportsResolver\Source\FirstClass;
 use Rector\Tests\Naming\Naming\UseImportsResolver\Source\SecondClass;
-use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class UseImportsResolverTest extends AbstractTestCase

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -13,7 +13,7 @@ use Rector\Testing\PHPUnit\AbstractTestCase;
 use Rector\Testing\TestingParser\TestingParser;
 use Rector\Tests\Naming\Naming\UseImportsResolver\Source\FirstClass;
 use Rector\Tests\Naming\Naming\UseImportsResolver\Source\SecondClass;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class UseImportsResolverTest extends AbstractTestCase
@@ -61,6 +61,6 @@ final class UseImportsResolverTest extends AbstractTestCase
      */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        return FixtureFileFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -238,7 +238,7 @@ CODE_SAMPLE;
             $this->connectParentNodes($refactoredNode);
         }
 
-        /** @var MutatingScope $currentScope */
+        /** @var MutatingScope|null $currentScope */
         $currentScope = $originalNode->getAttribute(AttributeKey::SCOPE);
         $this->changedNodeScopeRefresher->refresh($refactoredNode, $currentScope, $this->file->getSmartFileInfo());
 

--- a/tests/NonPhpFile/Rector/RenameClassNonPhpRector/RenameClassNonPhpRectorTest.php
+++ b/tests/NonPhpFile/Rector/RenameClassNonPhpRector/RenameClassNonPhpRectorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Core\Tests\NonPhpFile\Rector\RenameClassNonPhpRector;
 
 use Iterator;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class RenameClassNonPhpRectorTest extends AbstractRectorTestCase

--- a/tests/NonPhpFile/Rector/RenameClassNonPhpRector/RenameClassNonPhpRectorTest.php
+++ b/tests/NonPhpFile/Rector/RenameClassNonPhpRector/RenameClassNonPhpRectorTest.php
@@ -6,7 +6,7 @@ namespace Rector\Core\Tests\NonPhpFile\Rector\RenameClassNonPhpRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Rector\Testing\Fixture\FixtureFileFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class RenameClassNonPhpRectorTest extends AbstractRectorTestCase
@@ -24,7 +24,7 @@ final class RenameClassNonPhpRectorTest extends AbstractRectorTestCase
      */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*');
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*');
     }
 
     public function provideConfigFilePath(): string


### PR DESCRIPTION
@TomasVotruba PR for easy-testing removal:

- https://github.com/rectorphp/rector-src/pull/2858

cause error on other PR after merged:

```bash

There were 8 errors:

1) Error
The data provider specified for Rector\Tests\Naming\Naming\UseImportsResolver\UseImportsResolverTest::testUsesFromProperty is invalid.
Error: Class "Symplify\EasyTesting\DataProvider\StaticFixtureFinder" not found
/home/runner/work/rector-src/rector-src/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php:64
```

This PR update class reference to new one and remove seems unneded `StaticFixtureUpdater` in `AbstractRectorTestCase`.