### PR TITLE
[TypeDeclaration] Move method ParentClassMethodTypeOverrideGuard::isReturnTypeChangeAllowed to ClassMethodReturnTypeOverrideGuard and make it private

### DIFF
--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -18,6 +18,15 @@ use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
+use PHPStan\Reflection\FunctionVariantWithPhpDocs;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use Rector\Core\FileSystem\FilePathHelper;
+use Rector\Core\ValueObject\MethodName;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
+use Rector\StaticTypeMapper\StaticTypeMapper;
 
 final class ClassMethodReturnTypeOverrideGuard
 {
@@ -36,8 +45,58 @@ final class ClassMethodReturnTypeOverrideGuard
         private readonly AstResolver $astResolver,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ReturnTypeInferer $returnTypeInferer,
-        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private readonly FilePathHelper $filePathHelper
     ) {
+    }
+
+    private function isReturnTypeChangeAllowed(ClassMethod $classMethod): bool
+    {
+        // make sure return type is not protected by parent contract
+        $parentClassMethodReflection = $this->parentClassMethodTypeOverrideGuard->getParentClassMethod($classMethod);
+
+        // nothing to check
+        if (! $parentClassMethodReflection instanceof MethodReflection) {
+            return true;
+        }
+
+        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($parentClassMethodReflection->getVariants());
+        if ($parametersAcceptor instanceof FunctionVariantWithPhpDocs && ! $parametersAcceptor->getNativeReturnType() instanceof MixedType) {
+            return false;
+        }
+
+        $classReflection = $parentClassMethodReflection->getDeclaringClass();
+        $fileName = $classReflection->getFileName();
+
+        // probably internal
+        if ($fileName === null) {
+            return false;
+        }
+
+        /*
+         * Below verify that both current file name and parent file name is not in the /vendor/, if yes, then allowed.
+         * This can happen when rector run into /vendor/ directory while child and parent both are there.
+         *
+         *  @see https://3v4l.org/Rc0RF#v8.0.13
+         *
+         *     - both in /vendor/ -> allowed
+         *     - one of them in /vendor/ -> not allowed
+         *     - both not in /vendor/ -> allowed
+         */
+        /** @var ClassReflection $currentClassReflection */
+        $currentClassReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
+        /** @var string $currentFileName */
+        $currentFileName = $currentClassReflection->getFileName();
+
+        // child (current)
+        $normalizedCurrentFileName = $this->filePathHelper->normalizePathAndSchema($currentFileName);
+        $isCurrentInVendor = str_contains($normalizedCurrentFileName, '/vendor/');
+
+        // parent
+        $normalizedFileName = $this->filePathHelper->normalizePathAndSchema($fileName);
+        $isParentInVendor = str_contains($normalizedFileName, '/vendor/');
+
+        return ($isCurrentInVendor && $isParentInVendor) || (! $isCurrentInVendor && ! $isParentInVendor);
     }
 
     public function shouldSkipClassMethod(ClassMethod $classMethod): bool
@@ -57,7 +116,7 @@ final class ClassMethodReturnTypeOverrideGuard
             return true;
         }
 
-        if (! $this->parentClassMethodTypeOverrideGuard->isReturnTypeChangeAllowed($classMethod)) {
+        if (! $this->isReturnTypeChangeAllowed($classMethod)) {
             return true;
         }
 

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -25,63 +25,7 @@ final class ParentClassMethodTypeOverrideGuard
         private readonly ReflectionResolver $reflectionResolver,
         private readonly TypeComparator $typeComparator,
         private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly FilePathHelper $filePathHelper
     ) {
-    }
-
-    public function isReturnTypeChangeAllowed(ClassMethod $classMethod): bool
-    {
-        // __construct cannot declare a return type
-        // so the return type change is not allowed
-        if ($this->nodeNameResolver->isName($classMethod, MethodName::CONSTRUCT)) {
-            return false;
-        }
-
-        // make sure return type is not protected by parent contract
-        $parentClassMethodReflection = $this->getParentClassMethod($classMethod);
-
-        // nothing to check
-        if (! $parentClassMethodReflection instanceof MethodReflection) {
-            return true;
-        }
-
-        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($parentClassMethodReflection->getVariants());
-        if ($parametersAcceptor instanceof FunctionVariantWithPhpDocs && ! $parametersAcceptor->getNativeReturnType() instanceof MixedType) {
-            return false;
-        }
-
-        $classReflection = $parentClassMethodReflection->getDeclaringClass();
-        $fileName = $classReflection->getFileName();
-
-        // probably internal
-        if ($fileName === null) {
-            return false;
-        }
-
-        /*
-         * Below verify that both current file name and parent file name is not in the /vendor/, if yes, then allowed.
-         * This can happen when rector run into /vendor/ directory while child and parent both are there.
-         *
-         *  @see https://3v4l.org/Rc0RF#v8.0.13
-         *
-         *     - both in /vendor/ -> allowed
-         *     - one of them in /vendor/ -> not allowed
-         *     - both not in /vendor/ -> allowed
-         */
-        /** @var ClassReflection $currentClassReflection */
-        $currentClassReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
-        /** @var string $currentFileName */
-        $currentFileName = $currentClassReflection->getFileName();
-
-        // child (current)
-        $normalizedCurrentFileName = $this->filePathHelper->normalizePathAndSchema($currentFileName);
-        $isCurrentInVendor = str_contains($normalizedCurrentFileName, '/vendor/');
-
-        // parent
-        $normalizedFileName = $this->filePathHelper->normalizePathAndSchema($fileName);
-        $isParentInVendor = str_contains($normalizedFileName, '/vendor/');
-
-        return ($isCurrentInVendor && $isParentInVendor) || (! $isCurrentInVendor && ! $isParentInVendor);
     }
 
     public function hasParentClassMethod(ClassMethod $classMethod): bool

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -6,14 +6,9 @@ namespace Rector\VendorLocker;
 
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
-use Rector\Core\FileSystem\FilePathHelper;
 use Rector\Core\Reflection\ReflectionResolver;
-use Rector\Core\ValueObject\MethodName;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\StaticTypeMapper;


### PR DESCRIPTION
This is step 3, continue of PR:

- https://github.com/rectorphp/rector-src/pull/3321

Move method ParentClassMethodTypeOverrideGuard::isReturnTypeChangeAllowed to ClassMethodReturnTypeOverrideGuard and make it private

For child has type with equal parent type to change parent, that's need a separate PR as that make errornous in various tests.