### PR TITLE
Adapt PrivateConstantToSelfRector to work on non-final classes, too

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 412 Rules Overview
+# 413 Rules Overview
 
 <br>
 
@@ -48,7 +48,7 @@
 
 - [Php81](#php81) (11)
 
-- [Php82](#php82) (1)
+- [Php82](#php82) (2)
 
 - [Privatization](#privatization) (8)
 
@@ -596,9 +596,24 @@ Change multiple null compares to ?? queue
 
 ### ConvertStaticPrivateConstantToSelfRector
 
-Replaces static::* access to private constants with self::* on final classes
+Replaces static::* access to private constants with self::*
+
+:wrench: **configure it!**
 
 - class: [`Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector`](../rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php)
+
+```php
+use Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ConvertStaticPrivateConstantToSelfRector::class, [
+        ConvertStaticPrivateConstantToSelfRector::ENABLE_FOR_NON_FINAL_CLASSES => false,
+    ]);
+};
+```
+
+↓
 
 ```diff
  final class Foo {
@@ -6507,6 +6522,21 @@ Decorate read-only class with `readonly` attribute
      ) {
      }
  }
+```
+
+<br>
+
+### Utf8DecodeEncodeToMbConvertEncodingRector
+
+Change deprecated utf8_decode and utf8_encode to mb_convert_encoding
+
+- class: [`Rector\Php82\Rector\FuncCall\Utf8DecodeEncodeToMbConvertEncodingRector`](../rules/Php82/Rector/FuncCall/Utf8DecodeEncodeToMbConvertEncodingRector.php)
+
+```diff
+-utf8_decode($value);
+-utf8_encode($value);
++mb_convert_encoding($value, 'ISO-8859-1');
++mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
 ```
 
 <br>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/ConvertStaticPrivateConstantToSelfRectorForNonFinalClassesTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/ConvertStaticPrivateConstantToSelfRectorForNonFinalClassesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConvertStaticPrivateConstantToSelfRectorForNonFinalClassesTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureEnableForNonFinalClasses');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config_non_final_classes.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/replace-in-private-methods.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/replace-in-private-methods.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+class Foo
+{
+    private const BAR = 1;
+    private function baz(): void
+    {
+        echo static::BAR;
+    }
+}
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+class Foo
+{
+    private const BAR = 1;
+    private function baz(): void
+    {
+        echo self::BAR;
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/FixtureEnableForNonFinalClasses/do-not-replace-if-used-in-child-classes-as-protected.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/FixtureEnableForNonFinalClasses/do-not-replace-if-used-in-child-classes-as-protected.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+class ParentClass2
+{
+    private const BAR2 = 1;
+    public function baz(): void
+    {
+        echo static::BAR2;
+    }
+}
+
+class ChildClass2 extends ParentClass2 {
+    protected const BAR2 = 2;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/FixtureEnableForNonFinalClasses/do-not-replace-if-used-in-child-classes-as-public.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/FixtureEnableForNonFinalClasses/do-not-replace-if-used-in-child-classes-as-public.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+class ParentClass3
+{
+    private const BAR3 = 1;
+    public function baz(): void
+    {
+        echo static::BAR3;
+    }
+}
+
+class ChildClass3 extends ParentClass3 {
+    public const BAR3 = 2;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/FixtureEnableForNonFinalClasses/replace-if-not-used-in-child-classes.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/FixtureEnableForNonFinalClasses/replace-if-not-used-in-child-classes.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+class ParentClass1
+{
+    private const BAR1 = 1;
+    public function baz(): void
+    {
+        echo static::BAR1;
+    }
+}
+
+class ChildClass1 extends ParentClass1 {}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\Rector\UseDateTimeImmutableRector\Fixture;
+
+class ParentClass1
+{
+    private const BAR1 = 1;
+    public function baz(): void
+    {
+        echo self::BAR1;
+    }
+}
+
+class ChildClass1 extends ParentClass1 {}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/config/config_non_final_classes.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/config/config_non_final_classes.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(
+            ConvertStaticPrivateConstantToSelfRector::class,
+            [
+                ConvertStaticPrivateConstantToSelfRector::ENABLE_FOR_NON_FINAL_CLASSES => true,
+            ]
+        );
+};

--- a/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
@@ -9,8 +9,12 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
+use PHPStan\Reflection\ClassReflection;
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Rector\Core\Reflection\ReflectionResolver;
+use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
@@ -18,14 +22,28 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://3v4l.org/8Y0ba
  * @see https://phpstan.org/r/11d4c850-1a40-4fae-b665-291f96104d11
  */
-final class ConvertStaticPrivateConstantToSelfRector extends AbstractRector
+final class ConvertStaticPrivateConstantToSelfRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface
 {
+    /**
+     * @api
+     * @var string
+     */
+    public const ENABLE_FOR_NON_FINAL_CLASSES = 'enable_false_non_final_classes';
+
+    private bool $enableForNonFinalClasses = false;
+
+    public function __construct(
+        private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer,
+        private readonly ReflectionResolver $reflectionResolver,
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Replaces static::* access to private constants with self::* on final classes',
+            'Replaces static::* access to private constants with self::*',
             [
-                new CodeSample(
+                new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'
 final class Foo {
     private const BAR = 'bar';
@@ -46,6 +64,9 @@ final class Foo {
 }
 CODE_SAMPLE
                     ,
+                    [
+                        self::ENABLE_FOR_NON_FINAL_CLASSES => false,
+                    ],
                 ),
             ],
         );
@@ -56,16 +77,24 @@ CODE_SAMPLE
         return [ClassConstFetch::class];
     }
 
+    public function configure(array $configuration): void
+    {
+        $this->enableForNonFinalClasses = $configuration[self::ENABLE_FOR_NON_FINAL_CLASSES] ?? (bool) current(
+            $configuration
+        );
+    }
+
     /**
      * @param ClassConstFetch $node
      */
     public function refactor(Node $node): ?ClassConstFetch
     {
-        if (! $this->isUsingStatic($node)) {
+        $class = $this->betterNodeFinder->findParentType($node, Class_::class);
+        if (! $class instanceof Class_) {
             return null;
         }
 
-        if (! $this->isPrivateConstant($node)) {
+        if ($this->shouldBeSkipped($class, $node)) {
             return null;
         }
 
@@ -83,24 +112,14 @@ CODE_SAMPLE
         return $classConstFetch->class->toString() === 'static';
     }
 
-    private function isPrivateConstant(ClassConstFetch $classConstFetch): bool
+    private function isPrivateConstant(ClassConstFetch $constant, Class_ $class): bool
     {
-        $class = $this->betterNodeFinder->findParentType($classConstFetch, Class_::class);
-        if (! $class instanceof Class_) {
+        $constantName = $this->getConstantName($constant);
+        if ($constantName === null) {
             return false;
         }
-
-        if (! $class->isFinal()) {
-            return false;
-        }
-
-        $constantName = $classConstFetch->name;
-        if (! $constantName instanceof Identifier) {
-            return false;
-        }
-
         foreach ($class->getConstants() as $classConst) {
-            if (! $this->nodeNameResolver->isName($classConst, $constantName->toString())) {
+            if (! $this->nodeNameResolver->isName($classConst, $constantName)) {
                 continue;
             }
 
@@ -108,5 +127,67 @@ CODE_SAMPLE
         }
 
         return false;
+    }
+
+    private function isUsedInPrivateMethod(ClassConstFetch $node): bool
+    {
+        $method = $this->betterNodeFinder->findParentType($node, Node\Stmt\ClassMethod::class);
+
+        if (! $method instanceof Node\Stmt\ClassMethod) {
+            return false;
+        }
+
+        return $method->flags === Class_::MODIFIER_PRIVATE;
+    }
+
+    private function shouldBeSkipped(Class_ $class, ClassConstFetch $classConstFetch): bool
+    {
+        if (! $this->isUsingStatic($classConstFetch)) {
+            return true;
+        }
+        if (! $this->isPrivateConstant($classConstFetch, $class)) {
+            return true;
+        }
+        if ($this->isUsedInPrivateMethod($classConstFetch)) {
+            return false;
+        }
+
+        if ($this->enableForNonFinalClasses) {
+            return $this->isOverwrittenInChildClass($classConstFetch);
+        }
+
+        return ! $class->isFinal();
+    }
+
+    private function isOverwrittenInChildClass(ClassConstFetch $classConstFetch): bool
+    {
+        $constantName = $this->getConstantName($classConstFetch);
+        if ($constantName === null) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionResolver->resolveClassReflection($classConstFetch);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+        $childrenClassReflections = $this->familyRelationsAnalyzer->getChildrenOfClassReflection($classReflection);
+
+        foreach ($childrenClassReflections as $childrenClassReflection) {
+            if ($childrenClassReflection->hasConstant($constantName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getConstantName(ClassConstFetch $classConstFetch): ?string
+    {
+        $constantNameIdentifier = $classConstFetch->name;
+        if (! $constantNameIdentifier instanceof Identifier) {
+            return null;
+        }
+
+        return $constantNameIdentifier->toString();
     }
 }

--- a/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
@@ -28,7 +28,7 @@ final class ConvertStaticPrivateConstantToSelfRector extends AbstractRector impl
      * @api
      * @var string
      */
-    public const ENABLE_FOR_NON_FINAL_CLASSES = 'enable_self_non_final_classes';
+    public const ENABLE_FOR_NON_FINAL_CLASSES = 'enable_for_non_final_classes';
 
     private bool $enableForNonFinalClasses = false;
 

--- a/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
@@ -28,7 +28,7 @@ final class ConvertStaticPrivateConstantToSelfRector extends AbstractRector impl
      * @api
      * @var string
      */
-    public const ENABLE_FOR_NON_FINAL_CLASSES = 'enable_false_non_final_classes';
+    public const ENABLE_FOR_NON_FINAL_CLASSES = 'enable_self_non_final_classes';
 
     private bool $enableForNonFinalClasses = false;
 


### PR DESCRIPTION
Follow-up for #3178

Not sure about the change in the markdown files, part of it looks not unrelated to my change, probably someone forgot to generate that on `main`.

I'm not sure what to do for code like this:
```php
<?php
class ParentClass {
	private const FOO = 'from parent';
	
	public function foo() {
		echo static::FOO;
	}
}

class ChildClass1 extends ParentClass {
	private const FOO = 'from child1';
}
```

I might add a check that changes `static` to `self` if all child-classes declare it as a `private` constant.