### PR TITLE
[CodingStyle] Skip var ArrayDimFetch on SplitDoubleAssignRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Assign/SplitDoubleAssignRector/Fixture/skip_var_array_dim_fetch.php.inc
+++ b/rules-tests/CodingStyle/Rector/Assign/SplitDoubleAssignRector/Fixture/skip_var_array_dim_fetch.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Assign\SplitDoubleAssignRector\Fixture;
+
+use stdClass;
+
+class SkipVarArrayDimFetch
+{
+    public function run()
+    {
+        $vouchers[] = $voucher = new stdClass;
+    }
+}

--- a/rules/CodingStyle/Rector/Assign/SplitDoubleAssignRector.php
+++ b/rules/CodingStyle/Rector/Assign/SplitDoubleAssignRector.php
@@ -6,6 +6,7 @@ namespace Rector\CodingStyle\Rector\Assign;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Stmt\Expression;
@@ -73,7 +74,13 @@ CODE_SAMPLE
         }
 
         $lastAssignValue = $this->resolveLastAssignExpr($firstAssign);
-        return $this->collectExpressions($firstAssign, $lastAssignValue);
+        $collectExpressions = $this->collectExpressions($firstAssign, $lastAssignValue);
+
+        if ($collectExpressions === []) {
+            return null;
+        }
+
+        return $collectExpressions;
     }
 
     /**
@@ -85,6 +92,10 @@ CODE_SAMPLE
         $expressions = [];
 
         while ($assign instanceof Assign) {
+            if ($assign->var instanceof ArrayDimFetch) {
+                return [];
+            }
+
             $expressions[] = new Expression(new Assign($assign->var, $expr));
 
             // CallLike check need to be after first fill Expression


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7838