### PR TITLE
[Core] Remove ParentConnectingVisitor usage on AbstractRector

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
-use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\ObjectType;
@@ -239,7 +238,7 @@ CODE_SAMPLE;
             $firstNode = current($refactoredNode);
             $this->mirrorComments($firstNode, $originalNode);
 
-            $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
+            $this->updateParentNodes($refactoredNode, $parentNode);
             $this->connectNodes($refactoredNode, $node);
             $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
@@ -253,7 +252,7 @@ CODE_SAMPLE;
             ? new Expression($refactoredNode)
             : $refactoredNode;
 
-        $this->updateAndconnectParentNodes($refactoredNode, $parentNode);
+        $this->updateParentNodes($refactoredNode, $parentNode);
         $this->connectNodes([$refactoredNode], $node);
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
@@ -397,7 +396,7 @@ CODE_SAMPLE;
     /**
      * @param Node[]|Node $node
      */
-    private function updateAndconnectParentNodes(array | Node $node, ?Node $parentNode): void
+    private function updateParentNodes(array | Node $node, ?Node $parentNode): void
     {
         if (! $parentNode instanceof Node) {
             return;
@@ -406,13 +405,9 @@ CODE_SAMPLE;
         $nodes = $node instanceof Node ? [$node] : $node;
 
         foreach ($nodes as $node) {
-            // update parents relations - must run before addVisitor(new ParentConnectingVisitor())
+            // update parents relations
             $node->setAttribute(AttributeKey::PARENT_NODE, $parentNode);
         }
-
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor(new ParentConnectingVisitor());
-        $nodeTraverser->traverse($nodes);
     }
 
     /**


### PR DESCRIPTION
In `AbstractRector`, we use both:

- **1. ParentConnectingVisitor**

https://github.com/rectorphp/rector-src/blob/3445422189028175f9d99563c3ec5e5bad86e9b5/src/Rector/AbstractRector.php#L400-L416

- **2. NodeConnectingVisitor**

https://github.com/rectorphp/rector-src/blob/3445422189028175f9d99563c3ec5e5bad86e9b5/src/Rector/AbstractRector.php#L421-L446

Looking at the `NodeConnectingVisitor`, set parent attribute on previous stack already covered as well  on `NodeConnectingVisitor`, so when the first node has parent already, it will be continued in `NodeConnectingVisitor` so no need double visitor instance to connect.

https://github.com/nikic/PHP-Parser/blob/0ffddce52d816f72d0efc4d9b02e276d3309ef01/lib/PhpParser/NodeVisitor/NodeConnectingVisitor.php#L35-L37

