### PR TITLE
Add failing test fixture for SwapFuncCallArgumentsRector

### DIFF
--- a/rules-tests/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector/Fixture/demo_file.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\FuncCall\SwapFuncCallArgumentsRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        return transLoc(
+                $one,
+                $two,
+                $three
+            );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\FuncCall\SwapFuncCallArgumentsRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        return transLoc(
+                $one,
+                $three,
+                $two
+            );
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for SwapFuncCallArgumentsRector

Based on https://getrector.org/demo/67de1160-041b-4aa3-a318-2d3d4ae1e8ff