### PR TITLE
[Printer] Ensure disable flag isRequireReprintInlineHTML on change file on MixPhpHtmlDecorator

### DIFF
--- a/src/NodeDecorator/MixPhpHtmlDecorator.php
+++ b/src/NodeDecorator/MixPhpHtmlDecorator.php
@@ -31,6 +31,11 @@ final class MixPhpHtmlDecorator
         return $this->isRequireReprintInlineHTML;
     }
 
+    public function disableIsRequireReprintInlineHTML(): void
+    {
+        $this->isRequireReprintInlineHTML = false;
+    }
+
     /**
      * @param array<Node|null> $nodes
      */

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -124,6 +124,9 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return $content;
         }
 
+        // ensure disable flag isRequireReprintInlineHTML on change file
+        $this->mixPhpHtmlDecorator->disableIsRequireReprintInlineHTML();
+
         $content = $this->cleanSurplusTag($content);
         return $this->cleanEndWithPHPOpenTag($content);
     }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3382

The `MixPhpHtmlDecorator` is shared service, when jump to next file, the `isRequireReprintInlineHTML` should be back to false to re-check if there is require clean up php tag.