### PR TITLE
[CodeQuality] Skip static::class on InlineConstructorDefaultToPropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_static_class_const_fetch.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_static_class_const_fetch.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class SkipStaticClassConstFetch
+{
+    private $name;
+
+    public function __construct()
+    {
+        $this->name = static::class;
+    }
+}

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
@@ -84,15 +85,20 @@ final class ExprAnalyzer
         if ($expr instanceof ConstFetch) {
             return true;
         }
-        if (! $expr->class instanceof Name) {
+
+        if ($expr instanceof ClassConstFetch) {
+            if (! $expr->class instanceof Name) {
+                return false;
+            }
+
+            if (! $expr->name instanceof Identifier) {
+                return false;
+            }
+
             // static::class cannot be used for compile-time class name resolution
             return $expr->class->toString() !== ObjectReference::STATIC;
         }
-        if (! $expr->name instanceof Identifier) {
-            // static::class cannot be used for compile-time class name resolution
-            return $expr->class->toString() !== ObjectReference::STATIC;
-        }
-        // static::class cannot be used for compile-time class name resolution
-        return $expr->class->toString() !== ObjectReference::STATIC;
+
+        return false;
     }
 }

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -95,6 +95,10 @@ final class ExprAnalyzer
                 return false;
             }
 
+            if ($expr->name->toString() !== 'class') {
+                return true;
+            }
+
             // static::class cannot be used for compile-time class name resolution
             return $expr->class->toString() !== ObjectReference::STATIC;
         }

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\Encapsed;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Core\Enum\ObjectReference;
 use Rector\Core\NodeManipulator\ArrayManipulator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -88,7 +89,7 @@ final class ExprAnalyzer
         if ($expr instanceof ClassConstFetch) {
             if ($expr->class instanceof Name && $expr->name instanceof Identifier) {
                 // static::class cannot be used for compile-time class name resolution
-                return $expr->class->toString() !== 'static';
+                return $expr->class->toString() !== ObjectReference::STATIC;
             }
         }
 

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -6,7 +6,6 @@ namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
@@ -85,14 +84,15 @@ final class ExprAnalyzer
         if ($expr instanceof ConstFetch) {
             return true;
         }
-
-        if ($expr instanceof ClassConstFetch) {
-            if ($expr->class instanceof Name && $expr->name instanceof Identifier) {
-                // static::class cannot be used for compile-time class name resolution
-                return $expr->class->toString() !== ObjectReference::STATIC;
-            }
+        if (! $expr->class instanceof Name) {
+            // static::class cannot be used for compile-time class name resolution
+            return $expr->class->toString() !== ObjectReference::STATIC;
         }
-
-        return false;
+        if (! $expr->name instanceof Identifier) {
+            // static::class cannot be used for compile-time class name resolution
+            return $expr->class->toString() !== ObjectReference::STATIC;
+        }
+        // static::class cannot be used for compile-time class name resolution
+        return $expr->class->toString() !== ObjectReference::STATIC;
     }
 }

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -86,7 +86,10 @@ final class ExprAnalyzer
         }
 
         if ($expr instanceof ClassConstFetch) {
-            return $expr->class instanceof Name && $expr->name instanceof Identifier;
+            if ($expr->class instanceof Name && $expr->name instanceof Identifier) {
+                // static::class cannot be used for compile-time class name resolution
+                return $expr->class->toString() !== 'static';
+            }
         }
 
         return false;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7415