### PR TITLE
[DeadCode] Skip standalone @return false or true on RemoveUselessReturnTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_return_standalone_true_false_by_return_bool.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_return_standalone_true_false_by_return_bool.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+/**
+ * @see https://phpstan.org/r/6fbad07c-4b5e-4d89-8970-03df898abc6e
+ */
+final class SkipReturnStandaloneTrueFalseByReturnBool
+{
+    /**
+     * @return true
+     */
+    function someTrue(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return false
+     */
+    function someFalse(): bool
+    {
+        return false;
+    }
+}

--- a/rules/DeadCode/PhpDoc/Guard/StandaloneTypeRemovalGuard.php
+++ b/rules/DeadCode/PhpDoc/Guard/StandaloneTypeRemovalGuard.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\PhpDoc\Guard;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+
+final class StandaloneTypeRemovalGuard
+{
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_TYPES = ['false', 'true'];
+
+    public function isLegal(TypeNode $typeNode, Node $node): bool
+    {
+        if (! $typeNode instanceof IdentifierTypeNode) {
+            return true;
+        }
+
+        if (! $node instanceof Identifier) {
+            return true;
+        }
+
+        if ($node->toString() !== 'bool') {
+            return true;
+        }
+
+        return ! in_array($typeNode->name, self::ALLOWED_TYPES, true);
+    }
+}

--- a/rules/Php81/NodeFactory/EnumFactory.php
+++ b/rules/Php81/NodeFactory/EnumFactory.php
@@ -136,12 +136,15 @@ final class EnumFactory
                 if (! $item instanceof ArrayItem) {
                     continue;
                 }
+
                 if (! $item->key instanceof LNumber && ! $item->key instanceof String_) {
                     continue;
                 }
+
                 if (! $item->value instanceof LNumber && ! $item->value instanceof String_) {
                     continue;
                 }
+
                 $mapping[$item->key->value] = $item->value->value;
             }
         }


### PR DESCRIPTION
The following code should be skipped:

```php
final class SkipReturnStandaloneTrueFalseByReturnBool
{
    /**
     * @return true
     */
    function someTrue(): bool
    {
        return true;
    }

    /**
     * @return false
     */
    function someFalse(): bool
    {
        return false;
    }
}
```

Ref https://phpstan.org/r/6fbad07c-4b5e-4d89-8970-03df898abc6e