### PR TITLE
Performance: Improve AstResolver caching

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -44,19 +44,11 @@ final class AstResolver
 {
     /**
      * Parsing files is very heavy performance, so this will help to leverage it
-     * The value can be also null, as the method might not exist in the class.
+     * The value can be also null, when no statements could be parsed from the file.
      *
-     * @var array<class-string, array<string, ClassMethod|null>>
+     * @var array<string, Stmt[]|null>
      */
-    private array $classMethodsByClassAndMethod = [];
-
-    /**
-     * Parsing files is very heavy performance, so this will help to leverage it
-     * The value can be also null, as the method might not exist in the class.
-     *
-     * @var array<string, Function_|null>>
-     */
-    private array $functionsByName = [];
+    private array $parsedFileNodes = [];
 
     public function __construct(
         private readonly SmartPhpParser $smartPhpParser,
@@ -87,16 +79,6 @@ final class AstResolver
         $classLikeName = $classReflection->getName();
         $methodName = $methodReflection->getName();
 
-        if (isset($this->classMethodsByClassAndMethod[$classLikeName][$methodName])) {
-            return $this->classMethodsByClassAndMethod[$classLikeName][$methodName];
-        }
-
-        // saved as null data
-        if (array_key_exists($classLikeName, $this->classMethodsByClassAndMethod)
-            && array_key_exists($methodName, $this->classMethodsByClassAndMethod[$classLikeName])) {
-            return null;
-        }
-
         $fileName = $classReflection->getFileName();
 
         // probably native PHP method → un-parseable
@@ -122,12 +104,9 @@ final class AstResolver
                 continue;
             }
 
-            $this->classMethodsByClassAndMethod[$classLikeName][$methodName] = $classMethod;
             return $classMethod;
         }
 
-        // avoids looking for a class in a file where is not present
-        $this->classMethodsByClassAndMethod[$classLikeName][$methodName] = null;
         return null;
     }
 
@@ -146,15 +125,6 @@ final class AstResolver
     {
         $functionName = $functionReflection->getName();
 
-        if (isset($this->functionsByName[$functionName])) {
-            return $this->functionsByName[$functionName];
-        }
-
-        // saved as null data
-        if (array_key_exists($functionName, $this->functionsByName)) {
-            return null;
-        }
-
         $fileName = $functionReflection->getFileName();
         if ($fileName === null) {
             return null;
@@ -172,14 +142,8 @@ final class AstResolver
                 continue;
             }
 
-            // to avoid parsing missing function again
-            $this->functionsByName[$functionName] = $function;
-
             return $function;
         }
-
-        // to avoid parsing missing function again
-        $this->functionsByName[$functionName] = null;
 
         return null;
     }
@@ -308,7 +272,6 @@ final class AstResolver
             fn (Node $node): bool => $node instanceof ClassMethod && $this->nodeNameResolver->isName($node, $methodName)
         );
 
-        $this->classMethodsByClassAndMethod[$classReflection->getName()][$methodName] = $classMethod;
         if ($classMethod instanceof ClassMethod) {
             return $classMethod;
         }
@@ -321,13 +284,17 @@ final class AstResolver
      */
     private function parseFileNameToDecoratedNodes(string $fileName): ?array
     {
+        if (isset($this->parsedFileNodes[$fileName])) {
+            return $this->parsedFileNodes[$fileName];
+        }
+
         $stmts = $this->smartPhpParser->parseFile($fileName);
         if ($stmts === []) {
-            return null;
+            return $this->parsedFileNodes[$fileName] = null;
         }
 
         $file = new File($fileName, FileSystem::read($fileName));
-        return $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
+        return $this->parsedFileNodes[$fileName] = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
     }
 
     /**

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -91,20 +91,17 @@ final class AstResolver
             return null;
         }
 
-        /** @var ClassLike[] $classLikes */
-        $classLikes = $this->betterNodeFinder->findInstanceOf($nodes, ClassLike::class);
+        /** @var ClassLike|null $classLike */
+        $classLike = $this->betterNodeFinder->findFirst(
+            $nodes,
+            fn (Node $node): bool => $node instanceof ClassLike && $this->nodeNameResolver->isName(
+                    $node,
+                    $classLikeName
+                ) && $node->getMethod($methodName) instanceof ClassMethod
+        );
 
-        foreach ($classLikes as $classLike) {
-            if (! $this->nodeNameResolver->isName($classLike, $classLikeName)) {
-                continue;
-            }
-
-            $classMethod = $classLike->getMethod($methodName);
-            if (! $classMethod instanceof ClassMethod) {
-                continue;
-            }
-
-            return $classMethod;
+        if ($classLike instanceof ClassLike && ($method = $classLike->getMethod($methodName)) instanceof ClassMethod) {
+            return $method;
         }
 
         return null;
@@ -135,17 +132,16 @@ final class AstResolver
             return null;
         }
 
-        /** @var Function_[] $functions */
-        $functions = $this->betterNodeFinder->findInstanceOf($nodes, Function_::class);
-        foreach ($functions as $function) {
-            if (! $this->nodeNameResolver->isName($function, $functionName)) {
-                continue;
-            }
+        /** @var Function_|null $function */
+        $function = $this->betterNodeFinder->findFirst(
+            $nodes,
+            fn (Node $node): bool => $node instanceof Function_ && $this->nodeNameResolver->isName(
+                    $node,
+                    $functionName
+                )
+        );
 
-            return $function;
-        }
-
-        return null;
+        return $function;
     }
 
     /**
@@ -249,12 +245,17 @@ final class AstResolver
         $nativeReflectionProperty = $phpPropertyReflection->getNativeReflection();
         $desiredPropertyName = $nativeReflectionProperty->getName();
 
-        /** @var Property[] $properties */
-        $properties = $this->betterNodeFinder->findInstanceOf($nodes, Property::class);
-        foreach ($properties as $property) {
-            if ($this->nodeNameResolver->isName($property, $desiredPropertyName)) {
-                return $property;
-            }
+        /** @var Property|null $property */
+        $property = $this->betterNodeFinder->findFirst(
+            $nodes,
+            fn (Node $node): bool => $node instanceof Property && $this->nodeNameResolver->isName(
+                    $node,
+                    $desiredPropertyName
+                )
+        );
+
+        if ($property instanceof Property) {
+            return $property;
         }
 
         // promoted property


### PR DESCRIPTION
The `AstResolver` already used some caching/memoization to improve performance, but the actual implementation had some downsides:

1. Not everything was memoized, e.g `parseClassReflectionTraits` had no memoization, so calls to that method circumvented the memoization
2. Memoization was on a to detailed scale, this lead to a huge cache permutation and many cache hits, the actual memory intensive operation happens on file basis, but memoization was done on a per class **and** method basis or a per function basis, leading to parsing of the same file all over again until the cache was filled with all methods/functions per file

By memoizing on a per file basis i was able to increase performance ~25% and remove used memory by ~20%, see the blackfire comparison here: https://blackfire.io/profiles/compare/c33498d1-817e-470f-a921-8d743064698d/graph

![image](https://user-images.githubusercontent.com/15930605/225947629-5cd606cd-e240-465b-8e09-58b61c921625.png)


This is also related to https://github.com/rectorphp/rector/issues/7806 and improves stuff already a lot and is a nice improvement standalone.

However keeping all files in memory is not really viable in projects with >7.000 files, and it also does not scale with the parallel processing feature as every process needs keep all files in memory.

So this PR opens up possibillity for further improvements. Currently i think about the following two approaches to improve things further:

1. Use filesystem based cache instead of in memory, so multiple parallel processes can share the same cache, this would greatly reduce the memory footprint and probably also performance, because now only one process needs to parse a single file, the other processes can use the result of the first process. However there remain questions if serialization of the cached statements is possible at all and how fast that will be
2. Use a upper limit for the number of files that are cached and use something like a lightwight **least recently used** application, so the memory footprint will not grow endlessly with the number of processed files, but will flat out at some point

If there is a way to make the first (filesystem based approach) work at all, a optimal solution may probably be a combination of both approaches, so having a hot in-memory cache of the 500 (or so) most recently used files in memory, and cache the other files on the file system.

What do you think about those approaches? I'm happy to experiment further in those direction next week, as i think here is a lot room for improvement. :rocket: 