### PR TITLE
Add failing test fixture for NewInInitializerRector

### DIFF
--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/property_with_attributes.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/property_with_attributes.php.inc
@@ -1,11 +1,11 @@
 <?php
 
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
+
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Ulid;
 
 #[ORM\Entity]
-namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
-
 class Carrier
 {
     #[ORM\Id]
@@ -23,12 +23,12 @@ class Carrier
 -----
 <?php
 
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
+
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Ulid;
 
 #[ORM\Entity]
-namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
-
 class Carrier
 {
     public function __construct(

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/property_with_attributes.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/property_with_attributes.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Ulid;
+
+#[ORM\Entity]
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
+
+class Carrier
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'ulid', unique: true)]
+    private Ulid $id;
+
+    public function __construct(
+        ?Ulid $id = null,
+    ) {
+        $this->id = $id ?? new Ulid();
+    }
+}
+
+?>
+-----
+<?php
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Ulid;
+
+#[ORM\Entity]
+namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
+
+class Carrier
+{
+    public function __construct(
+        #[ORM\Id]
+        #[ORM\Column(type: 'ulid', unique: true)]
+        private Ulid $id = new Ulid(),
+    ) {
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for NewInInitializerRector

Based on https://getrector.com/demo/dd5bff80-0789-4aae-b2a3-686c23a3d164

The rule seems to remove property attributes