### PR TITLE
[Printer] Clean up nl usage on surplus tag check

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -525,14 +525,14 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         }
 
         if (str_ends_with($content, "<?php \n")) {
-            $content = substr($content, 0, -7);
+            return substr($content, 0, -7);
         }
 
         if (str_ends_with($content, '<?php ')) {
             return substr($content, 0, -6);
         }
 
-        return str_replace('<?php <?php ', '<?php ', $content);
+        return $content;
     }
 
     private function cleanSurplusTag(string $content): string

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -524,7 +524,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return $content;
         }
 
-        if (str_ends_with($content, '<?php \n')) {
+        if (str_ends_with($content, "<?php \n")) {
             $content = substr($content, 0, -7);
         }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -537,7 +537,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
 
     private function cleanSurplusTag(string $content): string
     {
-        if (str_starts_with($content, '<?php' . $this->nl . $this->nl . '?>')) {
+        if (str_starts_with($content, '<?php\n\n?>')) {
             return substr($content, 10);
         }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -537,7 +537,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
 
     private function cleanSurplusTag(string $content): string
     {
-        if (str_starts_with($content, '<?php\n\n?>')) {
+        if (str_starts_with($content, "<?php\n\n?>")) {
             return substr($content, 10);
         }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -524,7 +524,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return $content;
         }
 
-        if (str_ends_with($content, '<?php ' . $this->nl)) {
+        if (str_ends_with($content, '<?php \n')) {
             $content = substr($content, 0, -7);
         }
 


### PR DESCRIPTION
The substr result is goes to remove first 10 chars, so usage of `$this->nl` can be invalid. Use normal `\n` instead.