### PR TITLE
[TypeDeclaration] Skip optional yield on AddReturnTypeDeclarationFromYieldsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector/Fixture/skip_yield_optional.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector/Fixture/skip_yield_optional.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector\Fixture;
+
+$func = function ()  {
+    if (rand(0, 1)) {
+        yield 1;
+    }
+};
+

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/3227

The following code should be skipped:

```php
$func = function ()  {
    if (rand(0, 1)) {
        yield 1;
    }
};
```