### PR TITLE
[Core] Refactor NodeComparator::areSameNode() to always compare printed node on last

### DIFF
--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -97,6 +97,13 @@ final class NodeComparator
             return false;
         }
 
-        return $firstNode->getEndTokenPos() === $secondNode->getEndTokenPos();
+        if ($firstNode->getEndTokenPos() !== $secondNode->getEndTokenPos()) {
+            return false;
+        }
+
+        $printFirstNode = $this->nodePrinter->print($firstNode);
+        $printSecondNode = $this->nodePrinter->print($secondNode);
+
+        return $printFirstNode === $printSecondNode;
     }
 }


### PR DESCRIPTION
Compare start and token pos only may cause invalid result if the range is equal, but it different value, eg: `$a` => `$b`, both has same start and end token.

The solution is compare printed node on last after start token and end token compared equal check.