### PR TITLE
[Core] Enforce to not return null when node and original node is not equal on AbstractRector

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -216,7 +216,7 @@ CODE_SAMPLE;
         $originalNode ??= $node;
 
         // nothing to change → continue
-        if ($refactoredNode === null || ! $this->nodeComparator->areSameNode($node, $originalNode)) {
+        if ($refactoredNode === null || $this->nodeComparator->areSameNode($node, $originalNode)) {
             return null;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -208,14 +208,14 @@ CODE_SAMPLE;
 
         $refactoredNode = $this->refactor($node);
 
-        // nothing to change → continue
-        if ($refactoredNode === null) {
-            return null;
-        }
-
         if ($refactoredNode === []) {
             $errorMessage = sprintf(self::EMPTY_NODE_ARRAY_MESSAGE, static::class);
             throw new ShouldNotHappenException($errorMessage);
+        }
+
+        // nothing to change → continue
+        if ($refactoredNode === null || $refactoredNode === $node) {
+            return null;
         }
 
         $originalNode ??= $node;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -213,12 +213,12 @@ CODE_SAMPLE;
             throw new ShouldNotHappenException($errorMessage);
         }
 
+        $originalNode ??= $node;
+
         // nothing to change → continue
-        if ($refactoredNode === null || $refactoredNode === $node) {
+        if ($refactoredNode === null || ! $this->nodeComparator->areSameNode($node, $originalNode)) {
             return null;
         }
-
-        $originalNode ??= $node;
 
         /** @var non-empty-array<Node>|Node $refactoredNode */
         $this->createdByRuleDecorator->decorate($refactoredNode, $originalNode, static::class);


### PR DESCRIPTION
This is to ensure no regression when user write:

```php
    public function refactor(Node $node): FuncCall|null
    {
            $node->args = [];
            return null;
    }
```

above, the `Node` is changed. 

This PR ensure that above functionality keep working to avoid regression.