### PR TITLE
[Php81] Handle null defined in variable first on NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/null_defined_in_variable_first.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/null_defined_in_variable_first.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+class NullDefinedInVariableFirst
+{
+    public function getTitle()
+    {
+        $title = null;
+        return trim($title);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+class NullDefinedInVariableFirst
+{
+    public function getTitle()
+    {
+        $title = null;
+        return trim((string) $title);
+    }
+}
+
+?>

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -20,6 +20,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractScopeAwareRector;
@@ -468,7 +469,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $type instanceof MixedType || $argValue instanceof Encapsed) {
+        if (! $type instanceof MixedType && ! $type instanceof NullType) {
+            return null;
+        }
+
+        if ($argValue instanceof Encapsed) {
             return null;
         }
 
@@ -490,13 +495,13 @@ CODE_SAMPLE
         return $funcCall;
     }
 
-    private function shouldSkipTrait(Expr $expr, MixedType $mixedType, bool $isTrait): bool
+    private function shouldSkipTrait(Expr $expr, MixedType|NullType $mixedType, bool $isTrait): bool
     {
         if (! $isTrait) {
             return false;
         }
 
-        if ($mixedType->isExplicitMixed()) {
+        if ($mixedType instanceof MixedType && $mixedType->isExplicitMixed()) {
             return false;
         }
 

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -21,6 +21,7 @@ use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
 use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractScopeAwareRector;
@@ -481,7 +482,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($type instanceof MixedType && $this->shouldSkipTrait($argValue, $type, $isTrait)) {
+        if ($this->shouldSkipTrait($argValue, $type, $isTrait)) {
             return null;
         }
 
@@ -495,13 +496,17 @@ CODE_SAMPLE
         return $funcCall;
     }
 
-    private function shouldSkipTrait(Expr $expr, MixedType $mixedType, bool $isTrait): bool
+    private function shouldSkipTrait(Expr $expr, Type $type, bool $isTrait): bool
     {
+        if (! $type instanceof MixedType) {
+            return false;
+        }
+
         if (! $isTrait) {
             return false;
         }
 
-        if ($mixedType->isExplicitMixed()) {
+        if ($type->isExplicitMixed()) {
             return false;
         }
 

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -481,7 +481,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSkipTrait($argValue, $type, $isTrait)) {
+        if ($type instanceof MixedType && $this->shouldSkipTrait($argValue, $type, $isTrait)) {
             return null;
         }
 
@@ -495,13 +495,13 @@ CODE_SAMPLE
         return $funcCall;
     }
 
-    private function shouldSkipTrait(Expr $expr, MixedType|NullType $mixedType, bool $isTrait): bool
+    private function shouldSkipTrait(Expr $expr, MixedType $mixedType, bool $isTrait): bool
     {
         if (! $isTrait) {
             return false;
         }
 
-        if ($mixedType instanceof MixedType && $mixedType->isExplicitMixed()) {
+        if ($mixedType->isExplicitMixed()) {
             return false;
         }
 


### PR DESCRIPTION
This is discovered by:

- https://github.com/rectorphp/rector/issues/7775

On variable defined to null early.


Fixes https://github.com/rectorphp/rector/issues/7775