### PR TITLE
Skip default magic methods for StaticCallOnNonStaticToInstanceCallRector.

### DIFF
--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/allow_custom_magic_method.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/allow_custom_magic_method.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class AllowCustomMagicMethodBase
+{
+    public function __customMagicMethod()
+    {
+    }
+}
+
+class AllowCustomMagicMethodAdditional
+{
+    public function run()
+    {
+        return AllowCustomMagicMethodBase::__customMagicMethod();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class AllowCustomMagicMethodBase
+{
+    public function __customMagicMethod()
+    {
+    }
+}
+
+class AllowCustomMagicMethodAdditional
+{
+    public function run()
+    {
+        return (new AllowCustomMagicMethodBase())->__customMagicMethod();
+    }
+}
+
+?>

--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_default_magic_methods.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_default_magic_methods.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+use Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Source\MagicClass;
+
+class SkipDefaultMagicMethods
+{
+    public function __construct() { MagicClass::__construct(); }
+
+    public static function __set_state($state): static { return MagicClass::__set_state($state); }
+
+    public function __destruct() { MagicClass::__destruct(); }
+
+    public function __call($name, $value): void { MagicClass::__call($name, $value); }
+
+    public function __get($value): void { MagicClass::__get($value); }
+
+    public function __set($key, $value): void { MagicClass::__set($key, $value); }
+
+    public function __isset($key): bool { return MagicClass::__isset($key); }
+
+    public function __unset($key): void { MagicClass::__unset($key); }
+
+    public function __sleep(): array{ return MagicClass::__sleep(); }
+
+    public function __wakeup(): void{ MagicClass::__wakeup(); }
+
+    public function __serialize(): array{ return MagicClass::__serialize(); }
+
+    public function __unserialize($content): void { MagicClass::__unserialize($content); }
+
+    public function __toString(): string { return MagicClass::__toString(); }
+
+    public function __invoke(): void { MagicClass::__invoke(); }
+
+    public function __clone() { MagicClass::__clone(); }
+
+    public function __debugInfo(): array { return MagicClass::__debugInfo(); }
+}

--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Source/MagicClass.php
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Source/MagicClass.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Source;
+
+class MagicClass
+{
+    public function __construct() {}
+
+    public static function __set_state($state): static { return new static(); }
+
+    public function __destruct() {}
+
+    public function __call($name, $value): void {}
+
+    public function __get($value): void {}
+
+    public function __set($key, $value): void {}
+
+    public function __isset($key): bool { return false; }
+
+    public function __unset($key): void {}
+
+    public function __sleep(): array{ return []; }
+
+    public function __wakeup(): void {}
+
+    public function __serialize(): array { return [];}
+
+    public function __unserialize($content): void {}
+
+    public function __toString(): string { return ''; }
+
+    public function __invoke(): void {}
+
+    public function __clone() {}
+
+    public function __debugInfo(): array { return []; }
+}

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
+use Rector\CodingStyle\ValueObject\ObjectMagicMethods;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -144,6 +145,10 @@ CODE_SAMPLE
 
     private function shouldSkip(string $methodName, string $className, StaticCall $staticCall): bool
     {
+        if (in_array($methodName, ObjectMagicMethods::METHOD_NAMES, true)) {
+            return true;
+        }
+
         if (! $this->reflectionProvider->hasClass($className)) {
             return true;
         }


### PR DESCRIPTION
Hi, like already mentioned in https://github.com/rectorphp/rector-src/pull/2938#discussion_r974025413:~:text=But%20I%20have%20a%20legacy%20code%20where%20the%20constructor%20has%20optionally%20parameter%20and%20the%20parent%20constructor%20must%20skip.%20In%20this%20case%2C%20Rector%20will%20break%20the%20code%0Ahttps%3A//getrector.org/demo/d8d9037d%2D1af5%2D4477%2Daeaa%2D7947d0089fdc, I would like to skip all default magic methods, because refactorings like https://getrector.org/demo/d8d9037d-1af5-4477-aeaa-7947d0089fdc should be prevented.

My use case was actually to prevent refactorings in case of skipping the direct parent implementation, but I decided to skip all default magic methods. What do you think about the change?