### PR TITLE
Compatibility with BetterReflection 6.x on ClassFromEnumFactory (take 2)

### DIFF
--- a/rules/Php81/NodeFactory/EnumFactory.php
+++ b/rules/Php81/NodeFactory/EnumFactory.php
@@ -82,7 +82,7 @@ final class EnumFactory
             $enum->scalarType = new Identifier($identifierType);
 
             foreach ($docBlockMethods as $docBlockMethod) {
-                $enum->stmts[] = $this->createEnumCaseFromDocComment($docBlockMethod, $mapping);
+                $enum->stmts[] = $this->createEnumCaseFromDocComment($docBlockMethod, $class, $mapping);
             }
         }
 
@@ -92,7 +92,15 @@ final class EnumFactory
     private function createEnumCaseFromConst(ClassConst $classConst): EnumCase
     {
         $constConst = $classConst->consts[0];
-        $enumCase = new EnumCase($constConst->name, $constConst->value);
+        $enumCase = new EnumCase(
+            $constConst->name,
+            $constConst->value,
+            [],
+            [
+                'startLine' => $constConst->getStartLine(),
+                'endLine' => $constConst->getEndLine(),
+            ]
+        );
 
         // mirror comments
         $enumCase->setAttribute(AttributeKey::PHP_DOC_INFO, $classConst->getAttribute(AttributeKey::PHP_DOC_INFO));
@@ -104,15 +112,26 @@ final class EnumFactory
     /**
      * @param array<int|string, mixed> $mapping
      */
-    private function createEnumCaseFromDocComment(PhpDocTagNode $phpDocTagNode, array $mapping = []): EnumCase
-    {
+    private function createEnumCaseFromDocComment(
+        PhpDocTagNode $phpDocTagNode,
+        Class_ $class,
+        array $mapping = []
+    ): EnumCase {
         /** @var MethodTagValueNode $nodeValue */
         $nodeValue = $phpDocTagNode->value;
         $enumValue = $mapping[$nodeValue->methodName] ?? $nodeValue->methodName;
         $enumName = strtoupper($nodeValue->methodName);
         $enumExpr = $this->builderFactory->val($enumValue);
 
-        return new EnumCase($enumName, $enumExpr);
+        return new EnumCase(
+            $enumName,
+            $enumExpr,
+            [],
+            [
+                'startLine' => $class->getStartLine(),
+                'endLine' => $class->getEndLine(),
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
I just tried run phpunit locally on `SpatieEnumClassToEnumRectorTest` test:

```bash
➜  rector-src git:(main) vendor/bin/phpunit rules-tests/Php81/Rector/Class_/SpatieEnumClassToEnumRector/SpatieEnumClassToEnumRectorTest.php
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

.F                                                                  2 / 2 (100%)

Time: 00:00.809, Memory: 74.50 MB

There was 1 failure:

1) Rector\Tests\Php81\Rector\Class_\SpatieEnumClassToEnumRector\SpatieEnumClassToEnumRectorTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
assert($startLine > 0) in phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionEnumCase.php:66

Caused by
AssertionError: assert($startLine > 0) in phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionEnumCase.php:66
```

This PR ensure add stand line and end line to make compatibel with BetterReflection 6.x, after added, phpunit run green:

```bash
➜  rector-src git:(compat-better-6x) vendor/bin/phpunit rules-tests/Php81/Rector/Class_/SpatieEnumClassToEnumRector/SpatieEnumClassToEnumRectorTest.php
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

..                                                                  2 / 2 (100%)

Time: 00:00.825, Memory: 74.50 MB

OK (2 tests, 4 assertions)
```