### PR TITLE
Multiline string in GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -105,7 +105,10 @@ jobs:
             -
                 name: "Get Git log"
                 id: git-log
-                run: echo "log=$(git log ${{ github.event.before }}..${{ github.event.after }} --reverse --pretty='%H %s' | sed -e 's/^/https:\/\/github.com\/rectorphp\/rector-src\/commit\//')" >> $GITHUB_OUTPUT
+                run: |
+                    echo "log<<EOF" >> $GITHUB_OUTPUT
+                    echo "$(git log ${{ github.event.before }}..${{ github.event.after }} --reverse --pretty='%H %s' | sed -e 's/^/https:\/\/github.com\/rectorphp\/rector-src\/commit\//')" >> $GITHUB_OUTPUT
+                    echo 'EOF' >> $GITHUB_OUTPUT
 
             # 8.A publish it to remote repository without tag
             -


### PR DESCRIPTION
I thought well and I think it's worth making changes #3013 

The fact is that, perhaps, now you have not yet had commits to many lines with special. symbols that were in the phpstan repository.

Docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings