### PR TITLE
[Core] Make consistent BetterNodeFinder findParent and findParentByTypes

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -48,21 +48,24 @@ final class BetterNodeFinder
      * @param array<class-string<TNode>> $types
      * @return TNode|null
      */
-    public function findParentByTypes(Node $currentNode, array $types): ?Node
+    public function findParentByTypes(Node $node, array $types): ?Node
     {
         Assert::allIsAOf($types, Node::class);
 
-        while ($currentNode = $currentNode->getAttribute(AttributeKey::PARENT_NODE)) {
-            /** @var Node|null $currentNode */
-            if (! $currentNode instanceof Node) {
+        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+
+        while ($parentNode instanceof Node) {
+            if (! $parentNode instanceof Node) {
                 return null;
             }
 
             foreach ($types as $type) {
-                if (is_a($currentNode, $type, true)) {
-                    return $currentNode;
+                if (is_a($parentNode, $type, true)) {
+                    return $parentNode;
                 }
             }
+
+            $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
         }
 
         return null;
@@ -78,17 +81,18 @@ final class BetterNodeFinder
         Assert::isAOf($type, Node::class);
 
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parentNode instanceof Node) {
-            return null;
-        }
 
-        do {
+        while ($parentNode instanceof Node) {
+            if (! $parentNode instanceof Node) {
+                return null;
+            }
+
             if (is_a($parentNode, $type, true)) {
                 return $parentNode;
             }
 
             $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-        } while ($parentNode instanceof Node);
+        }
 
         return null;
     }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -55,8 +55,10 @@ final class BetterNodeFinder
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         while ($parentNode instanceof Node) {
-            if ($this->multiInstanceofChecker->isInstanceOf($parentNode, $types)) {
-                return $parentNode;
+            foreach ($types as $type) {
+                if ($parentNode instanceof $type) {
+                    return $parentNode;
+                }
             }
 
             $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -55,10 +55,8 @@ final class BetterNodeFinder
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         while ($parentNode instanceof Node) {
-            foreach ($types as $type) {
-                if ($parentNode instanceof $type) {
-                    return $parentNode;
-                }
+            if ($this->multiInstanceofChecker->isInstanceOf($parentNode, $types)) {
+                return $parentNode;
             }
 
             $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -56,7 +56,7 @@ final class BetterNodeFinder
 
         while ($parentNode instanceof Node) {
             foreach ($types as $type) {
-                if (is_a($parentNode, $type, true)) {
+                if ($parentNode instanceof $type) {
                     return $parentNode;
                 }
             }
@@ -79,7 +79,7 @@ final class BetterNodeFinder
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         while ($parentNode instanceof Node) {
-            if (is_a($parentNode, $type, true)) {
+            if ($parentNode instanceof $type) {
                 return $parentNode;
             }
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -62,9 +62,6 @@ final class BetterNodeFinder
             }
 
             $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-            if (! $parentNode instanceof Node) {
-                return null;
-            }
         }
 
         return null;
@@ -87,9 +84,6 @@ final class BetterNodeFinder
             }
 
             $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-            if (! $parentNode instanceof Node) {
-                return null;
-            }
         }
 
         return null;

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -55,10 +55,6 @@ final class BetterNodeFinder
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         while ($parentNode instanceof Node) {
-            if (! $parentNode instanceof Node) {
-                return null;
-            }
-
             foreach ($types as $type) {
                 if (is_a($parentNode, $type, true)) {
                     return $parentNode;
@@ -66,6 +62,9 @@ final class BetterNodeFinder
             }
 
             $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
+            if (! $parentNode instanceof Node) {
+                return null;
+            }
         }
 
         return null;
@@ -83,15 +82,14 @@ final class BetterNodeFinder
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         while ($parentNode instanceof Node) {
-            if (! $parentNode instanceof Node) {
-                return null;
-            }
-
             if (is_a($parentNode, $type, true)) {
                 return $parentNode;
             }
 
             $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
+            if (! $parentNode instanceof Node) {
+                return null;
+            }
         }
 
         return null;

--- a/src/Util/MultiInstanceofChecker.php
+++ b/src/Util/MultiInstanceofChecker.php
@@ -9,10 +9,10 @@ final class MultiInstanceofChecker
     /**
      * @param array<class-string> $types
      */
-    public function isInstanceOf(object | string $object, array $types): bool
+    public function isInstanceOf(object $object, array $types): bool
     {
         foreach ($types as $type) {
-            if (is_a($object, $type, true)) {
+            if ($object instanceof $type) {
                 return true;
             }
         }

--- a/src/Util/MultiInstanceofChecker.php
+++ b/src/Util/MultiInstanceofChecker.php
@@ -9,10 +9,10 @@ final class MultiInstanceofChecker
     /**
      * @param array<class-string> $types
      */
-    public function isInstanceOf(object $object, array $types): bool
+    public function isInstanceOf(object | string $object, array $types): bool
     {
         foreach ($types as $type) {
-            if ($object instanceof $type) {
+            if (is_a($object, $type, true)) {
                 return true;
             }
         }


### PR DESCRIPTION
Ensure both `findParent` and `findParentByTypes` have similar logic by apply `while` loop with ensure assign to new variable `$parentNode` instead of replace `$currentNode` object with parent node.