### PR TITLE
[Php80] Handle crash on Nested Annotation to Attribute setting PhpVersion::PHP_80 (initializer - 1)

### DIFF
--- a/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
@@ -41,7 +41,7 @@ final class ArrayItemNodeAnnotationToAttributeMapper implements AnnotationToAttr
     {
         $valueExpr = $this->annotationToAttributeMapper->map($arrayItemNode->value);
 
-        if (is_string($valueExpr) && $valueExpr == DocTagNodeState::REMOVE_ARRAY) {
+        if (is_string($valueExpr) && $valueExpr === DocTagNodeState::REMOVE_ARRAY) {
             return new ArrayItem(new String_($valueExpr), null);
         }
 

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Scalar\String_;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\PhpAttribute\AnnotationToAttributeMapper;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
+use Rector\PhpAttribute\Enum\DocTagNodeState;
 use Symfony\Contracts\Service\Attribute\Required;
 
 /**
@@ -39,6 +40,10 @@ final class ArrayItemNodeAnnotationToAttributeMapper implements AnnotationToAttr
     public function map($arrayItemNode): Expr
     {
         $valueExpr = $this->annotationToAttributeMapper->map($arrayItemNode->value);
+
+        if (is_string($valueExpr) && $valueExpr == DocTagNodeState::REMOVE_ARRAY) {
+            return new ArrayItem(new String_($valueExpr), null);
+        }
 
         if ($arrayItemNode->key !== null) {
             $keyValue = match ($arrayItemNode->kindKeyQuoted) {

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
@@ -41,7 +41,7 @@ final class ArrayItemNodeAnnotationToAttributeMapper implements AnnotationToAttr
     {
         $valueExpr = $this->annotationToAttributeMapper->map($arrayItemNode->value);
 
-        if (is_string($valueExpr) && $valueExpr === DocTagNodeState::REMOVE_ARRAY) {
+        if ($valueExpr === DocTagNodeState::REMOVE_ARRAY) {
             return new ArrayItem(new String_($valueExpr), null);
         }
 

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp80Nested/skip_nested_in_php80.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp80Nested/skip_nested_in_php80.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixturePhp81;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\SourcePhp81 as Assert;
+
+final class SkipNestedInPhp80
+{
+    public const DEFAULT_ITEMS_FILTER = ProductCriteria::FILTER_ITEMS_ALL;
+
+    /**
+     * @Assert\All({
+     *     @Assert\Uuid()
+     * })
+     */
+    public array $selected = [];
+
+    #[Assert\Type('string'), Assert\Choice(ProductCriteria::ALLOWED_FILTER_ITEMS)]
+    public string $filterItems = self::DEFAULT_ITEMS_FILTER;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp80Nested/skip_nested_in_php80.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp80Nested/skip_nested_in_php80.php.inc
@@ -13,5 +13,3 @@ final class SkipNestedInPhp80
      */
     public array $selected = [];
 }
-
-?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp80Nested/skip_nested_in_php80.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixturePhp80Nested/skip_nested_in_php80.php.inc
@@ -6,17 +6,12 @@ use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\SourcePhp81 as 
 
 final class SkipNestedInPhp80
 {
-    public const DEFAULT_ITEMS_FILTER = ProductCriteria::FILTER_ITEMS_ALL;
-
     /**
      * @Assert\All({
      *     @Assert\Uuid()
      * })
      */
     public array $selected = [];
-
-    #[Assert\Type('string'), Assert\Choice(ProductCriteria::ALLOWED_FILTER_ITEMS)]
-    public string $filterItems = self::DEFAULT_ITEMS_FILTER;
 }
 
 ?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Php80NestedAttributesRectorTest.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Php80NestedAttributesRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Php80NestedAttributesRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixturePhp80Nested');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/nested_attributes_php80.php';
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/nested_attributes_php80.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/nested_attributes_php80.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\SourcePhp81\All;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->phpVersion(PhpVersionFeature::NEW_INITIALIZERS - 1);
+
+    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+        new AnnotationToAttribute(All::class),
+    ]);
+};

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\Php80\NodeAnalyzer;
 
+use PhpParser\Node\Arg;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Param;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -12,6 +17,7 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\PhpAttribute\Enum\DocTagNodeState;
 
 final class PhpAttributeAnalyzer
 {
@@ -71,6 +77,48 @@ final class PhpAttributeAnalyzer
         foreach ($attributeClasses as $attributeClass) {
             if ($this->hasPhpAttribute($node, $attributeClass)) {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param AttributeGroup[] $attributeGroups
+     */
+    public function hasRemoveArrayState(array $attributeGroups): bool
+    {
+        foreach ($attributeGroups as $attributeGroup) {
+            foreach ($attributeGroup->attrs as $attribute) {
+                $args = $attribute->args;
+
+                if ($this->hasArgWithRemoveArrayValue($args)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Arg[] $args
+     */
+    private function hasArgWithRemoveArrayValue(array $args): bool
+    {
+        foreach ($args as $arg) {
+            if (! $arg->value instanceof Array_) {
+                continue;
+            }
+
+            foreach ($arg->value->items as $item) {
+                if (! $item instanceof ArrayItem) {
+                    continue;
+                }
+
+                if ($item->value instanceof String_ && $item->value->value === DocTagNodeState::REMOVE_ARRAY) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
Given the following code:

```php
final class SkipNestedInPhp80
{
    /**
     * @Assert\All({
     *     @Assert\Uuid()
     * })
     */
    public array $selected = [];
}
```

with set config for `PhpVersionFeature::NEW_INITIALIZERS - 1` or `Phpversion::PHP_80`

```php
return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->phpVersion(PhpVersionFeature::NEW_INITIALIZERS - 1);

    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
        new AnnotationToAttribute(All::class),
    ]);
};
```

It currently cause crash:

```bash
There was 1 error:

1) Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Php80NestedAttributesRectorTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
TypeError: PhpParser\Node\Expr\ArrayItem::__construct(): Argument #1 ($value) must be of type PhpParser\Node\Expr, string given, called in /Users/samsonasik/www/rector-src/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php on line 63
```

Fixes https://github.com/rectorphp/rector/issues/7480