### PR TITLE
Generics support in Rector rules

### DIFF
--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -34,6 +34,7 @@ use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\ArgumentAdderRectorTest
+ * @extends AbstractRector<MethodCall|StaticCall|ClassMethod>
  */
 final class ArgumentAdderRector extends AbstractRector implements ConfigurableRectorInterface
 {
@@ -92,17 +93,11 @@ CODE_SAMPLE
         );
     }
 
-    /**
-     * @return array<class-string<Node>>
-     */
     public function getNodeTypes(): array
     {
         return [MethodCall::class, StaticCall::class, ClassMethod::class];
     }
 
-    /**
-     * @param MethodCall|StaticCall|ClassMethod $node
-     */
     public function refactor(Node $node): MethodCall | StaticCall | ClassMethod | null
     {
         $this->haveArgumentsChanged = false;

--- a/src/Contract/Rector/PhpRectorInterface.php
+++ b/src/Contract/Rector/PhpRectorInterface.php
@@ -7,18 +7,23 @@ namespace Rector\Core\Contract\Rector;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
 
+/**
+ * @api
+ * @phpstan-template TNodeType of Node
+ */
 interface PhpRectorInterface extends NodeVisitor, RectorInterface
 {
     /**
      * List of nodes this class checks, classes that implements \PhpParser\Node
      * See beautiful map of all nodes https://github.com/rectorphp/php-parser-nodes-docs#node-overview
      *
-     * @return array<class-string<Node>>
+     * @return array<class-string<TNodeType>>
      */
     public function getNodeTypes(): array;
 
     /**
      * Process Node of matched type
+     * @phpstan-param TNodeType $node
      * @return Node|Node[]|null
      */
     public function refactor(Node $node);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -46,6 +46,10 @@ use Rector\Skipper\Skipper\Skipper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symfony\Contracts\Service\Attribute\Required;
 
+/**
+ * @phpstan-template TNodeType of Node
+ * @implements PhpRectorInterface<TNodeType>
+ */
 abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorInterface
 {
     /**
@@ -206,6 +210,10 @@ CODE_SAMPLE;
             $this->changedNodeScopeRefresher->reIndexNodeAttributes($node);
         }
 
+        /**
+         * @phpstan-param TNodeType $node
+         * @phpstan-ignore-next-line
+         */
         $refactoredNode = $this->refactor($node);
 
         // nothing to change → continue

--- a/tests/Issues/InfiniteLoop/Rector/MethodCall/InfinityLoopRector.php
+++ b/tests/Issues/InfiniteLoop/Rector/MethodCall/InfinityLoopRector.php
@@ -12,19 +12,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\Core\Tests\Issues\InfiniteLoop\InfiniteLoopTest
+ * @extends AbstractRector<MethodCall>
  */
 final class InfinityLoopRector extends AbstractRector
 {
-    /**
-     * @return array<class-string<Node>>
-     */
     public function getNodeTypes(): array
     {
         return [MethodCall::class];
     }
 
     /**
-     * @param MethodCall $node
      * @return Assign|null
      */
     public function refactor(Node $node): ?Node


### PR DESCRIPTION
After this changes IDE (and PHPStan) knows what exact kinds of `Node` can be passed to `refactor()` method. This is based on PHPStan's rule generics:
- [`Rule`](https://github.com/phpstan/phpstan-src/blob/1.10.x/src/Rules/Rule.php) interface
- [`example rule`](https://github.com/phpstan/phpstan-src/blob/1.10.x/src/Rules/Debug/FileAssertRule.php)

@TomasVotruba let me know if you're open for such change, then I'll think how to solve 792 PHPStan errors from all the rules 😆 Maybe some Rector rule should be created to:
- add `@extends AbstractRector<...>` to the rule class
- remove `@return` from `getNodeTypes()` method (generics should be inherited)
- remove `@param $node` from `refactor()` (generics should be inherited)

Background:
![image](https://user-images.githubusercontent.com/600668/213477352-be4cda91-b6b7-4ea3-8149-a36760162e42.png)
![image](https://user-images.githubusercontent.com/600668/213477404-36a67cb0-78fc-4768-9850-86121ed1655b.png)
