### PR TITLE
[Core] Improve performance: only update and connect parent Node when refactored Node is different

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -663,7 +663,7 @@ parameters:
 
         # false postive, on trait use in multiple classes
         -
-            message: '#Method name "(.*?)Attribute\(\)" is used in multiple traits\. Make it it unique to avoid conflicts#'
+            message: '#Method name "(.*?)Attribute\(\)" is used in multiple traits\. Make it unique to avoid conflicts#'
             paths:
                 - packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
                 - packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php

--- a/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\If_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Foreach_;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -254,6 +254,10 @@ CODE_SAMPLE;
 
         // is equals node type? return node early
         if ($originalNode::class === $refactoredNode::class) {
+            if ($refactoredNode instanceof Expression) {
+                $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
+            }
+
             return $refactoredNode;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -250,13 +250,14 @@ CODE_SAMPLE;
             return $originalNode;
         }
 
-        $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
         // is equals node type? return node early
         if ($originalNode::class === $refactoredNode::class) {
             return $refactoredNode;
         }
+
+        $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
         $originalNodeHash = spl_object_hash($originalNode);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -254,21 +254,17 @@ CODE_SAMPLE;
 
         // is equals node type? return node early
         if ($originalNode::class === $refactoredNode::class) {
-            if ($refactoredNode instanceof Expression) {
-                $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
-            }
-
             return $refactoredNode;
+        }
+
+        if ($originalNode instanceof Stmt && $refactoredNode instanceof Expr) {
+            $refactoredNode = new Expression($refactoredNode);
         }
 
         $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
         $originalNodeHash = spl_object_hash($originalNode);
-
-        $refactoredNode = $originalNode instanceof Stmt && $refactoredNode instanceof Expr
-            ? new Expression($refactoredNode)
-            : $refactoredNode;
 
         $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
 


### PR DESCRIPTION
After `refactor()` call, when returned Node is equal with original node, no need to update existing parent Node and apply ParentConnectingVisitor.