### PR TITLE
Allow class vs function names on imports

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -31,15 +31,13 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
         // "new X" or "X::static()"
         /** @var array<string, string> $shortNamesToFullyQualifiedNames */
         $shortNamesToFullyQualifiedNames = $this->shortNameResolver->resolveFromFile($file);
-        $loweredShortNameFullyQualified = $fullyQualifiedObjectType->getShortNameLowered();
 
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
-            $shortNameLowered = strtolower($shortName);
-            if ($loweredShortNameFullyQualified !== $shortNameLowered) {
+            if ($fullyQualifiedObjectType->getShortName() !== $shortName) {
                 continue;
             }
 
-            return $fullyQualifiedObjectType->getClassNameLowered() !== strtolower($fullyQualifiedName);
+            return $fullyQualifiedObjectType->getClassName() !== $fullyQualifiedName;
         }
 
         return false;


### PR DESCRIPTION
This used to block import of class name `View`, that was same as function name `view`:

https://github.com/TomasVotruba/tomasvotruba.com/pull/1366/files#diff-d7dc7f08f1bba97551472cbda3a39db9a18e93ab06e499d18f6895ecc3df25f7L11

The class can be easily imported :+1: 