### PR TITLE
[Psr4][Renaming] Remove clone $node on NormalizeNamespaceByPSR4ComposerAutoloadRector and PseudoNamespaceToNamespaceRector

### DIFF
--- a/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
+++ b/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
@@ -84,37 +84,36 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): Node|null|array
     {
-        $processNode = clone $node;
-        if ($this->inlineHTMLAnalyzer->hasInlineHTML($processNode)) {
+        if ($this->inlineHTMLAnalyzer->hasInlineHTML($node)) {
             return null;
         }
 
-        $expectedNamespace = $this->psr4AutoloadNamespaceMatcher->getExpectedNamespace($this->file, $processNode);
+        $expectedNamespace = $this->psr4AutoloadNamespaceMatcher->getExpectedNamespace($this->file, $node);
         if ($expectedNamespace === null) {
             return null;
         }
 
         // is namespace and already correctly named?
-        if ($processNode instanceof Namespace_ && $this->nodeNameResolver->isCaseSensitiveName(
-            $processNode,
+        if ($node instanceof Namespace_ && $this->nodeNameResolver->isCaseSensitiveName(
+            $node,
             $expectedNamespace
         )) {
             return null;
         }
 
-        if ($processNode instanceof Namespace_ && $this->hasNamespaceInPreviousNamespace($processNode)) {
+        if ($node instanceof Namespace_ && $this->hasNamespaceInPreviousNamespace($node)) {
             return null;
         }
 
         // to put declare_strict types on correct place
-        if ($processNode instanceof FileWithoutNamespace) {
-            return $this->refactorFileWithoutNamespace($processNode, $expectedNamespace);
+        if ($node instanceof FileWithoutNamespace) {
+            return $this->refactorFileWithoutNamespace($node, $expectedNamespace);
         }
 
-        $processNode->name = new Name($expectedNamespace);
-        $this->fullyQualifyStmtsAnalyzer->process($processNode->stmts);
+        $node->name = new Name($expectedNamespace);
+        $this->fullyQualifyStmtsAnalyzer->process($node->stmts);
 
-        return $processNode;
+        return $node;
     }
 
     private function hasNamespaceInPreviousNamespace(Namespace_ $namespace): bool

--- a/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
+++ b/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
@@ -82,16 +82,15 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $processNode = clone $node;
         $this->newNamespace = null;
 
-        if ($processNode instanceof FileWithoutNamespace) {
-            $changedStmts = $this->refactorStmts($processNode->stmts);
+        if ($node instanceof FileWithoutNamespace) {
+            $changedStmts = $this->refactorStmts($node->stmts);
             if ($changedStmts === null) {
                 return null;
             }
 
-            $processNode->stmts = $changedStmts;
+            $node->stmts = $changedStmts;
 
             // add a new namespace?
             if ($this->newNamespace !== null) {
@@ -99,8 +98,8 @@ CODE_SAMPLE
             }
         }
 
-        if ($processNode instanceof Namespace_) {
-            return $this->refactorNamespace($processNode);
+        if ($node instanceof Namespace_) {
+            return $this->refactorNamespace($node);
         }
 
         return null;


### PR DESCRIPTION
With node always returned with assigned:

```php
$this->nodesToReturn[$originalNodeHash] = $refactoredNode;
```

at

https://github.com/rectorphp/rector-src/blob/980dc83d2f4e2853658562fb86c1dc31ef182c21/src/Rector/AbstractRector.php#L259-L260

Let's see if we can remove clone node on `NormalizeNamespaceByPSR4ComposerAutoloadRector` and `PseudoNamespaceToNamespaceRector`