### PR TITLE
[Php74] Skip Nested ternary parenthesized multiline on ParenthesizeNestedTernaryRector

### DIFF
--- a/rules-tests/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector/Fixture/skip_nested_ternary_parenthesized_multiline.php.inc
+++ b/rules-tests/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector/Fixture/skip_nested_ternary_parenthesized_multiline.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Ternary\ParenthesizeNestedTernaryRector\Fixture;
+
+function SkipNestedTernaryParenthesizedIf()
+{
+    is_dir('app')
+        ? 'app'
+        : (is_dir('vendor/app')
+            ? 'vendor/app'
+            : 'vendor/alternative');
+}

--- a/rules-tests/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector/Fixture/skip_nested_ternary_parenthesized_multiline.php.inc
+++ b/rules-tests/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector/Fixture/skip_nested_ternary_parenthesized_multiline.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php74\Rector\Ternary\ParenthesizeNestedTernaryRector\Fixture;
 
-function SkipNestedTernaryParenthesizedIf()
+function SkipNestedTernaryParenthesizedMultiline()
 {
     is_dir('app')
         ? 'app'

--- a/rules/Php74/Tokenizer/ParenthesizedNestedTernaryAnalyzer.php
+++ b/rules/Php74/Tokenizer/ParenthesizedNestedTernaryAnalyzer.php
@@ -13,7 +13,11 @@ final class ParenthesizedNestedTernaryAnalyzer
     {
         $oldTokens = $file->getOldTokens();
         $startTokenPos = $ternary->getStartTokenPos();
+        $endTokenPos = $ternary->getEndTokenPos();
 
-        return isset($oldTokens[$startTokenPos]) && $oldTokens[$startTokenPos] === '(';
+        $hasOpenParentheses = isset($oldTokens[$startTokenPos]) && $oldTokens[$startTokenPos] === '(';
+        $hasCloseParentheses = isset($oldTokens[$endTokenPos]) && $oldTokens[$endTokenPos] === ')';
+
+        return $hasOpenParentheses || $hasCloseParentheses;
     }
 }


### PR DESCRIPTION
The following code should be skipped as else as ternary multiline already open and closed with parentheses.

```php
function SkipNestedTernaryParenthesizedMultiline()
{
    is_dir('app')
        ? 'app'
        : (is_dir('vendor/app')
            ? 'vendor/app'
            : 'vendor/alternative');
}
```