### PR TITLE
[DeadCode] Handle crash on has first class callable on RemoveUnusedConstructorParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/has_first_class_callable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/has_first_class_callable.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class HasFirstClassCallable
+{
+    private $hey;
+
+    public function __construct($hey, $man)
+    {
+        $this->hey = $hey;
+
+        $this->execute(...);
+    }
+
+    private function execute()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class HasFirstClassCallable
+{
+    private $hey;
+
+    public function __construct($hey)
+    {
+        $this->hey = $hey;
+
+        $this->execute(...);
+    }
+
+    private function execute()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/skip_used_by_exec_first_class_callable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/skip_used_by_exec_first_class_callable.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class SkipUsedByExecFirstClassCallable
+{
+    private $hey;
+
+    public function __construct($hey, $man)
+    {
+        $this->hey = $hey;
+
+        $this->execute(...)($man);
+    }
+
+    private function execute($man)
+    {
+        echo $man;
+    }
+}

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -147,6 +147,10 @@ final class ParamAnalyzer
     private function isUsedAsArg(Node $node, Param $param): bool
     {
         if ($node instanceof New_ || $node instanceof CallLike) {
+            if ($node->isFirstClassCallable()) {
+                return false;
+            }
+
             foreach ($node->getArgs() as $arg) {
                 if ($this->nodeComparator->areNodesEqual($param->var, $arg->value)) {
                     return true;


### PR DESCRIPTION
Given the following code:

```php
final class HasFirstClassCallable
{
    private $hey;

    public function __construct($hey, $man)
    {
        $this->hey = $hey;

        $this->execute(...);
    }

    private function execute()
    {
    }
}
```

It produce crash:

```bash
There was 1 failure:

1) Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\RemoveUnusedConstructorParamRectorTest::test with data set #6 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable()) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:36

Caused by
AssertionError: assert(!$this->isFirstClassCallable()) in /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:36
Stack trace:
#0 /Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php(36): assert(false, 'assert(!$this->...')
#1 /Users/samsonasik/www/rector-src/src/NodeAnalyzer/ParamAnalyzer.php(154): PhpParser\Node\Expr\CallLike->getArgs()
```

Fixes https://github.com/rectorphp/rector/issues/7559