### PR TITLE
[Core] Improve performance on PhpFileProcessor

### DIFF
--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -63,8 +63,16 @@ final class PhpFileProcessor implements FileProcessorInterface
             $file->changeHasChanged(false);
             $this->fileProcessor->refactor($file, $configuration);
 
+            $oldStmts = $file->getOldStmts();
+            $newStmts = $file->getNewStmts();
+
             // 3. apply post rectors
-            $newStmts = $this->postFileProcessor->traverse($file->getNewStmts());
+            $newStmts = $this->postFileProcessor->traverse($newStmts);
+
+            if ($oldStmts === $newStmts) {
+                break;
+            }
+
             // this is needed for new tokens added in "afterTraverse()"
             $file->changeNewStmts($newStmts);
 


### PR DESCRIPTION
When even after apply post rector, the `oldStmts` and `newStmts` still equal, then break the loop early, so:

- reduce unnecessary call `$file->changeNewStmts($newStmts);` next so no need verify change new stmts something that equal
- reduce unnecessary call `$this->printFile($file, $configuration)` next so no need to re-print something that equal
