### PR TITLE
[Core] Apply auto mirror comments by default on AbstractRector return node

### DIFF
--- a/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
+++ b/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
@@ -112,7 +112,6 @@ CODE_SAMPLE
         $if = new If_($expr);
         $if->stmts[] = new Expression($booleanExpr->right);
 
-        $this->mirrorComments($if, $expression);
         return $if;
     }
 }

--- a/rules/CodeQuality/Rector/For_/ForToForeachRector.php
+++ b/rules/CodeQuality/Rector/For_/ForToForeachRector.php
@@ -177,7 +177,6 @@ CODE_SAMPLE
             $this->iteratedExpr,
             $this->keyValueName
         );
-        $this->mirrorComments($foreach, $for);
 
         if ($this->keyValueName === null) {
             throw new ShouldNotHappenException();

--- a/rules/Privatization/NodeFactory/ClassConstantFactory.php
+++ b/rules/Privatization/NodeFactory/ClassConstantFactory.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Property;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Privatization\Naming\ConstantNaming;
 
 final class ClassConstantFactory
@@ -31,12 +30,6 @@ final class ClassConstantFactory
 
         $classConst = new ClassConst([$const]);
         $classConst->flags = $property->flags & ~Class_::MODIFIER_STATIC;
-
-        $const->setAttribute(AttributeKey::PARENT_NODE, $classConst);
-
-        $classConst->setAttribute(AttributeKey::PHP_DOC_INFO, $property->getAttribute(AttributeKey::PHP_DOC_INFO));
-        $classConst->setAttribute(AttributeKey::COMMENTS, $property->getAttribute(AttributeKey::COMMENTS));
-        $classConst->setAttribute(AttributeKey::PARENT_NODE, $property->getAttribute(AttributeKey::PARENT_NODE));
 
         return $classConst;
     }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -321,8 +321,7 @@ CODE_SAMPLE;
         }
 
         // comments attribute already exists in refactored Node
-        $newNodeComments = $newNode->getAttribute(AttributeKey::COMMENTS);
-        if ($newNodeComments !== null) {
+        if ($newNode->hasAttribute(AttributeKey::COMMENTS)) {
             return;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -320,6 +320,12 @@ CODE_SAMPLE;
             return;
         }
 
+        // comments attribute already exists in refactored Node
+        $newNodeComments = $newNode->getAttribute(AttributeKey::COMMENTS);
+        if ($newNodeComments !== null) {
+            return;
+        }
+
         $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO));
         if (! $newNode instanceof Nop) {
             $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -320,8 +320,8 @@ CODE_SAMPLE;
             return;
         }
 
-        // comments attribute already exists in refactored Node
-        if ($newNode->hasAttribute(AttributeKey::COMMENTS)) {
+        // comments or php_doc_info attribute already exists in refactored Node
+        if ($newNode->hasAttribute(AttributeKey::COMMENTS) || $newNode->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
             return;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -319,9 +319,11 @@ CODE_SAMPLE;
         if ($this->nodeComparator->areSameNode($newNode, $oldNode)) {
             return;
         }
-
         // comments or php_doc_info attribute already exists in refactored Node
-        if ($newNode->hasAttribute(AttributeKey::COMMENTS) || $newNode->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
+        if ($newNode->hasAttribute(AttributeKey::COMMENTS)) {
+            return;
+        }
+        if ($newNode->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
             return;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -252,6 +252,8 @@ CODE_SAMPLE;
             ? new Expression($refactoredNode)
             : $refactoredNode;
 
+        $this->mirrorComments($refactoredNode, $node);
+
         $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
         $this->connectNodes([$refactoredNode], $node);
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -319,10 +319,12 @@ CODE_SAMPLE;
         if ($this->nodeComparator->areSameNode($newNode, $oldNode)) {
             return;
         }
+
         // comments or php_doc_info attribute already exists in refactored Node
         if ($newNode->hasAttribute(AttributeKey::COMMENTS)) {
             return;
         }
+
         if ($newNode->hasAttribute(AttributeKey::PHP_DOC_INFO)) {
             return;
         }


### PR DESCRIPTION
Currently, there is auto mirror comment when AbstractRector return array of nodes:

https://github.com/rectorphp/rector-src/blob/bf9d5ab5056bb08317308707c035a45b5b658ea7/src/Rector/AbstractRector.php#L237-L239

This PR apply auto mirror comment when return single node as well, proven with various unnecessary tweak in previous PR:

- https://github.com/rectorphp/rector-src/pull/3204

and other rules.