### PR TITLE
[Php70] Handle crash on First class callable on ThisCallOnStaticMethodToStaticCallRector

### DIFF
--- a/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture;
+
+final class SkipFirstClassCallable
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('top_level_domain', $this->topLevelDomain(...)),
+        ];
+    }
+
+    public static function topLevelDomain(?string $host = null): string
+    {
+        if (null === $host) {
+            $host = $_SERVER['HTTP_HOST'];
+        }
+
+        $urlPieces = explode('.', (string) $host);
+
+        return end($urlPieces);
+    }
+}

--- a/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -125,6 +125,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $objectReference = $this->resolveClassSelf($node);
         return $this->nodeFactory->createStaticCall($objectReference, $methodName, $node->args);
     }


### PR DESCRIPTION
Given the following code:

```php
final class SkipFirstClassCallable
{
    public function getFunctions(): array
    {
        return [
            new TwigFunction('top_level_domain', $this->topLevelDomain(...)),
        ];
    }

    public static function topLevelDomain(?string $host = null): string
    {
        if (null === $host) {
            $host = $_SERVER['HTTP_HOST'];
        }

        $urlPieces = explode('.', (string) $host);

        return end($urlPieces);
    }
}
```

It produce crash:

```bash
There was 1 error:

1) Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\ThisCallOnStaticMethodToStaticCallRectorTest::test with data set #1 ('/Users/samsonasik/www/rector-...hp.inc')
LogicException: Invalid value

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/BuilderHelpers.php:272
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/BuilderFactory.php:252
/Users/samsonasik/www/rector-src/src/PhpParser/Node/NodeFactory.php:131
/Users/samsonasik/www/rector-src/src/PhpParser/Node/NodeFactory.php:297
```

Fixes https://github.com/rectorphp/rector/issues/7548