### PR TITLE
[NodeTraverser] Use NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN instead of NodeTraverser::DONT_TRAVERSE__CHILDREN

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/RemoveDeepChainMethodCallNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/RemoveDeepChainMethodCallNodeVisitor.php
@@ -43,7 +43,7 @@ final class RemoveDeepChainMethodCallNodeVisitor extends NodeVisitorAbstract
             if (count($nestedChainMethodCalls) > $this->nestedChainMethodCallLimit) {
                 $this->removingExpression = $node;
 
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
         }
 

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -60,7 +60,7 @@ final class LocalPropertyAnalyzer
             // skip anonymous class scope
             $isAnonymousClass = $this->classAnalyzer->isAnonymousClass($node);
             if ($isAnonymousClass) {
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
             if (! $node instanceof PropertyFetch) {

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -160,7 +160,7 @@ CODE_SAMPLE
         $new->setAttribute(AttributeKey::ORIGINAL_NODE, null);
 
         // nothing more to add
-        return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
     }
 
     private function resolveExceptionArgumentPosition(Name $exceptionName): ?int

--- a/rules/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector.php
+++ b/rules/CodeQuality/Rector/FunctionLike/RemoveAlwaysTrueConditionSetInConstructorRector.php
@@ -203,7 +203,7 @@ CODE_SAMPLE
 
         $this->traverseNodesWithCallable($stmts, function (Node $node) use ($propertyName, &$resolvedTypes): ?int {
             if ($node instanceof ClassMethod && $this->isName($node, MethodName::CONSTRUCT)) {
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
             if (! $this->isPropertyFetchAssignOfPropertyName($node, $propertyName)) {

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector.php
@@ -125,12 +125,12 @@ CODE_SAMPLE
         ) use (&$yieldNodes): ?int {
             // skip anonymous class and inner function
             if ($node instanceof Class_) {
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
             // skip nested scope
             if ($node instanceof FunctionLike) {
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
             if ($node instanceof Stmt && ! $node instanceof Expression) {

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
@@ -93,7 +93,7 @@ final class ReturnedNodesReturnTypeInfererTypeInferer
         ) use (&$returns): ?int {
             // skip Return_ nodes in nested functions or switch statements
             if ($node instanceof FunctionLike) {
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
             if (! $node instanceof Return_) {


### PR DESCRIPTION
Ensure use `NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN` to improve performance to avoid unnecessary lookup current as well when no need to traverse the passed node.