### PR TITLE
[Php81] Allow explicit mixed processed on trait on NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/explicit_mixed_in_trait.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/explicit_mixed_in_trait.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+trait ExplicitMixedInTrait
+{
+    public function setTitle(mixed $title)
+    {
+        $this->title = $title;
+        return trim($this->title);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+trait ExplicitMixedInTrait
+{
+    public function setTitle(mixed $title)
+    {
+        $this->title = $title;
+        return trim((string) $this->title);
+    }
+}
+
+?>

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -476,7 +476,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSkipTrait($argValue, $isTrait)) {
+        if ($this->shouldSkipTrait($argValue, $type, $isTrait)) {
             return null;
         }
 
@@ -490,10 +490,18 @@ CODE_SAMPLE
         return $funcCall;
     }
 
-    private function shouldSkipTrait(Expr $expr, bool $isTrait): bool
+    private function shouldSkipTrait(Expr $expr, MixedType $type, bool $isTrait): bool
     {
+        if (! $isTrait) {
+            return false;
+        }
+
+        if ($type->isExplicitMixed()) {
+            return false;
+        }
+
         if (! $expr instanceof MethodCall) {
-            return $isTrait && $this->propertyFetchAnalyzer->isLocalPropertyFetch($expr);
+            return $this->propertyFetchAnalyzer->isLocalPropertyFetch($expr);
         }
 
         return $isTrait;

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -504,7 +504,7 @@ CODE_SAMPLE
             return $this->propertyFetchAnalyzer->isLocalPropertyFetch($expr);
         }
 
-        return $isTrait;
+        return true;
     }
 
     private function isCastedReassign(Expr $expr): bool

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -490,13 +490,13 @@ CODE_SAMPLE
         return $funcCall;
     }
 
-    private function shouldSkipTrait(Expr $expr, MixedType $type, bool $isTrait): bool
+    private function shouldSkipTrait(Expr $expr, MixedType $mixedType, bool $isTrait): bool
     {
         if (! $isTrait) {
             return false;
         }
 
-        if ($type->isExplicitMixed()) {
+        if ($mixedType->isExplicitMixed()) {
             return false;
         }
 


### PR DESCRIPTION
Explit mixed in trait:

```php
trait ExplicitMixedInTrait
{
    public function setTitle(mixed $title)
    {
        $this->title = $title;
        return trim($this->title);
    }
}
```

should be allowed to be processed on `NullToStrictStringFuncCallArgRector` to be:

```diff
-return trim($this->title);
+return trim((string) $this->title);
```