### PR TITLE
Add failing test fixture for NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/trait.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/trait.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+trait TitleTrait
+{
+    public function getTitle()
+    {
+        if ($this->title === null) {
+            return null;
+        }
+        
+        return trim($this->title);
+    }
+}
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class DemoFile
+{
+    private ?string $title;
+    
+    use TitleTrait;
+}
+
+?>


### PR DESCRIPTION
# Failing Test for NullToStrictStringFuncCallArgRector

Based on https://getrector.org/demo/9a90408b-44b7-48f9-a5fa-458a526e8749

Code should be untouched: `trim` can't get a `null` value. If method is used without trait, it works fine. 