### PR TITLE
[Printer] Handle add Node after Nop not first stmt

### DIFF
--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -53,15 +53,15 @@ final class MixPhpHtmlDecorator
      */
     public function decorateAfterNop(Nop $nop, int $key, array $nodes): void
     {
-        if (! isset($nodes[$key+1]) || $nodes[$key+1] instanceof InlineHTML) {
+        if (! isset($nodes[$key + 1]) || $nodes[$key + 1] instanceof InlineHTML) {
             return;
         }
 
-        if (! $nodes[$key+1] instanceof Stmt) {
+        if (! $nodes[$key + 1] instanceof Stmt) {
             return;
         }
 
-        $firstNodeAfterNop = $nodes[$key+1];
+        $firstNodeAfterNop = $nodes[$key + 1];
         if ($firstNodeAfterNop->getStartTokenPos() >= 0) {
             return;
         }

--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -51,17 +51,17 @@ final class MixPhpHtmlDecorator
     /**
      * @param array<Node|null> $nodes
      */
-    public function decorateAfterNop(Nop $nop, array $nodes): void
+    public function decorateAfterNop(Nop $nop, int $key, array $nodes): void
     {
-        if (! isset($nodes[1]) || $nodes[1] instanceof InlineHTML) {
+        if (! isset($nodes[$key+1]) || $nodes[$key+1] instanceof InlineHTML) {
             return;
         }
 
-        if (! $nodes[1] instanceof Stmt) {
+        if (! $nodes[$key+1] instanceof Stmt) {
             return;
         }
 
-        $firstNodeAfterNop = $nodes[1];
+        $firstNodeAfterNop = $nodes[$key+1];
         if ($firstNodeAfterNop->getStartTokenPos() >= 0) {
             return;
         }

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -528,9 +528,9 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         return $content;
     }
 
-    private function cleanSurplusTag(Node $firstStmt, string $content): string
+    private function cleanSurplusTag(Node $node, string $content): string
     {
-        if (! $firstStmt instanceof InlineHTML) {
+        if (! $node instanceof InlineHTML) {
             return $content;
         }
 

--- a/tests/Issues/AddNodeAfterNodeStmt/FixtureNextNop/not_first_stmt.php.inc
+++ b/tests/Issues/AddNodeAfterNodeStmt/FixtureNextNop/not_first_stmt.php.inc
@@ -1,0 +1,14 @@
+<div></div>
+<?php
+/** @var Zend_View $this */
+?>
+<div></div>
+-----
+<div></div>
+<?php
+/** @var Zend_View $this */
+/**
+ * @var string $container
+ */
+echo 'this is new stmt after Nop';?>
+<div></div>


### PR DESCRIPTION
Given the following code:

```
<div></div>
<?php
/** @var Zend_View $this */
?>
<div></div>
```

Add Node after `Nop` currently got:

```diff
+?>
+
 /**
  * @var string $container
  */
-echo 'this is new stmt after Nop';?>
+echo 'this is new stmt after Nop';
+?>
```

which invalid as php tag closed too early. This PR try to fix it.