### PR TITLE
[AutoImport] Skip first stmt is InlineHTML

### DIFF
--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use PHPStan\Reflection\ReflectionProvider;
@@ -50,6 +51,11 @@ final class NameImportingPostRector extends AbstractPostRector
 
         $file = $this->currentFileProvider->getFile();
         if (! $file instanceof File) {
+            return null;
+        }
+
+        $currentStmt = current($file->getOldStmts());
+        if ($currentStmt instanceof InlineHTML) {
             return null;
         }
 

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -59,6 +59,11 @@ final class NameImportingPostRector extends AbstractPostRector
             return null;
         }
 
+        $currentStmt = current($file->getNewStmts());
+        if ($currentStmt instanceof InlineHTML) {
+            return null;
+        }
+
         if ($node instanceof Name) {
             return $this->processNodeName($node, $file);
         }

--- a/tests/Issues/PrintStmtsIndexAutoImport/Fixture/first_is_not_inline_html.php.inc
+++ b/tests/Issues/PrintStmtsIndexAutoImport/Fixture/first_is_not_inline_html.php.inc
@@ -1,0 +1,22 @@
+<?php
+$a = '';
+?>
+<div></div>
+<?php
+
+require(__DIR__ . '/../../vendor/autoload.php');
+
+$dotenv = \Dotenv\Dotenv::createUnsafeMutable(__DIR__ . '/../../');
+$dotenv->load();
+-----
+<?php
+use Dotenv\Dotenv;
+$a = '';
+?>
+<div></div>
+<?php
+
+require(__DIR__ . '/../../vendor/autoload.php');
+
+$dotenv = Dotenv::createUnsafeMutable(__DIR__ . '/../../');
+$dotenv->load();

--- a/tests/Issues/PrintStmtsIndexAutoImport/Fixture/skip_first_html.php.inc
+++ b/tests/Issues/PrintStmtsIndexAutoImport/Fixture/skip_first_html.php.inc
@@ -1,0 +1,8 @@
+#!/usr/local/bin/php -q
+
+<?php
+
+require(__DIR__ . '/../../vendor/autoload.php');
+
+$dotenv = \Dotenv\Dotenv::createUnsafeMutable(__DIR__ . '/../../');
+$dotenv->load();

--- a/tests/Issues/PrintStmtsIndexAutoImport/Fixture/skip_first_html2.php.inc
+++ b/tests/Issues/PrintStmtsIndexAutoImport/Fixture/skip_first_html2.php.inc
@@ -1,0 +1,10 @@
+<div>
+    some text
+</div>
+
+<?php
+
+require(__DIR__ . '/../../vendor/autoload.php');
+
+$dotenv = \Dotenv\Dotenv::createUnsafeMutable(__DIR__ . '/../../');
+$dotenv->load();


### PR DESCRIPTION
When first stmt is shebang as InlineHTML cause invalid code:

```
#!/usr/local/bin/php -q
```

Ref https://getrector.org/demo/a11313d3-7ec9-47a2-815e-93bf60b71f3f , 

make `<?php ?>` before it make the shebang printed as HTML, so not a solution.

also, skip when first stmt is normal HTML:

```
<div>
    some text
</div>
```

Ref https://getrector.org/demo/7ee487d4-020b-48d8-b1f5-b74597eef1fb

Fixes https://github.com/rectorphp/rector/issues/7714