### PR TITLE
[Privatization][TypeDeclaration] Skip inside class with @final docblock on PrivatizeFinalClassMethodRector and AddVoidReturnTypeWhereNoReturnRector

### DIFF
--- a/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/Fixture/skip_final_docblock.php.inc
+++ b/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/Fixture/skip_final_docblock.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector\Fixture;
+
+/**
+ * @final
+ */
+class SkipFinalDocblock
+{
+    protected function someMethod()
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_final_docblock.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_final_docblock.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector\Fixture;
+
+/**
+ * @final
+ */
+class SkipFinalDocblock
+{
+    protected function someMethod()
+    {
+    }
+}

--- a/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
+++ b/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Rector\Privatization\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Privatization\VisibilityGuard\ClassMethodVisibilityGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -76,7 +78,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $classReflection->isFinal()) {
+        /** @var Class_ $class */
+        $class = $node->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $class->isFinal()) {
             return null;
         }
 

--- a/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
+++ b/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
@@ -74,12 +74,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $classReflection->isClass()) {
+        $class = $node->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $class instanceof Class_) {
             return null;
         }
 
-        /** @var Class_ $class */
-        $class = $node->getAttribute(AttributeKey::PARENT_NODE);
         if (! $class->isFinal()) {
             return null;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -182,8 +182,8 @@ CODE_SAMPLE
             return false;
         }
 
-        /** @var Class_ $class */
-        $class = $classMethod->getAttribute(AttributeKey::PARENT_NODE);
-        return $class->isFinal();
+        /** @var Class_ $node */
+        $node = $classMethod->getAttribute(AttributeKey::PARENT_NODE);
+        return $node->isFinal();
     }
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -178,12 +178,11 @@ CODE_SAMPLE
             return false;
         }
 
-        if (! $classReflection->isClass()) {
+        $node = $classMethod->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $node instanceof Class_) {
             return false;
         }
 
-        /** @var Class_ $node */
-        $node = $classMethod->getAttribute(AttributeKey::PARENT_NODE);
         return $node->isFinal();
     }
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -7,6 +7,7 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Reflection\ClassReflection;
@@ -17,6 +18,7 @@ use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\TypeInferer\SilentVoidResolver;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnVendorLockResolver;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -176,6 +178,12 @@ CODE_SAMPLE
             return false;
         }
 
-        return $classReflection->isFinal();
+        if (! $classReflection->isClass()) {
+            return false;
+        }
+
+        /** @var Class_ $class */
+        $class = $classMethod->getAttribute(AttributeKey::PARENT_NODE);
+        return $class->isFinal();
     }
 }


### PR DESCRIPTION
`$classReflection->isFinal()` mark `@final` as final class, which should be avoided on changing protected  to private property and add void return.