### PR TITLE
Use fixture name as data provider test name.

### DIFF
--- a/build/target-repository/docs/how_to_add_test_for_rector_rule.md
+++ b/build/target-repository/docs/how_to_add_test_for_rector_rule.md
@@ -135,10 +135,10 @@ Run PHPUnit with the test file to confirm:
 vendor/bin/phpunit rules-tests/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenRector/FinalizeClassesWithoutChildrenRectorTest.php
 ```
 
-To run only the single test fixture, add `--filter test#X`, where X is the fixture's order number.
+To run only the single test fixture, add `--filter X`, where X is the fixture's file name.
 
 ```bash
-vendor/bin/phpunit rules-tests/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenRector/FinalizeClassesWithoutChildrenRectorTest.php --filter test#4
+vendor/bin/phpunit rules-tests/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenRector/FinalizeClassesWithoutChildrenRectorTest.php --filter add_final.php.inc
 ```
 
 If PHPUnit fails, you've successfully added a test case! :)

--- a/packages/Testing/Fixture/FixtureFileFinder.php
+++ b/packages/Testing/Fixture/FixtureFileFinder.php
@@ -22,7 +22,8 @@ final class FixtureFileFinder
 
         $fileInfos = iterator_to_array($finder);
         foreach ($fileInfos as $fileInfo) {
-            yield [$fileInfo->getRealPath()];
+            $realPath = $fileInfo->getRealPath();
+            yield \pathinfo($realPath, \PATHINFO_BASENAME) => [$realPath];
         }
     }
 }


### PR DESCRIPTION
It is not straight forward to work with the numeric array keys in data provider tests. This PR will use the fixture name to identify the dataset in data provider tests.

With this change, you can run a specific test by the fixture file name, and you will see the fixture filename on failing tests.

Before
```
1) Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector\SimplifyUselessVariableRectorTest::test with data set #11 ('/var/www/default/rules-tests/...hp.inc')
Failed asserting that string matches format description.
```

After
```
1) Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector\SimplifyUselessVariableRectorTest::test with data set "skip_on_function_return_ref.php.inc" ('/var/www/default/rules-tests/...hp.inc')
Failed asserting that string matches format description.
```