### PR TITLE
Improve docs on auto import short classes

### DIFF
--- a/build/target-repository/docs/auto_import_names.md
+++ b/build/target-repository/docs/auto_import_names.md
@@ -32,7 +32,7 @@ Single short classes are imported too:
 Do you want to keep those?
 
 ```php
-$parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+$rectorConfig->importShortClasses(false);
 ```
 
 <br>


### PR DESCRIPTION
`$parameters->set(Option::IMPORT_SHORT_CLASSES, false);` is deprecated and can be replaced by `$rectorConfig->importShortClasses(false);`