### PR TITLE
 [Core] Improve performance on NodeComparator 

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -814,3 +814,7 @@ parameters:
         -
             message: '#"empty\(\$right\)" is forbidden to use#'
             path: src/Util/ArrayParametersMerger.php
+
+        -
+            message: '#Cognitive complexity for "Rector\\Core\\Rector\\AbstractRector\:\:enterNode\(\)" is 11, keep it under 10#'
+            path: src/Rector/AbstractRector.php

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -42,6 +42,14 @@ final class NodeComparator
             return false;
         }
 
+        if (is_array($firstNode) && $secondNode === null) {
+            return false;
+        }
+
+        if (is_array($secondNode) && $firstNode === null) {
+            return false;
+        }
+
         return $this->printWithoutComments($firstNode) === $this->printWithoutComments($secondNode);
     }
 

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -7,6 +7,7 @@ namespace Rector\Core\PhpParser\Comparing;
 use PhpParser\Node;
 use Rector\Comments\CommentRemover;
 use Rector\Core\Contract\PhpParser\NodePrinterInterface;
+use Webmozart\Assert\Assert;
 
 final class NodeComparator
 {
@@ -42,12 +43,20 @@ final class NodeComparator
             return false;
         }
 
-        if (is_array($firstNode) && $secondNode === null) {
-            return false;
+        if (is_array($firstNode)) {
+            Assert::allIsInstanceOf($firstNode, Node::class);
+
+            if ($secondNode === null) {
+                return false;
+            }
         }
 
-        if (is_array($secondNode) && $firstNode === null) {
-            return false;
+        if (is_array($secondNode)) {
+            Assert::allIsInstanceOf($secondNode, Node::class);
+
+            if ($firstNode === null) {
+                return false;
+            }
         }
 
         return $this->printWithoutComments($firstNode) === $this->printWithoutComments($secondNode);

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -44,7 +44,7 @@ final class NodeComparator
         }
 
         if (is_array($firstNode)) {
-            Assert::allIsInstanceOf($firstNode, Node::class);
+            Assert::allIsAOf($firstNode, Node::class);
 
             if ($secondNode === null) {
                 return false;
@@ -52,7 +52,7 @@ final class NodeComparator
         }
 
         if (is_array($secondNode)) {
-            Assert::allIsInstanceOf($secondNode, Node::class);
+            Assert::allIsAOf($secondNode, Node::class);
 
             if ($firstNode === null) {
                 return false;

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -34,6 +34,14 @@ final class NodeComparator
      */
     public function areNodesEqual(Node | array | null $firstNode, Node | array | null $secondNode): bool
     {
+        if ($firstNode instanceof Node && $secondNode === null) {
+            return false;
+        }
+
+        if ($secondNode instanceof Node && $firstNode === null) {
+            return false;
+        }
+
         return $this->printWithoutComments($firstNode) === $this->printWithoutComments($secondNode);
     }
 
@@ -61,17 +69,17 @@ final class NodeComparator
             return true;
         }
 
+        $firstClass = $firstNode::class;
+        $secondClass = $secondNode::class;
+
+        if ($firstClass !== $secondClass) {
+            return false;
+        }
+
         if ($firstNode->getStartTokenPos() !== $secondNode->getStartTokenPos()) {
             return false;
         }
 
-        if ($firstNode->getEndTokenPos() !== $secondNode->getEndTokenPos()) {
-            return false;
-        }
-
-        $firstClass = $firstNode::class;
-        $secondClass = $secondNode::class;
-
-        return $firstClass === $secondClass;
+        return $firstNode->getEndTokenPos() === $secondNode->getEndTokenPos();
     }
 }


### PR DESCRIPTION
- [x] No need to print Node when comparing between null and Node, return false early on `areNodesEqual()`
- [x] Compare same node class early to return false early before check token start/end.