### PR TITLE
[Core] Improve performance: do not compare after refactor and after post Rector stmts if $hasChangedOnPostRector already true

### DIFF
--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -73,7 +73,7 @@ final class PhpFileProcessor implements FileProcessorInterface
             // this is needed for new tokens added in "afterTraverse()"
             $file->changeNewStmts($filePostRectorNewStmts);
 
-            if ($file->getRectorWithLineChanges() === [] && $fileNewStmts !== $filePostRectorNewStmts) {
+            if (! $hasChangedOnPostRector && $file->getRectorWithLineChanges() === [] && $fileNewStmts !== $filePostRectorNewStmts) {
                 $hasChangedOnPostRector = true;
             }
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3403

when the `$hasChangedOnPostRector` flag already true, no need to compare again.