### PR TITLE
[CodingStyle] Fix infinite loop on NewlineAfterStatementRector when parent attribute with next node is different

### DIFF
--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -116,6 +116,13 @@ CODE_SAMPLE
             return null;
         }
 
+        $parentCurrentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+        $parentNextNode = $nextNode->getAttribute(AttributeKey::PARENT_NODE);
+
+        if ($parentNextNode !== $parentCurrentNode) {
+            return null;
+        }
+
         if ($this->shouldSkip($nextNode)) {
             return null;
         }


### PR DESCRIPTION
This is to fix https://github.com/rectorphp/rector/issues/7816

Only reproducible with combined with `Typo3LevelSetList::UP_TO_TYPO3_11,`
