### PR TITLE
[CodeQuality] Handle mix HTML+PHP on ForRepeatedCountToOwnVariableRector 

### DIFF
--- a/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
+++ b/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
@@ -13,8 +13,8 @@
     <?php 
 $itemsCount = count($items);
 for ($i = 5; $i <= $itemsCount; $i++) {
-    echo $items[$i];
-}
+            echo $items[$i];
+        }
 ?>
 </div>
 <?php 

--- a/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
+++ b/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
@@ -13,8 +13,8 @@
     <?php 
 $itemsCount = count($items);
 for ($i = 5; $i <= $itemsCount; $i++) {
-            echo $items[$i];
-        }
+    echo $items[$i];
+}
 ?>
 </div>
 <?php 

--- a/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
+++ b/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
@@ -1,0 +1,20 @@
+<div>
+    <?php
+        for ($i = 5; $i <= count($items); $i++) {
+            echo $items[$i];
+        }
+    ?>
+</div>
+-----
+<?php
+
+?>
+<div>
+    <?php 
+$itemsCount = count($items);
+for ($i = 5; $i <= $itemsCount; $i++) {
+            echo $items[$i];
+        }
+?>
+</div>
+<?php 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -436,11 +436,6 @@ CODE_SAMPLE;
         if (! $lastNodeNextNode instanceof Node && $node->hasAttribute(AttributeKey::NEXT_NODE)) {
             /** @var Node $nextNode */
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
-
-            if ($nextNode instanceof InlineHTML && ! $node instanceof InlineHTML) {
-                $nextNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            }
-
             $nodes = [...$nodes, $nextNode];
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -424,7 +424,7 @@ CODE_SAMPLE;
             $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
 
             if ($previousNode instanceof InlineHTML && ! $firstNode instanceof InlineHTML) {
-                $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                $previousNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 
             $nodes = [$previousNode, ...$nodes];

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -436,6 +436,11 @@ CODE_SAMPLE;
         if (! $lastNodeNextNode instanceof Node && $node->hasAttribute(AttributeKey::NEXT_NODE)) {
             /** @var Node $nextNode */
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
+
+            if ($nextNode instanceof InlineHTML && ! $lastNode instanceof InlineHTML) {
+                $nextNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            }
+
             $nodes = [...$nodes, $nextNode];
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -424,6 +424,7 @@ CODE_SAMPLE;
             $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
 
             if ($previousNode instanceof InlineHTML && ! $firstNode instanceof InlineHTML) {
+                // re-print InlineHTML is safe
                 $previousNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 
@@ -438,6 +439,7 @@ CODE_SAMPLE;
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
 
             if ($nextNode instanceof InlineHTML && ! $lastNode instanceof InlineHTML) {
+                // re-print InlineHTML is safe
                 $nextNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -424,7 +424,7 @@ CODE_SAMPLE;
             $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
 
             if ($previousNode instanceof InlineHTML && ! $firstNode instanceof InlineHTML) {
-                $previousNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 
             $nodes = [$previousNode, ...$nodes];

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -423,7 +423,7 @@ CODE_SAMPLE;
             /** @var Node $previousNode */
             $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
 
-            if ($previousNode instanceof InlineHTML && ! $node instanceof InlineHTML) {
+            if ($previousNode instanceof InlineHTML && ! $firstNode instanceof InlineHTML) {
                 $previousNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
@@ -421,6 +422,11 @@ CODE_SAMPLE;
         if (! $firstNodePreviousNode instanceof Node && $node->hasAttribute(AttributeKey::PREVIOUS_NODE)) {
             /** @var Node $previousNode */
             $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
+
+            if ($previousNode instanceof InlineHTML && ! $node instanceof InlineHTML) {
+                $previousNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            }
+
             $nodes = [$previousNode, ...$nodes];
         }
 
@@ -430,6 +436,11 @@ CODE_SAMPLE;
         if (! $lastNodeNextNode instanceof Node && $node->hasAttribute(AttributeKey::NEXT_NODE)) {
             /** @var Node $nextNode */
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
+
+            if ($nextNode instanceof InlineHTML && ! $node instanceof InlineHTML) {
+                $nextNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            }
+
             $nodes = [...$nodes, $nextNode];
         }
 


### PR DESCRIPTION
This is actually general issue when use mix HTML+PHP and we need to insert code between, for this use case, I found at `ForRepeatedCountToOwnVariableRector`, which change to:

```diff
$itemsCount = count($items);<?php
+        for ($i = 5; $i <= $itemsCount; $i++) {
             echo $items[$i];
         }
```

when previous node is HTML, the code become invalid, The tweak is by re-print the previous/next node when previous/next Node is HTML.

see https://getrector.org/demo/5b00ff10-b7af-4465-bb5d-3e4727e4c948

This is not perfect as it cause unnecessary empty `<?php ?>` tag before the previous of previous node, and empty `<?php` after, but it make code keep working.

New Rector rule or cs tool may needed  to clean the code for that :)