### PR TITLE
Remove symfony/property-access from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
         "rector/rector-generator": "dev-main",
         "spatie/enum": "^3.13",
         "symfony/process": "^6.2",
-        "symfony/property-access": "^6.2",
         "symplify/easy-ci": "^11.1.10",
         "symplify/easy-coding-standard": "^11.1.10",
         "symplify/monorepo-builder": "^11.1.10",


### PR DESCRIPTION
It was used to make use temporary symfony 6.1 on PR:

- https://github.com/rectorphp/rector-src/pull/3134

Let's try remove it now.