### PR TITLE
[Core] Improve performance: no need to connect nodes when only 1 node

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -447,6 +447,10 @@ CODE_SAMPLE;
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
             $nodes = [...$nodes, $nextNode];
         }
+        
+        if (count($nodes) === 1) {
+            return;
+        }
 
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new NodeConnectingVisitor());

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -447,7 +447,7 @@ CODE_SAMPLE;
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
             $nodes = [...$nodes, $nextNode];
         }
-        
+
         if (count($nodes) === 1) {
             return;
         }


### PR DESCRIPTION
when transformed node only 1 and doesn't has prev and next node, no need to create `NodeTraverser` instance, add `NodeConnectingVisitor` and traverse.