### PR TITLE
Rollback ClassRenamePhpDocNodeVisitor to use clone $node to avoid unnecessary touch Identifier when no change

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
@@ -66,8 +66,9 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             return null;
         }
 
-        $node->name = $this->resolveNamespacedName($node, $phpParserNode, $node->name);
-        $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($node, $phpParserNode);
+        $identifier = clone $node;
+        $identifier->name = $this->resolveNamespacedName($identifier, $phpParserNode, $node->name);
+        $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($identifier, $phpParserNode);
 
         // make sure to compare FQNs
         $objectType = $this->expandShortenedObjectType($staticType);
@@ -136,19 +137,14 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         }
 
         $originalNode = $namespace->getAttribute(AttributeKey::ORIGINAL_NODE);
-
-        if (! $originalNode instanceof Namespace_) {
-            return $name;
-        }
-
         $namespaceName = (string) $this->nodeNameResolver->getName($namespace);
 
-        if (! $this->nodeNameResolver->isName($originalNode, $namespaceName)) {
+        if ($originalNode instanceof Namespace_ && ! $this->nodeNameResolver->isName($originalNode, $namespaceName)) {
             return $name;
         }
 
         if ($uses === []) {
-            return '\\' . ltrim($namespaceName . '\\' . $name, '\\');
+            return $namespaceName . '\\' . $name;
         }
 
         $nameFromUse = $this->resolveNamefromUse($uses, $name);
@@ -157,7 +153,7 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             return $nameFromUse;
         }
 
-        return '\\' . ltrim($namespaceName . '\\' . $nameFromUse, '\\');
+        return $namespaceName . '\\' . $nameFromUse;
     }
 
     /**

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
@@ -82,7 +82,10 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             }
 
             // tweak overlapped import + rename
-            if ($shouldImport && ! str_starts_with($identifier->name, '\\') && substr_count($identifier->name, '\\') === 0) {
+            if ($shouldImport && ! str_starts_with($identifier->name, '\\') && substr_count(
+                $identifier->name,
+                '\\'
+            ) === 0) {
                 continue;
             }
 

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
@@ -72,20 +72,18 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         $identifier->name = $this->resolveNamespacedName($identifier, $phpParserNode, $node->name);
         $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($identifier, $phpParserNode);
 
+        $shouldImport = $this->rectorConfigProvider->shouldImportNames();
+        $isNoNamespacedName = ! str_starts_with($identifier->name, '\\') && substr_count($identifier->name, '\\') === 0;
+
+        // tweak overlapped import + rename
+        if ($shouldImport && $isNoNamespacedName) {
+            return null;
+        }
+
         // make sure to compare FQNs
         $objectType = $this->expandShortenedObjectType($staticType);
-        $shouldImport = $this->rectorConfigProvider->shouldImportNames();
-
         foreach ($this->oldToNewTypes as $oldToNewType) {
             if (! $objectType->equals($oldToNewType->getOldType())) {
-                continue;
-            }
-
-            // tweak overlapped import + rename
-            if ($shouldImport && ! str_starts_with($identifier->name, '\\') && substr_count(
-                $identifier->name,
-                '\\'
-            ) === 0) {
                 continue;
             }
 

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/auto_import_conflict_name_all_fqcn_same_namespace.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/auto_import_conflict_name_all_fqcn_same_namespace.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Foo2;
+
+class AutoImportConflictNameAllFqcnSameNamespace extends FooBar
+{
+    /**
+     * @param \DateTime $foo
+     *
+     * @return \Foo2\Storage|\Storage
+     */
+    public function bar($foo){}
+}
+
+?>
+-----
+<?php
+
+namespace Foo2;
+
+use DateTime;
+class AutoImportConflictNameAllFqcnSameNamespace extends FooBar
+{
+    /**
+     * @param DateTime $foo
+     *
+     * @return Storage|\Illuminate\Support\Facades\Storage
+     */
+    public function bar($foo){}
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/auto_import_conflict_name_all_fqcn_same_namespace_inside.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/auto_import_conflict_name_all_fqcn_same_namespace_inside.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Foo2;
+
+class AutoImportConflictNameAllFqcnSameNamespaceInside extends FooBar
+{
+    /**
+     * @param \DateTime $foo
+     *
+     * @return \Foo2\Bar\Storage|\Storage
+     */
+    public function bar($foo){}
+}
+
+?>
+-----
+<?php
+
+namespace Foo2;
+
+use DateTime;
+use Foo2\Bar\Storage;
+class AutoImportConflictNameAllFqcnSameNamespaceInside extends FooBar
+{
+    /**
+     * @param DateTime $foo
+     *
+     * @return Storage|\Illuminate\Support\Facades\Storage
+     */
+    public function bar($foo){}
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/do_not_rename_class_with_same_name_inside_different_namespace_class_not_exists.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/do_not_rename_class_with_same_name_inside_different_namespace_class_not_exists.php.inc
@@ -24,7 +24,7 @@ class Foo3 extends FooBar
     /**
      * @param DateTime $foo
      *
-     * @return \Foo3\Storage|\Illuminate\Support\Facades\Storage
+     * @return Storage|\Illuminate\Support\Facades\Storage
      */
     public function bar($foo){}
 }

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Source/Foo2/Bar/Storage.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Source/Foo2/Bar/Storage.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Foo2\Bar;
+
+class Storage
+{}


### PR DESCRIPTION
Try to fix https://github.com/rectorphp/rector/issues/7636 while keep the existing functionality.