### PR TITLE
[Core] Decorate Node with created_by_rule attribute on refactor() return null

### DIFF
--- a/src/NodeDecorator/CreatedByRuleDecorator.php
+++ b/src/NodeDecorator/CreatedByRuleDecorator.php
@@ -37,7 +37,7 @@ final class CreatedByRuleDecorator
     /**
      * @param class-string<RectorInterface> $rectorClass
      */
-    private function createByRule(Node $node, string $rectorClass): void
+    public function createByRule(Node $node, string $rectorClass): void
     {
         /** @var class-string<RectorInterface>[] $createdByRule */
         $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -208,14 +208,15 @@ CODE_SAMPLE;
 
         $refactoredNode = $this->refactor($node);
 
-        // nothing to change → continue
-        if ($refactoredNode === null) {
-            return null;
-        }
-
         if ($refactoredNode === []) {
             $errorMessage = sprintf(self::EMPTY_NODE_ARRAY_MESSAGE, static::class);
             throw new ShouldNotHappenException($errorMessage);
+        }
+
+        // nothing to change → continue
+        if ($refactoredNode === null) {
+            $this->createdByRuleDecorator->createByRule($node, static::class);
+            return null;
         }
 
         $originalNode ??= $node;


### PR DESCRIPTION
This is ensure no consecutive same rule executed `return null` usage on `refactor()`.
