### PR TITLE
[Core] Handle no scope crash on foreach value with array item variable

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -7,6 +7,7 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
@@ -138,6 +139,13 @@ final class PHPStanNodeScopeResolver
             if ($node instanceof Foreach_) {
                 // decorate value as well
                 $node->valueVar->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+                if ($node->valueVar instanceof Array_) {
+                    $this->processArray($node->valueVar, $mutatingScope);
+                }
+            }
+
+            if ($node instanceof Array_) {
+                $this->processArray($node, $mutatingScope);
             }
 
             if ($node instanceof Property) {
@@ -217,6 +225,15 @@ final class PHPStanNodeScopeResolver
         };
 
         return $this->processNodesWithDependentFiles($filePath, $stmts, $scope, $nodeCallback);
+    }
+
+    private function processArray(Array_ $array, MutatingScope $mutatingScope): void
+    {
+        foreach ($array->items as $arrayItem) {
+            if ($arrayItem instanceof Expr) {
+                $arrayItem->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+            }
+        }
     }
 
     private function processArrayItem(ArrayItem $arrayItem, MutatingScope $mutatingScope): void

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -230,7 +230,7 @@ final class PHPStanNodeScopeResolver
     private function processArray(Array_ $array, MutatingScope $mutatingScope): void
     {
         foreach ($array->items as $arrayItem) {
-            if ($arrayItem instanceof Expr) {
+            if ($arrayItem instanceof ArrayItem) {
                 $arrayItem->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -71,6 +71,7 @@ parameters:
                 - rules/Php70/EregToPcreTransformer.php
                 - packages/NodeTypeResolver/NodeTypeResolver.php
                 - rules/Renaming/NodeManipulator/ClassRenamer.php
+                - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
 
         - "#^Cognitive complexity for \"Rector\\\\Php70\\\\EregToPcreTransformer\\:\\:(.*?)\" is (.*?), keep it under 10$#"
         - '#Cognitive complexity for "Rector\\Core\\PhpParser\\Node\\Value\\ValueResolver\:\:getValue\(\)" is \d+, keep it under 10#'
@@ -816,3 +817,6 @@ parameters:
 
         # not relevant anymore
         - '#Instead of "Symfony\\Component\\Finder\\SplFileInfo" class/interface use "Symplify\\SmartFileSystem\\SmartFileInfo"#'
+
+        # fixture class
+        - '#Class "Rector\\Core\\Tests\\Issues\\ScopeNotAvailable\\Variable\\ArrayItemForeachValueRector" is missing @see annotation with test case class reference#'

--- a/tests/Issues/ScopeNotAvailable/FixtureForeachValue/fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureForeachValue/fixture.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+
+class FixtureForeachValue
+{
+    public function run()
+    {
+        $value = [
+            [3, 1, false],
+            [1, 2, false],
+            [0, 0, true],
+        ];
+
+        foreach ($value as [$a_b, $b_c, $d_e]) {
+
+        }
+    }
+}

--- a/tests/Issues/ScopeNotAvailable/ForeachValueScopeTest.php
+++ b/tests/Issues/ScopeNotAvailable/ForeachValueScopeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ForeachValueScopeTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureForeachValue');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/foreach_value_configured.php';
+    }
+}

--- a/tests/Issues/ScopeNotAvailable/Utils/ArrayItemForeachValueRector.php
+++ b/tests/Issues/ScopeNotAvailable/Utils/ArrayItemForeachValueRector.php
@@ -5,25 +5,29 @@ declare(strict_types=1);
 namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Utils;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class ArrayItemForeachValueRector extends AbstractScopeAwareRector
+final class ArrayItemForeachValueRector extends AbstractScopeAwareRector
 {
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Hello!', [new CodeSample('', '')]);
     }
 
+    /**
+     * @return array<class-string<Expr>>
+     */
     public function getNodeTypes(): array
     {
         return [Variable::class];
     }
 
-    public function refactorWithScope(Node $node, Scope $scope)
+    public function refactorWithScope(Node $node, Scope $scope): Node
     {
         return $node;
     }

--- a/tests/Issues/ScopeNotAvailable/Utils/ArrayItemForeachValueRector.php
+++ b/tests/Issues/ScopeNotAvailable/Utils/ArrayItemForeachValueRector.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Utils;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use Rector\Core\Rector\AbstractScopeAwareRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ArrayItemForeachValueRector extends AbstractScopeAwareRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Hello!', [
+            new CodeSample('',''),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Variable::class];
+    }
+
+    public function refactorWithScope(Node $node, Scope $scope)
+    {
+        return $node;
+    }
+}

--- a/tests/Issues/ScopeNotAvailable/Utils/ArrayItemForeachValueRector.php
+++ b/tests/Issues/ScopeNotAvailable/Utils/ArrayItemForeachValueRector.php
@@ -15,9 +15,7 @@ class ArrayItemForeachValueRector extends AbstractScopeAwareRector
 {
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Hello!', [
-            new CodeSample('',''),
-        ]);
+        return new RuleDefinition('Hello!', [new CodeSample('', '')]);
     }
 
     public function getNodeTypes(): array

--- a/tests/Issues/ScopeNotAvailable/Variable/ArrayItemForeachValueRector.php
+++ b/tests/Issues/ScopeNotAvailable/Variable/ArrayItemForeachValueRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Utils;
+namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Variable;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;

--- a/tests/Issues/ScopeNotAvailable/config/foreach_value_configured.php
+++ b/tests/Issues/ScopeNotAvailable/config/foreach_value_configured.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\ScopeNotAvailable\Utils\ArrayItemForeachValueRector;
+use Rector\Core\Tests\Issues\ScopeNotAvailable\Variable\ArrayItemForeachValueRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ArrayItemForeachValueRector::class);

--- a/tests/Issues/ScopeNotAvailable/config/foreach_value_configured.php
+++ b/tests/Issues/ScopeNotAvailable/config/foreach_value_configured.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\Tests\Issues\ScopeNotAvailable\Utils\ArrayItemForeachValueRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ArrayItemForeachValueRector::class);
+};


### PR DESCRIPTION
Given the following code:

```php
        $value = [
            [3, 1, false],
            [1, 2, false],
            [0, 0, true],
        ];

        foreach ($value as [$a_b, $b_c, $d_e]) {

        }
```

It cause crash:

```bash
There was 1 error:

1) Rector\Core\Tests\Issues\ScopeNotAvailable\ForeachValueScopeTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Core\Exception\ShouldNotHappenException: Scope not available on "PhpParser\Node\Expr\Variable" node with parent node of "PhpParser\Node\Expr\ArrayItem", but is required by a refactorWithScope() method of "Rector\Core\Tests\Issues\ScopeNotAvailable\Utils\ArrayItemForeachValueRector" rule. Fix scope refresh on changed nodes first

/Users/samsonasik/www/rector-src/src/Rector/AbstractScopeAwareRector.php:62
/Users/samsonasik/www/rector-src/src/Rector/AbstractRector.php:214
```

with `Variable` as node type. 

This PR try to fix it.

Fixes https://github.com/rectorphp/rector/issues/7611