### PR TITLE
[Php73] Skip prev() call on items after key called on ArrayKeyFirstLastRector

### DIFF
--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_prev_call_after.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_prev_call_after.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeyFirstLastRector\Fixture;
+
+class SkipPrevCallAfter
+{
+    public function run()
+    {
+        $items = [1, 2, 3];
+
+        end($items);
+        $key = key($items);
+
+        while ($key !== null) {
+            $isFound = rand(0, 1) ? true : false;
+
+            if (! $isFound) {
+                prev($items);
+                $key = key($items);
+
+                continue;
+            }
+
+            return current($items);
+        }
+    }
+}


### PR DESCRIPTION
Given the following code should be skipped:

```php
        $items = [1, 2, 3];

        end($items);
        $key = key($items);

        while ($key !== null) {
            $isFound = rand(0, 1) ? true : false;

            if (! $isFound) {
                prev($items);
                $key = key($items);

                continue;
            }

            return current($items);
        }
```

as the `end()` is used to make the `prev()` working to point to previous key in the loop.