### PR TITLE
Automatically detect CPU number for parallel mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "composer/semver": "^3.3.2",
         "composer/xdebug-handler": "^3.0.3",
         "doctrine/inflector": "^2.0.5",
+        "fidry/cpu-core-counter": "^0.3.1",
         "nette/utils": "^3.2.8",
         "nikic/php-parser": "^4.15.2",
         "ondram/ci-detector": "^4.1",

--- a/config/config.php
+++ b/config/config.php
@@ -60,7 +60,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->autoloadPaths([]);
     $rectorConfig->bootstrapFiles([]);
-    $rectorConfig->parallel(seconds: 120, maxNumberOfProcess: 16, jobSize: 20);
+    $rectorConfig->parallel();
 
     // to avoid autoimporting out of the box
     $rectorConfig->importNames(false, false);

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Config;
 
+use Fidry\CpuCoreCounter\CpuCoreCounter;
+use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
 use Rector\Caching\Contract\ValueObject\Storage\CacheStorageInterface;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\ValueObjectInliner;
@@ -50,8 +52,18 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL, false);
     }
 
-    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20): void
+    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 0, int $jobSize = 20): void
     {
+        if ($maxNumberOfProcess === 0) {
+            $cpuCounter = new CpuCoreCounter();
+
+            try {
+                $maxNumberOfProcess = $cpuCounter->getCount();
+            } catch (NumberOfCpuCoreNotFound) {
+                $maxNumberOfProcess = 16;
+            }
+        }
+
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
 


### PR DESCRIPTION
Currently 16 is hardcoded as default number of CPU, what is pretty good for default GitHub action runners. it's also possible to automatically detect number of CPU cores to get benefits on different runners.


The question what is the best flag to run auto-detection: `0`, `-1`, `null`, `auto`?

I've decided to start from 0, as `-1`, `-2` can use used to deduct that number from detected number of CPU cores, like:

```php
    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 0, int $jobSize = 20): void
    {
        if ($maxNumberOfProcess < 1) {
            $cpuCounter = new CpuCoreCounter();

            try {
                $maxNumberOfProcess = max($cpuCounter->getCount() - $maxNumberOfProcess, 1);
            } catch (NumberOfCpuCoreNotFound) {
                $maxNumberOfProcess = 16;
            }
        }
```