### PR TITLE
[Php80] Handle crash leaveNode() returned invalid value of type integer on TokenGetAllToObjectRector

### DIFF
--- a/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/ternary_if.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/ternary_if.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\TokenGetAllToObjectRector\Fixture;
+
+final class TernaryIf
+{
+    public function run()
+    {
+        $tokens = token_get_all('<?php ' . implode('', array_slice($fileContent, $start, $end - $start)));
+
+        foreach ($tokens as $i => $token) {
+            $readableToken = is_array($token) ? $token[1] : $token;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\TokenGetAllToObjectRector\Fixture;
+
+final class TernaryIf
+{
+    public function run()
+    {
+        $tokens = \PhpToken::tokenize('<?php ' . implode('', array_slice($fileContent, $start, $end - $start)));
+
+        foreach ($tokens as $i => $token) {
+            $readableToken = $token->text;
+        }
+    }
+}
+
+?>

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -209,9 +209,11 @@ final class TokenManipulator
 
             if ($parentNode instanceof Ternary) {
                 $this->replaceTernary($parentNode);
-            } else {
-                $this->nodesToRemoveCollector->addNodeToRemove($nodeToRemove);
+                return $node;
             }
+
+            $this->nodesToRemoveCollector->addNodeToRemove($nodeToRemove);
+            return $node;
         });
     }
 

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -179,7 +179,7 @@ final class TokenManipulator
     {
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, function (Node $node) use (
             $singleTokenVariable
-        ) {
+        ): ?FuncCall {
             if (! $node instanceof FuncCall) {
                 return null;
             }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7719