### PR TITLE
[Core] Refactor AstResolver to locate node with SimpleCallableNodeTraverser

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -364,7 +364,7 @@ final class AstResolver
         $paramNode = null;
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $stmts,
-            function (Node $node) use ($desiredClassName, $desiredPropertyName, &$propertyNode) {
+            function (Node $node) use ($desiredClassName, $desiredPropertyName, &$paramNode) {
                 if (! $node instanceof Class_) {
                     return null;
                 }
@@ -384,7 +384,7 @@ final class AstResolver
                     }
 
                     if ($this->nodeNameResolver->isName($param, $desiredPropertyName)) {
-                        $propertyNode = $param;
+                        $paramNode = $param;
                         return NodeTraverser::STOP_TRAVERSAL;
                     }
                 }

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -289,7 +289,7 @@ final class AstResolver
 
                 $property = $node->getProperty($desiredPropertyName);
                 if ($property instanceof Property) {
-                    $propertyNode = $node;
+                    $propertyNode = $property;
                     return NodeTraverser::STOP_TRAVERSAL;
                 }
 

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -250,9 +250,6 @@ final class AstResolver
             }
 
             $traits[] = $traitNode;
-
-            // ensure nullify after assign to ensure it will re-fill
-            $traitNode = null;
         }
 
         return $traits;

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -250,6 +250,9 @@ final class AstResolver
             }
 
             $traits[] = $traitNode;
+
+            // ensure nullify after assign to ensure it will re-fill
+            $traitNode = null;
         }
 
         return $traits;


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3493

@keulinho while keep verify same class like name for locate property and property promotion, I refactor to use `SimpleCallableNodeTraverser` to avoid unnecessary lookup on `parent` attribute, to stop with 

```php
return NodeTraverser::STOP_TRAVERSAL;
```

on found. I also apply it into `locateClassMethodInTrait()` method.