### PR TITLE
[Privatization] Skip Property unsetted on ChangeReadOnlyPropertyWithDefaultValueToConstantRector

### DIFF
--- a/packages/ReadWrite/NodeAnalyzer/ReadWritePropertyAnalyzer.php
+++ b/packages/ReadWrite/NodeAnalyzer/ReadWritePropertyAnalyzer.php
@@ -67,7 +67,11 @@ final class ReadWritePropertyAnalyzer
             return false;
         }
 
-        return ! $this->isArrayDimFetchInImpureFunction($parentNode, $node);
+        if (! $this->isArrayDimFetchInImpureFunction($parentNode, $node)) {
+            return $this->isNotInsideIssetUnset($parentNode);
+        }
+
+        return false;
     }
 
     private function isArrayDimFetchInImpureFunction(ArrayDimFetch $arrayDimFetch, Node $node): bool

--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_unsetted_parent_array_dim_fetch.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_unsetted_parent_array_dim_fetch.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+final class SkipUnsettedParentArrayDimFetch {
+    private static $array = ['foo' => 'bar'];
+
+    public function run() {
+        unset(self::$array['foo']);
+    }
+}

--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_unsetted_property_fetch.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_unsetted_property_fetch.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+final class SkipUnsettedPropertyFetch {
+    private $array = ['foo' => 'bar'];
+
+    public function run() {
+        unset($this->array);
+    }
+}

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -301,7 +301,7 @@ final class PropertyManipulator
             return ! $this->readWritePropertyAnalyzer->isRead($propertyFetch);
         }
 
-        return false;
+        return $parentNode instanceof Unset_;
     }
 
     private function isFoundByRefParam(MethodCall | StaticCall $node): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7513