### PR TITLE
[Core] Ensure refresh Scope Nodes when AbstractRector refactor() return array of Nodes

### DIFF
--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -64,7 +64,7 @@ final class ScopeAnalyzer
 
         /**
          * There is no higher Node than FileWithoutNamespace
-         * There is no code that can live outside Namespace_, ref https://3v4l.org/har0k
+         * There is no code that can live outside Namespace_, @see https://3v4l.org/har0k
          */
         if ($parentNode instanceof FileWithoutNamespace || $parentNode instanceof Namespace_) {
             return $this->scopeFactory->createFromFile($filePath);

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -63,7 +63,8 @@ final class ScopeAnalyzer
         }
 
         /**
-         * There is no higher Node than FileWithoutNamespace and Namespace_
+         * There is no higher Node than FileWithoutNamespace
+         * There is no code that can live outside Namespace_
          */
         if ($parentNode instanceof FileWithoutNamespace || $parentNode instanceof Namespace_) {
             return $this->scopeFactory->createFromFile($filePath);

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -64,7 +64,7 @@ final class ScopeAnalyzer
 
         /**
          * There is no higher Node than FileWithoutNamespace
-         * There is no code that can live outside Namespace_
+         * There is no code that can live outside Namespace_, ref https://3v4l.org/har0k
          */
         if ($parentNode instanceof FileWithoutNamespace || $parentNode instanceof Namespace_) {
             return $this->scopeFactory->createFromFile($filePath);

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -9,7 +9,9 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Namespace_;
 use PHPStan\Analyser\MutatingScope;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 
@@ -56,6 +58,17 @@ final class ScopeAnalyzer
 
         /** @var MutatingScope|null $parentScope */
         $parentScope = $parentNode->getAttribute(AttributeKey::SCOPE);
-        return $parentScope;
+        if ($parentScope instanceof MutatingScope) {
+            return $parentScope;
+        }
+
+        /**
+         * There is no higher Node than FileWithoutNamespace and Namespace_
+         */
+        if ($parentNode instanceof FileWithoutNamespace || $parentNode instanceof Namespace_) {
+            return $this->scopeFactory->createFromFile($filePath);
+        }
+
+        return null;
     }
 }

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -70,6 +70,13 @@ final class ScopeAnalyzer
             return $this->scopeFactory->createFromFile($filePath);
         }
 
+        /**
+         * Fallback when current Node is FileWithoutNamespace or Namespace_ already
+         */
+        if ($node instanceof FileWithoutNamespace || $node instanceof Namespace_) {
+            return $this->scopeFactory->createFromFile($filePath);
+        }
+
         return null;
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -348,6 +348,9 @@ CODE_SAMPLE;
         $this->nodeRemover->removeNode($node);
     }
 
+    /**
+     * @param Node[]|Node $node
+     */
     private function refreshScopeNodes(array | Node $node, string $filePath, ?MutatingScope $mutatingScope): void
     {
         $nodes = $node instanceof Node ? [$node] : $node;


### PR DESCRIPTION
When `AbstractRector::refactor()` return array of Nodes, all nodes returned should has scope refreshed, same with only return single node.

Fixes https://github.com/rectorphp/rector/issues/7522