### PR TITLE
Skip properties with default values for MakeTypedPropertyNullableIfCheckedRector

### DIFF
--- a/rules-tests/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector/Fixture/skip_with_default_value.php.inc
+++ b/rules-tests/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector/Fixture/skip_with_default_value.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Restoration\Rector\Property\MakeTypedPropertyNullableIfCheckedRector\Fixture;
+
+final class SkipWithDefaultValue
+{
+    private bool $isDebugMode = false;
+
+    public function run()
+    {
+        if (!$this->isDebugMode) {
+            $this->isDebugMode = true;
+        }
+    }
+}

--- a/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
+++ b/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
@@ -83,8 +83,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $isPropretyNullChecked = $this->isPropertyNullChecked($onlyProperty);
-        if (! $isPropretyNullChecked) {
+        $isPropertyNullChecked = $this->isPropertyNullChecked($onlyProperty);
+        if (! $isPropertyNullChecked) {
             return null;
         }
 

--- a/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
+++ b/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
@@ -78,6 +78,11 @@ CODE_SAMPLE
         /** @var PropertyProperty $onlyProperty */
         $onlyProperty = $node->props[0];
 
+        //Skip properties with default values
+        if ($onlyProperty->default instanceof Node\Expr) {
+            return null;
+        }
+
         $isPropretyNullChecked = $this->isPropertyNullChecked($onlyProperty);
         if (! $isPropretyNullChecked) {
             return null;


### PR DESCRIPTION
Hi, I try to fix an issue with `MakeTypedPropertyNullableIfCheckedRector` and default values:
https://getrector.org/demo/f3e7962b-cda5-4f6f-9b23-c44c9220e839

I don't know if I have fixed this in the correct way and there are not so many tests for this rule.