### PR TITLE
[Strict] Fix warning configurable rector rules on BooleanInTernaryOperatorRuleFixerRector

### DIFF
--- a/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
+++ b/rules/Strict/Rector/AbstractFalsyScalarRuleFixerRector.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Strict\Rector;
 
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Strict\Rector\BooleanNot\BooleanInBooleanNotRuleFixerRector\BooleanInBooleanNotRuleFixerRectorTest
  */
-abstract class AbstractFalsyScalarRuleFixerRector extends AbstractRector implements ConfigurableRectorInterface
+abstract class AbstractFalsyScalarRuleFixerRector extends AbstractRector implements AllowEmptyConfigurableRectorInterface
 {
     /**
      * @api


### PR DESCRIPTION
The `BooleanInTernaryOperatorRuleFixerRector` extends `AbstractFalsyScalarRuleFixerRector` which has config default fallback:

```php
    public function configure(array $configuration): void
    {
        $treatAsNonEmpty = $configuration[self::TREAT_AS_NON_EMPTY] ?? (bool) current($configuration);
        Assert::boolean($treatAsNonEmpty);

        $this->treatAsNonEmpty = $treatAsNonEmpty;
    }
```

without the configuration, the rule still run ok, but give warning:

```bash
 [WARNING] Your project contains 1 configurable rector rules that are skipped as need to be configured to run.          
                                                                                                                        

 * Rector\Strict\Rector\Ternary\BooleanInTernaryOperatorRuleFixerRector

 ! [NOTE] Do you want to run them?                                                                                      
 !        Configure them in `rector.php` with "...$rectorConfig->ruleWithConfiguration(...);"     
```

That's due to it implements `ConfigurableRectorInterface`, I updated to implements `AllowEmptyConfigurableRectorInterface` instead.