### PR TITLE
[Core] Make consistent only setAnalysedFiles() from PHPStan NodeScopeResolver in both parallel and non-parallel for .php files

### DIFF
--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -7,7 +7,6 @@ namespace Rector\Parallel;
 use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
 use Nette\Utils\FileSystem;
-use PHPStan\Analyser\NodeScopeResolver;
 use Rector\Core\Application\ApplicationFileProcessor;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesProcessor;
 use Rector\Core\Console\Style\RectorConsoleOutputStyle;
@@ -38,7 +37,6 @@ final class WorkerRunner
     public function __construct(
         private readonly ArrayParametersMerger $arrayParametersMerger,
         private readonly CurrentFileProvider $currentFileProvider,
-        private readonly NodeScopeResolver $nodeScopeResolver,
         private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator,
         private readonly RectorConsoleOutputStyle $rectorConsoleOutputStyle,
         private readonly RemovedAndAddedFilesProcessor $removedAndAddedFilesProcessor,

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -8,6 +8,7 @@ use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
 use Nette\Utils\FileSystem;
 use PHPStan\Analyser\NodeScopeResolver;
+use Rector\Core\Application\ApplicationFileProcessor;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesProcessor;
 use Rector\Core\Console\Style\RectorConsoleOutputStyle;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
@@ -41,6 +42,7 @@ final class WorkerRunner
         private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator,
         private readonly RectorConsoleOutputStyle $rectorConsoleOutputStyle,
         private readonly RemovedAndAddedFilesProcessor $removedAndAddedFilesProcessor,
+        private readonly ApplicationFileProcessor $applicationFileProcessor,
         private readonly array $fileProcessors = []
     ) {
     }
@@ -82,7 +84,7 @@ final class WorkerRunner
             $systemErrors = [];
 
             // 1. allow PHPStan to work with static reflection on provided files
-            $this->nodeScopeResolver->setAnalysedFiles($filePaths);
+            $this->applicationFileProcessor->configurePHPStanNodeScopeResolver($filePaths);
 
             foreach ($filePaths as $filePath) {
                 try {

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -24,7 +24,6 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symplify\EasyParallel\CpuCoreCountProvider;
 use Symplify\EasyParallel\Exception\ParallelShouldNotHappenException;
 use Symplify\EasyParallel\ScheduleFactory;
-use Webmozart\Assert\Assert;
 
 final class ApplicationFileProcessor
 {
@@ -137,6 +136,18 @@ final class ApplicationFileProcessor
         $this->removedAndAddedFilesProcessor->run($configuration);
 
         return $systemErrorsAndFileDiffs;
+    }
+
+    /**
+     * @param string[] $filePaths
+     */
+    public function configurePHPStanNodeScopeResolver(array $filePaths): void
+    {
+        $phpFilePaths = array_filter(
+            $filePaths,
+            static fn (string $filePath): bool => str_ends_with($filePath, '.php')
+        );
+        $this->nodeScopeResolver->setAnalysedFiles($phpFilePaths);
     }
 
     /**
@@ -259,14 +270,5 @@ final class ApplicationFileProcessor
         }
 
         return $potentialEcsBinaryPath;
-    }
-
-    /**
-     * @param string[] $filePaths
-     */
-    public function configurePHPStanNodeScopeResolver(array $filePaths): void
-    {
-        $phpFilePaths = array_filter($filePaths, static fn (string $filePath): bool => str_ends_with($filePath, '.php'));
-        $this->nodeScopeResolver->setAnalysedFiles($phpFilePaths);
     }
 }

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -81,7 +81,7 @@ final class ApplicationFileProcessor
             $files = $this->fileFactory->createFromPaths($fileInfos);
 
             // 2. PHPStan has to know about all files too
-            $this->configurePHPStanNodeScopeResolver($files);
+            $this->configurePHPStanNodeScopeResolver($fileInfos);
 
             $systemErrorsAndFileDiffs = $this->processFiles($files, $configuration);
 
@@ -262,32 +262,11 @@ final class ApplicationFileProcessor
     }
 
     /**
-     * @param File[] $files
+     * @param string[] $filePaths
      */
-    private function configurePHPStanNodeScopeResolver(array $files): void
+    public function configurePHPStanNodeScopeResolver(array $filePaths): void
     {
-        $filePaths = $this->resolvePhpFilePaths($files);
-        $this->nodeScopeResolver->setAnalysedFiles($filePaths);
-    }
-
-    /**
-     * @param File[] $files
-     * @return string[]
-     */
-    private function resolvePhpFilePaths(array $files): array
-    {
-        Assert::allIsAOf($files, File::class);
-
-        $phpFilePaths = [];
-
-        foreach ($files as $file) {
-            $filePath = $file->getFilePath();
-
-            if (\str_ends_with($filePath, '.php')) {
-                $phpFilePaths[] = $filePath;
-            }
-        }
-
-        return $phpFilePaths;
+        $phpFilePaths = array_filter($filePaths, static fn (string $filePath): bool => str_ends_with($filePath, '.php'));
+        $this->nodeScopeResolver->setAnalysedFiles($phpFilePaths);
     }
 }


### PR DESCRIPTION
Currently, both disable and parallel has call: 

```php
$this->nodeScopeResolver->setAnalysedFiles($filePaths);
```

but there is different:

- on disable parallel: it check analyze `.php` files
- on enable parallel: it check analyze  all files

This PR make consistent to only analyze check `.php` files, also refactor to just directly compare string path instead of from object and loop method call `->getFilePath()`