### PR TITLE
[Core] Improve performance: only update and connect parent Node when different Node

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureImported/conflict_with_alias2.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureImported/conflict_with_alias2.php.inc
@@ -29,7 +29,7 @@ use Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\AnotherClass a
 
 final class ConflictWithAlias2
 {
-    private \Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\AnotherClass $anotherClass;
+    private AnotherClass $anotherClass;
 
     public function __construct(AnotherClass $anotherClass)
     {


### PR DESCRIPTION
when `refactor()` return Node, update and connect parent Node only needed when refactored node result is different, except for `Expression` and `Return_` usage, which can lead lost connection during transformation, eg: due to ArrowFunction_ change usage.

This PR also handle auto import on conflict with aliased use on `TypedPropertyRector`.