### PR TITLE
[AutoImport] Allow auto import to use existing alias in use statement

### DIFF
--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -113,7 +113,10 @@ CODE_SAMPLE
             $aliasName = $this->aliasNameResolver->resolveByName($name);
             $node = $name->getAttribute(AttributeKey::PARENT_NODE);
 
-            if (is_string($aliasName) && ! $node instanceof UseUse && ! $this->hasOtherSameUseStatementWithoutAlias($name, $currentUses)) {
+            if (is_string($aliasName) && ! $node instanceof UseUse && ! $this->hasOtherSameUseStatementWithoutAlias(
+                $name,
+                $currentUses
+            )) {
                 return new Name($aliasName);
             }
 

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -7,6 +7,7 @@ namespace Rector\PostRector\Rector;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
@@ -16,6 +17,8 @@ use Rector\Core\Configuration\Parameter\ParameterProvider;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
+use Rector\Naming\Naming\AliasNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockNameImporter;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -30,7 +33,8 @@ final class NameImportingPostRector extends AbstractPostRector
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly CurrentFileProvider $currentFileProvider,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly AliasNameResolver $aliasNameResolver
     ) {
     }
 
@@ -105,6 +109,13 @@ CODE_SAMPLE
         $currentUses = $this->betterNodeFinder->findInstanceOf($file->getNewStmts(), Use_::class);
 
         if ($this->shouldImportName($name, $currentUses)) {
+            $aliasName = $this->aliasNameResolver->resolveByName($name);
+            $node = $name->getAttribute(AttributeKey::PARENT_NODE);
+
+            if (is_string($aliasName) && ! $node instanceof UseUse) {
+                return new Name($aliasName);
+            }
+
             return $this->nameImporter->importName($name, $file, $currentUses);
         }
 

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -6,7 +6,6 @@ namespace Rector\TypeDeclaration\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
@@ -206,7 +205,7 @@ CODE_SAMPLE
 
     private function addReturnType(
         ClassMethod | Function_ $functionLike,
-        Name|NullableType|PhpParserUnionType|IntersectionType $inferredReturnNode
+        Name|NullableType|PhpParserUnionType $inferredReturnNode
     ): void {
         if ($functionLike->returnType === null) {
             $functionLike->returnType = $inferredReturnNode;

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclaration\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
@@ -157,7 +158,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var Name|NullableType|PhpParserUnionType $inferredReturnNode */
+        /** @var Name|NullableType|PhpParserUnionType|IntersectionType $inferredReturnNode */
         $this->addReturnType($node, $inferredReturnNode);
         $this->nonInformativeReturnTagRemover->removeReturnTagIfNotUseful($node);
 
@@ -205,7 +206,7 @@ CODE_SAMPLE
 
     private function addReturnType(
         ClassMethod | Function_ $functionLike,
-        Name|NullableType|PhpParserUnionType $inferredReturnNode
+        Name|NullableType|PhpParserUnionType|IntersectionType $inferredReturnNode
     ): void {
         if ($functionLike->returnType === null) {
             $functionLike->returnType = $inferredReturnNode;

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -206,7 +206,7 @@ CODE_SAMPLE
 
     private function addReturnType(
         ClassMethod | Function_ $functionLike,
-        Name|NullableType|\PhpParser\Node\UnionType|IntersectionType $inferredReturnNode
+        Name|NullableType|PhpParserUnionType|IntersectionType $inferredReturnNode
     ): void {
         if ($functionLike->returnType === null) {
             $functionLike->returnType = $inferredReturnNode;

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclaration\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
@@ -205,7 +206,7 @@ CODE_SAMPLE
 
     private function addReturnType(
         ClassMethod | Function_ $functionLike,
-        Name|NullableType|PhpParserUnionType $inferredReturnNode
+        Name|NullableType|\PhpParser\Node\UnionType|IntersectionType $inferredReturnNode
     ): void {
         if ($functionLike->returnType === null) {
             $functionLike->returnType = $inferredReturnNode;

--- a/tests/Issues/AutoImportInAlias/AutoImportInAliasTest.php
+++ b/tests/Issues/AutoImportInAlias/AutoImportInAliasTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\AutoImportInAlias;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AutoImportInAliasTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/AutoImportInAlias/Fixture/auto_import_in_alias.php.inc
+++ b/tests/Issues/AutoImportInAlias/Fixture/auto_import_in_alias.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImportDocInUse\Fixture;
+
+use stdClass as SomeObject;
+
+final class AutoImportInAlias extends \stdClass
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImportDocInUse\Fixture;
+
+use stdClass as SomeObject;
+
+final class AutoImportInAlias extends SomeObject
+{
+}
+
+?>

--- a/tests/Issues/AutoImportInAlias/config/configured_rule.php
+++ b/tests/Issues/AutoImportInAlias/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+};


### PR DESCRIPTION
Currently, auto import on given the following code is skipped:

```php
use stdClass as SomeObject;

final class AutoImportInAlias extends \stdClass
{
}
```

ref https://getrector.org/demo/cf4bc31b-d150-4050-9ba9-a3a3845aced2

This PR is make if there is existing alias in use statement, use as is.