### PR TITLE
Add failing test fixture for `ReadOnlyPropertyRector`

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/demo_file.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class DemoFile
+{
+    public function __construct(private string $value)
+    {
+		$this->value = trim($value);
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for ReadOnlyPropertyRector

Based on https://getrector.org/demo/172611a6-7c8c-4ae5-b4a4-ed046738b206

# Description

As `$value` is modified inside the actor, it should not be touched, it would otherwise result in an error:
> Cannot modify 'readonly' property