### PR TITLE
[Core] Use FullyQualifiedObjectType and ThisType detection for local property fetch on PropertyFetchAnalyzer

### DIFF
--- a/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
+++ b/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
@@ -5,17 +5,12 @@ declare(strict_types=1);
 namespace Rector\Naming\Rector\Foreach_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Foreach_;
-use PHPStan\Type\ThisType;
 use Rector\CodeQuality\NodeAnalyzer\ForeachAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\ExpectedNameResolver\InflectorSingularResolver;
-use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -78,18 +73,12 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $isPropertyFetch = $this->propertyFetchAnalyzer->isPropertyFetch($node->expr);
+        $isPropertyFetch = $this->propertyFetchAnalyzer->isLocalPropertyFetch($node->expr);
         if (! $node->expr instanceof Variable && ! $isPropertyFetch) {
             return null;
         }
 
-        /** @var Variable|PropertyFetch|StaticPropertyFetch $expr */
-        $expr = $node->expr;
-        if ($this->isNotCurrentClassLikePropertyFetch($expr, $isPropertyFetch)) {
-            return null;
-        }
-
-        $exprName = $this->getName($expr);
+        $exprName = $this->getName($node->expr);
         if ($exprName === null) {
             return null;
         }
@@ -117,29 +106,6 @@ CODE_SAMPLE
         }
 
         return $this->processRename($node, $valueVarName, $singularValueVarName);
-    }
-
-    private function isNotCurrentClassLikePropertyFetch(
-        PropertyFetch|StaticPropertyFetch|Variable $expr,
-        bool $isPropertyFetch
-    ): bool {
-        if (! $isPropertyFetch) {
-            return false;
-        }
-
-        /** @var PropertyFetch|StaticPropertyFetch $expr */
-        $variableType = $expr instanceof PropertyFetch
-            ? $this->nodeTypeResolver->getType($expr->var)
-            : $this->nodeTypeResolver->getType($expr->class);
-
-        if ($variableType instanceof FullyQualifiedObjectType) {
-            $currentClassLike = $this->betterNodeFinder->findParentType($expr, ClassLike::class);
-            if ($currentClassLike instanceof ClassLike) {
-                return ! $this->nodeNameResolver->isName($currentClassLike, $variableType->getClassName());
-            }
-        }
-
-        return ! $variableType instanceof ThisType;
     }
 
     private function processRename(Foreach_ $foreach, string $valueVarName, string $singularValueVarName): Foreach_

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
+use Rector\Core\Enum\ObjectReference;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\ValueObject\MethodName;

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -232,7 +232,7 @@ final class PropertyFetchAnalyzer
         return $this->nodeNameResolver->isNames($expr->name, $propertyNames);
     }
 
-    private function isTraitLocalPropertyFetch(Node $node)
+    private function isTraitLocalPropertyFetch(Node $node): bool
     {
         if ($node instanceof PropertyFetch) {
             if (! $node->var instanceof Variable) {

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -70,6 +70,8 @@ final class PropertyFetchAnalyzer
             if ($currentClassLike instanceof ClassLike) {
                 return $this->nodeNameResolver->isName($currentClassLike, $variableType->getClassName());
             }
+
+            return false;
         }
 
         return $variableType instanceof ThisType;


### PR DESCRIPTION
Instead of rely on `this` and `self` variable, use `FullyQualifiedObjectType` and `ThisType` instead, so unnecessary re-check current class usage on rules never needed.

For PropertyFetch inside trait, the PropertyFetch doesn't parent Node, so it still rely on `this`, `self`, `static` name as fallback.