### PR TITLE
Includes PHPStan bleedingEdge.neon config in phpstan-for-rector and phpstan-for-downgrade config

### DIFF
--- a/build/config/phpstan-for-downgrade.neon
+++ b/build/config/phpstan-for-downgrade.neon
@@ -1,3 +1,6 @@
+includes:
+    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
+
 # this config has extensions, that helps PHPStan inside Rector to resolve more precise types
 parameters:
     inferPrivatePropertyTypeFromConstructor: true

--- a/phpstan-for-rector.neon
+++ b/phpstan-for-rector.neon
@@ -1,3 +1,6 @@
+includes:
+    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
+
 # this config has extensions, that helps PHPStan inside Rector to resolve more precise types
 parameters:
     inferPrivatePropertyTypeFromConstructor: true


### PR DESCRIPTION
- To get early compatibilty check on latest PHPStan to early feature if found incompatibility.
- Most performance improvement happen on bleedingEdge feature.
- Give example how to include bleedingEdge.neon config in case next user ask how to include it, just point these files as reference example, see example issue https://github.com/rectorphp/rector/issues/7696