### PR TITLE
 [Php55] Allow alias name on StringClassNameToClassConstantRector 

### DIFF
--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/use_name_from_alias.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/use_name_from_alias.php.inc
@@ -2,6 +2,7 @@
 
 namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
 
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\Nested\AnotherClass;
 use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
 
 class UseNameFromAlias
@@ -18,6 +19,7 @@ class UseNameFromAlias
 
 namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
 
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\Nested\AnotherClass;
 use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
 
 class UseNameFromAlias

--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/use_name_from_alias.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/use_name_from_alias.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
+
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
+
+class UseNameFromAlias
+{
+    public function run()
+    {
+        return 'Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
+
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
+
+class UseNameFromAlias
+{
+    public function run()
+    {
+        return SomeAlias::class;
+    }
+}
+
+?>

--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/FixtureImport/use_name_from_alias.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/FixtureImport/use_name_from_alias.php.inc
@@ -2,6 +2,7 @@
 
 namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\FixtureImport;
 
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\Nested\AnotherClass;
 use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
 
 class UseNameFromAlias
@@ -18,6 +19,7 @@ class UseNameFromAlias
 
 namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\FixtureImport;
 
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\Nested\AnotherClass;
 use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
 
 class UseNameFromAlias

--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/FixtureImport/use_name_from_alias.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/FixtureImport/use_name_from_alias.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\FixtureImport;
+
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
+
+class UseNameFromAlias
+{
+    public function run()
+    {
+        return 'Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\FixtureImport;
+
+use Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass as SomeAlias;
+
+class UseNameFromAlias
+{
+    public function run()
+    {
+        return SomeAlias::class;
+    }
+}
+
+?>

--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Source/Nested/AnotherClass.php
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Source/Nested/AnotherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\Nested;
+
+final class AnotherClass
+{
+
+}

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -108,23 +108,26 @@ CODE_SAMPLE
             return null;
         }
 
-        $name = new FullyQualified($classLikeName);
+        $fullyQualified = new FullyQualified($classLikeName);
+
+        $name = clone $fullyQualified;
         $name->setAttribute(AttributeKey::PARENT_NODE, $node->getAttribute(AttributeKey::PARENT_NODE));
 
         $aliasName = $this->aliasNameResolver->resolveByName($name);
-        $name = is_string($aliasName)
+
+        $fullyQualifiedOrName = is_string($aliasName)
             ? new Name($aliasName)
-            : $name;
+            : $fullyQualified;
 
         if ($classLikeName !== $node->value) {
             $preSlashCount = strlen($node->value) - strlen($classLikeName);
             $preSlash = str_repeat('\\', $preSlashCount);
             $string = new String_($preSlash);
 
-            return new Concat($string, new ClassConstFetch($name, 'class'));
+            return new Concat($string, new ClassConstFetch($fullyQualifiedOrName, 'class'));
         }
 
-        return new ClassConstFetch($name, 'class');
+        return new ClassConstFetch($fullyQualifiedOrName, 'class');
     }
 
     /**

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
 
         $aliasName = $this->aliasNameResolver->resolveByName($name);
 
-        $fullyQualifiedOrName = is_string($aliasName)
+        $fullyQualifiedOrAliasName = is_string($aliasName)
             ? new Name($aliasName)
             : $fullyQualified;
 
@@ -124,10 +124,10 @@ CODE_SAMPLE
             $preSlash = str_repeat('\\', $preSlashCount);
             $string = new String_($preSlash);
 
-            return new Concat($string, new ClassConstFetch($fullyQualifiedOrName, 'class'));
+            return new Concat($string, new ClassConstFetch($fullyQualifiedOrAliasName, 'class'));
         }
 
-        return new ClassConstFetch($fullyQualifiedOrName, 'class');
+        return new ClassConstFetch($fullyQualifiedOrAliasName, 'class');
     }
 
     /**

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -38,7 +38,7 @@ final class VisibilityManipulator
         if (! $node->isStatic()) {
             return;
         }
-        
+
         $node->flags -= Class_::MODIFIER_STATIC;
     }
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -52,10 +52,12 @@ final class VisibilityManipulator
      */
     public function makeNonAbstract(ClassMethod | Property $node): void
     {
-        if (! $node instanceof ClassMethod || ! $node->isAbstract()) {
+        if (! $node instanceof ClassMethod) {
             return;
         }
-
+        if (! $node->isAbstract()) {
+            return;
+        }
         $node->flags -= Class_::MODIFIER_ABSTRACT;
     }
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -50,7 +50,7 @@ final class VisibilityManipulator
     /**
      * @api
      */
-    public function makeNonAbstract(ClassMethod $node): void
+    public function makeNonAbstract(ClassMethod | Class_ $node): void
     {
         if (! $node->isAbstract()) {
             return;

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -55,9 +55,11 @@ final class VisibilityManipulator
         if (! $node instanceof ClassMethod) {
             return;
         }
+
         if (! $node->isAbstract()) {
             return;
         }
+
         $node->flags -= Class_::MODIFIER_ABSTRACT;
     }
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -50,12 +50,8 @@ final class VisibilityManipulator
     /**
      * @api
      */
-    public function makeNonAbstract(ClassMethod | Property $node): void
+    public function makeNonAbstract(ClassMethod $node): void
     {
-        if (! $node instanceof ClassMethod) {
-            return;
-        }
-
         if (! $node->isAbstract()) {
             return;
         }


### PR DESCRIPTION
Previously, when class string name is in alias in use statement, it apply fully qualified name, even on auto import, see 

https://getrector.org/demo/ef743452-414a-4621-857f-c17bab4915ea

This PR apply alias support on StringClassNameToClassConstantRector, even there is a conflict on use name, it will use the alias name instead.