### PR TITLE
[Core] Refactor CreatedByRuleDecorator to make consistent check for consecutive same Rector run

### DIFF
--- a/src/NodeDecorator/CreatedByRuleDecorator.php
+++ b/src/NodeDecorator/CreatedByRuleDecorator.php
@@ -29,9 +29,25 @@ final class CreatedByRuleDecorator
 
     private function createByRule(Node $node, string $rectorClass): void
     {
-        $mergeCreatedByRule = array_merge($node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [], [$rectorClass]);
-        $mergeCreatedByRule = array_unique($mergeCreatedByRule);
+        $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
+        $lastRectorRuleKey = array_key_last($createdByRule);
 
-        $node->setAttribute(AttributeKey::CREATED_BY_RULE, $mergeCreatedByRule);
+        // empty array, insert
+        if ($lastRectorRuleKey === null) {
+            $node->setAttribute(AttributeKey::CREATED_BY_RULE, [$rectorClass]);
+            return;
+        }
+
+        // consecutive, no need to refill
+        if ($createdByRule[$lastRectorRuleKey] === $rectorClass) {
+            return;
+        }
+
+        // filter out when exists, then append
+        $createdByRule = array_filter(
+            $createdByRule,
+            static fn (string $rectorRule): bool => $rectorRule !== $rectorClass
+        );
+        $node->setAttribute(AttributeKey::CREATED_BY_RULE, [...$createdByRule, $rectorClass]);
     }
 }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -36,7 +36,7 @@ final class RectifiedAnalyzer
     {
         $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
 
-        if ($this->hasCreatedByRule($rectorClass, $node, $originalNode)) {
+        if ($this->hasConsecutiveCreatedByRule($rectorClass, $node, $originalNode)) {
             return new RectifiedNode($rectorClass, $node);
         }
 
@@ -62,21 +62,17 @@ final class RectifiedAnalyzer
     /**
      * @param class-string<RectorInterface> $rectorClass
      */
-    private function hasCreatedByRule(string $rectorClass, Node $node, ?Node $originalNode): bool
+    private function hasConsecutiveCreatedByRule(string $rectorClass, Node $node, ?Node $originalNode): bool
     {
-        if (! $originalNode instanceof Node) {
-            $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-            $lastRectorRuleKey = array_key_last($createdByRule);
+        $createdByRuleNode = $originalNode ?? $node;
+        $createdByRule = $createdByRuleNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
 
-            if ($lastRectorRuleKey === null) {
-                return false;
-            }
-
-            return $createdByRule[$lastRectorRuleKey] === $rectorClass;
+        $lastRectorRuleKey = array_key_last($createdByRule);
+        if ($lastRectorRuleKey === null) {
+            return false;
         }
 
-        $createdByRule = $originalNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-        return in_array($rectorClass, $createdByRule, true);
+        return $createdByRule[$lastRectorRuleKey] === $rectorClass;
     }
 
     /**


### PR DESCRIPTION
Refactor `CreatedByRuleDecorator` to correctly make unique append on fill of `CREATED_BY_RULE` attribute data with Rector rules passed, with verify:

- empty data -> insert
- has data with last equal with passed Rector rule -> stop
- otherwise, clear out existing `CREATED_BY_RULE` which consist of passed Rector rule, then append

so, by above, the passed Rector rule will always on the last. So, by this case, the `RectifiedAnalyzer` can do consistent check against `CREATED_BY_RULE` for `last data` === `passed rector class`.