### PR TITLE
[Renaming] Remove RenameClassRector::processCleanUpUse() as already covered on ClassRenamingPostRector

### DIFF
--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
 use PhpParser\NodeTraverser;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Configuration\RectorConfigProvider;
@@ -43,6 +44,10 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
 
         foreach ($node->stmts as $key => $namespaceStmt) {
             if (! $namespaceStmt instanceof Use_) {
+                continue;
+            }
+
+            if ($namespaceStmt->uses === []) {
                 continue;
             }
 

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -47,6 +47,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
             }
 
             if ($namespaceStmt->uses === []) {
+                unset($node->stmts[$key]);
                 continue;
             }
 

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -48,6 +48,8 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
 
             if ($namespaceStmt->uses === []) {
                 unset($node->stmts[$key]);
+                $hasChanged = true;
+
                 continue;
             }
 

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
-use PhpParser\Node\Stmt\UseUse;
 use PhpParser\NodeTraverser;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Configuration\RectorConfigProvider;

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Use_;
-use Rector\Core\Configuration\RectorConfigProvider;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -37,7 +36,6 @@ final class RenameClassRector extends AbstractRector implements ConfigurableRect
     public function __construct(
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
         private readonly ClassRenamer $classRenamer,
-        private readonly RectorConfigProvider $rectorConfigProvider,
         private readonly RenameClassCallbackHandler $renameClassCallbackHandler,
     ) {
     }

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -6,7 +6,6 @@ namespace Rector\Renaming\Rector\Name;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Expression;
@@ -98,7 +97,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param FunctionLike|Name|ClassLike|Expression|Namespace_|Property|FileWithoutNamespace|Use_ $node
+     * @param FunctionLike|Name|ClassLike|Expression|Namespace_|Property|FileWithoutNamespace $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -107,15 +106,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $node instanceof Use_) {
-            return $this->classRenamer->renameNode($node, $oldToNewClasses);
-        }
-
-        if (! $this->rectorConfigProvider->shouldImportNames()) {
-            return null;
-        }
-
-        return $this->processCleanUpUse($node, $oldToNewClasses);
+        return $this->classRenamer->renameNode($node, $oldToNewClasses);
     }
 
     /**
@@ -136,21 +127,6 @@ CODE_SAMPLE
         Assert::allString(array_keys($configuration));
 
         $this->addOldToNewClasses($configuration);
-    }
-
-    /**
-     * @param array<string, string> $oldToNewClasses
-     */
-    private function processCleanUpUse(Use_ $use, array $oldToNewClasses): ?Use_
-    {
-        foreach ($use->uses as $useUse) {
-            if (! $useUse->alias instanceof Identifier && isset($oldToNewClasses[$useUse->name->toString()])) {
-                $this->removeNode($use);
-                return $use;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -100,11 +100,13 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
-        if ($oldToNewClasses === [] && ! $this->renameClassCallbackHandler->hasOldToNewClassCallbacks()) {
-            return null;
+        if ($oldToNewClasses !== []) {
+            return $this->classRenamer->renameNode($node, $oldToNewClasses);
         }
-
-        return $this->classRenamer->renameNode($node, $oldToNewClasses);
+        if ($this->renameClassCallbackHandler->hasOldToNewClassCallbacks()) {
+            return $this->classRenamer->renameNode($node, $oldToNewClasses);
+        }
+        return null;
     }
 
     /**

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -103,9 +103,11 @@ CODE_SAMPLE
         if ($oldToNewClasses !== []) {
             return $this->classRenamer->renameNode($node, $oldToNewClasses);
         }
+
         if ($this->renameClassCallbackHandler->hasOldToNewClassCallbacks()) {
             return $this->classRenamer->renameNode($node, $oldToNewClasses);
         }
+
         return null;
     }
 


### PR DESCRIPTION
- Process clean up use is covered on `ClassRenamingPostRector` after rename
- Process add use statement for new name covered on `UseAddingPostRector` after cleaned up

so it can be removed.