### PR TITLE
[Privatization] Do not remove comment on ChangeReadOnlyPropertyWithDefaultValueToConstantRector

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -50,6 +50,9 @@ jobs:
 
             -   run: composer config minimum-stability dev
 
+            # issue with array shape
+            -   run: composer require phpstan/phpdoc-parser:1.15.0
+
             # test with current commit in a pull-request
             -
                 run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update

--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -50,7 +50,7 @@ jobs:
 
             -   run: composer config minimum-stability dev
 
-            # issue with array shape
+            # issue with array shape on just released 1.15.1
             -   run: composer require phpstan/phpdoc-parser:1.15.0
 
             # test with current commit in a pull-request

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "nette/utils": "^3.2.8",
         "nikic/php-parser": "^4.15.2",
         "ondram/ci-detector": "^4.1",
-        "phpstan/phpdoc-parser": "^1.15.0",
+        "phpstan/phpdoc-parser": "1.15.0",
         "phpstan/phpstan": "^1.9.3",
         "phpstan/phpstan-phpunit": "^1.2.2",
         "react/event-loop": "^1.3",

--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/do_not_remove_comment.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/do_not_remove_comment.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+class DoNotRemoveComment
+{
+    // some comment
+    private $magicMethods = [
+        '__toString',
+        '__wakeup',
+    ];
+
+    public function run()
+    {
+        foreach ($this->magicMethods as $magicMethod) {
+            echo $magicMethod;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+class DoNotRemoveComment
+{
+    // some comment
+    private const MAGIC_METHODS = [
+        '__toString',
+        '__wakeup',
+    ];
+
+    public function run()
+    {
+        foreach (self::MAGIC_METHODS as $magicMethod) {
+            echo $magicMethod;
+        }
+    }
+}
+
+?>

--- a/rules/Privatization/NodeFactory/ClassConstantFactory.php
+++ b/rules/Privatization/NodeFactory/ClassConstantFactory.php
@@ -9,15 +9,13 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Property;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Privatization\Naming\ConstantNaming;
 
 final class ClassConstantFactory
 {
     public function __construct(
-        private readonly ConstantNaming $constantNaming,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory
+        private readonly ConstantNaming $constantNaming
     ) {
     }
 

--- a/rules/Privatization/NodeFactory/ClassConstantFactory.php
+++ b/rules/Privatization/NodeFactory/ClassConstantFactory.php
@@ -36,10 +36,8 @@ final class ClassConstantFactory
 
         $const->setAttribute(AttributeKey::PARENT_NODE, $classConst);
 
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        $phpDocInfo->markAsChanged();
-
-        $classConst->setAttribute(AttributeKey::PHP_DOC_INFO, $phpDocInfo);
+        $classConst->setAttribute(AttributeKey::PHP_DOC_INFO, $property->getAttribute(AttributeKey::PHP_DOC_INFO));
+        $classConst->setAttribute(AttributeKey::COMMENTS, $property->getAttribute(AttributeKey::COMMENTS));
         $classConst->setAttribute(AttributeKey::PARENT_NODE, $property->getAttribute(AttributeKey::PARENT_NODE));
 
         return $classConst;


### PR DESCRIPTION
The comment on `ChangeReadOnlyPropertyWithDefaultValueToConstantRector` should be mirrored during transformation.