### PR TITLE
ParamAnalyzer: Accept all FunctionLike

### DIFF
--- a/rules/TypeDeclaration/NodeAnalyzer/ParamAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ParamAnalyzer.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\NodeAnalyzer;
 
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\FunctionLike;
 use Rector\NodeNameResolver\NodeNameResolver;
 
 final class ParamAnalyzer
@@ -16,7 +15,7 @@ final class ParamAnalyzer
     ) {
     }
 
-    public function getParamByName(string $desiredParamName, ClassMethod|Function_ $functionLike): ?Param
+    public function getParamByName(string $desiredParamName, FunctionLike $functionLike): ?Param
     {
         foreach ($functionLike->getParams() as $param) {
             $paramName = $this->nodeNameResolver->getName($param);


### PR DESCRIPTION
Otherwise, there will be fatal errors like:

    Uncaught TypeError: Rector\TypeDeclaration\NodeAnalyzer\ParamAnalyzer::getParamByName(): Argument #2 ($functionLike) must be of type PhpParser\Node\Stmt\ClassMethod|PhpParser\Node\Stmt\Function_, PhpParser\Node\Expr\Closure given, called in rector-src/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php on line 40 and defined in rector-src/rules/TypeDeclaration/NodeAnalyzer/ParamAnalyzer.php:19
