### PR TITLE
Add failing test fixture for `ReadOnlyClassRector`

### DIFF
--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/respect_annotation.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/respect_annotation.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+#[Route('/foo')]
+final class FooController
+{
+    public function __construct(
+        private readonly Responder $responder,
+        private readonly RepositoryInterface $repository,
+    ) {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+#[Route('/foo')]
+final readonly class FooController
+{
+    public function __construct(
+        private Responder $responder,
+        private RepositoryInterface $repository,
+    ) {
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for ReadOnlyClassRector

Closes https://github.com/rectorphp/rector/issues/7734

Based on https://getrector.com/demo/98cc3d94-3225-4cd1-96e3-d3a0dff6d8e6