### PR TITLE
Add failing test fixture for SplitDoubleAssignRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Assign/SplitDoubleAssignRector/Fixture/demo_file.php.inc
+++ b/rules-tests/CodingStyle/Rector/Assign/SplitDoubleAssignRector/Fixture/demo_file.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Assign\SplitDoubleAssignRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        $foo = $bar = $hello = $world = '';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Assign\SplitDoubleAssignRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        $foo = '';
+        $bar = '';
+        $hello = '';
+        $world = '';
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for SplitDoubleAssignRector

Based on https://getrector.org/demo/f7492463-ead4-44b9-bdd0-454b1811cf7e

For https://github.com/rectorphp/rector/issues/7435