### PR TITLE
[CodeQuality] Handle crash on ReturnTypeFromStrictScalarReturnExprRector on ConditionalTypeForParameter

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ConditionalTypeForParameterMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ConditionalTypeForParameterMapper.php
@@ -35,8 +35,8 @@ final class ConditionalTypeForParameterMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param ConditionalTypeForParameter $type
+     * @param TypeKind::* $typeKind
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode
     {
@@ -45,6 +45,7 @@ final class ConditionalTypeForParameterMapper implements TypeMapperInterface
 
     /**
      * @param ConditionalTypeForParameter $type
+     * @param TypeKind::* $typeKind
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
     {

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ConditionalTypeForParameterMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ConditionalTypeForParameterMapper.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
+
+use PhpParser\Node;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\ConditionalTypeForParameter;
+use PHPStan\Type\Type;
+use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
+use Symfony\Contracts\Service\Attribute\Required;
+
+/**
+ * @implements TypeMapperInterface<ConditionalTypeForParameter>
+ */
+final class ConditionalTypeForParameterMapper implements TypeMapperInterface
+{
+    private PHPStanStaticTypeMapper $phpStanStaticTypeMapper;
+
+    #[Required]
+    public function autowire(PHPStanStaticTypeMapper $phpStanStaticTypeMapper): void
+    {
+        $this->phpStanStaticTypeMapper = $phpStanStaticTypeMapper;
+    }
+
+    /**
+     * @return class-string<Type>
+     */
+    public function getNodeClass(): string
+    {
+        return ConditionalTypeForParameter::class;
+    }
+
+    /**
+     * @param TypeKind::* $typeKind
+     * @param ConditionalTypeForParameter $type
+     */
+    public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode
+    {
+        return $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($type->getTarget(), $typeKind);
+    }
+
+    /**
+     * @param ConditionalTypeForParameter $type
+     */
+    public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
+    {
+        return $this->phpStanStaticTypeMapper->mapToPhpParserNode($type->getTarget(), $typeKind);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/skip_conditional_type_for_parameter.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/skip_conditional_type_for_parameter.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\Fixture;
+
+final class SkipConditionalTypeForParameter
+{
+    public function run()
+    {
+        $username = 'xxxxxx';
+        $password = 'yyyyyyy';
+        return base64_encode(implode(':', [$username, $password]));
+    }
+}


### PR DESCRIPTION
Given the following code:

```php
final class SkipConditionalTypeForParameter
{
    public function run()
    {
        $username = 'xxxxxx';
        $password = 'yyyyyyy';
        return base64_encode(implode(':', [$username, $password]));
    }
}
```

It cause crash:

```bash
There was 1 error:

1) Rector\Tests\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\ReturnTypeFromStrictScalarReturnExprRectorTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Core\Exception\NotImplementedYetException: Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper::mapToPhpParserNode for PHPStan\Type\ConditionalTypeForParameter

/Users/samsonasik/www/rector-src/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php:71
/Users/samsonasik/www/rector-src/packages/StaticTypeMapper/StaticTypeMapper.php:68
/Users/samsonasik/www/rector-src/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php:90
```

Ref https://getrector.org/demo/620b427f-2427-47f1-a596-c2bab150b0a6

This PR try to fix it. Fixes https://github.com/rectorphp/rector/issues/7694