### PR TITLE
[Core] Improve performance: only reindex Node Attributes when Original Node is not null

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -206,7 +206,10 @@ CODE_SAMPLE;
 
         $this->printDebugCurrentFileAndRule();
 
-        $this->changedNodeScopeRefresher->reIndexNodeAttributes($node);
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+        if ($originalNode instanceof Node) {
+            $this->changedNodeScopeRefresher->reIndexNodeAttributes($node);
+        }
 
         $refactoredNode = $this->refactor($node);
 
@@ -220,8 +223,7 @@ CODE_SAMPLE;
             throw new ShouldNotHappenException($errorMessage);
         }
 
-        /** @var Node $originalNode */
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE) ?? $node;
+        $originalNode ??= $node;
 
         /** @var Node[]|Node $refactoredNode */
         $this->createdByRuleDecorator->decorate($refactoredNode, $originalNode, static::class);


### PR DESCRIPTION
When Original Node attribute is null, it means re-printed, which the Node attributes seems no need to be reindexed. 

This PR apply only reindex Node Attributes when Original Node is a Node to improve performance.