### PR TITLE
Show different code on found errors, and on fatal errors

### DIFF
--- a/src/Console/ExitCode.php
+++ b/src/Console/ExitCode.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Console;
+
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @api
+ */
+final class ExitCode
+{
+    /**
+     * @var int
+     */
+    public const SUCCESS = Command::SUCCESS;
+
+    /**
+     * @var int
+     */
+    public const FAILURE = Command::FAILURE;
+
+    /**
+     * @var int
+     */
+    public const CHANGED_CODE = 2;
+}


### PR DESCRIPTION
This should help other tool to separate failure = 1,
and success run with changed files = 2