### PR TITLE
[Core] No need NodeConnectingVisitor to connect nodes when nodes count is only 1

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -526,10 +526,6 @@ final class BetterNodeFinder
             return null;
         }
 
-        if ($previousNode === $node) {
-            return null;
-        }
-
         $foundNode = $this->findFirst($previousNode, $filter);
 
         // we found what we need

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -440,6 +440,12 @@ CODE_SAMPLE;
             $nodes = [...$nodes, $nextNode];
         }
 
+        // no need to connect nodes when only its own node
+        // this is to avoid infinite loop
+        if (count($nodes) === 1) {
+            return;
+        }
+
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new NodeConnectingVisitor());
         $nodeTraverser->traverse($nodes);


### PR DESCRIPTION
@defunctl this is the actual fix for:

- https://github.com/rectorphp/rector-src/pull/3484

that connecting node which previous node is a node itself cause infinite loop.