### PR TITLE
[Php81] Handle crash insensitive function name on NullToStrictStringFuncCallArgRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -126,7 +126,7 @@ final class UnionTypeMapper implements TypeMapperInterface
         return $this->mapNullabledType($nullabledType, $typeKind);
     }
 
-    /** 
+    /**
      * @param TypeKind::* $typeKind
      */
     private function mapNullabledType(Type $nullabledType, string $typeKind): ?Node

--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/case_insensitive_function_name.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/case_insensitive_function_name.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class CaseInsensitiveFunctionName
+{
+    public function run($var)
+    {
+        return strToLower($var);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class CaseInsensitiveFunctionName
+{
+    public function run($var)
+    {
+        return strToLower((string) $var);
+    }
+}
+
+?>

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -484,7 +484,7 @@ CODE_SAMPLE
             $funcCall,
             $scope
         );
-        $functionName = $this->nodeNameResolver->getName($funcCall);
+        $functionName = $functionReflection->getName();
         $argNames = self::ARG_POSITION_NAME_NULL_TO_STRICT_STRING[$functionName];
         $positions = [];
 

--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -83,6 +83,7 @@ final class AlwaysStrictScalarExprAnalyzer
         if ($type instanceof IntegerType) {
             return true;
         }
+
         return $type instanceof BooleanType;
     }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -56,7 +56,7 @@ final class AlwaysStrictScalarExprAnalyzer
         if ($expr instanceof FuncCall) {
             $returnType = $this->resolveFuncCallType($expr);
 
-            if ($returnType === null) {
+            if (! $returnType instanceof Type) {
                 return null;
             }
 
@@ -83,12 +83,7 @@ final class AlwaysStrictScalarExprAnalyzer
         if ($type instanceof IntegerType) {
             return true;
         }
-
-        if ($type instanceof BooleanType) {
-            return true;
-        }
-
-        return false;
+        return $type instanceof BooleanType;
     }
 
     private function resolveTypeFromScalar(Scalar $scalar): Type|null


### PR DESCRIPTION
Given the following code:

```php
final class CaseInsensitiveFunctionName
{
    public function run($var)
    {
        return strToLower($var);
    }
}
```

It currently make crash:

```bash
There was 1 error:

1) Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\NullToStrictStringFuncCallArgRectorTest::test with data set #14 ('/Users/samsonasik/www/rector-...hp.inc')
Undefined array key "strToLower"

/Users/samsonasik/www/rector-src/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php:488
/Users/samsonasik/www/rector-src/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php:334
```

This PR fix it.

Fixes https://github.com/rectorphp/rector/issues/7504