### PR TITLE
[CodeQuality] Skip different array_filter value on SimplifyEmptyArrayCheckRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector/Fixture/skip_different_array_filter_value.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector/Fixture/skip_different_array_filter_value.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector\Fixture;
+
+final class SkipDifferentArrayFilterValue
+{
+    public function functionCallInsideEmpty($a, $values): bool
+    {
+        return is_array($a) && empty(array_filter($values));
+    }
+}

--- a/rules/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector.php
+++ b/rules/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector.php
@@ -65,7 +65,7 @@ final class SimplifyEmptyArrayCheckRector extends AbstractRector
         /** @var Empty_ $emptyOrNotIdenticalNode */
         $emptyOrNotIdenticalNode = $twoNodeMatch->getSecondExpr();
 
-        if ($emptyOrNotIdenticalNode->expr instanceof FuncCall) {
+        if ($emptyOrNotIdenticalNode->expr instanceof FuncCall && $this->nodeComparator->areNodesEqual($emptyOrNotIdenticalNode->expr->args[0]->value, $firstArgValue)) {
             return new Identical($emptyOrNotIdenticalNode->expr, new Array_());
         }
 

--- a/rules/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector.php
+++ b/rules/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector.php
@@ -65,7 +65,10 @@ final class SimplifyEmptyArrayCheckRector extends AbstractRector
         /** @var Empty_ $emptyOrNotIdenticalNode */
         $emptyOrNotIdenticalNode = $twoNodeMatch->getSecondExpr();
 
-        if ($emptyOrNotIdenticalNode->expr instanceof FuncCall && $this->nodeComparator->areNodesEqual($emptyOrNotIdenticalNode->expr->args[0]->value, $firstArgValue)) {
+        if ($emptyOrNotIdenticalNode->expr instanceof FuncCall && $this->nodeComparator->areNodesEqual(
+            $emptyOrNotIdenticalNode->expr->args[0]->value,
+            $firstArgValue
+        )) {
             return new Identical($emptyOrNotIdenticalNode->expr, new Array_());
         }
 


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/2998, given the folllowing code should be skipped:

```php
final class SkipDifferentArrayFilterValue
{
    public function functionCallInsideEmpty($a, $values): bool
    {
        return is_array($a) && empty(array_filter($values));
    }
}
```

as the arg is different. ref https://getrector.org/demo/dcb1cba4-4e80-459f-9cfe-fcd240bac135