### PR TITLE
[Core] Remove DocBlockUpdater::updateRefactoredNodeWithPhpDocInfo(), re-use updateNodeWithPhpDocInfo()

### DIFF
--- a/packages/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/packages/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -47,23 +47,6 @@ final class DocBlockUpdater
         $node->setDocComment(new Doc($phpDoc));
     }
 
-    public function updateRefactoredNodeWithPhpDocInfo(Node $node): void
-    {
-        // nothing to change? don't save it
-        $phpDocInfo = $this->resolveChangedPhpDocInfo($node);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return;
-        }
-
-        $phpDocNode = $phpDocInfo->getPhpDocNode();
-        if ($phpDocNode->children === []) {
-            $node->setAttribute(AttributeKey::COMMENTS, null);
-            return;
-        }
-
-        $node->setDocComment(new Doc((string) $phpDocNode));
-    }
-
     private function resolveChangedPhpDocInfo(Node $node): ?PhpDocInfo
     {
         $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -366,7 +366,7 @@ CODE_SAMPLE;
              * Early refresh Doc Comment of Node before refresh Scope to ensure doc node is latest update
              * to make PHPStan type can be correctly detected
              */
-            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+            $this->docBlockUpdater->updateNodeWithPhpDocInfo($node);
 
             $this->changedNodeScopeRefresher->refresh($node, $mutatingScope, $filePath);
         }


### PR DESCRIPTION
The `DocBlockUpdater::updateRefactoredNodeWithPhpDocInfo()` was introduced at PR:

- https://github.com/rectorphp/rector-src/pull/3001

for ensure refresh refactored node with PhpDocInfo before refresh Scope, which was unable to use existing `DocBlockUpdater::updateNodeWithPhpDocInfo()`. 

After various `Scope` and `consecutive run rules` handling, it seems we can re-use existing `DocBlockUpdater::updateNodeWithPhpDocInfo()` 👍 

