### PR TITLE
[Php80] Do not remove existing attribute on NestedAnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/merge_with_existing_attribute.php.inc
+++ b/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/merge_with_existing_attribute.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Property\NestedAnnotationToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="api_alert")
+ */
+#[ApiResource]
+class Alert
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Property\NestedAnnotationToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[ORM\Table(name: 'api_alert')]
+class Alert
+{
+}
+
+?>

--- a/rules/Php80/Rector/Property/NestedAnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Property/NestedAnnotationToAttributeRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->attrGroups = $attributeGroups;
+        $node->attrGroups = array_merge($node->attrGroups, $attributeGroups);
         $this->completeExtraUseImports($attributeGroups);
 
         return $node;


### PR DESCRIPTION
Existing attribute should be kept (merged with new attribute) instead of removed, ref 

https://getrector.org/demo/cd388ba5-9256-4eda-8de3-317bd7090e50

Fixes https://github.com/rectorphp/rector/issues/7585