### PR TITLE
Add failing test fixture for RemoveDeadStmtRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRector/Fixture/demo_file.php.inc
+++ b/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRector/Fixture/demo_file.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Expression\RemoveDeadStmtRector\Fixture;
+
+final class DemoFile
+{
+	public $a = 0;
+
+	public $b = 0;
+
+	public function run() { ?>
+			<strong>A:</strong> <?php $this->a; ?><br>
+			<strong>B:</strong> <?php $this->b; ?><br>
+	<?php }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for RemoveDeadStmtRector

Based on https://getrector.org/demo/a0eea85b-e17c-4bd5-851f-ba654335e096

Not sure if no change at all in this case or it should be removed. Ideally it would give an error, but that's not an option with rector. So I guess completely removing it maybe without leaving broken code?