### PR TITLE
[Cache] Replace Strings::webalize() with sha1_file() from resolved path on ChangedFilesDetector

### DIFF
--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Caching\Detector;
 
-use Nette\Utils\Strings;
 use Rector\Caching\Cache;
 use Rector\Caching\Config\FileHashComputer;
 use Rector\Caching\Enum\CacheKey;

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -113,7 +113,7 @@ final class ChangedFilesDetector
 
     private function storeConfigurationDataHash(string $filePath, string $configurationHash): void
     {
-        $key = CacheKey::CONFIGURATION_HASH_KEY . '_' . Strings::webalize($filePath);
+        $key = CacheKey::CONFIGURATION_HASH_KEY . '_' . $this->hashFile($filePath);
         $this->invalidateCacheIfConfigurationChanged($key, $configurationHash);
 
         $this->cache->save($key, CacheKey::CONFIGURATION_HASH_KEY, $configurationHash);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7761

The `hashFile()` call sha1_file() with check realpath or relative path when exists.