### PR TITLE
Add failing test fixture for RemoveDeadReturnRector

### DIFF
--- a/rules-tests/DeadCode/Rector/FunctionLike/RemoveDeadReturnRector/Fixture/demo_file.php.inc
+++ b/rules-tests/DeadCode/Rector/FunctionLike/RemoveDeadReturnRector/Fixture/demo_file.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\FunctionLike\RemoveDeadReturnRector\Fixture;
+
+final class DemoFile
+{
+	public function run()
+	{ ?>
+		<div>
+			hello world	
+		</div>
+		<?php
+		return;
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\FunctionLike\RemoveDeadReturnRector\Fixture;
+
+final class DemoFile
+{
+	public function run()
+	{ ?>
+		<div>
+			hello world	
+		</div>
+		<?php
+	}
+}
+
+?>


### PR DESCRIPTION
# Failing Test for RemoveDeadReturnRector

Based on https://getrector.org/demo/38caa690-bf47-405c-af7c-bad1e6d166aa

Exactly the same issue also for \Rector\DeadCode\Rector\ClassMethod\RemoveLastReturnRector::class - do you need a separate test PR for it? (bc it's really exactly the same test code)