### PR TITLE
Use  stefanzweifel/git-auto-commit-action on templates (#3427)

### DIFF
--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -36,6 +36,6 @@ jobs:
                 if: github.event.pull_request.head.repo.full_name == github.repository
                 uses: stefanzweifel/git-auto-commit-action@v4
                 with:
-                    commit_message: '[ci-review] Rector Rectify'
+                    commit_message: '[rector] Rector fixes'
                     commit_author: 'GitHub Action <actions@github.com>'
                     commit_user_email: 'action@github.com'

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -34,13 +34,8 @@ jobs:
             -
                 # commit only to core contributors who have repository access
                 if: github.event.pull_request.head.repo.full_name == github.repository
-                uses: EndBug/add-and-commit@v7.5.0
+                uses: stefanzweifel/git-auto-commit-action@v4
                 with:
-                    # The arguments for the `git add` command (see the paragraph below for more info)
-                    add: .
-                    message: "[rector] Rector fixes"
-                    author_name: "GitHub Action"
-                    author_email: "action@github.com"
-                env:
-                    # to get push access
-                    GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+                    commit_message: '[ci-review] Rector Rectify'
+                    commit_author: 'GitHub Action <actions@github.com>'
+                    commit_user_email: 'action@github.com'


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3426

this make use of stefanzweifel/git-auto-commit-action on template as well.