### PR TITLE
Skip Doctrine Collection in RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_another_doctrine_collection.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_another_doctrine_collection.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Table;
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\Entity\SomeAnswerEntity;
+
+#[Entity]
+#[Table]
+class SkipAnotherDoctrineCollection
+{
+    /**
+     * @var Collection<int, SomeAnswerEntity>
+     */
+    #[OneToMany(mappedBy: 'user', targetEntity: SomeAnswerEntity::class)]
+    private Collection $someAnswers;
+
+    public function __construct(
+    ) {
+        $this->someAnswers = new ArrayCollection();
+    }
+}

--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Source/Entity/SomeAnswerEntity.php
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Source/Entity/SomeAnswerEntity.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\Entity;
+
+final class SomeAnswerEntity
+{
+
+}

--- a/rules/Naming/Naming/PropertyNaming.php
+++ b/rules/Naming/Naming/PropertyNaming.php
@@ -77,6 +77,11 @@ final class PropertyNaming
 
     public function getExpectedNameFromType(Type $type): ?ExpectedName
     {
+        // keep doctrine collections untouched
+        if ($type instanceof ObjectType && $type->isInstanceOf('Doctrine\Common\Collections\Collection')->yes()) {
+            return null;
+        }
+
         $className = $this->resolveClassNameFromType($type);
         if (! is_string($className)) {
             return null;
@@ -268,7 +273,6 @@ final class PropertyNaming
     private function resolveClassNameFromType(Type $type): ?string
     {
         $type = TypeCombinator::removeNull($type);
-
         if (! $type instanceof TypeWithClassName) {
             return null;
         }

--- a/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
+++ b/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
@@ -109,6 +109,7 @@ CODE_SAMPLE
             }
 
             $propertyRename = $this->propertyRenameFactory->createFromExpectedName($property, $expectedPropertyName);
+
             if (! $propertyRename instanceof PropertyRename) {
                 continue;
             }


### PR DESCRIPTION
- add skipped fixture
- skip doctine collection from rename in explicit way
