### PR TITLE
Clarify SwapFuncCallArguments rule documentation

### DIFF
--- a/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
+++ b/rules/Arguments/Rector/FuncCall/SwapFuncCallArgumentsRector.php
@@ -31,14 +31,14 @@ final class SwapFuncCallArgumentsRector extends AbstractRector implements Config
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Swap arguments in function calls', [
+        return new RuleDefinition('Reorder arguments in function calls', [
             new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run($one, $two)
+    public function run()
     {
-        return some_function($one, $two);
+        return some_function('one', 'two', 'three');
     }
 }
 CODE_SAMPLE
@@ -46,14 +46,14 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run($one, $two)
+    public function run()
     {
-        return some_function($two, $one);
+        return some_function('three', 'two', 'one');
     }
 }
 CODE_SAMPLE
                 ,
-                [new SwapFuncCallArguments('some_function', [1, 0])],
+                [new SwapFuncCallArguments('some_function', [2, 1, 0])],
             ),
         ]);
     }


### PR DESCRIPTION
`SwapFuncCallArgumentsRector` was mistakenly considered broken with 2+ arguments, when it was actually just unclear how to use the rule.

Previously it looked like the configuration argument was "which arguments to swap", when in reality it's "new order of arguments".

I tried to clarify as much as possible while keeping it as laconic as possible.

Thoughts?

References:

https://github.com/rectorphp/rector-src/pull/3032
Fixes https://github.com/rectorphp/rector/issues/7572