### PR TITLE
[test] AddReturnTypeDeclarationBasedOnParentClassMethodRector does not understand classes imported using aliases

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/a.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/a.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+use B as BAlias;
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+abstract class A
+{
+    public function getMe(): A
+    {
+        return new self();
+    }
+}
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+final class B extends A
+{
+    public function getMe(): BAlias
+    {
+        return parent::getMe();
+    }
+}
+?>


### PR DESCRIPTION
`AddReturnTypeDeclarationBasedOnParentClassMethodRector` doesn't properly process classes imported using aliases. It works fine when FQCN is used.