### PR TITLE
[Core] Improve RectifiedAnalyzer: no need to check created by rule when original Node is null

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -36,7 +36,7 @@ final class RectifiedAnalyzer
     {
         $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
 
-        if ($this->hasCreatedByRule($rectorClass, $node, $originalNode)) {
+        if ($this->hasCreatedByRule($rectorClass, $originalNode)) {
             return new RectifiedNode($rectorClass, $node);
         }
 
@@ -62,9 +62,12 @@ final class RectifiedAnalyzer
     /**
      * @param class-string<RectorInterface> $rectorClass
      */
-    private function hasCreatedByRule(string $rectorClass, Node $node, ?Node $originalNode): bool
+    private function hasCreatedByRule(string $rectorClass, ?Node $originalNode): bool
     {
-        $originalNode ??= $node;
+        if (! $originalNode instanceof Node) {
+            return false;
+        }
+
         $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
         return in_array($rectorClass, $createdByRule, true);
     }

--- a/tests/Issues/IssueOrIfExplicitBoolCompare/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueOrIfExplicitBoolCompare/Fixture/fixture.php.inc
@@ -28,7 +28,10 @@ class Fixture
      */
     public function run($a = '"', $b)
     {
-        if ($a === '' || $a === '0') {
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
             return;
         }
         if (! $b) {


### PR DESCRIPTION
Update `RectifiedAnalyzer` to no need to "created_by_rule" check original Node when null.

On result, the combination between:

```php
Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
```

make it continue running extract `ChangeOrIfReturnToEarlyReturnRector` after change explicit bool compare, on this case:

```php
    /**
     * @param string $a
     */
    public function run($a = '"', $b)
    {
        if (! $a || ! $b) {
            return;
        }
    }
```

transformed to:

```diff
-        if (! $a || ! $b) {
+        if ($a === '') {
+            return;
+        }
+        if ($a === '0') {
+            return;
+        }
+        if (! $b) {
             return;
         }
```
