### PR TITLE
[Printer] Override method BetterStandardPrinter::initializeInsertionMap() to remove unnecessary pStmt_ClassMethod method

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -92,14 +92,18 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
     ) {
         parent::__construct($options);
 
+        $this->tabOrSpaceIndentCharacter = $this->rectorConfigProvider->getIndentChar();
+    }
+
+    protected function initializeInsertionMap(): void
+    {
+        parent::initializeInsertionMap();
+
         // print return type double colon right after the bracket "function(): string"
-        $this->initializeInsertionMap();
         $this->insertionMap['Stmt_ClassMethod->returnType'] = [')', false, ': ', null];
         $this->insertionMap['Stmt_Function->returnType'] = [')', false, ': ', null];
         $this->insertionMap['Expr_Closure->returnType'] = [')', false, ': ', null];
         $this->insertionMap['Expr_ArrowFunction->returnType'] = [')', false, ': ', null];
-
-        $this->tabOrSpaceIndentCharacter = $this->rectorConfigProvider->getIndentChar();
     }
 
     /**
@@ -386,23 +390,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $this->moveCommentsFromAttributeObjectToCommentsAttribute($nodes);
 
         return parent::pStmts($nodes, $indent);
-    }
-
-    /**
-     * "...$params) : ReturnType"
-     * ↓
-     * "...$params): ReturnType"
-     */
-    protected function pStmt_ClassMethod(ClassMethod $classMethod): string
-    {
-        $content = parent::pStmt_ClassMethod($classMethod);
-
-        if (! $classMethod->returnType instanceof Node) {
-            return $content;
-        }
-
-        // this approach is chosen, to keep changes in parent pStmt_ClassMethod() updated
-        return Strings::replace($content, self::REPLACE_COLON_WITH_SPACE_REGEX, '$1: ');
     }
 
     /**

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -22,7 +22,6 @@ use PhpParser\Node\Scalar\EncapsedStringPart;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
@@ -87,17 +86,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         parent::__construct($options);
 
         $this->tabOrSpaceIndentCharacter = $this->rectorConfigProvider->getIndentChar();
-    }
-
-    protected function initializeInsertionMap(): void
-    {
-        parent::initializeInsertionMap();
-
-        // print return type double colon right after the bracket "function(): string"
-        $this->insertionMap['Stmt_ClassMethod->returnType'] = [')', false, ': ', null];
-        $this->insertionMap['Stmt_Function->returnType'] = [')', false, ': ', null];
-        $this->insertionMap['Expr_Closure->returnType'] = [')', false, ': ', null];
-        $this->insertionMap['Expr_ArrowFunction->returnType'] = [')', false, ': ', null];
     }
 
     /**
@@ -182,6 +170,17 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $content = $this->pStmts($fileWithoutNamespace->stmts, false);
 
         return ltrim($content);
+    }
+
+    protected function initializeInsertionMap(): void
+    {
+        parent::initializeInsertionMap();
+
+        // print return type double colon right after the bracket "function(): string"
+        $this->insertionMap['Stmt_ClassMethod->returnType'] = [')', false, ': ', null];
+        $this->insertionMap['Stmt_Function->returnType'] = [')', false, ': ', null];
+        $this->insertionMap['Expr_Closure->returnType'] = [')', false, ': ', null];
+        $this->insertionMap['Expr_ArrowFunction->returnType'] = [')', false, ': ', null];
     }
 
     protected function p(Node $node, $parentFormatPreserved = false): string

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -71,12 +71,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
 
     /**
-     * @see https://regex101.com/r/qZiqGo/13
-     * @var string
-     */
-    private const REPLACE_COLON_WITH_SPACE_REGEX = '#(^.*function .*\(.*\)) : #';
-
-    /**
      * Use space by default
      */
     private string $tabOrSpaceIndentCharacter = ' ';


### PR DESCRIPTION
The following config:

```php
$this->insertionMap['Stmt_ClassMethod->returnType'] = [')', false, ': ', null];
```

should be enough instead of override `pStmt_ClassMethod()` method with regex check, this PR try to override `initializeInsertionMap()` method instead of call under `__construct()`. 

Let's see if it works