### PR TITLE
[Core] Fix resolve scope handling when parent Node just re-printed

### DIFF
--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
-use PhpParser\Node\Stmt\UseUse;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -814,9 +814,5 @@ parameters:
             message: '#"empty\(\$right\)" is forbidden to use#'
             path: src/Util/ArrayParametersMerger.php
 
-        -
-            message: '#Cognitive complexity for "Rector\\Core\\Rector\\AbstractRector\:\:enterNode\(\)" is 11, keep it under 10#'
-            path: src/Rector/AbstractRector.php
-
         # not relevant anymore
         - '#Instead of "Symfony\\Component\\Finder\\SplFileInfo" class/interface use "Symplify\\SmartFileSystem\\SmartFileInfo"#'

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureImported/conflict_with_alias2.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/FixtureImported/conflict_with_alias2.php.inc
@@ -29,7 +29,7 @@ use Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\AnotherClass a
 
 final class ConflictWithAlias2
 {
-    private AnotherClass $anotherClass;
+    private \Rector\Tests\Php74\Rector\Property\TypedPropertyRector\Source\AnotherClass $anotherClass;
 
     public function __construct(AnotherClass $anotherClass)
     {

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -78,7 +78,7 @@ final class ScopeAnalyzer
         }
 
         /**
-         * Node and parent Node doesn't has Scope, and its Start token pos is < 0,
+         * Node and parent Node doesn't has Scope, and parent Node Start token pos is < 0,
          * it means the node and parent node just re-printed, the Scope need to be resolved from file
          */
         if ($parentNode->getStartTokenPos() < 0) {

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -78,7 +78,7 @@ final class ScopeAnalyzer
         }
 
         /**
-         * Node and parent Node doesn't has Scope, and its Start token pos must be < 0,
+         * Node and parent Node doesn't has Scope, and its Start token pos is < 0,
          * it means the node and parent node just re-printed, the Scope need to be resolved from file
          */
         if ($parentNode->getStartTokenPos() < 0) {

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -77,6 +77,14 @@ final class ScopeAnalyzer
             return $this->scopeFactory->createFromFile($filePath);
         }
 
+        /**
+         * Node and parent Node doesn't has Scope, and its Start token pos must be < 0,
+         * it means the node and parent node just re-printed, the Scope need to be resolved from file
+         */
+        if ($parentNode->getStartTokenPos() < 0) {
+            return $this->scopeFactory->createFromFile($filePath);
+        }
+
         return null;
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -253,32 +253,13 @@ CODE_SAMPLE;
             return $originalNode;
         }
 
-        // is equals node type? return node early
-        if ($originalNode::class === $refactoredNode::class) {
-            /**
-             * 1. Expression and Return_ are special
-             *
-             * Eg:
-             *  - Expression on Assign with ArrowFunction changed to Closure
-             *  - Return_ on ArrowFunction usage, Return_ is created dynamically on getStmts()
-             *
-             * 2. When returned refactored Node doesn't has parent yet,
-             *    it means returned with New Node instead of re-use existing Node
-             */
-            if (
-                $refactoredNode instanceof Expression
-                || $refactoredNode instanceof Return_
-                || ! $refactoredNode->hasAttribute(AttributeKey::PARENT_NODE)
-            ) {
-                $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
-            }
-
-            $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
-            return $refactoredNode;
-        }
-
         $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
+
+        // is equals node type? return node early
+        if ($originalNode::class === $refactoredNode::class) {
+            return $refactoredNode;
+        }
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
         $originalNodeHash = spl_object_hash($originalNode);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Nop;
-use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;


### PR DESCRIPTION
Previously, in the following PR:

- https://github.com/rectorphp/rector-src/pull/3044

It not update and connect Parent Node and same Node returned, which may cause issue as possibly the jump Node attribute not only `Expression` or `Return_`, that just what we found on our codebase.

After some thinking, I think it actually need to be connected, ensure that its Node attribute now always has parent. 

To make it work, instead of back loop of `StmtsAwareInterface` which will downgrade the performance, I add handling when next visited `Node` doesn't has Scope, resolving Scope via the `ScopeAnalyzer::resolveScope()` updated to:

- if no scope -> check parent Node scope
    - parent Node scope is null, and parent node start token pos < 0, then it means just reprinted
        - resolve from file

I rolled back use case for auto-import conflict, as while it is nice to auto-import docblock directly when there is alias conflict, it can just be re-run to resolve the name for auto-import it.