### PR TITLE
[Printer] Move handle mix php+html to BetterStandardPrinter

### DIFF
--- a/packages/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/packages/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -19,10 +19,10 @@ final class DocBlockUpdater
     ) {
     }
 
-    public function updateNodeWithPhpDocInfo(Stmt $stmt): void
+    public function updateNodeWithPhpDocInfo(Node $node): void
     {
         // nothing to change? don't save it
-        $phpDocInfo = $this->resolveChangedPhpDocInfo($stmt);
+        $phpDocInfo = $this->resolveChangedPhpDocInfo($node);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return;
         }
@@ -31,13 +31,13 @@ final class DocBlockUpdater
 
         // make sure, that many separated comments are not removed
         if ($phpDoc === '') {
-            $this->setCommentsAttribute($stmt);
+            $this->setCommentsAttribute($node);
 
             return;
         }
 
         // this is needed to remove duplicated // commentsAsText
-        $stmt->setDocComment(new Doc($phpDoc));
+        $node->setDocComment(new Doc($phpDoc));
     }
 
     public function updateRefactoredNodeWithPhpDocInfo(Node $node): void

--- a/packages/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/packages/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -19,10 +19,10 @@ final class DocBlockUpdater
     ) {
     }
 
-    public function updateNodeWithPhpDocInfo(Stmt $node): void
+    public function updateNodeWithPhpDocInfo(Stmt $stmt): void
     {
         // nothing to change? don't save it
-        $phpDocInfo = $this->resolveChangedPhpDocInfo($node);
+        $phpDocInfo = $this->resolveChangedPhpDocInfo($stmt);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return;
         }
@@ -31,13 +31,13 @@ final class DocBlockUpdater
 
         // make sure, that many separated comments are not removed
         if ($phpDoc === '') {
-            $this->setCommentsAttribute($node);
+            $this->setCommentsAttribute($stmt);
 
             return;
         }
 
         // this is needed to remove duplicated // commentsAsText
-        $node->setDocComment(new Doc($phpDoc));
+        $stmt->setDocComment(new Doc($phpDoc));
     }
 
     public function updateRefactoredNodeWithPhpDocInfo(Node $node): void

--- a/packages/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/packages/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -7,7 +7,6 @@ namespace Rector\Comments\NodeDocBlock;
 use PhpParser\Comment;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
 use Rector\NodeTypeResolver\Node\AttributeKey;

--- a/packages/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/packages/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -7,6 +7,7 @@ namespace Rector\Comments\NodeDocBlock;
 use PhpParser\Comment;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -18,7 +19,7 @@ final class DocBlockUpdater
     ) {
     }
 
-    public function updateNodeWithPhpDocInfo(Node $node): void
+    public function updateNodeWithPhpDocInfo(Stmt $node): void
     {
         // nothing to change? don't save it
         $phpDocInfo = $this->resolveChangedPhpDocInfo($node);

--- a/packages/PostRector/Rector/NodeAddingPostRector.php
+++ b/packages/PostRector/Rector/NodeAddingPostRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\PostRector\Rector;
 
 use PhpParser\Node;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Collector\NodesToAddCollector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;

--- a/packages/PostRector/Rector/NodeAddingPostRector.php
+++ b/packages/PostRector/Rector/NodeAddingPostRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\PostRector\Rector;
 
 use PhpParser\Node;
-use Rector\Core\NodeDecorator\MixPhpHtmlDecorator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Collector\NodesToAddCollector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -25,8 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class NodeAddingPostRector extends AbstractPostRector
 {
     public function __construct(
-        private readonly NodesToAddCollector $nodesToAddCollector,
-        private readonly MixPhpHtmlDecorator $mixPhpHtmlDecorator
+        private readonly NodesToAddCollector $nodesToAddCollector
     ) {
     }
 
@@ -46,17 +44,12 @@ final class NodeAddingPostRector extends AbstractPostRector
         if ($nodesToAddAfter !== []) {
             $this->nodesToAddCollector->clearNodesToAddAfter($node);
             $newNodes = array_merge($newNodes, $nodesToAddAfter);
-
-            $this->mixPhpHtmlDecorator->decorateAfter($node, [$node, ...$nodesToAddAfter]);
         }
 
         $nodesToAddBefore = $this->nodesToAddCollector->getNodesToAddBeforeNode($node);
         if ($nodesToAddBefore !== []) {
             $this->nodesToAddCollector->clearNodesToAddBefore($node);
             $newNodes = array_merge($nodesToAddBefore, $newNodes);
-
-            $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
-            $this->mixPhpHtmlDecorator->decorateBefore($node, $previousNode);
         }
 
         if ($newNodes === [$node]) {

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -51,10 +51,10 @@ final class MixPhpHtmlDecorator
     /**
      * @param array<Node|null> $nodes
      */
-    public function decorateAfterNop(Nop $node, array $nodes): void
+    public function decorateAfterNop(Nop $nop, array $nodes): void
     {
         $currentNode = current($nodes);
-        if ($currentNode !== $node) {
+        if ($currentNode !== $nop) {
             return;
         }
 
@@ -73,7 +73,7 @@ final class MixPhpHtmlDecorator
 
         // Token start = -1, just added
         $nodeComments = [];
-        foreach ($node->getComments() as $comment) {
+        foreach ($nop->getComments() as $comment) {
             if ($comment instanceof Doc) {
                 $nodeComments[] = new Comment(
                     $comment->getText(),
@@ -93,7 +93,7 @@ final class MixPhpHtmlDecorator
         $firstNodeAfterNop->setAttribute(AttributeKey::COMMENTS, $nodeComments);
 
         // remove Nop is marked  as comment of Next Node
-        $this->nodeRemover->removeNode($node);
+        $this->nodeRemover->removeNode($nop);
     }
 
     private function rePrintInlineHTML(InlineHTML $inlineHTML, Stmt $stmt): void

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -44,28 +44,24 @@ final class MixPhpHtmlDecorator
     }
 
     /**
-     * @param Node[] $nodes
+     * @param Stmt[] $stmts
      */
-    public function decorateAfterNop(Node $node, int $key, array $nodes): void
+    public function decorateAfterNop(Node $node, int $key, array $stmts): void
     {
         if (! $node instanceof Nop) {
             return;
         }
 
-        $currentNode = current($nodes);
+        $currentNode = current($stmts);
         if ($currentNode !== $node) {
             return;
         }
 
-        if (! isset($nodes[$key + 1]) || $nodes[$key + 1] instanceof InlineHTML) {
+        if (! isset($stmts[$key + 1]) || $stmts[$key + 1] instanceof InlineHTML) {
             return;
         }
 
-        $firstNodeAfterNop = $nodes[$key + 1];
-        if (! $firstNodeAfterNop instanceof Stmt) {
-            return;
-        }
-
+        $firstNodeAfterNop = $stmts[$key + 1];
         if ($firstNodeAfterNop->getStartTokenPos() >= 0) {
             return;
         }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -25,44 +25,52 @@ final class MixPhpHtmlDecorator
     }
 
     /**
-     * @param Stmt[] $stmts
+     * @param array<Node|null> $nodes
      */
-    public function decorateInlineHTML(InlineHTML $inlineHTML, int $key, array $stmts): void
+    public function decorateInlineHTML(InlineHTML $inlineHTML, int $key, array $nodes): void
     {
-        if (isset($stmts[$key - 1]) && ! $stmts[$key - 1] instanceof InlineHTML) {
-            $this->rePrintInlineHTML($inlineHTML, $stmts[$key - 1]);
+        if (isset($nodes[$key - 1]) && ! $nodes[$key - 1] instanceof InlineHTML && $nodes[$key - 1] instanceof Stmt) {
+            $this->rePrintInlineHTML($inlineHTML, $nodes[$key - 1]);
         }
 
-        if (! isset($stmts[$key + 1])) {
+        if (! isset($nodes[$key + 1])) {
             return;
         }
 
-        if ($stmts[$key + 1] instanceof InlineHTML) {
+        if ($nodes[$key + 1] instanceof InlineHTML) {
             return;
         }
 
-        $this->rePrintInlineHTML($inlineHTML, $stmts[$key + 1]);
+        if (! $nodes[$key + 1] instanceof Stmt) {
+            return;
+        }
+
+        $this->rePrintInlineHTML($inlineHTML, $nodes[$key + 1]);
     }
 
     /**
-     * @param Stmt[] $stmts
+     * @param array<Node|null> $nodes
      */
-    public function decorateAfterNop(Node $node, int $key, array $stmts): void
+    public function decorateAfterNop(Node $node, int $key, array $nodes): void
     {
         if (! $node instanceof Nop) {
             return;
         }
 
-        $currentNode = current($stmts);
+        $currentNode = current($nodes);
         if ($currentNode !== $node) {
             return;
         }
 
-        if (! isset($stmts[$key + 1]) || $stmts[$key + 1] instanceof InlineHTML) {
+        if (! isset($nodes[$key + 1]) || $nodes[$key + 1] instanceof InlineHTML) {
             return;
         }
 
-        $firstNodeAfterNop = $stmts[$key + 1];
+        if (! $nodes[$key + 1] instanceof Stmt) {
+            return;
+        }
+
+        $firstNodeAfterNop = $nodes[$key + 1];
         if ($firstNodeAfterNop->getStartTokenPos() >= 0) {
             return;
         }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -32,12 +32,15 @@ final class MixPhpHtmlDecorator
         if (isset($stmts[$key - 1]) && ! $stmts[$key - 1] instanceof InlineHTML) {
             $this->rePrintInlineHTML($inlineHTML, $stmts[$key - 1]);
         }
+
         if (! isset($stmts[$key + 1])) {
             return;
         }
+
         if ($stmts[$key + 1] instanceof InlineHTML) {
             return;
         }
+
         $this->rePrintInlineHTML($inlineHTML, $stmts[$key + 1]);
     }
 

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -35,17 +35,19 @@ final class MixPhpHtmlDecorator
     public function decorateInlineHTML(InlineHTML $inlineHTML, int $key, array $stmts): void
     {
         if (isset($stmts[$key - 1]) && ! $stmts[$key - 1] instanceof InlineHTML) {
-            $stmt = $stmts[$key - 1];
-            if ($stmt->getStartTokenPos() <= 0) {
-                $inlineHTML->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            }
+            $this->rePrintInlineHTML($inlineHTML, $stmts[$key - 1]);
         }
 
         if (isset($stmts[$key + 1]) && ! $stmts[$key + 1] instanceof InlineHTML) {
-            $stmt = $stmts[$key + 1];
-            if ($stmt->getStartTokenPos() <= 0) {
-                $inlineHTML->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            }
+            $this->rePrintInlineHTML($inlineHTML, $stmts[$key + 1]);
+        }
+    }
+
+    private function rePrintInlineHTML(InlineHTML $inlineHTML, Stmt $stmt): void
+    {
+        // Token start = -1, just added
+        if ($stmt->getStartTokenPos() <= 0) {
+            $inlineHTML->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }
     }
 
@@ -76,6 +78,7 @@ final class MixPhpHtmlDecorator
             return;
         }
 
+        // Token start = -1, just added
         $nodeComments = [];
         foreach ($node->getComments() as $comment) {
             if ($comment instanceof Doc) {

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -22,13 +22,12 @@ use Symfony\Contracts\Service\Attribute\Required;
 final class MixPhpHtmlDecorator
 {
     private NodeRemover $nodeRemover;
+
     private NodeComparator $nodeComparator;
 
     #[Required]
-    public function autowire(
-        NodeRemover $nodeRemover,
-        NodeComparator $nodeComparator
-    ): void {
+    public function autowire(NodeRemover $nodeRemover, NodeComparator $nodeComparator): void
+    {
         $this->nodeRemover = $nodeRemover;
         $this->nodeComparator = $nodeComparator;
     }
@@ -62,11 +61,11 @@ final class MixPhpHtmlDecorator
             return;
         }
 
-        if (! isset($nodes[$key+1])) {
+        if (! isset($nodes[$key + 1])) {
             return;
         }
 
-        $firstNodeAfterNode = $nodes[$key+1];
+        $firstNodeAfterNode = $nodes[$key + 1];
         if (! $firstNodeAfterNode instanceof Stmt || $firstNodeAfterNode instanceof InlineHTML) {
             return;
         }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -61,21 +61,21 @@ final class MixPhpHtmlDecorator
             return;
         }
 
-        if (! isset($nodes[$key + 1])) {
+        $currentNode = current($nodes);
+        if ($currentNode !== $node) {
             return;
         }
 
-        $firstNodeAfterNode = $nodes[$key + 1];
-        if (! $firstNodeAfterNode instanceof Stmt || $firstNodeAfterNode instanceof InlineHTML) {
+        if (! isset($nodes[$key + 1]) || $nodes[$key + 1] instanceof InlineHTML) {
             return;
         }
 
-        $stmt = $this->resolveAppendAfterNode($node, $nodes);
-        if (! $stmt instanceof Node) {
+        $firstNodeAfterNop = $nodes[$key + 1];
+        if (! $firstNodeAfterNop instanceof Stmt) {
             return;
         }
 
-        if ($stmt instanceof InlineHTML) {
+        if ($firstNodeAfterNop->getStartTokenPos() >= 0) {
             return;
         }
 
@@ -97,9 +97,7 @@ final class MixPhpHtmlDecorator
             $nodeComments[] = $comment;
         }
 
-        $stmt->setAttribute(AttributeKey::COMMENTS, $nodeComments);
-
-        $firstNodeAfterNode->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        $firstNodeAfterNop->setAttribute(AttributeKey::COMMENTS, $nodeComments);
 
         // remove Nop is marked  as comment of Next Node
         $this->nodeRemover->removeNode($node);

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -95,7 +95,7 @@ final class MixPhpHtmlDecorator
     private function rePrintInlineHTML(InlineHTML $inlineHTML, Stmt $stmt): void
     {
         // Token start = -1, just added
-        if ($stmt->getStartTokenPos() <= 0) {
+        if ($stmt->getStartTokenPos() < 0) {
             $inlineHTML->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }
     }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -14,10 +14,6 @@ use Rector\NodeRemoval\NodeRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symfony\Contracts\Service\Attribute\Required;
 
-/**
- * Mix PHP+HTML decorator, which require reprint the InlineHTML
- * which is the safe way to make next/prev Node has open and close php tag
- */
 final class MixPhpHtmlDecorator
 {
     private NodeRemover $nodeRemover;

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -43,14 +43,6 @@ final class MixPhpHtmlDecorator
         }
     }
 
-    private function rePrintInlineHTML(InlineHTML $inlineHTML, Stmt $stmt): void
-    {
-        // Token start = -1, just added
-        if ($stmt->getStartTokenPos() <= 0) {
-            $inlineHTML->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-        }
-    }
-
     /**
      * @param Node[] $nodes
      */
@@ -101,5 +93,13 @@ final class MixPhpHtmlDecorator
 
         // remove Nop is marked  as comment of Next Node
         $this->nodeRemover->removeNode($node);
+    }
+
+    private function rePrintInlineHTML(InlineHTML $inlineHTML, Stmt $stmt): void
+    {
+        // Token start = -1, just added
+        if ($stmt->getStartTokenPos() <= 0) {
+            $inlineHTML->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        }
     }
 }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -37,10 +37,13 @@ final class MixPhpHtmlDecorator
         if (isset($stmts[$key - 1]) && ! $stmts[$key - 1] instanceof InlineHTML) {
             $this->rePrintInlineHTML($inlineHTML, $stmts[$key - 1]);
         }
-
-        if (isset($stmts[$key + 1]) && ! $stmts[$key + 1] instanceof InlineHTML) {
-            $this->rePrintInlineHTML($inlineHTML, $stmts[$key + 1]);
+        if (! isset($stmts[$key + 1])) {
+            return;
         }
+        if ($stmts[$key + 1] instanceof InlineHTML) {
+            return;
+        }
+        $this->rePrintInlineHTML($inlineHTML, $stmts[$key + 1]);
     }
 
     /**

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -53,11 +53,6 @@ final class MixPhpHtmlDecorator
      */
     public function decorateAfterNop(Nop $nop, array $nodes): void
     {
-        $currentNode = current($nodes);
-        if ($currentNode !== $nop) {
-            return;
-        }
-
         if (! isset($nodes[1]) || $nodes[1] instanceof InlineHTML) {
             return;
         }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -51,26 +51,22 @@ final class MixPhpHtmlDecorator
     /**
      * @param array<Node|null> $nodes
      */
-    public function decorateAfterNop(Node $node, int $key, array $nodes): void
+    public function decorateAfterNop(Nop $node, array $nodes): void
     {
-        if (! $node instanceof Nop) {
-            return;
-        }
-
         $currentNode = current($nodes);
         if ($currentNode !== $node) {
             return;
         }
 
-        if (! isset($nodes[$key + 1]) || $nodes[$key + 1] instanceof InlineHTML) {
+        if (! isset($nodes[1]) || $nodes[1] instanceof InlineHTML) {
             return;
         }
 
-        if (! $nodes[$key + 1] instanceof Stmt) {
+        if (! $nodes[1] instanceof Stmt) {
             return;
         }
 
-        $firstNodeAfterNop = $nodes[$key + 1];
+        $firstNodeAfterNop = $nodes[1];
         if ($firstNodeAfterNop->getStartTokenPos() >= 0) {
             return;
         }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -23,19 +23,16 @@ final class MixPhpHtmlDecorator
 {
     private NodeRemover $nodeRemover;
 
-    private NodeComparator $nodeComparator;
-
     #[Required]
     public function autowire(NodeRemover $nodeRemover, NodeComparator $nodeComparator): void
     {
         $this->nodeRemover = $nodeRemover;
-        $this->nodeComparator = $nodeComparator;
     }
 
     /**
      * @param Stmt[] $stmts
      */
-    public function decorateInlineHTML(InlineHTML $inlineHTML, int $key, array $stmts)
+    public function decorateInlineHTML(InlineHTML $inlineHTML, int $key, array $stmts): void
     {
         if (isset($stmts[$key - 1]) && ! $stmts[$key - 1] instanceof InlineHTML) {
             $stmt = $stmts[$key - 1];
@@ -101,25 +98,5 @@ final class MixPhpHtmlDecorator
 
         // remove Nop is marked  as comment of Next Node
         $this->nodeRemover->removeNode($node);
-    }
-
-    /**
-     * @param Node[] $nodes
-     */
-    private function resolveAppendAfterNode(Nop $nop, array $nodes): ?Node
-    {
-        foreach ($nodes as $key => $subNode) {
-            if (! $this->nodeComparator->areSameNode($subNode, $nop)) {
-                continue;
-            }
-
-            if (! isset($nodes[$key + 1])) {
-                continue;
-            }
-
-            return $nodes[$key + 1];
-        }
-
-        return null;
     }
 }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -10,7 +10,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
-use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\NodeRemoval\NodeRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -24,7 +23,7 @@ final class MixPhpHtmlDecorator
     private NodeRemover $nodeRemover;
 
     #[Required]
-    public function autowire(NodeRemover $nodeRemover, NodeComparator $nodeComparator): void
+    public function autowire(NodeRemover $nodeRemover): void
     {
         $this->nodeRemover = $nodeRemover;
     }

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -21,7 +21,6 @@ use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\EncapsedStringPart;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Declare_;
@@ -610,12 +609,10 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             }
 
             if ($node instanceof InlineHTML && $hasDiff) {
-                /** @var Stmt[] $nodes */
                 $this->mixPhpHtmlDecorator->decorateInlineHTML($node, $key, $nodes);
             }
 
             if ($node instanceof Nop && $hasDiff) {
-                /** @var Stmt[] $nodes */
                 $this->mixPhpHtmlDecorator->decorateAfterNop($node, $key, $nodes);
             }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -612,8 +612,8 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
                 $this->mixPhpHtmlDecorator->decorateInlineHTML($node, $key, $nodes);
             }
 
-            if ($node instanceof Nop && $hasDiff) {
-                $this->mixPhpHtmlDecorator->decorateAfterNop($node, $key, $nodes);
+            if ($node instanceof Nop && $key === 0 && $hasDiff) {
+                $this->mixPhpHtmlDecorator->decorateAfterNop($node, $nodes);
             }
 
             $this->docBlockUpdater->updateNodeWithPhpDocInfo($node);

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -605,12 +605,8 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
 
         // move phpdoc from node to "comment" attribute
         foreach ($nodes as $key => $node) {
-            if (! $node instanceof Stmt) {
-                /**
-                 * Collection not Stmt don't need PhpDocInfo or InlineHTML check
-                 * to improve performance
-                 */
-                return;
+            if (! $node instanceof Node) {
+                continue;
             }
 
             if ($node instanceof InlineHTML && $hasDiff) {

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -142,7 +142,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         /** @var Node $firstStmt */
         $isFirstStmtReprinted = $firstStmt->getAttribute(AttributeKey::ORIGINAL_NODE) === null;
         if (! $isFirstStmtReprinted) {
-            return $content;
+            return $this->cleanSurplusTag($content);
         }
 
         if (! $firstStmt instanceof InlineHTML) {

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -614,10 +614,12 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             }
 
             if ($node instanceof InlineHTML && $hasDiff) {
+                /** @var Stmt[] $nodes */
                 $this->mixPhpHtmlDecorator->decorateInlineHTML($node, $key, $nodes);
             }
 
             if ($node instanceof Nop && $hasDiff) {
+                /** @var Stmt[] $nodes */
                 $this->mixPhpHtmlDecorator->decorateAfterNop($node, $key, $nodes);
             }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -258,7 +258,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         // reindex positions for printer
         $nodes = array_values($nodes);
 
-        $this->decorateInlineHTMLAndUpdatePhpdocInfo($nodes);
+        $this->decorateInlineHTMLOrNopAndUpdatePhpdocInfo($nodes);
 
         $content = parent::pArray($nodes, $origNodes, $pos, $indentAdjustment, $parentNodeType, $subNodeName, $fixup);
 
@@ -386,7 +386,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
      */
     protected function pStmts(array $nodes, bool $indent = true): string
     {
-        $this->decorateInlineHTMLAndUpdatePhpdocInfo($nodes);
+        $this->decorateInlineHTMLOrNopAndUpdatePhpdocInfo($nodes);
 
         return parent::pStmts($nodes, $indent);
     }
@@ -598,7 +598,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
     /**
      * @param array<Node|null> $nodes
      */
-    private function decorateInlineHTMLAndUpdatePhpdocInfo(array $nodes): void
+    private function decorateInlineHTMLOrNopAndUpdatePhpdocInfo(array $nodes): void
     {
         $file = $this->currentFileProvider->getFile();
         $hasDiff = $file instanceof File && $file->getFileDiff() instanceof FileDiff;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -319,7 +319,7 @@ CODE_SAMPLE;
             return;
         }
 
-        if ($newNode->getStartTokenPos() < 0 && $oldNode instanceof InlineHTML) {
+        if ($oldNode instanceof InlineHTML) {
             return;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -28,10 +28,8 @@ use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\FileSystem\FilePathHelper;
 use Rector\Core\Logging\CurrentRectorProvider;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
-use Rector\Core\NodeDecorator\MixPhpHtmlDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\ProcessAnalyzer\RectifiedAnalyzer;
@@ -117,8 +115,6 @@ CODE_SAMPLE;
 
     private DocBlockUpdater $docBlockUpdater;
 
-    private MixPhpHtmlDecorator $mixPhpHtmlDecorator;
-
     #[Required]
     public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
@@ -141,8 +137,7 @@ CODE_SAMPLE;
         ChangedNodeScopeRefresher $changedNodeScopeRefresher,
         RectorOutputStyle $rectorOutputStyle,
         FilePathHelper $filePathHelper,
-        DocBlockUpdater $docBlockUpdater,
-        MixPhpHtmlDecorator $mixPhpHtmlDecorator
+        DocBlockUpdater $docBlockUpdater
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
         $this->nodeRemover = $nodeRemover;
@@ -165,7 +160,6 @@ CODE_SAMPLE;
         $this->rectorOutputStyle = $rectorOutputStyle;
         $this->filePathHelper = $filePathHelper;
         $this->docBlockUpdater = $docBlockUpdater;
-        $this->mixPhpHtmlDecorator = $mixPhpHtmlDecorator;
     }
 
     /**
@@ -428,8 +422,6 @@ CODE_SAMPLE;
             /** @var Node $previousNode */
             $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
 
-            $this->mixPhpHtmlDecorator->decorateBefore($node, $previousNode);
-
             $nodes = [$previousNode, ...$nodes];
         }
 
@@ -440,15 +432,7 @@ CODE_SAMPLE;
             /** @var Node $nextNode */
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
 
-            $this->mixPhpHtmlDecorator->decorateAfter($node, $nodes);
-
             $nodes = [...$nodes, $nextNode];
-        }
-
-        if (count($nodes) > 1) {
-            $this->mixPhpHtmlDecorator->decorateNextNodesInlineHTML($nodes);
-        } elseif ($firstNode instanceof FileWithoutNamespace) {
-            $this->mixPhpHtmlDecorator->decorateNextNodesInlineHTML($firstNode->stmts);
         }
 
         $nodeTraverser = new NodeTraverser();

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
@@ -318,7 +319,7 @@ CODE_SAMPLE;
             return;
         }
 
-        if ($newNode->getStartTokenPos() < 0) {
+        if ($newNode->getStartTokenPos() < 0 && $oldNode instanceof InlineHTML) {
             return;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -318,6 +318,10 @@ CODE_SAMPLE;
             return;
         }
 
+        if ($newNode->getStartTokenPos() < 0) {
+            return;
+        }
+
         $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO));
         if (! $newNode instanceof Nop) {
             $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));

--- a/tests/Issues/AddNodeAfterNodeStmt/Fixture/next_html.php.inc
+++ b/tests/Issues/AddNodeAfterNodeStmt/Fixture/next_html.php.inc
@@ -5,6 +5,7 @@ if ($a === 1) {
 <div>some text</div>
 -----
 <?php
+
 if ($a === 1) {
 }
 echo 'this is new stmt after if';

--- a/tests/Issues/AddNodeBeforeNodeStmt/FixtureBeforeInlineHTML/fixture.php.inc
+++ b/tests/Issues/AddNodeBeforeNodeStmt/FixtureBeforeInlineHTML/fixture.php.inc
@@ -2,7 +2,13 @@
 -----
 <?php
 
+/**
+ * @var string $container
+ */
 $test = 'test';
+/**
+ * @var string $container
+ */
 $test2 = 'test2';
 ?>
 <div></div>

--- a/tests/Issues/AddNodeBeforeNodeStmt/FixtureBeforeInlineHTML/fixture2.php.inc
+++ b/tests/Issues/AddNodeBeforeNodeStmt/FixtureBeforeInlineHTML/fixture2.php.inc
@@ -2,7 +2,13 @@
 -----
 <?php
 
+/**
+ * @var string $container
+ */
 $test = 'test';
+/**
+ * @var string $container
+ */
 $test2 = 'test2';
 ?>
 <div><?php 

--- a/tests/Issues/AddNodeBeforeNodeStmt/Source/AddBeforeInlineHTMLRector.php
+++ b/tests/Issues/AddNodeBeforeNodeStmt/Source/AddBeforeInlineHTMLRector.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PostRector\Collector\NodesToAddCollector;
@@ -45,20 +47,43 @@ class AddBeforeInlineHTMLRector extends AbstractRector
 
         $firstStmt = current($node->stmts);
 
+        $expression1 = new Expression(
+            new Assign(
+                new Variable('test'), new String_('test')
+            )
+        );
+
+        $phpDocInfo = $this->phpDocInfoFactory->createEmpty($expression1);
+        $phpDocInfo->addTagValueNode(
+            new VarTagValueNode(
+                new IdentifierTypeNode('string'),
+                '$container',
+                ''
+            )
+        );
+
         $this->nodesToAddCollector->addNodeBeforeNode(
-            new Expression(
-                new Assign(
-                    new Variable('test'), new String_('test')
-                )
-            ),
+            $expression1,
             $firstStmt
         );
+
+        $expression2 = new Expression(
+            new Assign(
+                new Variable('test2'), new String_('test2')
+            )
+        );
+
+        $phpDocInfo = $this->phpDocInfoFactory->createEmpty($expression2);
+        $phpDocInfo->addTagValueNode(
+            new VarTagValueNode(
+                new IdentifierTypeNode('string'),
+                '$container',
+                ''
+            )
+        );
+
         $this->nodesToAddCollector->addNodeBeforeNode(
-            new Expression(
-                new Assign(
-                    new Variable('test2'), new String_('test2')
-                )
-            ),
+            $expression2,
             $firstStmt
         );
 

--- a/tests/Issues/InsertLastAfterInlineHTML/Fixture/fixture.php.inc
+++ b/tests/Issues/InsertLastAfterInlineHTML/Fixture/fixture.php.inc
@@ -1,0 +1,8 @@
+<div><?php echo $this->filter ;?></div>
+-----
+<div><?php 
+echo $this->filter ;
+?></div>
+<?php 
+echo 'this is new stmt after InlineHTML';
+echo 'this is new stmt after InlineHTML';

--- a/tests/Issues/InsertLastAfterInlineHTML/InsertLastAfterInlineHTMLTest.php
+++ b/tests/Issues/InsertLastAfterInlineHTML/InsertLastAfterInlineHTMLTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\InsertLastAfterInlineHTML;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class InsertLastAfterInlineHTMLTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/InsertLastAfterInlineHTML/Source/InsertAfterInlineHTMLRector.php
+++ b/tests/Issues/InsertLastAfterInlineHTML/Source/InsertAfterInlineHTMLRector.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\InsertLastAfterInlineHTML\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Echo_;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class InsertAfterInlineHTMLRector extends AbstractRector
+{
+    private array $justAdded = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('uff', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            FileWithoutNamespace::class,
+        ];
+    }
+
+    public function refactor(Node $node)
+    {
+        if (isset($this->justAdded[$this->file->getFilePath()])) {
+            return null;
+        }
+
+        $echo = new Echo_([new String_('this is new stmt after InlineHTML')]);
+
+        $node->stmts = array_merge(
+            $node->stmts,
+            [$echo, $echo],
+        );
+
+        $this->justAdded[$this->file->getFilePath()] = true;
+
+        return $node;
+    }
+}

--- a/tests/Issues/InsertLastAfterInlineHTML/config/configured_rule.php
+++ b/tests/Issues/InsertLastAfterInlineHTML/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\Tests\Issues\InsertLastAfterInlineHTML\Source\InsertAfterInlineHTMLRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(InsertAfterInlineHTMLRector::class);
+};

--- a/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/FixtureArrayAfterInlineHTML/fixture.php.inc
+++ b/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/FixtureArrayAfterInlineHTML/fixture.php.inc
@@ -1,0 +1,8 @@
+<div>some content</div>
+-----
+<div>some content</div>
+<?php 
+/**
+ * @var string $container
+ */
+echo 'this is new stmt after InlineHTML';

--- a/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/ReturnArrayNodeAfterInlineHTMLStmtTest.php
+++ b/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/ReturnArrayNodeAfterInlineHTMLStmtTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ReturnArrayNodeAfterInlineHTMLStmt;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReturnArrayNodeAfterInlineHTMLStmtTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureArrayAfterInlineHTML');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/Source/ArrayAddAfterInlineHTMLRector.php
+++ b/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/Source/ArrayAddAfterInlineHTMLRector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ReturnArrayNodeAfterInlineHTMLStmt\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Echo_;
+use PhpParser\Node\Stmt\InlineHTML;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\Core\Rector\AbstractRector;
+use Rector\PostRector\Collector\NodesToAddCollector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ArrayAddAfterInlineHTMLRector extends AbstractRector
+{
+    private array $justAdded = [];
+
+    public function __construct(private readonly NodesToAddCollector $nodesToAddCollector)
+    {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('uff', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            InlineHTML::class,
+        ];
+    }
+
+    public function refactor(Node $node)
+    {
+        if (isset($this->justAdded[$this->file->getFilePath()])) {
+            return null;
+        }
+
+        $echo = new Echo_([new String_("this is new stmt after InlineHTML")]);
+
+        $phpDocInfo = $this->phpDocInfoFactory->createEmpty($echo);
+        $phpDocInfo->addTagValueNode(
+            new VarTagValueNode(
+                new IdentifierTypeNode('string'),
+                '$container',
+                ''
+            )
+        );
+
+        $this->justAdded[$this->file->getFilePath()] = true;
+
+        return [
+            $node,
+            $echo,
+        ];
+    }
+}

--- a/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/config/configured_rule.php
+++ b/tests/Issues/ReturnArrayNodeAfterInlineHTMLStmt/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\Tests\Issues\ReturnArrayNodeAfterInlineHTMLStmt\Source\ArrayAddAfterInlineHTMLRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ArrayAddAfterInlineHTMLRector::class);
+};

--- a/tests/Issues/ReturnArrayNodeBeforeInlineHTMLStmt/FixtureArrayBeforeInlineHTML/fixture.php.inc
+++ b/tests/Issues/ReturnArrayNodeBeforeInlineHTMLStmt/FixtureArrayBeforeInlineHTML/fixture.php.inc
@@ -2,7 +2,13 @@
 -----
 <?php
 
+/**
+ * @var string $container
+ */
 echo 'this is new stmt before InlineHTML';
+/**
+ * @var string $container
+ */
 echo 'this is new stmt before InlineHTML';
 ?>
 <div><?php 

--- a/tests/Issues/ReturnArrayNodeBeforeInlineHTMLStmt/FixtureArrayBeforeInlineHTML/next_line_php_in_inline_html.php.inc
+++ b/tests/Issues/ReturnArrayNodeBeforeInlineHTMLStmt/FixtureArrayBeforeInlineHTML/next_line_php_in_inline_html.php.inc
@@ -5,6 +5,7 @@ echo $this->filter ;
 ?></div>
 -----
 <?php
+
 /**
  * @var string $container
  */

--- a/tests/Issues/ReturnArrayNodeBeforeInlineHTMLStmt/FixtureArrayBeforeInlineHTML/next_line_php_in_inline_html.php.inc
+++ b/tests/Issues/ReturnArrayNodeBeforeInlineHTMLStmt/FixtureArrayBeforeInlineHTML/next_line_php_in_inline_html.php.inc
@@ -5,8 +5,13 @@ echo $this->filter ;
 ?></div>
 -----
 <?php
-
+/**
+ * @var string $container
+ */
 echo 'this is new stmt before InlineHTML';
+/**
+ * @var string $container
+ */
 echo 'this is new stmt before InlineHTML';
 ?>
 <div><?php 


### PR DESCRIPTION
@TomasVotruba @staabm previously, I handle mix php+html in various locations:

- packages/PostRector/Rector/NodeAddingPostRector.php
- src/Rector/AbstractRector.php

which need back and forth in case of change in the future. 

This PR move it to centralize handling in `BetterStandPrinter`, with utilize simplified `MixPhpHtmlDecorator`.