### PR TITLE
[Caching] Alternative Fix caching on change config cache not cleared

### DIFF
--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -112,7 +112,7 @@ final class ChangedFilesDetector
 
     private function storeConfigurationDataHash(string $filePath, string $configurationHash): void
     {
-        $key = CacheKey::CONFIGURATION_HASH_KEY . '_' . $this->hashFile($filePath);
+        $key = CacheKey::CONFIGURATION_HASH_KEY . '_' . $this->getFilePathCacheKey($filePath);
         $this->invalidateCacheIfConfigurationChanged($key, $configurationHash);
 
         $this->cache->save($key, CacheKey::CONFIGURATION_HASH_KEY, $configurationHash);


### PR DESCRIPTION
@jackbentley this is alternative of PR:

- https://github.com/rectorphp/rector-src/pull/3479

also make consistent with key definition instead of the value of key on other methods. 

Closes https://github.com/rectorphp/rector-src/pull/3479
Fixes https://github.com/rectorphp/rector/issues/7835