### PR TITLE
[Php56][Php70] Handle infinite loop on AddDefaultValueForUndefinedVariableRector+IfToSpaceshipRector

### DIFF
--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -33,6 +33,7 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+use Rector\PostRector\Collector\NodesToRemoveCollector;
 
 final class UndefinedVariableResolver
 {
@@ -41,7 +42,8 @@ final class UndefinedVariableResolver
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly NodeComparator $nodeComparator,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly VariableAnalyzer $variableAnalyzer
+        private readonly VariableAnalyzer $variableAnalyzer,
+        private readonly NodesToRemoveCollector $nodesToRemoveCollector
     ) {
     }
 
@@ -62,6 +64,11 @@ final class UndefinedVariableResolver
 
             if ($node instanceof Foreach_) {
                 // handled above
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            // the Stmt just replaced
+            if ($node instanceof Stmt && ! $node->getAttribute(AttributeKey::ORIGINAL_NODE) instanceof Node) {
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -88,6 +88,7 @@ final class UndefinedVariableResolver
                 return null;
             }
 
+            /** @var string $variableName */
             $undefinedVariables[] = $variableName;
 
             return null;

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -66,14 +66,10 @@ final class UndefinedVariableResolver
             }
 
             /**
-             * The Stmt is
-             *
-             *      - an indirect replacement below changed Node
-             *      - as Stmt that just reprinted,
-             *
-             * so need separate run to get type correctly
+             * The Stmt that doesn't have origNode attribute yet
+             * means the Stmt is a replacement below other changed node
              */
-            if ($node instanceof Stmt && ! $node->getAttribute(AttributeKey::ORIGINAL_NODE) instanceof Node) {
+            if ($node instanceof Stmt && ! $node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -33,7 +33,6 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
-use Rector\PostRector\Collector\NodesToRemoveCollector;
 
 final class UndefinedVariableResolver
 {
@@ -42,8 +41,7 @@ final class UndefinedVariableResolver
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly NodeComparator $nodeComparator,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly VariableAnalyzer $variableAnalyzer,
-        private readonly NodesToRemoveCollector $nodesToRemoveCollector
+        private readonly VariableAnalyzer $variableAnalyzer
     ) {
     }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -65,7 +65,14 @@ final class UndefinedVariableResolver
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
-            // the Stmt just replaced
+            /**
+             * The Stmt is
+             *
+             *      - an indirect replacement below changed Node
+             *      - as Stmt that just reprinted,
+             *
+             * so need separate run to get type correctly
+             */
             if ($node instanceof Stmt && ! $node->getAttribute(AttributeKey::ORIGINAL_NODE) instanceof Node) {
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -84,10 +84,6 @@ final class UndefinedVariableResolver
             }
 
             $variableName = $this->nodeNameResolver->getName($node);
-            if (! is_string($variableName)) {
-                return null;
-            }
-
             if ($this->hasVariableTypeOrCurrentStmtUnreachable($node, $variableName)) {
                 return null;
             }
@@ -100,8 +96,12 @@ final class UndefinedVariableResolver
         return array_unique($undefinedVariables);
     }
 
-    private function hasVariableTypeOrCurrentStmtUnreachable(Variable $variable, string $variableName): bool
+    private function hasVariableTypeOrCurrentStmtUnreachable(Variable $variable, ?string $variableName): bool
     {
+        if (! is_string($variableName)) {
+            return true;
+        }
+
         // defined 100 %
         /** @var Scope $scope */
         $scope = $variable->getAttribute(AttributeKey::SCOPE);

--- a/tests/Issues/DefaultValueSpaceShip/DefaultValueSpaceShipTest.php
+++ b/tests/Issues/DefaultValueSpaceShip/DefaultValueSpaceShipTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\DefaultValueSpaceShip;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DefaultValueSpaceShipTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DefaultValueSpaceShip/Fixture/fixture.php.inc
+++ b/tests/Issues/DefaultValueSpaceShip/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\DefaultValueSpaceShip\Fixture;
+
+class Fixture
+{
+    public function sortRank($a, $b)
+    {
+        if ($a == $b) {
+            return 0;
+        }
+
+        return ($a > $b) ? -1 : 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\DefaultValueSpaceShip\Fixture;
+
+class Fixture
+{
+    public function sortRank($a, $b)
+    {
+        return $b <=> $a;
+    }
+}
+
+?>

--- a/tests/Issues/DefaultValueSpaceShip/config/configured_rule.php
+++ b/tests/Issues/DefaultValueSpaceShip/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
+use Rector\Php70\Rector\If_\IfToSpaceshipRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddDefaultValueForUndefinedVariableRector::class);
+    $rectorConfig->rule(IfToSpaceshipRector::class);
+};


### PR DESCRIPTION
Given th following code

```php
class Fixture
{
    public function sortRank($a, $b)
    {
        if ($a == $b) {
            return 0;
        }

        return ($a > $b) ? -1 : 1;
    }
}
```

It cause crash:

```
Runtime:       PHP 8.1.13
Configuration: /Users/samsonasik/www/rector-src/phpunit.xml

[1]    14431 segmentation fault  vendor/bin/phpunit tests/Issues/DefaultValueSpaceShip
```

Ref https://getrector.com/demo/b0b4b1b4-dfd3-4034-a2c7-402b618f56d2
Fixes https://github.com/rectorphp/rector/issues/7788