### PR TITLE
deprecate createShortClassConstFetch() as the FQN must be used by convention

### DIFF
--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -74,6 +74,7 @@ final class NodeFactory
 
     /**
      * Creates "SomeClass::CONSTANT"
+     * @deprecated
      */
     public function createShortClassConstFetch(string $shortClassName, string $constantName): ClassConstFetch
     {


### PR DESCRIPTION
The "short" name should never be used, as it looses the type that other rules by convention.
See https://github.com/rectorphp/rector-symfony/issues/293#issuecomment-1327581399