### PR TITLE
[CodeQuality] Handle BooleanNot on SimplifyEmptyCheckOnEmptyArrayRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/replace_array_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/replace_array_type.php.inc
@@ -55,7 +55,7 @@ final class ReplaceArrayType
 
     public function isNotEmptyArray(array $values): bool
     {
-        return !($values === []);
+        return $values !== [];
     }
 
     public function isEmptyArrayMixedType(mixed $values): bool

--- a/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/replace_is_array_check.php.inc
+++ b/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/replace_is_array_check.php.inc
@@ -39,7 +39,7 @@ final class ReplaceIsArrayCheck
 
     public function isNotEmptyArray($values): bool
     {
-        return is_array($values) && !($values === []);
+        return is_array($values) && $values !== [];
     }
 
     public function isEmptyArrayProperty(): bool

--- a/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_boolean_not_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_boolean_not_array.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRectorTest\Fixture;
 
-final class SkipBooleanNotNotArray
+final class SkipBooleanNotArray
 {
     public function verify($values): bool
     {

--- a/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_boolean_not_not_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_boolean_not_not_array.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRectorTest\Fixture;
+
+final class SkipBooleanNotNotArray
+{
+    public function verify($values): bool
+    {
+        return ! empty($values);
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
+++ b/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
@@ -8,6 +8,8 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
@@ -42,33 +44,37 @@ final class SimplifyEmptyCheckOnEmptyArrayRector extends AbstractScopeAwareRecto
      */
     public function getNodeTypes(): array
     {
-        return [Empty_::class];
+        return [Empty_::class, BooleanNot::class];
     }
 
     /**
-     * @param Empty_ $node $node
+     * @param Empty_|BooleanNot $node $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
-        if (! $this->isAllowedExpr($node->expr)) {
+        if ($node instanceof BooleanNot) {
+            if ($node->expr instanceof Empty_ && $this->isAllowedExpr($node->expr->expr, $scope)) {
+                return new NotIdentical($node->expr->expr, new Array_());
+            }
+
             return null;
         }
 
-        if (! $scope->getType($node->expr) instanceof ArrayType) {
-            return null;
-        }
-
-        if ($this->exprAnalyzer->isNonTypedFromParam($node->expr)) {
+        if (! $this->isAllowedExpr($node->expr, $scope)) {
             return null;
         }
 
         return new Identical($node->expr, new Array_());
     }
 
-    private function isAllowedExpr(Expr $expr): bool
+    private function isAllowedExpr(Expr $expr, Scope $scope): bool
     {
+        if (! $scope->getType($expr) instanceof ArrayType) {
+            return false;
+        }
+
         if ($expr instanceof Variable) {
-            return true;
+            return ! $this->exprAnalyzer->isNonTypedFromParam($expr);
         }
 
         if ($expr instanceof PropertyFetch) {


### PR DESCRIPTION
The `BooleanNot` on:

```php
! empty($values)
```

it currently produce:

```diff
-! empty($values)
+!($values === [])
```

which will be readable with direct not identical:

```diff
-! empty($values)
+$values !== []
```