### PR TITLE
[Printer] Avoid undefined index 0 on printing FileWithoutNamespace

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -570,13 +570,10 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
      */
     private function resolveNewStmts(array $stmts): array
     {
-        if (count($stmts) !== 1) {
-            return $stmts;
-        }
-        
-        $node = current($stmts);
-        if ($node instanceof FileWithoutNamespace) {
-            return $this->resolveNewStmts($node->stmts);
+        $stmts = array_values($stmts);
+
+        if (count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace) {
+            return $this->resolveNewStmts($stmts[0]->stmts);
         }
 
         return $stmts;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -570,8 +570,13 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
      */
     private function resolveNewStmts(array $stmts): array
     {
-        if (count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace) {
-            return $this->resolveNewStmts($stmts[0]->stmts);
+        if (count($stmts) !== 1) {
+            return $stmts;
+        }
+        
+        $currentStmt = current($stmts);
+        if ($currentStmt instanceof FileWithoutNamespace) {
+            return $this->resolveNewStmts($currentStmt->stmts);
         }
 
         return $stmts;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -574,9 +574,9 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return $stmts;
         }
         
-        $currentStmt = current($stmts);
-        if ($currentStmt instanceof FileWithoutNamespace) {
-            return $this->resolveNewStmts($currentStmt->stmts);
+        $node = current($stmts);
+        if ($node instanceof FileWithoutNamespace) {
+            return $this->resolveNewStmts($node->stmts);
         }
 
         return $stmts;


### PR DESCRIPTION
use array_values() for ensure index start from 0