### PR TITLE
[Php55] Skip StringClassNameToClassConstantRector on case insensitive

### DIFF
--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/skip_class_name_case_insensitive.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/skip_class_name_case_insensitive.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
+
+final class SkipClassNameCaseInsensitive
+{
+    public function run()
+    {
+        return 'STDCLASS';
+    }
+}

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -144,6 +144,11 @@ CODE_SAMPLE
             return true;
         }
 
+        $classReflection = $this->reflectionProvider->getClass($classLikeName);
+        if ($classReflection->getName() !== $classLikeName) {
+            return true;
+        }
+
         // possibly string
         if (ctype_lower($classLikeName[0])) {
             return true;


### PR DESCRIPTION
The following code should be skipped:

```php
final class SkipClassNameCaseInsensitive
{
    public function run()
    {
        return 'STDCLASS';
    }
}
```

as the resolved class name is `stdClass`, not `STDCLASS`.