### PR TITLE
[Set] Add missing LevelSetList::UP_TO_PHP_53

### DIFF
--- a/config/set/level/up-to-php53.php
+++ b/config/set/level/up-to-php53.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
-use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([SetList::PHP_54, LevelSetList::UP_TO_PHP_53]);
+    $rectorConfig->sets([SetList::PHP_53, SetList::PHP_52]);
 
     // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_54);
+    $rectorConfig->phpVersion(PhpVersion::PHP_53);
 };

--- a/packages/Set/ValueObject/LevelSetList.php
+++ b/packages/Set/ValueObject/LevelSetList.php
@@ -65,4 +65,9 @@ final class LevelSetList implements SetListInterface
      * @var string
      */
     public const UP_TO_PHP_54 = __DIR__ . '/../../../config/set/level/up-to-php54.php';
+
+    /**
+     * @var string
+     */
+    public const UP_TO_PHP_53 = __DIR__ . '/../../../config/set/level/up-to-php53.php';
 }


### PR DESCRIPTION
Without php 5.2 included, the level set list will not apply PHP 5.2 Rector rules.

Fixes https://github.com/rectorphp/rector/issues/7634