### PR TITLE
[Core] Remove second param on ClassLikeAstResolver::resolveClassFromClassReflection()

### DIFF
--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -90,7 +90,7 @@ final class FamilyRelationsAnalyzer
                 continue;
             }
 
-            $class = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection, $ancestorClassName);
+            $class = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection);
             if (! $class instanceof Class_) {
                 continue;
             }

--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -84,8 +84,6 @@ final class FamilyRelationsAnalyzer
         $kindPropertyFetch = $this->getKindPropertyFetch($property);
 
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
-            $ancestorClassReflection->getName();
-
             if ($ancestorClassReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;
             }

--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -84,7 +84,7 @@ final class FamilyRelationsAnalyzer
         $kindPropertyFetch = $this->getKindPropertyFetch($property);
 
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
-            $ancestorClassName = $ancestorClassReflection->getName();
+            $ancestorClassReflection->getName();
 
             if ($ancestorClassReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -33,8 +33,7 @@ final class ClassConstManipulator
         $className = (string) $this->nodeNameResolver->getName($class);
         foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
             $ancestorClass = $this->astResolver->resolveClassFromClassReflection(
-                $ancestorClassReflection,
-                $ancestorClassReflection->getName()
+                $ancestorClassReflection
             );
 
             if (! $ancestorClass instanceof ClassLike) {

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -32,9 +32,7 @@ final class ClassConstManipulator
 
         $className = (string) $this->nodeNameResolver->getName($class);
         foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
-            $ancestorClass = $this->astResolver->resolveClassFromClassReflection(
-                $ancestorClassReflection
-            );
+            $ancestorClass = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection);
 
             if (! $ancestorClass instanceof ClassLike) {
                 continue;

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -77,7 +77,7 @@ final class AstResolver
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        return $this->resolveClassFromClassReflection($classReflection, $className);
+        return $this->resolveClassFromClassReflection($classReflection);
     }
 
     public function resolveClassFromObjectType(
@@ -216,10 +216,9 @@ final class AstResolver
     }
 
     public function resolveClassFromClassReflection(
-        ClassReflection $classReflection,
-        string $className
+        ClassReflection $classReflection
     ): Trait_ | Class_ | Interface_ | Enum_ | null {
-        return $this->classLikeAstResolver->resolveClassFromClassReflection($classReflection, $className);
+        return $this->classLikeAstResolver->resolveClassFromClassReflection($classReflection);
     }
 
     /**

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\Core\ValueObject\Application\File;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\PhpParser\SmartPhpParser;
 
 final class ClassLikeAstResolver
@@ -27,12 +27,12 @@ final class ClassLikeAstResolver
     public function __construct(
         private readonly SmartPhpParser $smartPhpParser,
         private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 
     public function resolveClassFromClassReflection(
-        ClassReflection $classReflection,
-        string $desiredClassName
+        ClassReflection $classReflection
     ): Trait_ | Class_ | Interface_ | Enum_ | null {
         if ($classReflection->isBuiltin()) {
             return null;
@@ -63,7 +63,7 @@ final class ClassLikeAstResolver
 
         $reflectionClassName = $classReflection->getName();
         foreach ($classLikes as $classLike) {
-            if ($reflectionClassName !== $desiredClassName) {
+            if (! $this->nodeNameResolver->isName($classLike, $reflectionClassName)) {
                 continue;
             }
 

--- a/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
@@ -46,6 +46,8 @@ final class ParentAttributeSourceLocator implements SourceLocator
         if ($identifierName === 'Symfony\Component\DependencyInjection\Attribute\Autoconfigure' && $this->reflectionProvider->hasClass(
             $identifierName
         )) {
+            $classReflection = $this->reflectionProvider->getClass($identifierName);
+
             $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
             if ($class === null) {
                 return null;

--- a/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
@@ -46,9 +46,7 @@ final class ParentAttributeSourceLocator implements SourceLocator
         if ($identifierName === 'Symfony\Component\DependencyInjection\Attribute\Autoconfigure' && $this->reflectionProvider->hasClass(
             $identifierName
         )) {
-            $classReflection = $this->reflectionProvider->getClass($identifierName);
-
-            $class = $this->astResolver->resolveClassFromClassReflection($classReflection, $identifierName);
+            $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
             if ($class === null) {
                 return null;
             }


### PR DESCRIPTION
The second param of `ClassLikeAstResolver::resolveClassFromClassReflection()` is always a current class name itself, which can be pulled from passed ClassReflection itself, so it can be removed.