### PR TITLE
Add unused dependencies Scanner

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -52,6 +52,10 @@ jobs:
                             bin/rector init-recipe --ansi
                             bin/rector generate --ansi
 
+                    -
+                        name: 'Detect unused dependencies'
+                        run: vendor/bin/unused_scanner unused-scanner.php
+
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
         timeout-minutes: 10

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "phpstan/phpdoc-parser": "^1.8",
         "phpstan/phpstan": "^1.8.6",
         "phpstan/phpstan-phpunit": "^1.1.1",
-        "react/child-process": "^0.6.5",
         "react/event-loop": "^1.3",
         "react/socket": "^1.12",
         "rector/extension-installer": "^0.11.2",
@@ -46,6 +45,7 @@
     "require-dev": {
         "brianium/paratest": "^6.6.4",
         "cweagans/composer-patches": "^1.7.2",
+        "insolita/unused-scanner": "^2.4",
         "myclabs/php-enum": "^1.8.4",
         "nategood/httpful": "^0.3.2",
         "phpstan/extension-installer": "^1.1",

--- a/unused-scanner.php
+++ b/unused-scanner.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+// @see https://cylab.be/blog/53/detect-unused-composer-dependencies?accept-cookies=1
+// @see https://github.com/Insolita/unused-scanner/blob/master/scanner_config.example.php
+
+return [
+    'composerJsonPath' => __DIR__ . '/composer.json',
+    'vendorPath' => __DIR__ . '/vendor',
+    'scanDirectories' => [
+        __DIR__ . '/src',
+        __DIR__ . '/packages',
+        __DIR__ . '/rules',
+    ],
+    'skipPackages' => [
+        // meta package for applying patches
+        'cweagans/composer-patches',
+        // core extensions
+        'rector/rector-php-parser',
+        'rector/rector-phpunit',
+        'rector/rector-phpoffice',
+        'rector/rector-laravel',
+        'rector/rector-doctrine',
+        'rector/rector-symfony',
+    ],
+];


### PR DESCRIPTION
Inspired by https://cylab.be/blog/53/detect-unused-composer-dependencies :slightly_smiling_face: 

and from Symplify setup: https://github.com/symplify/symplify/pull/4419