### PR TITLE
Upgrade ramsey/composer-install to v2

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -75,6 +75,6 @@ jobs:
                     php-version: 8.1
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v1"
+            -   uses: "ramsey/composer-install@v2"
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,6 @@ jobs:
                     php-version: ${{ matrix.php }}
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v1"
+            -   uses: "ramsey/composer-install@v2"
 
             -   run: vendor/bin/paratest ${{ matrix.path }} --colors

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -49,7 +49,7 @@ jobs:
                     php-version: 8.1
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v1"
+            -   uses: "ramsey/composer-install@v2"
 
             -   run: ${{ matrix.actions.run }}
 


### PR DESCRIPTION
The errors from #3135 seems to be gone. Upgrading this actions removes the PR annotation about using a deprecated node versions and `save-state` / `set-output` usage.