### PR TITLE
Add failing test fixture for RemoveAlwaysTrueIfConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/subclass_of_in_trait.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/subclass_of_in_trait.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+final class Class1
+{
+    use TheTrait;
+}
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+final class Class2
+{
+    use TheTrait;
+}
+
+trait TheTrait
+{
+    public static function theFunction(): void
+    {
+        if (!\is_subclass_of(static::class, Class1::class)) {
+            echo "ok";
+
+            return;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+// what is expected code?
+// should remain the same? delete part below ----- (included)
+
+?>


### PR DESCRIPTION
# Failing Test for RemoveAlwaysTrueIfConditionRector

Based on https://getrector.org/demo/83866b66-43f5-4530-9e66-331c1bc67ba3

related issue: https://github.com/rectorphp/rector/issues/7595