### PR TITLE
[Php72] Handle crash on trailing comma last on WhileEachToForeachRector

### DIFF
--- a/rules-tests/Php72/Rector/While_/WhileEachToForeachRector/Fixture/trailing_comma_last.php.inc
+++ b/rules-tests/Php72/Rector/While_/WhileEachToForeachRector/Fixture/trailing_comma_last.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\Php72\Rector\While_\WhileEachToForeachRector\Fixture;
+
+// ref https://3v4l.org/mTeIL#v7.1.31 vs https://3v4l.org/UJH9S
+final class TrailingCommaLast
+{
+    public function run()
+    {
+        while(list($code_name,) = each($poster_xd))
+        {
+            $poster_xd[$code_name] = preg_replace($orig_word, $replacement_word, $poster_xd[$code_name]);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php72\Rector\While_\WhileEachToForeachRector\Fixture;
+
+// ref https://3v4l.org/mTeIL#v7.1.31 vs https://3v4l.org/UJH9S
+final class TrailingCommaLast
+{
+    public function run()
+    {
+        foreach (array_keys($poster_xd) as $code_name) {
+            $poster_xd[$code_name] = preg_replace($orig_word, $replacement_word, $poster_xd[$code_name]);
+        }
+    }
+}
+
+?>

--- a/rules/Php72/Rector/While_/WhileEachToForeachRector.php
+++ b/rules/Php72/Rector/While_/WhileEachToForeachRector.php
@@ -115,17 +115,17 @@ CODE_SAMPLE
 
         $arrayItem = array_pop($listNode->items);
         $isTrailingCommaLast = false;
-        if ($arrayItem instanceof ArrayItem) {
-            $foreach = new Foreach_($foreachedExpr, $arrayItem, [
-                'stmts' => $node->stmts,
-            ]);
-        } else {
+        if (! $arrayItem instanceof ArrayItem) {
             $foreachedExpr = $this->nodeFactory->createFuncCall('array_keys', [$eachFuncCall->args[0]]);
-            $foreach = new Foreach_($foreachedExpr, current($listNode->items), [
-                'stmts' => $node->stmts,
-            ]);
+            /** @var ArrayItem $arrayItem */
+            $arrayItem = current($listNode->items);
+
             $isTrailingCommaLast = true;
         }
+
+        $foreach = new Foreach_($foreachedExpr, $arrayItem, [
+            'stmts' => $node->stmts,
+        ]);
 
         $this->mirrorComments($foreach, $node);
 

--- a/rules/Php72/Rector/While_/WhileEachToForeachRector.php
+++ b/rules/Php72/Rector/While_/WhileEachToForeachRector.php
@@ -113,11 +113,19 @@ CODE_SAMPLE
             [$eachFuncCall->args[0]]
         ) : $eachFuncCall->args[0]->value;
 
-        /** @var ArrayItem $arrayItem */
         $arrayItem = array_pop($listNode->items);
-        $foreach = new Foreach_($foreachedExpr, $arrayItem, [
-            'stmts' => $node->stmts,
-        ]);
+        $isTrailingCommaLast = false;
+        if ($arrayItem instanceof ArrayItem) {
+            $foreach = new Foreach_($foreachedExpr, $arrayItem, [
+                'stmts' => $node->stmts,
+            ]);
+        } else {
+            $foreachedExpr = $this->nodeFactory->createFuncCall('array_keys', [$eachFuncCall->args[0]]);
+            $foreach = new Foreach_($foreachedExpr, current($listNode->items), [
+                'stmts' => $node->stmts,
+            ]);
+            $isTrailingCommaLast = true;
+        }
 
         $this->mirrorComments($foreach, $node);
 
@@ -126,7 +134,7 @@ CODE_SAMPLE
             /** @var ArrayItem|null $keyItem */
             $keyItem = array_pop($listNode->items);
 
-            if ($keyItem !== null) {
+            if ($keyItem !== null && ! $isTrailingCommaLast) {
                 $foreach->keyVar = $keyItem->value;
             }
         }


### PR DESCRIPTION
Given the following code:

```php
final class TrailingCommaLast
{
    public function run()
    {
        while(list($code_name,) = each($poster_xd))
        {
            $poster_xd[$code_name] = preg_replace($orig_word, $replacement_word, $poster_xd[$code_name]);
        }
    }
}
```

It cause crash:

```bash
There was 1 error:

1) Rector\Tests\Php72\Rector\While_\WhileEachToForeachRector\WhileEachToForeachRectorTest::test with data set #3 ('/Users/samsonasik/www/rector-...hp.inc')
TypeError: PhpParser\Node\Stmt\Foreach_::__construct(): Argument #2 ($valueVar) must be of type PhpParser\Node\Expr, null given, called in /Users/samsonasik/www/rector-src/rules/Php72/Rector/While_/WhileEachToForeachRector.php on line 131
```

Ref https://getrector.org/demo/ec8b7f3a-918f-4bfe-bf70-28fa2a992916
Fixes https://github.com/rectorphp/rector/issues/7654

The transformation should be

https://3v4l.org/mTeIL#v7.1.31 --> https://3v4l.org/UJH9S
