### PR TITLE
Move Rector Laravel to the community

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -24,7 +24,6 @@ jobs:
                     - rectorphp/rector-symfony
                     - rectorphp/rector-phpunit
                     - rectorphp/rector-doctrine
-                    - rectorphp/rector-laravel
                     - rectorphp/rector-phpoffice
                     - rectorphp/rector-downgrade-php
                     - rectorphp/rector-php-parser

--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -8,7 +8,7 @@ Rector instantly upgrades and refactors the PHP code of your application.  It ca
 
 ### 1. Instant Upgrades
 
-Rector now supports upgrades from PHP 5.3 to 8.1 and major open-source projects like [Symfony](https://github.com/rectorphp/rector-symfony), [PHPUnit](https://github.com/rectorphp/rector-phpunit), [Laravel](https://github.com/rectorphp/rector-laravel), and [Doctrine](https://github.com/rectorphp/rector-doctrine). Do you want to **be constantly on the latest PHP and Framework without effort**?
+Rector now supports upgrades from PHP 5.3 to 8.1 and major open-source projects like [Symfony](https://github.com/rectorphp/rector-symfony), [PHPUnit](https://github.com/rectorphp/rector-phpunit), and [Doctrine](https://github.com/rectorphp/rector-doctrine). Do you want to **be constantly on the latest PHP and Framework without effort**?
 
 Use Rector to handle **instant upgrades** for you.
 

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -23,7 +23,6 @@
         "rector/rector-phpunit": "*",
         "rector/rector-symfony": "*",
         "rector/rector-doctrine": "*",
-        "rector/rector-laravel": "*",
         "rector/rector-phpoffice": "*",
         "rector/rector-php-parser": "*",
         "rector/rector-downgrade-php": "*"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "rector/extension-installer": "^0.11.2",
         "rector/rector-doctrine": "dev-main",
         "rector/rector-downgrade-php": "dev-main",
-        "rector/rector-laravel": "dev-main",
         "rector/rector-php-parser": "dev-main",
         "rector/rector-phpoffice": "dev-main",
         "rector/rector-phpunit": "dev-main",

--- a/dev-docs/packages_ci_status.md
+++ b/dev-docs/packages_ci_status.md
@@ -18,12 +18,6 @@
 * ![](https://github.com/rectorphp/rector-symfony/actions/workflows/tests.yaml/badge.svg)
 * ![](https://github.com/rectorphp/rector-symfony/actions/workflows/code_analysis.yaml/badge.svg)
 
-## Laravel
-
-* https://github.com/rectorphp/rector-laravel
-* ![](https://github.com/rectorphp/rector-laravel/actions/workflows/tests.yaml/badge.svg)
-* ![](https://github.com/rectorphp/rector-laravel/actions/workflows/code_analysis.yaml/badge.svg)
-
 ## PHPUnit
 
 * https://github.com/rectorphp/rector-phpunit


### PR DESCRIPTION
In the past, we've moved few Rector-framework packages from the core directly to their communities.
It gives the community full power and freedom to decide what to add to the upgrade sets :+1:


See: 

* [getrector.org/blog/separating-typo3-and-nette-as-community-packages](https://getrector.org/blog/separating-typo3-and-nette-as-community-packages)
* https://github.com/rectorphp/rector-cakephp

Based on such a great experience and positive community feedback, we've decided to do this for a Laravel framework package, that deserves much more contributions and maintainer from their own community.

See tweet https://twitter.com/rectorphp/status/1585361016262639616 :)