### PR TITLE
[CodeQuality] Skip static class const fetch on InlineConstructorDefaultToPropertyRector

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -29,6 +29,7 @@ final class NodeNameResolver
      * @see https://regex101.com/r/ImTV1W/1
      */
     private const CONTAINS_WILDCARD_CHARS_REGEX = '/[\*\#\~\/]/';
+
     /**
      * @var array<string, NodeNameResolverInterface|null>
      */

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_static_class_const_fetch2.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_static_class_const_fetch2.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class SkipStaticClassConstFetch2
+{
+    private $name;
+
+    private const NUMBER = 1;
+
+    public function __construct()
+    {
+        $this->name = static::NUMBER;
+    }
+}

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -95,10 +95,6 @@ final class ExprAnalyzer
                 return false;
             }
 
-            if ($expr->name->toString() !== 'class') {
-                return true;
-            }
-
             // static::class cannot be used for compile-time class name resolution
             return $expr->class->toString() !== ObjectReference::STATIC;
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7852 it cause error on compile-time constants https://3v4l.org/dfOck