### PR TITLE
Add new rule to simplify a last useless variable assignment.

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 398 Rules Overview
+# 399 Rules Overview
 
 <br>
 
@@ -6,7 +6,7 @@
 
 - [Arguments](#arguments) (5)
 
-- [CodeQuality](#codequality) (75)
+- [CodeQuality](#codequality) (76)
 
 - [CodingStyle](#codingstyle) (36)
 
@@ -1474,6 +1474,25 @@ Simplify tautology ternary to value
 ```diff
 -$value = ($fullyQualifiedTypeHint !== $typeHint) ? $fullyQualifiedTypeHint : $typeHint;
 +$value = $fullyQualifiedTypeHint;
+```
+
+<br>
+
+### SimplifyUselessLastVariableAssignRector
+
+Removes the latest useless variable assigns before a variable will return.
+
+- class: [`Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector`](../rules/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector.php)
+
+```diff
+ function ($b) {
+-    $a = true;
+     if ($b === 1) {
+         return $b;
+     }
+-    return $a;
++    return true;
+ };
 ```
 
 <br>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/assign_ops.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/assign_ops.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+function () {
+    $b += 1;
+    return $b;
+};
+
+function () {
+    $e /= 1;
+    return $e;
+};
+
+function () {
+    $f **= 1;
+    return $f;
+};
+
+function () {
+    $m .= 1;
+    return $m;
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+function () {
+    return $b + 1;
+};
+
+function () {
+    return $e / 1;
+};
+
+function () {
+    return $f ** 1;
+};
+
+function () {
+    return $m . 1;
+};
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/empty_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/empty_array.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class EmptyArray
+{
+    public function run()
+    {
+        $content = [];
+        if (\rand(0, 1)) {
+            echo '';
+        }
+
+        return $content;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class EmptyArray
+{
+    public function run()
+    {
+        if (\rand(0, 1)) {
+            echo '';
+        }
+
+        return [];
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/fixture.php.inc
@@ -1,0 +1,91 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+function () {
+    $a = true;
+    return $a;
+};
+
+function sameVariableInDifferentScope()
+{
+    $n = array_map(function () {
+        return $n + 1;
+    }, []);
+
+    return $n;
+}
+
+function moreVariableOneWithoutAssigment() {
+    $o++;
+    $o = 10;
+
+    return $o;
+}
+
+function assigmentAsFunctionParametr() {
+    doSomething($p = 0);
+    return $p;
+}
+
+function assigmentAfterAssignment() {
+    doSomething($qq = $q = 0);
+    return $q;
+}
+
+function () {
+    $a = 1;
+    $b = 1;
+    $c = [
+        $b-- => $a++,
+        --$b => ++$a,
+    ];
+    return $c;
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+function () {
+    return true;
+};
+
+function sameVariableInDifferentScope()
+{
+    $n = array_map(function () {
+        return $n + 1;
+    }, []);
+
+    return $n;
+}
+
+function moreVariableOneWithoutAssigment() {
+    $o++;
+
+    return 10;
+}
+
+function assigmentAsFunctionParametr() {
+    doSomething($p = 0);
+    return $p;
+}
+
+function assigmentAfterAssignment() {
+    doSomething($qq = $q = 0);
+    return $q;
+}
+
+function () {
+    $a = 1;
+    $b = 1;
+    $c = [
+        $b-- => $a++,
+        --$b => ++$a,
+    ];
+    return $c;
+};
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/fixture2.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/fixture2.php.inc
@@ -1,0 +1,413 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipFixture2
+{
+    private $noError = 'noError';
+
+    private static $static;
+
+    public function __construct($parameter)
+    {
+        self::$static = 'static';
+        $this->$parameter = 'this';
+    }
+
+}
+
+$noErrorToo = null;
+function ($noError = 'noError') use ($noErrorToo) {
+
+};
+
+$used = true;
+
+function foo($foo) {
+    return preg_replace_callback('~~', function ($matches) {
+        return $matches[0];
+    }, $foo);
+}
+
+return $used;
+
+function ($values) {
+    $foo = '';
+
+    foreach ($values as $value) {
+        echo $foo . $value;
+    }
+};
+
+function () {
+    for ($i = 0; $i < 10; $i++) {
+    }
+};
+
+function ($values) {
+    foreach ($values as $value) {
+        $foo = 'foo' . $value;
+    }
+    echo $foo;
+};
+
+function ($values) {
+    list($a, $b) = $values;
+    return $a + $b;
+};
+
+function ($values) {
+    [$c, $d] = $values;
+    return $c * $d;
+};
+
+function ($values) {
+    $current = 'current';
+    $next = 'next';
+
+    while ($next) {
+        if ($current) {
+
+        }
+
+        $current = false;
+
+        if (true) {
+            foreach ($values as $value) {
+                $next = $value;
+            }
+        }
+
+        do {
+            $previous = 'previous';
+        } while ($previous);
+    }
+};
+
+function (&$parameter) {
+    $parameter = 'value-by-reference';
+};
+
+function () use (&$inheritedVariable) {
+    $inheritedVariable = 'value-by-reference';
+};
+
+function ($interval) {
+    $j = 0;
+    for ($i = $j; $i < 10; $i += $interval) {
+    }
+};
+
+function () {
+    static $static = false;
+    if ($static) {
+        return;
+    }
+
+    $static = true;
+};
+
+function () {
+    $a = 'a';
+    $b = 'b';
+
+    $this->compact;
+
+    return compact('a', "b");
+};
+
+function () {
+    $a = '';
+    echo "$a";
+};
+
+function () {
+    $a = '';
+    echo "${a}";
+};
+
+function () {
+    $a = '';
+    echo "$a()";
+};
+
+function () {
+    $a = '';
+    echo <<<TEXT
+	$a
+TEXT;
+};
+
+function () {
+    $a = '';
+    echo <<<TEXT
+	${a}
+TEXT;
+};
+
+function () {
+    $a = 10;
+    max(1, $a += 10);
+};
+
+class Whatever
+{
+
+    public function listFunction($a, $b) {
+        list($this->a, $this->b) = [$a, $b];
+    }
+
+}
+
+function () {
+    $i = 0;
+    while ($i++ <= 10) {
+    }
+};
+
+function () {
+    $i = 0;
+    do {
+    } while (++$i <= 10);
+};
+
+function () {
+    $i = 10;
+    while ($i-- > 0) {
+    }
+};
+
+function () {
+    $i = 10;
+    do {
+    } while (--$i > 0);
+};
+
+function ($data) {
+    $i = 0;
+    $c = '';
+    foreach ($data as $c) {
+        $c = $i++;
+    }
+    echo $c;
+};
+
+function ($values) {
+    $expectedKey = 0;
+
+    foreach ($values as $key => $value) {
+        if ($key !== $expectedKey++) {
+            return $value;
+        }
+    }
+
+    return null;
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipFixture2
+{
+    private $noError = 'noError';
+
+    private static $static;
+
+    public function __construct($parameter)
+    {
+        self::$static = 'static';
+        $this->$parameter = 'this';
+    }
+
+}
+
+$noErrorToo = null;
+function ($noError = 'noError') use ($noErrorToo) {
+
+};
+
+function foo($foo) {
+    return preg_replace_callback('~~', function ($matches) {
+        return $matches[0];
+    }, $foo);
+}
+
+return true;
+
+function ($values) {
+    $foo = '';
+
+    foreach ($values as $value) {
+        echo $foo . $value;
+    }
+};
+
+function () {
+    for ($i = 0; $i < 10; $i++) {
+    }
+};
+
+function ($values) {
+    foreach ($values as $value) {
+        $foo = 'foo' . $value;
+    }
+    echo $foo;
+};
+
+function ($values) {
+    list($a, $b) = $values;
+    return $a + $b;
+};
+
+function ($values) {
+    [$c, $d] = $values;
+    return $c * $d;
+};
+
+function ($values) {
+    $current = 'current';
+    $next = 'next';
+
+    while ($next) {
+        if ($current) {
+
+        }
+
+        $current = false;
+
+        if (true) {
+            foreach ($values as $value) {
+                $next = $value;
+            }
+        }
+
+        do {
+            $previous = 'previous';
+        } while ($previous);
+    }
+};
+
+function (&$parameter) {
+    $parameter = 'value-by-reference';
+};
+
+function () use (&$inheritedVariable) {
+    $inheritedVariable = 'value-by-reference';
+};
+
+function ($interval) {
+    $j = 0;
+    for ($i = $j; $i < 10; $i += $interval) {
+    }
+};
+
+function () {
+    static $static = false;
+    if ($static) {
+        return;
+    }
+
+    $static = true;
+};
+
+function () {
+    $a = 'a';
+    $b = 'b';
+
+    $this->compact;
+
+    return compact('a', "b");
+};
+
+function () {
+    $a = '';
+    echo "$a";
+};
+
+function () {
+    $a = '';
+    echo "${a}";
+};
+
+function () {
+    $a = '';
+    echo "$a()";
+};
+
+function () {
+    $a = '';
+    echo <<<TEXT
+	$a
+TEXT;
+};
+
+function () {
+    $a = '';
+    echo <<<TEXT
+	${a}
+TEXT;
+};
+
+function () {
+    $a = 10;
+    max(1, $a += 10);
+};
+
+class Whatever
+{
+
+    public function listFunction($a, $b) {
+        list($this->a, $this->b) = [$a, $b];
+    }
+
+}
+
+function () {
+    $i = 0;
+    while ($i++ <= 10) {
+    }
+};
+
+function () {
+    $i = 0;
+    do {
+    } while (++$i <= 10);
+};
+
+function () {
+    $i = 10;
+    while ($i-- > 0) {
+    }
+};
+
+function () {
+    $i = 10;
+    do {
+    } while (--$i > 0);
+};
+
+function ($data) {
+    $i = 0;
+    $c = '';
+    foreach ($data as $c) {
+        $c = $i++;
+    }
+    echo $c;
+};
+
+function ($values) {
+    $expectedKey = 0;
+
+    foreach ($values as $key => $value) {
+        if ($key !== $expectedKey++) {
+            return $value;
+        }
+    }
+
+    return null;
+};
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/nested_ifs.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/nested_ifs.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class EmptyArray
+{
+    public function run()
+    {
+        if (\rand(0, 1)) {
+            $foo = 1;
+            if (\rand(0, 1)) {
+                $bar = 2;
+                if (\rand(0, 1)) {
+                    $baz = 3;
+                    if (\rand(0, 1)) {
+                        echo '';
+                    }
+                    return $baz;
+                }
+                return $bar;
+            }
+            return $foo;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class EmptyArray
+{
+    public function run()
+    {
+        if (\rand(0, 1)) {
+            if (\rand(0, 1)) {
+                if (\rand(0, 1)) {
+                    if (\rand(0, 1)) {
+                        echo '';
+                    }
+                    return 3;
+                }
+                return 2;
+            }
+            return 1;
+        }
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_call_by_ref.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_call_by_ref.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipCallByRef
+{
+    public function run(&$content)
+    {
+        $content = null;
+        return $content;
+    }
+}
+

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_closure_same_parameter_name.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_closure_same_parameter_name.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+function SkipClosureUseByReference()
+{
+    $isChanged = false;
+    (function ($isChanged) {
+        if ($isChanged) {
+            return 1;
+        }
+
+        return 0;
+    })(true);
+
+    return $isChanged;
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_closure_use_by_reference.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_closure_use_by_reference.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+function SkipClosureUseByReference()
+{
+    $isChanged = false;
+    (function ($x) use (&$isChanged) {
+        $isChanged = true;
+        return $isChanged;
+    })('x');
+
+    return $isChanged;
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_dynamic_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_dynamic_array.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class StaticArray
+{
+    public function run()
+    {
+        $value   = 'foo';
+        $content = [
+            1     => $value,
+            'bar',
+            'baz' => [
+                'qux',
+            ],
+        ];
+
+        if (\rand(0, 1)) {
+            echo '';
+        }
+
+        return $content;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_global_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_global_variable.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipGlobalVariable
+{
+    public function clear()
+    {
+        global $conn;
+        $conn = null;
+        return $conn;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_if_assignment.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_if_assignment.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipIfAssignment
+{
+    public function run()
+    {
+        if ($content = 'test') {
+            echo '';
+        }
+
+        return $content;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_method_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_method_call.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipOnMethodCall
+{
+    public function run(SkipOnMethodCall $skipOnMethodCall)
+    {
+        $content = $skipOnMethodCall->run($skipOnMethodCall);
+        return $content;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_nested_return.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_nested_return.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipOnNew
+{
+    public function run()
+    {
+        $content = 'content';
+        if (rand(0, 1)) {
+            return $content;
+        }
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_new.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_new.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipOnNew
+{
+    public function run()
+    {
+        $content = new \stdClass();
+        return $content;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_return_comment.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_on_return_comment.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipOnReturnComment
+{
+    public function run()
+    {
+        $name = $this->getValue();
+
+        /** @var string $name */
+        return $name;
+    }
+
+    private function getValue()
+    {
+        return 'name';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_return_by_ref.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_return_by_ref.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipReturnByRef
+{
+    function &test()
+    {
+        $var = 9000;
+        return $var;
+    }
+}
+
+function &() {
+    $var = 26;
+    return $var;
+};
+
+function &notAnonymous()
+{
+    for ($i = 0; $i < 4; $i++) {
+        $var = 42;
+        return $var;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_static_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_static_variable.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipStaticVariable
+{
+    public function run()
+    {
+        static $content;
+        $content = 'test';
+        return $content;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_variable_ref.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_variable_ref.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipOnVarVar
+{
+    public function run1()
+    {
+        $other   = 'content';
+        $content = &$other;
+        $content = 'foo';
+        return $content;
+    }
+
+    public function run2()
+    {
+        $content = 'content';
+        $other   = &$content;
+        $content = 'foo';
+        return $content;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_variable_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/skip_variable_variable.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class SkipOnVarVar
+{
+    public function run()
+    {
+        $other   = 'content';
+        $content = 1;
+        $$other  = 'foo';
+        return $content;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/static_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/static_array.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class StaticArray
+{
+    public function run()
+    {
+        $content = [
+            1     => 'foo',
+            'bar',
+            'baz' => [
+                'qux',
+            ],
+        ];
+
+        if (\rand(0, 1)) {
+            echo '';
+        }
+
+        return $content;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class StaticArray
+{
+    public function run()
+    {
+        if (\rand(0, 1)) {
+            echo '';
+        }
+
+        return [
+            1     => 'foo',
+            'bar',
+            'baz' => [
+                'qux',
+            ],
+        ];
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/variable_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/Fixture/variable_variable.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class VarVar
+{
+    public function run()
+    {
+        $other   = 'content';
+        $$other  = 'foo';
+        $content = 1;
+        return $content;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\Fixture;
+
+class VarVar
+{
+    public function run()
+    {
+        $other   = 'content';
+        $$other  = 'foo';
+        return 1;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/SimplifyUselessLastVariableAssignRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/SimplifyUselessLastVariableAssignRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SimplifyUselessLastVariableAssignRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(SimplifyUselessLastVariableAssignRector::class);
+};

--- a/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector.php
+++ b/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Type\MixedType;
+use Rector\CodeQuality\NodeAnalyzer\ReturnAnalyzer;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
+use Rector\Core\NodeAnalyzer\VariableAnalyzer;
+use Rector\Core\NodeManipulator\ArrayManipulator;
+use Rector\Core\PhpParser\Node\AssignAndBinaryMap;
+use Rector\Core\Rector\AbstractRector;
+use Rector\DeadCode\NodeAnalyzer\ExprUsedInNodeAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessLastVariableAssignRector\SimplifyUselessLastVariableAssignRectorTest
+ */
+final class SimplifyUselessLastVariableAssignRector extends AbstractRector
+{
+    public function __construct(
+        private readonly AssignAndBinaryMap $assignAndBinaryMap,
+        private readonly VariableAnalyzer $variableAnalyzer,
+        private readonly ReturnAnalyzer $returnAnalyzer,
+        private readonly ExprUsedInNodeAnalyzer $exprUsedInNodeAnalyzer,
+        private readonly ArrayManipulator $arrayManipulator,
+        private readonly ExprAnalyzer $exprAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Removes the latest useless variable assigns before a variable will return.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+function ($b) {
+    $a = true;
+    if ($b === 1) {
+        return $b;
+    }
+    return $a;
+};
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+function ($b) {
+    if ($b === 1) {
+        return $b;
+    }
+    return true;
+};
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [StmtsAwareInterface::class];
+    }
+
+    /**
+     * @param StmtsAwareInterface $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $stmts = $node->stmts;
+        if ($stmts === null) {
+            return null;
+        }
+
+        foreach ($stmts as $stmt) {
+            if (! $stmt instanceof Return_) {
+                continue;
+            }
+
+            if ($this->shouldSkip($stmt)) {
+                return null;
+            }
+
+            $assignStmt = $this->getLatestVariableAssignment($stmts, $stmt);
+            if (! $assignStmt instanceof Expression) {
+                return null;
+            }
+
+            if ($this->shouldSkipOnAssignStmt($assignStmt)) {
+                return null;
+            }
+
+            if ($this->isAssigmentUseless($stmts, $assignStmt, $stmt)) {
+                return null;
+            }
+
+            $assign = $assignStmt->expr;
+            if (! $assign instanceof Assign && ! $assign instanceof AssignOp) {
+                return null;
+            }
+
+            $this->removeNode($assignStmt);
+            return $this->processSimplifyUselessVariable($node, $stmt, $assign);
+        }
+
+        return null;
+    }
+
+    private function shouldSkip(Return_ $return): bool
+    {
+        $variable = $return->expr;
+        if (! $variable instanceof Variable) {
+            return true;
+        }
+
+        if ($this->returnAnalyzer->hasByRefReturn($return)) {
+            return true;
+        }
+
+        if ($this->variableAnalyzer->isStaticOrGlobal($variable)) {
+            return true;
+        }
+
+        if ($this->variableAnalyzer->isUsedByReference($variable)) {
+            return true;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($return);
+        return ! $phpDocInfo->getVarType() instanceof MixedType;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function getLatestVariableAssignment(array $stmts, Return_ $return): ?Expression
+    {
+        $returnVariable = $return->expr;
+        if (! $returnVariable instanceof Variable) {
+            return null;
+        }
+
+        //Search for the latest variable assigment
+        foreach (\array_reverse($stmts) as $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            $assignNode = $stmt->expr;
+            if (! $assignNode instanceof Assign && ! $assignNode instanceof AssignOp) {
+                continue;
+            }
+
+            $currentVariableNode = $assignNode->var;
+            if (! $currentVariableNode instanceof Variable) {
+                continue;
+            }
+
+            if ($this->nodeNameResolver->areNamesEqual($returnVariable, $currentVariableNode)) {
+                return $stmt;
+            }
+        }
+
+        return null;
+    }
+
+    private function shouldSkipOnAssignStmt(Expression $assignStmt): bool
+    {
+        if ($this->hasSomeComment($assignStmt)) {
+            return true;
+        }
+
+        $assign = $assignStmt->expr;
+        if (! $assign instanceof Assign && ! $assign instanceof AssignOp) {
+            return true;
+        }
+
+        $variable = $assign->var;
+        if (! $variable instanceof Variable) {
+            return true;
+        }
+
+        $value = $assign->expr;
+        if ($this->exprAnalyzer->isDynamicExpr($value)) {
+            return true;
+        }
+
+        if ($value instanceof Array_ && $this->arrayManipulator->isDynamicArray($value)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function hasSomeComment(Expression $stmt): bool
+    {
+        if ($stmt->getComments() !== []) {
+            return true;
+        }
+
+        return $stmt->getDocComment() !== null;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function isAssigmentUseless(array $stmts, Expression $assignStmt, Return_ $return): bool
+    {
+        $assign = $assignStmt->expr;
+        if (! $assign instanceof Assign && ! $assign instanceof AssignOp) {
+            return false;
+        }
+
+        $variable = $assign->var;
+        if (! $variable instanceof Variable) {
+            return false;
+        }
+
+        //Find the variable usage
+        $variableUsageNodes = $this->betterNodeFinder->find(
+            $this->getNodesInRange($stmts, $assignStmt, $return),
+            fn (Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $variable)
+        );
+
+        //Should be exactly used 2 times (assignment + return)
+        return count($variableUsageNodes) !== 2;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     * @return Stmt[]
+     */
+    private function getNodesInRange(array $stmts, Expression $start, Return_ $end): array
+    {
+        $resultStmts = [];
+        $wasStarted = false;
+
+        foreach ($stmts as $stmt) {
+            if ($stmt === $start) {
+                $wasStarted = true;
+            }
+
+            if ($wasStarted) {
+                $resultStmts[] = $stmt;
+            }
+
+            if ($stmt === $end) {
+                return $resultStmts;
+            }
+        }
+
+        if ($wasStarted) {
+            throw new ShouldNotHappenException('End node was not found.');
+        }
+
+        return $resultStmts;
+    }
+
+    private function processSimplifyUselessVariable(
+        StmtsAwareInterface $stmtsAware,
+        Return_ $return,
+        Assign|AssignOp $assign,
+    ): ?StmtsAwareInterface {
+        if (! $assign instanceof Assign) {
+            $binaryClass = $this->assignAndBinaryMap->getAlternative($assign);
+            if ($binaryClass === null) {
+                return null;
+            }
+
+            $return->expr = new $binaryClass($assign->var, $assign->expr);
+        } else {
+            $return->expr = $assign->expr;
+        }
+
+        return $stmtsAware;
+    }
+}

--- a/src/NodeAnalyzer/VariableAnalyzer.php
+++ b/src/NodeAnalyzer/VariableAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\ClosureUse;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
@@ -73,11 +74,11 @@ final class VariableAnalyzer
             }
 
             $parentNode = $subNode->getAttribute(AttributeKey::PARENT_NODE);
-            if (! $parentNode instanceof ClosureUse) {
-                return false;
+            if ($parentNode instanceof ClosureUse) {
+                return $parentNode->byRef;
             }
 
-            return $parentNode->byRef;
+            return $parentNode instanceof AssignRef;
         });
     }
 


### PR DESCRIPTION
Hi, the new rule `SimplifyUselessLastVariableAssignRector` try to remove the latest variable assignment before the variable will return. Variable assignment and return, must be in the same scope.

This rule is inspired by `SimplifyUselessVariableRector` but will not replace it.

```php
function ($b) {
    $a = true;
    if ($b === 1) {
        return $b;
    }
    return $a;
};
```

to

```php
function ($b) {
    if ($b === 1) {
        return $b;
    }
    return true;
};
```

I have one additional question. How should I handle these errors for my method [`getNodesInRange`](https://github.com/Wohlie/rector-src/blob/e3839ec3a25413bd904e9f42d0579ab7103f8799/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector.php#L248) or maybe there is already such a method?
```
 -------------------------------------------------------------------------------------------------------------------------
  rules/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector.php:248
 -------------------------------------------------------------------------------------------------------------------------
  - '#Parameter 2 should use "PhpParser\\Node\\Stmt\\Expression" type as the only type passed to this method#'
 -------------------------------------------------------------------------------------------------------------------------

 -------------------------------------------------------------------------------------------------------------------------
  rules/CodeQuality/Rector/FunctionLike/SimplifyUselessLastVariableAssignRector.php:248
 -------------------------------------------------------------------------------------------------------------------------
  - '#Parameter 3 should use "PhpParser\\Node\\Stmt\\Return_" type as the only type passed to this method#'
 -------------------------------------------------------------------------------------------------------------------------
```