### PR TITLE
[TypeDeclaration] Replace ParentClassMethodTypeOverrideGuard::isReturnTypeChangeAllowed() with ClassMethodReturnTypeOverrideGuard::shouldSkipClassMethod()  in ReturnNeverTypeRector

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -20,7 +20,7 @@ use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeNestingScope\ValueObject\ControlStructure;
-use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -32,7 +32,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnNeverTypeRector extends AbstractRector
 {
     public function __construct(
-        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly PhpVersionProvider $phpVersionProvider,
     ) {
@@ -130,7 +130,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($node instanceof ClassMethod && ! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed(
+        if ($node instanceof ClassMethod && ! $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node
         )) {
             return true;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -130,7 +130,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($node instanceof ClassMethod && ! $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node
         )) {
             return true;


### PR DESCRIPTION
This is step 2, continue of PR:

-  https://github.com/rectorphp/rector-src/pull/3320

to replace usage `ParentClassMethodTypeOverrideGuard::isReturnTypeChangeAllowed()` with `ClassMethodReturnTypeOverrideGuard::shouldSkipClassMethod()`