### PR TITLE
[TypeDeclaration] Skip intersection array on ReturnTypeDeclarationRector on PHP 8.1 feature enabled

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeCorrector/HasOffsetTypeCorrector.php
+++ b/packages/NodeTypeResolver/NodeTypeCorrector/HasOffsetTypeCorrector.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\NodeTypeCorrector;
 
 use PHPStan\Type\Accessory\HasOffsetType;
+use PHPStan\Type\Accessory\HasOffsetValueType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 
 final class HasOffsetTypeCorrector
@@ -30,7 +32,15 @@ final class HasOffsetTypeCorrector
                 continue;
             }
 
+            if ($intersectionedType instanceof HasOffsetValueType) {
+                continue;
+            }
+
             $clearTypes[] = $intersectionedType;
+        }
+
+        if ($clearTypes === []) {
+            return new MixedType();
         }
 
         if (count($clearTypes) === 1) {

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp81/skip_intersection_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/FixtureForPhp81/skip_intersection_array.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector\FixtureForPhp81;
+
+final class SkipIntersectionArray
+{
+    public function setAuthorizationHeader(array $config): array
+    {
+        if (!isset($config['headers'])) {
+            $config['headers'] = [];
+        }
+
+        return $config;
+    }
+}


### PR DESCRIPTION
When on PHP 8.1 env, the following code:

```php
final class SkipIntersectionArray
{
    public function setAuthorizationHeader(array $config): array
    {
        if (!isset($config['headers'])) {
            $config['headers'] = [];
        }

        return $config;
    }
}
```

produce multiple `array&array` type https://getrector.org/demo/aa69f911-2a43-417e-95a9-83c44178a957

This PR fix it.

Fixes https://github.com/rectorphp/rector/issues/7488