### PR TITLE
[Privatization] Optimize ParentPropertyLookupGuard, make $class parameter required

### DIFF
--- a/rules/Php74/Guard/PropertyTypeChangeGuard.php
+++ b/rules/Php74/Guard/PropertyTypeChangeGuard.php
@@ -85,6 +85,6 @@ final class PropertyTypeChangeGuard
             return false;
         }
 
-        return $this->parentPropertyLookupGuard->isLegal($property);
+        return $this->parentPropertyLookupGuard->isLegal($property, $parentNode);
     }
 }

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Enum\ObjectReference;
+use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\PhpParser\AstResolver;
@@ -28,21 +29,18 @@ final class ParentPropertyLookupGuard
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly AstResolver $astResolver,
-        private readonly PropertyManipulator $propertyManipulator
+        private readonly PropertyManipulator $propertyManipulator,
+        private readonly ClassAnalyzer $classAnalyzer,
     ) {
     }
 
-    public function isLegal(Property $property, ?Class_ $class = null): bool
+    public function isLegal(Property $property, Class_ $class): bool
     {
-        if (! $class instanceof Class_) {
-            // @todo optimize
-            $class = $this->betterNodeFinder->findParentType($property, Class_::class);
-            if (! $class instanceof Class_) {
-                return false;
-            }
+        if ($this->classAnalyzer->isAnonymousClass($class)) {
+            return false;
         }
-
-        $classReflection = $this->reflectionResolver->resolveClassReflection($property);
+        
+        $classReflection = $this->reflectionResolver->resolveClassReflection($class);
         if (! $classReflection instanceof ClassReflection) {
             return false;
         }

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -39,7 +39,7 @@ final class ParentPropertyLookupGuard
         if ($this->classAnalyzer->isAnonymousClass($class)) {
             return false;
         }
-        
+
         $classReflection = $this->reflectionResolver->resolveClassReflection($class);
         if (! $classReflection instanceof ClassReflection) {
             return false;

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -68,7 +68,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $this->parentPropertyLookupGuard->isLegal($property)) {
+            if (! $this->parentPropertyLookupGuard->isLegal($property, $node)) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
@@ -110,7 +110,7 @@ CODE_SAMPLE
             }
 
             // include fault value in the type
-            if ($this->isConclictingDefaultExprType($property, $getterReturnType)) {
+            if ($this->isConflictingDefaultExprType($property, $getterReturnType)) {
                 continue;
             }
 
@@ -148,7 +148,7 @@ CODE_SAMPLE
         $propertyProperty->default = $this->nodeFactory->createNull();
     }
 
-    private function isConclictingDefaultExprType(Property $property, Type $getterReturnType): bool
+    private function isConflictingDefaultExprType(Property $property, Type $getterReturnType): bool
     {
         $onlyPropertyProperty = $property->props[0];
         if (! $onlyPropertyProperty->default instanceof Expr) {


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-src/pull/3251, make shared `ParentPropertyLookupGuard` `$class` parameter required.