### PR TITLE
[Privatization] Fix crash on assign inside Arg on ChangeReadOnlyVariableWithDefaultValueToConstantRector

### DIFF
--- a/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_assign_inside_arg.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector/Fixture/skip_assign_inside_arg.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector\Fixture;
+
+final class SkipAssignInsideArg
+{
+    public function run()
+    {
+        $c = base64_decode(str_replace(['--', '_'], ['+', '/'], $key));
+
+        $ivlen = openssl_cipher_iv_length($cipher = "AES-128-CFB");
+        $hmac = substr($c, $ivlen, $sha2len = 32);
+        $ciphertext_raw = substr($c, $ivlen + $sha2len);
+    }
+}

--- a/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Privatization\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
@@ -19,6 +20,7 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\VarAnnotationManipulator;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeManipulator\ClassMethodAssignManipulator;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Collector\PropertyToAddCollector;
 use Rector\Privatization\Naming\ConstantNaming;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -201,6 +203,11 @@ CODE_SAMPLE
                 if ($this->nodeNameResolver->isName($param->var, $variableName)) {
                     continue 2;
                 }
+            }
+
+            $parentAssign = $readOnlyVariableAssign->getAttribute(AttributeKey::PARENT_NODE);
+            if ($parentAssign instanceof Arg) {
+                continue;
             }
 
             $this->removeNode($readOnlyVariableAssign);

--- a/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
+++ b/rules/Privatization/Rector/Class_/ChangeReadOnlyVariableWithDefaultValueToConstantRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Privatization\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
@@ -16,6 +15,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
 use Rector\BetterPhpDocParser\PhpDocManipulator\VarAnnotationManipulator;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeManipulator\ClassMethodAssignManipulator;
@@ -206,7 +206,7 @@ CODE_SAMPLE
             }
 
             $parentAssign = $readOnlyVariableAssign->getAttribute(AttributeKey::PARENT_NODE);
-            if ($parentAssign instanceof Arg) {
+            if (! $parentAssign instanceof Expression) {
                 continue;
             }
 


### PR DESCRIPTION
Given the following code:

```php
final class SkipAssignInsideArg
{
    public function run()
    {
        $c = base64_decode(str_replace(['--', '_'], ['+', '/'], $key));

        $ivlen = openssl_cipher_iv_length($cipher = "AES-128-CFB");
        $hmac = substr($c, $ivlen, $sha2len = 32);
        $ciphertext_raw = substr($c, $ivlen + $sha2len);
    }
}
```

cause crash:

```bash
Time: 00:00.882, Memory: 78.50 MB

There was 1 error:

1) Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector\ChangeReadOnlyVariableWithDefaultValueToConstantRectorTest::test with data set #6
LogicException: leaveNode() returned invalid value of type integer

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:168
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
```

Ref https://getrector.com/demo/d7728f83-a22f-4e08-8e76-e10e4b433c5e
Fixes https://github.com/rectorphp/rector/issues/7805