### PR TITLE
[Printer] Use <= 0 check for getStartTokenPos() for current node availability on MixPhpHtmlDecorator

### DIFF
--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -10,7 +10,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\ValueObject\Application\File;
 use Rector\NodeRemoval\NodeRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -47,7 +47,7 @@ final class MixPhpHtmlDecorator
             if ($nodes[$key + 1] instanceof InlineHTML) {
                 // No token end? Just added
                 $nodes[$key + 1]->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-                break;
+                return;
             }
         }
     }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -36,7 +36,7 @@ final class MixPhpHtmlDecorator
                 continue;
             }
 
-            if ($subNode->getEndTokenPos() >= 0) {
+            if ($subNode->getStartTokenPos() >= 0) {
                 return;
             }
 

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -29,17 +29,14 @@ final class MixPhpHtmlDecorator
     /**
      * @param Node[] $nodes
      */
-    public function decorateNextNodesInlineHTML(File $file, array $nodes): void
+    public function decorateNextNodesInlineHTML(array $nodes): void
     {
-        $oldTokens = $file->getOldTokens();
-
         foreach ($nodes as $key => $subNode) {
             if ($subNode instanceof InlineHTML) {
                 continue;
             }
 
-            $endTokenPost = $subNode->getEndTokenPos();
-            if (isset($oldTokens[$endTokenPost])) {
+            if ($subNode->getEndTokenPos() >= 0) {
                 return;
             }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -446,9 +446,9 @@ CODE_SAMPLE;
         }
 
         if (count($nodes) > 1) {
-            $this->mixPhpHtmlDecorator->decorateNextNodesInlineHTML($this->file, $nodes);
+            $this->mixPhpHtmlDecorator->decorateNextNodesInlineHTML($nodes);
         } elseif ($firstNode instanceof FileWithoutNamespace) {
-            $this->mixPhpHtmlDecorator->decorateNextNodesInlineHTML($this->file, $firstNode->stmts);
+            $this->mixPhpHtmlDecorator->decorateNextNodesInlineHTML($firstNode->stmts);
         }
 
         $nodeTraverser = new NodeTraverser();


### PR DESCRIPTION
When node just added, it still has `getStartTokenPos()` === `-1`