### PR TITLE
[CodeQuality] Skip from non-typed param on SimplifyEmptyCheckOnEmptyArrayRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_from_non_typed_param.php.inc
+++ b/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_from_non_typed_param.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRectorTest\Fixture;
+
+final class SkipFromNonTypedParam
+{
+    /**
+     * @param array $values
+     */
+    public function isEmptyArray($values): bool
+    {
+        return empty($values);
+    }
+}

--- a/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
+++ b/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
@@ -24,8 +24,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyEmptyCheckOnEmptyArrayRector extends AbstractScopeAwareRector
 {
-    public function __construct(private readonly ExprAnalyzer $exprAnalyzer)
-    {
+    public function __construct(
+        private readonly ExprAnalyzer $exprAnalyzer
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
+++ b/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -23,6 +24,10 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyEmptyCheckOnEmptyArrayRector extends AbstractScopeAwareRector
 {
+    public function __construct(private readonly ExprAnalyzer $exprAnalyzer)
+    {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -49,6 +54,10 @@ final class SimplifyEmptyCheckOnEmptyArrayRector extends AbstractScopeAwareRecto
         }
 
         if (! $scope->getType($node->expr) instanceof ArrayType) {
+            return null;
+        }
+
+        if ($this->exprAnalyzer->isNonTypedFromParam($node->expr)) {
             return null;
         }
 


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/3069#issuecomment-1317236849, The following code should be skipped:

```php
final class SkipFromNonTypedParam
{
    /**
     * @param array $values
     */
    public function isEmptyArray($values): bool
    {
        return empty($values);
    }
}
```