### PR TITLE
Skip not natively typed property in AddParamTypeFromPropertyTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_not_natively_typed_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_not_natively_typed_property.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+final class SkipNotNativelyTypedProperty
+{
+    /**
+     * @var int
+     */
+    private $user;
+
+    public function run()
+    {
+        $this->runData($this->user);
+    }
+
+    private function runData($user)
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Fixture/skip_not_natively_typed_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Fixture/skip_not_natively_typed_property.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector\Fixture;
+
+final class SkipNotNativelyTypedProperty
+{
+    /**
+     * @var int
+     */
+    private $user;
+
+    public function run($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
@@ -162,11 +162,11 @@ CODE_SAMPLE
                 return null;
             }
 
-            $exprType = $this->nodeTypeResolver->getType($node->expr);
+            $exprType = $this->nodeTypeResolver->getNativeType($node->expr);
 
             $nodeExprType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($exprType, TypeKind::PARAM);
 
-            $varType = $this->nodeTypeResolver->getType($node->var);
+            $varType = $this->nodeTypeResolver->getNativeType($node->var);
             $nodeVarType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, TypeKind::ANY);
 
             if ($nodeExprType instanceof Node && ! $this->nodeComparator->areNodesEqual($nodeExprType, $nodeVarType)) {


### PR DESCRIPTION
In the `AddParamTypeFromPropertyTypeRector` the property type inference also used the PHPDoc types. This PR fixes this. 

I also the same (regression) test fixture for the AddMethodCallBasedStrictParamTypeRector.

I'm wondering if we should replace `NodeTypeResolver->getType()` with `getNativeType()` on more places in the TypeDeclaration namespace.