### PR TITLE
[Core] Remove second param on ClassLikeAstResolver::resolveClassFromClassReflection()

### DIFF
--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -90,7 +90,7 @@ final class FamilyRelationsAnalyzer
                 continue;
             }
 
-            $class = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection, $ancestorClassName);
+            $class = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection);
             if (! $class instanceof Class_) {
                 continue;
             }

--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -84,8 +84,6 @@ final class FamilyRelationsAnalyzer
         $kindPropertyFetch = $this->getKindPropertyFetch($property);
 
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
-            $ancestorClassReflection->getName();
-
             if ($ancestorClassReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;
             }

--- a/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -84,7 +84,7 @@ final class FamilyRelationsAnalyzer
         $kindPropertyFetch = $this->getKindPropertyFetch($property);
 
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
-            $ancestorClassName = $ancestorClassReflection->getName();
+            $ancestorClassReflection->getName();
 
             if ($ancestorClassReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector/Fixture/fixture_remove_method_call_on_this_use_abstract2.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector/Fixture/fixture_remove_method_call_on_this_use_abstract2.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector\Fixture;
+
+final class GeneratorStubUseAbstract2 extends Validator2
+{
+    public function __construct()
+    {
+        $this->validateLineLengths();
+    }
+}
+
+abstract class Validator2
+{
+    protected function validateLineLengths(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector\Fixture;
+
+final class GeneratorStubUseAbstract2 extends Validator2
+{
+    public function __construct()
+    {
+    }
+}
+
+abstract class Validator2
+{
+    protected function validateLineLengths(): void
+    {
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
@@ -20,7 +20,6 @@ use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\TypeWithClassName;
 use Rector\Core\NodeAnalyzer\CallAnalyzer;
@@ -97,15 +96,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
+        $classLike = $this->resolveClassLike($node);
 
-        if (! $classReflection instanceof ClassReflection) {
-            return null;
-        }
-
-        $classLike = $this->reflectionAstResolver->resolveClassFromObjectType(
-            new ObjectType($classReflection->getName())
-        );
         if (! $classLike instanceof ClassLike) {
             return null;
         }
@@ -135,6 +127,17 @@ CODE_SAMPLE
         $this->removeNode($node);
 
         return $node;
+    }
+
+    private function resolveClassLike(MethodCall $methodCall): ?ClassLike
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($methodCall);
+
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        return $this->reflectionAstResolver->resolveClassFromName($classReflection->getName());
     }
 
     private function getScope(MethodCall $methodCall): ?Scope

--- a/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
@@ -102,6 +102,7 @@ CODE_SAMPLE
             return null;
         }
 
+        /** @var Class_|Trait_|Interface_|Enum_ $classLike */
         if ($this->shouldSkipClassMethod($classLike, $node, $type)) {
             return null;
         }

--- a/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
@@ -92,6 +92,11 @@ CODE_SAMPLE
             return null;
         }
 
+        $type = $scope->getType($node->var);
+        if (! $type instanceof TypeWithClassName) {
+            return null;
+        }
+
         $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($node);
 
         if (! $classReflection instanceof ClassReflection) {
@@ -105,7 +110,6 @@ CODE_SAMPLE
             return null;
         }
 
-        $type = $scope->getType($node->var);
         if ($this->shouldSkipClassMethod($classLike, $node, $type)) {
             return null;
         }

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -33,8 +33,7 @@ final class ClassConstManipulator
         $className = (string) $this->nodeNameResolver->getName($class);
         foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
             $ancestorClass = $this->astResolver->resolveClassFromClassReflection(
-                $ancestorClassReflection,
-                $ancestorClassReflection->getName()
+                $ancestorClassReflection
             );
 
             if (! $ancestorClass instanceof ClassLike) {

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -32,9 +32,7 @@ final class ClassConstManipulator
 
         $className = (string) $this->nodeNameResolver->getName($class);
         foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
-            $ancestorClass = $this->astResolver->resolveClassFromClassReflection(
-                $ancestorClassReflection
-            );
+            $ancestorClass = $this->astResolver->resolveClassFromClassReflection($ancestorClassReflection);
 
             if (! $ancestorClass instanceof ClassLike) {
                 continue;

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -77,7 +77,7 @@ final class AstResolver
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        return $this->resolveClassFromClassReflection($classReflection, $className);
+        return $this->resolveClassFromClassReflection($classReflection);
     }
 
     public function resolveClassFromObjectType(
@@ -216,10 +216,9 @@ final class AstResolver
     }
 
     public function resolveClassFromClassReflection(
-        ClassReflection $classReflection,
-        string $className
+        ClassReflection $classReflection
     ): Trait_ | Class_ | Interface_ | Enum_ | null {
-        return $this->classLikeAstResolver->resolveClassFromClassReflection($classReflection, $className);
+        return $this->classLikeAstResolver->resolveClassFromClassReflection($classReflection);
     }
 
     /**

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser;
 
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Interface_;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\Core\ValueObject\Application\File;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\PhpParser\SmartPhpParser;
 
 final class ClassLikeAstResolver
@@ -27,12 +27,12 @@ final class ClassLikeAstResolver
     public function __construct(
         private readonly SmartPhpParser $smartPhpParser,
         private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 
     public function resolveClassFromClassReflection(
-        ClassReflection $classReflection,
-        string $desiredClassName
+        ClassReflection $classReflection
     ): Trait_ | Class_ | Interface_ | Enum_ | null {
         if ($classReflection->isBuiltin()) {
             return null;
@@ -63,7 +63,7 @@ final class ClassLikeAstResolver
 
         $reflectionClassName = $classReflection->getName();
         foreach ($classLikes as $classLike) {
-            if ($reflectionClassName !== $desiredClassName) {
+            if (! $this->nodeNameResolver->isName($classLike, $reflectionClassName)) {
                 continue;
             }
 

--- a/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
@@ -44,6 +44,8 @@ final class ParentAttributeSourceLocator implements SourceLocator
         if ($identifierName === 'Symfony\Component\DependencyInjection\Attribute\Autoconfigure' && $this->reflectionProvider->hasClass(
             $identifierName
         )) {
+            $classReflection = $this->reflectionProvider->getClass($identifierName);
+
             $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
             if ($class === null) {
                 return null;

--- a/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/ParentAttributeSourceLocator.php
@@ -44,9 +44,7 @@ final class ParentAttributeSourceLocator implements SourceLocator
         if ($identifierName === 'Symfony\Component\DependencyInjection\Attribute\Autoconfigure' && $this->reflectionProvider->hasClass(
             $identifierName
         )) {
-            $classReflection = $this->reflectionProvider->getClass($identifierName);
-
-            $class = $this->astResolver->resolveClassFromClassReflection($classReflection, $identifierName);
+            $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
             if ($class === null) {
                 return null;
             }


### PR DESCRIPTION
Re-open of https://github.com/rectorphp/rector-src/pull/2971

The second param of ClassLikeAstResolver::resolveClassFromClassReflection() is always a current class name from the ClassReflection itself, which can be pulled from passed ClassReflection itself, so it can be removed.

This `RemoveEmptyMethodCallRector` require update to use `ReflectionResolver::resolveClassReflectionSourceObject()` to correctly get the object source of the method call.