### PR TITLE
[Core] Performance improvement: Remove unnecessary re-call FileFactory::createFileInfosFromPaths()

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -78,7 +78,7 @@ final class ApplicationFileProcessor
             $systemErrorsAndFileDiffs = $this->runParallel($fileInfos, $configuration, $input);
         } else {
             // 1. collect all files from files+dirs provided paths
-            $files = $this->fileFactory->createFromPaths($configuration->getPaths(), $configuration);
+            $files = $this->fileFactory->createFromPaths($fileInfos);
 
             // 2. PHPStan has to know about all files too
             $this->configurePHPStanNodeScopeResolver($files);

--- a/src/ValueObjectFactory/Application/FileFactory.php
+++ b/src/ValueObjectFactory/Application/FileFactory.php
@@ -42,13 +42,11 @@ final class FileFactory
     }
 
     /**
-     * @param string[] $paths
+     * @param string[] $filePaths
      * @return File[]
      */
-    public function createFromPaths(array $paths, Configuration $configuration): array
+    public function createFromPaths(array $filePaths): array
     {
-        $filePaths = $this->createFileInfosFromPaths($paths, $configuration);
-
         $files = [];
         foreach ($filePaths as $filePath) {
             $files[] = new File($filePath, FileSystem::read($filePath));


### PR DESCRIPTION
There is already initialization early in `ApplicationFileProcessor::run()`

```php
$fileInfos = $this->fileFactory->createFileInfosFromPaths($configuration->getPaths(), $configuration);
```

https://github.com/rectorphp/rector-src/blob/f2e4da5e7f836d1618ece81f646cfe11ea4ac561/src/Application/ApplicationFileProcessor.php#L63-L65

so, internal call:

```php
$filePaths = $this->createFileInfosFromPaths($paths, $configuration);
```

inside `createFromPaths()` method no longer needed, as it can just consume existing defined initialization `$fileInfos` string array data.

It only happen on non-parallel configuration.

so:

✔️ Remove double Loop (only once at initialization already)
✔️ Remove double run clear cache
✔️ Remove double method call internally.
