### PR TITLE
[CodeQuality] Handle class-string case insensitive on CompleteDynamicPropertiesRector

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
+++ b/packages/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\NodeTypeCorrector;
 
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 
@@ -26,11 +28,18 @@ final class GenericClassStringTypeCorrector
                 return $traverseCallback($traversedType);
             }
 
-            if (! $this->reflectionProvider->hasClass($traversedType->getValue())) {
+            $value = $traversedType->getValue();
+            if (! $this->reflectionProvider->hasClass($value)) {
                 return $traverseCallback($traversedType);
             }
 
-            return new GenericClassStringType(new ObjectType($traversedType->getValue()));
+            /** @var ClassReflection $classReflection */
+            $classReflection = $this->reflectionProvider->getClass($value);
+            if ($classReflection->getName() !== $value) {
+                return new StringType();
+            }
+
+            return new GenericClassStringType(new ObjectType($value));
         });
     }
 }

--- a/packages/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
+++ b/packages/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
@@ -9,7 +9,6 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 
@@ -36,7 +35,7 @@ final class GenericClassStringTypeCorrector
             /** @var ClassReflection $classReflection */
             $classReflection = $this->reflectionProvider->getClass($value);
             if ($classReflection->getName() !== $value) {
-                return new StringType();
+                return $traverseCallback($traversedType);
             }
 
             return new GenericClassStringType(new ObjectType($value));

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/class_string_case_insensitive.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/class_string_case_insensitive.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+/** No namespace on purpose to simplify demo that case insensitive string should not be marked as class-string */
+class ClassStringCaseInsensitive
+{
+    public function set()
+    {
+        $this->value = 'classStringCaseInSensitive';
+    }
+}
+
+?>
+-----
+<?php
+
+/** No namespace on purpose to simplify demo that case insensitive string should not be marked as class-string */
+class ClassStringCaseInsensitive
+{
+    /**
+     * @var string
+     */
+    public $value;
+    public function set()
+    {
+        $this->value = 'classStringCaseInSensitive';
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/class_string_case_sensitive.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/class_string_case_sensitive.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+/** No namespace on purpose to simplify demo that case sensitive string should be marked as class-string */
+class ClassStringCaseSensitive
+{
+    public function set()
+    {
+        $this->value = 'ClassStringCaseSensitive';
+    }
+}
+
+?>
+-----
+<?php
+
+/** No namespace on purpose to simplify demo that case sensitive string should be marked as class-string */
+class ClassStringCaseSensitive
+{
+    /**
+     * @var class-string<\ClassStringCaseSensitive>
+     */
+    public $value;
+    public function set()
+    {
+        $this->value = 'ClassStringCaseSensitive';
+    }
+}
+
+?>


### PR DESCRIPTION
Given the following code:

```php
class ClassStringCaseInsensitive
{
    public function set()
    {
        $this->value = 'classStringCaseInSensitive';
    }
}
```

It currently produce:

```diff
+     /**
+     * @var class-string<\classStringCaseInSensitive>
+      */
+     public $value;
```

which should be `@var string` type as case insensitve., ref https://getrector.org/demo/29b1a750-b121-4ff7-a506-b04812e8a4e3

This PR try to fix it 