### PR TITLE
Add failing test fixture for RenameNamespaceRector

### DIFF
--- a/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/namespace_part_of_class_name.php.inc
+++ b/rules-tests/Renaming/Rector/Namespace_/RenameNamespaceRector/Fixture/namespace_part_of_class_name.php.inc
@@ -1,0 +1,67 @@
+<?php
+
+namespace OldNamespace;
+
+class OldNamespace
+{
+    private bool $isInitialized = false;
+    
+    public function __construct()
+    {
+        $this->isInitialized = true;
+    }
+}
+
+namespace MyDifferent\OtherNamespace;
+
+use OldNamespace\OldNamespace;
+
+class MyClassFactory
+{
+    public function createInstanceFromFullQualifiedClassName(): \OldNamespace\OldNamespace
+    {
+        return new \OldNamespace\OldNamespace();
+    }
+
+    public function createInstanceFromImportedName(): OldNamespace
+    {
+        return new OldNamespace();
+    }
+}
+
+
+?>
+-----
+<?php
+
+namespace NewNamespace;
+
+class OldNamespace
+{
+    private bool $isInitialized = false;
+    
+    public function __construct()
+    {
+        $this->isInitialized = true;
+    }
+}
+
+namespace MyDifferent\OtherNamespace;
+
+use NewNamespace\OldNamespace;
+
+class MyClassFactory
+{
+    public function createInstanceFromFullQualifiedClassName(): \NewNamespace\OldNamespace
+    {
+        return new \NewNamespace\OldNamespace();
+    }
+
+    public function createInstanceFromImportedName(): \NewNamespace\OldNamespace
+    {
+        return new \NewNamespace\OldNamespace();
+    }
+}
+
+
+?>


### PR DESCRIPTION
# Failing Test for RenameNamespaceRector

Based on https://getrector.org/demo/2b0021b2-3080-449a-95b8-01084ba16c8c

The RenameNamespaceRector doesn't work as I would expect it. Discovered this when I tried to rename a namespace in an legacy Symfony 3.4 app having many bundles like `MyLegacySymfonyBundle\MyLegacySymfonyBundle` in `src/MyLegacySymfonyBundle/MyLegacySymfonyBundle.php`