### PR TITLE
[Php80][AutoImport] Do not import iterable on AutoImport enabled on UnionTypesRector

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IterableTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IterableTypeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
@@ -57,7 +58,7 @@ final class IterableTypeMapper implements TypeMapperInterface
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
     {
-        return new Name('iterable');
+        return new Identifier('iterable');
     }
 
     private function convertUnionArrayTypeNodesToArrayTypeOfUnionTypeNodes(

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IterableTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IterableTypeMapper.php
@@ -6,7 +6,6 @@ namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -110,7 +110,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
 
         if ($type->getClassName() === 'iterable') {
             // fallback
-            return new Identifier('iterable');
+            return new Name('iterable');
         }
 
         if ($type->getClassName() !== 'object') {

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -6,6 +6,7 @@ namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use Nette\Utils\Strings;
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
@@ -109,7 +110,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
 
         if ($type->getClassName() === 'iterable') {
             // fallback
-            return new Name('iterable');
+            return new Identifier('iterable');
         }
 
         if ($type->getClassName() !== 'object') {
@@ -117,7 +118,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
             return new FullyQualified($type->getClassName());
         }
 
-        return new Name('object');
+        return new Identifier('object');
     }
 
     #[Required]

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -118,7 +118,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
             return new FullyQualified($type->getClassName());
         }
 
-        return new Identifier('object');
+        return new Name('object');
     }
 
     #[Required]

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -6,7 +6,6 @@ namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use Nette\Utils\Strings;
 use PhpParser\Node;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/AutoImportTest.php
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/AutoImportTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AutoImportTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureAutoImport');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_auto_import.php';
+    }
+}

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/FixtureAutoImport/do_not_import_iterable.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/FixtureAutoImport/do_not_import_iterable.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\FixtureAutoImport;
+
+use Closure;
+
+class DoNotImportIterable
+{
+    /**
+     * @param iterable|int $baz
+     */
+    public function bar($baz)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\UnionTypesRector\FixtureAutoImport;
+
+use Closure;
+
+class DoNotImportIterable
+{
+    public function bar(iterable|int $baz)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/config/configured_rule_auto_import.php
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/config/configured_rule_auto_import.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(UnionTypesRector::class);
+    $rectorConfig->phpVersion(PhpVersionFeature::UNION_TYPES);
+
+    $rectorConfig->importNames();
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7706
Ref https://getrector.com/demo/fae5e947-2252-40a7-8645-30216aa246c3

"iterable" type should not be imported to use statement.