### PR TITLE
Handle missing token on Rector CI workflow on forks

### DIFF
--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -20,11 +20,19 @@ jobs:
         timeout-minutes: 8
 
         steps:
+            # workaround for missing secret in fork PRs - see https://github.com/actions/checkout/issues/298
+            # see https://github.com/rectorphp/rector/commit/d395e1c28b8e6a56711dcc2e10490a82965850e4
             -
+                if: github.event.pull_request.head.repo.full_name == github.repository
                 uses: actions/checkout@v3
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
+
+            # in forks, the token is not available - so we cannot us eit
+            -
+                if: github.event.pull_request.head.repo.full_name != github.repository
+                uses: actions/checkout@v3
 
             -
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -29,7 +29,7 @@ jobs:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
 
-            # in forks, the token is not available - so we cannot us eit
+            # in forks, the token is not available - so we cannot use it
             -
                 if: github.event.pull_request.head.repo.full_name != github.repository
                 uses: actions/checkout@v3

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -19,7 +19,7 @@ jobs:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
 
-            # in forks, the token is not available - so we cannot us eit
+            # in forks, the token is not available - so we cannot use it
             -
                 if: github.event.pull_request.head.repo.full_name != github.repository
                 uses: actions/checkout@v3

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -10,11 +10,19 @@ jobs:
         if: github.repository == '__CURRENT_REPOSITORY__'
         runs-on: ubuntu-latest
         steps:
+            # workaround for missing secret in fork PRs - see https://github.com/actions/checkout/issues/298
+            # see https://github.com/rectorphp/rector/commit/d395e1c28b8e6a56711dcc2e10490a82965850e4
             -
+                if: github.event.pull_request.head.repo.full_name == github.repository
                 uses: actions/checkout@v3
                 with:
-                    # needed to trigger workflow after push
+                    # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
+
+            # in forks, the token is not available - so we cannot us eit
+            -
+                if: github.event.pull_request.head.repo.full_name != github.repository
+                uses: actions/checkout@v3
 
             -
                 uses: shivammathur/setup-php@v2

--- a/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
+++ b/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
@@ -12,6 +12,8 @@ use Webmozart\Assert\Assert;
  */
 final class ChangelogContentsFactory
 {
+    private $unused;
+
     /**
      * @var array<string, string[]>
      */

--- a/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
+++ b/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
@@ -12,8 +12,6 @@ use Webmozart\Assert\Assert;
  */
 final class ChangelogContentsFactory
 {
-    private $unused;
-
     /**
      * @var array<string, string[]>
      */


### PR DESCRIPTION
@TomasVotruba @jackbentley this is to avoid error on running on fork, see https://github.com/rectorphp/rector-src/actions/runs/4305120316/jobs/7507111232#step:2:1 on PR https://github.com/rectorphp/rector-src/pull/3430

@jackbentley please rebase your PRs after this merged.