### PR TITLE
Handle $reflectionProperty->getDefaultValueExpression() return null

### DIFF
--- a/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -162,8 +162,13 @@ final class ArrayTypeAnalyzer
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if ($phpPropertyReflection instanceof PhpPropertyReflection) {
             $reflectionProperty = $phpPropertyReflection->getNativeReflection();
+            $defaultValueExpr = $reflectionProperty->getDefaultValueExpression();
 
-            $defaultValueType = $this->nodeTypeResolver->getType($reflectionProperty->getDefaultValueExpression());
+            if (! $defaultValueExpr instanceof Expr) {
+                return false;
+            }
+
+            $defaultValueType = $this->nodeTypeResolver->getType($defaultValueExpr);
             return $defaultValueType->isArray()
                 ->yes();
         }

--- a/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -162,11 +162,14 @@ final class ArrayTypeAnalyzer
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if ($phpPropertyReflection instanceof PhpPropertyReflection) {
             $reflectionProperty = $phpPropertyReflection->getNativeReflection();
-            if (! $reflectionProperty->hasDefaultValue()) {
+            $betterReflection = $reflectionProperty->getBetterReflection();
+            $defaultValueExpr = $betterReflection->getDefaultValueExpression();
+
+            if (! $defaultValueExpr instanceof Expr) {
                 return false;
             }
 
-            $defaultValueType = $this->nodeTypeResolver->getType($reflectionProperty->getDefaultValueExpression());
+            $defaultValueType = $this->nodeTypeResolver->getType($defaultValueExpr);
             return $defaultValueType->isArray()
                 ->yes();
         }

--- a/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -162,13 +162,11 @@ final class ArrayTypeAnalyzer
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if ($phpPropertyReflection instanceof PhpPropertyReflection) {
             $reflectionProperty = $phpPropertyReflection->getNativeReflection();
-            $defaultValueExpr = $reflectionProperty->getDefaultValueExpression();
-
-            if (! $defaultValueExpr instanceof Expr) {
+            if (! $reflectionProperty->isDefaultValueAvailable()) {
                 return false;
             }
 
-            $defaultValueType = $this->nodeTypeResolver->getType($defaultValueExpr);
+            $defaultValueType = $this->nodeTypeResolver->getType($reflectionProperty->getDefaultValueExpression());
             return $defaultValueType->isArray()
                 ->yes();
         }

--- a/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -162,7 +162,7 @@ final class ArrayTypeAnalyzer
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if ($phpPropertyReflection instanceof PhpPropertyReflection) {
             $reflectionProperty = $phpPropertyReflection->getNativeReflection();
-            if (! $reflectionProperty->isDefaultValueAvailable()) {
+            if (! $reflectionProperty->hasDefaultValue()) {
                 return false;
             }
 


### PR DESCRIPTION
Ref rector-doctrine test error https://github.com/rectorphp/rector-doctrine/actions/runs/4321563757/jobs/7542937994#step:5:19

```

 [ERROR] Could not process                                                      
         "/home/runner/work/rector-doctrine/rector-doctrine/src/NodeAnalyzer/Set
         terClassMethodAnalyzer.php" file, due to:                              
         "System error:                                                         
         "PHPStan\BetterReflection\Reflection\Adapter\ReflectionProperty::getDef
         aultValueExpression(): Return value must be of type                    
         PhpParser\Node\Expr, null returned"                                    
         Run Rector with "--debug" option and post the report here: 
https://github.com/rectorphp/rector/issues/new
". On line:
```

On PR https://github.com/rectorphp/rector-doctrine/pull/154