### PR TITLE
Add failing test fixture for RenameVariableToMatchMethodCallReturnTyp…

### DIFF
--- a/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/demo_file.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @var Redis
+     */
+    public static $foo_bar;
+    public function run()
+    {
+        $lala = self::$foo_bar->multi();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @var Redis
+     */
+    public static $foo_bar;
+    public function run()
+    {
+        $multi = self::$foo_bar->multi();
+    }
+}
+
+?>


### PR DESCRIPTION
…eRector

# Failing Test for RenameVariableToMatchMethodCallReturnTypeRector

Based on https://getrector.org/demo/800125b7-433e-4d5d-a0df-26b2d8309f66

Not sure about the right "name" of the variable here.
Strangely enough: when you use anything else but "Redis" (e.g. "Chicken") it doesn't rename at all? Does it need a separate test for this?