### PR TITLE
Update PHP-Parser to ^4.15.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer/xdebug-handler": "^3.0.3",
         "doctrine/inflector": "^2.0.5",
         "nette/utils": "^3.2.8",
-        "nikic/php-parser": "^4.15.1",
+        "nikic/php-parser": "^4.15.2",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.8",
         "phpstan/phpstan": "^1.9.0",


### PR DESCRIPTION
PHP-Parser  4.15.2 just released with support for formatting-preserving  on code that use inline html

https://github.com/nikic/PHP-Parser/releases/tag/v4.15.2