### PR TITLE
[NodeTypeResolver] Add ParametersAcceptorSelectorVariantsWrapper::selectFromVariants()

### DIFF
--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Rector\FamilyTree\NodeAnalyzer;
 
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
@@ -79,10 +77,6 @@ final class ClassChildAnalyzer
 
         foreach ($parentClassMethods as $parentClassMethod) {
             $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($parentClassMethod->getVariants());
-            if (! $parametersAcceptor instanceof ParametersAcceptorWithPhpDocs) {
-                continue;
-            }
-
             $nativeReturnType = $parametersAcceptor->getNativeReturnType();
 
             if (! $nativeReturnType instanceof MixedType) {

--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 
 final class ClassChildAnalyzer
 {
@@ -76,7 +77,7 @@ final class ClassChildAnalyzer
         }
 
         foreach ($parentClassMethods as $parentClassMethod) {
-            $parametersAcceptor = ParametersAcceptorSelector::selectSingle($parentClassMethod->getVariants());
+            $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($parentClassMethod->getVariants());
             $nativeReturnType = $parametersAcceptor->getNativeReturnType();
 
             if (! $nativeReturnType instanceof MixedType) {

--- a/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/packages/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\FamilyTree\NodeAnalyzer;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
@@ -78,6 +79,10 @@ final class ClassChildAnalyzer
 
         foreach ($parentClassMethods as $parentClassMethod) {
             $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($parentClassMethod->getVariants());
+            if (! $parametersAcceptor instanceof ParametersAcceptorWithPhpDocs) {
+                continue;
+            }
+
             $nativeReturnType = $parametersAcceptor->getNativeReturnType();
 
             if (! $nativeReturnType instanceof MixedType) {

--- a/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/packages/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -31,6 +31,7 @@ use Rector\NodeCollector\ValueObject\ArrayCallableDynamicMethod;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 
 final class ArrayCallableMethodMatcher
 {
@@ -180,7 +181,7 @@ final class ArrayCallableMethodMatcher
         }
 
         $extendedMethodReflection = $classReflection->getMethod(MethodName::CONSTRUCT, $scope);
-        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelector::selectSingle(
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants(
             $extendedMethodReflection->getVariants()
         );
 

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -11,7 +11,6 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 
 final class ParametersAcceptorSelectorVariantsWrapper
 {
@@ -19,7 +18,7 @@ final class ParametersAcceptorSelectorVariantsWrapper
         FunctionReflection|MethodReflection $reflection,
         CallLike|FunctionLike $node,
         Scope $scope
-    ): ParametersAcceptor|ParametersAcceptorWithPhpDocs {
+    ): ParametersAcceptor {
         $variants = $reflection->getVariants();
         if ($node instanceof FunctionLike) {
             return self::selectFromVariants($variants);
@@ -39,7 +38,7 @@ final class ParametersAcceptorSelectorVariantsWrapper
     /**
      * @param ParametersAcceptor[]  $variants
      */
-    public static function selectFromVariants(array $variants): ParametersAcceptor|ParametersAcceptorWithPhpDocs
+    public static function selectFromVariants(array $variants): ParametersAcceptor
     {
         $parameterAcceptors = [];
         foreach ($variants as $variant) {

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 
 final class ParametersAcceptorSelectorVariantsWrapper
 {
@@ -38,7 +39,7 @@ final class ParametersAcceptorSelectorVariantsWrapper
     /**
      * @param ParametersAcceptor[]  $variants
      */
-    public static function selectFromVariants(array $variants): ParametersAcceptor
+    public static function selectFromVariants(array $variants): ParametersAcceptorWithPhpDocs
     {
         $parameterAcceptors = [];
         foreach ($variants as $variant) {

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -41,11 +41,6 @@ final class ParametersAcceptorSelectorVariantsWrapper
      */
     public static function selectFromVariants(array $variants): ParametersAcceptorWithPhpDocs
     {
-        $parameterAcceptors = [];
-        foreach ($variants as $variant) {
-            $parameterAcceptors[] = ParametersAcceptorSelector::selectSingle([$variant]);
-        }
-
-        return ParametersAcceptorSelector::combineAcceptors($parameterAcceptors);
+        return ParametersAcceptorSelector::combineAcceptors($variants);
     }
 }

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -28,7 +28,8 @@ final class ParametersAcceptorSelectorVariantsWrapper
             return ParametersAcceptorSelector::selectSingle($variants);
         }
 
-        // on CallLike, using count() is more performance than direct selectFromArgs()
+        // on CallLike, using count() check to fallback to use selectSingle()
+        // is more performance than direct selectFromArgs()
         return count($variants) > 1
             ? ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $variants)
             : ParametersAcceptorSelector::selectSingle($variants);

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -21,12 +21,7 @@ final class ParametersAcceptorSelectorVariantsWrapper
     ): ParametersAcceptor {
         $variants = $reflection->getVariants();
         if ($node instanceof FunctionLike) {
-            $parameterAcceptors = [];
-            foreach ($variants as $variant) {
-                $parameterAcceptors[] = ParametersAcceptorSelector::selectSingle([$variant]);
-            }
-
-            return ParametersAcceptorSelector::combineAcceptors($parameterAcceptors);
+            return self::selectFromVariants($variants);
         }
 
         if ($node->isFirstClassCallable()) {

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -37,4 +37,14 @@ final class ParametersAcceptorSelectorVariantsWrapper
             ? ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $variants)
             : ParametersAcceptorSelector::selectSingle($variants);
     }
+
+    public static function selectFromVariants(array $variants): ParametersAcceptor
+    {
+        $parameterAcceptors = [];
+        foreach ($variants as $variant) {
+            $parameterAcceptors[] = ParametersAcceptorSelector::selectSingle([$variant]);
+        }
+
+        return ParametersAcceptorSelector::combineAcceptors($parameterAcceptors);
+    }
 }

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 
 final class ParametersAcceptorSelectorVariantsWrapper
 {
@@ -18,7 +19,7 @@ final class ParametersAcceptorSelectorVariantsWrapper
         FunctionReflection|MethodReflection $reflection,
         CallLike|FunctionLike $node,
         Scope $scope
-    ): ParametersAcceptor {
+    ): ParametersAcceptor|ParametersAcceptorWithPhpDocs {
         $variants = $reflection->getVariants();
         if ($node instanceof FunctionLike) {
             return self::selectFromVariants($variants);
@@ -35,7 +36,10 @@ final class ParametersAcceptorSelectorVariantsWrapper
             : ParametersAcceptorSelector::selectSingle($variants);
     }
 
-    public static function selectFromVariants(array $variants): ParametersAcceptor
+    /**
+     * @param ParametersAcceptor[]  $variants
+     */
+    public static function selectFromVariants(array $variants): ParametersAcceptor|ParametersAcceptorWithPhpDocs
     {
         $parameterAcceptors = [];
         foreach ($variants as $variant) {

--- a/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/packages/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -28,6 +28,7 @@ final class ParametersAcceptorSelectorVariantsWrapper
             return ParametersAcceptorSelector::selectSingle($variants);
         }
 
+        // on CallLike, using count() is more performance than direct selectFromArgs()
         return count($variants) > 1
             ? ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $variants)
             : ParametersAcceptorSelector::selectSingle($variants);

--- a/packages/PhpAttribute/NodeAnalyzer/ExprParameterReflectionTypeCorrector.php
+++ b/packages/PhpAttribute/NodeAnalyzer/ExprParameterReflectionTypeCorrector.php
@@ -15,6 +15,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\TypeCombinator;
 use Rector\Core\PhpParser\Node\NodeFactory;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
 final class ExprParameterReflectionTypeCorrector
@@ -49,7 +50,7 @@ final class ExprParameterReflectionTypeCorrector
 
         $extendedMethodReflection = $attributeClassReflection->getConstructor();
 
-        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelector::selectSingle(
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants(
             $extendedMethodReflection->getVariants()
         );
 

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -21,6 +21,7 @@ use PHPStan\Type\TypeWithClassName;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -183,7 +184,7 @@ CODE_SAMPLE
         }
 
         $extendedMethodReflection = $classReflection->getConstructor();
-        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelector::selectSingle(
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants(
             $extendedMethodReflection->getVariants()
         );
 

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -217,8 +217,8 @@ CODE_SAMPLE
             return false;
         }
 
-        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($extendedMethodReflection->getVariants());
-        $parameters = $parametersAcceptor->getParameters();
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($extendedMethodReflection->getVariants());
+        $parameters = $parametersAcceptorWithPhpDocs->getParameters();
         if (count($parameters) !== 1) {
             return true;
         }

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -16,6 +16,7 @@ use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -167,7 +168,7 @@ CODE_SAMPLE
 
             $methodReflection = $callerType->getMethod($possibleGetterMethodName, $scope);
 
-            $variant = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+            $variant = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
             $returnType = $variant->getReturnType();
 
             if (! $propertyType->isSuperTypeOf($returnType)->yes()) {
@@ -216,7 +217,7 @@ CODE_SAMPLE
             return false;
         }
 
-        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($extendedMethodReflection->getVariants());
+        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($extendedMethodReflection->getVariants());
         $parameters = $parametersAcceptor->getParameters();
         if (count($parameters) !== 1) {
             return true;

--- a/rules/CodingStyle/NodeAnalyzer/SpreadVariablesCollector.php
+++ b/rules/CodingStyle/NodeAnalyzer/SpreadVariablesCollector.php
@@ -22,12 +22,12 @@ final class SpreadVariablesCollector
         $spreadParameterReflections = [];
 
         $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
-        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $key => $parameterReflection) {
-            if (! $parameterReflection->isVariadic()) {
+        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $key => $parameterReflectionWithPhpDoc) {
+            if (! $parameterReflectionWithPhpDoc->isVariadic()) {
                 continue;
             }
 
-            $spreadParameterReflections[$key] = $parameterReflection;
+            $spreadParameterReflections[$key] = $parameterReflectionWithPhpDoc;
         }
 
         return $spreadParameterReflections;

--- a/rules/CodingStyle/NodeAnalyzer/SpreadVariablesCollector.php
+++ b/rules/CodingStyle/NodeAnalyzer/SpreadVariablesCollector.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 
 final class SpreadVariablesCollector
 {
@@ -20,7 +21,7 @@ final class SpreadVariablesCollector
     {
         $spreadParameterReflections = [];
 
-        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
         foreach ($parametersAcceptor->getParameters() as $key => $parameterReflection) {
             if (! $parameterReflection->isVariadic()) {
                 continue;

--- a/rules/CodingStyle/NodeAnalyzer/SpreadVariablesCollector.php
+++ b/rules/CodingStyle/NodeAnalyzer/SpreadVariablesCollector.php
@@ -21,8 +21,8 @@ final class SpreadVariablesCollector
     {
         $spreadParameterReflections = [];
 
-        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
-        foreach ($parametersAcceptor->getParameters() as $key => $parameterReflection) {
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
+        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $key => $parameterReflection) {
             if (! $parameterReflection->isVariadic()) {
                 continue;
             }

--- a/rules/DeadCode/Comparator/CurrentAndParentClassMethodComparator.php
+++ b/rules/DeadCode/Comparator/CurrentAndParentClassMethodComparator.php
@@ -21,6 +21,7 @@ use Rector\DeadCode\Comparator\Parameter\ParameterDefaultsComparator;
 use Rector\DeadCode\Comparator\Parameter\ParameterTypeComparator;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 
 final class CurrentAndParentClassMethodComparator
 {
@@ -157,7 +158,7 @@ final class CurrentAndParentClassMethodComparator
         ClassMethod $classMethod,
         ExtendedMethodReflection $extendedMethodReflection
     ): bool {
-        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelector::selectSingle(
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants(
             $extendedMethodReflection->getVariants()
         );
 

--- a/rules/Php72/NodeFactory/AnonymousFunctionFactory.php
+++ b/rules/Php72/NodeFactory/AnonymousFunctionFactory.php
@@ -45,6 +45,7 @@ use Rector\Core\PhpParser\Parser\SimplePhpParser;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\Php72\NodeManipulator\ClosureNestedUsesDecorator;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -112,7 +113,7 @@ final class AnonymousFunctionFactory
     public function createFromPhpMethodReflection(PhpMethodReflection $phpMethodReflection, Expr $expr): ?Closure
     {
         /** @var FunctionVariantWithPhpDocs $parametersAcceptorWithPhpDocs */
-        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelector::selectSingle($phpMethodReflection->getVariants());
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($phpMethodReflection->getVariants());
 
         $newParams = $this->createParams($phpMethodReflection, $parametersAcceptorWithPhpDocs->getParameters());
 

--- a/rules/Php80/NodeAnalyzer/EnumParamAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/EnumParamAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php80\NodeAnalyzer;
 
+use PHPStan\Reflection\ParameterReflectionWithPhpDocs;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
@@ -28,10 +29,10 @@ final class EnumParamAnalyzer
     }
 
     public function matchParameterClassName(
-        ParameterReflection $parameterReflection,
+        ParameterReflectionWithPhpDocs $parameterReflectionWithPhpDocs,
         PhpDocInfo $phpDocInfo
     ): ?ClassNameAndTagValueNode {
-        $paramTagValueNode = $phpDocInfo->getParamTagValueByName($parameterReflection->getName());
+        $paramTagValueNode = $phpDocInfo->getParamTagValueByName($parameterReflectionWithPhpDocs->getName());
         if (! $paramTagValueNode instanceof ParamTagValueNode) {
             return null;
         }

--- a/rules/Php81/Rector/Class_/ConstantListClassToEnumRector.php
+++ b/rules/Php81/Rector/Class_/ConstantListClassToEnumRector.php
@@ -16,6 +16,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\Php80\NodeAnalyzer\EnumParamAnalyzer;
 use Rector\Php80\ValueObject\ClassNameAndTagValueNode;
 use Rector\Php81\NodeAnalyzer\EnumConstListClassDetector;
@@ -139,7 +140,7 @@ CODE_SAMPLE
     ): bool {
         $hasNodeChanged = false;
 
-        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
         foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
             $classNameAndTagValueNode = $this->enumParamAnalyzer->matchParameterClassName(
                 $parameterReflection,

--- a/rules/Php81/Rector/Class_/ConstantListClassToEnumRector.php
+++ b/rules/Php81/Rector/Class_/ConstantListClassToEnumRector.php
@@ -140,8 +140,8 @@ CODE_SAMPLE
     ): bool {
         $hasNodeChanged = false;
 
-        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
-        foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
+        $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
+        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $parameterReflection) {
             $classNameAndTagValueNode = $this->enumParamAnalyzer->matchParameterClassName(
                 $parameterReflection,
                 $phpDocInfo

--- a/rules/Php81/Rector/Class_/ConstantListClassToEnumRector.php
+++ b/rules/Php81/Rector/Class_/ConstantListClassToEnumRector.php
@@ -141,16 +141,16 @@ CODE_SAMPLE
         $hasNodeChanged = false;
 
         $parametersAcceptorWithPhpDocs = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
-        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $parameterReflection) {
+        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $parameterReflectionWithPhpDoc) {
             $classNameAndTagValueNode = $this->enumParamAnalyzer->matchParameterClassName(
-                $parameterReflection,
+                $parameterReflectionWithPhpDoc,
                 $phpDocInfo
             );
             if (! $classNameAndTagValueNode instanceof ClassNameAndTagValueNode) {
                 continue;
             }
 
-            $param = $this->getParamByName($classMethod, $parameterReflection->getName());
+            $param = $this->getParamByName($classMethod, $parameterReflectionWithPhpDoc->getName());
             if (! $param instanceof Param) {
                 continue;
             }

--- a/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
+++ b/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
@@ -25,6 +25,7 @@ use Rector\Core\ValueObject\MethodName;
 use Rector\Naming\Naming\PropertyNaming;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 
 final class TypeProvidingExprFromClassResolver
 {
@@ -74,7 +75,7 @@ final class TypeProvidingExprFromClassResolver
         $methodReflections = $this->getClassMethodReflections($classReflection);
 
         foreach ($methodReflections as $methodReflection) {
-            $functionVariant = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
+            $functionVariant = ParametersAcceptorSelectorVariantsWrapper::selectFromVariants($methodReflection->getVariants());
             $returnType = $functionVariant->getReturnType();
 
             if (! $this->isMatchingType($returnType, $objectType)) {


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3359

that multiple variants can happen on `FunctionLike` that was cause error to use multiple variants, on case which only can access its `variants`, I think the specific method `selectFromVariants()` is needed.