### PR TITLE
Run tests workflow as well on push

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,11 @@ name: Tests
 
 on:
     pull_request: null
+    push:
+     branches:
+        - main
+
+
 
 env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361


### PR DESCRIPTION
@TomasVotruba this is to ensure no left over run test on trigger build direct push to main https://github.com/rectorphp/rector-src/commit/58da24c6aef2117167d14c79e2c0751f887e7f54 after rector-* packages updated.