### PR TITLE
[BetterPhpDocParser] Compare start_and_end attribute value on ChangedPhpDocNodeVisitor

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocNodeVisitor/ChangedPhpDocNodeVisitor.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeVisitor/ChangedPhpDocNodeVisitor.php
@@ -6,6 +6,7 @@ namespace Rector\BetterPhpDocParser\PhpDocNodeVisitor;
 
 use PHPStan\PhpDocParser\Ast\Node;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
+use Rector\BetterPhpDocParser\ValueObject\StartAndEnd;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeVisitor\AbstractPhpDocNodeVisitor;
 
 final class ChangedPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
@@ -20,8 +21,25 @@ final class ChangedPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
     public function enterNode(Node $node): ?Node
     {
         $origNode = $node->getAttribute(PhpDocAttributeKey::ORIG_NODE);
-        if ($origNode === null) {
+        if (! $origNode instanceof Node) {
             $this->hasChanged = true;
+            return $node;
+        }
+
+        $nodeStartAndEnd = $node->getAttribute(PhpDocAttributeKey::START_AND_END);
+        $origNodeStartAndEnd = $origNode->getAttribute(PhpDocAttributeKey::START_AND_END);
+
+        if (! $nodeStartAndEnd instanceof StartAndEnd) {
+            return null;
+        }
+
+        if (! $origNodeStartAndEnd instanceof StartAndEnd) {
+            return null;
+        }
+
+        if ($nodeStartAndEnd->getStart() !== $origNodeStartAndEnd->getStart() || $nodeStartAndEnd->getEnd() !== $origNodeStartAndEnd->getEnd()) {
+            $this->hasChanged = true;
+            return true;
         }
 
         return null;

--- a/packages/BetterPhpDocParser/PhpDocNodeVisitor/ChangedPhpDocNodeVisitor.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeVisitor/ChangedPhpDocNodeVisitor.php
@@ -39,7 +39,7 @@ final class ChangedPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
 
         if ($nodeStartAndEnd->getStart() !== $origNodeStartAndEnd->getStart() || $nodeStartAndEnd->getEnd() !== $origNodeStartAndEnd->getEnd()) {
             $this->hasChanged = true;
-            return true;
+            return $node;
         }
 
         return null;


### PR DESCRIPTION
Improve PhpDocInfo `hasChanged()` detection by compare start and end attribute values that handle via `ChangedPhpDocNodeVisitor` via on : 

https://github.com/rectorphp/rector-src/blob/f37a6eb0de44306065b24137a7922190622f5ccc/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php#L459-L471