### PR TITLE
[AutoImport] Add mirror comment support on first Use_ on no namespace code

### DIFF
--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -81,7 +81,7 @@ final class UseImportsAdder
                     $nodesToAdd = array_merge([new Nop()], $newUses);
                 }
 
-                $this->mirrorUseComments($stmts, $newUses, 1);
+                $this->mirrorUseComments($stmts, $newUses, $key + 1);
 
                 array_splice($stmts, $key + 1, 0, $nodesToAdd);
 

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -27,6 +27,30 @@ final class UseImportsAdder
 
     /**
      * @param Stmt[] $stmts
+     * @param Use_[] $newUses
+     */
+    private function mirrorUseComments(array $stmts, array $newUses): void
+    {
+        if ($stmts === []) {
+            return;
+        }
+
+        if ($stmts[0] instanceof Use_) {
+            $comments = (array) $stmts[0]->getAttribute(AttributeKey::COMMENTS);
+
+            if ($comments !== []) {
+                $newUses[0]->setAttribute(
+                    AttributeKey::COMMENTS,
+                    $stmts[0]->getAttribute(AttributeKey::COMMENTS)
+                );
+
+                $stmts[0]->setAttribute(AttributeKey::COMMENTS, null);
+            }
+        }
+    }
+
+    /**
+     * @param Stmt[] $stmts
      * @param array<FullyQualifiedObjectType|AliasedObjectType> $useImportTypes
      * @param array<FullyQualifiedObjectType|AliasedObjectType> $functionUseImportTypes
      * @return Stmt[]
@@ -63,6 +87,8 @@ final class UseImportsAdder
             }
         }
 
+        $this->mirrorUseComments($stmts, $newUses);
+
         // make use stmts first
         return array_merge($newUses, $stmts);
     }
@@ -96,18 +122,7 @@ final class UseImportsAdder
             return;
         }
 
-        if ($namespace->stmts[0] instanceof Use_) {
-            $comments = (array) $namespace->stmts[0]->getAttribute(AttributeKey::COMMENTS);
-
-            if ($comments !== []) {
-                $newUses[0]->setAttribute(
-                    AttributeKey::COMMENTS,
-                    $namespace->stmts[0]->getAttribute(AttributeKey::COMMENTS)
-                );
-
-                $namespace->stmts[0]->setAttribute(AttributeKey::COMMENTS, null);
-            }
-        }
+        $this->mirrorUseComments($namespace->stmts, $newUses);
 
         $namespace->stmts = array_merge($newUses, $namespace->stmts);
     }

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -29,22 +29,22 @@ final class UseImportsAdder
      * @param Stmt[] $stmts
      * @param Use_[] $newUses
      */
-    private function mirrorUseComments(array $stmts, array $newUses): void
+    private function mirrorUseComments(array $stmts, array $newUses, int $indexStmt = 0): void
     {
         if ($stmts === []) {
             return;
         }
 
-        if ($stmts[0] instanceof Use_) {
-            $comments = (array) $stmts[0]->getAttribute(AttributeKey::COMMENTS);
+        if ($stmts[$indexStmt] instanceof Use_) {
+            $comments = (array) $stmts[$indexStmt]->getAttribute(AttributeKey::COMMENTS);
 
             if ($comments !== []) {
                 $newUses[0]->setAttribute(
                     AttributeKey::COMMENTS,
-                    $stmts[0]->getAttribute(AttributeKey::COMMENTS)
+                    $stmts[$indexStmt]->getAttribute(AttributeKey::COMMENTS)
                 );
 
-                $stmts[0]->setAttribute(AttributeKey::COMMENTS, null);
+                $stmts[$indexStmt]->setAttribute(AttributeKey::COMMENTS, null);
             }
         }
     }
@@ -80,6 +80,8 @@ final class UseImportsAdder
                     // add extra space, if there are no new use imports to be added
                     $nodesToAdd = array_merge([new Nop()], $newUses);
                 }
+
+                $this->mirrorUseComments($stmts, $newUses, 1);
 
                 array_splice($stmts, $key + 1, 0, $nodesToAdd);
 

--- a/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace.php.inc
+++ b/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace.php.inc
@@ -9,7 +9,7 @@ use Foobar\A;
 /**
  * Docblock
  */
-final class DemoFile
+final class NoNamespace
 {
     public function run()
     {
@@ -31,7 +31,7 @@ use Foobar\A;
 /**
  * Docblock
  */
-final class DemoFile
+final class NoNamespace
 {
     public function run()
     {

--- a/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace.php.inc
+++ b/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * License
+ */
+
+use Foobar\A;
+
+/**
+ * Docblock
+ */
+final class DemoFile
+{
+    public function run()
+    {
+        new A();
+        new \Foobar\B();
+    }
+}
+
+?>
+-----
+<?php
+
+/**
+ * License
+ */
+use Foobar\B;
+use Foobar\A;
+
+/**
+ * Docblock
+ */
+final class DemoFile
+{
+    public function run()
+    {
+        new A();
+        new B();
+    }
+}
+
+?>

--- a/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace_with_strict_types.php.inc
+++ b/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace_with_strict_types.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * License
+ */
+
+use Foobar\A;
+
+/**
+ * Docblock
+ */
+final class NoNamespaceWithStrictTypes
+{
+    public function run()
+    {
+        new A();
+        new \Foobar\B();
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+/**
+ * License
+ */
+use Foobar\B;
+use Foobar\A;
+
+/**
+ * Docblock
+ */
+final class NoNamespaceWithStrictTypes
+{
+    public function run()
+    {
+        new A();
+        new B();
+    }
+}
+
+?>

--- a/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace_with_strict_types.php.inc
+++ b/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace_with_strict_types.php.inc
@@ -25,11 +25,11 @@ final class NoNamespaceWithStrictTypes
 <?php
 
 declare(strict_types=1);
-
 /**
  * License
  */
 use Foobar\B;
+
 use Foobar\A;
 
 /**

--- a/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace_with_strict_types_no_existing_use.php.inc
+++ b/tests/Issues/AutoImportBeforeDocblock/Fixture/no_namespace_with_strict_types_no_existing_use.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+ /**
+ * Docblock
+ */
+final class NoNamespaceWithStrictTypesNoExistingUse
+{
+    public function run()
+    {
+        new A();
+        new \Foobar\B();
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+use Foobar\B;
+
+ /**
+ * Docblock
+ */
+final class NoNamespaceWithStrictTypesNoExistingUse
+{
+    public function run()
+    {
+        new A();
+        new B();
+    }
+}
+
+?>


### PR DESCRIPTION
Mirror comment of first use statement currently only happen on namespaced code:

https://getrector.com/demo/d2de82ef-d14b-4eae-b91b-b3ebe2cd3cd9

while in no-namespace, currently not yet:

https://getrector.com/demo/4ce41472-899a-4803-ba0e-c822397aac7d

This PR try to add it.

Fixes https://github.com/rectorphp/rector/issues/7738