### PR TITLE
[NodeRemoval] Refactor NodeRemover to always use removeNode() method to ensure Node in NodesToRemoveCollector

### DIFF
--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -43,12 +43,13 @@ final class NodeRemover
         Class_ | ClassMethod | Function_ $nodeWithStatements,
         Node $toBeRemovedNode
     ): void {
-        foreach ((array) $nodeWithStatements->stmts as $stmt) {
+        foreach ((array) $nodeWithStatements->stmts as $key => $stmt) {
             if ($toBeRemovedNode !== $stmt) {
                 continue;
             }
 
             $this->removeNode($stmt);
+            unset($nodeWithStatements->stmts[$key]);
             break;
         }
     }
@@ -77,6 +78,7 @@ final class NodeRemover
         }
 
         $this->removeNode($classMethod->params[$key]);
+        unset($classMethod->params[$key]);
     }
 
     public function removeArg(FuncCall | MethodCall | StaticCall $node, int $key): void
@@ -91,6 +93,7 @@ final class NodeRemover
         }
 
         $this->removeNode($node->args[$key]);
+        unset($node->args[$key]);
     }
 
     /**
@@ -108,5 +111,6 @@ final class NodeRemover
         }
 
         $this->removeNode($functionLike->stmts[$key]);
+        unset($functionLike->stmts[$key]);
     }
 }

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -43,12 +43,12 @@ final class NodeRemover
         Class_ | ClassMethod | Function_ $nodeWithStatements,
         Node $toBeRemovedNode
     ): void {
-        foreach ((array) $nodeWithStatements->stmts as $key => $stmt) {
+        foreach ((array) $nodeWithStatements->stmts as $stmt) {
             if ($toBeRemovedNode !== $stmt) {
                 continue;
             }
 
-            $this->removeNode($nodeWithStatements->stmts[$key]);
+            $this->removeNode($stmt);
             break;
         }
     }

--- a/packages/NodeRemoval/NodeRemover.php
+++ b/packages/NodeRemoval/NodeRemover.php
@@ -48,7 +48,7 @@ final class NodeRemover
                 continue;
             }
 
-            unset($nodeWithStatements->stmts[$key]);
+            $this->removeNode($nodeWithStatements->stmts[$key]);
             break;
         }
     }
@@ -76,10 +76,7 @@ final class NodeRemover
             return;
         }
 
-        // notify about remove node
-        $this->rectorChangeCollector->notifyNodeFileInfo($classMethod->params[$key]);
-
-        unset($classMethod->params[$key]);
+        $this->removeNode($classMethod->params[$key]);
     }
 
     public function removeArg(FuncCall | MethodCall | StaticCall $node, int $key): void
@@ -93,10 +90,7 @@ final class NodeRemover
             return;
         }
 
-        // notify about remove node
-        $this->rectorChangeCollector->notifyNodeFileInfo($node->args[$key]);
-
-        unset($node->args[$key]);
+        $this->removeNode($node->args[$key]);
     }
 
     /**
@@ -108,9 +102,11 @@ final class NodeRemover
             throw new ShouldNotHappenException();
         }
 
-        // notify about remove node
-        $this->rectorChangeCollector->notifyNodeFileInfo($functionLike->stmts[$key]);
+        // already removed
+        if (! isset($functionLike->stmts[$key])) {
+            return;
+        }
 
-        unset($functionLike->stmts[$key]);
+        $this->removeNode($functionLike->stmts[$key]);
     }
 }


### PR DESCRIPTION
The `removeNode()` utilize `NodesToRemoveCollector` to collect nodes that removed, this PR ensure use the method so on next rector rule run, when it exists in the collector, it will be skipped from process.