### PR TITLE
[TypeDeclaration] Use existing MakePropertyTypedGuard on TypedPropertyFromStrictConstructorRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -779,4 +779,4 @@ parameters:
 
         # on purpose, as rule it about to be removed
         - '#Register "Rector\\Php74\\Rector\\Property\\TypedPropertyRector" service to "php74\.php" config set#'
-        - '#Cognitive complexity for "Rector\\TypeDeclaration\\Rector\\Property\\TypedPropertyFromStrictConstructorRector\:\:refactor\(\)" is 13, keep it under 10#'
+        - '#Cognitive complexity for "Rector\\TypeDeclaration\\Rector\\Property\\TypedPropertyFromStrictConstructorRector\:\:refactor\(\)" is 12, keep it under 10#'

--- a/rules/TypeDeclaration/Guard/PropertyTypeOverrideGuard.php
+++ b/rules/TypeDeclaration/Guard/PropertyTypeOverrideGuard.php
@@ -8,12 +8,14 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\Php74\Guard\MakePropertyTypedGuard;
 
 final class PropertyTypeOverrideGuard
 {
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly MakePropertyTypedGuard $makePropertyTypedGuard
     ) {
     }
 
@@ -22,10 +24,14 @@ final class PropertyTypeOverrideGuard
         $classReflection = $this->reflectionResolver->resolveClassReflection($property);
 
         if (! $classReflection instanceof ClassReflection) {
-            return true;
+            return false;
         }
 
         $propertyName = $this->nodeNameResolver->getName($property);
+        if (! $this->makePropertyTypedGuard->isLegal($property)) {
+            return false;
+        }
+
         foreach ($classReflection->getParents() as $parentClassReflection) {
             $nativeReflectionClass = $parentClassReflection->getNativeReflection();
 

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -36,8 +36,7 @@ final class TypedPropertyFromStrictConstructorRector extends AbstractRector impl
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly ConstructorAssignDetector $constructorAssignDetector,
         private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly PropertyTypeOverrideGuard $propertyTypeOverrideGuard,
-        private readonly MakePropertyTypedGuard $makePropertyTypedGuard
+        private readonly PropertyTypeOverrideGuard $propertyTypeOverrideGuard
     ) {
     }
 
@@ -94,10 +93,6 @@ CODE_SAMPLE
         }
 
         foreach ($node->getProperties() as $property) {
-            if (! $this->makePropertyTypedGuard->isLegal($property)) {
-                continue;
-            }
-
             $propertyType = $this->trustedClassMethodPropertyTypeInferer->inferProperty(
                 $property,
                 $constructClassMethod

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -16,7 +16,6 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
-use Rector\Php74\Guard\MakePropertyTypedGuard;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 use Rector\TypeDeclaration\Guard\PropertyTypeOverrideGuard;

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Enum\ObjectReference;
@@ -107,6 +108,10 @@ final class PropertyFetchAnalyzer
 
     public function containsLocalPropertyFetchName(Trait_ $trait, string $propertyName): bool
     {
+        if ($trait->getProperty($propertyName) instanceof Property) {
+            return true;
+        }
+
         return (bool) $this->betterNodeFinder->findFirst(
             $trait,
             fn (Node $node): bool => $this->isLocalPropertyFetchName($node, $propertyName)

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -242,10 +242,6 @@ final class PropertyManipulator
                 continue;
             }
 
-            if ($trait->getProperty($propertyName) instanceof Property) {
-                return true;
-            }
-
             if ($this->propertyFetchAnalyzer->containsLocalPropertyFetchName($trait, $propertyName)) {
                 return true;
             }

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -242,6 +242,10 @@ final class PropertyManipulator
                 continue;
             }
 
+            if ($trait->getProperty($propertyName) instanceof Property) {
+                return true;
+            }
+
             if ($this->propertyFetchAnalyzer->containsLocalPropertyFetchName($trait, $propertyName)) {
                 return true;
             }


### PR DESCRIPTION
`MakePropertyTypedGuard` already cover many handling on forbidden type and used by trait already, so use the service instead.