### PR TITLE
Update to phpdoc-parser ^1.5.2

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -50,9 +50,6 @@ jobs:
 
             -   run: composer config minimum-stability dev
 
-            # issue with array shape on just released 1.15.1
-            -   run: composer require phpstan/phpdoc-parser:1.15.0
-
             # test with current commit in a pull-request
             -
                 run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "nette/utils": "^3.2.8",
         "nikic/php-parser": "^4.15.2",
         "ondram/ci-detector": "^4.1",
-        "phpstan/phpdoc-parser": "1.15.0",
+        "phpstan/phpdoc-parser": "^1.15.2",
         "phpstan/phpstan": "^1.9.3",
         "phpstan/phpstan-phpunit": "^1.2.2",
         "react/event-loop": "^1.3",


### PR DESCRIPTION
phpstan/phpdoc-parser 1.15.2 just released with fix printing array shape https://github.com/phpstan/phpdoc-parser/releases/tag/1.15.2