### PR TITLE
[EarlyReturn] Handle crash on RemoveAlwaysElseRector+ReturnEarlyIfVariableRector

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -92,45 +92,18 @@ final class RectifiedAnalyzer
             return true;
         }
 
-        if ($this->isPreviousCreatedByRuleAttributeEquals($rectifiedNodeClass, $rectifiedNodeNode, $node)) {
+        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+
+        if (! $parentNode instanceof Node) {
+            return true;
+        }
+
+        $parentOriginalNode = $parentNode->getAttribute(AttributeKey::ORIGINAL_NODE);
+        if ($parentOriginalNode instanceof Node) {
             return true;
         }
 
         $startTokenPos = $node->getStartTokenPos();
         return $startTokenPos < 0;
-    }
-
-    /**
-     * @param class-string<RectorInterface> $rectifiedNodeClass
-     */
-    private function isPreviousCreatedByRuleAttributeEquals(
-        string $rectifiedNodeClass,
-        Node $rectifiedNodeNode,
-        Node $node
-    ): bool {
-        /** @var class-string<RectorInterface>[] $createdByRule */
-        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-        $countCreatedByRule = count($createdByRule);
-        if ($countCreatedByRule !== 1) {
-            return $countCreatedByRule !== 0;
-        }
-
-        /**
-         * different rule, allowed if:
-         *      - node parent is Node and parent Node's original Node is a Node, which not just reprinted
-         *      - doesn't has parent node
-         */
-        if (current($createdByRule) !== $rectifiedNodeClass) {
-            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-
-            if ($parentNode instanceof Node) {
-                $parentOriginalNode = $parentNode->getAttribute(AttributeKey::ORIGINAL_NODE);
-                return $parentOriginalNode instanceof Node;
-            }
-
-            return true;
-        }
-
-        return $rectifiedNodeNode === $node;
     }
 }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -115,9 +115,10 @@ final class RectifiedAnalyzer
             return $countCreatedByRule !== 0;
         }
 
-        // different rule, allowed
+        // different rule, allowed if the $rectifiedNodeNode is parent of Node
         if (current($createdByRule) !== $rectifiedNodeClass) {
-            return true;
+            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+            return $parentNode === $rectifiedNodeNode;
         }
 
         return $rectifiedNodeNode === $node;

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -103,6 +103,12 @@ final class RectifiedAnalyzer
             return true;
         }
 
+        /**
+         * Start token pos must be < 0 to continue, as the node and parent node just re-printed
+         *
+         * - Node's original node is null
+         * - Parent Node's original node is null
+         */
         $startTokenPos = $node->getStartTokenPos();
         return $startTokenPos < 0;
     }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -115,10 +115,20 @@ final class RectifiedAnalyzer
             return $countCreatedByRule !== 0;
         }
 
-        // different rule, allowed if the $rectifiedNodeNode is parent of Node
+        /**
+         * different rule, allowed if:
+         *      - node parent is Node and parent Node's original Node is a Node, which not just reprinted
+         *      - doesn't has parent node
+         */
         if (current($createdByRule) !== $rectifiedNodeClass) {
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-            return $parentNode === $rectifiedNodeNode;
+
+            if ($parentNode instanceof Node) {
+                $parentOriginalNode = $parentNode->getAttribute(AttributeKey::ORIGINAL_NODE);
+                return $parentOriginalNode instanceof Node;
+            }
+
+            return true;
         }
 
         return $rectifiedNodeNode === $node;

--- a/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/Fixture/fixture.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable\Fixture;
+
+final class Fixture
+{
+    public function get($a, $b = false)
+    {
+        if ($b !== true) {
+            $value = $a * 5;
+
+            if ($value === 'hello') {
+                $value = false;
+            }
+
+            return $value;
+        } elseif ($a === true) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable\Fixture;
+
+final class Fixture
+{
+    public function get($a, $b = false)
+    {
+        if ($b !== true) {
+            $value = $a * 5;
+            if ($value === 'hello') {
+                return false;
+            }
+            return $value;
+        }
+        if ($a === true) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>

--- a/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/IssueRemoveAlwaysElseReturnEarlyIfVariableTest.php
+++ b/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/IssueRemoveAlwaysElseReturnEarlyIfVariableTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class IssueRemoveAlwaysElseReturnEarlyIfVariableTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/config/configured_rule.php
+++ b/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+	$rectorConfig->rule(RemoveAlwaysElseRector::class );
+	$rectorConfig->rule(ReturnEarlyIfVariableRector::class );
+};

--- a/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/config/configured_rule.php
+++ b/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/config/configured_rule.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
-use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-	$rectorConfig->rule(RemoveAlwaysElseRector::class );
-	$rectorConfig->rule(ReturnEarlyIfVariableRector::class );
+    $rectorConfig->rule(RemoveAlwaysElseRector::class);
+    $rectorConfig->rule(ReturnEarlyIfVariableRector::class);
 };


### PR DESCRIPTION
Given the following code:

```php
final class Fixture
{
    public function get($a, $b = false)
    {
        if ($b !== true) {
            $value = $a * 5;

            if ($value === 'hello') {
                $value = false;
            }

            return $value;
        } elseif ($a === true) {
            return false;
        }

        return true;
    }
}
```

It currently cause crash:

```bash
There was 1 failure:

1) Rector\Core\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable\IssueRemoveAlwaysElseReturnEarlyIfVariableTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
assert($itemStartPos >= 0 && $itemEndPos >= 0 && $itemStartPos >= $pos) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:759

Caused by
AssertionError: assert($itemStartPos >= 0 && $itemEndPos >= 0 && $itemStartPos >= $pos) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:759
```

ref https://getrector.org/demo/214db20a-2710-4424-ae1f-0165576834f5

Fixes https://github.com/rectorphp/rector/issues/7557