### PR TITLE
[CodingStyle] Skip new line /\r\n|\r|\n/i on ConsistentPregDelimiterRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/skip_new_line.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/skip_new_line.php.inc
@@ -11,4 +11,10 @@ class SkipNewLine
         $content = 'some texte';
         $parts = preg_split("/(\r\n|\n|\r){2}/", $content);
     }
+
+    public function run2()
+    {
+        $content = 'some texte';
+        $parts = preg_split("/\r\n|\r|\n/i", $content);
+    }
 }

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -202,7 +202,11 @@ CODE_SAMPLE
             return false;
         }
 
-        return StringUtils::isMatch($matchInnerUnionRegex['content'], self::NEW_LINE_REGEX);
+        if (StringUtils::isMatch($matchInnerUnionRegex['content'], self::NEW_LINE_REGEX)) {
+            return true;
+        }
+
+        return isset($string[0]) && $matchInnerUnionRegex['content'] === $string[0];
     }
 
     private function hasEscapedQuote(String_ $string): bool


### PR DESCRIPTION
Given the following code:

```php
    public function run2()
    {
        $content = 'some texte';
        $parts = preg_split("/\r\n|\r|\n/i", $content);
    }
```

It currently produce:

```diff
     public function run2()
     {
         $content = 'some texte';
-        $parts = preg_split("/\r\n|\r|\n/i", $content);
+        $parts = preg_split("#
||
+#i", $content);
```

Ref https://getrector.org/demo/94c2d1af-be82-478a-ae1b-a44783a1f741

It should be skipped instead.