### PR TITLE
[Core] Improve BetterStandardPrinter printFormatPreserving on mix HTML + PHP

### DIFF
--- a/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
+++ b/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
@@ -6,9 +6,6 @@
     ?>
 </div>
 -----
-<?php
-
-?>
 <div>
     <?php 
 $itemsCount = count($items);

--- a/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
+++ b/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/mix_html_php.php.inc
@@ -17,4 +17,3 @@ for ($i = 5; $i <= $itemsCount; $i++) {
         }
 ?>
 </div>
-<?php 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -24,6 +24,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\PrettyPrinter\Standard;
@@ -111,6 +112,15 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         // add new line in case of added stmts
         if (count($stmts) !== count($origStmts) && ! StringUtils::isMatch($content, self::NEWLINE_END_REGEX)) {
             $content .= $this->nl;
+        }
+
+        $lastStmt = end($stmts);
+        if (! $lastStmt instanceof InlineHTML && ! $lastStmt instanceof FileWithoutNamespace) {
+            return $content;
+        }
+
+        if (str_ends_with($content, '<?php ' . $this->nl)) {
+            return substr($content, 0, -7);
         }
 
         return $content;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -119,7 +119,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         }
 
         $lastStmt = end($newStmts);
-        if (! $lastStmt instanceof InlineHTML && ! $lastStmt instanceof FileWithoutNamespace) {
+        if (! $lastStmt instanceof InlineHTML) {
             return $content;
         }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -114,6 +114,10 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             $content .= $this->nl;
         }
 
+        if ($newStmts === []) {
+            return $content;
+        }
+
         $lastStmt = end($stmts);
         if (! $lastStmt instanceof InlineHTML && ! $lastStmt instanceof FileWithoutNamespace) {
             return $content;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -121,15 +121,11 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $firstStmt = current($newStmts);
         $lastStmt = end($newStmts);
 
-        if (! $firstStmt instanceof InlineHTML && ! $lastStmt instanceof InlineHTML) {
-            return $content;
-        }
-
-        if (str_starts_with($content, '<?php' . $this->nl . $this->nl . '?>')) {
+        if ($firstStmt instanceof InlineHTML && str_starts_with($content, '<?php' . $this->nl . $this->nl . '?>')) {
             $content = substr($content, 10);
         }
 
-        if (str_ends_with($content, '<?php ' . $this->nl)) {
+        if ($lastStmt instanceof InlineHTML && str_ends_with($content, '<?php ' . $this->nl)) {
             return substr($content, 0, -7);
         }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -130,7 +130,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         }
 
         if (str_ends_with($content, '<?php ' . $this->nl)) {
-            $content = substr($content, 0, -7);
+            return substr($content, 0, -7);
         }
 
         return $content;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -118,13 +118,19 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return $content;
         }
 
+        $firstStmt = current($newStmts);
         $lastStmt = end($newStmts);
-        if (! $lastStmt instanceof InlineHTML) {
+
+        if (! $firstStmt instanceof InlineHTML && ! $lastStmt instanceof InlineHTML) {
             return $content;
         }
 
+        if (str_starts_with($content, '<?php' . $this->nl . $this->nl . '?>')) {
+            $content = substr($content, 10);
+        }
+
         if (str_ends_with($content, '<?php ' . $this->nl)) {
-            return substr($content, 0, -7);
+            $content = substr($content, 0, -7);
         }
 
         return $content;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -118,7 +118,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return $content;
         }
 
-        $lastStmt = end($stmts);
+        $lastStmt = end($newStmts);
         if (! $lastStmt instanceof InlineHTML && ! $lastStmt instanceof FileWithoutNamespace) {
             return $content;
         }


### PR DESCRIPTION
@TomasVotruba this is continue of PR:

- https://github.com/rectorphp/rector-src/pull/3282

to not need to add `<?php` at the end of `InlineHTML` that just re-printed.