### PR TITLE
Performance: Memoize sipped file paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "phpstan/phpstan-php-parser": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.4.4",
         "phpstan/phpstan-webmozart-assert": "^1.2.2",
-        "phpunit/phpunit": "^10.0.6",
+        "phpunit/phpunit": "10.0.16",
         "rector/phpstan-rules": "^0.6.5",
         "rector/rector-generator": "dev-main",
         "spatie/enum": "^3.13",

--- a/packages/Skipper/SkipVoter/PathSkipVoter.php
+++ b/packages/Skipper/SkipVoter/PathSkipVoter.php
@@ -10,6 +10,11 @@ use Rector\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
 
 final class PathSkipVoter implements SkipVoterInterface
 {
+    /**
+     * @var array<string, bool>
+     */
+    private array $skippedFiles = [];
+
     public function __construct(
         private readonly FileInfoMatcher $fileInfoMatcher,
         private readonly SkippedPathsResolver $skippedPathsResolver
@@ -23,7 +28,11 @@ final class PathSkipVoter implements SkipVoterInterface
 
     public function shouldSkip(string | object $element, string $filePath): bool
     {
+        if (isset($this->skippedFiles[$filePath])) {
+            return $this->skippedFiles[$filePath];
+        }
+
         $skippedPaths = $this->skippedPathsResolver->resolve();
-        return $this->fileInfoMatcher->doesFileInfoMatchPatterns($filePath, $skippedPaths);
+        return $this->skippedFiles[$filePath] = $this->fileInfoMatcher->doesFileInfoMatchPatterns($filePath, $skippedPaths);
     }
 }


### PR DESCRIPTION
Every `AbstractRector` checks if it should be skipped and executes all skippers, this leads to a lot of calls to the `SkipVoters`.

The `PathSkipVoter` only skips based on the file path, but will be called for each configured rector and file in combination. Each call executed the `doesFileInfoMatchPatterns` which internally does a pcre match costing a lot of memory.

By memoizing the skipped file path we can greatly reduce the needed memory. See this blackfire screenshot to see the impact: 
![image](https://user-images.githubusercontent.com/15930605/226378975-e1088d44-eb1c-42bb-ada2-67f2207d1976.png)
You can see the full blackfire comparison here: https://blackfire.io/profiles/compare/d05668b7-6aea-4f8e-a9ef-88185948bfb7/graph

The used memory is decreased by ~50% in a test run with ~250 files. Also note that this method is called >75 000 times for this small test run.

This is related to https://github.com/rectorphp/rector/issues/7806 and improves the situation for larger code bases quite a lot.