### PR TITLE
[CodeQuality][TypeDeclaration] Handle default value from constructor removed on InlineConstructorDefaultToPropertyRector+TypedPropertyFromStrictConstructorRector

### DIFF
--- a/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
+++ b/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
@@ -14,8 +14,10 @@ use PhpParser\NodeTraverser;
 use PHPStan\Type\ObjectType;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\ValueObject\MethodName;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+use Rector\PostRector\Collector\NodesToRemoveCollector;
 use Rector\TypeDeclaration\Matcher\PropertyAssignMatcher;
 use Rector\TypeDeclaration\NodeAnalyzer\AutowiredClassMethodOrPropertyAnalyzer;
 
@@ -31,7 +33,8 @@ final class ConstructorAssignDetector
         private readonly PropertyAssignMatcher $propertyAssignMatcher,
         private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private readonly AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodOrPropertyAnalyzer,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private readonly NodesToRemoveCollector $nodesToRemoveCollector
     ) {
     }
 
@@ -61,6 +64,11 @@ final class ConstructorAssignDetector
 
                 // cannot be nested
                 if ($isFirstLevelStatement !== true) {
+                    return null;
+                }
+
+                $parentNode = $assign->getAttribute(AttributeKey::PARENT_NODE);
+                if ($parentNode instanceof Expression && $this->nodesToRemoveCollector->isNodeRemoved($parentNode)) {
                     return null;
                 }
 

--- a/tests/Issues/InlineTypedFromConstructorDefaultValue/Fixture/fixture.php.inc
+++ b/tests/Issues/InlineTypedFromConstructorDefaultValue/Fixture/fixture.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\InlineTypedFromConstructorDefaultValue\Fixture;
+
+final class Fixture
+{
+    private $url;
+
+    public function __construct()
+    {
+        $this->url = 'https://website.tld';
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\InlineTypedFromConstructorDefaultValue\Fixture;
+
+final class Fixture
+{
+    private string $url = 'https://website.tld';
+
+    public function __construct()
+    {
+    }
+}
+
+?>

--- a/tests/Issues/InlineTypedFromConstructorDefaultValue/InlineTypedFromConstructorDefaultValueTest.php
+++ b/tests/Issues/InlineTypedFromConstructorDefaultValue/InlineTypedFromConstructorDefaultValueTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\InlineTypedFromConstructorDefaultValue;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class InlineTypedFromConstructorDefaultValueTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/InlineTypedFromConstructorDefaultValue/config/configured_rule.php
+++ b/tests/Issues/InlineTypedFromConstructorDefaultValue/config/configured_rule.php
@@ -1,7 +1,9 @@
 <?php
 
-use Rector\Config\RectorConfig;
+declare(strict_types=1);
+
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 
 return static function (RectorConfig $rectorConfig): void {

--- a/tests/Issues/InlineTypedFromConstructorDefaultValue/config/configured_rule.php
+++ b/tests/Issues/InlineTypedFromConstructorDefaultValue/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        InlineConstructorDefaultToPropertyRector::class,
+        TypedPropertyFromStrictConstructorRector::class,
+    ]);
+};


### PR DESCRIPTION
Given the following code:

```php
final class Fixture
{
    private $url;

    public function __construct()
    {
        $this->url = 'https://website.tld';
    }
}
```

The moved value from constructor assign should not be removed, ref https://getrector.org/demo/082ad859-87da-4222-bc3f-b50bc1b3c101

Current diff:

```diff
-    private $url;
+    private string $url;
```

Expected diff:

```diff
-    private $url;
+    private string $url = 'https://website.tld';
```

Applied rules:

```
- Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector
- Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector
```