### PR TITLE
[Php80] Handle crash on extends \mysqli on AddParamBasedOnParentClassMethodRector

### DIFF
--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/extends_mysqli.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/extends_mysqli.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Fixture;
+
+// when there is no \mysqli class, it may pull from scoper phar file
+final class ExtendsMysqli extends \mysqli
+{
+    public function query($query) {
+        //Code
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Fixture;
+
+// when there is no \mysqli class, it may pull from scoper phar file
+final class ExtendsMysqli extends \mysqli
+{
+    public function query($query,
+    #[\JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable(from: '7.1')]
+    int $result_mode = \MYSQLI_STORE_RESULT) {
+        //Code
+    }
+}
+
+?>

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php80\Rector\ClassMethod;
 
+use PhpParser\Comment;
 use PhpParser\Node;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr;
@@ -222,9 +223,13 @@ CODE_SAMPLE
                 $parentClassMethodParam->byRef,
                 $parentClassMethodParam->variadic,
                 [],
-                $parentClassMethodParam->flags,
-                $parentClassMethodParam->attrGroups
+                $parentClassMethodParam->flags
             );
+
+            if ($parentClassMethodParam->attrGroups !== []) {
+                $attrGroupsAsComment = $this->nodePrinter->print($parentClassMethodParam->attrGroups);
+                $node->params[$key]->setAttribute(AttributeKey::COMMENTS, [new Comment($attrGroupsAsComment)]);
+            }
         }
 
         return $node;


### PR DESCRIPTION
Given the following code:

```php
// when there is no \mysqli class, it may pull from scoper phar file
final class ExtendsMysqli extends \mysqli
{
    public function query($query) {
        //Code
    }
}
```

it currently make crash:

```bash
There was 1 error:

1) Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\AddParamBasedOnParentClassMethodRectorTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Undefined array key 1504

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Internal/TokenStream.php:217
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:551
/Users/samsonasik/www/rector-src/src/PhpParser/Printer/BetterStandardPrinter.php:156
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinter/Standard.php:1108
```

Or show:

```bash
System error: \"PhpParser\\Internal\\TokenStream::getIndentationBefore(): Return value must be of type int, null returned
```

On https://getrector.org/demo/db0e9b48-9c85-4451-a710-e123b90124ec

It seems due to if there is no \mysqli class, it may pull from scoper phar file, which read the phar file may cause invalid indentation.

Fixes https://github.com/rectorphp/rector/issues/7512