### PR TITLE
Add failing test fixture for TernaryFalseExpressionToIfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Expression/TernaryFalseExpressionToIfRector/Fixture/demo_file.php.inc
+++ b/rules-tests/CodeQuality/Rector/Expression/TernaryFalseExpressionToIfRector/Fixture/demo_file.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Expression\TernaryFalseExpressionToIfRector\Fixture;
+
+final class DemoFile
+{
+    public function run( $foo, $bar )
+    {
+    ?>
+        <input type="number" name="<?php echo $foo; ?>" value="<?php isset( $bar ) ? $bar : 0 ?>">
+    <?php 
+    }
+}
+
+?>
+-----
+


### PR DESCRIPTION
# Failing Test for TernaryFalseExpressionToIfRector

Based on https://getrector.com/demo/d48f8822-9454-4055-b14c-174a6b4f2ec8

The input code makes no sense (missing echo), but is valid. Rector should not change it to invalid (fatal) code.

Possible sanity check if the change results in `?> ?>` or `<?php <?php` it shouldn't apply the change but report an error right away, to make debugging rector rules faster?