### PR TITLE
[Visibility] Does not turn abstraction into static from implicit public abstractions in ExplicitPublicClassMethodRector (#7483)

### DIFF
--- a/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture.php.inc
+++ b/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture.php.inc
@@ -1,5 +1,32 @@
 <?php
 
+abstract class SomeAbstractClass
+{
+    abstract function noExplicitVis();
+
+    abstract public function publicVis();
+
+    abstract protected function protectedVis();
+
+    abstract private function privateVis();
+
+    static function noExplicitVisStatic()
+    {
+    }
+
+    public static function publicVisStatic()
+    {
+    }
+    
+    protected static function protectedVisStatic()
+    {
+    }
+    
+    private static function privateVisStatic()
+    {
+    }
+}
+
 class SomeClass
 {
     function noExplicitVis()
@@ -9,6 +36,10 @@ class SomeClass
             return $a + $b;
         };
         return $closure;
+    }
+
+    final function noExplicitVisFinal()
+    {
     }
 
     public function publicVis()
@@ -32,6 +63,33 @@ function notInScope()
 -----
 <?php
 
+abstract class SomeAbstractClass
+{
+    abstract public function noExplicitVis();
+
+    abstract public function publicVis();
+
+    abstract protected function protectedVis();
+
+    abstract private function privateVis();
+
+    public static function noExplicitVisStatic()
+    {
+    }
+
+    public static function publicVisStatic()
+    {
+    }
+    
+    protected static function protectedVisStatic()
+    {
+    }
+    
+    private static function privateVisStatic()
+    {
+    }
+}
+
 class SomeClass
 {
     public function noExplicitVis()
@@ -41,6 +99,10 @@ class SomeClass
             return $a + $b;
         };
         return $closure;
+    }
+
+    final public function noExplicitVisFinal()
+    {
     }
 
     public function publicVis()

--- a/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture.php.inc
+++ b/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture.php.inc
@@ -1,32 +1,5 @@
 <?php
 
-abstract class SomeAbstractClass
-{
-    abstract function noExplicitVis();
-
-    abstract public function publicVis();
-
-    abstract protected function protectedVis();
-
-    abstract private function privateVis();
-
-    static function noExplicitVisStatic()
-    {
-    }
-
-    public static function publicVisStatic()
-    {
-    }
-    
-    protected static function protectedVisStatic()
-    {
-    }
-    
-    private static function privateVisStatic()
-    {
-    }
-}
-
 class SomeClass
 {
     function noExplicitVis()
@@ -36,10 +9,6 @@ class SomeClass
             return $a + $b;
         };
         return $closure;
-    }
-
-    final function noExplicitVisFinal()
-    {
     }
 
     public function publicVis()
@@ -63,33 +32,6 @@ function notInScope()
 -----
 <?php
 
-abstract class SomeAbstractClass
-{
-    abstract public function noExplicitVis();
-
-    abstract public function publicVis();
-
-    abstract protected function protectedVis();
-
-    abstract private function privateVis();
-
-    public static function noExplicitVisStatic()
-    {
-    }
-
-    public static function publicVisStatic()
-    {
-    }
-    
-    protected static function protectedVisStatic()
-    {
-    }
-    
-    private static function privateVisStatic()
-    {
-    }
-}
-
 class SomeClass
 {
     public function noExplicitVis()
@@ -99,10 +41,6 @@ class SomeClass
             return $a + $b;
         };
         return $closure;
-    }
-
-    final public function noExplicitVisFinal()
-    {
     }
 
     public function publicVis()

--- a/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture_abstract.php.inc
+++ b/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture_abstract.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+abstract class SomeAbstractClass
+{
+    abstract function noExplicitVis();
+
+    abstract public function publicVis();
+
+    abstract protected function protectedVis();
+
+    abstract private function privateVis();
+
+    static function noExplicitVisStatic()
+    {
+    }
+
+    public static function publicVisStatic()
+    {
+    }
+
+    protected static function protectedVisStatic()
+    {
+    }
+
+    private static function privateVisStatic()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+abstract class SomeAbstractClass
+{
+    abstract public function noExplicitVis();
+
+    abstract public function publicVis();
+
+    abstract protected function protectedVis();
+
+    abstract private function privateVis();
+
+    public static function noExplicitVisStatic()
+    {
+    }
+
+    public static function publicVisStatic()
+    {
+    }
+
+    protected static function protectedVisStatic()
+    {
+    }
+
+    private static function privateVisStatic()
+    {
+    }
+}
+
+?>

--- a/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture_final.php.inc
+++ b/rules-tests/Visibility/Rector/ClassMethod/ExplicitPublicClassMethodRector/Fixture/fixture_final.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+final class SomeFinalClass
+{
+    final function noExplicitVisFinal()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+final class SomeFinalClass
+{
+    final public function noExplicitVisFinal()
+    {
+    }
+}
+
+?>

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -52,7 +52,7 @@ final class VisibilityManipulator
      */
     public function makeNonAbstract(ClassMethod | Property $node): void
     {
-        if (! $node->isAbstract()) {
+        if (!($node instanceof ClassMethod) || ! $node->isAbstract()) {
             return;
         }
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -52,7 +52,7 @@ final class VisibilityManipulator
      */
     public function makeNonAbstract(ClassMethod | Property $node): void
     {
-        if (!($node instanceof ClassMethod) || ! $node->isAbstract()) {
+        if (! $node instanceof ClassMethod || ! $node->isAbstract()) {
             return;
         }
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -30,11 +30,6 @@ final class VisibilityManipulator
         $this->addVisibilityFlag($node, Visibility::STATIC);
     }
 
-    public function makeAbstract(ClassMethod | Class_ $node): void
-    {
-        $this->addVisibilityFlag($node, Visibility::ABSTRACT);
-    }
-
     /**
      * @api
      */
@@ -43,8 +38,25 @@ final class VisibilityManipulator
         if (! $node->isStatic()) {
             return;
         }
-
+        
         $node->flags -= Class_::MODIFIER_STATIC;
+    }
+
+    public function makeAbstract(ClassMethod | Class_ $node): void
+    {
+        $this->addVisibilityFlag($node, Visibility::ABSTRACT);
+    }
+
+    /**
+     * @api
+     */
+    public function makeNonAbstract(ClassMethod | Property $node): void
+    {
+        if (! $node->isAbstract()) {
+            return;
+        }
+
+        $node->flags -= Class_::MODIFIER_ABSTRACT;
     }
 
     public function makeFinal(Class_ | ClassMethod | ClassConst $node): void
@@ -75,6 +87,7 @@ final class VisibilityManipulator
         }
 
         if ($node->isPublic()) {
+            $node->flags |= Class_::MODIFIER_PUBLIC;
             $node->flags -= Class_::MODIFIER_PUBLIC;
         }
 


### PR DESCRIPTION
Incorrect result of the rule ExplicitPublicClassMethodRector

Fixes https://github.com/rectorphp/rector/issues/7483