### PR TITLE
[Core] Use Original node to pull Scope on AbstractScopeAwareRector

### DIFF
--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -29,18 +29,21 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
      */
     public function refactor(Node $node)
     {
-        /** @var MutatingScope|null $scope */
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+        $originalNode ??= $node;
 
-        if (! $scope instanceof MutatingScope) {
-            $scope = $this->scopeAnalyzer->resolveScope($node, $this->file->getFilePath());
+        /** @var MutatingScope|null $currentScope */
+        $currentScope = $originalNode->getAttribute(AttributeKey::SCOPE);
 
-            if ($scope instanceof MutatingScope) {
-                $this->changedNodeScopeRefresher->refresh($node, $scope, $this->file->getFilePath());
+        if (! $currentScope instanceof MutatingScope) {
+            $currentScope = $this->scopeAnalyzer->resolveScope($node, $this->file->getFilePath());
+
+            if ($currentScope instanceof MutatingScope) {
+                $this->changedNodeScopeRefresher->refresh($node, $currentScope, $this->file->getFilePath());
             }
         }
 
-        if (! $scope instanceof Scope) {
+        if (! $currentScope instanceof Scope) {
             /**
              * @var Node $parentNode
              *
@@ -62,6 +65,6 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
             throw new ShouldNotHappenException($errorMessage);
         }
 
-        return $this->refactorWithScope($node, $scope);
+        return $this->refactorWithScope($node, $currentScope);
     }
 }


### PR DESCRIPTION
To make consistent use with `AbstractRector` one:

https://github.com/rectorphp/rector-src/blob/2d6869fe3933347397a2ce879805a91e829e09a9/src/Rector/AbstractRector.php#L231-L232

I tried to flip around to use `$node` on `AbstractRector` on PR:

- https://github.com/rectorphp/rector-src/pull/3110

but got error `RenameClassRector`, so I think pull from `Original Node` for both is the way to go to make it consistent.