### PR TITLE
Add three failing tests

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+use \Drupal\Core\Url;
+
+final class ParamTest {
+
+  /**
+   * A dummy method to test rector param removal.
+   *
+   * @param \Drupal\Core\Url $url
+   *   A URL object.
+   *
+   * @return string
+   *   A fixed string.
+   */
+  public function dummy(Url $url): string {
+    return 'dummy';
+  }
+
+}
+
+?>
+

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\F
 
 use \Drupal\Core\Url;
 
-final class ParamTest {
+final class ParamAndReturnWithDescriptionOnNextLine {
 
   /**
    * A dummy method to test rector param removal.

--- a/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\Php80\Rector\FunctionLike\MixedTypeRector\Fixture;
 
 use \Drupal\Core\Url;
 
-final class ParamTest {
+final class ParamAndReturnWithDescriptionOnNextLine {
 
   /**
    * A dummy method to test rector param removal.

--- a/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+use \Drupal\Core\Url;
+
+final class ParamTest {
+
+  /**
+   * A dummy method to test rector param removal.
+   *
+   * @param \Drupal\Core\Url $url
+   *   A URL object.
+   *
+   * @return string
+   *   A fixed string.
+   */
+  public function dummy(Url $url): string {
+    return 'dummy';
+  }
+
+}
+
+?>
+

--- a/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+namespace Rector\Tests\Php80\Rector\FunctionLike\MixedTypeRector\Fixture;
 
 use \Drupal\Core\Url;
 

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
 
 use \Drupal\Core\Url;
 
-final class ParamTest {
+final class ParamAndReturnWithDescriptionOnNextLine {
 
   /**
    * A dummy method to test rector param removal.

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+use \Drupal\Core\Url;
+
+final class ParamTest {
+
+  /**
+   * A dummy method to test rector param removal.
+   *
+   * @param \Drupal\Core\Url $url
+   *   A URL object.
+   *
+   * @return string
+   *   A fixed string.
+   */
+  public function dummy(Url $url): string {
+    return 'dummy';
+  }
+
+}
+
+?>
+

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/skip_param_and_return_with_description_on_next_line.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\Fixture;
 
 use \Drupal\Core\Url;
 


### PR DESCRIPTION
This MR adds three failing tests for incorrect removal of param / return documentation lines. I have identified three different Rectors that remove parts of the documentation block even though there is a description, albeit on the next line.

This may be related to the issues described in https://github.com/rectorphp/rector-src/pull/969.
The demo links in the comments do not work for me so I cannot be sure.