### PR TITLE
[Php70] Handle crash on IfToSpaceshipRector with enum case

### DIFF
--- a/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum.php.inc
+++ b/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\Fixture;
+
+enum Status {
+    case Foo;
+    case Bar;
+}
+
+final class Service {
+    public function status(int $param): Status {
+        /**
+         * These pass:
+         *
+         * - if ($param)
+         * - if (true)
+         */
+        if ($param === 1) {
+            return Status::Foo;
+        }
+
+        return Status::Bar;
+    }
+}

--- a/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum.php.inc
+++ b/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum.php.inc
@@ -2,13 +2,7 @@
 
 namespace Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\Fixture;
 
-/**
- * Use both Enum and usage in same file on purpose to reproduce the error
- */
-enum Status {
-    case Foo;
-    case Bar;
-}
+use Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\Source\Status;
 
 final class Service {
     public function status(int $param): Status {

--- a/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum.php.inc
+++ b/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum.php.inc
@@ -2,6 +2,9 @@
 
 namespace Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\Fixture;
 
+/**
+ * Use both Enum and usage in same file on purpose to reproduce the error
+ */
 enum Status {
     case Foo;
     case Bar;

--- a/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum2.php.inc
+++ b/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Fixture/skip_crash_with_enum2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\Fixture;
+
+/**
+ * Both Enum and class in same file on purpose for differentiate use case
+ */
+enum Status {
+    case Foo;
+    case Bar;
+}
+
+final class Service2 {
+    public function status(int $param): Status {
+        /**
+         * These pass:
+         *
+         * - if ($param)
+         * - if (true)
+         */
+        if ($param === 1) {
+            return Status::Foo;
+        }
+
+        return Status::Bar;
+    }
+}

--- a/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Source/Status.php
+++ b/rules-tests/Php70/Rector/If_/IfToSpaceshipRector/Source/Status.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\Source;
+
+enum Status {
+    case Foo;
+    case Bar;
+}

--- a/rules/Php70/Rector/If_/IfToSpaceshipRector.php
+++ b/rules/Php70/Rector/If_/IfToSpaceshipRector.php
@@ -203,7 +203,12 @@ CODE_SAMPLE
                 return;
             }
 
-            $this->onEqual = $this->valueResolver->getValue($onlyIfStmt->expr);
+            $value = $this->valueResolver->getValue($onlyIfStmt->expr);
+            if (is_object($value)) {
+                return;
+            }
+
+            $this->onEqual = $value;
         }
     }
 

--- a/rules/Php70/Rector/If_/IfToSpaceshipRector.php
+++ b/rules/Php70/Rector/If_/IfToSpaceshipRector.php
@@ -203,6 +203,7 @@ CODE_SAMPLE
                 return;
             }
 
+            // on Enum usage on same file, it got object
             $value = $this->valueResolver->getValue($onlyIfStmt->expr);
             if (is_object($value)) {
                 return;

--- a/rules/Php70/Rector/If_/IfToSpaceshipRector.php
+++ b/rules/Php70/Rector/If_/IfToSpaceshipRector.php
@@ -203,7 +203,7 @@ CODE_SAMPLE
                 return;
             }
 
-            // on Enum usage on same file, it got object
+            // on Enum usage not in same file, it got object
             $value = $this->valueResolver->getValue($onlyIfStmt->expr);
             if (is_object($value)) {
                 return;

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -291,6 +291,12 @@ final class ValueResolver
         }
 
         $constantReflection = $classReflection->getConstant($constant);
+
+        if ($classReflection->isEnum()) {
+            // fallback to constant reference itself, to avoid fatal error
+            return $classConstantReference;
+        }
+
         $valueExpr = $constantReflection->getValueExpr();
 
         if ($valueExpr instanceof ConstFetch) {

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -291,6 +291,7 @@ final class ValueResolver
         }
 
         if ($classReflection->isEnum()) {
+            // fallback to constant reference itself, to avoid fatal error
             return $classConstantReference;
         }
 

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -292,12 +292,12 @@ final class ValueResolver
 
         $constantReflection = $classReflection->getConstant($constant);
 
-        if ($classReflection->isEnum()) {
+        try {
+            $valueExpr = $constantReflection->getValueExpr();
+        } catch (\LogicException) {
             // fallback to constant reference itself, to avoid fatal error
             return $classConstantReference;
         }
-
-        $valueExpr = $constantReflection->getValueExpr();
 
         if ($valueExpr instanceof ConstFetch) {
             return $this->resolveExprValueForConst($valueExpr);

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -290,14 +290,12 @@ final class ValueResolver
             return $classConstantReference;
         }
 
-        $constantReflection = $classReflection->getConstant($constant);
-
-        try {
-            $valueExpr = $constantReflection->getValueExpr();
-        } catch (\LogicException) {
-            // fallback to constant reference itself, to avoid fatal error
+        if ($classReflection->isEnum()) {
             return $classConstantReference;
         }
+
+        $constantReflection = $classReflection->getConstant($constant);
+        $valueExpr = $constantReflection->getValueExpr();
 
         if ($valueExpr instanceof ConstFetch) {
             return $this->resolveExprValueForConst($valueExpr);


### PR DESCRIPTION
Given the following code:

```php
enum Status {
    case Foo;
    case Bar;
}

final class Service {
    public function status(int $param): Status {
        /**
         * These pass:
         *
         * - if ($param)
         * - if (true)
         */
        if ($param === 1) {
            return Status::Foo;
        }

        return Status::Bar;
    }
}
```

It produce crash:

```bash
There was 1 error:

1) Rector\Tests\Php70\Rector\If_\IfToSpaceshipRector\IfToSpaceshipRectorTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc')
LogicException: This enum case does not have a value

phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionEnumCase.php:99
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/Adapter/ReflectionClassConstant.php:64
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ClassConstantReflection.php:78
/Users/samsonasik/www/rector-src/src/PhpParser/Node/Value/ValueResolver.php:300
/Users/samsonasik/www/rector-src/src/PhpParser/Node/Value/ValueResolver.php:191
```

This PR try to fix it. Fixes https://github.com/rectorphp/rector/issues/7737 Fixes https://github.com/rectorphp/rector/issues/7736