### PR TITLE
Add failing test fixture for SplitDoubleAssignRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Assign/SplitDoubleAssignRector/Fixture/demo_file.php.inc
+++ b/rules-tests/CodingStyle/Rector/Assign/SplitDoubleAssignRector/Fixture/demo_file.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Assign\SplitDoubleAssignRector\Fixture;
+
+final class DemoFile
+{
+	public function run( $x )
+	{
+		$a = get_a();
+
+		if ( strpos( $a, ', ' ) !== false ) {
+			$b = $x . ' hello';
+		} else {
+			$as = explode( ':', $a );
+			if ( isset( $as[1] ) ) {
+				$b = $x . ' ' . $as[1];
+			} else {
+				$b = $x . ' ' . $a;
+			}
+		}
+
+		return $b;
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Assign\SplitDoubleAssignRector\Fixture;
+
+final class DemoFile
+{
+	public function run( $x )
+	{
+		$a = get_a();
+
+		if ( strpos( $a, ', ' ) !== false ) {
+			return $x . ' hello';
+		} else {
+			$as = explode( ':', $a );
+			return isset( $as[1] ) ? $x . ' ' . $as[1] : $x . ' ' . $a;
+		}
+	}
+}
+
+?>


### PR DESCRIPTION
# Failing Test for SplitDoubleAssignRector

Based on https://getrector.org/demo/bb6e5f3f-08c4-4b4b-bfe9-56335d7276ec

Expected is a suggestion. Atm I get a fatal error when running these 2 rules together with this code. Which was reproducable on "demo", but suddenly the fatal is gone. Probably you changed somethign internally. Anyway, the code isn't changed as expected.