### PR TITLE
[Php74] Register TypedPropertyFromAssignsRector to php74 config set

### DIFF
--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -18,6 +18,7 @@ use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
 use Rector\Php74\Rector\StaticCall\ExportToReflectionFunctionRector;
 use Rector\Php74\Rector\Ternary\ParenthesizeNestedTernaryRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
@@ -46,5 +47,6 @@ return static function (RectorConfig $rectorConfig): void {
         CurlyToSquareBracketArrayStringRector::class,
         MoneyFormatToNumberFormatRector::class,
         ParenthesizeNestedTernaryRector::class,
+        TypedPropertyFromAssignsRector::class,
     ]);
 };


### PR DESCRIPTION
Since TypedPropertyRector is now deprecated:

https://github.com/rectorphp/rector-src/blob/2b35d2e75ea03ffe643c012485952ec6df3ea2ba/rules/Php74/Rector/Property/TypedPropertyRector.php#L78-L81

running `LevelSetList::UP_TO_PHP_74` will not get the typed property functionality, this PR add `TypedPropertyFromAssignsRector` so when there is assign for property fetch, it will set property type.