### PR TITLE
Fix type error on downgraded version.

### DIFF
--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return Stmt[]|null
+     * @return null|Stmt[]|If_
      */
     private function processMayDeadInstanceOf(If_ $if, Instanceof_ $instanceof): null|array|If_
     {


### PR DESCRIPTION
Hi, the downgraded version create a fatal error for `RemoveDeadInstanceOfRector`:
https://getrector.org/demo/fdba3d0f-4f97-4d01-9512-9dd71cb6730a

Because the type of [`null|array|If_`](https://github.com/Wohlie/rector-src/blob/caf433cec4477022459bced6f5179399d7df6a70/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php#L117) will be converted to [`?array`](https://github.com/rectorphp/rector/blob/main/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php#L127) for `processMayDeadInstanceOf`.

This is just a quick fix, but I think on downgrades the real type should be used and not the doc types. But maybe the type came from PhpStan, I don't know.
