### PR TITLE
Add failing test fixture for ShortenElseIfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/If_/ShortenElseIfRector/Fixture/demo_file.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/ShortenElseIfRector/Fixture/demo_file.php.inc
@@ -1,0 +1,52 @@
+<?php
+namespace Rector\Tests\CodeQuality\Rector\If_\ShortenElseIfRector\Fixture;
+
+final class DemoFile
+{
+	public function run( int $arg, array $b_arg ) {
+		if ( $arg > 5 ) {
+			echo "a";
+		} else {
+			// above if comment
+			if ( $a === 5 ) {
+				// inside if comment
+				foreach ( $b_arg as $element ) {
+					// inside foreach comment
+					echo $element;
+				}
+				echo "b";
+			} else {
+			 	// inside else comment
+				echo "c";
+			}
+		}
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\ShortenElseIfRector\Fixture;
+
+final class DemoFile
+{
+	public function run( int $arg, array $b_arg ) {
+		if ( $arg > 5 ) {
+			echo "a";
+		} elseif ( $a === 5 ) {
+			// above if comment
+			// inside if comment
+			foreach ( $b_arg as $element ) {
+				// inside foreach comment
+				echo $element;
+			}
+			echo "b";
+		} else {
+			// inside else comment
+			echo "c";
+		}
+	}
+}
+
+?>


### PR DESCRIPTION
# Failing Test for ShortenElseIfRector

Based on https://getrector.com/demo/9434743e-4ebc-45d9-a12f-694c87d6e4db

The issue is that this rector rule puts EVERY comment found anywhere inside the if (or elseif or else) inside, on top of the newly created elseif, creating a major mess.