### PR TITLE
Pin phpstan/phpstan-phpunit to 1.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.8",
         "phpstan/phpstan": "^1.8.7",
-        "phpstan/phpstan-phpunit": "^1.1.1",
+        "phpstan/phpstan-phpunit": "1.1.3",
         "react/event-loop": "^1.3",
         "react/socket": "^1.12",
         "rector/extension-installer": "^0.11.2",


### PR DESCRIPTION
I cherry-picked commit from PR:

- https://github.com/rectorphp/rector-src/pull/3017

The latest phpstan/phpstan-phpunit 1.2.0 and 1.2.1 cause error:

```bash
Run bin/rector process src tests rules-tests packages packages-tests --ansi
PHP Fatal error:  Uncaught _PHPStan_71ced81c9\Nette\DI\ServiceCreationException: Multiple services of type PHPStan\Rules\PHPUnit\CoversHelper found: 0293, 0305 in phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/Autowiring.php:53
Stack trace:
#0 phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/ContainerBuilder.php(170): _PHPStan_71ced81c9\Nette\DI\Autowiring->getByType()
#1 phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/Resolver.php(312): _PHPStan_71ced81c9\Nette\DI\ContainerBuilder->getByType()
#2 phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/Resolver.php(137): _PHPStan_71ced81c9\Nette\DI\Resolver->getByType()
#3 phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/Resolver.php(443): _PHPStan_71ced81c9\Nette\DI\Resolver->_PHPStan_71ced81c9\Nette\DI\{closure}()
#4 phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/Resolver.php(410): _PHPStan_71ced81c9\Nette\DI\Resolver::autowireArgument()
#5 phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/Resolver.php(170): _PHPStan_71ced81c9\Nette\DI\Resolver::autowireArguments()
#6 phar:///home/runner/work/rector-src/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/Definitions/ServiceDefinition.php(158): _PHPStan_71ced81c9\Nette\DI\Resolver->completeStatement()
```

This PR solve it.