### PR TITLE
Fix var/property usage for RemoveUnusedNonEmptyArrayBeforeForeachRector.

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/if_check.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/if_check.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+class IfCheck
+{
+    public function run()
+    {
+        $values = [];
+        if ($values) {
+            foreach ($values as $value) {
+                echo $value;
+            }
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+class IfCheck
+{
+    public function run()
+    {
+        $values = [];
+        foreach ($values as $value) {
+            echo $value;
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_if_class_property.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_if_class_property.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+class SkipIfClassProperty
+{
+    /** @var string[] */
+    private array $allowedValues = [];
+
+    protected function filterValues(array $values): array
+    {
+        if ($this->allowedValues) {
+            foreach ($values as $index => $value) {
+                if (!isset($this->allowedValues[$value])) {
+                    unset($values[$index]);
+                }
+            }
+        }
+
+        return $values;
+    }
+}

--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_value_can_null.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_value_can_null.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+class SkipPropertyNull
+{
+    private $items = null;
+
+    public function run()
+    {
+        if ($this->items) {
+            foreach ($this->items as $value) {
+                echo $value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR should fix https://github.com/rectorphp/rector/issues/7584