### PR TITLE
[Renaming][PostRector] Handle skip path after defined at RenameClassRector

### DIFF
--- a/packages/PostRector/Application/PostFileProcessor.php
+++ b/packages/PostRector/Application/PostFileProcessor.php
@@ -10,6 +10,7 @@ use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Logging\CurrentRectorProvider;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
+use Rector\PostRector\Contract\Rector\PostRectorDependencyInterface;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Rector\Skipper\Skipper\Skipper;
 
@@ -81,6 +82,20 @@ final class PostFileProcessor
             return false;
         }
 
-        return $this->skipper->shouldSkipElementAndFilePath($postRector, $file->getFilePath());
+        $filePath = $file->getFilePath();
+        if ($this->skipper->shouldSkipElementAndFilePath($postRector, $filePath)) {
+            return true;
+        }
+
+        if ($postRector instanceof PostRectorDependencyInterface) {
+            $dependencies = $postRector->getRectorDependencies();
+            foreach ($dependencies as $dependency) {
+                if ($this->skipper->shouldSkipElementAndFilePath($dependency, $filePath)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/packages/PostRector/Contract/Rector/PostRectorDependencyInterface.php
+++ b/packages/PostRector/Contract/Rector/PostRectorDependencyInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PostRector\Contract\Rector;
+
+use Rector\Core\Contract\Rector\RectorInterface;
+
+interface PostRectorDependencyInterface
+{
+    /**
+     * @return class-string<RectorInterface>[]
+     */
+    public function getRectorDependencies(): array;
+}

--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -7,7 +7,6 @@ namespace Rector\PostRector\Rector;
 use PhpParser\Node;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Contract\Rector\RectorInterface;
-use Rector\Core\NonPhpFile\Rector\RenameClassNonPhpRector;
 use Rector\PostRector\Contract\Rector\PostRectorDependencyInterface;
 use Rector\Renaming\NodeManipulator\ClassRenamer;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -33,7 +32,7 @@ final class ClassRenamingPostRector extends AbstractPostRector implements PostRe
      */
     public function getRectorDependencies(): array
     {
-        return [RenameClassRector::class, RenameClassNonPhpRector::class];
+        return [RenameClassRector::class];
     }
 
     public function enterNode(Node $node): ?Node

--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -6,11 +6,15 @@ namespace Rector\PostRector\Rector;
 
 use PhpParser\Node;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
+use Rector\Core\Contract\Rector\RectorInterface;
+use Rector\Core\NonPhpFile\Rector\RenameClassNonPhpRector;
+use Rector\PostRector\Contract\Rector\PostRectorDependencyInterface;
 use Rector\Renaming\NodeManipulator\ClassRenamer;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class ClassRenamingPostRector extends AbstractPostRector
+final class ClassRenamingPostRector extends AbstractPostRector implements PostRectorDependencyInterface
 {
     public function __construct(
         private readonly ClassRenamer $classRenamer,
@@ -22,6 +26,14 @@ final class ClassRenamingPostRector extends AbstractPostRector
     {
         // must be run before name importing, so new names are imported
         return 650;
+    }
+
+    /**
+     * @return class-string<RectorInterface>[]
+     */
+    public function getRectorDependencies(): array
+    {
+        return [RenameClassRector::class, RenameClassNonPhpRector::class];
     }
 
     public function enterNode(Node $node): ?Node

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureSkipAfterDefined/skip_after_defined.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureSkipAfterDefined/skip_after_defined.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+class SkipAfterDefined extends \Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\OldClass
+{
+}

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/SkipAfterDefinedTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/SkipAfterDefinedTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
+
+use Iterator;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @see RenameClassRector
+ */
+final class SkipAfterDefinedTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureSkipAfterDefined');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/skip_after_defined_configured_rule.php';
+    }
+}

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/skip_after_defined_configured_rule.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/skip_after_defined_configured_rule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\NewClass;
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\OldClass;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(RenameClassRector::class, [
+            OldClass::class => NewClass::class,
+        ]);
+
+    // skip the path after defined
+    $rectorConfig->skip([
+        RenameClassRector::class => [sys_get_temp_dir() . '/rector/tests_fixture_'],
+    ]);
+};


### PR DESCRIPTION
Given the following config in tests:

```php
use Rector\Config\RectorConfig;
use Rector\Renaming\Rector\Name\RenameClassRector;
use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\NewClass;
use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\OldClass;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig
        ->ruleWithConfiguration(RenameClassRector::class, [
            OldClass::class => NewClass::class,
        ]);

    // skip the path after defined
    $rectorConfig->skip([
        RenameClassRector::class => [sys_get_temp_dir() . '/rector/tests_fixture_'],
    ]);
};
```

It not properly skipped, as there are 2 services:

- RenameClassRector
- ClassRenamingPostRector

The `ClassRenamingPostRector` apply the change already before it actually skipped because that read the configs:

https://github.com/rectorphp/rector-src/blob/3c168f03d38bb967a5e65e453f82adf120ef4eba/packages/PostRector/Rector/ClassRenamingPostRector.php#L27-L35

This PR try to fix it with add new interface: `PostRectorDependencyInterface` to define the dependencies of the PostRector when needed.

Fixes https://github.com/rectorphp/rector/issues/7417
