### PR TITLE
[Core] Connect Expression parent Node on transform Stmt to Expr

### DIFF
--- a/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
+++ b/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\Empty_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\Empty_;
@@ -54,18 +55,16 @@ final class SimplifyEmptyCheckOnEmptyArrayRector extends AbstractScopeAwareRecto
         return new Identical($node->expr, new Array_());
     }
 
-    private function isAllowedExpr(Node\Expr $expr): bool
+    private function isAllowedExpr(Expr $expr): bool
     {
         if ($expr instanceof Variable) {
             return true;
         }
+
         if ($expr instanceof PropertyFetch) {
             return true;
         }
-        if ($expr instanceof StaticPropertyFetch) {
-            return true;
-        }
 
-        return false;
+        return $expr instanceof StaticPropertyFetch;
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -251,6 +251,10 @@ CODE_SAMPLE;
             // will be replaced in leaveNode() the original node must be passed
             return $originalNode;
         }
+        
+        $refactoredNode = $originalNode instanceof Stmt && $refactoredNode instanceof Expr
+            ? new Expression($refactoredNode)
+            : $refactoredNode;
 
         $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
@@ -262,11 +266,6 @@ CODE_SAMPLE;
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
         $originalNodeHash = spl_object_hash($originalNode);
-
-        $refactoredNode = $originalNode instanceof Stmt && $refactoredNode instanceof Expr
-            ? new Expression($refactoredNode)
-            : $refactoredNode;
-
         $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
 
         return $refactoredNode;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -251,7 +251,7 @@ CODE_SAMPLE;
             // will be replaced in leaveNode() the original node must be passed
             return $originalNode;
         }
-        
+
         $refactoredNode = $originalNode instanceof Stmt && $refactoredNode instanceof Expr
             ? new Expression($refactoredNode)
             : $refactoredNode;


### PR DESCRIPTION
When transforming Stmt to Expr, it changed to 

```php
new Expression($refactoredNode)
```

The Expression need to have mirrored with original parent node.