### PR TITLE
[Php80][CodeQuality] Handle crash on ExplicitMethodCallOverMagicGetSetRector+ChangeSwitchToMatchRector

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -231,6 +231,11 @@ final class PHPStanNodeScopeResolver
         }
 
         foreach ($stmtsAware->stmts as $stmt) {
+            $scope = $stmt->getAttribute(AttributeKey::SCOPE);
+            if ($scope instanceof MutatingScope) {
+                continue;
+            }
+
             $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
         }
     }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\EnumCase;
 use PhpParser\Node\Stmt\Expression;
@@ -165,6 +166,10 @@ final class PHPStanNodeScopeResolver
                 $node->var->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
+            if ($node instanceof Else_) {
+                $this->processElse($node, $mutatingScope);
+            }
+
             if ($node instanceof Trait_) {
                 $traitName = $this->resolveClassName($node);
 
@@ -217,6 +222,13 @@ final class PHPStanNodeScopeResolver
         };
 
         return $this->processNodesWithDependentFiles($filePath, $stmts, $scope, $nodeCallback);
+    }
+
+    private function processElse(Else_ $else, MutatingScope $mutatingScope): void
+    {
+        foreach ($else->stmts as $stmt) {
+            $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+        }
     }
 
     private function processArrayItem(ArrayItem $arrayItem, MutatingScope $mutatingScope): void

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -45,6 +45,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Caching\FileSystem\DependencyResolver;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\StaticReflection\SourceLocator\ParentAttributeSourceLocator;
 use Rector\Core\StaticReflection\SourceLocator\RenamedClassesSourceLocator;
@@ -166,8 +167,8 @@ final class PHPStanNodeScopeResolver
                 $node->var->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
-            if ($node instanceof Else_) {
-                $this->processElse($node, $mutatingScope);
+            if ($node instanceof StmtsAwareInterface) {
+                $this->processStmtsAwareInterface($node, $mutatingScope);
             }
 
             if ($node instanceof Trait_) {
@@ -224,9 +225,13 @@ final class PHPStanNodeScopeResolver
         return $this->processNodesWithDependentFiles($filePath, $stmts, $scope, $nodeCallback);
     }
 
-    private function processElse(Else_ $else, MutatingScope $mutatingScope): void
+    private function processStmtsAwareInterface(StmtsAwareInterface $stmtsAware, MutatingScope $mutatingScope): void
     {
-        foreach ($else->stmts as $stmt) {
+        if ($stmtsAware->stmts === null) {
+            return;
+        }
+
+        foreach ($stmtsAware->stmts as $stmt) {
             $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
         }
     }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -231,11 +231,6 @@ final class PHPStanNodeScopeResolver
         }
 
         foreach ($stmtsAware->stmts as $stmt) {
-            $scope = $stmt->getAttribute(AttributeKey::SCOPE);
-            if ($scope instanceof MutatingScope) {
-                continue;
-            }
-
             $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
         }
     }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\EnumCase;
 use PhpParser\Node\Stmt\Expression;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -71,6 +71,7 @@ parameters:
                 - rules/Php70/EregToPcreTransformer.php
                 - packages/NodeTypeResolver/NodeTypeResolver.php
                 - rules/Renaming/NodeManipulator/ClassRenamer.php
+                - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
 
         - "#^Cognitive complexity for \"Rector\\\\Php70\\\\EregToPcreTransformer\\:\\:(.*?)\" is (.*?), keep it under 10$#"
         - '#Cognitive complexity for "Rector\\Core\\PhpParser\\Node\\Value\\ValueResolver\:\:getValue\(\)" is \d+, keep it under 10#'

--- a/tests/Issues/ScopeNotAvailable/ChangeSwitchToMatchMagicGetSetTest.php
+++ b/tests/Issues/ScopeNotAvailable/ChangeSwitchToMatchMagicGetSetTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeSwitchToMatchMagicGetSetTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureChangeSwitchToMatchMagicGetSet');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/change_switch_to_match_magic_get_set_configurable_rule.php';
+    }
+}

--- a/tests/Issues/ScopeNotAvailable/FixtureChangeSwitchToMatchMagicGetSet/Fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureChangeSwitchToMatchMagicGetSet/Fixture.php.inc
@@ -15,13 +15,21 @@ final class Fixture
                 default:
                     $result = "foo default";
             }
-        } else {
+        } elseif ($rand === 0) {
             switch ($rand) {
                 case 1:
                     $result = "bar";
                     break;
                 default:
                     $result = "bar default";
+            }
+        } else {
+            switch ($rand) {
+                case 1:
+                    $result = "baz";
+                    break;
+                default:
+                    $result = "baz default";
             }
         }
 
@@ -45,10 +53,15 @@ final class Fixture
                 1 => "foo",
                 default => "foo default",
             };
-        } else {
+        } elseif ($rand === 0) {
             $result = match ($rand) {
                 1 => "bar",
                 default => "bar default",
+            };
+        } else {
+            $result = match ($rand) {
+                1 => "baz",
+                default => "baz default",
             };
         }
 

--- a/tests/Issues/ScopeNotAvailable/FixtureChangeSwitchToMatchMagicGetSet/Fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureChangeSwitchToMatchMagicGetSet/Fixture.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\FixtureChangeSwitchToMatchMagicGetSet\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $rand = random_int(0, 1);
+        if ($rand) {
+            switch ($rand) {
+                case 1:
+                    $result = "foo";
+                    break;
+                default:
+                    $result = "foo default";
+            }
+        } else {
+            switch ($rand) {
+                case 1:
+                    $result = "bar";
+                    break;
+                default:
+                    $result = "bar default";
+            }
+        }
+
+        return $result;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\FixtureChangeSwitchToMatchMagicGetSet\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $rand = random_int(0, 1);
+        if ($rand) {
+            $result = match ($rand) {
+                1 => "foo",
+                default => "foo default",
+            };
+        } else {
+            $result = match ($rand) {
+                1 => "bar",
+                default => "bar default",
+            };
+        }
+
+        return $result;
+    }
+}
+
+?>

--- a/tests/Issues/ScopeNotAvailable/config/change_switch_to_match_magic_get_set_configurable_rule.php
+++ b/tests/Issues/ScopeNotAvailable/config/change_switch_to_match_magic_get_set_configurable_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector;
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeSwitchToMatchRector::class);
+    $rectorConfig->rule(ExplicitMethodCallOverMagicGetSetRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
final class Fixture
{
    public function run()
    {
        $rand = random_int(0, 1);
        if ($rand) {
            switch ($rand) {
                case 1:
                    $result = "foo";
                    break;
                default:
                    $result = "foo default";
            }
        } else {
            switch ($rand) {
                case 1:
                    $result = "bar";
                    break;
                default:
                    $result = "bar default";
            }
        }

        return $result;
    }
}
```

It currently produce crash:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\ScopeNotAvailable\ChangeSwitchToMatchMagicGetSetTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Core\Exception\ShouldNotHappenException: Scope not available on "PhpParser\Node\Expr\Assign" node with parent node of "PhpParser\Node\Stmt\Expression", but is required by a refactorWithScope() method of "Rector\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector" rule. Fix scope refresh on changed nodes first
```

This PR try to fix it.

Fixes https://github.com/rectorphp/rector/issues/7576