### PR TITLE
[DeadCode] Handle RemoveUnusedPrivateMethodRector+RemoveDuplicatedIfReturnRector when private method used in FuncCall with ArrowFunction

### DIFF
--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -52,11 +52,11 @@ final class SimpleCallableNodeTraverser
         foreach ($nodes as $node) {
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
-            if ($parentNode instanceof Node) {
-                return true;
+            if (! $parentNode instanceof Node) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 }

--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -39,7 +39,7 @@ final class SimpleCallableNodeTraverser
         $nodeTraverser = new NodeTraverser();
         $callableNodeVisitor = new CallableNodeVisitor($callable);
         $nodeTraverser->addVisitor($callableNodeVisitor);
-        $this->mirrorParent($nodes);
+        $this->mirrorParentReturnArrowFunction($nodes);
         $nodeTraverser->addVisitor(new ParentConnectingVisitor());
         $nodeTraverser->traverse($nodes);
     }
@@ -47,7 +47,7 @@ final class SimpleCallableNodeTraverser
     /**
      * @param Node[] $nodes
      */
-    private function mirrorParent(array $nodes): void
+    private function mirrorParentReturnArrowFunction(array $nodes): void
     {
         foreach ($nodes as $node) {
             if (! $node instanceof Return_) {

--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -45,6 +45,13 @@ final class SimpleCallableNodeTraverser
     }
 
     /**
+     * The ArrowFunction when call ->getStmts(), it returns
+     *
+     *      return [new Node\Stmt\Return_($this->expr)]
+     *
+     * The $expr property has parent Node ArrowFunction, but not the Return_ stmt,
+     * so need to mirror $expr parent Node into Return_ stmt
+     *
      * @param Node[] $nodes
      */
     private function mirrorParentReturnArrowFunction(array $nodes): void

--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -7,6 +7,7 @@ namespace Rector\PhpDocParser\NodeTraverser;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeVisitor\CallableNodeVisitor;
 
 /**
@@ -35,7 +36,27 @@ final class SimpleCallableNodeTraverser
         $nodeTraverser = new NodeTraverser();
         $callableNodeVisitor = new CallableNodeVisitor($callable);
         $nodeTraverser->addVisitor($callableNodeVisitor);
-        $nodeTraverser->addVisitor(new ParentConnectingVisitor());
+
+        if ($this->shouldConnectParent($nodes)) {
+            $nodeTraverser->addVisitor(new ParentConnectingVisitor());
+        }
+
         $nodeTraverser->traverse($nodes);
+    }
+
+    /**
+     * @param Node[] $nodes
+     */
+    private function shouldConnectParent(array $nodes): bool
+    {
+        foreach ($nodes as $node) {
+            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+
+            if ($parentNode instanceof Node) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -92,7 +92,7 @@ final class IsClassMethodUsedAnalyzer
         }
 
         if (count($array->items) !== 2) {
-            return true;
+            return false;
         }
 
         if (! $array->items[1] instanceof ArrayItem) {

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -92,7 +92,7 @@ final class IsClassMethodUsedAnalyzer
         }
 
         if (count($array->items) !== 2) {
-            return false;
+            return true;
         }
 
         if (! $array->items[1] instanceof ArrayItem) {

--- a/tests/Issues/RemoveUnusedPrivateDuplicatedIf/Fixture/skip_used_in_array_map.php.inc
+++ b/tests/Issues/RemoveUnusedPrivateDuplicatedIf/Fixture/skip_used_in_array_map.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\RemoveUnusedPrivateDuplicatedIf;
+
+final class SkipUsedInArrayMap
+{
+    public function run(): array
+    {
+        return array_map(
+            static fn (string $bar): string => self::returnFoo(),
+            ['bar']
+        );
+    }
+
+    private static function returnFoo(): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Issues/RemoveUnusedPrivateDuplicatedIf/RemoveUnusedPrivateDuplicatedIfTest.php
+++ b/tests/Issues/RemoveUnusedPrivateDuplicatedIf/RemoveUnusedPrivateDuplicatedIfTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveUnusedPrivateDuplicatedIf;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveUnusedPrivateDuplicatedIfTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RemoveUnusedPrivateDuplicatedIf/config/configured_rule.php
+++ b/tests/Issues/RemoveUnusedPrivateDuplicatedIf/config/configured_rule.php
@@ -7,8 +7,5 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\FunctionLike\RemoveDuplicatedIfReturnRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
-        RemoveUnusedPrivateMethodRector::class,
-        RemoveDuplicatedIfReturnRector::class,
-    ]);
+    $rectorConfig->rules([RemoveUnusedPrivateMethodRector::class, RemoveDuplicatedIfReturnRector::class]);
 };

--- a/tests/Issues/RemoveUnusedPrivateDuplicatedIf/config/configured_rule.php
+++ b/tests/Issues/RemoveUnusedPrivateDuplicatedIf/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\DeadCode\Rector\FunctionLike\RemoveDuplicatedIfReturnRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        RemoveUnusedPrivateMethodRector::class,
+        RemoveDuplicatedIfReturnRector::class,
+    ]);
+};


### PR DESCRIPTION
Given the following code:

```php
final class SkipUsedInArrayMap
{
    public function run(): array
    {
        return array_map(
            static fn (string $bar): string => self::returnFoo(),
            ['bar']
        );
    }

    private static function returnFoo(): string
    {
        return 'foo';
    }
}
```

It currently remove the private method, which should not, as it used. Applied rules:

```php
Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
Rector\DeadCode\Rector\FunctionLike\RemoveDuplicatedIfReturnRector;
```

Ref https://getrector.org/demo/66d03737-04b4-4345-89e5-074046ba496c

This PR try to fix it. Fixes https://github.com/rectorphp/rector/issues/7547