### PR TITLE
Skip method of abstract class for StaticCallOnNonStaticToInstanceCallRector.

### DIFF
--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_abstract_class.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_abstract_class.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+use Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Source\AbstractClassHello;
+
+class SkipAbstractClassWorld extends AbstractClassHello
+{
+    public function say()
+    {
+        parent::say();
+        echo "Wold!";
+    }
+}
+
+class SkipAbstractClassUniverse extends SkipAbstractClassWorld
+{
+    public function say()
+    {
+        AbstractClassHello::say();
+        echo "Universe!";
+    }
+}

--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Source/AbstractClassHello.php
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Source/AbstractClassHello.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Source;
+
+abstract class AbstractClassHello
+{
+    public function say()
+    {
+        echo "Hello ";
+    }
+}

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -148,8 +148,12 @@ CODE_SAMPLE
             return true;
         }
 
-        // does the method even exist?
         $classReflection = $this->reflectionProvider->getClass($className);
+        if ($classReflection->isAbstract()) {
+            return true;
+        }
+
+        // does the method even exist?
         if (! $classReflection->hasMethod($methodName)) {
             return true;
         }


### PR DESCRIPTION
Hi, the rule `StaticCallOnNonStaticToInstanceCallRector` currently not allow "jumping" over the `parent` method implementation: 

https://getrector.org/demo/24102d31-d518-4e51-8470-e3f93073470b
https://3v4l.org/t4Fdn