### PR TITLE
Update to use sebastian/diff:^5.0

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -2050,7 +2050,7 @@ Change data provider in PHPUnit test case to newline per item
          // ...
      }
 
-     public function provideData(): array
+     public static function provideData(): array
      {
 -        return [['content', 8], ['content123', 11]];
 +        return [
@@ -9132,7 +9132,7 @@ Adds param type declaration based on PHPUnit provider return type declaration
      {
      }
 
-     public function provideData()
+     public static function provideData()
      {
          yield ['name'];
      }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "rector/rector-php-parser": "dev-main",
         "rector/rector-phpunit": "dev-main",
         "rector/rector-symfony": "dev-main",
+        "sebastian/diff": "^5.0",
         "symfony/config": "^6.2",
         "symfony/console": "^6.2.2",
         "symfony/contracts": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "rector/rector-php-parser": "dev-main",
         "rector/rector-phpunit": "dev-main",
         "rector/rector-symfony": "dev-main",
-        "sebastian/diff": "5.0 as 4.0.4",
         "symfony/config": "^6.2",
         "symfony/console": "^6.2.2",
         "symfony/contracts": "^3.2",


### PR DESCRIPTION
Since latest release symplify/rule-doc-generator, the sebastian/diff 5.0 as 4.0.4 alias no longer needed. 

Also regenerate docs.