### PR TITLE
[Core] Remove deprecated ContainerConfigurator warning since RectorConfig available since 0.12

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/config/config.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/config/config.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(ConvertStaticPrivateConstantToSelfRector::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ConvertStaticPrivateConstantToSelfRector::class);
 };

--- a/rules/Renaming/Helper/RenameClassCallbackHandler.php
+++ b/rules/Renaming/Helper/RenameClassCallbackHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Renaming\Helper;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\Reflection\ReflectionProvider;
@@ -53,18 +54,18 @@ final class RenameClassCallbackHandler extends NodeVisitorAbstract
     /**
      * @return array<string, string>
      */
-    public function handleClassLike(ClassLike $node): array
+    public function handleClassLike(ClassLike $classLike): array
     {
         $oldToNewClasses = [];
-        $className = $node->name;
-        if ($className === null) {
+        $className = $classLike->name;
+        if (! $className instanceof Identifier) {
             return [];
         }
 
         foreach ($this->oldToNewClassCallbacks as $oldToNewClassCallback) {
-            $newClassName = $oldToNewClassCallback($node, $this->nodeNameResolver, $this->reflectionProvider);
+            $newClassName = $oldToNewClassCallback($classLike, $this->nodeNameResolver, $this->reflectionProvider);
             if ($newClassName !== null) {
-                $fullyQualifiedClassName = (string) $this->nodeNameResolver->getName($node);
+                $fullyQualifiedClassName = (string) $this->nodeNameResolver->getName($classLike);
                 $this->renamedClassesDataCollector->addOldToNewClass($fullyQualifiedClassName, $newClassName);
                 $oldToNewClasses[$fullyQualifiedClassName] = $newClassName;
             }

--- a/src/DependencyInjection/RectorContainerFactory.php
+++ b/src/DependencyInjection/RectorContainerFactory.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Core\DependencyInjection;
 
-use Nette\Utils\FileSystem;
 use Psr\Container\ContainerInterface;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Core\Autoloading\BootstrapFilesIncluder;
-use Rector\Core\Exception\DeprecatedException;
 use Rector\Core\Kernel\RectorKernel;
 use Rector\Core\ValueObject\Bootstrap\BootstrapConfigs;
 
@@ -21,17 +19,6 @@ final class RectorContainerFactory
         $mainConfigFile = $bootstrapConfigs->getMainConfigFile();
 
         if ($mainConfigFile !== null) {
-            // warning about old syntax before RectorConfig
-            $fileContents = FileSystem::read($mainConfigFile);
-            if (str_contains($fileContents, 'ContainerConfigurator $containerConfigurator')) {
-                $warningMessage = sprintf(
-                    'Your "%s" config uses deprecated syntax with "ContainerConfigurator".%sUpgrade to "RectorConfig": https://getrector.org/blog/new-in-rector-012-introducing-rector-config-with-autocomplete',
-                    $mainConfigFile,
-                    PHP_EOL,
-                );
-                throw new DeprecatedException($warningMessage);
-            }
-
             /** @var ChangedFilesDetector $changedFilesDetector */
             $changedFilesDetector = $container->get(ChangedFilesDetector::class);
             $changedFilesDetector->setFirstResolvedConfigFileInfo($mainConfigFile);

--- a/src/Exception/DeprecatedException.php
+++ b/src/Exception/DeprecatedException.php
@@ -6,6 +6,9 @@ namespace Rector\Core\Exception;
 
 use Exception;
 
+/**
+ * @api
+ */
 final class DeprecatedException extends Exception
 {
 }

--- a/tests/Issues/PartialValueDocblockUpdate/config/configured_rule.php
+++ b/tests/Issues/PartialValueDocblockUpdate/config/configured_rule.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
+use Rector\Config\RectorConfig;
 use Rector\Core\Tests\Issues\PartialValueDocblockUpdate\Source\TestRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(TestRector::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TestRector::class);
 };


### PR DESCRIPTION
`RectorConfig` is available since 0.12, I think deprecated warning `ContainerConfigurator $containerConfigurator` can be removed now.