### PR TITLE
[TypeDeclaration] Skip yield return on AddClosureReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/skip_yield.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeRector/Fixture/skip_yield.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector\Fixture;
+
+final class SkipYield
+{
+    public function someFunction(string $type): array
+    {
+        return collect($this->types, static function (SomeClass $parameterType, int $index) use ($type) {
+            if ($parameterType::class === $type) {
+                yield $index;
+            }
+        });
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector/Fixture/on_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector/Fixture/on_closure.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector\Fixture;
+
+$func = function (): iterable {
+    yield 1;
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector\Fixture;
+
+$func = function (): \Iterator {
+    yield 1;
+};
+
+?>

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclaration\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\FunctionLike;
@@ -74,11 +75,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Function_::class, ClassMethod::class];
+        return [Function_::class, ClassMethod::class, Closure::class];
     }
 
     /**
-     * @param Function_|ClassMethod $node
+     * @param Function_|ClassMethod|Closure $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -181,7 +182,7 @@ CODE_SAMPLE
      */
     private function resolveYieldType(
         array $yieldNodes,
-        ClassMethod|Function_ $functionLike
+        ClassMethod|Function_|Closure $functionLike
     ): FullyQualifiedObjectType|FullyQualifiedGenericObjectType {
         $yieldedTypes = $this->resolveYieldedTypes($yieldNodes);
 
@@ -195,7 +196,7 @@ CODE_SAMPLE
         return new FullyQualifiedGenericObjectType($className, [$yieldedTypes]);
     }
 
-    private function resolveClassName(Function_|ClassMethod $functionLike): string
+    private function resolveClassName(Function_|ClassMethod|Closure $functionLike): string
     {
         $returnTypeNode = $functionLike->getReturnType();
 

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -134,7 +135,8 @@ final class ReturnTypeInferer
                 $functionLike,
                 static function (Node $subNode): bool {
                     if (! $subNode instanceof Return_) {
-                        return false;
+                        // yield return is handled on speicific rule: AddReturnTypeDeclarationFromYieldsRector
+                        return $subNode instanceof Yield_;
                     }
 
                     return $subNode->expr instanceof Expr;


### PR DESCRIPTION
skip yield return on AddClosureReturnTypeRector, use `AddReturnTypeDeclarationFromYieldsRector` to cover it.

Fixes https://github.com/rectorphp/rector/issues/7673