### PR TITLE
[Renaming] Remove Use_ from getNodeTypes() on RenameClassRector

### DIFF
--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
-use PhpParser\Node\Stmt\Use_;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -90,7 +89,6 @@ CODE_SAMPLE
             ClassLike::class,
             Namespace_::class,
             FileWithoutNamespace::class,
-            Use_::class,
         ];
     }
 


### PR DESCRIPTION
I forgot to remove `Use_` from node types on PR:

- https://github.com/rectorphp/rector-src/pull/3463

This PR remove it, the `Use_` handling duplicate already covered on PostRector when auto import enabled:

- Process clean up use is covered on `ClassRenamingPostRector` after rename
- Process add use statement for new name covered on `UseAddingPostRector` after cleaned up