### PR TITLE
Performance: Improve node name resolver performance

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -25,6 +25,9 @@ final class NodeNameResolver
 {
     /**
      * Used to check if a string might contain a regex or fnmatch pattern
+     *
+     * @var string
+     * @see https://regex101.com/r/ImTV1W/1
      */
     private const CONTAINS_WILDCARD_CHARS_REGEX = '/[\*\#\~\/]/';
     /**

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeNameResolver;
 
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
@@ -22,6 +23,15 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class NodeNameResolver
 {
+    /**
+     * Used to check if a string might contain a regex or fnmatch pattern
+     */
+    private const CONTAINS_WILDCARD_CHARS_PATTERN = '/[\*\#\~\/]/';
+    /**
+     * @var array<string, NodeNameResolverInterface|null>
+     */
+    private array $nodeNameResolversByClass = [];
+
     /**
      * @param NodeNameResolverInterface[] $nodeNameResolvers
      */
@@ -117,12 +127,9 @@ final class NodeNameResolver
             $this->invalidNameNodeReporter->reportInvalidNodeForName($node);
         }
 
-        foreach ($this->nodeNameResolvers as $nodeNameResolver) {
-            if (! is_a($node, $nodeNameResolver->getNode(), true)) {
-                continue;
-            }
-
-            return $nodeNameResolver->resolve($node);
+        $resolvedName = $this->resolveNodeName($node);
+        if ($resolvedName !== null) {
+            return $resolvedName;
         }
 
         // more complex
@@ -188,19 +195,21 @@ final class NodeNameResolver
             return false;
         }
 
-        // is probably regex pattern
-        if ($this->regexPatternDetector->isRegexPattern($desiredName)) {
-            return StringUtils::isMatch($resolvedName, $desiredName);
-        }
-
-        // is probably fnmatch
-        if (\str_contains($desiredName, '*')) {
-            return fnmatch($desiredName, $resolvedName, FNM_NOESCAPE);
-        }
-
         // special case
         if ($desiredName === 'Object') {
             return $desiredName === $resolvedName;
+        }
+
+        if (Strings::match($desiredName, self::CONTAINS_WILDCARD_CHARS_PATTERN) !== null) {
+            // is probably regex pattern
+            if ($this->regexPatternDetector->isRegexPattern($desiredName)) {
+                return StringUtils::isMatch($resolvedName, $desiredName);
+            }
+
+            // is probably fnmatch
+            if (\str_contains($desiredName, '*')) {
+                return fnmatch($desiredName, $resolvedName, FNM_NOESCAPE);
+            }
         }
 
         return strtolower($resolvedName) === strtolower($desiredName);
@@ -228,5 +237,33 @@ final class NodeNameResolver
         }
 
         return $this->isStringName($resolvedName, $desiredName);
+    }
+
+    private function resolveNodeName(Node $node): ?string
+    {
+        $nodeClass = \get_class($node);
+        if (array_key_exists($nodeClass, $this->nodeNameResolversByClass)) {
+            $resolver = $this->nodeNameResolversByClass[$nodeClass];
+
+            if ($resolver instanceof NodeNameResolverInterface) {
+                return $resolver->resolve($node);
+            }
+
+            return null;
+        }
+
+        foreach ($this->nodeNameResolvers as $nodeNameResolver) {
+            if (!\is_a($node, $nodeNameResolver->getNode(), \true)) {
+                continue;
+            }
+
+            $this->nodeNameResolversByClass[$nodeClass] = $nodeNameResolver;
+
+            return $nodeNameResolver->resolve($node);
+        }
+
+        $this->nodeNameResolversByClass[$nodeClass] = null;
+
+        return null;
     }
 }

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -26,7 +26,7 @@ final class NodeNameResolver
     /**
      * Used to check if a string might contain a regex or fnmatch pattern
      */
-    private const CONTAINS_WILDCARD_CHARS_PATTERN = '/[\*\#\~\/]/';
+    private const CONTAINS_WILDCARD_CHARS_REGEX = '/[\*\#\~\/]/';
     /**
      * @var array<string, NodeNameResolverInterface|null>
      */
@@ -200,7 +200,7 @@ final class NodeNameResolver
             return $desiredName === $resolvedName;
         }
 
-        if (Strings::match($desiredName, self::CONTAINS_WILDCARD_CHARS_PATTERN) !== null) {
+        if (Strings::match($desiredName, self::CONTAINS_WILDCARD_CHARS_REGEX) !== null) {
             // is probably regex pattern
             if ($this->regexPatternDetector->isRegexPattern($desiredName)) {
                 return StringUtils::isMatch($resolvedName, $desiredName);

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\NodeNameResolver;
 
-use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
@@ -203,7 +202,7 @@ final class NodeNameResolver
             return $desiredName === $resolvedName;
         }
 
-        if (Strings::match($desiredName, self::CONTAINS_WILDCARD_CHARS_REGEX) !== null) {
+        if (StringUtils::isMatch($desiredName, self::CONTAINS_WILDCARD_CHARS_REGEX)) {
             // is probably regex pattern
             if ($this->regexPatternDetector->isRegexPattern($desiredName)) {
                 return StringUtils::isMatch($resolvedName, $desiredName);
@@ -244,7 +243,7 @@ final class NodeNameResolver
 
     private function resolveNodeName(Node $node): ?string
     {
-        $nodeClass = \get_class($node);
+        $nodeClass = $node::class;
         if (array_key_exists($nodeClass, $this->nodeNameResolversByClass)) {
             $resolver = $this->nodeNameResolversByClass[$nodeClass];
 


### PR DESCRIPTION
In https://github.com/rectorphp/rector-src/pull/3502 we changed a lot of rectors to use `isName` over `isObject`, because `isName` is a lot faster. 

But we can make it even faster. This contains two performance fixes:

1. Don't loop every time through all node name resolvers:
This code may be executed millions of times always looping to find the one name resolver can be improved by caching the used resolver per node class

2. Checking if a string contains regex or fnmatch special chars before really analyzing if it is a regex pattern is much faster, as in most cases the desired name does not contain a special char

This brings another 10% performance increase in our test scenario: https://blackfire.io/profiles/compare/33d481dc-2a9d-439f-bed6-636f6eaaa8fa/graph
![image](https://user-images.githubusercontent.com/15930605/227140498-d9ff0423-f11e-4bc4-b46a-b302fa5536fc.png)

