### PR TITLE
Add AddAllowDynamicPropertiesAttribute to php82 set

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -6647,6 +6647,8 @@ Change deprecated utf8_decode and utf8_encode to mb_convert_encoding
 +mb_convert_encoding($value, 'ISO-8859-1');
 +mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
 ```
+### AllowDynamicPropertiesAttributeRector
+[Rule description](#AddAllowDynamicPropertiesAttributeRector)
 
 <br>
 

--- a/config/set/php82.php
+++ b/config/set/php82.php
@@ -6,11 +6,13 @@ use Rector\Config\RectorConfig;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\Php82\Rector\FuncCall\Utf8DecodeEncodeToMbConvertEncodingRector;
 use Rector\Php82\Rector\New_\FilesystemIteratorSkipDotsRector;
+use Rector\Transform\Rector\Class_\AddAllowDynamicPropertiesAttributeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         ReadOnlyClassRector::class,
         Utf8DecodeEncodeToMbConvertEncodingRector::class,
         FilesystemIteratorSkipDotsRector::class,
+        AddAllowDynamicPropertiesAttributeRector::class
     ]);
 };


### PR DESCRIPTION
This PR adds the AddAllowDynamicPropertiesAttribute to the PHP 8.2 set list as it is needed in lots of legacy applications for a php8.2 upgrade.
It might not be the sexiest solution as some projects might not need it and especially not all classes, but it is the least risky method I think.

I also added a link on the rules overview.