### PR TITLE
[Core] Add FileProcessorRunner service for re-use code between parallel and disable parallel

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -330,6 +330,7 @@ parameters:
                 # reported only in non-CI, for some reason; keep it there even if it's reported as fixed error
                 - packages/Parallel/Application/ParallelFileProcessor.php
                 - packages/Parallel/WorkerRunner.php
+                - src/Application/FileProcessor/FileProcessorRunner.php
 
         # skipped on purpose, as ctor overrie
         - '#Rector\\StaticTypeMapper\\ValueObject\\Type\\SimpleStaticType\:\:__construct\(\) does not call parent constructor from PHPStan\\Type\\StaticType#'

--- a/src/Application/FileProcessor/FileProcessorRunner.php
+++ b/src/Application/FileProcessor/FileProcessorRunner.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Application\FileProcessor;
+
+use PHPStan\Analyser\NodeScopeResolver;
+use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\ValueObject\Configuration;
+
+final class FileProcessorRunner
+{
+    /**
+     * @param FileProcessorInterface[] $fileProcessors
+     */
+    public function __construct(
+        private readonly NodeScopeResolver $nodeScopeResolver,
+        private readonly array $fileProcessors = [])
+    {
+    }
+
+    public function run(array $filePaths, Configuration $configuration): array
+    {
+        // 1. allow PHPStan to work with static reflection on provided files
+        $this->configurePHPStanNodeScopeResolver($filePaths);
+
+        // todo: copy more re-usable code...
+
+        return [];
+    }
+
+    /**
+     * @param string[] $filePaths
+     */
+    private function configurePHPStanNodeScopeResolver(array $filePaths): void
+    {
+        $phpFilePaths = array_filter($filePaths, static fn (string $filePath): bool => str_ends_with($filePath, '.php'));
+        $this->nodeScopeResolver->setAnalysedFiles($phpFilePaths);
+    }
+}

--- a/src/Application/FileProcessor/FileProcessorRunner.php
+++ b/src/Application/FileProcessor/FileProcessorRunner.php
@@ -4,29 +4,64 @@ declare(strict_types=1);
 
 namespace Rector\Core\Application\FileProcessor;
 
+use Nette\Utils\FileSystem;
 use PHPStan\Analyser\NodeScopeResolver;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
+use Rector\Core\ValueObject\Error\SystemError;
+use Rector\Core\ValueObject\Reporting\FileDiff;
 
 final class FileProcessorRunner
 {
+    public $arrayParametersMerger;
+
     /**
      * @param FileProcessorInterface[] $fileProcessors
      */
     public function __construct(
         private readonly NodeScopeResolver $nodeScopeResolver,
-        private readonly array $fileProcessors = [])
-    {
+        private readonly array $fileProcessors = []
+    ) {
     }
 
+    /**
+     * @return array{system_errors: SystemError[], file_diffs: FileDiff[]}
+     */
     public function run(array $filePaths, Configuration $configuration): array
     {
         // 1. allow PHPStan to work with static reflection on provided files
         $this->configurePHPStanNodeScopeResolver($filePaths);
 
-        // todo: copy more re-usable code...
+        // 2. process files
+        $errorAndFileDiffs = $this->processFiles($filePaths, $configuration, []);
 
-        return [];
+        return $errorAndFileDiffs;
+    }
+
+    /**
+     * @param array{system_errors: SystemError[], file_diffs: FileDiff[]}|mixed[] $errorAndFileDiffs
+     * @return array{system_errors: SystemError[], file_diffs: FileDiff[]}
+     */
+    public function processFiles(array $filePaths, Configuration $configuration, array $errorAndFileDiffs): array
+    {
+        foreach ($filePaths as $filePath) {
+            $file = new File($filePath, FileSystem::read($filePath));
+
+            foreach ($this->fileProcessors as $fileProcessor) {
+                if (! $fileProcessor->supports($file, $configuration)) {
+                    continue;
+                }
+
+                $currentErrorsAndFileDiffs = $fileProcessor->process($file, $configuration);
+                $errorAndFileDiffs = $this->arrayParametersMerger->merge(
+                    $errorAndFileDiffs,
+                    $currentErrorsAndFileDiffs
+                );
+            }
+        }
+
+        return $errorAndFileDiffs;
     }
 
     /**
@@ -34,7 +69,10 @@ final class FileProcessorRunner
      */
     private function configurePHPStanNodeScopeResolver(array $filePaths): void
     {
-        $phpFilePaths = array_filter($filePaths, static fn (string $filePath): bool => str_ends_with($filePath, '.php'));
+        $phpFilePaths = array_filter(
+            $filePaths,
+            static fn (string $filePath): bool => str_ends_with($filePath, '.php')
+        );
         $this->nodeScopeResolver->setAnalysedFiles($phpFilePaths);
     }
 }

--- a/src/Application/FileProcessor/FileProcessorRunner.php
+++ b/src/Application/FileProcessor/FileProcessorRunner.php
@@ -7,6 +7,7 @@ namespace Rector\Core\Application\FileProcessor;
 use Nette\Utils\FileSystem;
 use PHPStan\Analyser\NodeScopeResolver;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\Util\ArrayParametersMerger;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
 use Rector\Core\ValueObject\Error\SystemError;
@@ -14,18 +15,18 @@ use Rector\Core\ValueObject\Reporting\FileDiff;
 
 final class FileProcessorRunner
 {
-    public $arrayParametersMerger;
-
     /**
      * @param FileProcessorInterface[] $fileProcessors
      */
     public function __construct(
         private readonly NodeScopeResolver $nodeScopeResolver,
+        private readonly ArrayParametersMerger $arrayParametersMerger,
         private readonly array $fileProcessors = []
     ) {
     }
 
     /**
+     * @param string[] $filePaths
      * @return array{system_errors: SystemError[], file_diffs: FileDiff[]}
      */
     public function run(array $filePaths, Configuration $configuration): array
@@ -34,17 +35,18 @@ final class FileProcessorRunner
         $this->configurePHPStanNodeScopeResolver($filePaths);
 
         // 2. process files
-        $errorAndFileDiffs = $this->processFiles($filePaths, $configuration, []);
+        $errorAndFileDiffs = $this->processFiles($filePaths, $configuration);
 
         return $errorAndFileDiffs;
     }
 
     /**
-     * @param array{system_errors: SystemError[], file_diffs: FileDiff[]}|mixed[] $errorAndFileDiffs
+     * @param string[] $filePaths
      * @return array{system_errors: SystemError[], file_diffs: FileDiff[]}
      */
-    public function processFiles(array $filePaths, Configuration $configuration, array $errorAndFileDiffs): array
+    public function processFiles(array $filePaths, Configuration $configuration): array
     {
+        $errorAndFileDiffs = [];
         foreach ($filePaths as $filePath) {
             $file = new File($filePath, FileSystem::read($filePath));
 


### PR DESCRIPTION
Currently, we have duplicated code between parallel and disable parallel.

This PR add a service named `FileProcessorRunner` to make re-use repetitive code between between parallel and disable parallel