### PR TITLE
[Core] Improve performance: remove repetitive currentFileProvider->setFile() call on PhpFileProcessor

### DIFF
--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -58,12 +58,10 @@ final class PhpFileProcessor implements FileProcessorInterface
             return $systemErrorsAndFileDiffs;
         }
 
-        $this->currentFileProvider->setFile($file);
-
         // 2. change nodes with Rectors
         do {
             $file->changeHasChanged(false);
-            $this->refactorNodesWithRectors($file, $configuration);
+            $this->fileProcessor->refactor($file, $configuration);
 
             // 3. apply post rectors
             $newStmts = $this->postFileProcessor->traverse($file->getNewStmts());
@@ -97,12 +95,6 @@ final class PhpFileProcessor implements FileProcessorInterface
     public function getSupportedFileExtensions(): array
     {
         return ['php'];
-    }
-
-    private function refactorNodesWithRectors(File $file, Configuration $configuration): void
-    {
-        $this->currentFileProvider->setFile($file);
-        $this->fileProcessor->refactor($file, $configuration);
     }
 
     /**


### PR DESCRIPTION
There is already initialization early of `$this->currentFileProvider->setFile($file);` when call: 

```php
$parsingSystemErrors = $this->parseFileAndDecorateNodes($file);
```

in `parseFileAndDecorateNodes()` method:

https://github.com/rectorphp/rector-src/blob/21c9e59aaaae15e1baac98b80b6d3e3be5c5d88d/src/Application/FileProcessor/PhpFileProcessor.php#L111-L113

so, next calls no longer needed as already set early.

so:

✔️ Remove 2 unused call `$this->currentFileProvider->setFile($file);`
✔️ Remove unused private method that only call another method, just use as is directly:

```php
$this->fileProcessor->refactor($file, $configuration)
```

as it only do that now.
