### PR TITLE
[DeadCode] Skip if cond use variable from @param doc on RemoveAlwaysTrueIfConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_by_param_doc.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_by_param_doc.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class SkipByParamDoc
+{
+    /**
+     * @param \DateTime $param
+     */
+    public function verify($param)
+    {
+        if ($param instanceof \DateTime) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -8,10 +8,12 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\If_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -23,7 +25,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveAlwaysTrueIfConditionRector extends AbstractRector
 {
     public function __construct(
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ExprAnalyzer $exprAnalyzer
     ) {
     }
 
@@ -96,12 +99,33 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->shouldSkipFromParam($node->cond)) {
+            return null;
+        }
+
         if ($node->stmts === []) {
             $this->removeNode($node);
             return null;
         }
 
         return $node->stmts;
+    }
+
+    private function shouldSkipFromParam(Expr $expr): bool
+    {
+        /** @var Variable[] $variables */
+        $variables = $this->betterNodeFinder->findInstancesOf(
+            $expr,
+            [Variable::class]
+        );
+
+        foreach ($variables as $variable) {
+            if ($this->exprAnalyzer->isNonTypedFromParam($variable)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function shouldSkipPropertyFetch(Expr $expr): bool

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -114,10 +114,7 @@ CODE_SAMPLE
     private function shouldSkipFromParam(Expr $expr): bool
     {
         /** @var Variable[] $variables */
-        $variables = $this->betterNodeFinder->findInstancesOf(
-            $expr,
-            [Variable::class]
-        );
+        $variables = $this->betterNodeFinder->findInstancesOf($expr, [Variable::class]);
 
         foreach ($variables as $variable) {
             if ($this->exprAnalyzer->isNonTypedFromParam($variable)) {


### PR DESCRIPTION
The following code should be skipped:

```php
class SkipByParamDoc
{
    /**
     * @param \DateTime $param
     */
    public function verify($param)
    {
        if ($param instanceof \DateTime) {
            return true;
        }

        return false;
    }
}
```

as it rely on `@param` doc.