### PR TITLE
[Caching] Fix cache consecutive run rector with --dry-run

### DIFF
--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -90,20 +90,25 @@ final class ChangedFilesDetector
         $this->storeConfigurationDataHash($filePath, $configHash);
     }
 
-    private function getFilePathCacheKey(string $filePath): string
+    private function resolvePath(string $filePath): string
     {
         $realPath = realpath($filePath);
 
         if ($realPath === false) {
-            return sha1($filePath);
+            return $filePath;
         }
 
-        return sha1($realPath);
+        return $realPath;
+    }
+
+    private function getFilePathCacheKey(string $filePath): string
+    {
+        return sha1($this->resolvePath($filePath));
     }
 
     private function hashFile(string $filePath): string
     {
-        return (string) sha1_file($filePath);
+        return (string) sha1_file($this->resolvePath($filePath));
     }
 
     private function storeConfigurationDataHash(string $filePath, string $configurationHash): void

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -27,8 +27,6 @@ final class ChangedFilesDetector
      */
     public function addFileWithDependencies(string $filePath, array $dependentFiles): void
     {
-        $filePath = (string) realpath($filePath);
-
         $filePathCacheKey = $this->getFilePathCacheKey($filePath);
         $hash = $this->hashFile($filePath);
 
@@ -38,8 +36,6 @@ final class ChangedFilesDetector
 
     public function hasFileChanged(string $filePath): bool
     {
-        $filePath = (string) realpath($filePath);
-
         $currentFileHash = $this->hashFile($filePath);
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
 
@@ -49,8 +45,6 @@ final class ChangedFilesDetector
 
     public function invalidateFile(string $filePath): void
     {
-        $filePath = (string) realpath($filePath);
-
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
         $this->cache->clean($fileInfoCacheKey);
     }
@@ -65,8 +59,6 @@ final class ChangedFilesDetector
      */
     public function getDependentFilePaths(string $filePath): array
     {
-        $filePath = (string) realpath($filePath);
-
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
 
         $cacheValue = $this->cache->load($fileInfoCacheKey . '_files', CacheKey::DEPENDENT_FILES_KEY);
@@ -93,8 +85,6 @@ final class ChangedFilesDetector
      */
     public function setFirstResolvedConfigFileInfo(string $filePath): void
     {
-        $filePath = (string) realpath($filePath);
-
         // the first config is core to all → if it was changed, just invalidate it
         $configHash = $this->fileHashComputer->compute($filePath);
         $this->storeConfigurationDataHash($filePath, $configHash);
@@ -102,6 +92,7 @@ final class ChangedFilesDetector
 
     private function getFilePathCacheKey(string $filePath): string
     {
+        $filePath = (string) realpath($filePath);
         return sha1($filePath);
     }
 

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -92,8 +92,13 @@ final class ChangedFilesDetector
 
     private function getFilePathCacheKey(string $filePath): string
     {
-        $filePath = realpath($filePath) ?: $filePath;
-        return sha1($filePath);
+        $realPath = realpath($filePath);
+
+        if ($realPath === false) {
+            return sha1($filePath);
+        }
+
+        return sha1($realPath);
     }
 
     private function hashFile(string $filePath): string

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -92,7 +92,7 @@ final class ChangedFilesDetector
 
     private function getFilePathCacheKey(string $filePath): string
     {
-        $filePath = (string) realpath($filePath);
+        $filePath = realpath($filePath) ?: $filePath;
         return sha1($filePath);
     }
 

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -27,6 +27,8 @@ final class ChangedFilesDetector
      */
     public function addFileWithDependencies(string $filePath, array $dependentFiles): void
     {
+        $filePath = (string) realpath($filePath);
+
         $filePathCacheKey = $this->getFilePathCacheKey($filePath);
         $hash = $this->hashFile($filePath);
 
@@ -36,6 +38,8 @@ final class ChangedFilesDetector
 
     public function hasFileChanged(string $filePath): bool
     {
+        $filePath = (string) realpath($filePath);
+
         $currentFileHash = $this->hashFile($filePath);
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
 
@@ -45,6 +49,8 @@ final class ChangedFilesDetector
 
     public function invalidateFile(string $filePath): void
     {
+        $filePath = (string) realpath($filePath);
+
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
         $this->cache->clean($fileInfoCacheKey);
     }
@@ -59,6 +65,8 @@ final class ChangedFilesDetector
      */
     public function getDependentFilePaths(string $filePath): array
     {
+        $filePath = (string) realpath($filePath);
+
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
 
         $cacheValue = $this->cache->load($fileInfoCacheKey . '_files', CacheKey::DEPENDENT_FILES_KEY);
@@ -85,6 +93,8 @@ final class ChangedFilesDetector
      */
     public function setFirstResolvedConfigFileInfo(string $filePath): void
     {
+        $filePath = (string) realpath($filePath);
+
         // the first config is core to all → if it was changed, just invalidate it
         $configHash = $this->fileHashComputer->compute($filePath);
         $this->storeConfigurationDataHash($filePath, $configHash);


### PR DESCRIPTION
**Before** _consecutive --dry-run, on next run, it doesn't show the diff_

![Screen Shot 2022-11-13 at 13 13 25](https://user-images.githubusercontent.com/459648/201508587-a19fdc16-2ba5-455a-8102-0d94a0a04cae.png)

**After** _consecutive --dry-run, on next run, it still show the diff_

![after](https://user-images.githubusercontent.com/459648/201508598-bf0a81a2-3ff0-43fa-a7b8-32234b329e6c.png)

The patch is by ensure file path to be realpath to be processed save path into cache.

@tuupola  this should Fix https://github.com/rectorphp/rector/issues/7499

