### PR TITLE
Adding helper methods for interfaces

### DIFF
--- a/src/NodeAnalyzer/ClassAnalyzer.php
+++ b/src/NodeAnalyzer/ClassAnalyzer.php
@@ -52,4 +52,15 @@ final class ClassAnalyzer
         // match PHPStan pattern for anonymous classes
         return StringUtils::isMatch($className, self::ANONYMOUS_CLASS_REGEX);
     }
+
+    public function hasImplements(Class_ $class, string $interfaceFQN): bool
+    {
+        foreach ($class->implements as $implement) {
+            if ($this->nodeNameResolver->isName($implement, $interfaceFQN)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/NodeAnalyzer/ClassAnalyzer.php
+++ b/src/NodeAnalyzer/ClassAnalyzer.php
@@ -53,6 +53,9 @@ final class ClassAnalyzer
         return StringUtils::isMatch($className, self::ANONYMOUS_CLASS_REGEX);
     }
 
+    /**
+     * @api
+     */
     public function hasImplements(Class_ $class, string $interfaceFQN): bool
     {
         foreach ($class->implements as $implement) {

--- a/src/NodeManipulator/ClassManipulator.php
+++ b/src/NodeManipulator/ClassManipulator.php
@@ -59,4 +59,18 @@ final class ClassManipulator
 
         return false;
     }
+
+    /**
+     * @param string[]  $interfaceFQNS
+     */
+    public function removeImplements(Class_ $class, array $interfaceFQNS): void
+    {
+        foreach ($class->implements as $key => $implement) {
+            if (! $this->nodeNameResolver->isNames($implement, $interfaceFQNS)) {
+                continue;
+            }
+
+            unset($class->implements[$key]);
+        }
+    }
 }

--- a/src/NodeManipulator/ClassManipulator.php
+++ b/src/NodeManipulator/ClassManipulator.php
@@ -61,6 +61,7 @@ final class ClassManipulator
     }
 
     /**
+     * @api
      * @param string[]  $interfaceFQNS
      */
     public function removeImplements(Class_ $class, array $interfaceFQNS): void


### PR DESCRIPTION
While working on a Rector for rector-symfony I stumbled upon some repeated logic across multiple rules.

I found some classes that might be suitable for these functions so other Rector libraries can benefit from them (Since they need rector-src). Only issue is PHPStan notices they're not being used in this project.

Any thoughts?