### PR TITLE
[Renaming] Remove FileWithoutNamespace from getNodeTypes() on RenameClassRector

### DIFF
--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Renaming\Helper\RenameClassCallbackHandler;
@@ -88,12 +87,11 @@ CODE_SAMPLE
             Expression::class,
             ClassLike::class,
             Namespace_::class,
-            FileWithoutNamespace::class,
         ];
     }
 
     /**
-     * @param FunctionLike|Name|ClassLike|Expression|Namespace_|Property|FileWithoutNamespace $node
+     * @param FunctionLike|Name|ClassLike|Expression|Namespace_|Property $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/rules/Strict/Rector/ClassMethod/AddConstructorParentCallRector.php
+++ b/rules/Strict/Rector/ClassMethod/AddConstructorParentCallRector.php
@@ -80,8 +80,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $class = $this->betterNodeFinder->findParentType($node, ClassLike::class);
-        if (! $class instanceof Class_) {
+        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
+        if (! $classLike instanceof Class_) {
             return null;
         }
 
@@ -98,7 +98,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->dependencyClassMethodDecorator->decorateConstructorWithParentDependencies($class, $node, $scope);
+        $this->dependencyClassMethodDecorator->decorateConstructorWithParentDependencies($classLike, $node, $scope);
 
         return $node;
     }

--- a/src/NodeManipulator/Dependency/DependencyClassMethodDecorator.php
+++ b/src/NodeManipulator/Dependency/DependencyClassMethodDecorator.php
@@ -86,9 +86,9 @@ final class DependencyClassMethodDecorator
 
         // replicate parent parameters
         if ($cleanParamsToAdd !== []) {
-            foreach ($cleanParamsToAdd as $toAdd) {
-                $paramName = $this->nodeNameResolver->getName($toAdd);
-                $this->incrementParamIfExists($toAdd, $paramName, $cleanParamsToAdd, $classMethod->params);
+            foreach ($cleanParamsToAdd as $cleanParamToAdd) {
+                $paramName = $this->nodeNameResolver->getName($cleanParamToAdd);
+                $this->incrementParamIfExists($cleanParamToAdd, $paramName, $cleanParamsToAdd, $classMethod->params);
             }
 
             $classMethod->params = array_merge($cleanParamsToAdd, $classMethod->params);
@@ -156,7 +156,7 @@ final class DependencyClassMethodDecorator
      * @param Param[] $newParams
      * @param Param[] $originalParams
      */
-    private function incrementParamIfExists(Param $paramToAdd, string $newName, array $newParams, array $originalParams, int $count = 0): void
+    private function incrementParamIfExists(Param $param, string $newName, array $newParams, array $originalParams, int $count = 0): void
     {
         $name = $newName;
 
@@ -164,29 +164,29 @@ final class DependencyClassMethodDecorator
             $name .= $count;
         }
 
-        foreach ($newParams as $param) {
-            if ($paramToAdd === $param) {
+        foreach ($newParams as $newParam) {
+            if ($param === $newParam) {
                 continue;
             }
 
-            if ($this->nodeNameResolver->isName($param, $name)) {
+            if ($this->nodeNameResolver->isName($newParam, $name)) {
                 ++$count;
-                $this->incrementParamIfExists($paramToAdd, $newName, $newParams, $originalParams, $count);
+                $this->incrementParamIfExists($param, $newName, $newParams, $originalParams, $count);
                 return;
             }
         }
 
-        foreach ($originalParams as $param) {
-            if ($this->nodeNameResolver->isName($param, $name)) {
+        foreach ($originalParams as $originalParam) {
+            if ($this->nodeNameResolver->isName($originalParam, $name)) {
                 ++$count;
-                $this->incrementParamIfExists($paramToAdd, $newName, $newParams, $originalParams, $count);
+                $this->incrementParamIfExists($param, $newName, $newParams, $originalParams, $count);
                 return;
             }
         }
 
         if ($name !== $newName) {
-            $paramToAdd->var = clone $paramToAdd->var;
-            $paramToAdd->var->name = $name;
+            $param->var = clone $param->var;
+            $param->var->name = $name;
         }
     }
 


### PR DESCRIPTION
`RenameClassRector` mostly used on 

- `Name`, 
- `Namespace_` (rename class included current namespace)
- `ClassLike`

otherwise ,that will on `Stmt` that possibly use define docblock on it, eg: 

- `Property`, 
- `FunctionLike`
- `Expression`

for `FileWithoutNamespace`, the use case seems not exists since the docblock will be on its `stmts` instead. This PR remove it from the `getNodeTypes()` method.