### PR TITLE
[Php72] Handle crash on CreateFunctionToAnonymousFunctionRector on quoted variable arg concat

### DIFF
--- a/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg.php.inc
+++ b/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg.php.inc
@@ -29,7 +29,7 @@ class QuotedVariableArg
         $strArgs = join(', ',$argL);
 
         return function ($v) use ($strFunc, $strArgs) {
-            return $strFunc($strArgs);
+            return $strFunc($v . $strArgs);
         };
     }
 }

--- a/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg.php.inc
+++ b/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
+
+class QuotedVariableArg
+{
+    public function pk_gen()
+    {
+        $argL = func_get_args();
+        $strFunc = array_shift($argL);
+        $strArgs = join(', ',$argL);
+
+        return create_function('$v', 'return '.$strFunc.'($v'.$strArgs.');');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
+
+class QuotedVariableArg
+{
+    public function pk_gen()
+    {
+        $argL = func_get_args();
+        $strFunc = array_shift($argL);
+        $strArgs = join(', ',$argL);
+
+        return function ($v) use ($strFunc, $strArgs) {
+            return $strFunc($strArgs);
+        };
+    }
+}
+
+?>

--- a/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg_concat.php.inc
+++ b/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg_concat.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
 
-class QuotedVariableArg
+class QuotedVariableArgConcat
 {
     public function pk_gen()
     {
@@ -20,7 +20,7 @@ class QuotedVariableArg
 
 namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
 
-class QuotedVariableArg
+class QuotedVariableArgConcat
 {
     public function pk_gen()
     {

--- a/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg_concat2.php.inc
+++ b/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/quoted_variable_arg_concat2.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
+
+class QuotedVariableArgConcat2
+{
+    public function pk_gen()
+    {
+        $argL = func_get_args();
+        $strFunc = array_shift($argL);
+        $strArgs = join(', ',$argL);
+
+        return create_function('$v', 'return '.$strFunc.'('.$strArgs.'$v);');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\Fixture;
+
+class QuotedVariableArgConcat2
+{
+    public function pk_gen()
+    {
+        $argL = func_get_args();
+        $strFunc = array_shift($argL);
+        $strArgs = join(', ',$argL);
+
+        return function ($v) use ($strFunc, $strArgs) {
+            return $strFunc($strArgs . $v);
+        };
+    }
+}
+
+?>

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -113,6 +113,10 @@ final class InlineCodeParser
         }
 
         if ($expr instanceof Concat) {
+            if ($expr->right instanceof String_ && str_starts_with($expr->right->value, '($')) {
+                $expr->right->value = '(';
+            }
+
             $string = $this->stringify($expr->left) . $this->stringify($expr->right);
             return Strings::replace(
                 $string,

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -124,8 +124,8 @@ final class InlineCodeParser
     private function resolveConcatValue(Concat $concat): string
     {
         if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
-            $nextVariable = $concat->getAttribute(AttributeKey::NEXT_NODE);
-            if ($nextVariable instanceof Node) {
+            $node = $concat->getAttribute(AttributeKey::NEXT_NODE);
+            if ($node instanceof Node) {
                 $concat->right->value .= '.';
             }
         }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -119,7 +119,7 @@ final class InlineCodeParser
         return $this->nodePrinter->print($expr);
     }
 
-    private function resolveConcatValue(Concat $expr) {
+    private function resolveConcatValue(Concat $expr)
     {
         if ($expr->right instanceof String_ && str_starts_with($expr->right->value, '($')) {
             $expr->right->value = '(';

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -6,9 +6,9 @@ namespace Rector\Core\PhpParser\Parser;
 
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
-use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
@@ -123,16 +123,14 @@ final class InlineCodeParser
 
     private function resolveConcatValue(Concat $concat): string
     {
-        if ($concat->left instanceof Concat && $concat->right instanceof String_ && str_starts_with(
-            $concat->right->value,
-            '$'
-        )) {
+        if ($concat->left instanceof Concat &&
+            $concat->right instanceof String_ && str_starts_with($concat->right->value, '$')) {
             $concat->right->value = '.' . $concat->right->value;
         }
 
         if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
             $node = $concat->getAttribute(AttributeKey::NEXT_NODE);
-            if ($node instanceof Node) {
+            if ($node instanceof Variable) {
                 $concat->right->value .= '.';
             }
         }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -9,7 +9,6 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
@@ -124,7 +123,10 @@ final class InlineCodeParser
 
     private function resolveConcatValue(Concat $concat): string
     {
-        if ($concat->left instanceof Concat && $concat->right instanceof String_ && str_starts_with($concat->right->value, '$')) {
+        if ($concat->left instanceof Concat && $concat->right instanceof String_ && str_starts_with(
+            $concat->right->value,
+            '$'
+        )) {
             $concat->right->value = '.' . $concat->right->value;
         }
 

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -9,6 +9,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
@@ -123,6 +124,10 @@ final class InlineCodeParser
 
     private function resolveConcatValue(Concat $concat): string
     {
+        if ($concat->left instanceof Concat && $concat->right instanceof String_ && str_starts_with($concat->right->value, '$')) {
+            $concat->right->value = '.' . $concat->right->value;
+        }
+
         if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
             $node = $concat->getAttribute(AttributeKey::NEXT_NODE);
             if ($node instanceof Node) {

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -119,13 +119,13 @@ final class InlineCodeParser
         return $this->nodePrinter->print($expr);
     }
 
-    private function resolveConcatValue(Concat $expr)
+    private function resolveConcatValue(Concat $concat): string
     {
-        if ($expr->right instanceof String_ && str_starts_with($expr->right->value, '($')) {
-            $expr->right->value = '(';
+        if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
+            $concat->right->value = '(';
         }
 
-        $string = $this->stringify($expr->left) . $this->stringify($expr->right);
+        $string = $this->stringify($concat->left) . $this->stringify($concat->right);
         return Strings::replace(
             $string,
             self::VARIABLE_IN_SINGLE_QUOTED_REGEX,

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -6,14 +6,17 @@ namespace Rector\Core\PhpParser\Parser;
 
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
+use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Util\StringUtils;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 
 final class InlineCodeParser
@@ -122,7 +125,10 @@ final class InlineCodeParser
     private function resolveConcatValue(Concat $concat): string
     {
         if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
-            $concat->right->value .= '.';
+            $nextVariable = $concat->getAttribute(AttributeKey::NEXT_NODE);
+            if ($nextVariable instanceof Node && ! $nextVariable instanceof Concat) {
+                $concat->right->value .= '.';
+            }
         }
 
         $string = $this->stringify($concat->left) . $this->stringify($concat->right);

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -113,18 +113,23 @@ final class InlineCodeParser
         }
 
         if ($expr instanceof Concat) {
-            if ($expr->right instanceof String_ && str_starts_with($expr->right->value, '($')) {
-                $expr->right->value = '(';
-            }
-
-            $string = $this->stringify($expr->left) . $this->stringify($expr->right);
-            return Strings::replace(
-                $string,
-                self::VARIABLE_IN_SINGLE_QUOTED_REGEX,
-                static fn (array $match) => $match['variable']
-            );
+            return $this->resolveConcatValue($expr);
         }
 
         return $this->nodePrinter->print($expr);
+    }
+
+    private function resolveConcatValue(Concat $expr) {
+    {
+        if ($expr->right instanceof String_ && str_starts_with($expr->right->value, '($')) {
+            $expr->right->value = '(';
+        }
+
+        $string = $this->stringify($expr->left) . $this->stringify($expr->right);
+        return Strings::replace(
+            $string,
+            self::VARIABLE_IN_SINGLE_QUOTED_REGEX,
+            static fn (array $match) => $match['variable']
+        );
     }
 }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -9,7 +9,6 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -122,7 +122,7 @@ final class InlineCodeParser
     private function resolveConcatValue(Concat $concat): string
     {
         if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
-            $concat->right->value = '(';
+            $concat->right->value .= '.';
         }
 
         $string = $this->stringify($concat->left) . $this->stringify($concat->right);

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -125,7 +125,7 @@ final class InlineCodeParser
     {
         if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
             $nextVariable = $concat->getAttribute(AttributeKey::NEXT_NODE);
-            if ($nextVariable instanceof Node && ! $nextVariable instanceof Concat) {
+            if ($nextVariable instanceof Node) {
                 $concat->right->value .= '.';
             }
         }


### PR DESCRIPTION
Given the following code:

```php
class QuotedVariableArgConcat
{
    public function pk_gen()
    {
        $argL = func_get_args();
        $strFunc = array_shift($argL);
        $strArgs = join(', ',$argL);

        return create_function('$v', 'return '.$strFunc.'($v'.$strArgs.');');
    }
}
```

It cause crash:

```bash
There was 1 error:

1) Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\CreateFunctionToAnonymousFunctionRectorTest::test with data set #3 ('/Users/samsonasik/www/rector-...hp.inc')
PhpParser\Error: Syntax error, unexpected T_VARIABLE, expecting ')' on line 1

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:318
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:159
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:51
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:32
/Users/samsonasik/www/rector-src/src/PhpParser/Parser/SimplePhpParser.php:39
/Users/samsonasik/www/rector-src/src/PhpParser/Parser/InlineCodeParser.php:79
/Users/samsonasik/www/rector-src/rules/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php:163
```

This PR try to fix it.
Fixes https://github.com/rectorphp/rector/issues/7729

Ref https://3v4l.org/AD0cq#v7.1.33 vs https://3v4l.org/XR1vD#v7.2.1