### PR TITLE
Add failing test fixture for RemoveAlwaysElseRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/demo_file.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/demo_file.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    { ?>
+        <div>
+            hello
+        </div>
+        <?php
+        if ( rand( 0, 5 ) > 2 ) {
+            return;
+        } else {
+            this is <?php echo "hello"; ?> world
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+final class DemoFile
+{
+    public function run()
+    { ?>
+        <div>
+            hello
+        </div>
+        <?php
+        if ( rand( 0, 5 ) > 2 ) {
+            return;
+        }
+        this is <?php echo "hello"; ?> world
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for RemoveAlwaysElseRector

Based on https://getrector.org/demo/e19b5dec-5f62-40b9-87b3-5a599a96b20d

Works correctly if no closing PHP tags are used: https://getrector.org/demo/2ed98e86-cc53-4aa9-90bf-82b6b286217e