### PR TITLE
Performance: Improve NodeTypeResolver::isObjectType() performance

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -26,6 +26,11 @@ final class AttributeKey
     public const SCOPE = 'scope';
 
     /**
+     * @var string
+     */
+    public const TYPE = 'type';
+
+    /**
      * Internal php-parser name.
      * Do not change this even if you want!
      *


### PR DESCRIPTION
`NodeTypeResolver::isObjectType()` is called from multiple rectory on the same node and taking quite a long time. 

By saving the resolved type to the node for later reuse and checking if a object type is actually a trait before analysing all traits improves performance by ~30% in our test run.

see the blackfire comparison here: https://blackfire.io/profiles/compare/49347102-5585-4e90-9a9c-9b4f5e8b74fb/graph

![image](https://user-images.githubusercontent.com/15930605/226861246-215aa90e-ed43-4c0a-a714-f04a4d0c2d55.png)
