### PR TITLE
Add refactorings for ...val()

### DIFF
--- a/config/set/code-quality.php
+++ b/config/set/code-quality.php
@@ -42,6 +42,7 @@ use Rector\CodeQuality\Rector\FuncCall\SimplifyInArrayValuesRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector;
 use Rector\CodeQuality\Rector\FuncCall\SingleInArrayToCompareRector;
+use Rector\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodeQuality\Rector\FunctionLike\RemoveAlwaysTrueConditionSetInConstructorRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
@@ -139,6 +140,7 @@ return static function (RectorConfig $rectorConfig): void {
         SimplifyBoolIdenticalTrueRector::class,
         SimplifyRegexPatternRector::class,
         BooleanNotIdenticalToNotIdenticalRector::class,
+        StrvalToTypeCastRector::class,
         CallableThisArrayToAnonymousFunctionRector::class,
         AndAssignsToSeparateLinesRector::class,
         ForToForeachRector::class,

--- a/config/set/code-quality.php
+++ b/config/set/code-quality.php
@@ -28,6 +28,7 @@ use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
 use Rector\CodeQuality\Rector\FuncCall\AddPregQuoteDelimiterRector;
 use Rector\CodeQuality\Rector\FuncCall\ArrayKeysAndInArrayToArrayKeyExistsRector;
 use Rector\CodeQuality\Rector\FuncCall\ArrayMergeOfNonArraysToSimpleArrayRector;
+use Rector\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\CallUserFuncWithArrowFunctionToInlineRector;
 use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
@@ -152,6 +153,7 @@ return static function (RectorConfig $rectorConfig): void {
         AddPregQuoteDelimiterRector::class,
         ArrayMergeOfNonArraysToSimpleArrayRector::class,
         IntvalToTypeCastRector::class,
+        BoolvalToTypeCastRector::class,
         ArrayKeyExistsTernaryThenValueToCoalescingRector::class,
         AbsolutizeRequireAndIncludePathRector::class,
         ChangeArrayPushToArrayAssignRector::class,

--- a/config/set/code-quality.php
+++ b/config/set/code-quality.php
@@ -32,6 +32,7 @@ use Rector\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\CallUserFuncWithArrowFunctionToInlineRector;
 use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
+use Rector\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\InlineIsAInstanceOfRector;
 use Rector\CodeQuality\Rector\FuncCall\IntvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\IsAWithStringWithThirdArgumentRector;
@@ -141,6 +142,7 @@ return static function (RectorConfig $rectorConfig): void {
         SimplifyRegexPatternRector::class,
         BooleanNotIdenticalToNotIdenticalRector::class,
         StrvalToTypeCastRector::class,
+        FloatvalToTypeCastRector::class,
         CallableThisArrayToAnonymousFunctionRector::class,
         AndAssignsToSeparateLinesRector::class,
         ForToForeachRector::class,

--- a/rules-tests/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector/BoolvalToTypeCastRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector/BoolvalToTypeCastRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class BoolvalToTypeCastRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        $value = boolval($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        $value = (bool) $value;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(BoolvalToTypeCastRector::class);
+};

--- a/rules-tests/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        $a = floatval($value);
+        $b = doubleval($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        $a = (float) $value;
+        $b = (float) $value;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector/FloatvalToTypeCastRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector/FloatvalToTypeCastRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FloatvalToTypeCastRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(FloatvalToTypeCastRector::class);
+};

--- a/rules-tests/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        $value = strval($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        $value = (string) $value;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector/StrvalToTypeCastRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector/StrvalToTypeCastRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class StrvalToTypeCastRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(StrvalToTypeCastRector::class);
+};

--- a/rules/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/BoolvalToTypeCastRector.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Cast\Bool_;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector\BoolvalToTypeCastRectorTest
+ */
+final class BoolvalToTypeCastRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change boolval() to faster and readable (bool) $value',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        return boolval($value);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        return (bool) $value;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node, 'boolval')) {
+            return null;
+        }
+
+        if (! isset($node->args[0])) {
+            return null;
+        }
+
+        if (! $node->args[0] instanceof Arg) {
+            return null;
+        }
+
+        return new Bool_($node->args[0]->value);
+    }
+}

--- a/rules/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Cast\Double;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector\FloatvalToTypeCastRectorTest
+ */
+final class FloatvalToTypeCastRector extends AbstractRector
+{
+    /**
+     * @var array<int, string>
+     */
+    private const VAL_FUNCTION_NAMES = ['floatval', 'doubleval'];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change floatval() and doubleval() to faster and readable (float) $value',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        $a = floatval($value);
+        $b = doubleval($value);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        $a = (float) $value;
+        $b = (float) $value;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $methodName = $this->getName($node);
+        if ($methodName === null) {
+            return null;
+        }
+
+        if (! \in_array($methodName, self::VAL_FUNCTION_NAMES, true)) {
+            return null;
+        }
+
+        if (! isset($node->args[0])) {
+            return null;
+        }
+
+        if (! $node->args[0] instanceof Arg) {
+            return null;
+        }
+
+        $castNode = new Double($node->args[0]->value);
+        $castNode->setAttribute(AttributeKey::KIND, Double::KIND_FLOAT);
+        return $castNode;
+    }
+}

--- a/rules/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/StrvalToTypeCastRector.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Cast\String_;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector\StrvalToTypeCastRectorTest
+ */
+final class StrvalToTypeCastRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change strval() to faster and readable (string) $value',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        return strval($value);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        return (string) $value;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node, 'strval')) {
+            return null;
+        }
+
+        if (! isset($node->args[0])) {
+            return null;
+        }
+
+        if (! $node->args[0] instanceof Arg) {
+            return null;
+        }
+
+        return new String_($node->args[0]->value);
+    }
+}


### PR DESCRIPTION
Hi, this is the PR to fix https://github.com/rectorphp/rector/issues/7492 to convert the functions `boolval`, `strval` and `floatval`/`doubleval` to their actual cast operator.