### PR TITLE
Skip first class callables in NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipFirstClassCallable
+{
+    public function run()
+    {
+        array_map(trim(...), [' ']);
+    }
+}

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -500,6 +500,6 @@ CODE_SAMPLE
     private function shouldSkip(FuncCall $funcCall): bool
     {
         $functionNames = array_keys(self::ARG_POSITION_NAME_NULL_TO_STRICT_STRING);
-        return ! $this->nodeNameResolver->isNames($funcCall, $functionNames);
+        return ! $this->nodeNameResolver->isNames($funcCall, $functionNames) || $funcCall->isFirstClassCallable();
     }
 }


### PR DESCRIPTION
Without skipping first class callables, the included test fails:

```
1) Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\NullToStrictStringFuncCallArgRectorTest::test with data set #6 ('./rec...hp.inc')
assert(!$this->isFirstClassCallable()) in ./rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:36

Caused by
AssertionError: assert(!$this->isFirstClassCallable()) in ./rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:36
Stack trace:
#0 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php(36): assert(false, 'assert(!$this->...')
#1 ./rector-src/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php(331): PhpParser\Node\Expr\CallLike->getArgs()
#2 ./rector-src/src/Rector/AbstractRector.php(203): Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector->refactor(Object(PhpParser\Node\Expr\FuncCall))
#3 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(123): Rector\Core\Rector\AbstractRector->enterNode(Object(PhpParser\Node\Expr\FuncCall))
#4 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Arg))
#5 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#6 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(146): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Expr\FuncCall))
#7 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Expression))
#8 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#9 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\ClassMethod))
#10 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#11 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Class_))
#12 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#13 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))
#14 ./rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(91): PhpParser\NodeTraverser->traverseArray(Array)
#15 ./rector-src/src/PhpParser/NodeTraverser/RectorNodeTraverser.php(33): PhpParser\NodeTraverser->traverse(Array)
#16 ./rector-src/src/Application/FileProcessor.php(41): Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser->traverse(Array)
#17 ./rector-src/src/Application/FileProcessor/PhpFileProcessor.php(105): Rector\Core\Application\FileProcessor->refactor(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#18 ./rector-src/src/Application/FileProcessor/PhpFileProcessor.php(64): Rector\Core\Application\FileProcessor\PhpFileProcessor->refactorNodesWithRectors(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#19 ./rector-src/src/Application/ApplicationFileProcessor.php(127): Rector\Core\Application\FileProcessor\PhpFileProcessor->process(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#20 ./rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php(204): Rector\Core\Application\ApplicationFileProcessor->processFiles(Array, Object(Rector\Core\ValueObject\Configuration))
#21 ./rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php(171): Rector\Testing\PHPUnit\AbstractRectorTestCase->processFilePath('/var/folders/km...')
#22 ./rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php(119): Rector\Testing\PHPUnit\AbstractRectorTestCase->doTestFileMatchesExpectedContent('/var/folders/km...', '/var/folders/km...', '...')
#23 ./rector-src/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/NullToStrictStringFuncCallArgRectorTest.php(17): Rector\Testing\PHPUnit\AbstractRectorTestCase->doTestFile('...')
#24 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestCase.php(1545): Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\NullToStrictStringFuncCallArgRectorTest->test('...')
#25 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestCase.php(1151): PHPUnit\Framework\TestCase->runTest()
#26 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestResult.php(726): PHPUnit\Framework\TestCase->runBare()
#27 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestCase.php(903): PHPUnit\Framework\TestResult->run(Object(Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\NullToStrictStringFuncCallArgRectorTest))
#28 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestSuite.php(672): PHPUnit\Framework\TestCase->run(Object(PHPUnit\Framework\TestResult))
#29 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestSuite.php(672): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#30 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestSuite.php(672): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#31 ./rector-src/vendor/phpunit/phpunit/src/Framework/TestSuite.php(672): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#32 ./rector-src/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(673): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#33 ./rector-src/vendor/phpunit/phpunit/src/TextUI/Command.php(143): PHPUnit\TextUI\TestRunner->run(Object(PHPUnit\Framework\TestSuite), Array, Array, true)
#34 ./rector-src/vendor/phpunit/phpunit/src/TextUI/Command.php(96): PHPUnit\TextUI\Command->run(Array, true)
#35 ./rector-src/vendor/phpunit/phpunit/phpunit(98): PHPUnit\TextUI\Command::main()
#36 {main}
```