### PR TITLE
Fixing random stop rules-tests with paratest

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchMethodCallReturnTypeRector/RenameForeachValueVariableToMatchMethodCallReturnTypeRectorTest.php
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchMethodCallReturnTypeRector/RenameForeachValueVariableToMatchMethodCallReturnTypeRectorTest.php
@@ -6,10 +6,8 @@ namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchM
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-#[RunTestsInSeparateProcesses]
 final class RenameForeachValueVariableToMatchMethodCallReturnTypeRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules-tests/Naming/ValueObjectFactory/PropertyRenameFactory/PropertyRenameFactoryTest.php
+++ b/rules-tests/Naming/ValueObjectFactory/PropertyRenameFactory/PropertyRenameFactoryTest.php
@@ -8,7 +8,6 @@ use Iterator;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\FileSystemRector\Parser\FileInfoParser;
 use Rector\Naming\ExpectedNameResolver\MatchPropertyTypeExpectedNameResolver;
@@ -16,7 +15,6 @@ use Rector\Naming\ValueObject\PropertyRename;
 use Rector\Naming\ValueObjectFactory\PropertyRenameFactory;
 use Rector\Testing\PHPUnit\AbstractTestCase;
 
-#[RunTestsInSeparateProcesses]
 final class PropertyRenameFactoryTest extends AbstractTestCase
 {
     private PropertyRenameFactory $propertyRenameFactory;

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
@@ -6,10 +6,8 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-#[RunTestsInSeparateProcesses]
 final class RenameClassRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/tests/Issues/PartialValueDocblockUpdate/PartialValueDocblockUpdateTest.php
+++ b/tests/Issues/PartialValueDocblockUpdate/PartialValueDocblockUpdateTest.php
@@ -6,10 +6,8 @@ namespace Rector\Core\Tests\Issues\PartialValueDocblockUpdate;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-#[RunTestsInSeparateProcesses]
 final class PartialValueDocblockUpdateTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]


### PR DESCRIPTION
`#[RunTestsInSeparateProcesses]` was used to fix fixture duplicate file random error, let's now try remove it and see if it works without it.