### PR TITLE
[Core] Improve performance: remove unnecessary loop on SimpleCallableNodeTraverser

### DIFF
--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Rector\PhpDocParser\NodeTraverser;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -20,60 +17,41 @@ final class SimpleCallableNodeTraverser
 {
     /**
      * @param callable(Node $node): (int|Node|null) $callable
-     * @param Node|Node[]|null $nodes
+     * @param Node|Node[]|null $node
      */
-    public function traverseNodesWithCallable(Node | array | null $nodes, callable $callable): void
+    public function traverseNodesWithCallable(Node | array | null $node, callable $callable): void
     {
-        if ($nodes === null) {
+        if ($node === null) {
             return;
         }
 
-        if ($nodes === []) {
+        if ($node === []) {
             return;
-        }
-
-        if (! is_array($nodes)) {
-            $nodes = [$nodes];
         }
 
         $nodeTraverser = new NodeTraverser();
         $callableNodeVisitor = new CallableNodeVisitor($callable);
         $nodeTraverser->addVisitor($callableNodeVisitor);
-        $this->mirrorParentReturnArrowFunction($nodes);
-        $nodeTraverser->addVisitor(new ParentConnectingVisitor());
+
+        if ($this->shouldConnectParent($node)) {
+            $nodeTraverser->addVisitor(new ParentConnectingVisitor());
+        }
+
+        $nodes = $node instanceof Node ? [$node] : $node;
         $nodeTraverser->traverse($nodes);
     }
 
     /**
-     * The ArrowFunction when call ->getStmts(), it returns
-     *
-     *      return [new Node\Stmt\Return_($this->expr)]
-     *
-     * The $expr property has parent Node ArrowFunction, but not the Return_ stmt,
-     * so need to mirror $expr parent Node into Return_ stmt
-     *
-     * @param Node[] $nodes
+     * @param Node|Node[] $node
      */
-    private function mirrorParentReturnArrowFunction(array $nodes): void
+    private function shouldConnectParent(Node | array $node): bool
     {
-        foreach ($nodes as $node) {
-            if (! $node instanceof Return_) {
-                continue;
-            }
-
-            if (! $node->expr instanceof Expr) {
-                continue;
-            }
-
+        if ($node instanceof Node) {
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-            if ($parentNode instanceof Node) {
-                continue;
-            }
-
-            $exprParent = $node->expr->getAttribute(AttributeKey::PARENT_NODE);
-            if ($exprParent instanceof ArrowFunction) {
-                $node->setAttribute(AttributeKey::PARENT_NODE, $exprParent);
-            }
+            return $parentNode instanceof Node;
         }
+
+        // usage mostly by pass $node->stmts which parent node is the node
+        return true;
     }
 }


### PR DESCRIPTION
Loop over nodes with verify parent Node was introduced on PR:

- https://github.com/rectorphp/rector-src/pull/3007

to handle private method used in FuncCall with ArrowFunction.

This PR try to improve performance by remove the loop, with simplified solution by verify:

- passed node variable is a Node
    - then check if its parent Node is Node
        -  when no parent, no need to connect.

- otherwise, it is an array of Nodes, which mostly usage is by pass `$node->stmts`, which parent node is the `$node` so no need to loop over to verify.

