### PR TITLE
[Core] Remove BetterStandardPrinter::pStmts()

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -361,16 +361,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
     }
 
     /**
-     * @param Node[] $nodes
-     */
-    protected function pStmts(array $nodes, bool $indent = true): string
-    {
-        $this->decorateInlineHTMLOrNopAndUpdatePhpdocInfo($nodes);
-
-        return parent::pStmts($nodes, $indent);
-    }
-
-    /**
      * "...$params) : ReturnType"
      * ↓
      * "...$params): ReturnType"


### PR DESCRIPTION
The `BetterStandardPrinter::pStmts()` is overridden to decorate the stmts php doc info, which no need to be called into loop when not yet refactored.

Decorate before `refactor()` is actually already covered by `pArray()`

https://github.com/rectorphp/rector-src/blob/658e48f31fcb26a0e56740a49a994dbab3c1e6b5/src/PhpParser/Printer/BetterStandardPrinter.php#L228-L240

This PR remove it, and move the loop into `DocBlockUpdater::updateRefactoredNodeWithPhpDocInfo()` so it only loop after refactored.