### PR TITLE
Add failing test fixture for TypedPropertyFromStrictGetterMethodReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/FixturePhp80/self.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/FixturePhp80/self.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector\Fixture;
+
+final class Test
+{
+    private $test;
+
+    public function getTest(): self
+    {
+        return $this->test;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector\Fixture;
+
+final class Test
+{
+    private self $test;
+
+    public function getTest(): self
+    {
+        return $this->test;
+    }
+}
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/TypedPropertyFromStrictGetterMethodReturnTypePhp80RectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/TypedPropertyFromStrictGetterMethodReturnTypePhp80RectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TypedPropertyFromStrictGetterMethodReturnTypePhp80RectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixturePhp80');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/rule_php80.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/config/rule_php80.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/config/rule_php80.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TypedPropertyFromStrictGetterMethodReturnTypeRector::class);
+
+    $rectorConfig->phpVersion(PhpVersionFeature::STATIC_RETURN_TYPE);
+};


### PR DESCRIPTION
# Failing Test for TypedPropertyFromStrictGetterMethodReturnTypeRector

Based on https://getrector.org/demo/ee1243f2-fa5c-4460-a27d-31fb67439bbf