### PR TITLE
[Php80] Skip callable type different definition on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition.php.inc
@@ -7,9 +7,6 @@ final class SkipCallableTypeDifferentDefinition
     /** @var CallbackHandler */
     private $fallback;
 
-    /**
-     * @param mixed[] $cache
-     */
     public function __construct(callable $fallback)
     {
         $this->fallback = $fallback;

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class SkipCallableTypeDifferentDefinition
+{
+    /** @var CallbackHandler */
+    private $fallback;
+
+    /**
+     * @param mixed[] $cache
+     */
+    public function __construct(callable $fallback)
+    {
+        $this->fallback = $fallback;
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition2.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition2.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class SkipCallableTypeDifferentDefinition2
+{
+    /** @var \stdClass */
+    private $fallback;
+
+    /**
+     * @param mixed[] $cache
+     */
+    public function __construct(callable $fallback)
+    {
+        $this->fallback = $fallback;
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition2.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_callable_type_different_definition2.php.inc
@@ -7,9 +7,6 @@ final class SkipCallableTypeDifferentDefinition2
     /** @var \stdClass */
     private $fallback;
 
-    /**
-     * @param mixed[] $cache
-     */
     public function __construct(callable $fallback)
     {
         $this->fallback = $fallback;

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -206,22 +206,25 @@ CODE_SAMPLE
             $type = $param->type;
         }
 
+        if ($this->isCallableTypeIdentifier($type)) {
+            return true;
+        }
+
         if (! $type instanceof UnionType) {
             return false;
         }
 
         foreach ($type->types as $type) {
-            if (! $type instanceof Identifier) {
-                continue;
+            if ($this->isCallableTypeIdentifier($type)) {
+                return true;
             }
-
-            if (! $this->isName($type, 'callable')) {
-                continue;
-            }
-
-            return true;
         }
 
         return false;
+    }
+
+    private function isCallableTypeIdentifier(?Node $node): bool
+    {
+        return $node instanceof Identifier && $this->isName($node, 'callable');
     }
 }

--- a/src/NodeAnalyzer/PropertyAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyAnalyzer.php
@@ -11,6 +11,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\StaticTypeMapper\ValueObject\Type\NonExistingObjectType;
 
 final class PropertyAnalyzer
 {
@@ -26,7 +27,7 @@ final class PropertyAnalyzer
             return true;
         }
 
-        if ($this->isCallableType($propertyType)) {
+        if ($this->isForbiddenType($propertyType)) {
             return true;
         }
 
@@ -36,12 +37,21 @@ final class PropertyAnalyzer
 
         $types = $propertyType->getTypes();
         foreach ($types as $type) {
-            if ($this->isCallableType($type)) {
+            if ($this->isForbiddenType($type)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function isForbiddenType(Type $type): bool
+    {
+        if ($type instanceof NonExistingObjectType) {
+            return true;
+        }
+
+        return $this->isCallableType($type);
     }
 
     private function isCallableType(Type $type): bool


### PR DESCRIPTION
Given the following code:

```php
final class SkipCallableTypeDifferentDefinition
{
    /** @var CallbackHandler */
    private $fallback;

    public function __construct(callable $fallback)
    {
        $this->fallback = $fallback;
    }
}
```

It currently produce:

```diff
+public function __construct(private callable $fallback)
```

which make error:

```
Fatal error: Property SkipCallableTypeDifferentDefinition::$fallback cannot have type callable
```