### PR TITLE
[Core] Move update node with php doc info changed into PhpDocInfo::markAsChanged()

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocInfo;
 
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Stmt\InlineHTML;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
@@ -28,6 +30,7 @@ use Rector\BetterPhpDocParser\PhpDocNodeVisitor\ChangedPhpDocNodeVisitor;
 use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 use Rector\BetterPhpDocParser\ValueObject\Type\ShortenedIdentifierTypeNode;
 use Rector\ChangesReporting\Collector\RectorChangeCollector;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Configuration\CurrentNodeProvider;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -62,7 +65,8 @@ final class PhpDocInfo
         private readonly AnnotationNaming $annotationNaming,
         private readonly CurrentNodeProvider $currentNodeProvider,
         private readonly RectorChangeCollector $rectorChangeCollector,
-        private readonly PhpDocNodeByTypeFinder $phpDocNodeByTypeFinder
+        private readonly PhpDocNodeByTypeFinder $phpDocNodeByTypeFinder,
+        private readonly DocBlockUpdater $docBlockUpdater
     ) {
         $this->originalPhpDocNode = clone $phpDocNode;
 
@@ -452,6 +456,10 @@ final class PhpDocInfo
 
         $node = $this->currentNodeProvider->getNode();
         if ($node !== null) {
+            if (! $node instanceof InlineHTML) {
+                $this->docBlockUpdater->updateNodeWithPhpDocInfo($node);
+            }
+
             $this->rectorChangeCollector->notifyNodeFileInfo($node);
         }
     }

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocInfo;
 
-use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\InlineHTML;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -16,6 +16,7 @@ use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 use Rector\BetterPhpDocParser\ValueObject\StartAndEnd;
 use Rector\ChangesReporting\Collector\RectorChangeCollector;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Configuration\CurrentNodeProvider;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -36,6 +37,7 @@ final class PhpDocInfoFactory
         private readonly AnnotationNaming $annotationNaming,
         private readonly RectorChangeCollector $rectorChangeCollector,
         private readonly PhpDocNodeByTypeFinder $phpDocNodeByTypeFinder,
+        private readonly DocBlockUpdater $docBlockUpdater
     ) {
     }
 
@@ -139,7 +141,8 @@ final class PhpDocInfoFactory
             $this->annotationNaming,
             $this->currentNodeProvider,
             $this->rectorChangeCollector,
-            $this->phpDocNodeByTypeFinder
+            $this->phpDocNodeByTypeFinder,
+            $this->docBlockUpdater
         );
 
         $node->setAttribute(AttributeKey::PHP_DOC_INFO, $phpDocInfo);

--- a/packages/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/packages/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -47,23 +47,6 @@ final class DocBlockUpdater
         $node->setDocComment(new Doc($phpDoc));
     }
 
-    public function updateRefactoredNodeWithPhpDocInfo(Node $node): void
-    {
-        // nothing to change? don't save it
-        $phpDocInfo = $this->resolveChangedPhpDocInfo($node);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return;
-        }
-
-        $phpDocNode = $phpDocInfo->getPhpDocNode();
-        if ($phpDocNode->children === []) {
-            $node->setAttribute(AttributeKey::COMMENTS, null);
-            return;
-        }
-
-        $node->setDocComment(new Doc((string) $phpDocNode));
-    }
-
     private function resolveChangedPhpDocInfo(Node $node): ?PhpDocInfo
     {
         $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);

--- a/rules/Arguments/NodeAnalyzer/ChangedArgumentsDetector.php
+++ b/rules/Arguments/NodeAnalyzer/ChangedArgumentsDetector.php
@@ -28,6 +28,7 @@ final class ChangedArgumentsDetector
         return ! $this->valueResolver->isValue($param->default, $value);
     }
 
+
     public function isTypeChanged(Param $param, ?Type $newType): bool
     {
         if ($param->type === null) {

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -263,6 +263,7 @@ CODE_SAMPLE
         return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
     }
 
+
     private function addClassMethodParam(
         ClassMethod $classMethod,
         ArgumentAdder $argumentAdder,

--- a/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
+++ b/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
@@ -131,6 +131,7 @@ CODE_SAMPLE
         return $node;
     }
 
+
     private function shouldSkip(Type $conditionStaticType, BinaryOp $binaryOp, ?Node $nextNode): bool
     {
         if (! $conditionStaticType->isString()

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -168,6 +168,7 @@ CODE_SAMPLE
         $this->replaceNextUsageVariable($tryCatch, $nextNode, $oldVariableName, $newVariableName);
     }
 
+
     private function replaceNextUsageVariable(
         Node $currentNode,
         ?Node $nextNode,

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -166,6 +166,7 @@ CODE_SAMPLE
         return ! isset($comments[0]);
     }
 
+
     private function shouldSkip(?Node $nextNode): bool
     {
         if (! $nextNode instanceof Stmt) {

--- a/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
@@ -181,6 +181,7 @@ CODE_SAMPLE
         return ! (bool) $this->getPreviousIfLinearEquals($ifsBefore[0], $returnExpr);
     }
 
+
     private function getPreviousIfLinearEquals(?Node $node, ?Expr $expr): ?Expression
     {
         if (! $node instanceof Node) {

--- a/rules/Naming/Naming/VariableNaming.php
+++ b/rules/Naming/Naming/VariableNaming.php
@@ -56,6 +56,7 @@ final class VariableNaming
         return lcfirst($countedValueName);
     }
 
+
     public function createCountedValueName(string $valueName, ?Scope $scope): string
     {
         if ($scope === null) {

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -223,6 +223,7 @@ CODE_SAMPLE
         return false;
     }
 
+
     private function isCallableTypeIdentifier(?Node $node): bool
     {
         return $node instanceof Identifier && $this->isName($node, 'callable');

--- a/rules/Php80/Rector/NotIdentical/StrContainsRector.php
+++ b/rules/Php80/Rector/NotIdentical/StrContainsRector.php
@@ -87,7 +87,10 @@ CODE_SAMPLE
 
         if (isset($funcCall->args[2])) {
             if ($this->isName($funcCall->name, 'strpos') && $this->isPositiveInteger($funcCall->args[2]->value)) {
-                $funcCall->args[0] = new Arg($this->nodeFactory->createFuncCall('substr', [$funcCall->args[0], $funcCall->args[2]]));
+                $funcCall->args[0] = new Arg($this->nodeFactory->createFuncCall(
+                    'substr',
+                    [$funcCall->args[0], $funcCall->args[2]]
+                ));
             }
             unset($funcCall->args[2]);
         }

--- a/rules/Php80/Rector/NotIdentical/StrContainsRector.php
+++ b/rules/Php80/Rector/NotIdentical/StrContainsRector.php
@@ -92,6 +92,7 @@ CODE_SAMPLE
                     [$funcCall->args[0], $funcCall->args[2]]
                 ));
             }
+
             unset($funcCall->args[2]);
         }
 
@@ -137,12 +138,12 @@ CODE_SAMPLE
         return null;
     }
 
-    private function isPositiveInteger(Expr $offset): bool
+    private function isPositiveInteger(Expr $expr): bool
     {
-        if (! $offset instanceof LNumber) {
+        if (! $expr instanceof LNumber) {
             return false;
         }
 
-        return $offset->value > 0;
+        return $expr->value > 0;
     }
 }

--- a/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
+++ b/rules/Privatization/TypeManipulator/NormalizeTypeToRespectArrayScalarType.php
@@ -21,6 +21,7 @@ final class NormalizeTypeToRespectArrayScalarType
     ) {
     }
 
+
     public function normalizeToArray(Type $type, ?Node $returnNode): ArrayType|UnionType|Type
     {
         if ($returnNode === null) {

--- a/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
+++ b/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
@@ -129,6 +129,7 @@ final class ObjectTypeSpecifier
         return null;
     }
 
+
     private function processAliasedObject(
         string $alias,
         string $className,

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
@@ -105,6 +105,7 @@ final class TrustedClassMethodPropertyTypeInferer
         return $this->resolveType($property, $propertyName, $classLike, $resolvedType);
     }
 
+
     private function resolveType(
         Property $property,
         string $propertyName,

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -255,6 +255,7 @@ final class ReturnTypeInferer
         return false;
     }
 
+
     private function isNamespacedFullyQualified(?Node $node): bool
     {
         return $node instanceof FullyQualified && str_contains($node->toString(), '\\');

--- a/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/VarDocPropertyTypeInferer.php
@@ -92,6 +92,7 @@ final class VarDocPropertyTypeInferer
         return $resolvedType;
     }
 
+
     private function shouldAddNull(Type $resolvedType, ?Type $assignInferredPropertyType): bool
     {
         if (! $assignInferredPropertyType instanceof Type) {

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -19,7 +19,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
-use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Application\ChangedNodeScopeRefresher;
 use Rector\Core\Configuration\CurrentNodeProvider;
 use Rector\Core\Console\Output\RectorOutputStyle;
@@ -116,8 +115,6 @@ CODE_SAMPLE;
 
     private FilePathHelper $filePathHelper;
 
-    private DocBlockUpdater $docBlockUpdater;
-
     #[Required]
     public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
@@ -140,8 +137,7 @@ CODE_SAMPLE;
         CreatedByRuleDecorator $createdByRuleDecorator,
         ChangedNodeScopeRefresher $changedNodeScopeRefresher,
         RectorOutputStyle $rectorOutputStyle,
-        FilePathHelper $filePathHelper,
-        DocBlockUpdater $docBlockUpdater
+        FilePathHelper $filePathHelper
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
         $this->nodeRemover = $nodeRemover;
@@ -164,7 +160,6 @@ CODE_SAMPLE;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
         $this->rectorOutputStyle = $rectorOutputStyle;
         $this->filePathHelper = $filePathHelper;
-        $this->docBlockUpdater = $docBlockUpdater;
     }
 
     /**
@@ -362,12 +357,6 @@ CODE_SAMPLE;
         $nodes = $node instanceof Node ? [$node] : $node;
 
         foreach ($nodes as $node) {
-            /**
-             * Early refresh Doc Comment of Node before refresh Scope to ensure doc node is latest update
-             * to make PHPStan type can be correctly detected
-             */
-            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
-
             $this->changedNodeScopeRefresher->refresh($node, $mutatingScope, $filePath);
         }
     }


### PR DESCRIPTION
The `DocBlockUpdater::updateRefactoredNodeWithPhpDocInfo()` was introduced at PR:

- https://github.com/rectorphp/rector-src/pull/3001

for ensure refresh refactored node with PhpDocInfo before refresh Scope, which was unable to use existing `DocBlockUpdater::updateNodeWithPhpDocInfo()`. 

After various try, it seems it can be moved to `PhpDocInfo::markAsChanged()` so it only apply when `PhpDocInfo::markAsChanged()` called.