### PR TITLE
[Php80] Handle constructor promotion on MixedTypeRector

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/on_constructor_promotion.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/on_constructor_promotion.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\MixedTypeRector\Fixture;
+
+final class OnConstructorPromotion
+{
+    /** @param mixed $foo*/
+    public function __construct(public $foo): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\MixedTypeRector\Fixture;
+
+final class OnConstructorPromotion
+{
+    public function __construct(public mixed $foo): void
+    {
+    }
+}
+
+?>

--- a/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
+++ b/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
@@ -141,6 +141,9 @@ CODE_SAMPLE
 
             $this->hasChanged = true;
             $param->type = new Identifier('mixed');
+            if ($param->flags !== 0) {
+                $param->setAttribute(\Rector\NodeTypeResolver\Node\AttributeKey::ORIGINAL_NODE, null);
+            }
         }
     }
 }


### PR DESCRIPTION
# Failing Test for MixedTypeRector

Discovered while working on https://github.com/doctrine/orm/issues/9772
What happens currently is rector gets the order of the type and the visibility mixed (get it?) up.

Based on https://getrector.org/demo/a5d5e17c-d965-430d-81cb-750887599963