### PR TITLE
[TypeDeclaration] Consume ParentClassMethodTypeOverrideGuard from ClassMethodReturnTypeOverrideGuard::shouldSkipClassMethod()

### DIFF
--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -17,6 +17,7 @@ use Rector\Core\Reflection\ReflectionResolver;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 
 final class ClassMethodReturnTypeOverrideGuard
 {
@@ -34,7 +35,8 @@ final class ClassMethodReturnTypeOverrideGuard
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly AstResolver $astResolver,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly ReturnTypeInferer $returnTypeInferer
+        private readonly ReturnTypeInferer $returnTypeInferer,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
     ) {
     }
 
@@ -52,6 +54,10 @@ final class ClassMethodReturnTypeOverrideGuard
 
         $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
         if (! $classReflection instanceof ClassReflection) {
+            return true;
+        }
+
+        if (! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed($classMethod)) {
             return true;
         }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -19,7 +19,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\TypeDeclaration\ValueObject\TernaryIfElseTypes;
-use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -30,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnTypeFromStrictTernaryRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard
     ) {
     }
 
@@ -106,12 +106,11 @@ CODE_SAMPLE
                 continue;
             }
 
-            $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($ifType, TypeKind::RETURN);
-
-            if ($this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange($classMethod, $ifType)) {
+            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod)) {
                 continue;
             }
 
+            $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($ifType, TypeKind::RETURN);
             if (! $returnTypeNode instanceof Node) {
                 continue;
             }


### PR DESCRIPTION
@TomasVotruba this is the first step to merge  `ParentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed()` and `ClassMethodReturnTypeOverrideGuard->shouldSkipClassMethod()` as the method used in various location.