### PR TITLE
Add test for fully qualified name usage.

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/full_qualified_name_usage.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/full_qualified_name_usage.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+class FullQualifiedNameUsage
+{
+    /** @var \Magento\Checkout\Model\Session */
+    protected $checkoutSession;
+
+    /**
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     */
+    public function __construct(\Magento\Checkout\Model\Session $checkoutSession)
+    {
+        $this->checkoutSession = $checkoutSession;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+class FullQualifiedNameUsage
+{
+    /** @var \Magento\Checkout\Model\Session */
+    protected \Magento\Checkout\Model\Session $checkoutSession;
+
+    /**
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     */
+    public function __construct(\Magento\Checkout\Model\Session $checkoutSession)
+    {
+        $this->checkoutSession = $checkoutSession;
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for TypedPropertyFromStrictConstructorRector

Based on https://getrector.org/demo/7dd941f8-eecf-4b50-ab62-fe2f2f1195bc