### PR TITLE
Fix ShortenedObjectType not resolving to correct class reflection

### DIFF
--- a/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Fixture/skip_phpstan_phar.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Fixture/skip_phpstan_phar.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\FuncCall\RemoveExtraParametersRector\Fixture;
+
+use Rector\Tests\Php71\Rector\FuncCall\RemoveExtraParametersRector\Source\Stan;
+
+final class SkipPHPStanPhar
+{
+    public function run()
+    {
+        $stan = new Stan();
+        $stan->foo(1, 2);
+
+        Stan::bar(1, 2);
+    }
+}

--- a/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Source/phpstan.phar/Stan.php
+++ b/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Source/phpstan.phar/Stan.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php71\Rector\FuncCall\RemoveExtraParametersRector\Source;
+
+final class Stan
+{
+    public function foo(): void
+    {
+    }
+
+    public static function bar(): void
+    {
+    }
+}

--- a/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
+++ b/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
@@ -112,6 +112,13 @@ final class RemoveExtraParametersRector extends AbstractRector implements MinPhp
             }
         }
 
+        if ($reflection instanceof MethodReflection) {
+            $fileName = (string) $reflection->getDeclaringClass()->getFileName();
+            if (str_contains($fileName, 'phpstan.phar')) {
+                return \true;
+            }
+        }
+
         return false;
     }
 

--- a/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
+++ b/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
@@ -113,7 +113,8 @@ final class RemoveExtraParametersRector extends AbstractRector implements MinPhp
         }
 
         if ($reflection instanceof MethodReflection) {
-            $fileName = (string) $reflection->getDeclaringClass()->getFileName();
+            $class = $reflection->getDeclaringClass();
+            $fileName = (string) $class->getFileName();
             if (str_contains($fileName, 'phpstan.phar')) {
                 return \true;
             }

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -32,6 +32,7 @@ use Rector\Core\ValueObject\MethodName;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Symfony\Contracts\Service\Attribute\Required;
 
 final class ReflectionResolver
@@ -138,7 +139,11 @@ final class ReflectionResolver
         $objectType = $this->nodeTypeResolver->getType($staticCall->class);
 
         /** @var array<class-string> $classNames */
-        $classNames = TypeUtils::getDirectClassNames($objectType);
+        if ($objectType instanceof ShortenedObjectType) {
+            $classNames = [$objectType->getFullyQualifiedName()];
+        } else {
+            $classNames = TypeUtils::getDirectClassNames($objectType);
+        }
 
         $methodName = $this->nodeNameResolver->getName($staticCall->name);
         if ($methodName === null) {

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -138,10 +138,11 @@ final class ReflectionResolver
     {
         $objectType = $this->nodeTypeResolver->getType($staticCall->class);
 
-        /** @var array<class-string> $classNames */
         if ($objectType instanceof ShortenedObjectType) {
+            /** @var array<class-string> $classNames */
             $classNames = [$objectType->getFullyQualifiedName()];
         } else {
+            /** @var array<class-string> $classNames */
             $classNames = TypeUtils::getDirectClassNames($objectType);
         }
 


### PR DESCRIPTION
Fix for bug described in rectorphp/rector#7794

I'm unsure how to test this.
