### PR TITLE
[Php80] Skip no default next indirect in return Expr on ChangeSwitchToMatchRector

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_no_default_next_indirect_in_return_expr.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_no_default_next_indirect_in_return_expr.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class SkipNoDefaultNextIndirectInReturnExpr
+{
+    public function price_action_by_server_name($price, $server)
+    {
+        $factor = 1.0;
+
+        switch ($server->name) {
+            case 'a':
+                $factor = 0.95;
+                break;
+            case 'b':
+            case 'c':
+                $factor = 0.8;
+                break;
+        }
+
+        return $price * $factor;
+    }
+}

--- a/rules/Php80/NodeFactory/MatchFactory.php
+++ b/rules/Php80/NodeFactory/MatchFactory.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_ as ThrowsStmt;
+use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Php80\Enum\MatchKind;
 use Rector\Php80\NodeAnalyzer\MatchSwitchAnalyzer;
 use Rector\Php80\ValueObject\CondAndExpr;
@@ -21,7 +22,8 @@ final class MatchFactory
 {
     public function __construct(
         private readonly MatchArmsFactory $matchArmsFactory,
-        private readonly MatchSwitchAnalyzer $matchSwitchAnalyzer
+        private readonly MatchSwitchAnalyzer $matchSwitchAnalyzer,
+        private readonly NodeComparator $nodeComparator
     ) {
     }
 
@@ -49,6 +51,10 @@ final class MatchFactory
                 // @todo this should be improved
                 $expr = $this->resolveAssignVar($condAndExprs);
                 if ($expr instanceof ArrayDimFetch) {
+                    return null;
+                }
+
+                if ($expr instanceof Expr && ! $this->nodeComparator->areNodesEqual($nextStmt->expr, $expr)) {
                     return null;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7478