### PR TITLE
[Core] Set compatible with latest BetterReflection usage to handle assert($startLine > 0) notice

### DIFF
--- a/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
@@ -9,9 +9,7 @@ use PHPStan\BetterReflection\Identifier\Identifier;
 use PHPStan\BetterReflection\Identifier\IdentifierType;
 use PHPStan\BetterReflection\Reflection\Reflection;
 use PHPStan\BetterReflection\Reflection\ReflectionClass;
-use PHPStan\BetterReflection\Reflector\ClassReflector;
 use PHPStan\BetterReflection\Reflector\Reflector;
-use PHPStan\BetterReflection\SourceLocator\Located\LocatedSource;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 
@@ -37,7 +35,6 @@ final class RenamedClassesSourceLocator implements SourceLocator
                 continue;
             }
 
-            // inspired at https://github.com/phpstan/phpstan-src/blob/a9dd9af959fb0c1e0a09d4850f78e05e8dff3d91/src/Reflection/BetterReflection/BetterReflectionProvider.php#L220-L225
             return $this->createFakeReflectionClassFromClassName($oldClass);
         }
 
@@ -57,9 +54,6 @@ final class RenamedClassesSourceLocator implements SourceLocator
         $classBuilder = new Class_($oldClass);
         $class = $classBuilder->getNode();
 
-        $fakeLocatedSource = new LocatedSource('virtual', null);
-
-        $classReflector = new ClassReflector($this);
-        return ReflectionClass::createFromNode($classReflector, $class, $fakeLocatedSource);
+        return ReflectionClass::createFromInstance($class);
     }
 }


### PR DESCRIPTION
I just run composer update locally, and it seems it cause error in tests:

```
vendor/bin/phpunit tests/Issues/PrintStmtsIndexAutoImport/PrintStmtsIndexAutoImportTest.php

PHPUnit 9.5.25 #StandWithUkraine

FFF                                                                 3 / 3 (100%)

Time: 00:00.500, Memory: 54.50 MB

There were 3 failures:

1) Rector\Core\Tests\Issues\PrintStmtsIndexAutoImport\PrintStmtsIndexAutoImportTest::test with data set #1 ('/Users/samsonasik/www/rector-...hp.inc')
assert($startLine > 0) in phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionClass.php:180
```

Change the `RenamedClassesSourceLocator::createFakeReflectionClassFromClassName()` to use `ReflectionClass::createFromInstance()` seems solve it.