### PR TITLE
[Core] Typo fix on @param callable on ForeachManipulator and BinaryOpManipulator

### DIFF
--- a/src/NodeManipulator/BinaryOpManipulator.php
+++ b/src/NodeManipulator/BinaryOpManipulator.php
@@ -25,8 +25,8 @@ final class BinaryOpManipulator
      * Tries to match left or right parts (xor),
      * returns null or match on first condition and then second condition. No matter what the origin order is.
      *
-     * @param callable(Node $firstNode, Node $secondNode=): bool|class-string<Node> $firstCondition
-     * @param callable(Node $firstNode, Node $secondNode=): bool|class-string<Node> $secondCondition
+     * @param callable(Node $firstNode, Node $secondNode): bool|class-string<Node> $firstCondition
+     * @param callable(Node $firstNode, Node $secondNode): bool|class-string<Node> $secondCondition
      */
     public function matchFirstAndSecondConditionNode(
         BinaryOp $binaryOp,
@@ -112,7 +112,7 @@ final class BinaryOpManipulator
     }
 
     /**
-     * @param callable(Node $firstNode, Node $secondNode=): bool|class-string<Node> $firstCondition
+     * @param callable(Node $firstNode, Node $secondNode): bool|class-string<Node> $firstCondition
      */
     private function validateCondition(callable|string $firstCondition): void
     {
@@ -128,8 +128,8 @@ final class BinaryOpManipulator
     }
 
     /**
-     * @param callable(Node $firstNode, Node $secondNode=): bool|class-string<Node> $condition
-     * @return callable(Node $firstNode, Node $secondNode=): bool
+     * @param callable(Node $firstNode, Node $secondNode): bool|class-string<Node> $condition
+     * @return callable(Node $firstNode, Node $secondNode): bool
      */
     private function normalizeCondition(callable|string $condition): callable
     {

--- a/src/NodeManipulator/ForeachManipulator.php
+++ b/src/NodeManipulator/ForeachManipulator.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Stmt\Foreach_;
 final class ForeachManipulator
 {
     /**
-     * @param callable(Node $node, Foreach_ $foreach=): ?Node $callable
+     * @param callable(Node $node, Foreach_ $foreach): ?Node $callable
      */
     public function matchOnlyStmt(Foreach_ $foreach, callable $callable): ?Node
     {


### PR DESCRIPTION
There are surplus `=` on `@param callable`, it seems it was typos.