### PR TITLE
[Core][Symfony] Handle crash on get dynamic value ClassConstFetch by method call on ChangeStringCollectionOptionToConstantRector

### DIFF
--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -152,7 +152,7 @@ final class ValueResolver
 
     private function resolveExprValueForConst(Expr $expr): mixed
     {
-        if ($this->exprAnalyzer->isDynamicExpr($expr)) {
+        if ($expr instanceof ClassConstFetch && $this->exprAnalyzer->isDynamicExpr($expr)) {
             return null;
         }
 

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -22,6 +22,7 @@ use PHPStan\Type\TypeWithClassName;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ConstFetchAnalyzer;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -41,7 +42,8 @@ final class ValueResolver
         private readonly ConstFetchAnalyzer $constFetchAnalyzer,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly CurrentFileProvider $currentFileProvider,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ExprAnalyzer $exprAnalyzer
     ) {
     }
 
@@ -150,6 +152,10 @@ final class ValueResolver
 
     private function resolveExprValueForConst(Expr $expr): mixed
     {
+        if ($this->exprAnalyzer->isDynamicExpr($expr)) {
+            return null;
+        }
+
         try {
             $constExprEvaluator = $this->getConstExprEvaluator();
             return $constExprEvaluator->evaluateDirectly($expr);

--- a/tests/Issues/Issue7536/DynamicExprConstantTest.php
+++ b/tests/Issues/Issue7536/DynamicExprConstantTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\Issue7536;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7536
+ */
+final class DynamicExprConstantTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue7536/Fixture/skip_dynamic_class_const_fetch.php.inc
+++ b/tests/Issues/Issue7536/Fixture/skip_dynamic_class_const_fetch.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\Issue7536\Fixture;
+
+use Symfony\Component\Form\FormInterface;
+
+class SkipDynamicClassConstFetch
+{
+    private function pocMethod(FormInterface $childType, FormInterface $parentType)
+    {
+        $parentType->add(
+           $childType->methodA(),
+           $childType->methodB()::class
+        );
+    }
+}

--- a/tests/Issues/Issue7536/config/configured_rule.php
+++ b/tests/Issues/Issue7536/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Rector\MethodCall\ChangeStringCollectionOptionToConstantRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeStringCollectionOptionToConstantRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
use Symfony\Component\Form\FormInterface;

class SkipDynamicClassConstFetch
{
    private function pocMethod(FormInterface $childType, FormInterface $parentType)
    {
        $parentType->add(
           $childType->methodA(),
           $childType->methodB()::class
        );
    }
}
```

It currently produce error:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\Issue7536\DynamicExprConstantTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Core\Exception\ShouldNotHappenException: Look at "Rector\Core\PhpParser\Node\Value\ValueResolver::resolveClassConstFetch()" on line 259

/Users/samsonasik/www/rector-src/src/PhpParser/Node/Value/ValueResolver.php:259
/Users/samsonasik/www/rector-src/src/PhpParser/Node/Value/ValueResolver.php:189
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ConstExprEvaluator.php:146
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ConstExprEvaluator.php:101
```

The patch need to be in the `ValueResolver`. 

Fixes https://github.com/rectorphp/rector/issues/7536