### PR TITLE
[BetterPhpDocParser] Call phpdocInfo->markAsChanged() on change param/return type on PhpDocTypeChanger

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -86,6 +86,7 @@ final class PhpDocTypeChanger
         if ($currentVarTagValueNode !== null) {
             // only change type
             $currentVarTagValueNode->type = $newPHPStanPhpDocType;
+            $phpDocInfo->markAsChanged();
         } else {
             // add completely new one
             $varTagValueNode = new VarTagValueNode($newPHPStanPhpDocType, '', '');
@@ -117,6 +118,7 @@ final class PhpDocTypeChanger
         if ($currentReturnTagValueNode !== null) {
             // only change type
             $currentReturnTagValueNode->type = $newPHPStanPhpDocType;
+            $phpDocInfo->markAsChanged();
         } else {
             // add completely new one
             $returnTagValueNode = new ReturnTagValueNode($newPHPStanPhpDocType, '');
@@ -154,6 +156,7 @@ final class PhpDocTypeChanger
             }
 
             $paramTagValueNode->type = $phpDocType;
+            $phpDocInfo->markAsChanged();
         } else {
             $paramTagValueNode = $this->paramPhpDocNodeFactory->create($phpDocType, $param);
             $phpDocInfo->addTagValueNode($paramTagValueNode);

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddArrayParamDocTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddArrayParamDocTypeRector.php
@@ -119,7 +119,9 @@ CODE_SAMPLE
             $paramName = $this->getName($param);
             $this->phpDocTypeChanger->changeParamType($phpDocInfo, $paramType, $param, $paramName);
 
-            $hasChangedNode = true;
+            if ($phpDocInfo->hasChanged()) {
+                $hasChangedNode = true;
+            }
         }
 
         if ($phpDocInfo->hasChanged() && $hasChangedNode) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddArrayParamDocTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddArrayParamDocTypeRector.php
@@ -96,8 +96,6 @@ CODE_SAMPLE
         }
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        $hasChangedNode = false;
-
         foreach ($node->getParams() as $param) {
             if ($this->shouldSkipParam($param)) {
                 continue;
@@ -118,13 +116,9 @@ CODE_SAMPLE
 
             $paramName = $this->getName($param);
             $this->phpDocTypeChanger->changeParamType($phpDocInfo, $paramType, $param, $paramName);
-
-            if ($phpDocInfo->hasChanged()) {
-                $hasChangedNode = true;
-            }
         }
 
-        if ($phpDocInfo->hasChanged() && $hasChangedNode) {
+        if ($phpDocInfo->hasChanged()) {
             $this->paramTagRemover->removeParamTagsIfUseless($phpDocInfo, $node);
             return $node;
         }


### PR DESCRIPTION
It need to be called to make it marked as changed so it detected correctly.