### PR TITLE
Add parent constructor call only once

### DIFF
--- a/rules-tests/DependencyInjection/Rector/Class_/ActionInjectionToConstructorInjectionRector/Fixture/fixture3.php.inc
+++ b/rules-tests/DependencyInjection/Rector/Class_/ActionInjectionToConstructorInjectionRector/Fixture/fixture3.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Fixture;
+
+use Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\CategoryRepository;
+use Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\ProductRepository;
+use Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\SomeProduct;
+
+abstract class ParentFixture3Constructor {
+    public function __construct(protected SomeProduct $someProduct)
+    {
+    }
+}
+
+final class Fixture3Controller extends ParentFixture3Constructor
+{
+    public function default(CategoryRepository $categoryRepository, ProductRepository $productRepository)
+    {
+        $products = $productRepository->fetchAll();
+        $categories = $categoryRepository->fetchAll();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Fixture;
+
+use Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\CategoryRepository;
+use Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\ProductRepository;
+use Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\SomeProduct;
+
+abstract class ParentFixture3Constructor {
+    public function __construct(protected SomeProduct $someProduct)
+    {
+    }
+}
+
+final class Fixture3Controller extends ParentFixture3Constructor
+{
+    public function __construct(\Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\SomeProduct $someProduct, private \Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\CategoryRepository $categoryRepository, private \Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\ProductRepository $productRepository)
+    {
+        parent::__construct($someProduct);
+    }
+    public function default()
+    {
+        $products = $this->productRepository->fetchAll();
+        $categories = $this->categoryRepository->fetchAll();
+    }
+}
+
+?>

--- a/rules-tests/DependencyInjection/Rector/Class_/ActionInjectionToConstructorInjectionRector/Source/CategoryRepository.php
+++ b/rules-tests/DependencyInjection/Rector/Class_/ActionInjectionToConstructorInjectionRector/Source/CategoryRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source;
+
+final class CategoryRepository
+{
+
+}

--- a/rules-tests/DependencyInjection/Rector/Class_/ActionInjectionToConstructorInjectionRector/xml/services.xml
+++ b/rules-tests/DependencyInjection/Rector/Class_/ActionInjectionToConstructorInjectionRector/xml/services.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\CategoryRepository"></service>
         <service id="Rector\Tests\DependencyInjection\Rector\Class_\ActionInjectionToConstructorInjectionRector\Source\ProductRepository"></service>
     </services>
 </container>

--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -164,16 +164,16 @@ final class ClassDependencyManipulator
             $constructClassMethod = $this->nodeFactory->createPublicMethod(MethodName::CONSTRUCT);
             $constructClassMethod->params[] = $param;
             $this->classInsertManipulator->addAsFirstMethod($class, $constructClassMethod);
+
+            /** @var Scope $scope */
+            $scope = $class->getAttribute(AttributeKey::SCOPE);
+
+            $this->dependencyClassMethodDecorator->decorateConstructorWithParentDependencies(
+                $class,
+                $constructClassMethod,
+                $scope
+            );
         }
-
-        /** @var Scope $scope */
-        $scope = $class->getAttribute(AttributeKey::SCOPE);
-
-        $this->dependencyClassMethodDecorator->decorateConstructorWithParentDependencies(
-            $class,
-            $constructClassMethod,
-            $scope
-        );
     }
 
     private function hasClassParentClassMethod(Class_ $class, string $methodName): bool


### PR DESCRIPTION
If a promoted property is added to a class constructor and if this constructor method is already present in the class, there is no need to add a parent constructor call to this method just because a new promoted property is added to the child's constructor. Adding the parent constructor call is only necessary when the child class currently has no constructor when the promoted property is added so that a new constructor method has to be added to the child class.

Fixes rectorphp/rector-symfony#275