### PR TITLE
Do not run paratest on merge to main

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,4 +38,10 @@ jobs:
 
             -   uses: "ramsey/composer-install@v2"
 
-            -   run: vendor/bin/paratest ${{ matrix.path }} --colors
+            -
+                if: github.ref == 'refs/heads/main'
+                run: vendor/bin/phpunit ${{ matrix.path }} --colors
+
+            -
+                if: github.ref != 'refs/heads/main'
+                run: vendor/bin/paratest ${{ matrix.path }} --colors


### PR DESCRIPTION
On merge to main, it seems there are random phpunit test error, this try to not run paratest on merge to main.