### PR TITLE
[DeadCode] Handle crash on RemoveUnusedPrivatePropertyRector+RemoveJustPropertyFetchForAssignRector

### DIFF
--- a/rules/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/FloatvalToTypeCastRector.php
@@ -19,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class FloatvalToTypeCastRector extends AbstractRector
 {
     /**
-     * @var array<int, string>
+     * @var string[]
      */
     private const VAL_FUNCTION_NAMES = ['floatval', 'doubleval'];
 
@@ -85,8 +85,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $castNode = new Double($node->args[0]->value);
-        $castNode->setAttribute(AttributeKey::KIND, Double::KIND_FLOAT);
-        return $castNode;
+        $double = new Double($node->args[0]->value);
+        $double->setAttribute(AttributeKey::KIND, Double::KIND_FLOAT);
+        return $double;
     }
 }

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -91,13 +91,11 @@ final class ChangedNodeScopeRefresher
             $node = new Property(0, [], [], null, [$attributeGroup]);
         }
 
-        $this->reIndexNodeAttributes($node);
-
         $stmts = $this->resolveStmts($node);
         $this->phpStanNodeScopeResolver->processNodes($stmts, $filePath, $mutatingScope);
     }
 
-    private function reIndexNodeAttributes(Node $node): void
+    public function reIndexNodeAttributes(Node $node): void
     {
         if (($node instanceof ClassLike || $node instanceof StmtsAwareInterface) && $node->stmts !== null) {
             $node->stmts = array_values($node->stmts);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -200,6 +200,8 @@ CODE_SAMPLE;
 
         $this->printDebugCurrentFileAndRule();
 
+        $this->changedNodeScopeRefresher->reIndexNodeAttributes($node);
+
         $refactoredNode = $this->refactor($node);
 
         // nothing to change → continue

--- a/tests/Issues/Issue7495/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7495/Fixture/fixture.php.inc
@@ -1,0 +1,69 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7495\Fixture;
+
+class Fixture
+{
+    private UrlInterface $urlInterface;
+    private InvoicesHelper $invoicesHelper;
+    private Registry $coreRegistry;
+
+    public function __construct(
+        UrlInterface $urlInterface,
+        Template\Context $context,
+        GetInvoicesHelper $invoicesHelper,
+        Registry $registry,
+    ) {
+        $this->urlInterface   = $urlInterface;
+        $this->invoicesHelper = $invoicesHelper;
+        $this->coreRegistry   = $registry;
+
+        parent::__construct($context);
+    }
+
+    public function getInvoices(): InvoicesHelper
+    {
+        return $this->invoicesHelper;
+    }
+
+    public function getOrder(): Registry
+    {
+        return $this->coreRegistry;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7495\Fixture;
+
+class Fixture
+{
+    private InvoicesHelper $invoicesHelper;
+    private Registry $coreRegistry;
+
+    public function __construct(
+        UrlInterface $urlInterface,
+        Template\Context $context,
+        GetInvoicesHelper $invoicesHelper,
+        Registry $registry,
+    ) {
+        $this->invoicesHelper = $invoicesHelper;
+        $this->coreRegistry   = $registry;
+
+        parent::__construct($context);
+    }
+
+    public function getInvoices(): InvoicesHelper
+    {
+        return $this->invoicesHelper;
+    }
+
+    public function getOrder(): Registry
+    {
+        return $this->coreRegistry;
+    }
+}
+
+?>

--- a/tests/Issues/Issue7495/RemoveUnusedPrivateJustPropertyFetchTest.php
+++ b/tests/Issues/Issue7495/RemoveUnusedPrivateJustPropertyFetchTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue7495;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7495
+ */
+final class RemoveUnusedPrivateJustPropertyFetchTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue7495/config/configured_rule.php
+++ b/tests/Issues/Issue7495/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
+use Rector\DeadCode\Rector\StmtsAwareInterface\RemoveJustPropertyFetchForAssignRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveUnusedPrivatePropertyRector::class);
+    $rectorConfig->rule(RemoveJustPropertyFetchForAssignRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
class Fixture
{
    private UrlInterface $urlInterface;
    private InvoicesHelper $invoicesHelper;
    private Registry $coreRegistry;

    public function __construct(
        UrlInterface $urlInterface,
        Template\Context $context,
        GetInvoicesHelper $invoicesHelper,
        Registry $registry,
    ) {
        $this->urlInterface   = $urlInterface;
        $this->invoicesHelper = $invoicesHelper;
        $this->coreRegistry   = $registry;

        parent::__construct($context);
    }

    public function getInvoices(): InvoicesHelper
    {
        return $this->invoicesHelper;
    }

    public function getOrder(): Registry
    {
        return $this->coreRegistry;
    }
}
```

It crash:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\Issue7495\RemoveUnusedPrivateJustPropertyFetchTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Undefined array key 0
```

Ref https://getrector.org/demo/b426dfd8-47f1-4ac5-8ddc-0a48b5bcfeed

Fixes https://github.com/rectorphp/rector/issues/7495