### PR TITLE
Reuse AstResolver memoizing on ClassLikeAstResolver

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -266,7 +266,7 @@ final class AstResolver
         }
 
         $nodes = $this->parseFileNameToDecoratedNodes($fileName);
-        if ($nodes === null) {
+        if ($nodes === []) {
             return null;
         }
 

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -332,9 +332,9 @@ final class AstResolver
     }
 
     /**
-     * @return Stmt[]|null
+     * @return Stmt[]
      */
-    public function parseFileNameToDecoratedNodes(string $fileName): ?array
+    public function parseFileNameToDecoratedNodes(string $fileName): array
     {
         if (isset($this->parsedFileNodes[$fileName])) {
             return $this->parsedFileNodes[$fileName];
@@ -342,7 +342,7 @@ final class AstResolver
 
         $stmts = $this->smartPhpParser->parseFile($fileName);
         if ($stmts === []) {
-            return $this->parsedFileNodes[$fileName] = null;
+            return $this->parsedFileNodes[$fileName] = [];
         }
 
         $file = new File($fileName, FileSystem::read($fileName));

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -88,7 +88,7 @@ final class AstResolver
         }
 
         $nodes = $this->parseFileNameToDecoratedNodes($fileName);
-        if ($nodes === null) {
+        if ($nodes === []) {
             return null;
         }
 
@@ -139,7 +139,7 @@ final class AstResolver
         }
 
         $nodes = $this->parseFileNameToDecoratedNodes($fileName);
-        if ($nodes === null) {
+        if ($nodes === []) {
             return null;
         }
 
@@ -222,7 +222,7 @@ final class AstResolver
             }
 
             $nodes = $this->parseFileNameToDecoratedNodes($fileName);
-            if ($nodes === null) {
+            if ($nodes === []) {
                 continue;
             }
 
@@ -334,7 +334,7 @@ final class AstResolver
     /**
      * @return Stmt[]|null
      */
-    private function parseFileNameToDecoratedNodes(string $fileName): ?array
+    public function parseFileNameToDecoratedNodes(string $fileName): ?array
     {
         if (isset($this->parsedFileNodes[$fileName])) {
             return $this->parsedFileNodes[$fileName];


### PR DESCRIPTION
@keulinho this is to re-use your memoizing on `AstResolver` already on `ClassLikeAstResolver`, also fix usage of `parseFileNameToDecoratedNodes()` that to be consistent to return array.