### PR TITLE
Add failing test fixture for RemoveNonExistingVarAnnotationRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/demo_fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/demo_fixture.php.inc
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @var My_Class $this
+ */
+?>
+hello
+<?php
+$this->foo();
+
+?>
+


### PR DESCRIPTION
# Failing Test for RemoveNonExistingVarAnnotationRector

Based on https://getrector.org/demo/adc6e1a7-7ac3-430e-aa88-7db78529a180

When not using PHP closing tags in-between, then it works correctly already: https://getrector.org/demo/cf1b4471-c98a-4e70-bd66-358d13be54e7