### PR TITLE
Fix wrong results in ExactCompareFactory

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -631,10 +631,6 @@ parameters:
                 - src/ValueObject/StaticNonPhpFileSuffixes.php
                 - tests/FileSystem/FilesFinder/FilesFinderTest.php
 
-        # union booleans
-        - '#Method Rector\\Strict\\NodeFactory\\ExactCompareFactory\:\:createTruthyFromUnionType\(\) should return PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\BooleanNot\|PhpParser\\Node\\Expr\\Instanceof_\|null but returns PhpParser\\Node\\Expr\\BinaryOp\\BooleanAnd\|PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\Instanceof_\|null#'
-        - '#Parameter \#1 \$compareExprs of method Rector\\Strict\\NodeFactory\\ExactCompareFactory\:\:resolveTruthyExpr\(\) expects array<PhpParser\\Node\\Expr\\BinaryOp\\BooleanAnd\|PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\Instanceof_\|null>, array<PhpParser\\Node\\Expr\\BinaryOp\\BooleanOr\|PhpParser\\Node\\Expr\\BinaryOp\\Identical\|PhpParser\\Node\\Expr\\BinaryOp\\NotIdentical\|PhpParser\\Node\\Expr\\BooleanNot\|PhpParser\\Node\\Expr\\Instanceof_\|null> given#'
-
         # part of tests
         - '#Call to method PHPUnit\\Framework\\Assert\:\:assertIsInt\(\) with 50200\|50300\|50400\|50500\|50600\|70000\|70100\|70200\|70300\|70400\|80000\|80100\|80200\|100000 will always evaluate to true#'
 

--- a/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/union_null_boolean.php.inc
+++ b/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/union_null_boolean.php.inc
@@ -28,7 +28,7 @@ final class UnionNullBoolean
 {
     public function run(bool|null $maye)
     {
-        if ($maye === true) {
+        if ($maye !== true) {
             return true;
         }
 

--- a/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/negated_union-types.php.inc
+++ b/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/negated_union-types.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector\Fixture;
+
+final class NegatedUnionType
+{
+    /**
+     * @param int|int[]|string $value
+     */
+    public function run($value)
+    {
+        return ! empty($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector\Fixture;
+
+final class NegatedUnionType
+{
+    /**
+     * @param int|int[]|string $value
+     */
+    public function run($value)
+    {
+        return $value !== 0 && $value !== '' && $value !== [];
+    }
+}
+
+?>

--- a/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/nullable_bool.php.inc
+++ b/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/nullable_bool.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector\Fixture;
+
+final class NullableBool
+{
+    public function run(bool|null $value)
+    {
+        return empty($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector\Fixture;
+
+final class NullableBool
+{
+    public function run(bool|null $value)
+    {
+        return $value !== true;
+    }
+}
+
+?>

--- a/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/integer_union_string.php.inc
+++ b/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/integer_union_string.php.inc
@@ -28,7 +28,7 @@ final class IntegerUnionString
 {
     public function run(int|string $value)
     {
-        if ($value !== 0 || $value !== '') {
+        if ($value !== 0 && $value !== '') {
             return 'name';
         }
 


### PR DESCRIPTION
Fixes rectorphp/rector#7518

As a side effect, this also fixes bugs present in `BooleanInBooleanNotRuleFixerRector` and `BooleanInIfConditionRuleFixerRector`, where the tests were wrong.