### PR TITLE
Add real path to filePaths when not false

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -68,6 +68,7 @@ final class FilesFinder
 
         $filePaths = [];
         foreach ($finder as $fileInfo) {
+            /** @var string|false $path */
             $path = $fileInfo->getRealPath();
             if ($path !== false) {
                 $filePaths[] = $path;

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -68,6 +68,9 @@ final class FilesFinder
 
         $filePaths = [];
         foreach ($finder as $fileInfo) {
+            // getRealPath() function will return false when it checks broken symlinks.
+            // So we should check if this file exists or we got broken symlink
+
             /** @var string|false $path */
             $path = $fileInfo->getRealPath();
             if ($path !== false) {

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -69,7 +69,7 @@ final class FilesFinder
         $filePaths = [];
         foreach ($finder as $fileInfo) {
             $path = $fileInfo->getRealPath();
-            if ($path) {
+            if ($path !== false) {
                 $filePaths[] = $path;
             }
         }

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -68,7 +68,10 @@ final class FilesFinder
 
         $filePaths = [];
         foreach ($finder as $fileInfo) {
-            $filePaths[] = $fileInfo->getRealPath();
+            $path = $fileInfo->getRealPath();
+            if ($path) {
+                $filePaths[] = $path;
+            }
         }
 
         return $this->unchangedFilesFilter->filterAndJoinWithDependentFileInfos($filePaths);


### PR DESCRIPTION
When I tried to use rector I got TypeError exception. After debugging its cause I got this solution. The problem was that I have some broken symlink directories in my code, and when `getRealPath()` function tried to find path to this symlinks, it returns false. Then other functions that uses `$filePaths` array tries proceed bool variable, they throws TypeError.
I thought it will be nice to check what returns `getRealPath()` function before adding its value to `$filePaths` array.