### PR TITLE
[Core] Fix crash indentation on indent(\t, 1) config

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -181,6 +181,11 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $indentSize = $this->rectorConfigProvider->getIndentSize();
 
         $this->indentLevel += $indentSize;
+
+        if ($this->tabOrSpaceIndentCharacter === ' ' && $this->indentLevel < 4) {
+            $this->indentLevel = 4;
+        }
+
         $this->nl .= str_repeat($this->tabOrSpaceIndentCharacter, $indentSize);
     }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -181,7 +181,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $indentSize = $this->rectorConfigProvider->getIndentSize();
 
         $this->indentLevel += $indentSize;
-
         $this->nl .= str_repeat($this->tabOrSpaceIndentCharacter, $indentSize);
     }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -93,6 +93,8 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $this->insertionMap['Stmt_Function->returnType'] = [')', false, ': ', null];
         $this->insertionMap['Expr_Closure->returnType'] = [')', false, ': ', null];
         $this->insertionMap['Expr_ArrowFunction->returnType'] = [')', false, ': ', null];
+
+        $this->tabOrSpaceIndentCharacter = $this->rectorConfigProvider->getIndentChar();
     }
 
     /**
@@ -103,8 +105,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
     public function printFormatPreserving(array $stmts, array $origStmts, array $origTokens): string
     {
         $newStmts = $this->resolveNewStmts($stmts);
-
-        $this->tabOrSpaceIndentCharacter = $this->rectorConfigProvider->getIndentChar();
 
         $content = parent::printFormatPreserving($newStmts, $origStmts, $origTokens);
 
@@ -181,10 +181,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $indentSize = $this->rectorConfigProvider->getIndentSize();
 
         $this->indentLevel += $indentSize;
-
-        if ($this->tabOrSpaceIndentCharacter === ' ' && $this->indentLevel < 4) {
-            $this->indentLevel = 4;
-        }
 
         $this->nl .= str_repeat($this->tabOrSpaceIndentCharacter, $indentSize);
     }

--- a/tests/Issues/IndentationCrash/FixtureTab/if_else_tab_indentation.php.inc
+++ b/tests/Issues/IndentationCrash/FixtureTab/if_else_tab_indentation.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IndentationCrash\FixtureTab;
+
+final class IfElseTabIndentation
+{
+	/**
+	 * @param string[]|string $args
+	 *
+	 * @return void
+	 */
+	public function run( $args ) {
+		if ( is_array( $args ) ) {
+			foreach ( $args as $data ) {
+				echo $data;
+			}
+		} else {
+			echo $args;
+		}
+	}
+}

--- a/tests/Issues/IndentationCrash/TabIndentationCrashTest.php
+++ b/tests/Issues/IndentationCrash/TabIndentationCrashTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IndentationCrash;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TabIndentationCrashTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureTab');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/tab_configured_rule.php';
+    }
+}

--- a/tests/Issues/IndentationCrash/config/tab_configured_rule.php
+++ b/tests/Issues/IndentationCrash/config/tab_configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->indent("\t", 1);
+    $rectorConfig->rule(SimplifyIfElseWithSameContentRector::class);
+};


### PR DESCRIPTION
Given the following config:

```php
use Rector\Config\RectorConfig;
use Rector\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->indent("\t", 1);
    $rectorConfig->rule(SimplifyIfElseWithSameContentRector::class);
};
```

It cause crash:

```
There was 1 failure:

1) Rector\Core\Tests\Issues\IndentationCrash\TabIndentationCrashTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
assert($this->indentLevel >= 4) in /Users/samsonasik/www/rector-src/src/PhpParser/Printer/BetterStandardPrinter.php:199

Caused by
AssertionError: assert($this->indentLevel >= 4) in /Users/samsonasik/www/rector-src/src/PhpParser/Printer/BetterStandardPrinter.php:199
```

Ref https://getrector.org/demo/1d6243b2-ab0c-4002-814c-86f36b465412
Fixes https://github.com/rectorphp/rector/issues/7638