### PR TITLE
add failing plain view test fixture

### DIFF
--- a/e2e/plain-views/src/comment_before_closing_tag.php
+++ b/e2e/plain-views/src/comment_before_closing_tag.php
@@ -1,0 +1,6 @@
+<div>
+	<?php foreach ($arr as $a) {
+		// aaa
+		?>
+	<?php } ?>
+</div>


### PR DESCRIPTION
https://github.com/rectorphp/rector/issues/7845

It seems that the issue is not `OPEN_TAG_SPACED_REGEX` as was suggested in the issue, but rather the fact that only one of the `<?php` is indented incorrectly, while the other one remains correctly indented. So [this condition](https://github.com/rectorphp/rector-src/blob/e1dd98dc51c214a743fe1785fd264d2ea27efd72/src/Application/FileProcessor/PhpFileProcessor.php#L176) is not triggered.