### PR TITLE
[Down_To_PHP71] Handle both parent and child typed for trailing comma downgrade on DowngradeLevelSetList::DOWN_TO_PHP_71

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -109,8 +109,9 @@ final class RectifiedAnalyzer
     ): bool {
         /** @var class-string<RectorInterface>[] $createdByRule */
         $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-        if (count($createdByRule) !== 1) {
-            return false;
+        $countCreatedByRule = count($createdByRule);
+        if ($countCreatedByRule !== 1) {
+            return $countCreatedByRule !== 0;
         }
 
         // different rule, allowed

--- a/tests/Issues/IssueDowngradeParamType/FixtureDownToPhp71/both_parent_child_typed.php.inc
+++ b/tests/Issues/IssueDowngradeParamType/FixtureDownToPhp71/both_parent_child_typed.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeParamType\FixtureDownToPhp71;
+
+class ParentClassTyped
+{
+    public function resolveValue(object $object,): mixed
+    {
+        return true;
+    }
+}
+
+class ChildClassTyped extends ParentClassTyped
+{
+    public function resolveValue(object $object,): mixed
+    {
+        return false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeParamType\FixtureDownToPhp71;
+
+class ParentClassTyped
+{
+    /**
+     * @return mixed
+     * @param object $object
+     */
+    public function resolveValue($object)
+    {
+        return true;
+    }
+}
+
+class ChildClassTyped extends ParentClassTyped
+{
+    /**
+     * @return mixed
+     * @param object $object
+     */
+    public function resolveValue($object)
+    {
+        return false;
+    }
+}
+
+?>

--- a/tests/Issues/IssueDowngradeParamType/FixtureDownToPhp71/fixture.php.inc
+++ b/tests/Issues/IssueDowngradeParamType/FixtureDownToPhp71/fixture.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeParamType\Fixture;
+
+class ParentClass
+{
+    public function execute(string $param,): void
+    {
+    }
+}
+
+class ChildClass extends ParentClass
+{
+    public function execute($param): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueDowngradeParamType\Fixture;
+
+class ParentClass
+{
+    /**
+     * @param string $param
+     */
+    public function execute($param): void
+    {
+    }
+}
+
+class ChildClass extends ParentClass
+{
+    public function execute($param): void
+    {
+    }
+}
+
+?>

--- a/tests/Issues/IssueDowngradeParamType/IssueDowngradeParamTypeToPhp71Test.php
+++ b/tests/Issues/IssueDowngradeParamType/IssueDowngradeParamTypeToPhp71Test.php
@@ -22,7 +22,7 @@ final class IssueDowngradeParamTypeToPhp71Test extends AbstractRectorTestCase
      */
     public function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureDownToPhp71');
     }
 
     public function provideConfigFilePath(): string


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7452