### PR TITLE
Add failing test fixture for VarAnnotationIncorrectNullableRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/demo_file.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/VarAnnotationIncorrectNullableRector/Fixture/demo_file.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class DemoFile
+{
+    /** @var \Closure(string): string */
+    private ?\Closure $tooltipGenerator = null;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\VarAnnotationIncorrectNullableRector\Fixture;
+
+final class DemoFile
+{
+    /** @var null|\Closure(string): string */
+    private ?\Closure $tooltipGenerator = null;
+}
+
+?>


### PR DESCRIPTION
# Failing Test for VarAnnotationIncorrectNullableRector

Based on https://getrector.org/demo/25f9ff22-7f69-4361-aa48-50b3156fab73

In nutshell: `VarAnnotationIncorrectNullableRector` removes parameters info from Closure


The controversial part: usually `null` type added to the end of possible types list, but in case of callable types it makes PHPDoc less readable:
```php
/** @var null|\Closure(string): string */

/** @var (\Closure(string): string) | null */

// or even worse and more ambiguous:
/** @var \Closure(string): string|null */

```