### PR TITLE
[TypeDeclaration] Allow to change parent type when type is equal with child on ReturnTypeFromStrictTernaryRector

### DIFF
--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -111,7 +111,9 @@ final class ClassMethodReturnTypeOverrideGuard
     private function shouldSkipChildTyped(ClassMethod $classMethod, Type|Node $type): bool
     {
         if ($classMethod->returnType instanceof Node) {
-            if ($type instanceof Type && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
+            // Use ! operator as shouldSkipReturnTypeChange() is used originallly for changing type
+            // use here for re-use, that's why ! can be used
+            if ($type instanceof Type && ! $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
                 $classMethod,
                 $type
             )) {

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -38,7 +38,7 @@ final class ClassMethodReturnTypeOverrideGuard
     ) {
     }
 
-    public function shouldSkipClassMethod(ClassMethod $classMethod, Node $type): bool
+    public function shouldSkipClassMethod(ClassMethod $classMethod, Node $node): bool
     {
         // 1. skip magic methods
         if ($classMethod->isMagic()) {
@@ -68,7 +68,7 @@ final class ClassMethodReturnTypeOverrideGuard
             return true;
         }
 
-        return $this->shouldSkipHasChildHasReturnType($childrenClassReflections, $classMethod, $type);
+        return $this->shouldSkipHasChildHasReturnType($childrenClassReflections, $classMethod, $node);
     }
 
     /**
@@ -77,7 +77,7 @@ final class ClassMethodReturnTypeOverrideGuard
     private function shouldSkipHasChildHasReturnType(
         array $childrenClassReflections,
         ClassMethod $classMethod,
-        Node $type
+        Node $node
     ): bool {
         $returnType = $this->returnTypeInferer->inferFunctionLike($classMethod);
 
@@ -94,7 +94,7 @@ final class ClassMethodReturnTypeOverrideGuard
                 continue;
             }
 
-            if ($this->shouldSkipChildTyped($method, $type)) {
+            if ($this->shouldSkipChildTyped($method, $node)) {
                 return true;
             }
 
@@ -107,11 +107,11 @@ final class ClassMethodReturnTypeOverrideGuard
         return false;
     }
 
-    private function shouldSkipChildTyped(ClassMethod $classMethod, Node $type): bool
+    private function shouldSkipChildTyped(ClassMethod $classMethod, Node $node): bool
     {
         return $classMethod->returnType instanceof Node && ! $this->nodeComparator->areNodesEqual(
             $classMethod->returnType,
-            $type
+            $node
         );
     }
 

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -100,9 +100,7 @@ final class ClassMethodReturnTypeOverrideGuard
             }
 
             if ($method->returnType instanceof Node) {
-                return false;
-                return false;
-                return $this->nodeComparator->areNodesEqual($method->returnType, $returnTypeNode);
+                return ! $this->nodeComparator->areNodesEqual($method->returnType, $returnTypeNode);
             }
 
             $childReturnType = $this->returnTypeInferer->inferFunctionLike($method);

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Rector\VendorLocker\NodeVendorLocker;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Type;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -103,21 +103,30 @@ final class ClassMethodReturnTypeOverrideGuard
                 continue;
             }
 
-            if ($method->returnType instanceof Node) {
-                if ($type instanceof Type && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
-                    $method,
-                    $type
-                )) {
-                    return true;
-                }
-
-                if ($type instanceof Node && $this->nodeComparator->areNodesEqual($method->returnType, $type)) {
-                    return true;
-                }
+            if ($this->shouldSkipChildTyped($method, $type)) {
+                return true;
             }
 
             $childReturnType = $this->returnTypeInferer->inferFunctionLike($method);
             if ($returnType instanceof VoidType && ! $childReturnType instanceof VoidType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function shouldSkipChildTyped(ClassMethod $method, Type|Node $type): bool
+    {
+        if ($method->returnType instanceof Node) {
+            if ($type instanceof Type && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
+                $method,
+                $type
+            )) {
+                return true;
+            }
+
+            if ($type instanceof Node && $this->nodeComparator->areNodesEqual($method->returnType, $type)) {
                 return true;
             }
         }

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Type;
 use PHPStan\Type\VoidType;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
@@ -17,7 +18,6 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 
@@ -39,12 +39,11 @@ final class ClassMethodReturnTypeOverrideGuard
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ReturnTypeInferer $returnTypeInferer,
         private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
-        private readonly StaticTypeMapper $staticTypeMapper,
         private readonly NodeComparator $nodeComparator
     ) {
     }
 
-    public function shouldSkipClassMethod(ClassMethod $classMethod, \PHPStan\Type\Type|Node $type): bool
+    public function shouldSkipClassMethod(ClassMethod $classMethod, Type|Node $type): bool
     {
         // 1. skip magic methods
         if ($classMethod->isMagic()) {
@@ -87,7 +86,7 @@ final class ClassMethodReturnTypeOverrideGuard
     private function shouldSkipHasChildHasReturnType(
         array $childrenClassReflections,
         ClassMethod $classMethod,
-        \PHPStan\Type\Type|Node $type
+        Type|Node $type
     ): bool {
         $returnType = $this->returnTypeInferer->inferFunctionLike($classMethod);
 
@@ -105,7 +104,7 @@ final class ClassMethodReturnTypeOverrideGuard
             }
 
             if ($method->returnType instanceof Node) {
-                if ($type instanceof \PHPStan\Type\Type && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
+                if ($type instanceof Type && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
                     $method,
                     $type
                 )) {

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -82,8 +82,11 @@ final class ClassMethodReturnTypeOverrideGuard
     /**
      * @param ClassReflection[] $childrenClassReflections
      */
-    private function shouldSkipHasChildHasReturnType(array $childrenClassReflections, ClassMethod $classMethod, \PHPStan\Type\Type $type): bool
-    {
+    private function shouldSkipHasChildHasReturnType(
+        array $childrenClassReflections,
+        ClassMethod $classMethod,
+        \PHPStan\Type\Type $type
+    ): bool {
         $returnType = $this->returnTypeInferer->inferFunctionLike($classMethod);
 
         $methodName = $this->nodeNameResolver->getName($classMethod);
@@ -99,7 +102,10 @@ final class ClassMethodReturnTypeOverrideGuard
                 continue;
             }
 
-            if ($method->returnType instanceof Node && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange($method, $type)) {
+            if ($method->returnType instanceof Node && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
+                $method,
+                $type
+            )) {
                 return true;
             }
 

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -12,7 +12,6 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\VoidType;
 use Rector\Core\PhpParser\AstResolver;
-use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -39,7 +39,7 @@ final class ClassMethodReturnTypeOverrideGuard
     ) {
     }
 
-    public function shouldSkipClassMethod(ClassMethod $classMethod, Type|Node $type): bool
+    public function shouldSkipClassMethod(ClassMethod $classMethod, Node $type): bool
     {
         // 1. skip magic methods
         if ($classMethod->isMagic()) {
@@ -78,7 +78,7 @@ final class ClassMethodReturnTypeOverrideGuard
     private function shouldSkipHasChildHasReturnType(
         array $childrenClassReflections,
         ClassMethod $classMethod,
-        Type|Node $type
+        Node $type
     ): bool {
         $returnType = $this->returnTypeInferer->inferFunctionLike($classMethod);
 
@@ -108,24 +108,9 @@ final class ClassMethodReturnTypeOverrideGuard
         return false;
     }
 
-    private function shouldSkipChildTyped(ClassMethod $classMethod, Type|Node $type): bool
+    private function shouldSkipChildTyped(ClassMethod $classMethod, Node $type): bool
     {
-        if ($classMethod->returnType instanceof Node) {
-            // Use ! operator as shouldSkipReturnTypeChange() is used originallly for changing type
-            // use here for re-use, that's why ! can be used
-            if ($type instanceof Type && ! $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
-                $classMethod,
-                $type
-            )) {
-                return true;
-            }
-
-            if ($type instanceof Node && ! $this->nodeComparator->areNodesEqual($classMethod->returnType, $type)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $classMethod->returnType instanceof Node && ! $this->nodeComparator->areNodesEqual($classMethod->returnType, $type);
     }
 
     private function shouldSkipChaoticClassMethods(ClassMethod $classMethod): bool

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\Type;
 use PHPStan\Type\VoidType;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
@@ -110,7 +109,10 @@ final class ClassMethodReturnTypeOverrideGuard
 
     private function shouldSkipChildTyped(ClassMethod $classMethod, Node $type): bool
     {
-        return $classMethod->returnType instanceof Node && ! $this->nodeComparator->areNodesEqual($classMethod->returnType, $type);
+        return $classMethod->returnType instanceof Node && ! $this->nodeComparator->areNodesEqual(
+            $classMethod->returnType,
+            $type
+        );
     }
 
     private function shouldSkipChaoticClassMethods(ClassMethod $classMethod): bool

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -112,7 +112,7 @@ final class ClassMethodReturnTypeOverrideGuard
                     return true;
                 }
 
-                if ($this->nodeComparator->areNodesEqual($method->returnType, $type)) {
+                if ($type instanceof Node && $this->nodeComparator->areNodesEqual($method->returnType, $type)) {
                     return true;
                 }
             }

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -118,7 +118,7 @@ final class ClassMethodReturnTypeOverrideGuard
                 return true;
             }
 
-            if ($type instanceof Node && $this->nodeComparator->areNodesEqual($classMethod->returnType, $type)) {
+            if ($type instanceof Node && ! $this->nodeComparator->areNodesEqual($classMethod->returnType, $type)) {
                 return true;
             }
         }

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -12,7 +12,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\VoidType;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -32,7 +31,6 @@ final class ClassMethodReturnTypeOverrideGuard
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer,
-        private readonly BetterNodeFinder $betterNodeFinder,
         private readonly AstResolver $astResolver,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ReturnTypeInferer $returnTypeInferer,
@@ -110,17 +108,17 @@ final class ClassMethodReturnTypeOverrideGuard
         return false;
     }
 
-    private function shouldSkipChildTyped(ClassMethod $method, Type|Node $type): bool
+    private function shouldSkipChildTyped(ClassMethod $classMethod, Type|Node $type): bool
     {
-        if ($method->returnType instanceof Node) {
+        if ($classMethod->returnType instanceof Node) {
             if ($type instanceof Type && $this->parentClassMethodTypeOverrideGuard->shouldSkipReturnTypeChange(
-                $method,
+                $classMethod,
                 $type
             )) {
                 return true;
             }
 
-            if ($type instanceof Node && $this->nodeComparator->areNodesEqual($method->returnType, $type)) {
+            if ($type instanceof Node && $this->nodeComparator->areNodesEqual($classMethod->returnType, $type)) {
                 return true;
             }
         }

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -73,11 +73,7 @@ final class ClassMethodReturnTypeOverrideGuard
             return true;
         }
 
-        if ($this->shouldSkipHasChildHasReturnType($childrenClassReflections, $classMethod, $type)) {
-            return true;
-        }
-
-        return ! $this->hasClassMethodExprReturn($classMethod);
+        return $this->shouldSkipHasChildHasReturnType($childrenClassReflections, $classMethod, $type);
     }
 
     /**
@@ -155,19 +151,5 @@ final class ClassMethodReturnTypeOverrideGuard
         }
 
         return false;
-    }
-
-    private function hasClassMethodExprReturn(ClassMethod $classMethod): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst(
-            (array) $classMethod->stmts,
-            static function (Node $node): bool {
-                if (! $node instanceof Return_) {
-                    return false;
-                }
-
-                return $node->expr instanceof Expr;
-            }
-        );
     }
 }

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/skip_if_child_has_different_typed.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/skip_if_child_has_different_typed.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\Fixture;
 
-class SkipIfChildClassHasTyped
+class SkipIfChildClassHasTypedDifferent
 {
     public function test()
     {
@@ -10,7 +10,7 @@ class SkipIfChildClassHasTyped
     }
 }
 
-class SomeChild extends SkipIfChildClassHasTyped
+class SomeChild extends SkipIfChildClassHasTypedDifferent
 {
     public function test(): string
     {

--- a/rules-tests/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector/Fixture/parent_and_child_same_type_child_already_has_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector/Fixture/parent_and_child_same_type_child_already_has_type.php.inc
@@ -21,7 +21,7 @@ final class SomeChild extends SomeParent
     const FIRST = 'hey';
     const SECOND = 'hou';
 
-    public function getValue($number): bool
+    public function getValue($number): string
     {
         return $number ? self::FIRST : self::SECOND;
     }
@@ -41,7 +41,7 @@ final class SomeParent
     const FIRST = 'hey';
     const SECOND = 'hou';
 
-    public function getValue($number): bool
+    public function getValue($number): string
     {
         return $number ? self::FIRST : self::SECOND;
     }
@@ -52,7 +52,7 @@ final class SomeChild extends SomeParent
     const FIRST = 'hey';
     const SECOND = 'hou';
 
-    public function getValue($number): bool
+    public function getValue($number): string
     {
         return $number ? self::FIRST : self::SECOND;
     }

--- a/rules-tests/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector/Fixture/parent_and_child_same_type_child_already_has_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector/Fixture/parent_and_child_same_type_child_already_has_type.php.inc
@@ -41,7 +41,7 @@ final class SomeParent
     const FIRST = 'hey';
     const SECOND = 'hou';
 
-    public function getValue($number)
+    public function getValue($number): bool
     {
         return $number ? self::FIRST : self::SECOND;
     }

--- a/rules-tests/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector/Fixture/parent_and_child_same_type_child_already_has_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector/Fixture/parent_and_child_same_type_child_already_has_type.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\ReturnTypeFromStrictTernaryRector\Fixture;
+
+/**
+ * Both classes need to in single file as the changed part is parent
+ */
+final class SomeParent
+{
+    const FIRST = 'hey';
+    const SECOND = 'hou';
+
+    public function getValue($number)
+    {
+        return $number ? self::FIRST : self::SECOND;
+    }
+}
+
+final class SomeChild extends SomeParent
+{
+    const FIRST = 'hey';
+    const SECOND = 'hou';
+
+    public function getValue($number): bool
+    {
+        return $number ? self::FIRST : self::SECOND;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\ReturnTypeFromStrictTernaryRector\Fixture;
+
+/**
+ * Both classes need to in single file as the changed part is parent
+ */
+final class SomeParent
+{
+    const FIRST = 'hey';
+    const SECOND = 'hou';
+
+    public function getValue($number)
+    {
+        return $number ? self::FIRST : self::SECOND;
+    }
+}
+
+final class SomeChild extends SomeParent
+{
+    const FIRST = 'hey';
+    const SECOND = 'hou';
+
+    public function getValue($number): bool
+    {
+        return $number ? self::FIRST : self::SECOND;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scalarReturnType)) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            $returnTypeNode
+            $scalarReturnType
         )) {
             return null;
         }

--- a/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
@@ -92,7 +92,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scalarReturnType)) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scalarReturnType
+        )) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            $scalarReturnType
+            $returnTypeNode
         )) {
             return null;
         }

--- a/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
+++ b/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
@@ -96,10 +96,6 @@ CODE_SAMPLE
     {
         $this->hasChanged = false;
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return null;
-        }
-
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         $this->refactorParamTypes($node, $phpDocInfo);
@@ -196,6 +192,10 @@ CODE_SAMPLE
 
         $returnType = $phpDocInfo->getReturnType();
         if (! $returnType instanceof UnionType) {
+            return;
+        }
+
+        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($functionLike, $returnType)) {
             return;
         }
 

--- a/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
+++ b/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
@@ -195,13 +195,6 @@ CODE_SAMPLE
             return;
         }
 
-        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
-            $functionLike,
-            $returnType
-        )) {
-            return;
-        }
-
         $uniqueatedReturnType = $this->filterOutDuplicatedArrayTypes($returnType);
         if (! $uniqueatedReturnType instanceof UnionType) {
             return;
@@ -218,6 +211,13 @@ CODE_SAMPLE
         );
 
         if (! $phpParserUnionType instanceof PhpParserUnionType) {
+            return;
+        }
+
+        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $functionLike,
+            $phpParserUnionType
+        )) {
             return;
         }
 

--- a/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
+++ b/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
@@ -195,7 +195,10 @@ CODE_SAMPLE
             return;
         }
 
-        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($functionLike, $returnType)) {
+        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $functionLike,
+            $returnType
+        )) {
             return;
         }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -86,6 +86,14 @@ final class StrictReturnNewAnalyzer
 
         $returnedVariableName = $this->nodeNameResolver->getName($onlyReturn->expr);
 
+        return $this->resolveClassName($returnType, $createdVariablesToTypes, $returnedVariableName);
+    }
+
+    /**
+     * @param string[] $createdVariablesToTypes
+     */
+    private function resolveClassName(ObjectType $returnType, array $createdVariablesToTypes, ?string $returnedVariableName): ?string
+    {
         $className = $createdVariablesToTypes[$returnedVariableName] ?? null;
         if (! is_string($className)) {
             return $className;

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -28,8 +28,7 @@ final class StrictReturnNewAnalyzer
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ReturnAnalyzer $returnAnalyzer,
-        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard
+        private readonly ReturnAnalyzer $returnAnalyzer
     ) {
     }
 
@@ -72,13 +71,6 @@ final class StrictReturnNewAnalyzer
         $returnType = $this->nodeTypeResolver->getType($onlyReturn->expr);
 
         if (! $returnType instanceof ObjectType) {
-            return null;
-        }
-
-        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
-            $functionLike,
-            $returnType
-        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -92,8 +92,11 @@ final class StrictReturnNewAnalyzer
     /**
      * @param string[] $createdVariablesToTypes
      */
-    private function resolveClassName(ObjectType $returnType, array $createdVariablesToTypes, ?string $returnedVariableName): ?string
-    {
+    private function resolveClassName(
+        ObjectType $returnType,
+        array $createdVariablesToTypes,
+        ?string $returnedVariableName
+    ): ?string {
         $className = $createdVariablesToTypes[$returnedVariableName] ?? null;
         if (! is_string($className)) {
             return $className;

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -93,7 +93,7 @@ final class StrictReturnNewAnalyzer
      * @param string[] $createdVariablesToTypes
      */
     private function resolveClassName(
-        ObjectType $returnType,
+        ObjectType $objectType,
         array $createdVariablesToTypes,
         ?string $returnedVariableName
     ): ?string {
@@ -102,7 +102,7 @@ final class StrictReturnNewAnalyzer
             return $className;
         }
 
-        if ($returnType->getClassName() === $className) {
+        if ($objectType->getClassName() === $className) {
             return $className;
         }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -75,7 +75,10 @@ final class StrictReturnNewAnalyzer
             return null;
         }
 
-        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($functionLike, $returnType)) {
+        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $functionLike,
+            $returnType
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -20,7 +20,6 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\TypeDeclaration\ValueObject\AssignToVariable;
-use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 
 final class StrictReturnNewAnalyzer
 {

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -20,6 +20,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\TypeDeclaration\ValueObject\AssignToVariable;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 
 final class StrictReturnNewAnalyzer
 {
@@ -27,7 +28,8 @@ final class StrictReturnNewAnalyzer
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ReturnAnalyzer $returnAnalyzer
+        private readonly ReturnAnalyzer $returnAnalyzer,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard
     ) {
     }
 
@@ -70,6 +72,10 @@ final class StrictReturnNewAnalyzer
         $returnType = $this->nodeTypeResolver->getType($onlyReturn->expr);
 
         if (! $returnType instanceof ObjectType) {
+            return null;
+        }
+
+        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($functionLike, $returnType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
@@ -106,12 +106,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $returnTypeNode = new NullableType($typeNode);
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnTypeNode)) {
+        $nullableType = new NullableType($typeNode);
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $nullableType)) {
             return null;
         }
 
-        $node->returnType = $returnTypeNode;
+        $node->returnType = $nullableType;
 
         $this->clearReturnPhpDocTagNode($node);
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
@@ -11,8 +11,6 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\NullType;
-use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;

--- a/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
@@ -88,10 +88,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return null;
-        }
-
         $returnFalseAndReturnOther = $this->returnFalseAndReturnOtherMatcher->match($node);
         if (! $returnFalseAndReturnOther instanceof ReturnFalseAndReturnOther) {
             return null;
@@ -107,6 +103,11 @@ CODE_SAMPLE
 
         $typeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($anotherType, TypeKind::RETURN);
         if (! $typeNode instanceof Name && ! $typeNode instanceof Identifier) {
+            return null;
+        }
+
+        $type = new \PHPStan\Type\UnionType([$anotherType, new \PHPStan\Type\NullType()]);
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $type)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
@@ -11,6 +11,8 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -106,8 +108,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $type = new \PHPStan\Type\UnionType([$anotherType, new \PHPStan\Type\NullType()]);
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $type)) {
+        $unionType = new UnionType([$anotherType, new NullType()]);
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $unionType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/FalseReturnClassMethodToNullableRector.php
@@ -108,12 +108,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $unionType = new UnionType([$anotherType, new NullType()]);
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $unionType)) {
+        $returnTypeNode = new NullableType($typeNode);
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnTypeNode)) {
             return null;
         }
 
-        $node->returnType = new NullableType($typeNode);
+        $node->returnType = $returnTypeNode;
 
         $this->clearReturnPhpDocTagNode($node);
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            $updatedPhpDocType
+            $returnType
         )) {
             return null;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
@@ -85,10 +85,6 @@ CODE_SAMPLE
     {
         $returnType = $node->getReturnType();
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return null;
-        }
-
         if ($returnType === null) {
             return null;
         }
@@ -117,6 +113,10 @@ CODE_SAMPLE
         );
 
         if (! $updatedPhpDocType instanceof Type) {
+            return null;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $updatedPhpDocType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnAnnotationIncorrectNullableRector.php
@@ -116,7 +116,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $updatedPhpDocType)) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $updatedPhpDocType
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            new \PHPStan\Type\NeverType()
+            new NeverType()
         )) {
             return true;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -7,6 +7,7 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -132,7 +133,7 @@ CODE_SAMPLE
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            new NeverType()
+            new Identifier('never')
         )) {
             return true;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -131,7 +131,7 @@ CODE_SAMPLE
         }
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
-            $node
+            $node, new \PHPStan\Type\NeverType()
         )) {
             return true;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -131,7 +131,8 @@ CODE_SAMPLE
         }
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
-            $node, new \PHPStan\Type\NeverType()
+            $node,
+            new \PHPStan\Type\NeverType()
         )) {
             return true;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
@@ -85,7 +85,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, new \PHPStan\Type\ArrayType())) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            new \PHPStan\Type\ArrayType()
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
@@ -76,16 +76,16 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return null;
-        }
-
         if (! $this->hasReturnArray($node)) {
             return null;
         }
 
         $type = $this->returnTypeInferer->inferFunctionLike($node);
         if (! $type->isArray()->yes()) {
+            return null;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, new \PHPStan\Type\ArrayType())) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->returnType = new Identifier('array');
+        $node->returnType = $returnType;
 
         return $node;
     }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnDirectArrayRector.php
@@ -85,9 +85,10 @@ CODE_SAMPLE
             return null;
         }
 
+        $returnType = new Identifier('array');
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            new \PHPStan\Type\ArrayType()
+            $returnType
         )) {
             return null;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -96,15 +96,15 @@ CODE_SAMPLE
                 return null;
             }
 
-            $returnTypeNode = new FullyQualified($returnedNewClassName);
+            $fullyQualified = new FullyQualified($returnedNewClassName);
             if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
                 $node,
-                $returnTypeNode
+                $fullyQualified
             )) {
                 return null;
             }
 
-            $node->returnType = $returnTypeNode;
+            $node->returnType = $fullyQualified;
 
             return $node;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -90,10 +90,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return null;
-        }
-
         if (! $node instanceof ArrowFunction) {
             $returnedNewClassName = $this->strictReturnNewAnalyzer->matchAlwaysReturnVariableNew($node);
             if (is_string($returnedNewClassName)) {
@@ -155,6 +151,10 @@ CODE_SAMPLE
         }
 
         $returnType = $this->typeFactory->createMixedPassedOrUnionType($newTypes);
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
+            return null;
+        }
 
         $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
         if (! $returnTypeNode instanceof Node) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -152,7 +152,10 @@ CODE_SAMPLE
 
         $returnType = $this->typeFactory->createMixedPassedOrUnionType($newTypes);
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $returnType
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
@@ -77,7 +77,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, new \PHPStan\Type\BooleanType())) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            new \PHPStan\Type\BooleanType()
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
@@ -78,14 +78,15 @@ CODE_SAMPLE
             return null;
         }
 
+        $identifier = new Identifier('bool');
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            new BooleanType()
+            $identifier
         )) {
             return null;
         }
 
-        $node->returnType = new Identifier('bool');
+        $node->returnType = $identifier;
         return $node;
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
@@ -73,11 +73,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
+        if (! $this->strictBoolReturnTypeAnalyzer->hasAlwaysStrictBoolReturn($node)) {
             return null;
         }
 
-        if (! $this->strictBoolReturnTypeAnalyzer->hasAlwaysStrictBoolReturn($node)) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, new \PHPStan\Type\BooleanType())) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
-use PHPStan\Type\BooleanType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer\StrictBoolReturnTypeAnalyzer;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictBoolReturnExprRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use PHPStan\Type\BooleanType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer\StrictBoolReturnTypeAnalyzer;
@@ -79,7 +80,7 @@ CODE_SAMPLE
 
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            new \PHPStan\Type\BooleanType()
+            new BooleanType()
         )) {
             return null;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
@@ -75,12 +75,12 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
+        $matchedType = $this->strictReturnClassConstReturnTypeAnalyzer->matchAlwaysReturnConstFetch($node);
+        if (! $matchedType instanceof Type) {
             return null;
         }
 
-        $matchedType = $this->strictReturnClassConstReturnTypeAnalyzer->matchAlwaysReturnConstFetch($node);
-        if (! $matchedType instanceof Type) {
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $matchedType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
@@ -80,12 +80,12 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $matchedType)) {
+        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($matchedType, TypeKind::RETURN);
+        if (! $returnTypeNode instanceof Node) {
             return null;
         }
 
-        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($matchedType, TypeKind::RETURN);
-        if (! $returnTypeNode instanceof Node) {
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnTypeNode)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNativeCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNativeCallRector.php
@@ -91,7 +91,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $returnType
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNativeCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNativeCallRector.php
@@ -76,10 +76,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return null;
-        }
-
         $nativeCallLikes = $this->strictNativeFunctionReturnTypeAnalyzer->matchAlwaysReturnNativeCallLikes($node);
         if ($nativeCallLikes === null) {
             return null;
@@ -92,6 +88,10 @@ CODE_SAMPLE
 
         $returnType = $this->typeFactory->createMixedPassedOrUnionType($callLikeTypes);
         if ($returnType instanceof MixedType) {
+            return null;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNativeCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNativeCallRector.php
@@ -91,15 +91,15 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
-            $node,
-            $returnType
-        )) {
+        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
+        if (! $returnTypeNode instanceof Node) {
             return null;
         }
 
-        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
-        if (! $returnTypeNode instanceof Node) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $returnTypeNode
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -125,12 +125,13 @@ CODE_SAMPLE
         }
 
         $returnType = $this->nodeTypeResolver->getType($onlyReturn->expr);
-        if ($this->shouldSkipReturnType($node, $onlyReturn->expr, $variable, $returnType)) {
+        $returnTypeNode = new Identifier('array');
+        if ($this->shouldSkipReturnType($node, $onlyReturn->expr, $variable, $returnType, $returnTypeNode)) {
             return null;
         }
 
         // 3. always returns array
-        $node->returnType = new Identifier('array');
+        $node->returnType = $returnTypeNode;
 
         // 4. add more precise type if suitable
         $exprType = $this->getType($onlyReturn->expr);
@@ -147,7 +148,7 @@ CODE_SAMPLE
         return PhpVersion::PHP_70;
     }
 
-    private function shouldSkipReturnType(Node $node, Variable $expr, Variable $variable, Type $returnType): bool
+    private function shouldSkipReturnType(Node $node, Variable $expr, Variable $variable, Type $returnType, Identifier $returnTypeNode): bool
     {
         if (! $returnType->isArray()->yes()) {
             return true;
@@ -159,7 +160,7 @@ CODE_SAMPLE
 
         return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            $returnType
+            $returnTypeNode
         );
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -134,7 +134,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, new \PHPStan\Type\ArrayType())) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            new \PHPStan\Type\ArrayType()
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -134,15 +134,16 @@ CODE_SAMPLE
             return null;
         }
 
+        $returnTypeNode = new Identifier('array');
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            new \PHPStan\Type\ArrayType()
+            $returnTypeNode
         )) {
             return null;
         }
 
         // 3. always returns array
-        $node->returnType = new Identifier('array');
+        $node->returnType = $returnTypeNode;
 
         // 4. add more precise type if suitable
         $exprType = $this->getType($onlyReturn->expr);

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -134,6 +134,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, new \PHPStan\Type\ArrayType())) {
+            return null;
+        }
+
         // 3. always returns array
         $node->returnType = new Identifier('array');
 
@@ -154,11 +158,7 @@ CODE_SAMPLE
 
     private function shouldSkip(ClassMethod|Function_|Closure $node): bool
     {
-        if ($node->returnType !== null) {
-            return true;
-        }
-
-        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node);
+        return $node->returnType !== null;
     }
 
     private function changeReturnType(Node $node, Type $exprType): void

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -148,8 +148,13 @@ CODE_SAMPLE
         return PhpVersion::PHP_70;
     }
 
-    private function shouldSkipReturnType(Node $node, Variable $expr, Variable $variable, Type $returnType, Identifier $returnTypeNode): bool
-    {
+    private function shouldSkipReturnType(
+        Node $node,
+        Variable $expr,
+        Variable $variable,
+        Type $returnType,
+        Identifier $returnTypeNode
+    ): bool {
         if (! $returnType->isArray()->yes()) {
             return true;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -125,13 +125,13 @@ CODE_SAMPLE
         }
 
         $returnType = $this->nodeTypeResolver->getType($onlyReturn->expr);
-        $returnTypeNode = new Identifier('array');
-        if ($this->shouldSkipReturnType($node, $onlyReturn->expr, $variable, $returnType, $returnTypeNode)) {
+        $identifier = new Identifier('array');
+        if ($this->shouldSkipReturnType($node, $onlyReturn->expr, $variable, $returnType, $identifier)) {
             return null;
         }
 
         // 3. always returns array
-        $node->returnType = $returnTypeNode;
+        $node->returnType = $identifier;
 
         // 4. add more precise type if suitable
         $exprType = $this->getType($onlyReturn->expr);
@@ -153,7 +153,7 @@ CODE_SAMPLE
         Variable $expr,
         Variable $variable,
         Type $returnType,
-        Identifier $returnTypeNode
+        Identifier $identifier
     ): bool {
         if (! $returnType->isArray()->yes()) {
             return true;
@@ -165,7 +165,7 @@ CODE_SAMPLE
 
         return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            $returnTypeNode
+            $identifier
         );
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -134,16 +134,16 @@ CODE_SAMPLE
             return null;
         }
 
-        $returnTypeNode = new Identifier('array');
+        $identifier = new Identifier('array');
         if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
             $node,
-            $returnTypeNode
+            $identifier
         )) {
             return null;
         }
 
         // 3. always returns array
-        $node->returnType = $returnTypeNode;
+        $node->returnType = $identifier;
 
         // 4. add more precise type if suitable
         $exprType = $this->getType($onlyReturn->expr);

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -119,7 +119,10 @@ CODE_SAMPLE
             $unwrappedTypes = $this->typeNodeUnwrapper->unwrapNullableUnionTypes($returnedStrictTypes);
 
             $returnType = new PhpParserUnionType($unwrappedTypes);
-            if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
+            if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+                $node,
+                $returnType
+            )) {
                 return null;
             }
 
@@ -200,7 +203,10 @@ CODE_SAMPLE
             ? new NullableType(new FullyQualified($types[0]->getClassName()))
             : $nullableType;
 
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $returnType
+        )) {
             return null;
         }
 
@@ -253,7 +259,10 @@ CODE_SAMPLE
             ? new FullyQualified($resolvedType->getClassName())
             : $returnedStrictTypeNode;
 
-        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($functionLike, $returnType)) {
+        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $functionLike,
+            $returnType
+        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -103,26 +103,7 @@ CODE_SAMPLE
             return $this->processArrowFunction($node);
         }
 
-        /** @var Return_[] $returns */
-        $returns = $this->betterNodeFinder->find((array) $node->stmts, function (Node $subNode) use ($node): bool {
-            $currentFunctionLike = $this->betterNodeFinder->findParentType($subNode, FunctionLike::class);
-
-            if ($currentFunctionLike === $node) {
-                return $subNode instanceof Return_;
-            }
-
-            $currentReturn = $this->betterNodeFinder->findParentType($subNode, Return_::class);
-            if (! $currentReturn instanceof Return_) {
-                return false;
-            }
-
-            $currentFunctionLike = $this->betterNodeFinder->findParentType($currentReturn, FunctionLike::class);
-            if ($currentFunctionLike !== $node) {
-                return false;
-            }
-
-            return $subNode instanceof Return_;
-        });
+        $returns = $this->resolveReturns($node);
 
         $returnedStrictTypes = $this->returnStrictTypeAnalyzer->collectStrictReturnTypes($returns);
         if ($returnedStrictTypes === []) {
@@ -148,6 +129,32 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    /**
+     * @return Return_[]
+     */
+    private function resolveReturns(ClassMethod|Function_|Closure $node): array
+    {
+        return $this->betterNodeFinder->find((array) $node->stmts, function (Node $subNode) use ($node): bool {
+            $currentFunctionLike = $this->betterNodeFinder->findParentType($subNode, FunctionLike::class);
+
+            if ($currentFunctionLike === $node) {
+                return $subNode instanceof Return_;
+            }
+
+            $currentReturn = $this->betterNodeFinder->findParentType($subNode, Return_::class);
+            if (! $currentReturn instanceof Return_) {
+                return false;
+            }
+
+            $currentFunctionLike = $this->betterNodeFinder->findParentType($currentReturn, FunctionLike::class);
+            if ($currentFunctionLike !== $node) {
+                return false;
+            }
+
+            return $subNode instanceof Return_;
+        });
     }
 
     private function processArrowFunction(ArrowFunction $arrowFunction): ?ArrowFunction

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -187,7 +187,7 @@ CODE_SAMPLE
         ClassMethod | Function_ | Closure $node,
         UnionType $unionType,
         NullableType $nullableType
-    ): Closure | ClassMethod | Function_ {
+    ): Closure | ClassMethod | Function_ | null {
         $types = $unionType->getTypes();
         $returnType = $types[0] instanceof ObjectType && $types[1] instanceof NullType
             ? new NullableType(new FullyQualified($types[0]->getClassName()))
@@ -230,7 +230,7 @@ CODE_SAMPLE
         Return_ $return,
         Identifier|Name|NullableType $returnedStrictTypeNode,
         ClassMethod | Function_ | Closure $functionLike
-    ): Closure | ClassMethod | Function_ {
+    ): Closure | ClassMethod | Function_ | null {
         $resolvedType = $this->nodeTypeResolver->getType($return);
 
         if ($resolvedType instanceof UnionType) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -136,7 +136,13 @@ CODE_SAMPLE
         if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_TYPES)) {
             /** @var PhpParserUnionType[] $returnedStrictTypes */
             $unwrappedTypes = $this->typeNodeUnwrapper->unwrapNullableUnionTypes($returnedStrictTypes);
-            $node->returnType = new PhpParserUnionType($unwrappedTypes);
+
+            $returnType = new PhpParserUnionType($unwrappedTypes);
+            if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
+                return null;
+            }
+
+            $node->returnType = $returnType;
 
             return $node;
         }
@@ -187,6 +193,10 @@ CODE_SAMPLE
             ? new NullableType(new FullyQualified($types[0]->getClassName()))
             : $nullableType;
 
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $returnType)) {
+            return null;
+        }
+
         $node->returnType = $returnType;
         return $node;
     }
@@ -235,6 +245,10 @@ CODE_SAMPLE
         $returnType = $resolvedType instanceof ObjectType
             ? new FullyQualified($resolvedType->getClassName())
             : $returnedStrictTypeNode;
+
+        if ($functionLike instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($functionLike, $returnType)) {
+            return null;
+        }
 
         $functionLike->returnType = $returnType;
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -209,10 +209,6 @@ CODE_SAMPLE
             return $this->isUnionPossibleReturnsVoid($node);
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return true;
-        }
-
         if (! $node->isMagic()) {
             return $this->isUnionPossibleReturnsVoid($node);
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
@@ -98,7 +98,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $propertyType)) {
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $propertyTypeNode)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
@@ -93,12 +93,12 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $propertyType)) {
+        $propertyTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($propertyType, TypeKind::RETURN);
+        if (! $propertyTypeNode instanceof Node) {
             return null;
         }
 
-        $propertyTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($propertyType, TypeKind::RETURN);
-        if (! $propertyTypeNode instanceof Node) {
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $propertyTypeNode)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
@@ -98,7 +98,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $propertyTypeNode)) {
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $propertyType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector.php
@@ -82,10 +82,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node)) {
-            return null;
-        }
-
         $propertyTypes = $this->resolveReturnPropertyType($node);
         if ($propertyTypes === []) {
             return null;
@@ -94,6 +90,10 @@ CODE_SAMPLE
         // add type to return type
         $propertyType = $this->typeFactory->createMixedPassedOrUnionType($propertyTypes);
         if ($propertyType instanceof MixedType) {
+            return null;
+        }
+
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $propertyType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -106,12 +106,12 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod)) {
+            $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($ifType, TypeKind::RETURN);
+            if (! $returnTypeNode instanceof Node) {
                 continue;
             }
 
-            $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($ifType, TypeKind::RETURN);
-            if (! $returnTypeNode instanceof Node) {
+            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod, $returnTypeNode)) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod, $returnTypeNode)) {
+            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod, $ifType)) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod, $ifType)) {
+            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod, $returnTypeNode)) {
                 continue;
             }
 


### PR DESCRIPTION
@TomasVotruba When parent class return type is equal with child, and child already typed, parent need to allow to change the return type too.