### PR TITLE
Fix test error Call to undefined method Rector\Config\RectorConfig::disableImportNames()

### DIFF
--- a/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/config/normalize_namespace_without_namespace_config.php
+++ b/rules-tests/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector/config/normalize_namespace_without_namespace_config.php
@@ -9,7 +9,7 @@ use Rector\Tests\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4Compos
 
 return static function (RectorConfig $rectorConfig): void {
     $services = $rectorConfig->services();
-    $rectorConfig->disableImportNames();
+    $rectorConfig->importNames(false, false);
     $rectorConfig->rule(NormalizeNamespaceByPSR4ComposerAutoloadRector::class);
 
     $services->set(DummyPSR4AutoloadWithoutNamespaceMatcher::class);


### PR DESCRIPTION
@TomasVotruba the removal `disableImportNames()` on direct commit to main https://github.com/rectorphp/rector-src/commit/2f0fca8ba89353a96a8f3a1aecdc8b5db028fc0f method cause error in tests:

```
 12) Rector\Tests\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector\NormalizeNamespaceByPSR4ComposerAutoloadRectorTest::test with data set #11 ('/home/runner/work/rector-src/...hp.inc')
BadMethodCallException: Call to undefined method "Rector\Config\RectorConfig::disableImportNames()".
```

This PR try to fix it.