### PR TITLE
[Caching] Fix caching on change config cache not cleared

### DIFF
--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -121,9 +121,6 @@ final class ChangedFilesDetector
     private function invalidateCacheIfConfigurationChanged(string $key, string $configurationHash): void
     {
         $oldCachedValue = $this->cache->load($key, CacheKey::CONFIGURATION_HASH_KEY);
-        if ($oldCachedValue === null) {
-            return;
-        }
 
         if ($oldCachedValue === $configurationHash) {
             return;


### PR DESCRIPTION
@jackbentley this should fix https://github.com/rectorphp/rector/issues/7835.

The `invalidateCacheIfConfigurationChanged()` is called before `save()`, so before `save()`, if it still `null`, the cache data need to be cleared to ensure no left over cache

https://github.com/rectorphp/rector-src/blob/c240c69f45c29685eeace5ad0737ef049dff5211/packages/Caching/Detector/ChangedFilesDetector.php#L116-L118