### PR TITLE
Performance: Use faster hashing algo for cache key generation

### DIFF
--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -452,7 +452,15 @@ final class ClassRenamer
     private function createOldToNewTypes(Node $node, array $oldToNewClasses): array
     {
         $oldToNewClasses = $this->resolveOldToNewClassCallbacks($node, $oldToNewClasses);
-        $cacheKey = \hash('crc32c', \serialize($oldToNewClasses));
+
+        // md4 is faster then md5 https://php.watch/articles/php-hash-benchmark
+        $hashingAlgorithm = 'md4';
+        if (\PHP_VERSION_ID >= 80100) {
+            // if xxh128 is available use it, as it is way faster then md4 https://php.watch/articles/php-hash-benchmark
+            $hashingAlgorithm = 'xxh128';
+        }
+
+        $cacheKey = \hash($hashingAlgorithm, \serialize($oldToNewClasses));
 
         if (isset($this->oldToNewTypesByCacheKey[$cacheKey])) {
             return $this->oldToNewTypesByCacheKey[$cacheKey];

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -452,7 +452,7 @@ final class ClassRenamer
     private function createOldToNewTypes(Node $node, array $oldToNewClasses): array
     {
         $oldToNewClasses = $this->resolveOldToNewClassCallbacks($node, $oldToNewClasses);
-        $cacheKey = md5(serialize($oldToNewClasses));
+        $cacheKey = \hash('crc32c', \serialize($oldToNewClasses));
 
         if (isset($this->oldToNewTypesByCacheKey[$cacheKey])) {
             return $this->oldToNewTypesByCacheKey[$cacheKey];


### PR DESCRIPTION
The serialized array can become quite big and md5 slows down the bigger the input data. 

On our test run this saved ~2s: https://blackfire.io/profiles/compare/0abc026f-4855-4bb0-ac84-c4a2eef825e0/graph
![image](https://user-images.githubusercontent.com/15930605/227237664-c2ae6270-a5c9-42f5-a551-8a426ccb3ec7.png)


I guess now we are at the limit of the "quick fixes" in terms of performance improvements without actually touching the architecture of the whole system 