### PR TITLE
[PHPStan] Fix Multiple services of type PHPStan\Rules\PHPUnit\CoversHelper on require phpstan-phpunit ^1.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.8",
         "phpstan/phpstan": "^1.8.7",
-        "phpstan/phpstan-phpunit": "1.1.3",
+        "phpstan/phpstan-phpunit": "^1.2.1",
         "react/event-loop": "^1.3",
         "react/socket": "^1.12",
         "rector/extension-installer": "^0.11.2",

--- a/phpstan-for-rector.neon
+++ b/phpstan-for-rector.neon
@@ -9,6 +9,3 @@ parameters:
     featureToggles:
         disableRuntimeReflectionProvider: true
 
-# load extension
-includes:
-    - vendor/phpstan/phpstan-webmozart-assert/extension.neon

--- a/phpstan-for-rector.neon
+++ b/phpstan-for-rector.neon
@@ -12,4 +12,3 @@ parameters:
 # load extension
 includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
-    - vendor/phpstan/phpstan-phpunit/extension.neon


### PR DESCRIPTION
Based on suggestion from @ondrejmirtes on https://github.com/phpstan/phpstan-phpunit/issues/142#issuecomment-1293903252, this PR patch to remove already loaded `vendor/phpstan/phpstan-phpunit/extension.neon` on `PHPStanServicesFactory::resolveExtensionConfigs()`