### PR TITLE
[CodeQuality] Remove type addition on CompleteDynamicPropertiesRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/fixture.php.inc
@@ -18,7 +18,10 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 
 class Fixture
 {
-    public int $value;
+    /**
+     * @var int
+     */
+    public $value;
     public function set()
     {
         $this->value = 5;

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/with_array_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/with_array_type.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 final class WithArrayType
 {
     /**
-     * @var array<string, true>
+     * @var array<string, bool>
      */
     public $someProperty;
     public function addSome(string $name)

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/with_array_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/with_array_type.php.inc
@@ -19,9 +19,9 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 final class WithArrayType
 {
     /**
-     * @var array<string, bool>
+     * @var array<string, true>
      */
-    public array $someProperty;
+    public $someProperty;
     public function addSome(string $name)
     {
         $this->someProperty[$name] = true;

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
@@ -22,7 +22,10 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 
 class MultipleTypes
 {
-    public int|string|bool $value;
+    /**
+     * @var int|string|bool
+     */
+    public $value;
     public function set()
     {
         $this->value = 5;

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -10,11 +10,13 @@ use PhpParser\Node\Stmt\PropertyProperty;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\Privatization\TypeManipulator\TypeNormalizer;
 
 final class MissingPropertiesFactory
 {
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly TypeNormalizer $typeNormalizer,
         private readonly PhpDocTypeChanger $phpDocTypeChanger
     ) {
     }
@@ -36,6 +38,9 @@ final class MissingPropertiesFactory
 
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
             $phpDocInfo->makeMultiLined();
+
+            // generalize false/true type to bool, as mostly default value but accepts both
+            $propertyType = $this->typeNormalizer->generalizeConstantBoolTypes($propertyType);
 
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
 

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -8,16 +8,11 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\Privatization\TypeManipulator\TypeNormalizer;
 
 final class MissingPropertiesFactory
 {
     public function __construct(
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly TypeNormalizer $typeNormalizer,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger
+        private readonly PropertyTypeDecorator $propertyTypeDecorator
     ) {
     }
 
@@ -35,14 +30,7 @@ final class MissingPropertiesFactory
             }
 
             $property = new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty($propertyName)]);
-
-            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-            $phpDocInfo->makeMultiLined();
-
-            // generalize false/true type to bool, as mostly default value but accepts both
-            $propertyType = $this->typeNormalizer->generalizeConstantBoolTypes($propertyType);
-
-            $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
+            $this->propertyTypeDecorator->decorateProperty($property, $propertyType);
 
             $newProperties[] = $property;
         }

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -8,11 +8,14 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 
 final class MissingPropertiesFactory
 {
     public function __construct(
-        private readonly PropertyTypeDecorator $propertyTypeDecorator
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpDocTypeChanger $phpDocTypeChanger
     ) {
     }
 
@@ -30,7 +33,11 @@ final class MissingPropertiesFactory
             }
 
             $property = new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty($propertyName)]);
-            $this->propertyTypeDecorator->decoratePropertyWithVarDoc($property, $propertyType, true);
+
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+            $phpDocInfo->makeMultiLined();
+
+            $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
 
             $newProperties[] = $property;
         }

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -30,7 +30,7 @@ final class MissingPropertiesFactory
             }
 
             $property = new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty($propertyName)]);
-            $this->propertyTypeDecorator->decorateProperty($property, $propertyType);
+            $this->propertyTypeDecorator->decoratePropertyWithVarDoc($property, $propertyType, true);
 
             $newProperties[] = $property;
         }

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -8,22 +8,36 @@ use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\Privatization\TypeManipulator\TypeNormalizer;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-/**
- * @api downgrade
- */
 final class PropertyTypeDecorator
 {
     public function __construct(
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly TypeNormalizer $typeNormalizer
     ) {
     }
 
+    public function decorateProperty(Property $property, Type $propertyType): void
+    {
+        // generalize false/true type to bool, as mostly default value but accepts both
+        $propertyType = $this->typeNormalizer->generalizeConstantBoolTypes($propertyType);
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+        $phpDocInfo->makeMultiLined();
+
+        $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
+    }
+
+    /**
+     * @api downgrade
+     */
     public function decoratePropertyWithDocBlock(Property $property, ComplexType|Identifier|Name $typeNode): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -54,18 +54,18 @@ final class PropertyTypeDecorator
         $this->phpDocTypeChanger->changeVarType($phpDocInfo, $newType);
     }
 
-    public function decoratePropertyWithVarDoc(Property $property, Type $propertyType, bool $changeOnlyDoc = false): void
+    private function decoratePropertyWithVarDoc(Property $property, Type $propertyType): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         $phpDocInfo->makeMultiLined();
 
-        if ($this->isNonMixedArrayType($propertyType) && ! $changeOnlyDoc) {
+        if ($this->isNonMixedArrayType($propertyType)) {
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
             $property->type = new Identifier('array');
             return;
         }
 
-        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES) && ! $changeOnlyDoc) {
+        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
             $phpParserNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
                 $propertyType,
                 TypeKind::PROPERTY

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -54,18 +54,18 @@ final class PropertyTypeDecorator
         $this->phpDocTypeChanger->changeVarType($phpDocInfo, $newType);
     }
 
-    private function decoratePropertyWithVarDoc(Property $property, Type $propertyType): void
+    public function decoratePropertyWithVarDoc(Property $property, Type $propertyType, bool $changeOnlyDoc = false): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         $phpDocInfo->makeMultiLined();
 
-        if ($this->isNonMixedArrayType($propertyType)) {
+        if ($this->isNonMixedArrayType($propertyType) && ! $changeOnlyDoc) {
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
             $property->type = new Identifier('array');
             return;
         }
 
-        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
+        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES) && ! $changeOnlyDoc) {
             $phpParserNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
                 $propertyType,
                 TypeKind::PROPERTY

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -10,8 +10,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\Core\Php\PhpVersionProvider;
-use Rector\Privatization\TypeManipulator\TypeNormalizer;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
 /**
@@ -20,11 +18,9 @@ use Rector\StaticTypeMapper\StaticTypeMapper;
 final class PropertyTypeDecorator
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly TypeNormalizer $typeNormalizer,
     ) {
     }
 

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -4,19 +4,13 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\NodeFactory;
 
-use PhpParser\Node;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Php\PhpVersionProvider;
-use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Privatization\TypeManipulator\TypeNormalizer;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -20,6 +20,9 @@ use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Privatization\TypeManipulator\TypeNormalizer;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
+/**
+ * @api downgrade
+ */
 final class PropertyTypeDecorator
 {
     public function __construct(
@@ -31,9 +34,6 @@ final class PropertyTypeDecorator
     ) {
     }
 
-    /**
-     * @api downgrade
-     */
     public function decoratePropertyWithDocBlock(Property $property, ComplexType|Identifier|Name $typeNode): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
@@ -43,57 +43,5 @@ final class PropertyTypeDecorator
 
         $newType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($typeNode);
         $this->phpDocTypeChanger->changeVarType($phpDocInfo, $newType);
-    }
-
-    private function decoratePropertyWithVarDoc(Property $property, Type $propertyType): void
-    {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        $phpDocInfo->makeMultiLined();
-
-        if ($this->isNonMixedArrayType($propertyType)) {
-            $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
-            $property->type = new Identifier('array');
-            return;
-        }
-
-        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
-            $phpParserNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
-                $propertyType,
-                TypeKind::PROPERTY
-            );
-            if (! $phpParserNode instanceof Node) {
-                // fallback to doc type in PHP 7.4
-                $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
-            }
-        } else {
-            $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
-        }
-    }
-
-    private function decoratePropertyWithType(Property $property, Type $propertyType): void
-    {
-        if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
-            return;
-        }
-
-        $phpParserNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($propertyType, TypeKind::PROPERTY);
-        if (! $phpParserNode instanceof Node) {
-            return;
-        }
-
-        $property->type = $phpParserNode;
-    }
-
-    private function isNonMixedArrayType(Type $type): bool
-    {
-        if (! $type instanceof ArrayType) {
-            return false;
-        }
-
-        if ($type->getKeyType() instanceof MixedType) {
-            return false;
-        }
-
-        return ! $type->getItemType() instanceof MixedType;
     }
 }

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -31,15 +31,6 @@ final class PropertyTypeDecorator
     ) {
     }
 
-    public function decorateProperty(Property $property, Type $propertyType): void
-    {
-        // generalize false/true type to bool, as mostly default value but accepts both
-        $propertyType = $this->typeNormalizer->generalizeConstantBoolTypes($propertyType);
-
-        $this->decoratePropertyWithVarDoc($property, $propertyType);
-        $this->decoratePropertyWithType($property, $propertyType);
-    }
-
     /**
      * @api downgrade
      */


### PR DESCRIPTION
@Etienne-Schmitt this is to fix https://github.com/rectorphp/rector/issues/7687

the dynamic property can be anything accessible from object creation, so better to remove the type, ref https://3v4l.org/tHRgE