### PR TITLE
[PostRector][AutoImport] Move check duplicate use of rename class from UseAddingPostRector to ClassRenamingPostRector

### DIFF
--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Rector\PostRector\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Namespace_;
+use Rector\CodingStyle\Application\UseImportsRemover;
+use Rector\Core\Configuration\RectorConfigProvider;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\NonPhpFile\Rector\RenameClassNonPhpRector;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\PostRector\Contract\Rector\PostRectorDependencyInterface;
 use Rector\Renaming\NodeManipulator\ClassRenamer;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -18,7 +23,10 @@ final class ClassRenamingPostRector extends AbstractPostRector implements PostRe
 {
     public function __construct(
         private readonly ClassRenamer $classRenamer,
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
+        private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
+        private readonly RectorConfigProvider $rectorConfigProvider,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly UseImportsRemover $useImportsRemover
     ) {
     }
 
@@ -40,10 +48,29 @@ final class ClassRenamingPostRector extends AbstractPostRector implements PostRe
     {
         $oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
         if ($oldToNewClasses === []) {
-            return $node;
+            return null;
         }
 
-        return $this->classRenamer->renameNode($node, $oldToNewClasses);
+        $result = $this->classRenamer->renameNode($node, $oldToNewClasses);
+
+        if (! $this->rectorConfigProvider->shouldImportNames()) {
+            return $result;
+        }
+
+        $removedUses = $this->renamedClassesDataCollector->getOldClasses();
+        $rootNode = $this->betterNodeFinder->findParentType($node, Namespace_::class);
+        if ($rootNode instanceof Namespace_) {
+            $this->useImportsRemover->removeImportsFromStmts($rootNode->stmts, $removedUses);
+            return $result;
+        }
+
+        $rootNode = $this->betterNodeFinder->findParentType($node, FileWithoutNamespace::class);
+        if ($rootNode instanceof FileWithoutNamespace) {
+            $this->useImportsRemover->removeImportsFromStmts($rootNode->stmts, $removedUses);
+            return $result;
+        }
+
+        return $result;
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -57,18 +57,13 @@ final class ClassRenamingPostRector extends AbstractPostRector implements PostRe
             return $result;
         }
 
-        $removedUses = $this->renamedClassesDataCollector->getOldClasses();
-        $rootNode = $this->betterNodeFinder->findParentType($node, Namespace_::class);
-        if ($rootNode instanceof Namespace_) {
-            $this->useImportsRemover->removeImportsFromStmts($rootNode->stmts, $removedUses);
+        $rootNode = $this->betterNodeFinder->findParentByTypes($node, [Namespace_::class, FileWithoutNamespace::class]);
+        if (! $rootNode instanceof Node) {
             return $result;
         }
 
-        $rootNode = $this->betterNodeFinder->findParentType($node, FileWithoutNamespace::class);
-        if ($rootNode instanceof FileWithoutNamespace) {
-            $this->useImportsRemover->removeImportsFromStmts($rootNode->stmts, $removedUses);
-            return $result;
-        }
+        $removedUses = $this->renamedClassesDataCollector->getOldClasses();
+        $this->useImportsRemover->removeImportsFromStmts($rootNode->stmts, $removedUses);
 
         return $result;
     }

--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -48,6 +48,10 @@ final class UseAddingPostRector extends AbstractPostRector
         $useImportTypes = $this->useNodesToAddCollector->getObjectImportsByFilePath($file->getFilePath());
         $functionUseImportTypes = $this->useNodesToAddCollector->getFunctionImportsByFilePath($file->getFilePath());
 
+        if ($useImportTypes === [] && $functionUseImportTypes === []) {
+            return $nodes;
+        }
+
         /** @var FullyQualifiedObjectType[] $useImportTypes */
         $useImportTypes = $this->typeFactory->uniquateTypes($useImportTypes);
         $firstNode = $nodes[0];

--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -7,8 +7,6 @@ namespace Rector\PostRector\Rector;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
 use Rector\CodingStyle\Application\UseImportsAdder;
-use Rector\CodingStyle\Application\UseImportsRemover;
-use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -26,10 +24,8 @@ final class UseAddingPostRector extends AbstractPostRector
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly TypeFactory $typeFactory,
         private readonly UseImportsAdder $useImportsAdder,
-        private readonly UseImportsRemover $useImportsRemover,
         private readonly UseNodesToAddCollector $useNodesToAddCollector,
-        private readonly CurrentFileProvider $currentFileProvider,
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 
@@ -52,17 +48,10 @@ final class UseAddingPostRector extends AbstractPostRector
         $useImportTypes = $this->useNodesToAddCollector->getObjectImportsByFilePath($file->getFilePath());
         $functionUseImportTypes = $this->useNodesToAddCollector->getFunctionImportsByFilePath($file->getFilePath());
 
-        $removedUses = $this->renamedClassesDataCollector->getOldClasses();
-
-        // nothing to import or remove
-        if ($useImportTypes === [] && $functionUseImportTypes === [] && $removedUses === []) {
-            return $nodes;
-        }
-
         /** @var FullyQualifiedObjectType[] $useImportTypes */
         $useImportTypes = $this->typeFactory->uniquateTypes($useImportTypes);
-
         $firstNode = $nodes[0];
+
         if ($firstNode instanceof FileWithoutNamespace) {
             $nodes = $firstNode->stmts;
         }
@@ -72,40 +61,7 @@ final class UseAddingPostRector extends AbstractPostRector
             return $nodes;
         }
 
-        if ($namespace instanceof Namespace_) {
-            // clean namespace stmts, don't assign, this used to clean the stmts of Namespace_
-            $this->useImportsRemover->removeImportsFromStmts($namespace->stmts, $removedUses);
-        }
-
-        if ($firstNode instanceof FileWithoutNamespace) {
-            // clean no-namespace stmts, assign
-            $nodes = $this->useImportsRemover->removeImportsFromStmts($nodes, $removedUses);
-        }
-
         return $this->resolveNodesWithImportedUses($nodes, $useImportTypes, $functionUseImportTypes, $namespace);
-    }
-
-    /**
-     * @param Stmt[] $nodes
-     * @param FullyQualifiedObjectType[] $useImportTypes
-     * @param FullyQualifiedObjectType[] $functionUseImportTypes
-     * @return Stmt[]
-     */
-    private function resolveNodesWithImportedUses(array $nodes, array $useImportTypes, array $functionUseImportTypes, ?Namespace_ $namespace): array
-    {
-        // A. has namespace? add under it
-        if ($namespace instanceof Namespace_) {
-            // then add, to prevent adding + removing false positive of same short use
-            $this->useImportsAdder->addImportsToNamespace($namespace, $useImportTypes, $functionUseImportTypes);
-
-            return $nodes;
-        }
-
-        // B. no namespace? add in the top
-        $useImportTypes = $this->filterOutNonNamespacedNames($useImportTypes);
-
-        // then add, to prevent adding + removing false positive of same short use
-        return $this->useImportsAdder->addImportsToStmts($nodes, $useImportTypes, $functionUseImportTypes);
     }
 
     public function getPriority(): int
@@ -141,6 +97,33 @@ class SomeClass
 CODE_SAMPLE
                 ), ]
         );
+    }
+
+    /**
+     * @param Stmt[] $nodes
+     * @param FullyQualifiedObjectType[] $useImportTypes
+     * @param FullyQualifiedObjectType[] $functionUseImportTypes
+     * @return Stmt[]
+     */
+    private function resolveNodesWithImportedUses(
+        array $nodes,
+        array $useImportTypes,
+        array $functionUseImportTypes,
+        ?Namespace_ $namespace
+    ): array {
+        // A. has namespace? add under it
+        if ($namespace instanceof Namespace_) {
+            // then add, to prevent adding + removing false positive of same short use
+            $this->useImportsAdder->addImportsToNamespace($namespace, $useImportTypes, $functionUseImportTypes);
+
+            return $nodes;
+        }
+
+        // B. no namespace? add in the top
+        $useImportTypes = $this->filterOutNonNamespacedNames($useImportTypes);
+
+        // then add, to prevent adding + removing false positive of same short use
+        return $this->useImportsAdder->addImportsToStmts($nodes, $useImportTypes, $functionUseImportTypes);
     }
 
     /**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -537,7 +537,6 @@ parameters:
                 - rules/CodingStyle/Rector/ClassMethod/FuncGetArgsToVariadicParamRector.php
                 - packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
                 - packages/PhpDocParser/PhpDocParser/PhpDocNodeTraverser.php
-                - packages/PostRector/Rector/UseAddingPostRector.php
 
         -
             message: '#Method call return value that should be used, but is not#'

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -92,7 +92,11 @@ final class UseImportsAdder
 
         $newUses = $this->createUses($useImportTypes, $functionUseImportTypes, $namespaceName);
 
-        if ($namespace->stmts[0] instanceof Use_ && $newUses !== []) {
+        if ($newUses === []) {
+            return;
+        }
+
+        if ($namespace->stmts[0] instanceof Use_) {
             $comments = (array) $namespace->stmts[0]->getAttribute(AttributeKey::COMMENTS);
 
             if ($comments !== []) {

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -6,47 +6,28 @@ namespace Rector\CodingStyle\Application;
 
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Use_;
-use Rector\Core\Configuration\RectorConfigProvider;
 use Rector\NodeRemoval\NodeRemover;
 
 final class UseImportsRemover
 {
     public function __construct(
-        private readonly RectorConfigProvider $rectorConfigProvider,
         private readonly NodeRemover $nodeRemover
-    )
-    {
+    ) {
     }
 
     /**
      * @param Stmt[] $stmts
      * @param string[] $removedUses
-     * @return Stmt[]
      */
-    public function removeImportsFromStmts(array $stmts, array $removedUses): array
+    public function removeImportsFromStmts(array $stmts, array $removedUses): void
     {
-        /**
-         * Verify import name to cover conflict on rename+import,
-         * but without $rectorConfig->removeUnusedImports() used
-         */
-        if (! $this->rectorConfigProvider->shouldImportNames()) {
-            return $stmts;
-        }
-
-        foreach ($stmts as $stmtKey => $stmt) {
+        foreach ($stmts as $stmt) {
             if (! $stmt instanceof Use_) {
                 continue;
             }
 
             $this->removeUseFromUse($removedUses, $stmt);
-
-            // nothing left → remove
-            if ($stmt->uses === []) {
-                unset($stmts[$stmtKey]);
-            }
         }
-
-        return $stmts;
     }
 
     /**

--- a/src/NodeManipulator/ClassInsertManipulator.php
+++ b/src/NodeManipulator/ClassInsertManipulator.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\TraitUse;
 use PHPStan\Type\Type;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\ValueObject\PropertyMetadata;
 
 final class ClassInsertManipulator
@@ -34,6 +35,9 @@ final class ClassInsertManipulator
      */
     public function addAsFirstMethod(Class_ $class, Property | ClassConst | ClassMethod $stmt): void
     {
+        $scope = $class->getAttribute(AttributeKey::SCOPE);
+        $stmt->setAttribute(AttributeKey::SCOPE, $scope);
+
         if ($this->isSuccessToInsertBeforeFirstMethod($class, $stmt)) {
             return;
         }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3461

This PR move the check of duplicating use on conflict during auto import + rename from `UseAddingPostRector` to `ClassRenamingPostRector` because of usage of rector dependencies:

https://github.com/rectorphp/rector-src/blob/f9900dd236001d117a7b3fdb9fcc2d0d5ec569bc/packages/PostRector/Rector/ClassRenamingPostRector.php#L34-L37

so skip it will correctly apply skip as well on auto import enabled.