### PR TITLE
 [Renaming] Remove FileWithoutNamespace from getNodeTypes() on RenameNamespaceRector

### DIFF
--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNamespaceRenamer.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\Node as DocNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Naming\NamespaceMatcher;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\Renaming\ValueObject\RenamedNamespace;
@@ -30,7 +29,7 @@ final class DocBlockNamespaceRenamer
      * @param array<string, string> $oldToNewNamespaces
      */
     public function renameFullyQualifiedNamespace(
-        Property|ClassMethod|Function_|Expression|ClassLike|FileWithoutNamespace $node,
+        Property|ClassMethod|Function_|Expression|ClassLike $node,
         array $oldToNewNamespaces
     ): ?Node {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);

--- a/rules/Renaming/Rector/Namespace_/RenameNamespaceRector.php
+++ b/rules/Renaming/Rector/Namespace_/RenameNamespaceRector.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\NamespaceMatcher;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -41,7 +40,6 @@ final class RenameNamespaceRector extends AbstractRector implements Configurable
         Function_::class,
         Expression::class,
         ClassLike::class,
-        FileWithoutNamespace::class,
     ];
 
     /**
@@ -82,12 +80,12 @@ final class RenameNamespaceRector extends AbstractRector implements Configurable
     }
 
     /**
-     * @param Namespace_|Use_|Name|Property|ClassMethod|Function_|Expression|ClassLike|FileWithoutNamespace $node
+     * @param Namespace_|Use_|Name|Property|ClassMethod|Function_|Expression|ClassLike $node
      */
     public function refactor(Node $node): ?Node
     {
         if (in_array($node::class, self::ONLY_CHANGE_DOCBLOCK_NODE, true)) {
-            /** @var Property|ClassMethod|Function_|Expression|ClassLike|FileWithoutNamespace $node */
+            /** @var Property|ClassMethod|Function_|Expression|ClassLike $node */
             return $this->docBlockNamespaceRenamer->renameFullyQualifiedNamespace($node, $this->oldToNewNamespaces);
         }
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3470

`FileWithoutNamespace` can be removed from `RenameNamespaceRector::getNodeType()` as the changed docblock is on its stmts.