### PR TITLE
fix(UpdateFileNameByClassNameFileSystemRector): compare shortClass Wi…

### DIFF
--- a/rules/Restoration/Rector/ClassLike/UpdateFileNameByClassNameFileSystemRector.php
+++ b/rules/Restoration/Rector/ClassLike/UpdateFileNameByClassNameFileSystemRector.php
@@ -64,7 +64,7 @@ CODE_SAMPLE
         $classShortName = $this->nodeNameResolver->getShortName($className);
 
         $filePath = $this->file->getFilePath();
-        $basename = pathinfo($filePath, PATHINFO_BASENAME);
+        $basename = pathinfo($filePath, PATHINFO_FILENAME);
 
         if ($classShortName === $basename) {
             return null;


### PR DESCRIPTION
[BUG]
we compare the class name with the file name with the extension which is always false
Before 
<img width="679" alt="Capture d’écran 2022-11-16 à 21 16 12" src="https://user-images.githubusercontent.com/15124496/202285987-aab6438a-1f29-4f53-82a4-2a787bb3dd1c.png">

After
<img width="679" alt="Capture d’écran 2022-11-16 à 21 16 28" src="https://user-images.githubusercontent.com/15124496/202286104-634a9d87-7bfd-4c7a-ba61-18b3fdc987ee.png">

