### PR TITLE
[Scoped] Clean up SmartFileInfo

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -23,12 +23,4 @@ spl_autoload_register(function (string $class): void {
             $composerAutoloader->loadClass($class);
         }
     }
-
-    // @deprecated, to be removed
-    if ($class === 'Symplify\SmartFileSystem\SmartFileInfo') {
-        $filePath = __DIR__ . '/vendor/symplify/smart-file-system/src/SmartFileInfo.php';
-        if (file_exists($filePath)) {
-            require_once $filePath;
-        }
-    }
 });

--- a/packages/Testing/Fixture/FixtureFileFinder.php
+++ b/packages/Testing/Fixture/FixtureFileFinder.php
@@ -7,7 +7,6 @@ namespace Rector\Testing\Fixture;
 use Iterator;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class FixtureFileFinder
 {
@@ -20,20 +19,6 @@ final class FixtureFileFinder
 
         foreach ($fileInfos as $fileInfo) {
             yield [$fileInfo->getRealPath()];
-        }
-    }
-
-    /**
-     * @deprecated
-     */
-    public static function yieldDirectory(string $directory, string $suffix = '*.php.inc'): Iterator
-    {
-        $fileInfos = self::findFilesInDirectory($directory, $suffix);
-
-        foreach ($fileInfos as $fileInfo) {
-            // @todo is this one needed? maybe symfony is good enough :)
-            $smartFileInfo = new SmartFileInfo($fileInfo->getRealPath());
-            yield [$smartFileInfo];
         }
     }
 

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -25,7 +25,6 @@ use Rector\Testing\Fixture\FixtureFileUpdater;
 use Rector\Testing\Fixture\FixtureSplitter;
 use Rector\Testing\Fixture\FixtureTempFileDumper;
 use Rector\Testing\PHPUnit\Behavior\MovingFilesTrait;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 abstract class AbstractRectorTestCase extends AbstractTestCase implements RectorTestInterface
 {
@@ -126,15 +125,6 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
         $this->originalTempFilePath = $inputFilePath;
 
         $this->doTestFileMatchesExpectedContent($inputFilePath, $expectedFilePath, $fixtureFilePath);
-    }
-
-    /**
-     * @deprecated Use doTestFile() with file path instead
-     */
-    protected function doTestFileInfo(SmartFileInfo $fixtureFileInfo): void
-    {
-        $fixtureFileRealPath = $fixtureFileInfo->getRealPath();
-        $this->doTestFile($fixtureFileRealPath);
     }
 
     protected function getFixtureTempDirectory(): string

--- a/scoper.php
+++ b/scoper.php
@@ -61,9 +61,7 @@ return [
     ],
 
     // expose
-    'expose-classes' => [
-        'Normalizer',
-    ],
+    'expose-classes' => ['Normalizer'],
     'expose-functions' => ['u', 'b', 's', 'trigger_deprecation'],
     'expose-constants' => ['__RECTOR_RUNNING__', '#^SYMFONY\_[\p{L}_]+$#'],
 

--- a/scoper.php
+++ b/scoper.php
@@ -63,9 +63,6 @@ return [
     // expose
     'expose-classes' => [
         'Normalizer',
-        // used by public API
-        // @deprecated, to be removed
-        'Symplify\SmartFileSystem\SmartFileInfo',
     ],
     'expose-functions' => ['u', 'b', 's', 'trigger_deprecation'],
     'expose-constants' => ['__RECTOR_RUNNING__', '#^SYMFONY\_[\p{L}_]+$#'],
@@ -76,14 +73,6 @@ return [
             sprintf('use %s\PhpParser;', $prefix),
             'use PhpParser;',
             $content
-        ),
-
-        // @deprecated - to be removed
-        // unprefixed SmartFileInfo - needed in AbstractTestCase
-        static fn (string $filePath, string $prefix, string $content): string => Strings::replace(
-            $content,
-            '#' . $prefix . '\\\\Symplify\\\\SmartFileSystem\\\\SmartFileInfo#',
-            'Symplify\SmartFileSystem\SmartFileInfo'
         ),
 
         static function (string $filePath, string $prefix, string $content): string {


### PR DESCRIPTION
SmartFileInfo class no longer exists on scoped vendor:

https://github.com/rectorphp/rector/tree/6d11119b512d67880786243031f116efae87477e/vendor/symplify

so I think it should be removed. 

- remove class `Symplify\SmartFileSystem\SmartFileInfo` reference
- remove method using it as no longer working, provide deprecated method is no use of it.