### PR TITLE
[Naming] Skip Doctrine collection with @var Collection<int, Checkbox> on RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_doctrine_collection_private_property.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_doctrine_collection_private_property.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+final class SkipDoctrineCollectionPrivateProperty
+{
+    /**
+     * @var Collection<int, Checkbox>
+     */
+    private Collection $checkboxes;
+
+    public function __construct()
+    {
+        $this->checkboxes = new ArrayCollection();
+    }
+
+    public function getCheckboxes(): Collection
+    {
+        return $this->checkboxes;
+    }
+}

--- a/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
+++ b/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\NodeManipulator\PropertyManipulator;
@@ -69,16 +69,16 @@ final class MatchPropertyTypeExpectedNameResolver
         // property type first
         if ($property->type instanceof Node) {
             $propertyType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($property->type);
+            // not has docblock, use property type
             if (! $isPhpDocInfo) {
                 return $this->propertyNaming->getExpectedNameFromType($propertyType);
             }
 
+            // @var type is ObjectType, use property type
             $varType = $phpDocInfo->getVarType();
-            if (! $varType instanceof IntersectionType) {
+            if ($varType instanceof ObjectType) {
                 return $this->propertyNaming->getExpectedNameFromType($propertyType);
             }
-
-            return $this->propertyNaming->getExpectedNameFromType($varType);
         }
 
         // fallback to docblock


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7672