### PR TITLE
Skip namespaced use no backslash on removeUnusedImports()

### DIFF
--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -181,6 +181,10 @@ CODE_SAMPLE
 
         $namespacedPrefix = Strings::after($comparedName, '\\', -1) . '\\';
 
+        if ($namespacedPrefix === '\\') {
+            $namespacedPrefix = '';
+        }
+
         // match partial import
         foreach ($names as $name) {
             if (str_ends_with($comparedName, $name)) {

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -191,7 +191,7 @@ CODE_SAMPLE
                 return true;
             }
 
-            if (! str_starts_with($name, '\\') && str_starts_with($name, $namespacedPrefix)) {
+            if (str_starts_with($name, $namespacedPrefix)) {
                 return true;
             }
         }

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -182,7 +182,7 @@ CODE_SAMPLE
         $namespacedPrefix = Strings::after($comparedName, '\\', -1) . '\\';
 
         if ($namespacedPrefix === '\\') {
-            $namespacedPrefix = '';
+            $namespacedPrefix = $comparedName . '\\';
         }
 
         // match partial import

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -191,7 +191,7 @@ CODE_SAMPLE
                 return true;
             }
 
-            if (str_starts_with($name, $namespacedPrefix)) {
+            if (! str_starts_with($name, '\\') && str_starts_with($name, $namespacedPrefix)) {
                 return true;
             }
         }

--- a/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_class_new.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_class_new.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+
+use Foo2;
+
+final class SkipNamespacedUse2
+{
+    public function __construct()
+    {
+        new Foo2\Storage();
+    }
+}

--- a/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_single_namespace.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_single_namespace.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
 
 use Foo2;
 
-final class SkipNamespacedUse2
+final class SkipNamespacedUseSingleNamespace
 {
     public function __construct()
     {

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/namespace_use_single_imported.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/namespace_use_single_imported.php.inc
@@ -2,13 +2,14 @@
 
 namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
+use Foo2\Storage;
 use Foo2;
 
-final class NamespacedUseSingleNamespace
+final class NamespacedUseSingleNamespaceImported
 {
     public function __construct()
     {
-        new Foo2\Storage();
+        new Storage();
     }
 }
 
@@ -19,9 +20,8 @@ final class NamespacedUseSingleNamespace
 namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
 use Foo2\Storage;
-use Foo2;
 
-final class NamespacedUseSingleNamespace
+final class NamespacedUseSingleNamespaceImported
 {
     public function __construct()
     {

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_single_namespace.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_single_namespace.php.inc
@@ -19,7 +19,6 @@ final class NamespacedUseSingleNamespace
 namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
 use Foo2\Storage;
-use Foo2;
 
 final class NamespacedUseSingleNamespace
 {

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_single_namespace.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_single_namespace.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use Foo2;
+
+final class SkipNamespacedUseSingleNamespace
+{
+    public function __construct()
+    {
+        new Foo2\Storage();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use Foo2\Storage;
+use Foo2;
+
+final class SkipNamespacedUseSingleNamespace
+{
+    public function __construct()
+    {
+        new Storage();
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba continue of PR:

-  https://github.com/rectorphp/rector-src/pull/3365

this code should be skipped as well for no backslash inside namespace;

```php
use Foo2;

final class SkipNamespacedUse2
{
    public function __construct()
    {
        new Foo2\Storage();
    }
}
```