### PR TITLE
[TypeMapper] Use Identifier instead of Name on ObjectWithoutClassType

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ReflectionProvider;
@@ -82,8 +83,8 @@ final class IntersectionTypeMapper implements TypeMapperInterface
         foreach ($type->getTypes() as $intersectionedType) {
             $resolvedType = $this->phpStanStaticTypeMapper->mapToPhpParserNode($intersectionedType, $typeKind);
 
-            if (! $resolvedType instanceof Name) {
-                continue;
+            if (! $resolvedType instanceof Name && ! $resolvedType instanceof Identifier) {
+                return null;
             }
 
             $resolvedTypeName = (string) $resolvedType;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -93,14 +93,6 @@ final class IntersectionTypeMapper implements TypeMapperInterface
                 return $resolvedType;
             }
 
-            /**
-             * $this->reflectionProvider->hasClass($resolvedTypeName) returns true on iterable type
-             * this ensure type is ObjectType early
-             */
-            if (! $intersectionedType instanceof ObjectType) {
-                continue;
-            }
-
             if (! $this->reflectionProvider->hasClass($resolvedTypeName)) {
                 continue;
             }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -102,7 +102,7 @@ final class IntersectionTypeMapper implements TypeMapperInterface
             }
 
             if (! $this->reflectionProvider->hasClass($resolvedTypeName)) {
-                continue;
+                return null;
             }
 
             $intersectionedTypeNodes[] = $resolvedType;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -88,6 +88,10 @@ final class IntersectionTypeMapper implements TypeMapperInterface
 
             $resolvedTypeName = (string) $resolvedType;
 
+            /**
+             * ObjectWithoutClassType can happen when use along with \PHPStan\Type\Accessory\HasMethodType
+             * Use "object" as returned type
+             */
             if ($intersectionedType instanceof ObjectWithoutClassType) {
                 return $resolvedType;
             }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Name;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\IntersectionType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
-use PHPStan\Type\ObjectType;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
+use PHPStan\Type\ObjectType;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -94,6 +95,10 @@ final class IntersectionTypeMapper implements TypeMapperInterface
              */
             if ($intersectionedType instanceof ObjectWithoutClassType) {
                 return $resolvedType;
+            }
+
+            if (! $intersectionedType instanceof ObjectType) {
+                return null;
             }
 
             if (! $this->reflectionProvider->hasClass($resolvedTypeName)) {

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
@@ -6,7 +6,6 @@ namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -82,6 +83,6 @@ final class ObjectWithoutClassTypeMapper implements TypeMapperInterface
             return null;
         }
 
-        return new Name('object');
+        return new Identifier('object');
     }
 }

--- a/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
+++ b/rules/Php80/Rector/FunctionLike/UnionTypesRector.php
@@ -181,7 +181,7 @@ CODE_SAMPLE
             return;
         }
 
-        $param->type = new Name('object');
+        $param->type = new Identifier('object');
         $this->hasChanged = true;
     }
 


### PR DESCRIPTION
This is continue of PR:

- https://github.com/rectorphp/rector-src/pull/3375

Apply `Identifier` instead of `Name` as well on "object" type that doesn't specify class name so it can't get fully qualified name, so `Identifier` can be used.