### PR TITLE
Add failing test fixture for ArgumentAdderRector

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_compiler_pass.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_compiler_pass.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use App\DependencyInjection\Compiler\AppProviderPass;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AppProviderPass());
+    }
+}


### PR DESCRIPTION
# Failing Test for ArgumentAdderRector

Based on: https://getrector.com/demo/47837904-3aec-4dc0-a3d3-6216411007c5
Bug report: https://github.com/rectorphp/rector-symfony/issues/397