### PR TITLE
[Config] Increase default nested chain method call limit to 120

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -69,7 +69,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->indent(' ', 4);
 
     $rectorConfig->fileExtensions(['php']);
-    $rectorConfig->nestedChainMethodCallLimit(60);
+    $rectorConfig->nestedChainMethodCallLimit(120);
 
     $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/rector_cached_files');
 


### PR DESCRIPTION
**Before** (can't detect variable used on deep chain usages)

https://getrector.com/demo/93e1174f-3586-4b65-b3e3-f5d5c78884dc

**After** (can detect variable used on deep chain usages)

https://getrector.com/demo/e9033c97-5415-4b05-94dd-667cfa1f59f5

see issue https://github.com/rectorphp/rector/issues/7747 /cc @Yoann-TYT 