### PR TITLE
[Core] Pull Scope from Node instead of from Original Node on AbstractRector

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -228,7 +228,7 @@ CODE_SAMPLE;
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         /** @var MutatingScope|null $currentScope */
-        $currentScope = $originalNode->getAttribute(AttributeKey::SCOPE);
+        $currentScope = $node->getAttribute(AttributeKey::SCOPE);
         $filePath = $this->file->getFilePath();
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown


### PR DESCRIPTION
Same with AbstractScopeAwareRector:

https://github.com/rectorphp/rector-src/blob/f862bf997aa6cb52d0c2fa3ed75744e4da1b3475/src/Rector/AbstractScopeAwareRector.php#L33

The Scope is pulled from `Node`.