### PR TITLE
Add failing test fixture for AddDefaultValueForUndefinedVariableRector with infinite loop

### DIFF
--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/demo_file.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/demo_file.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+final class DemoFile
+{   
+    public function run(Item $yes)
+    {
+        while (true !== false) {
+        }
+        
+        $a = [];
+        
+        if ($b = $yes) {
+            $a[] = 'test';
+        }
+        
+        return $a;
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for AddDefaultValueForUndefinedVariableRector

Based on https://getrector.com/demo/e1b4cf4e-c34f-466d-ac1a-4ecdbffca61c

See rectorphp/rector#7777