### PR TITLE
[Container] Add RectorConfig::containerCacheDirectory()

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -72,6 +72,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->nestedChainMethodCallLimit(60);
 
     $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/rector_cached_files');
+    $rectorConfig->containerCacheDirectory(sys_get_temp_dir());
 
     $services = $rectorConfig->services();
     $services->defaults()

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -212,11 +212,7 @@ final class RectorConfig extends ContainerConfigurator
     public function cacheDirectory(string $directoryPath): void
     {
         // cache directory path is created via mkdir in CacheFactory
-        // when not exists, eg: default sys_get_temp_dir() . '/rector_cached_files' value
-        // on config/config.php, so:
-        //
-        //       no need to validate $directoryPath is a directory
-
+        // when not exists on config/config.php, so no need to validate $directoryPath is a directory
         $parameters = $this->parameters();
         $parameters->set(Option::CACHE_DIR, $directoryPath);
     }

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -219,7 +219,7 @@ final class RectorConfig extends ContainerConfigurator
 
     public function containerCacheDirectory(string $directoryPath): void
     {
-        // the container cache directory must be a directory on the first place
+        // container cache directory must be a directory on the first place
         Assert::directory($directoryPath);
 
         $parameters = $this->parameters();

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -211,12 +211,20 @@ final class RectorConfig extends ContainerConfigurator
 
     public function cacheDirectory(string $directoryPath): void
     {
+        // cache directory path is created via mkdir in CacheFactory
+        // when not exists, eg: default sys_get_temp_dir() . '/rector_cached_files' value
+        // on config/config.php, so:
+        //
+        //       no need to validate $directoryPath is a directory
+
         $parameters = $this->parameters();
         $parameters->set(Option::CACHE_DIR, $directoryPath);
     }
 
     public function containerCacheDirectory(string $directoryPath): void
     {
+        // the container cache is default to sys_get_temp_dir() in config/config.php which must be a directory
+        // on the first place
         Assert::directory($directoryPath);
 
         $parameters = $this->parameters();

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -212,7 +212,7 @@ final class RectorConfig extends ContainerConfigurator
     public function cacheDirectory(string $directoryPath): void
     {
         // cache directory path is created via mkdir in CacheFactory
-        // when not exists on config/config.php, so no need to validate $directoryPath is a directory
+        // when not exists, so no need to validate $directoryPath is a directory
         $parameters = $this->parameters();
         $parameters->set(Option::CACHE_DIR, $directoryPath);
     }

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -219,8 +219,7 @@ final class RectorConfig extends ContainerConfigurator
 
     public function containerCacheDirectory(string $directoryPath): void
     {
-        // the container cache is default to sys_get_temp_dir() in config/config.php which must be a directory
-        // on the first place
+        // the container cache directory must be a directory on the first place
         Assert::directory($directoryPath);
 
         $parameters = $this->parameters();

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -215,6 +215,14 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::CACHE_DIR, $directoryPath);
     }
 
+    public function containerCacheDirectory(string $directoryPath): void
+    {
+        Assert::directory($directoryPath);
+
+        $parameters = $this->parameters();
+        $parameters->set(Option::CONTAINER_CACHE_DIRECTORY, $directoryPath);
+    }
+
     /**
      * @param class-string<CacheStorageInterface> $cacheClass
      */

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -219,7 +219,7 @@ final class RectorConfig extends ContainerConfigurator
 
     public function containerCacheDirectory(string $directoryPath): void
     {
-        // container cache directory must be a directory on the first place
+        // container cache directory path must be a directory on the first place
         Assert::directory($directoryPath);
 
         $parameters = $this->parameters();

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -50,7 +50,11 @@ final class PHPStanServicesFactory
         }
 
         $containerFactory = new ContainerFactory(getcwd());
-        $this->container = $containerFactory->create(sys_get_temp_dir(), $additionalConfigFiles, []);
+        $this->container = $containerFactory->create(
+            $parameterProvider->provideStringParameter(Option::CONTAINER_CACHE_DIRECTORY),
+            $additionalConfigFiles,
+            []
+        );
 
         // clear temporary files, after container is created
         $filesystem = new Filesystem();

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -218,4 +218,10 @@ final class Option
      * @var string
      */
     public const REMOVE_UNUSED_IMPORTS = 'remove-unused-imports';
+
+    /**
+     * @internal Use @see \Rector\Config\RectorConfig::containerCacheDirectory() method
+     * @var string
+     */
+    public const CONTAINER_CACHE_DIRECTORY = 'container-cache-directory';
 }


### PR DESCRIPTION
This is new config to resolve https://github.com/rectorphp/rector/issues/7700 to able to configure container cache directory beside the cache directory that used in `PHPStanServicesFactory`.

so on shared hosting, the cache and container cache can be configured:

```php
    $rectorConfig->cacheDirectory('/project/var/rector_cached_files');
    $rectorConfig->containerCacheDirectory('/project/var');
```

/cc @scottybcoder @ernestbuffington 