### PR TITLE
[TypeDeclaration] Remove unused intersection docblock on nullable intersection on TypedPropertyFromAssignsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/nullable_intersection_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/nullable_intersection_type.php.inc
@@ -33,9 +33,6 @@ use PHPUnit\Framework\TestCase;
 
 class NullableIntersectionType extends TestCase
 {
-    /**
-     * @var DateTime&MockObject
-     */
     private (\DateTime&\PHPUnit\Framework\MockObject\MockObject)|null $property = null;
 
     public function testExample(): void

--- a/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
@@ -6,7 +6,6 @@ namespace Rector\DeadCode\PhpDoc;
 
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -29,7 +28,7 @@ final class DeadVarTagValueNodeAnalyzer
         $propertyType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($property->type);
         $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($varTagValueNode->type, $property);
 
-        if ($propertyType instanceof UnionType && ! $docType instanceof UnionType && ! $docType instanceof IntersectionType) {
+        if ($propertyType instanceof UnionType && ! $docType instanceof UnionType) {
             return true;
         }
 


### PR DESCRIPTION
@VincentLanglet @puniserv @TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/3372

The intersection docblock actually not needed after transformed to nullable intersection as part of Union Type: `(\DateTime&\PHPUnit\Framework\MockObject\MockObject)|null` as already included.