### PR TITLE
[Php55] Handle crash on direct $ without double quote backreference on PregReplaceEModifierRector

### DIFF
--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/direct_dollar_number.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/direct_dollar_number.php.inc
@@ -22,7 +22,7 @@ class DirectDollarNumber
     public function run()
     {
         $str = '&#123;';
-        echo preg_replace_callback('/&#(\\d+);/', function ($matches) {
+        echo preg_replace_callback('/&#(\d+);/', function ($matches) {
             return strlen($matches[1]);
         }, utf8_encode($str));
     }

--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/direct_dollar_number.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/direct_dollar_number.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\Fixture;
+
+class DirectDollarNumber
+{
+    public function run()
+    {
+        $str = '&#123;';
+        echo preg_replace('/&#(\\d+);/e', 'strlen($1)', utf8_encode($str));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\Fixture;
+
+class DirectDollarNumber
+{
+    public function run()
+    {
+        $str = '&#123;';
+        echo preg_replace_callback('/&#(\\d+);/', function ($matches) {
+            return strlen($matches[1]);
+        }, utf8_encode($str));
+    }
+}
+
+?>

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -60,7 +60,7 @@ final class InlineCodeParser
      * @var string
      * @see https://regex101.com/r/jO2lfl/1
      */
-    private const BACKREFERENCE_NO_CURLY_START_REGEX = '#(?<!{)\$(?<backreference_number>\d+)#';
+    private const BACKREFERENCE_NO_CURLY_START_REGEX = '#(?<!")\$(?<backreference_number>\d+)#';
 
     public function __construct(
         private readonly NodePrinterInterface $nodePrinter,

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -58,9 +58,9 @@ final class InlineCodeParser
 
     /**
      * @var string
-     * @see https://regex101.com/r/jO2lfl/1
+     * @see https://regex101.com/r/nSO3Eq/1
      */
-    private const BACKREFERENCE_NO_CURLY_START_REGEX = '#(?<!")\$(?<backreference_number>\d+)#';
+    private const BACKREFERENCE_NO_DOUBLE_QUOTE_START_REGEX = '#(?<!")(?<backreference>\$\d+)#';
 
     public function __construct(
         private readonly NodePrinterInterface $nodePrinter,
@@ -92,13 +92,11 @@ final class InlineCodeParser
     {
         if ($expr instanceof String_) {
             if (! StringUtils::isMatch($expr->value, self::BACKREFERENCE_NO_QUOTE_REGEX)) {
-                $expr->value = Strings::replace(
+                return Strings::replace(
                     $expr->value,
-                    self::BACKREFERENCE_NO_CURLY_START_REGEX,
-                    static fn (array $match): string => "\\" . $match['backreference_number']
+                    self::BACKREFERENCE_NO_DOUBLE_QUOTE_START_REGEX,
+                    static fn (array $match): string => '"' . $match['backreference'] . '"'
                 );
-
-                return $expr->value;
             }
 
             return Strings::replace(

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -56,6 +56,12 @@ final class InlineCodeParser
      */
     private const BACKREFERENCE_NO_QUOTE_REGEX = '#(?<!")(?<backreference>\\\\\d+)(?!")#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/10kB6S/1
+     */
+    private const BACKREFERENCE_NO_CURLY_START_REGEX = '#(?<!{)\$(?<backreference_number>\d+)#';
+
     public function __construct(
         private readonly NodePrinterInterface $nodePrinter,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
@@ -86,7 +92,11 @@ final class InlineCodeParser
     {
         if ($expr instanceof String_) {
             if (! StringUtils::isMatch($expr->value, self::BACKREFERENCE_NO_QUOTE_REGEX)) {
-                return $expr->value;
+                return Strings::replace(
+                    $expr->value,
+                    self::BACKREFERENCE_NO_CURLY_START_REGEX,
+                    static fn (array $match): string => '\\' . $match['backreference_number']
+                );
             }
 
             return Strings::replace(

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -58,7 +58,7 @@ final class InlineCodeParser
 
     /**
      * @var string
-     * @see https://regex101.com/r/10kB6S/1
+     * @see https://regex101.com/r/jO2lfl/1
      */
     private const BACKREFERENCE_NO_CURLY_START_REGEX = '#(?<!{)\$(?<backreference_number>\d+)#';
 
@@ -92,11 +92,13 @@ final class InlineCodeParser
     {
         if ($expr instanceof String_) {
             if (! StringUtils::isMatch($expr->value, self::BACKREFERENCE_NO_QUOTE_REGEX)) {
-                return Strings::replace(
+                $expr->value = Strings::replace(
                     $expr->value,
                     self::BACKREFERENCE_NO_CURLY_START_REGEX,
-                    static fn (array $match): string => '\\' . $match['backreference_number']
+                    static fn (array $match): string => "\\" . $match['backreference_number']
                 );
+
+                return $expr->value;
             }
 
             return Strings::replace(


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7758