### PR TITLE
[Php81] Register Ctype functions on NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -315,6 +315,17 @@ final class NullToStrictStringFuncCallArgRector extends AbstractRector implement
         'socket_send' => ['data'],
         'mail' => ['to', 'subject', 'message'],
         'mb_send_mail' => ['to', 'subject', 'message'],
+        'ctype_alnum' => ['text'],
+        'ctype_alpha' => ['text'],
+        'ctype_cntrl' => ['text'],
+        'ctype_digit' => ['text'],
+        'ctype_graph' => ['text'],
+        'ctype_lower' => ['text'],
+        'ctype_print' => ['text'],
+        'ctype_punct' => ['text'],
+        'ctype_space' => ['text'],
+        'ctype_upper' => ['text'],
+        'ctype_xdigit' => ['text'],
     ];
 
     public function __construct(


### PR DESCRIPTION
> Warning
> As of PHP 8.1.0, passing a non-string argument is deprecated. In the future, the argument will be interpreted as a string instead of an ASCII codepoint. Depending on the intended behavior, the argument should either be cast to string or an explicit call to chr() should be made.

https://www.php.net/manual/en/intro.ctype.php

https://3v4l.org/f2Ddp