### PR TITLE
[Core] Improve performance: remove unnecessary loop StmtsAwareInterface to fill Scope on PHPStanNodeScopeResolver

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -44,7 +44,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Caching\FileSystem\DependencyResolver;
-use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\StaticReflection\SourceLocator\ParentAttributeSourceLocator;
 use Rector\Core\StaticReflection\SourceLocator\RenamedClassesSourceLocator;
@@ -166,10 +165,6 @@ final class PHPStanNodeScopeResolver
                 $node->var->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
-            if ($node instanceof StmtsAwareInterface) {
-                $this->processStmtsAwareInterface($node, $mutatingScope);
-            }
-
             if ($node instanceof Trait_) {
                 $traitName = $this->resolveClassName($node);
 
@@ -222,17 +217,6 @@ final class PHPStanNodeScopeResolver
         };
 
         return $this->processNodesWithDependentFiles($filePath, $stmts, $scope, $nodeCallback);
-    }
-
-    private function processStmtsAwareInterface(StmtsAwareInterface $stmtsAware, MutatingScope $mutatingScope): void
-    {
-        if ($stmtsAware->stmts === null) {
-            return;
-        }
-
-        foreach ($stmtsAware->stmts as $stmt) {
-            $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-        }
     }
 
     private function processArrayItem(ArrayItem $arrayItem, MutatingScope $mutatingScope): void

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -813,3 +813,7 @@ parameters:
         -
             message: '#"empty\(\$right\)" is forbidden to use#'
             path: src/Util/ArrayParametersMerger.php
+
+        -
+            message: '#Cognitive complexity for "Rector\\Core\\Rector\\AbstractRector\:\:enterNode\(\)" is 11, keep it under 10#'
+            path: src/Rector/AbstractRector.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -71,7 +71,6 @@ parameters:
                 - rules/Php70/EregToPcreTransformer.php
                 - packages/NodeTypeResolver/NodeTypeResolver.php
                 - rules/Renaming/NodeManipulator/ClassRenamer.php
-                - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
 
         - "#^Cognitive complexity for \"Rector\\\\Php70\\\\EregToPcreTransformer\\:\\:(.*?)\" is (.*?), keep it under 10$#"
         - '#Cognitive complexity for "Rector\\Core\\PhpParser\\Node\\Value\\ValueResolver\:\:getValue\(\)" is \d+, keep it under 10#'


### PR DESCRIPTION
The loop of StmtsAwareInterface stmts was introduced at PR:

- https://github.com/rectorphp/rector-src/pull/3034

to resolve crash on combination between `ExplicitMethodCallOverMagicGetSetRector` and `ChangeSwitchToMatchRector`

By consecutive Rector rule check PR on:

- https://github.com/rectorphp/rector-src/pull/3047

The loop is no longer needed