### PR TITLE
[Core] Move currentFileProvider->setFile() early before loop on PhpFileProcessor::process()

### DIFF
--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -58,6 +58,8 @@ final class PhpFileProcessor implements FileProcessorInterface
             return $systemErrorsAndFileDiffs;
         }
 
+        $this->currentFileProvider->setFile($file);
+
         // 2. change nodes with Rectors
         do {
             $file->changeHasChanged(false);
@@ -69,8 +71,6 @@ final class PhpFileProcessor implements FileProcessorInterface
             $file->changeNewStmts($newStmts);
 
             // 4. print to file or string
-            $this->currentFileProvider->setFile($file);
-
             // important to detect if file has changed
             $this->printFile($file, $configuration);
         } while ($file->hasChanged());


### PR DESCRIPTION
The loop in `PhpFileProcessor::process()` is using `do {} while`, so it will always executed at least once. The set file:

```php
$this->currentFileProvider->setFile($file);
```

is only need to be set once, as object is referenced, see https://3v4l.org/dl4Cq