### PR TITLE
[tests] Docblock is not parsed when preceeded by annotation

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/entity_with_attribute_above.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/entity_with_attribute_above.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Symfony;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Annotation\OpenApi\PastAnnotation;
+
+#[ORM\Entity]
+/**
+ * @PastAnnotation
+ */
+final class EntityWithAttributeAbove
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Symfony;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Annotation\OpenApi\FutureAttribute;
+
+#[ORM\Entity]
+#[FutureAttribute]
+final class EntityWithAttributeAbove
+{
+}
+
+?>


### PR DESCRIPTION
Test for https://github.com/rectorphp/rector/issues/7453

Seems like bug in php-parser: https://github.com/nikic/PHP-Parser/pull/887