### PR TITLE
[Php81][Restoration] Handle crash on ReadOnlyPropertyRector+MakeTypedPropertyNullableIfCheckedRector

### DIFF
--- a/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
+++ b/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
@@ -25,8 +25,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MakeTypedPropertyNullableIfCheckedRector extends AbstractRector
 {
-    public function __construct(private VisibilityManipulator $visibilityManipulator)
-    {
+    public function __construct(
+        private VisibilityManipulator $visibilityManipulator
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
+++ b/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,6 +25,10 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MakeTypedPropertyNullableIfCheckedRector extends AbstractRector
 {
+    public function __construct(private VisibilityManipulator $visibilityManipulator)
+    {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Make typed property nullable if checked', [
@@ -100,6 +105,10 @@ CODE_SAMPLE
 
         $node->type = new NullableType($currentPropertyType);
         $onlyProperty->default = $this->nodeFactory->createNull();
+
+        if ($node->isReadonly()) {
+            $this->visibilityManipulator->removeReadonly($node);
+        }
 
         return $node;
     }

--- a/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
+++ b/rules/Restoration/Rector/Property/MakeTypedPropertyNullableIfCheckedRector.php
@@ -26,7 +26,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class MakeTypedPropertyNullableIfCheckedRector extends AbstractRector
 {
     public function __construct(
-        private VisibilityManipulator $visibilityManipulator
+        private readonly VisibilityManipulator $visibilityManipulator
     ) {
     }
 

--- a/tests/Issues/IssueReadonlyPropertyNullable/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueReadonlyPropertyNullable/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueReadonlyPropertyNullable\Fixture;
+
+final class SomeClass
+{
+    private AnotherClass $anotherClass;
+
+    public function run()
+    {
+        if ($this->anotherClass === null) {
+            return null;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueReadonlyPropertyNullable\Fixture;
+
+final class SomeClass
+{
+    private ?AnotherClass $anotherClass = null;
+
+    public function run()
+    {
+        if ($this->anotherClass === null) {
+            return null;
+        }
+    }
+}
+
+?>

--- a/tests/Issues/IssueReadonlyPropertyNullable/IssueReadonlyPropertyNullableTest.php
+++ b/tests/Issues/IssueReadonlyPropertyNullable/IssueReadonlyPropertyNullableTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueReadonlyPropertyNullable;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/7590
+ */
+final class IssueReadonlyPropertyNullableTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueReadonlyPropertyNullable/config/configured_rule.php
+++ b/tests/Issues/IssueReadonlyPropertyNullable/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Restoration\Rector\Property\MakeTypedPropertyNullableIfCheckedRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReadOnlyPropertyRector::class);
+    $rectorConfig->rule(MakeTypedPropertyNullableIfCheckedRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
final class SomeClass
{
    private AnotherClass $anotherClass;

    public function run()
    {
        if ($this->anotherClass === null) {
            return null;
        }
    }
}
```

It changed to:

```diff
-private AnotherClass $anotherClass;
+private readonly ?AnotherClass $anotherClass = null;
```

which nullable property can't be readonly, and immediatelly cause fatal error:

```bash
Fatal error: Readonly property SomeClass::$anotherClass cannot have default value
```

see https://3v4l.org/3RBpN

Applied rules:

```diff
Rector\Php81\Rector\Property\ReadOnlyPropertyRector
Rector\Restoration\Rector\Property\MakeTypedPropertyNullableIfCheckedRector
```

This PR try to fix it.

Fixes https://github.com/rectorphp/rector/issues/7590