### PR TITLE
[AutoImport][PostRector] Handle duplicated import on namespaced class on UseAddingPostRector

### DIFF
--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -83,6 +83,17 @@ final class UseAddingPostRector extends AbstractPostRector
             $nodes = $this->useImportsRemover->removeImportsFromStmts($nodes, $removedUses);
         }
 
+        return $this->resolveNodesWithImportedUses($nodes, $useImportTypes, $functionUseImportTypes, $namespace);
+    }
+
+    /**
+     * @param Stmt[] $nodes
+     * @param FullyQualifiedObjectType[] $useImportTypes
+     * @param FullyQualifiedObjectType[] $functionUseImportTypes
+     * @return Stmt[]
+     */
+    private function resolveNodesWithImportedUses(array $nodes, array $useImportTypes, array $functionUseImportTypes, ?Namespace_ $namespace): array
+    {
         // A. has namespace? add under it
         if ($namespace instanceof Namespace_) {
             // then add, to prevent adding + removing false positive of same short use

--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -6,7 +6,6 @@ namespace Rector\PostRector\Rector;
 
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
-use PhpParser\Node\Stmt\Use_;
 use Rector\CodingStyle\Application\UseImportsAdder;
 use Rector\CodingStyle\Application\UseImportsRemover;
 use Rector\Core\Configuration\RenamedClassesDataCollector;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -537,6 +537,7 @@ parameters:
                 - rules/CodingStyle/Rector/ClassMethod/FuncGetArgsToVariadicParamRector.php
                 - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
                 - packages/PhpDocParser/PhpDocParser/PhpDocNodeTraverser.php
+                - packages/PostRector/Rector/UseAddingPostRector.php
 
         -
             message: '#Method call return value that should be used, but is not#'

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -51,8 +51,8 @@ final class UseImportsRemover
     private function removeUseFromUse(array $removedUses, Use_ $use): void
     {
         foreach ($use->uses as $usesKey => $useUse) {
-            foreach ($removedUses as $removedShortUse) {
-                if ($useUse->name->toString() === $removedShortUse) {
+            foreach ($removedUses as $removedUse) {
+                if ($useUse->name->toString() === $removedUse) {
                     unset($use->uses[$usesKey]);
                 }
             }

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -6,11 +6,16 @@ namespace Rector\CodingStyle\Application;
 
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
 use Rector\Core\Configuration\RectorConfigProvider;
+use Rector\NodeRemoval\NodeRemover;
 
 final class UseImportsRemover
 {
-    public function __construct(private readonly RectorConfigProvider $rectorConfigProvider)
+    public function __construct(
+        private readonly RectorConfigProvider $rectorConfigProvider,
+        private readonly NodeRemover $nodeRemover
+    )
     {
     }
 
@@ -56,6 +61,10 @@ final class UseImportsRemover
                     unset($use->uses[$usesKey]);
                 }
             }
+        }
+
+        if ($use->uses === []) {
+            $this->nodeRemover->removeNode($use);
         }
     }
 }

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -16,10 +16,10 @@ final class UseImportsRemover
 
     /**
      * @param Stmt[] $stmts
-     * @param string[] $removedShortUses
+     * @param string[] $removedUses
      * @return Stmt[]
      */
-    public function removeImportsFromStmts(array $stmts, array $removedShortUses): array
+    public function removeImportsFromStmts(array $stmts, array $removedUses): array
     {
         /**
          * Verify import name to cover conflict on rename+import,
@@ -34,7 +34,7 @@ final class UseImportsRemover
                 continue;
             }
 
-            $this->removeUseFromUse($removedShortUses, $stmt);
+            $this->removeUseFromUse($removedUses, $stmt);
 
             // nothing left → remove
             if ($stmt->uses === []) {
@@ -46,12 +46,12 @@ final class UseImportsRemover
     }
 
     /**
-     * @param string[] $removedShortUses
+     * @param string[] $removedUses
      */
-    private function removeUseFromUse(array $removedShortUses, Use_ $use): void
+    private function removeUseFromUse(array $removedUses, Use_ $use): void
     {
         foreach ($use->uses as $usesKey => $useUse) {
-            foreach ($removedShortUses as $removedShortUse) {
+            foreach ($removedUses as $removedShortUse) {
                 if ($useUse->name->toString() === $removedShortUse) {
                     unset($use->uses[$usesKey]);
                 }

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -6,7 +6,6 @@ namespace Rector\CodingStyle\Application;
 
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Use_;
-use PhpParser\Node\Stmt\UseUse;
 use Rector\Core\Configuration\RectorConfigProvider;
 use Rector\NodeRemoval\NodeRemover;
 

--- a/src/Console/Command/SetupCICommand.php
+++ b/src/Console/Command/SetupCICommand.php
@@ -90,6 +90,7 @@ final class SetupCICommand extends Command
         );
 
         $this->symfonyStyle->newLine();
+
         $repositoryNewSecretsLink = sprintf('https://github.com/%s/settings/secrets/actions/new', $currentRepository);
         $this->symfonyStyle->writeln(
             '2) Add the token to Action secrets as "ACCESS_TOKEN":' . \PHP_EOL . $repositoryNewSecretsLink
@@ -120,10 +121,5 @@ final class SetupCICommand extends Command
 
         $match = Strings::match($output, self::GITHUB_REPOSITORY_REGEX);
         return $match['repository_name'] ?? null;
-    }
-
-    private function createClickableLink(string $url): string
-    {
-        return sprintf('<href=%s>%s</>', $url, $url);
     }
 }

--- a/tests/Issues/Issue6496/Fixture/namespaced_import_doc_after_rename.php.inc
+++ b/tests/Issues/Issue6496/Fixture/namespaced_import_doc_after_rename.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace App;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @Route("/someUrl")
+ */
+class SomeController extends Controller
+{
+}
+
+?>
+-----
+<?php
+
+namespace App;
+
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @Route("/someUrl")
+ */
+class SomeController extends Controller
+{
+}
+
+?>


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3460

When auto import is namespaced, the old classname should be cleaned up before add to avoid duplicated import. 

Given the following config:

```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\Symfony\Rector\ClassMethod\ReplaceSensioRouteAnnotationWithSymfonyRector;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->importNames();
    $rectorConfig->rule(ReplaceSensioRouteAnnotationWithSymfonyRector::class);
};
```

with class:

```php
<?php

namespace App;

use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
use Symfony\Bundle\FrameworkBundle\Controller\Controller;

/**
 * @Route("/someUrl")
 */
class SomeController extends Controller
{
}
```

It currently produce duplicated use statement.

```diff
 namespace App;
 
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
```

This PR try to fix it.
