### PR TITLE
Performance: Reduce isObjectType calls

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -55,6 +55,11 @@ final class NodeTypeResolver
     private array $nodeTypeResolvers = [];
 
     /**
+     * @var array<string, bool>
+     */
+    private array $traitExistsCache = [];
+
+    /**
      * @param NodeTypeResolverInterface[] $nodeTypeResolvers
      */
     public function __construct(
@@ -350,7 +355,11 @@ final class NodeTypeResolver
         }
 
         $classReflection = $this->reflectionProvider->getClass($resolvedObjectType->getClassName());
-        if (\trait_exists($requiredObjectType->getClassName())) {
+        if (!isset($this->traitExistsCache[$classReflection->getName()])) {
+            $this->traitExistsCache[$classReflection->getName()] = \trait_exists($requiredObjectType->getClassName());
+        }
+
+        if ($this->traitExistsCache[$classReflection->getName()]) {
             foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
                 if ($ancestorClassReflection->hasTraitUse($requiredObjectType->getClassName())) {
                     return true;

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -108,11 +108,11 @@ CODE_SAMPLE
         $this->haveArgumentsChanged = false;
 
         foreach ($this->addedArguments as $addedArgument) {
-            if (! $this->isObjectTypeMatch($node, $addedArgument->getObjectType())) {
+            if (! $this->isName($node->name, $addedArgument->getMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $addedArgument->getMethod())) {
+            if (! $this->isObjectTypeMatch($node, $addedArgument->getObjectType())) {
                 continue;
             }
 

--- a/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
@@ -77,14 +77,14 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($this->replacedArguments as $replacedArgument) {
+            if (! $this->isName($node->name, $replacedArgument->getMethod())) {
+                continue;
+            }
+
             if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
                 $node,
                 $replacedArgument->getObjectType()
             )) {
-                continue;
-            }
-
-            if (! $this->isName($node->name, $replacedArgument->getMethod())) {
                 continue;
             }
 

--- a/rules/CodingStyle/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
@@ -88,11 +88,11 @@ CODE_SAMPLE
     {
         $hasChanged = false;
         foreach ($this->methodsToYields as $methodToYield) {
-            if (! $this->isObjectType($node, $methodToYield->getObjectType())) {
+            if (! $this->isName($node, $methodToYield->getMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node, $methodToYield->getMethod())) {
+            if (! $this->isObjectType($node, $methodToYield->getObjectType())) {
                 continue;
             }
 

--- a/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
+++ b/rules/DependencyInjection/Rector/ClassMethod/AddMethodParentCallRector.php
@@ -85,16 +85,16 @@ CODE_SAMPLE
         $className = (string) $this->nodeNameResolver->getName($classLike);
 
         foreach ($this->methodByParentTypes as $type => $method) {
-            if (! $this->isObjectType($classLike, new ObjectType($type))) {
-                continue;
-            }
-
             // not itself
             if ($className === $type) {
                 continue;
             }
 
             if ($this->shouldSkipMethod($node, $method)) {
+                continue;
+            }
+
+            if (! $this->isObjectType($classLike, new ObjectType($type))) {
                 continue;
             }
 

--- a/rules/Php72/Rector/FuncCall/IsObjectOnIncompleteClassRector.php
+++ b/rules/Php72/Rector/FuncCall/IsObjectOnIncompleteClassRector.php
@@ -74,11 +74,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->isObjectType($node->args[0]->value, $incompleteClassObjectType)) {
+        if ($this->shouldSkip($node)) {
             return null;
         }
 
-        if ($this->shouldSkip($node)) {
+        if (! $this->isObjectType($node->args[0]->value, $incompleteClassObjectType)) {
             return null;
         }
 

--- a/rules/Php74/Rector/MethodCall/ChangeReflectionTypeToStringToGetNameRector.php
+++ b/rules/Php74/Rector/MethodCall/ChangeReflectionTypeToStringToGetNameRector.php
@@ -220,11 +220,11 @@ CODE_SAMPLE
 
     private function isReflectionParameterGetTypeMethodCall(MethodCall $methodCall): bool
     {
-        if (! $this->isObjectType($methodCall->var, new ObjectType('ReflectionParameter'))) {
+        if (! $this->isName($methodCall->name, 'getType')) {
             return false;
         }
 
-        return $this->isName($methodCall->name, 'getType');
+        return $this->isObjectType($methodCall->var, new ObjectType('ReflectionParameter'));
     }
 
     private function refactorReflectionParameterGetName(MethodCall $methodCall): Ternary
@@ -236,11 +236,11 @@ CODE_SAMPLE
 
     private function isReflectionFunctionAbstractGetReturnTypeMethodCall(MethodCall $methodCall): bool
     {
-        if (! $this->isObjectType($methodCall->var, new ObjectType('ReflectionFunctionAbstract'))) {
+        if (! $this->isName($methodCall->name, 'getReturnType')) {
             return false;
         }
 
-        return $this->isName($methodCall->name, 'getReturnType');
+        return $this->isObjectType($methodCall->var, new ObjectType('ReflectionFunctionAbstract'));
     }
 
     private function refactorReflectionFunctionGetReturnType(MethodCall $methodCall): Node | Ternary

--- a/rules/Php82/Rector/New_/FilesystemIteratorSkipDotsRector.php
+++ b/rules/Php82/Rector/New_/FilesystemIteratorSkipDotsRector.php
@@ -54,11 +54,11 @@ final class FilesystemIteratorSkipDotsRector extends AbstractRector implements M
      */
     public function refactor(Node $node): ?New_
     {
-        if (! $this->isObjectType($node->class, new ObjectType('FilesystemIterator'))) {
+        if ($node->isFirstClassCallable()) {
             return null;
         }
 
-        if ($node->isFirstClassCallable()) {
+        if (! $this->isObjectType($node->class, new ObjectType('FilesystemIterator'))) {
             return null;
         }
 

--- a/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
+++ b/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
@@ -67,14 +67,14 @@ CODE_SAMPLE
         $this->hasChanged = false;
 
         foreach ($this->removedArguments as $removedArgument) {
+            if (! $this->isName($node->name, $removedArgument->getMethod())) {
+                continue;
+            }
+
             if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
                 $node,
                 $removedArgument->getObjectType()
             )) {
-                continue;
-            }
-
-            if (! $this->isName($node->name, $removedArgument->getMethod())) {
                 continue;
             }
 

--- a/rules/Renaming/Rector/ClassConstFetch/RenameClassConstFetchRector.php
+++ b/rules/Renaming/Rector/ClassConstFetch/RenameClassConstFetchRector.php
@@ -71,11 +71,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?ClassConstFetch
     {
         foreach ($this->renameClassConstFetches as $renameClassConstFetch) {
-            if (! $this->isObjectType($node->class, $renameClassConstFetch->getOldObjectType())) {
+            if (! $this->isName($node->name, $renameClassConstFetch->getOldConstant())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $renameClassConstFetch->getOldConstant())) {
+            if (! $this->isObjectType($node->class, $renameClassConstFetch->getOldObjectType())) {
                 continue;
             }
 

--- a/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
+++ b/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
@@ -115,12 +115,12 @@ final class RenamePropertyRector extends AbstractRector implements ConfigurableR
         $class = $this->betterNodeFinder->findParentType($propertyFetch, Class_::class);
 
         foreach ($this->renamedProperties as $renamedProperty) {
-            if (! $this->isObjectType($propertyFetch->var, $renamedProperty->getObjectType())) {
+            $oldProperty = $renamedProperty->getOldProperty();
+            if (! $this->isName($propertyFetch, $oldProperty)) {
                 continue;
             }
 
-            $oldProperty = $renamedProperty->getOldProperty();
-            if (! $this->isName($propertyFetch, $oldProperty)) {
+            if (! $this->isObjectType($propertyFetch->var, $renamedProperty->getObjectType())) {
                 continue;
             }
 

--- a/rules/Renaming/Rector/StaticCall/RenameStaticMethodRector.php
+++ b/rules/Renaming/Rector/StaticCall/RenameStaticMethodRector.php
@@ -50,11 +50,11 @@ final class RenameStaticMethodRector extends AbstractRector implements Configura
     public function refactor(Node $node): ?Node
     {
         foreach ($this->staticMethodRenames as $staticMethodRename) {
-            if (! $this->isObjectType($node->class, $staticMethodRename->getOldObjectType())) {
+            if (! $this->isName($node->name, $staticMethodRename->getOldMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $staticMethodRename->getOldMethod())) {
+            if (! $this->isObjectType($node->class, $staticMethodRename->getOldObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/Assign/PropertyAssignToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/PropertyAssignToMethodCallRector.php
@@ -67,11 +67,11 @@ CODE_SAMPLE
         $propertyNode = $propertyFetchNode->var;
 
         foreach ($this->propertyAssignsToMethodCalls as $propertyAssignToMethodCall) {
-            if (! $this->isObjectType($propertyFetchNode->var, $propertyAssignToMethodCall->getObjectType())) {
+            if (! $this->isName($propertyFetchNode, $propertyAssignToMethodCall->getOldPropertyName())) {
                 continue;
             }
 
-            if (! $this->isName($propertyFetchNode, $propertyAssignToMethodCall->getOldPropertyName())) {
+            if (! $this->isObjectType($propertyFetchNode->var, $propertyAssignToMethodCall->getObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
@@ -134,11 +134,11 @@ CODE_SAMPLE
     private function matchPropertyFetchCandidate(PropertyFetch $propertyFetch): ?PropertyFetchToMethodCall
     {
         foreach ($this->propertiesToMethodCalls as $propertyToMethodCall) {
-            if (! $this->isObjectType($propertyFetch->var, $propertyToMethodCall->getOldObjectType())) {
+            if (! $this->isName($propertyFetch, $propertyToMethodCall->getOldProperty())) {
                 continue;
             }
 
-            if (! $this->isName($propertyFetch, $propertyToMethodCall->getOldProperty())) {
+            if (! $this->isObjectType($propertyFetch->var, $propertyToMethodCall->getOldObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/ClassMethod/WrapReturnRector.php
+++ b/rules/Transform/Rector/ClassMethod/WrapReturnRector.php
@@ -69,11 +69,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->typeMethodWraps as $typeMethodWrap) {
-            if (! $this->isObjectType($node, $typeMethodWrap->getObjectType())) {
+            if (! $this->isName($node, $typeMethodWrap->getMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node, $typeMethodWrap->getMethod())) {
+            if (! $this->isObjectType($node, $typeMethodWrap->getObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/MethodCall/MethodCallToAnotherMethodCallWithArgumentsRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToAnotherMethodCallWithArgumentsRector.php
@@ -64,11 +64,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->methodCallRenamesWithAddedArguments as $methodCallRenameWithAddedArgument) {
-            if (! $this->isObjectType($node->var, $methodCallRenameWithAddedArgument->getObjectType())) {
+            if (! $this->isName($node->name, $methodCallRenameWithAddedArgument->getOldMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $methodCallRenameWithAddedArgument->getOldMethod())) {
+            if (! $this->isObjectType($node->var, $methodCallRenameWithAddedArgument->getObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/MethodCall/MethodCallToMethodCallRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToMethodCallRector.php
@@ -165,11 +165,11 @@ CODE_SAMPLE
             return $this->isName($methodCall->name, $methodCallToMethodCall->getOldMethod());
         }
 
-        if (! $this->isObjectType($methodCall->var, $oldTypeObject)) {
+        if (! $this->isName($methodCall->name, $methodCallToMethodCall->getOldMethod())) {
             return false;
         }
 
-        return $this->isName($methodCall->name, $methodCallToMethodCall->getOldMethod());
+        return $this->isObjectType($methodCall->var, $oldTypeObject);
     }
 
     private function matchNewPropertyName(MethodCallToMethodCall $methodCallToMethodCall, Class_ $class): ?string

--- a/rules/Transform/Rector/MethodCall/MethodCallToStaticCallRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToStaticCallRector.php
@@ -80,11 +80,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->methodCallsToStaticCalls as $methodCallToStaticCall) {
-            if (! $this->isObjectType($node->var, $methodCallToStaticCall->getOldObjectType())) {
+            if (! $this->isName($node->name, $methodCallToStaticCall->getOldMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $methodCallToStaticCall->getOldMethod())) {
+            if (! $this->isObjectType($node->var, $methodCallToStaticCall->getOldObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/MethodCall/ReplaceParentCallByPropertyCallRector.php
+++ b/rules/Transform/Rector/MethodCall/ReplaceParentCallByPropertyCallRector.php
@@ -69,11 +69,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->parentCallToProperties as $parentCallToProperty) {
-            if (! $this->isObjectType($node->var, $parentCallToProperty->getObjectType())) {
+            if (! $this->isName($node->name, $parentCallToProperty->getMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $parentCallToProperty->getMethod())) {
+            if (! $this->isObjectType($node->var, $parentCallToProperty->getObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/StaticCall/StaticCallToFuncCallRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToFuncCallRector.php
@@ -53,11 +53,11 @@ final class StaticCallToFuncCallRector extends AbstractRector implements Configu
     public function refactor(Node $node): ?Node
     {
         foreach ($this->staticCallsToFunctions as $staticCallToFunction) {
-            if (! $this->isObjectType($node->class, $staticCallToFunction->getObjectType())) {
+            if (! $this->isName($node->name, $staticCallToFunction->getMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node->name, $staticCallToFunction->getMethod())) {
+            if (! $this->isObjectType($node->class, $staticCallToFunction->getObjectType())) {
                 continue;
             }
 

--- a/rules/Transform/Rector/String_/ToStringToMethodCallRector.php
+++ b/rules/Transform/Rector/String_/ToStringToMethodCallRector.php
@@ -96,11 +96,11 @@ CODE_SAMPLE
     private function processMethodCall(MethodCall $methodCall): ?Node
     {
         foreach ($this->methodNamesByType as $type => $methodName) {
-            if (! $this->isObjectType($methodCall->var, new ObjectType($type))) {
+            if (! $this->isName($methodCall->name, '__toString')) {
                 continue;
             }
 
-            if (! $this->isName($methodCall->name, '__toString')) {
+            if (! $this->isObjectType($methodCall->var, new ObjectType($type))) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -89,11 +89,11 @@ CODE_SAMPLE
         $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
 
         foreach ($this->addParamTypeDeclarations as $addParamTypeDeclaration) {
-            if (! $this->isObjectType($classLike, $addParamTypeDeclaration->getObjectType())) {
+            if (! $this->isName($node, $addParamTypeDeclaration->getMethodName())) {
                 continue;
             }
 
-            if (! $this->isName($node, $addParamTypeDeclaration->getMethodName())) {
+            if (! $this->isObjectType($classLike, $addParamTypeDeclaration->getObjectType())) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
@@ -84,12 +84,12 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->methodReturnTypes as $methodReturnType) {
-            $objectType = $methodReturnType->getObjectType();
-            if (! $this->isObjectType($node, $objectType)) {
+            if (! $this->isName($node, $methodReturnType->getMethod())) {
                 continue;
             }
 
-            if (! $this->isName($node, $methodReturnType->getMethod())) {
+            $objectType = $methodReturnType->getObjectType();
+            if (! $this->isObjectType($node, $objectType)) {
                 continue;
             }
 

--- a/rules/Visibility/Rector/ClassConst/ChangeConstantVisibilityRector.php
+++ b/rules/Visibility/Rector/ClassConst/ChangeConstantVisibilityRector.php
@@ -80,11 +80,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->classConstantVisibilityChanges as $classConstantVisibilityChange) {
-            if (! $this->isObjectType($node, $classConstantVisibilityChange->getObjectType())) {
+            if (! $this->isName($node, $classConstantVisibilityChange->getConstant())) {
                 continue;
             }
 
-            if (! $this->isName($node, $classConstantVisibilityChange->getConstant())) {
+            if (! $this->isObjectType($node, $classConstantVisibilityChange->getObjectType())) {
                 continue;
             }
 


### PR DESCRIPTION
As seen in https://github.com/rectorphp/rector-src/pull/3500 `isObjectType`-calls can be pretty costly in terms of performance, in a lot of cases `isObjectType` was used in combination with `isName` in multiple rectors, in those cases checking `isName` first is a lot faster and removes a lot of not needed calls to `isObjectType` 

Together with https://github.com/rectorphp/rector-src/pull/3501 this PR leads to the same performance improvements as the original PR https://github.com/rectorphp/rector-src/pull/3500