### PR TITLE
[DeadCode] Skip append array data on RemoveJustPropertyFetchRector

### DIFF
--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveJustPropertyFetchRector/Fixture/skip_append_array_data.php.inc
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveJustPropertyFetchRector/Fixture/skip_append_array_data.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveJustPropertyFetchRector\Fixture;
+
+final class SkipAppendArrayData
+{
+    private $default = ['some data'];
+
+    public function run()
+    {
+        $where = $this->default;
+        $where[] = 'some append data';
+    }
+}

--- a/rules/DeadCode/Rector/StmtsAwareInterface/RemoveJustPropertyFetchRector.php
+++ b/rules/DeadCode/Rector/StmtsAwareInterface/RemoveJustPropertyFetchRector.php
@@ -22,6 +22,7 @@ use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\ValueObject\PropertyFetchToVariableAssign;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\ReadWrite\NodeAnalyzer\ReadExprAnalyzer;
 use Rector\ReadWrite\NodeFinder\NodeUsageFinder;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -32,7 +33,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveJustPropertyFetchRector extends AbstractRector
 {
     public function __construct(
-        private readonly NodeUsageFinder $nodeUsageFinder
+        private readonly NodeUsageFinder $nodeUsageFinder,
+        private readonly ReadExprAnalyzer $readExprAnalyzer
     ) {
     }
 
@@ -109,6 +111,10 @@ CODE_SAMPLE
             $followingStmts = array_slice($stmts, $key + 1);
             if ($this->isFollowingStatementStaticClosure($followingStmts)) {
                 // can not replace usages in anonymous static functions
+                continue;
+            }
+
+            if (! $this->readExprAnalyzer->isExprRead($variableToPropertyAssign->getVariable())) {
                 continue;
             }
 


### PR DESCRIPTION
The following code should be skipped:

```php
final class SkipAppendArrayData
{
    private $default = ['some data'];

    public function run()
    {
        $where = $this->default;
        $where[] = 'some append data';
    }
}
```

ref https://3v4l.org/UlZB6 