### PR TITLE
Bump to PHPStan ^1.9.5

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "phpstan/phpstan": "^1.9.4"
+        "phpstan/phpstan": "^1.9.5"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "nikic/php-parser": "^4.15.2",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.15.3",
-        "phpstan/phpstan": "^1.9.4",
+        "phpstan/phpstan": "^1.9.5",
         "phpstan/phpstan-phpunit": "^1.3.2",
         "react/event-loop": "^1.3",
         "react/socket": "^1.12",


### PR DESCRIPTION
PHPStan 1.9.5 released https://github.com/phpstan/phpstan/releases/tag/1.9.5

This PR bump PHPStan requirement to ^1.9.5