### PR TITLE
[Core] Improve performance on AstResolver and ClassLikeAstResolver 

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -90,8 +90,12 @@ final class AstResolver
     {
         $classReflection = $methodReflection->getDeclaringClass();
 
-        if (isset($this->classMethodsByClassAndMethod[$classReflection->getName()][$methodReflection->getName()])) {
-            return $this->classMethodsByClassAndMethod[$classReflection->getName()][$methodReflection->getName()];
+        $classLikeName = $classReflection->getName();
+        $methodReflectionName = $methodReflection->getName();
+
+        if (array_key_exists($classLikeName, $this->classMethodsByClassAndMethod)
+            && array_key_exists($methodReflectionName, $this->classMethodsByClassAndMethod[$classLikeName])) {
+            return $this->classMethodsByClassAndMethod[$classLikeName][$methodReflectionName];
         }
 
         $fileName = $classReflection->getFileName();
@@ -108,8 +112,6 @@ final class AstResolver
 
         /** @var ClassLike[] $classLikes */
         $classLikes = $this->betterNodeFinder->findInstanceOf($nodes, ClassLike::class);
-        $classLikeName = $classReflection->getName();
-        $methodReflectionName = $methodReflection->getName();
 
         foreach ($classLikes as $classLike) {
             if (! $this->nodeNameResolver->isName($classLike, $classLikeName)) {
@@ -143,7 +145,7 @@ final class AstResolver
 
     public function resolveFunctionFromFunctionReflection(FunctionReflection $functionReflection): ?Function_
     {
-        if (isset($this->functionsByName[$functionReflection->getName()])) {
+        if (array_key_exists($functionReflection->getName(), $this->functionsByName)) {
             return $this->functionsByName[$functionReflection->getName()];
         }
 

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -97,9 +97,10 @@ final class AstResolver
             return $this->classMethodsByClassAndMethod[$classLikeName][$methodName];
         }
 
+        // saved as null data
         if (array_key_exists($classLikeName, $this->classMethodsByClassAndMethod)
             && array_key_exists($methodName, $this->classMethodsByClassAndMethod[$classLikeName])) {
-            return $this->classMethodsByClassAndMethod[$classLikeName][$methodName];
+            return null;
         }
 
         $fileName = $classReflection->getFileName();
@@ -155,8 +156,9 @@ final class AstResolver
             return $this->functionsByName[$functionName];
         }
 
+        // saved as null data
         if (array_key_exists($functionName, $this->functionsByName)) {
-            return $this->functionsByName[$functionName];
+            return null;
         }
 
         $fileName = $functionReflection->getFileName();

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -145,8 +145,9 @@ final class AstResolver
 
     public function resolveFunctionFromFunctionReflection(FunctionReflection $functionReflection): ?Function_
     {
-        if (array_key_exists($functionReflection->getName(), $this->functionsByName)) {
-            return $this->functionsByName[$functionReflection->getName()];
+        $functionReflectionName = $functionReflection->getName();
+        if (array_key_exists($functionReflectionName, $this->functionsByName)) {
+            return $this->functionsByName[$functionReflectionName];
         }
 
         $fileName = $functionReflection->getFileName();
@@ -162,18 +163,18 @@ final class AstResolver
         /** @var Function_[] $functions */
         $functions = $this->betterNodeFinder->findInstanceOf($nodes, Function_::class);
         foreach ($functions as $function) {
-            if (! $this->nodeNameResolver->isName($function, $functionReflection->getName())) {
+            if (! $this->nodeNameResolver->isName($function, $functionReflectionName)) {
                 continue;
             }
 
             // to avoid parsing missing function again
-            $this->functionsByName[$functionReflection->getName()] = $function;
+            $this->functionsByName[$functionReflectionName] = $function;
 
             return $function;
         }
 
         // to avoid parsing missing function again
-        $this->functionsByName[$functionReflection->getName()] = null;
+        $this->functionsByName[$functionReflectionName] = null;
 
         return null;
     }

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -93,6 +93,10 @@ final class AstResolver
         $classLikeName = $classReflection->getName();
         $methodName = $methodReflection->getName();
 
+        if (isset($this->classMethodsByClassAndMethod[$classLikeName][$methodName])) {
+            return $this->classMethodsByClassAndMethod[$classLikeName][$methodName];
+        }
+
         if (array_key_exists($classLikeName, $this->classMethodsByClassAndMethod)
             && array_key_exists($methodName, $this->classMethodsByClassAndMethod[$classLikeName])) {
             return $this->classMethodsByClassAndMethod[$classLikeName][$methodName];
@@ -146,6 +150,11 @@ final class AstResolver
     public function resolveFunctionFromFunctionReflection(FunctionReflection $functionReflection): ?Function_
     {
         $functionName = $functionReflection->getName();
+
+        if (isset($this->functionsByName[$functionName])) {
+            return $this->functionsByName[$functionName];
+        }
+
         if (array_key_exists($functionName, $this->functionsByName)) {
             return $this->functionsByName[$functionName];
         }

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -91,11 +91,11 @@ final class AstResolver
         $classReflection = $methodReflection->getDeclaringClass();
 
         $classLikeName = $classReflection->getName();
-        $methodReflectionName = $methodReflection->getName();
+        $methodName = $methodReflection->getName();
 
         if (array_key_exists($classLikeName, $this->classMethodsByClassAndMethod)
-            && array_key_exists($methodReflectionName, $this->classMethodsByClassAndMethod[$classLikeName])) {
-            return $this->classMethodsByClassAndMethod[$classLikeName][$methodReflectionName];
+            && array_key_exists($methodName, $this->classMethodsByClassAndMethod[$classLikeName])) {
+            return $this->classMethodsByClassAndMethod[$classLikeName][$methodName];
         }
 
         $fileName = $classReflection->getFileName();
@@ -118,17 +118,17 @@ final class AstResolver
                 continue;
             }
 
-            $classMethod = $classLike->getMethod($methodReflectionName);
+            $classMethod = $classLike->getMethod($methodName);
             if (! $classMethod instanceof ClassMethod) {
                 continue;
             }
 
-            $this->classMethodsByClassAndMethod[$classLikeName][$methodReflectionName] = $classMethod;
+            $this->classMethodsByClassAndMethod[$classLikeName][$methodName] = $classMethod;
             return $classMethod;
         }
 
         // avoids looking for a class in a file where is not present
-        $this->classMethodsByClassAndMethod[$classLikeName][$methodReflectionName] = null;
+        $this->classMethodsByClassAndMethod[$classLikeName][$methodName] = null;
         return null;
     }
 
@@ -145,9 +145,9 @@ final class AstResolver
 
     public function resolveFunctionFromFunctionReflection(FunctionReflection $functionReflection): ?Function_
     {
-        $functionReflectionName = $functionReflection->getName();
-        if (array_key_exists($functionReflectionName, $this->functionsByName)) {
-            return $this->functionsByName[$functionReflectionName];
+        $functionName = $functionReflection->getName();
+        if (array_key_exists($functionName, $this->functionsByName)) {
+            return $this->functionsByName[$functionName];
         }
 
         $fileName = $functionReflection->getFileName();
@@ -163,18 +163,18 @@ final class AstResolver
         /** @var Function_[] $functions */
         $functions = $this->betterNodeFinder->findInstanceOf($nodes, Function_::class);
         foreach ($functions as $function) {
-            if (! $this->nodeNameResolver->isName($function, $functionReflectionName)) {
+            if (! $this->nodeNameResolver->isName($function, $functionName)) {
                 continue;
             }
 
             // to avoid parsing missing function again
-            $this->functionsByName[$functionReflectionName] = $function;
+            $this->functionsByName[$functionName] = $function;
 
             return $function;
         }
 
         // to avoid parsing missing function again
-        $this->functionsByName[$functionReflectionName] = null;
+        $this->functionsByName[$functionName] = null;
 
         return null;
     }

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -39,6 +39,10 @@ final class ClassLikeAstResolver
         }
 
         $className = $classReflection->getName();
+        if (isset($this->classLikesByName[$className])) {
+            return $this->classLikesByName[$className];
+        }
+
         if (array_key_exists($className, $this->classLikesByName)) {
             return $this->classLikesByName[$className];
         }

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -39,7 +39,7 @@ final class ClassLikeAstResolver
         }
 
         $className = $classReflection->getName();
-        if (isset($this->classLikesByName[$className])) {
+        if (array_key_exists($className, $this->classLikesByName)) {
             return $this->classLikesByName[$className];
         }
 

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -43,8 +43,9 @@ final class ClassLikeAstResolver
             return $this->classLikesByName[$className];
         }
 
+        // saved as null data
         if (array_key_exists($className, $this->classLikesByName)) {
-            return $this->classLikesByName[$className];
+            return null;
         }
 
         $fileName = $classReflection->getFileName();


### PR DESCRIPTION
Currently, we have `isset()` to verify that collection of class/method exists, but that doesn't match when previous search saved as `null` data, eg:

https://github.com/rectorphp/rector-src/blob/84faf2905518aad5fb97caf613517f8a50827867/src/PhpParser/AstResolver.php#L173-L174

the `isset()` will always got `false` result when it fill `null` value, this PR change to use `isset()` early, then apply `array_key_exists` as fallback so it will use the `null` value as is when it found, 

see https://3v4l.org/JrQ9n