### PR TITLE
Alternative Rector workflow on check repo before steps run

### DIFF
--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 8
 
-        if: github.repository == 'rectorphp/rector-src'
+        if: github.event.pull_request.head.repo.full_name == 'rectorphp/rector-src'
         steps:
             -
                 uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
 
-            - run: echo "run on ${{ github.repository }}"
+            - run: echo "run on ${{ github.event.pull_request.head.repo.full_name }}"
 
             -
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -5,9 +5,6 @@ on:
 
 jobs:
     rector:
-        # Don't run on forks.
-        if: github.repository == 'rectorphp/rector-src'
-
         strategy:
             fail-fast: false
             matrix:
@@ -19,20 +16,13 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 8
 
+        if: github.repository == 'rectorphp/rector-src'
         steps:
-            # workaround for missing secret in fork PRs - see https://github.com/actions/checkout/issues/298
-            # see https://github.com/rectorphp/rector/commit/d395e1c28b8e6a56711dcc2e10490a82965850e4
             -
-                if: github.event.pull_request.head.repo.full_name == github.repository
                 uses: actions/checkout@v3
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
-
-            # in forks, the token is not available - so we cannot use it
-            -
-                if: github.event.pull_request.head.repo.full_name != github.repository
-                uses: actions/checkout@v3
 
             -
                 uses: shivammathur/setup-php@v2
@@ -46,12 +36,8 @@ jobs:
             ## First run Rector - here can't be --dry-run !!! it would stop the job with it and not commit anything in the future
             -   run: bin/rector process ${{ matrix.paths }} --ansi
 
-            -   run: vendor/bin/ecs check --fix --ansi
-
-            # see https://github.com/rectorphp/rector/issues/7579
             -
                 # commit only to core contributors who have repository access
-                if: github.event.pull_request.head.repo.full_name == github.repository
                 uses: stefanzweifel/git-auto-commit-action@v4
                 with:
                     commit_message: '[ci-review] Rector Rectify'

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -24,6 +24,8 @@ jobs:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
 
+            - run: echo "run on ${{ github.repository }}"
+
             -
                 uses: shivammathur/setup-php@v2
                 with:

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -6,23 +6,15 @@ on:
 
 jobs:
     rector:
-        # Don't run on forks.
-        if: github.repository == '__CURRENT_REPOSITORY__'
         runs-on: ubuntu-latest
+        if: github.event.pull_request.head.repo.full_name == '__CURRENT_REPOSITORY__'
         steps:
-            # workaround for missing secret in fork PRs - see https://github.com/actions/checkout/issues/298
-            # see https://github.com/rectorphp/rector/commit/d395e1c28b8e6a56711dcc2e10490a82965850e4
             -
                 if: github.event.pull_request.head.repo.full_name == github.repository
                 uses: actions/checkout@v3
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
-
-            # in forks, the token is not available - so we cannot use it
-            -
-                if: github.event.pull_request.head.repo.full_name != github.repository
-                uses: actions/checkout@v3
 
             -
                 uses: shivammathur/setup-php@v2
@@ -36,7 +28,6 @@ jobs:
 
             -
                 # commit only to core contributors who have repository access
-                if: github.event.pull_request.head.repo.full_name == github.repository
                 uses: stefanzweifel/git-auto-commit-action@v4
                 with:
                     commit_message: '[rector] Rector fixes'

--- a/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
+++ b/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
@@ -12,7 +12,6 @@ use Webmozart\Assert\Assert;
  */
 final class ChangelogContentsFactory
 {
-    private $unused;
     /**
      * @var array<string, string[]>
      */

--- a/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
+++ b/utils/ChangelogGenerator/Changelog/ChangelogContentsFactory.php
@@ -12,6 +12,7 @@ use Webmozart\Assert\Assert;
  */
 final class ChangelogContentsFactory
 {
+    private $unused;
     /**
      * @var array<string, string[]>
      */


### PR DESCRIPTION
@TomasVotruba this is alternative PR of:

- https://github.com/rectorphp/rector-src/pull/3439

which move the check on before steps instead of before strategy.

Closes https://github.com/rectorphp/rector-src/pull/3439