### PR TITLE
Fix rectorphp/rector#7795 by skipping extensions not supporting this way to be loaded.

### DIFF
--- a/packages-tests/NodeTypeResolver/DependencyInjection/PHPStanExtensionsConfigResolverTest.php
+++ b/packages-tests/NodeTypeResolver/DependencyInjection/PHPStanExtensionsConfigResolverTest.php
@@ -18,7 +18,7 @@ final class PHPStanExtensionsConfigResolverTest extends AbstractTestCase
         $this->phpStanExtensionsConfigResolver = $this->getService(PHPStanExtensionsConfigResolver::class);
     }
 
-    public function test(): void
+    public function testRequiredConfigs(): void
     {
         // these configs are required by this package, so must be in there
 
@@ -32,5 +32,16 @@ final class PHPStanExtensionsConfigResolverTest extends AbstractTestCase
 
         $this->assertContains($phpunitExtensionFilePath, $extensionConfigFiles);
         $this->assertContains($assertExtensionFilePath, $extensionConfigFiles);
+    }
+
+    public function testSkippedConfigs(): void
+    {
+        // these configs are skipped by this package, so must not be in there
+
+        $mglamanPhpstanDrupalExtensionFilePath = realpath(__DIR__ . '/../../../vendor/') . '/mglaman/phpstan-drupal/drupal-autoloader.php';
+
+        $extensionConfigFiles = $this->phpStanExtensionsConfigResolver->resolve();
+
+        $this->assertNotContains($mglamanPhpstanDrupalExtensionFilePath, $extensionConfigFiles);
     }
 }

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanExtensionsConfigResolver.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanExtensionsConfigResolver.php
@@ -41,8 +41,14 @@ final class PHPStanExtensionsConfigResolver
         $generatedConfigDirectory = dirname($generatedConfigClassFileName);
 
         $extensionConfigFiles = [];
-
-        foreach (GeneratedConfig::EXTENSIONS as $extension) {
+        // Some extensions are unsupported and only work when used by PHPstan directly, so we skip them.
+        $unsupportedExtensions = [
+            'mglaman/phpstan-drupal', // https://github.com/rectorphp/rector/issues/7795
+        ];
+        foreach (GeneratedConfig::EXTENSIONS as $name => $extension) {
+            if (in_array($name, $unsupportedExtensions, true)) {
+                continue;
+            }
             $fileNames = $extension['extra']['includes'] ?? [];
             foreach ($fileNames as $fileName) {
                 $configFilePath = $generatedConfigDirectory . '/' . $extension['relative_install_path'] . '/' . $fileName;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/FixtureIntersection/intersection_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/FixtureIntersection/intersection_in_union.php.inc
@@ -15,7 +15,7 @@ abstract class IntersectionInUnion
         return [];
     }
 
-    private function removeEmptyValues(array $input): array
+    private function removeEmptyValues($input): array
     {
         foreach ($input as &$value) {
             if (! is_array($value)) {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/FixtureIntersection/intersection_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/FixtureIntersection/intersection_in_union.php.inc
@@ -15,7 +15,7 @@ abstract class IntersectionInUnion
         return [];
     }
 
-    private function removeEmptyValues($input): array
+    private function removeEmptyValues(array $input): array
     {
         foreach ($input as &$value) {
             if (! is_array($value)) {


### PR DESCRIPTION
Skip loading PHPstan extension which are not compatible with the way rector tries to load them.

This is just a hotfix for rectorphp/rector#7795 handling the fact that loading extensions like `mglaman/phpstan-drupal` fail when loaded improperly. According to @mglaman they way of loading the extensions is not correct and must be fixed.

No tests changed or added for this fix, as this might only be a temporary change to be used as patch by those affected until a proper fix is available.