### PR TITLE
[e2e] Update nikic/php-parser ^4.15.4 to fix commented alternative if elseif syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "fidry/cpu-core-counter": "^0.5.1",
         "nette/neon": "^3.4",
         "nette/utils": "^3.2.9",
-        "nikic/php-parser": "^4.15.3",
+        "nikic/php-parser": "^4.15.4",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.16",
         "phpstan/phpstan": "^1.10.1",

--- a/e2e/plain-views/src/commented_elseif_alternate_syntax.php
+++ b/e2e/plain-views/src/commented_elseif_alternate_syntax.php
@@ -1,0 +1,17 @@
+<div class="price-box">
+    <?php if (($_min = $this->getMinAmount()) && ($_max = $this->getMaxAmount()) && ($_min == $_max)): ?>
+        <span class="price" id="product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_min, true, false) ?>
+        </span>
+    <?php elseif (($_min = $this->getMinAmount()) && $_min != 0): ?>
+        <span class="label"><?php echo Mage::helper('brainvire_giftcard')->__('From') ?></span>
+        <span class="price" id="min-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_min,true,false) ?>
+        </span>
+    <?php /*elseif ($_max = $this->getMaxAmount()): ?>
+        <span class="label"><?php echo Mage::helper('brainvire_giftcard')->__('Up To') ?></span>
+        <span class="price" id="max-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_max,true,false) ?>
+        </span>
+    <?php */endif; ?>
+</div>


### PR DESCRIPTION
@TomasVotruba @DCoderLT nikic/php-parser 4.15.4 just released with fix of printing if elseif on alternative syntax, see :

- https://github.com/nikic/PHP-Parser/pull/914

Fixes https://github.com/rectorphp/rector/issues/7703