### PR TITLE
Fix nested extends pattern in AddReturnTypeDeclarationBasedOnParentClassMethodRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/recursive_extended_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/recursive_extended_class.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeNestedClassWithoutReturnType;
+
+class MyClass extends SomeNestedClassWithoutReturnType
+{
+    public function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeNestedClassWithoutReturnType;
+
+class MyClass extends SomeNestedClassWithoutReturnType
+{
+    public function run(): int
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeNestedClassWithoutReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeNestedClassWithoutReturnType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
+
+class SomeNestedClassWithoutReturnType extends SomeClassWithReturnType
+{
+    public function run()
+    {
+        return 5;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
@@ -96,31 +96,33 @@ CODE_SAMPLE
             return null;
         }
 
-        $parentMethodReflection = $this->parentClassMethodTypeOverrideGuard->getParentClassMethod($node);
-        if (! $parentMethodReflection instanceof MethodReflection) {
-            return null;
-        }
-
-        $parentClassMethod = $this->astResolver->resolveClassMethodFromMethodReflection($parentMethodReflection);
-
-        if (! $parentClassMethod instanceof ClassMethod) {
-            return null;
-        }
-
-        if ($parentClassMethod->isPrivate()) {
-            return null;
-        }
-
-        $parentClassMethodReturnType = $parentClassMethod->getReturnType();
+        $parentClassMethodReturnType = $this->getReturnTypeRecursive($node);
         if ($parentClassMethodReturnType === null) {
             return null;
         }
 
-        $parentClassMethodReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType(
-            $parentClassMethodReturnType
-        );
-
         return $this->processClassMethodReturnType($node, $parentClassMethodReturnType);
+    }
+
+    private function getReturnTypeRecursive(ClassMethod $classMethod): ?Type
+    {
+        $returnType = $classMethod->getReturnType();
+
+        if ($returnType === null) {
+            $parentMethodReflection = $this->parentClassMethodTypeOverrideGuard->getParentClassMethod($classMethod);
+            if (! $parentMethodReflection instanceof MethodReflection) {
+                return null;
+            }
+
+            $parentClassMethod = $this->astResolver->resolveClassMethodFromMethodReflection($parentMethodReflection);
+            if (! $parentClassMethod instanceof ClassMethod || $parentClassMethod->isPrivate()) {
+                return null;
+            }
+
+            return $this->getReturnTypeRecursive($parentClassMethod);
+        }
+
+        return $this->staticTypeMapper->mapPhpParserNodePHPStanType($returnType);
     }
 
     private function processClassMethodReturnType(ClassMethod $classMethod, Type $parentType): ?ClassMethod


### PR DESCRIPTION
If return-type is declared in the top-level class but not declared in the intermediate class, this Rector rule will not perform the conversion. Fix them to be recursive.