### PR TITLE
[TypeDeclaration] Handle Anonymous class extends existing class in union

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Generic\TemplateObjectWithoutClassType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\ValueObject\Type\EmptyGenericTypeNode;
+use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\PHPStan\ObjectWithoutClassTypeWithParentTypes;
@@ -49,6 +50,15 @@ final class ObjectWithoutClassTypeMapper implements TypeMapperInterface
         if ($type instanceof TemplateObjectWithoutClassType) {
             $attributeAwareIdentifierTypeNode = new IdentifierTypeNode($type->getName());
             return new EmptyGenericTypeNode($attributeAwareIdentifierTypeNode);
+        }
+
+        // special case for anonymous classes that implement another type
+        if ($type instanceof ObjectWithoutClassTypeWithParentTypes) {
+            $parentTypes = $type->getParentTypes();
+            if (count($parentTypes) === 1) {
+                $parentType = $parentTypes[0];
+                return new FullyQualifiedIdentifierTypeNode($parentType->getClassName());
+            }
         }
 
         return new IdentifierTypeNode('object');

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -32,7 +32,6 @@ use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\PHPStan\ObjectWithoutClassTypeWithParentTypes;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -32,6 +32,7 @@ use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\PHPStan\ObjectWithoutClassTypeWithParentTypes;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/anonymous_extends_existing_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/anonymous_extends_existing_class.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class AnonymousExtendsExistingClass
+{
+    private $x;
+
+    public function __construct()
+    {
+        $this->x = new class extends \DateTime {};
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class AnonymousExtendsExistingClass
+{
+    private \DateTime $x;
+
+    public function __construct()
+    {
+        $this->x = new class extends \DateTime {};
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/anonymous_extends_existing_class_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/anonymous_extends_existing_class_in_union.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class AnonymousExtendsExistingClassInUnion
+{
+    private $x;
+
+    public function __construct()
+    {
+        if (rand(0,1)) {
+            $this->x = new \DateTime('now');
+        } else {
+            $this->x = new class extends \DateTime {};
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class AnonymousExtendsExistingClassInUnion
+{
+    /**
+     * @var \DateTime|null
+     */
+    private $x;
+
+    public function __construct()
+    {
+        if (rand(0,1)) {
+            $this->x = new \DateTime('now');
+        } else {
+            $this->x = new class extends \DateTime {};
+        }
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/anonymous_extends_existing_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/anonymous_extends_existing_class.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+
+final class AnonymousExtendsExistingClassInUnion
+{
+    private $x;
+
+    public function __construct()
+    {
+        if (rand(0,1)) {
+            $this->x = new \DateTime('now');
+        } else {
+            $this->x = new class extends \DateTime {};
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+
+final class AnonymousExtendsExistingClassInUnion
+{
+    private \DateTime|null $x = null;
+
+    public function __construct()
+    {
+        if (rand(0,1)) {
+            $this->x = new \DateTime('now');
+        } else {
+            $this->x = new class extends \DateTime {};
+        }
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/anonymous_extends_existing_class_remove_docblock.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/anonymous_extends_existing_class_remove_docblock.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+
+final class AnonymousExtendsExistingClassInUnionRemoveDocblock
+{
+    /**
+     * @var \DateTime|null
+     */
+    private $x;
+
+    public function __construct()
+    {
+        if (rand(0,1)) {
+            $this->x = new \DateTime('now');
+        } else {
+            $this->x = new class extends \DateTime {};
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+
+final class AnonymousExtendsExistingClassInUnion
+{
+    private \DateTime|null $x = null;
+
+    public function __construct()
+    {
+        if (rand(0,1)) {
+            $this->x = new \DateTime('now');
+        } else {
+            $this->x = new class extends \DateTime {};
+        }
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/anonymous_extends_existing_class_remove_docblock.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/anonymous_extends_existing_class_remove_docblock.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
 
@@ -11,10 +11,11 @@ final class AnonymousExtendsExistingClassInUnionRemoveDocblock
 
     public function __construct()
     {
-        if (rand(0,1)) {
+        if (rand(0, 1)) {
             $this->x = new \DateTime('now');
         } else {
-            $this->x = new class extends \DateTime {};
+            $this->x = new class() extends \DateTime {
+            };
         }
     }
 }
@@ -31,10 +32,11 @@ final class AnonymousExtendsExistingClassInUnion
 
     public function __construct()
     {
-        if (rand(0,1)) {
+        if (rand(0, 1)) {
             $this->x = new \DateTime('now');
         } else {
-            $this->x = new class extends \DateTime {};
+            $this->x = new class() extends \DateTime {
+            };
         }
     }
 }

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -11,6 +11,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Php\PhpVersionProvider;
@@ -129,18 +130,18 @@ CODE_SAMPLE
         $typeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($inferredType, TypeKind::PROPERTY);
         if ($typeNode === null) {
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $inferredType);
-            return $node;
+            return $this->processChangedPhpDocInfo($phpDocInfo, $node);
         }
 
         if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $inferredType);
-            return $node;
+            return $this->processChangedPhpDocInfo($phpDocInfo, $node);
         }
 
         // non-private property can be anything with not inline public configured
         if (! $node->isPrivate() && ! $this->inlinePublic) {
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $inferredType);
-            return $node;
+            return $this->processChangedPhpDocInfo($phpDocInfo, $node);
         }
 
         if ($inferredType instanceof UnionType) {
@@ -152,6 +153,15 @@ CODE_SAMPLE
         $this->varTagRemover->removeVarTagIfUseless($phpDocInfo, $node);
 
         return $node;
+    }
+
+    private function processChangedPhpDocInfo(PhpDocInfo $phpDocInfo, Node $node): ?Node
+    {
+        if ($phpDocInfo->hasChanged()) {
+            return $node;
+        }
+
+        return null;
     }
 
     private function decorateTypeWithNullableIfDefaultPropertyNull(Property $property, Type $inferredType): Type


### PR DESCRIPTION
In PHP 7.4 feature set, given the following code with `new class extends` usage:

```php
final class AnonymousExtendsExistingClassInUnion
{
    private $x;

    public function __construct()
    {
        if (rand(0,1)) {
            $this->x = new \DateTime('now');
        } else {
            $this->x = new class extends \DateTime { };
        }
    }
}
```

it currently produce diff:

```diff
+    /**
+     * @var \DateTime|object|null
+     */
     private $x;
```

ref https://getrector.org/demo/7be14431-6643-4dd6-8edb-98f533cf9002

which the `object` is extends `DateTime`, which can be removed and use:

```diff
+    /**
+    * @var \DateTime|null
+    */
```

instead. This PR try to handle it.