### PR TITLE
[StaticReflection] Fix unintended behavior in PHP 8.1 and later

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -710,6 +710,13 @@ parameters:
 
 		-
 			message: """
+				#Function "class_exists\\(\\)" cannot be used/left in the code\\: use ReflectionProvider\\->has\\*\\(\\) instead#
+			"""
+			count: 1
+			path: src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
+
+		-
+			message: """
 				#^Fetching class constant class of deprecated class Rector\\\\TypeDeclaration\\\\Rector\\\\FunctionLike\\\\ReturnTypeDeclarationRector\\:
 				Moving doc types to type declarations is dangerous\\. Use specific strict types instead\\.
 				This rule will be split info many small ones\\.$#

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureRenameMissingParent/missing_parent_with_method.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureRenameMissingParent/missing_parent_with_method.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureRenameMissingParent;
+
+use Missing\ParentClass;
+
+class MissingParent extends ParentClass
+{
+    public function foo(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureRenameMissingParent;
+
+use Missing\ParentClass;
+
+class MissingParent extends \Renamed\Missing\ParentWithMethod
+{
+    public function foo(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameMissingParent.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameMissingParent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @see RenameClassRector
+ */
+final class RenameMissingParent extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureRenameMissingParent');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/rename_missing_parent.php';
+    }
+}

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameMissingParentTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameMissingParentTest.php
@@ -12,7 +12,7 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 /**
  * @see RenameClassRector
  */
-final class RenameMissingParent extends AbstractRectorTestCase
+final class RenameMissingParentTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
     public function test(string $filePath): void

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/rename_missing_parent.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/rename_missing_parent.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(RenameClassRector::class, [
+            'Missing\\ParentClass' => 'Renamed\\Missing\\ParentWithMethod',
+        ]);
+};

--- a/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
@@ -19,7 +19,7 @@ use Rector\Core\Configuration\RenamedClassesDataCollector;
 final class RenamedClassesSourceLocator implements SourceLocator
 {
     public function __construct(
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
+        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
     ) {
     }
 
@@ -35,9 +35,12 @@ final class RenamedClassesSourceLocator implements SourceLocator
                 continue;
             }
 
-            if (class_exists($oldClass)) {
-                return $this->createFakeReflectionClassFromClassName($oldClass);
+            /* Use ReflectionProvider causes infinite loop */
+            if (!class_exists($oldClass)) {
+                continue;
             }
+
+            return $this->createFakeReflectionClassFromClassName($oldClass);
         }
 
         return null;

--- a/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
@@ -19,7 +19,7 @@ use Rector\Core\Configuration\RenamedClassesDataCollector;
 final class RenamedClassesSourceLocator implements SourceLocator
 {
     public function __construct(
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
+        private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
     ) {
     }
 

--- a/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
+++ b/src/StaticReflection/SourceLocator/RenamedClassesSourceLocator.php
@@ -35,7 +35,9 @@ final class RenamedClassesSourceLocator implements SourceLocator
                 continue;
             }
 
-            return $this->createFakeReflectionClassFromClassName($oldClass);
+            if (class_exists($oldClass)) {
+                return $this->createFakeReflectionClassFromClassName($oldClass);
+            }
         }
 
         return null;


### PR DESCRIPTION
PHP 8.1 changes the behavior of passing null to built-in functions, so that the current Rector does not throw an error when processing non-existent classes and does not properly perform code conversion.

https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal

Applying this fix will at least correct the above problem with Reflection.

But maybe this is an issue that should be addressed on the PHPStan side. I suggest a workaround on the Rector side for now.

```
$ vendor/bin/phpunit rules-tests/Renaming/Rector/Name/RenameClassRector/RenameMissingParent.php

1) Rector\Tests\Renaming\Rector\Name\RenameClassRector\RenameMissingParent::test with data set #0
TypeError: array_keys(): Argument #1 ($array) must be of type array, null given

phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionClass.php:1038
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionClass.php:1361
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionClass.php:1211
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/ReflectionClass.php:1212
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/Adapter/ReflectionClass.php:301
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ClassReflection.php:761
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ClassReflection.php:714
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/PhpDoc/PhpDocBlock.php:227
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/PhpDoc/PhpDocBlock.php:206
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/PhpDoc/PhpDocBlock.php:180
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/PhpDoc/PhpDocBlock.php:172
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/PhpDoc/PhpDocInheritanceResolver.php:41
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:3335
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:469
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:360
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:599
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:360
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:571
phar:///Users/zeriyoshi/Development/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:327
/Users/zeriyoshi/Development/rector-src/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:348
/Users/zeriyoshi/Development/rector-src/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:225
/Users/zeriyoshi/Development/rector-src/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php:31
/Users/zeriyoshi/Development/rector-src/src/Application/FileProcessor.php:34
/Users/zeriyoshi/Development/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:109
/Users/zeriyoshi/Development/rector-src/src/Application/FileProcessor/PhpFileProcessor.php:53
/Users/zeriyoshi/Development/rector-src/src/Application/ApplicationFileProcessor.php:126
/Users/zeriyoshi/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:204
/Users/zeriyoshi/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:171
/Users/zeriyoshi/Development/rector-src/packages/Testing/PHPUnit/AbstractRectorTestCase.php:119
/Users/zeriyoshi/Development/rector-src/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameMissingParent.php:20
```
