### PR TITLE
[Naming] Handle crash on VariableNaming::resolveBareFromNode() on unwrapNode() return null

### DIFF
--- a/rules/Naming/Naming/VariableNaming.php
+++ b/rules/Naming/Naming/VariableNaming.php
@@ -119,33 +119,33 @@ final class VariableNaming
 
     private function resolveBareFromNode(Node $node): ?string
     {
-        $node = $this->unwrapNode($node);
+        $unwrappedNode = $this->unwrapNode($node);
+
+        if (! $unwrappedNode instanceof Node) {
+            return null;
+        }
 
         foreach ($this->assignVariableNameResolvers as $assignVariableNameResolver) {
-            if ($assignVariableNameResolver->match($node)) {
-                return $assignVariableNameResolver->resolve($node);
+            if ($assignVariableNameResolver->match($unwrappedNode)) {
+                return $assignVariableNameResolver->resolve($unwrappedNode);
             }
         }
 
-        if ($node !== null && ($node instanceof MethodCall || $node instanceof NullsafeMethodCall || $node instanceof StaticCall)) {
-            return $this->resolveFromMethodCall($node);
+        if ($unwrappedNode instanceof MethodCall || $unwrappedNode instanceof NullsafeMethodCall || $unwrappedNode instanceof StaticCall) {
+            return $this->resolveFromMethodCall($unwrappedNode);
         }
 
-        if ($node instanceof FuncCall) {
-            return $this->resolveFromNode($node->name);
+        if ($unwrappedNode instanceof FuncCall) {
+            return $this->resolveFromNode($unwrappedNode->name);
         }
 
-        if (! $node instanceof Node) {
-            throw new NotImplementedYetException();
-        }
-
-        $paramName = $this->nodeNameResolver->getName($node);
+        $paramName = $this->nodeNameResolver->getName($unwrappedNode);
         if ($paramName !== null) {
             return $paramName;
         }
 
-        if ($node instanceof String_) {
-            return $node->value;
+        if ($unwrappedNode instanceof String_) {
+            return $unwrappedNode->value;
         }
 
         return null;

--- a/rules/Naming/Naming/VariableNaming.php
+++ b/rules/Naming/Naming/VariableNaming.php
@@ -20,7 +20,6 @@ use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
-use Rector\Core\Exception\NotImplementedYetException;
 use Rector\Naming\Contract\AssignVariableNameResolverInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;


### PR DESCRIPTION
Based on error log reported at:

https://github.com/rectorphp/rector/issues/7632#issue-1471005287

- [x] ensure changed Node with `$this->unwrapNode($node)` is into new variable so it always pointed to new result instead of ambiguous use old Node object passed.
- [x] return null when it return null to avoid crash.