### PR TITLE
Don't get type from PropertyFetch for not natively typed properties

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/natively_typed_property_from_data_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/natively_typed_property_from_data_object.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Source\NativelyTypedDataObject;
+
+final class NativelyTypedPropertyFromDataObject
+{
+    private $property;
+
+    public function __construct(NativelyTypedDataObject $dataObject)
+    {
+        $this->property = $dataObject->nativelyTypedProperty;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Source\NativelyTypedDataObject;
+
+final class NativelyTypedPropertyFromDataObject
+{
+    private string $property;
+
+    public function __construct(NativelyTypedDataObject $dataObject)
+    {
+        $this->property = $dataObject->nativelyTypedProperty;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+class NotNativelyTypedDataObject
+{
+    /**
+     * @var string
+     */
+    public $notNativelyTypedProperty;
+}
+
+final class SkipNotNativelyTypedPropertyFromDataObject
+{
+    private $property;
+
+    public function __construct(NotNativelyTypedDataObject $dataObject)
+    {
+        $this->property = $dataObject->notNativelyTypedProperty;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
@@ -2,14 +2,6 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
 
-class NotNativelyTypedDataObject
-{
-    /**
-     * @var string
-     */
-    public $notNativelyTypedProperty;
-}
-
 final class SkipNotNativelyTypedPropertyFromDataObject
 {
     private $property;

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Source/NativelyTypedDataObject.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Source/NativelyTypedDataObject.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Source;
+
+final class NativelyTypedDataObject
+{
+    public string $nativelyTypedProperty;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Source/NotNativelyTypedDataObject.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Source/NotNativelyTypedDataObject.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Source;
+
+final class NotNativelyTypedDataObject
+{
+    /**
+     * @var string
+     */
+    public $notNativelyTypedProperty;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/natively_typed_property_from_data_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/natively_typed_property_from_data_object.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Source\NativelyTypedDataObject;
+
+final class NativelyTypedPropertyFromDataObject
+{
+    private $property;
+
+    public function __construct(NativelyTypedDataObject $dataObject)
+    {
+        $this->property = $dataObject->nativelyTypedProperty;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Source\NativelyTypedDataObject;
+
+final class NativelyTypedPropertyFromDataObject
+{
+    private string $property;
+
+    public function __construct(NativelyTypedDataObject $dataObject)
+    {
+        $this->property = $dataObject->nativelyTypedProperty;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+class NotNativelyTypedDataObject
+{
+    /**
+     * @var string
+     */
+    public $notNativelyTypedProperty;
+}
+
+final class SkipNotNativelyTypedPropertyFromDataObject
+{
+    private $property;
+
+    public function __construct(NotNativelyTypedDataObject $dataObject)
+    {
+        $this->property = $dataObject->notNativelyTypedProperty;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_not_natively_typed_property_from_data_object.php.inc
@@ -2,13 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
 
-class NotNativelyTypedDataObject
-{
-    /**
-     * @var string
-     */
-    public $notNativelyTypedProperty;
-}
+use Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Source\NotNativelyTypedDataObject;
 
 final class SkipNotNativelyTypedPropertyFromDataObject
 {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Source/NativelyTypedDataObject.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Source/NativelyTypedDataObject.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Source;
+
+final class NativelyTypedDataObject
+{
+    public string $nativelyTypedProperty;
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Source/NotNativelyTypedDataObject.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Source/NotNativelyTypedDataObject.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Source;
+
+final class NotNativelyTypedDataObject
+{
+    /**
+     * @var string
+     */
+    public $notNativelyTypedProperty;
+}

--- a/rules/TypeDeclaration/TypeAnalyzer/PropertyFetchTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/PropertyFetchTypeAnalyzer.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\TypeAnalyzer;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Php\PhpPropertyReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Reflection\WrapperPropertyReflection;
+use PHPStan\Type\MixedType;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class PropertyFetchTypeAnalyzer
+{
+    public function isPropertyFetchExprNotNativelyTyped(Expr $expr): bool
+    {
+        if (! $expr instanceof PropertyFetch) {
+            return false;
+        }
+
+        if (! $expr->name instanceof Identifier) {
+            return false;
+        }
+
+        $scope = $expr->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return false;
+        }
+
+        $propertyName = $expr->name->toString();
+        $propertyHolderType = $scope->getType($expr->var);
+        if (! $propertyHolderType->hasProperty($propertyName)->yes()) {
+            return false;
+        }
+
+        $originalProperty = $propertyHolderType->getProperty($propertyName, $scope);
+        $nativePropertyReflection = $this->getNativeReflectionForProperty($originalProperty);
+
+        if ($nativePropertyReflection === null) {
+            return false;
+        }
+
+        if ($nativePropertyReflection->getNativeType() instanceof MixedType) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function getNativeReflectionForProperty(PropertyReflection $propertyReflection): ?PhpPropertyReflection
+    {
+        $reflection = $propertyReflection;
+        while ($reflection instanceof WrapperPropertyReflection) {
+            $reflection = $reflection->getOriginalReflection();
+        }
+
+        if (! $reflection instanceof PhpPropertyReflection) {
+            return null;
+        }
+
+        return $reflection;
+    }
+}

--- a/rules/TypeDeclaration/TypeAnalyzer/PropertyFetchTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/PropertyFetchTypeAnalyzer.php
@@ -37,18 +37,14 @@ final class PropertyFetchTypeAnalyzer
             return false;
         }
 
-        $originalProperty = $propertyHolderType->getProperty($propertyName, $scope);
-        $nativePropertyReflection = $this->getNativeReflectionForProperty($originalProperty);
+        $propertyReflection = $propertyHolderType->getProperty($propertyName, $scope);
+        $phpPropertyReflection = $this->getNativeReflectionForProperty($propertyReflection);
 
-        if ($nativePropertyReflection === null) {
+        if ($phpPropertyReflection === null) {
             return false;
         }
 
-        if ($nativePropertyReflection->getNativeType() instanceof MixedType) {
-            return true;
-        }
-
-        return false;
+        return $phpPropertyReflection->getNativeType() instanceof MixedType;
     }
 
     private function getNativeReflectionForProperty(PropertyReflection $propertyReflection): ?PhpPropertyReflection

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -28,6 +28,7 @@ use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 use Rector\TypeDeclaration\AlreadyAssignDetector\NullTypeAssignDetector;
 use Rector\TypeDeclaration\AlreadyAssignDetector\PropertyDefaultAssignDetector;
 use Rector\TypeDeclaration\Matcher\PropertyAssignMatcher;
+use Rector\TypeDeclaration\TypeAnalyzer\PropertyFetchTypeAnalyzer;
 
 /**
  * @deprecated
@@ -45,7 +46,8 @@ final class AssignToPropertyTypeInferer
         private readonly NodeTypeResolver $nodeTypeResolver,
         private readonly ExprAnalyzer $exprAnalyzer,
         private readonly ValueResolver $valueResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private readonly PropertyFetchTypeAnalyzer $propertyFetchTypeAnalyzer,
     ) {
     }
 
@@ -195,6 +197,12 @@ final class AssignToPropertyTypeInferer
 
             $expr = $this->propertyAssignMatcher->matchPropertyAssignExpr($node, $propertyName);
             if (! $expr instanceof Expr) {
+                return null;
+            }
+
+            if ($this->propertyFetchAnalyzer->isPropertyFetch($node->expr)
+                && $this->propertyFetchTypeAnalyzer->isPropertyFetchExprNotNativelyTyped($node->expr)
+            ) {
                 return null;
             }
 

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
@@ -23,6 +23,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use Rector\Core\NodeAnalyzer\ParamAnalyzer;
+use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\NodeManipulator\ClassMethodPropertyFetchManipulator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -34,6 +35,7 @@ use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Rector\TypeDeclaration\TypeAnalyzer\PropertyFetchTypeAnalyzer;
 use Rector\TypeDeclaration\TypeInferer\AssignToPropertyTypeInferer;
 
 /**
@@ -53,7 +55,9 @@ final class TrustedClassMethodPropertyTypeInferer
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly ParamAnalyzer $paramAnalyzer,
         private readonly AssignToPropertyTypeInferer $assignToPropertyTypeInferer,
-        private readonly TypeComparator $typeComparator
+        private readonly TypeComparator $typeComparator,
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private readonly PropertyFetchTypeAnalyzer $propertyFetchTypeAnalyzer,
     ) {
     }
 
@@ -81,6 +85,12 @@ final class TrustedClassMethodPropertyTypeInferer
 
         $resolvedTypes = [];
         foreach ($assignedExprs as $assignedExpr) {
+            if ($this->propertyFetchAnalyzer->isPropertyFetch($assignedExpr)
+                && $this->propertyFetchTypeAnalyzer->isPropertyFetchExprNotNativelyTyped($assignedExpr)
+            ) {
+                continue;
+            }
+
             $resolvedTypes[] = $this->nodeTypeResolver->getType($assignedExpr);
         }
 


### PR DESCRIPTION
Both `TypedPropertyFromAssignsRector` and `TypedPropertyFromStrictConstructorRector` read types from properties of other objects. The problem here is that the types of those properties can't be trusted, they may be determined by an `@var` docblock. I provided test fixtures for both rules. 

You can also check out the wrong results in the demo ([TypedPropertyFromAssignsRector](https://getrector.com/demo/70f2e3c4-7949-4327-a198-31b625c6e87e) , [TypedPropertyFromStrictConstructorRector](https://getrector.com/demo/75a269d6-4972-459e-91a3-6528020bd4f1)). I expect the types not to be changed at all in both cases.

I don't have much experience with writing Rector rules so I hope that you like my solution.