### PR TITLE
[Core] Remove BetterStandardPrinter::pStmt_Class()

### DIFF
--- a/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
+++ b/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\Empty_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\Empty_;
@@ -54,18 +55,16 @@ final class SimplifyEmptyCheckOnEmptyArrayRector extends AbstractScopeAwareRecto
         return new Identical($node->expr, new Array_());
     }
 
-    private function isAllowedExpr(Node\Expr $expr): bool
+    private function isAllowedExpr(Expr $expr): bool
     {
         if ($expr instanceof Variable) {
             return true;
         }
+
         if ($expr instanceof PropertyFetch) {
             return true;
         }
-        if ($expr instanceof StaticPropertyFetch) {
-            return true;
-        }
 
-        return false;
+        return $expr instanceof StaticPropertyFetch;
     }
 }

--- a/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
+++ b/rules/Removing/Rector/Class_/RemoveTraitUseRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Trait_;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
@@ -19,8 +18,6 @@ use Webmozart\Assert\Assert;
  */
 final class RemoveTraitUseRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    private bool $classHasChanged = false;
-
     /**
      * @var string[]
      */
@@ -61,7 +58,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $this->classHasChanged = false;
+        $classHasChanged = false;
 
         foreach ($node->getTraitUses() as $traitUse) {
             foreach ($traitUse->traits as $trait) {
@@ -70,13 +67,11 @@ CODE_SAMPLE
                 }
 
                 $this->removeNode($traitUse);
-                $this->classHasChanged = true;
+                $classHasChanged = true;
             }
         }
 
-        // invoke re-print
-        if ($this->classHasChanged) {
-            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        if ($classHasChanged) {
             return $node;
         }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -25,7 +25,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Nop;
-use PhpParser\Node\Stmt\TraitUse;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\PrettyPrinter\Standard;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -361,28 +360,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
 
         // this approach is chosen, to keep changes in parent pStmt_ClassMethod() updated
         return Strings::replace($content, self::REPLACE_COLON_WITH_SPACE_REGEX, '$1: ');
-    }
-
-    /**
-     * Clean class and trait from empty "use x;" for traits causing invalid code
-     */
-    protected function pStmt_Class(Class_ $class): string
-    {
-        $shouldReindex = false;
-
-        foreach ($class->stmts as $key => $stmt) {
-            // remove empty ones
-            if ($stmt instanceof TraitUse && $stmt->traits === []) {
-                unset($class->stmts[$key]);
-                $shouldReindex = true;
-            }
-        }
-
-        if ($shouldReindex) {
-            $class->stmts = array_values($class->stmts);
-        }
-
-        return parent::pStmt_Class($class);
     }
 
     /**


### PR DESCRIPTION
The overridden method `BetterStandardPrinter::pStmt_Class()` seems introduced back in 2019 on https://github.com/rectorphp/rector-src/commit/c8478557d420c1e2295c4f1c74ea651642dc34ec, long before fully static analysys phpstan and rector reindex and scope handling added.

I think it now can be removed 👍  