### PR TITLE
[Core] Remove BetterStandardPrinter::pStmts()

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -339,16 +339,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
     }
 
     /**
-     * @param Node[] $nodes
-     */
-    protected function pStmts(array $nodes, bool $indent = true): string
-    {
-        $this->moveCommentsFromAttributeObjectToCommentsAttribute($nodes);
-
-        return parent::pStmts($nodes, $indent);
-    }
-
-    /**
      * "...$params) : ReturnType"
      * ↓
      * "...$params): ReturnType"


### PR DESCRIPTION
The `BetterStandardPrinter::pStmts()` override `pStmts` method is calling:

```php
$this->moveCommentsFromAttributeObjectToCommentsAttribute($nodes);
```

which already called in `pArray()`: 

https://github.com/rectorphp/rector-src/blob/8c439cffaee2124388b4fd03db951f43f10a5359/src/PhpParser/Printer/BetterStandardPrinter.php#L213-L225

so it seems it no longer needed.

