### PR TITLE
[Php80] Handle crash after transform with trait-string on UnionTypesRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -13,7 +13,6 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -90,7 +90,7 @@ final class IntersectionTypeMapper implements TypeMapperInterface
                 $resolvedTypeName = self::STRING;
                 $resolvedType = new Name(self::STRING);
             } elseif (! $resolvedType instanceof Name) {
-                throw new ShouldNotHappenException();
+                return null;
             } else {
                 $resolvedTypeName = (string) $resolvedType;
             }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -98,6 +98,10 @@ final class ObjectTypeMapper implements TypeMapperInterface
             return new FullyQualified($className);
         }
 
+        if ($type instanceof NonExistingObjectType) {
+            return null;
+        }
+
         if (! $type instanceof GenericObjectType) {
             // fallback
             return new FullyQualified($type->getClassName());

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_generic_with_intersection.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/do_not_remove_generic_with_intersection.php.inc
@@ -2,8 +2,8 @@
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
 
-use MockObject;
-use ObjectRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\Doctrine\ObjectRepository;
 
 final class DemoFile
 {
@@ -19,15 +19,15 @@ final class DemoFile
 
 namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
 
-use MockObject;
-use ObjectRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\Doctrine\ObjectRepository;
 
 final class DemoFile
 {
     /**
      * @var MockObject&ObjectRepository<ItemCountry>
      */
-    private \MockObject&\ObjectRepository $itemCountryRepo;
+    private \PHPUnit\Framework\MockObject\MockObject&\Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\Doctrine\ObjectRepository $itemCountryRepo;
 }
 
 ?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_object_type_not_exists.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureUnionIntersectionTypes/skip_object_type_not_exists.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\TypedPropertyRector\FixtureUnionIntersectionTypes;
+
+final class SkipObjectTypeNotExists
+{
+    /**
+     * @var NotExistClass1&NotExistClass2<ItemCountry>
+     */
+    private $itemCountryRepo;
+}

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_trait_string.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_union_trait_string.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+class SkipUnionTraitString
+{
+    /**
+     * @param string|trait-string $fromId
+     */
+    public function withFromId(string $fromId): static
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
Given the following code:

```php
class SkipUnionTraitString
{
    /**
     * @param string|trait-string $fromId
     */
    public function withFromId(string $fromId): static
    {
        return $this;
    }
}
```

It currently produce:

```diff
-    public function withFromId(string $fromId): static
+    public function withFromId(string|\trait-string $fromId): static
```

which cause error:

```
Parse error: syntax error, unexpected token "-", expecting variable
```

see 

- https://getrector.org/demo/44ae214d-d91b-4525-9b89-acc30728eea1
- https://3v4l.org/h0oG0

This PR try to fix it.