### PR TITLE
[Core] Use parent attribute check instead of origNode for check update and connect parent node after refactor

### DIFF
--- a/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
+++ b/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
@@ -19,6 +19,7 @@ use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DeadCode\PhpDoc\TagRemover\ParamTagRemover;
 use Rector\FamilyTree\NodeAnalyzer\ClassChildAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -142,7 +143,7 @@ CODE_SAMPLE
             $this->hasChanged = true;
             $param->type = new Identifier('mixed');
             if ($param->flags !== 0) {
-                $param->setAttribute(\Rector\NodeTypeResolver\Node\AttributeKey::ORIGINAL_NODE, null);
+                $param->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
         }
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -262,13 +262,13 @@ CODE_SAMPLE;
              *  - Expression on Assign with ArrowFunction changed to Closure
              *  - Return_ on ArrowFunction usage, Return_ is created dynamically on getStmts()
              *
-             * 2. When returned refactored Node doesn't has origNode yet,
+             * 2. When returned refactored Node doesn't has parent yet,
              *    it means returned with New Node instead of re-use existing Node
              */
             if (
                 $refactoredNode instanceof Expression
                 || $refactoredNode instanceof Return_
-                || ! $refactoredNode->hasAttribute(AttributeKey::ORIGINAL_NODE)
+                || ! $refactoredNode->hasAttribute(AttributeKey::PARENT_NODE)
             ) {
                 $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
             }


### PR DESCRIPTION
Ensure check against parent attribute instead of origNode for update and connect parent node after refactor from PR:

- https://github.com/rectorphp/rector-src/pull/3044