### PR TITLE
[TypeDeclaration] Do not remove multiple docblocks with comment on TypedPropertyFromAssignsRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -298,26 +298,6 @@ final class PhpDocInfo
         $this->renewMainDocOnMultipleDocs();
     }
 
-    private function renewMainDocOnMultipleDocs()
-    {
-        if ($this->phpDocNode->children !== []) {
-            return;
-        }
-
-        $node = $this->getNode();
-        if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
-            /** @var Comment[] $previousDocsAsComments */
-            $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);
-            $node->setAttribute(AttributeKey::COMMENTS, $previousDocsAsComments);
-        }
-
-        if ($node->hasAttribute(AttributeKey::NEW_MAIN_DOC)) {
-            /** @var Doc $newMainDoc */
-            $newMainDoc = $node->getAttribute(AttributeKey::NEW_MAIN_DOC);
-            $node->setDocComment($newMainDoc);
-        }
-    }
-
     public function addTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): void
     {
         if ($phpDocTagValueNode instanceof DoctrineAnnotationTagValueNode) {
@@ -453,6 +433,26 @@ final class PhpDocInfo
     public function getNode(): \PhpParser\Node
     {
         return $this->node;
+    }
+
+    private function renewMainDocOnMultipleDocs()
+    {
+        if ($this->phpDocNode->children !== []) {
+            return;
+        }
+
+        $node = $this->getNode();
+        if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
+            /** @var Comment[] $previousDocsAsComments */
+            $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);
+            $node->setAttribute(AttributeKey::COMMENTS, $previousDocsAsComments);
+        }
+
+        if ($node->hasAttribute(AttributeKey::NEW_MAIN_DOC)) {
+            /** @var Doc $newMainDoc */
+            $newMainDoc = $node->getAttribute(AttributeKey::NEW_MAIN_DOC);
+            $node->setDocComment($newMainDoc);
+        }
     }
 
     private function resolveNameForPhpDocTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): ?string

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocInfo;
 
-use PhpParser\Comment;
-use PhpParser\Comment\Doc;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
@@ -30,7 +28,6 @@ use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 use Rector\BetterPhpDocParser\ValueObject\Type\ShortenedIdentifierTypeNode;
 use Rector\ChangesReporting\Collector\RectorChangeCollector;
 use Rector\Core\Configuration\CurrentNodeProvider;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
@@ -294,8 +291,6 @@ final class PhpDocInfo
             $this->markAsChanged();
             return PhpDocNodeTraverser::NODE_REMOVE;
         });
-
-        $this->renewMainDocOnMultipleDocs();
     }
 
     public function addTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): void
@@ -433,26 +428,6 @@ final class PhpDocInfo
     public function getNode(): \PhpParser\Node
     {
         return $this->node;
-    }
-
-    private function renewMainDocOnMultipleDocs(): void
-    {
-        if ($this->phpDocNode->children !== []) {
-            return;
-        }
-
-        $node = $this->node;
-        if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
-            /** @var Comment[] $previousDocsAsComments */
-            $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);
-            $node->setAttribute(AttributeKey::COMMENTS, $previousDocsAsComments);
-        }
-
-        if ($node->hasAttribute(AttributeKey::NEW_MAIN_DOC)) {
-            /** @var Doc $newMainDoc */
-            $newMainDoc = $node->getAttribute(AttributeKey::NEW_MAIN_DOC);
-            $node->setDocComment($newMainDoc);
-        }
     }
 
     private function resolveNameForPhpDocTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): ?string

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -435,13 +435,13 @@ final class PhpDocInfo
         return $this->node;
     }
 
-    private function renewMainDocOnMultipleDocs()
+    private function renewMainDocOnMultipleDocs(): void
     {
         if ($this->phpDocNode->children !== []) {
             return;
         }
 
-        $node = $this->getNode();
+        $node = $this->node;
         if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
             /** @var Comment[] $previousDocsAsComments */
             $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocInfo;
 
+use PhpParser\Comment\Doc;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
@@ -28,6 +29,7 @@ use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 use Rector\BetterPhpDocParser\ValueObject\Type\ShortenedIdentifierTypeNode;
 use Rector\ChangesReporting\Collector\RectorChangeCollector;
 use Rector\Core\Configuration\CurrentNodeProvider;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
@@ -291,6 +293,13 @@ final class PhpDocInfo
             $this->markAsChanged();
             return PhpDocNodeTraverser::NODE_REMOVE;
         });
+
+        if ($this->phpDocNode->children === []) {
+            $node = $this->getNode();
+            if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
+                $node->setAttribute(AttributeKey::COMMENTS, $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS));
+            }
+        }
     }
 
     public function addTagValueNode(PhpDocTagValueNode $phpDocTagValueNode): void

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -295,19 +295,26 @@ final class PhpDocInfo
             return PhpDocNodeTraverser::NODE_REMOVE;
         });
 
-        if ($this->phpDocNode->children === []) {
-            $node = $this->getNode();
-            if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
-                /** @var Comment[] $previousDocsAsComments */
-                $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);
-                $node->setAttribute(AttributeKey::COMMENTS, $previousDocsAsComments);
-            }
+        $this->renewMainDocOnMultipleDocs();
+    }
 
-            if ($node->hasAttribute(AttributeKey::NEW_MAIN_DOC)) {
-                /** @var Doc $newMainDoc */
-                $newMainDoc = $node->getAttribute(AttributeKey::NEW_MAIN_DOC);
-                $node->setDocComment($newMainDoc);
-            }
+    private function renewMainDocOnMultipleDocs()
+    {
+        if ($this->phpDocNode->children !== []) {
+            return;
+        }
+
+        $node = $this->getNode();
+        if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
+            /** @var Comment[] $previousDocsAsComments */
+            $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);
+            $node->setAttribute(AttributeKey::COMMENTS, $previousDocsAsComments);
+        }
+
+        if ($node->hasAttribute(AttributeKey::NEW_MAIN_DOC)) {
+            /** @var Doc $newMainDoc */
+            $newMainDoc = $node->getAttribute(AttributeKey::NEW_MAIN_DOC);
+            $node->setDocComment($newMainDoc);
         }
     }
 

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocInfo;
 
+use PhpParser\Comment;
 use PhpParser\Comment\Doc;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
@@ -297,7 +298,15 @@ final class PhpDocInfo
         if ($this->phpDocNode->children === []) {
             $node = $this->getNode();
             if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
-                $node->setAttribute(AttributeKey::COMMENTS, $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS));
+                /** @var Comment[] $previousDocsAsComments */
+                $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);
+                $node->setAttribute(AttributeKey::COMMENTS, $previousDocsAsComments);
+            }
+
+            if ($node->hasAttribute(AttributeKey::NEW_MAIN_DOC)) {
+                /** @var Doc $newMainDoc */
+                $newMainDoc = $node->getAttribute(AttributeKey::NEW_MAIN_DOC);
+                $node->setDocComment($newMainDoc);
             }
         }
     }

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -122,13 +122,14 @@ final class PhpDocInfoFactory
 
     /**
      * @param Comment[]|Doc[] $comments
-     * @param Doc[] $docs
      */
-    private function storePreviousDocs(Node $node, array $comments, Doc $docComment): void
+    private function storePreviousDocs(Node $node, array $comments, Doc $doc): void
     {
         $previousDocsAsComments = [];
+        $newMainDoc = null;
+
         foreach ($comments as $comment) {
-            if ($comment === $docComment) {
+            if ($comment === $doc) {
                 break;
             }
 
@@ -148,9 +149,11 @@ final class PhpDocInfoFactory
                 $comment->getEndFilePos(),
                 $comment->getEndTokenPos()
             );
+            $newMainDoc = $comment;
         }
 
         $node->setAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS, $previousDocsAsComments);
+        $node->setAttribute(AttributeKey::NEW_MAIN_DOC, $newMainDoc);
     }
 
     /**

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -77,25 +77,20 @@ final class PhpDocInfoFactory
             // create empty node
             $tokenIterator = new BetterTokenIterator([]);
             $phpDocNode = new PhpDocNode([]);
+        } else {
+            $docs = array_filter($comments, static fn (Comment $comment): bool => $comment instanceof Doc);
 
-            $phpDocInfo = $this->createFromPhpDocNode($phpDocNode, $tokenIterator, $node);
-            $this->phpDocInfosByObjectHash[$objectHash] = $phpDocInfo;
+            if (count($docs) > 1) {
+                $this->storePreviousDocs($node, $comments, $docComment);
+            }
 
-            return $phpDocInfo;
+            $text = $docComment->getText();
+            $tokens = $this->lexer->tokenize($text);
+            $tokenIterator = new BetterTokenIterator($tokens);
+
+            $phpDocNode = $this->betterPhpDocParser->parse($tokenIterator);
+            $this->setPositionOfLastToken($phpDocNode);
         }
-
-        $docs = array_filter($comments, static fn (Comment $comment): bool => $comment instanceof Doc);
-
-        if (count($docs) > 1) {
-            $this->storePreviousDocs($node, $comments, $docComment);
-        }
-
-        $text = $docComment->getText();
-        $tokens = $this->lexer->tokenize($text);
-        $tokenIterator = new BetterTokenIterator($tokens);
-
-        $phpDocNode = $this->betterPhpDocParser->parse($tokenIterator);
-        $this->setPositionOfLastToken($phpDocNode);
 
         $phpDocInfo = $this->createFromPhpDocNode($phpDocNode, $tokenIterator, $node);
         $this->phpDocInfosByObjectHash[$objectHash] = $phpDocInfo;

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -66,11 +66,10 @@ final class PhpDocInfoFactory
         /** @see \Rector\BetterPhpDocParser\PhpDocParser\DoctrineAnnotationDecorator::decorate() */
         $this->currentNodeProvider->setNode($node);
 
-        $comments = $node->getComments();
         $docComment = $node->getDocComment();
 
         if (! $docComment instanceof Doc) {
-            if ($comments === []) {
+            if ($node->getComments() === []) {
                 return null;
             }
 
@@ -78,6 +77,7 @@ final class PhpDocInfoFactory
             $tokenIterator = new BetterTokenIterator([]);
             $phpDocNode = new PhpDocNode([]);
         } else {
+            $comments = $node->getComments();
             $docs = array_filter($comments, static fn (Comment $comment): bool => $comment instanceof Doc);
 
             if (count($docs) > 1) {

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -124,6 +124,7 @@ final class PhpDocInfoFactory
         $newMainDoc = null;
 
         foreach ($comments as $comment) {
+            // On last Doc, stop
             if ($comment === $doc) {
                 break;
             }
@@ -144,6 +145,11 @@ final class PhpDocInfoFactory
                 $comment->getEndFilePos(),
                 $comment->getEndTokenPos()
             );
+
+            /**
+             * Make last Doc before main Doc to candidate main Doc
+             * so it can immediatelly be used as replacement of Main doc when main doc removed
+             */
             $newMainDoc = $comment;
         }
 

--- a/packages/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/packages/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -58,6 +58,18 @@ final class DocBlockUpdater
 
     private function setCommentsAttribute(Node $node): void
     {
+        if ($node->hasAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS)) {
+            /** @var Comment[] $previousDocsAsComments */
+            $previousDocsAsComments = $node->getAttribute(AttributeKey::PREVIOUS_DOCS_AS_COMMENTS);
+            $node->setAttribute(AttributeKey::COMMENTS, $previousDocsAsComments);
+        }
+
+        if ($node->hasAttribute(AttributeKey::NEW_MAIN_DOC)) {
+            /** @var Doc $newMainDoc */
+            $newMainDoc = $node->getAttribute(AttributeKey::NEW_MAIN_DOC);
+            $node->setDocComment($newMainDoc);
+        }
+
         $comments = array_filter($node->getComments(), static fn (Comment $comment): bool => ! $comment instanceof Doc);
         $node->setAttribute(AttributeKey::COMMENTS, $comments);
     }

--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -43,11 +43,13 @@ final class AttributeKey
 
     /**
      * Cover multi docs
+     * @var string
      */
     public const PREVIOUS_DOCS_AS_COMMENTS = 'previous_docs_as_comments';
 
     /**
      * Cover multi docs
+     * @var string
      */
     public const NEW_MAIN_DOC = 'new_main_doc';
 

--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -47,6 +47,11 @@ final class AttributeKey
     public const PREVIOUS_DOCS_AS_COMMENTS = 'previous_docs_as_comments';
 
     /**
+     * Cover multi docs
+     */
+    public const NEW_MAIN_DOC = 'new_main_doc';
+
+    /**
      * Internal php-parser name.
      * Do not change this even if you want!
      *

--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -42,6 +42,11 @@ final class AttributeKey
     public const COMMENTS = 'comments';
 
     /**
+     * Cover multi docs
+     */
+    public const PREVIOUS_DOCS_AS_COMMENTS = 'previous_docs_as_comments';
+
+    /**
      * Internal php-parser name.
      * Do not change this even if you want!
      *

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/do_not_remove_multiple_docblock_comment.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/do_not_remove_multiple_docblock_comment.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class DoNotRemoveMultipleDocblockComment
+{
+    // A comment
+
+    /**
+     * Another comment
+     */
+
+    /**
+     * @var \DateTime
+     */
+    private $property;
+
+    public function __construct()
+    {
+        $this->property = new \DateTime();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class DoNotRemoveMultipleDocblockComment
+{
+    // A comment
+    /**
+     * Another comment
+     */
+    private \DateTime $property;
+
+    public function __construct()
+    {
+        $this->property = new \DateTime();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/do_not_remove_multiple_docblock_comment_2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/do_not_remove_multiple_docblock_comment_2.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class DoNotRemoveMultipleDocblockComment2
+{
+    // A comment
+
+    /**
+     * Another comment
+     */
+
+    /**
+     * Another comment inside main doc
+     *
+     * @var \DateTime
+     */
+    private $property;
+
+    public function __construct()
+    {
+        $this->property = new \DateTime();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class DoNotRemoveMultipleDocblockComment2
+{
+    // A comment
+    /**
+     * Another comment
+     */
+    /**
+     * Another comment inside main doc
+     */
+    private \DateTime $property;
+
+    public function __construct()
+    {
+        $this->property = new \DateTime();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/preserve_multiple_docs_no_change.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/preserve_multiple_docs_no_change.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class PreserveMultipleDocsNoChange
+{
+    // A comment
+
+    /**
+     * Another comment
+     */
+
+    /**
+     * @var class-string
+     */
+    private $property;
+
+    public function __construct()
+    {
+        $this->property = 'DateTime';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class PreserveMultipleDocsNoChange
+{
+    // A comment
+
+    /**
+     * Another comment
+     */
+
+    /**
+     * @var class-string
+     */
+    private string $property;
+
+    public function __construct()
+    {
+        $this->property = 'DateTime';
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7693

Multiiple docblock should only remove last doc as detected one is the last:

```diff
    // A comment

    /**
     * Another comment
     */

-    /**
-     * @var \DateTime
-     */
```

For only `comment + docblock`, it remove the docblock part:

```diff
   // A comment
-    /**
-     * @var \DateTime
-     */
```
