### PR TITLE
[core] Remove ParentConnectingVisitor from SimpleCallableNodeTraverser

### DIFF
--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -6,8 +6,6 @@ namespace Rector\PhpDocParser\NodeTraverser;
 
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\ParentConnectingVisitor;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeVisitor\CallableNodeVisitor;
 
 /**
@@ -33,25 +31,7 @@ final class SimpleCallableNodeTraverser
         $callableNodeVisitor = new CallableNodeVisitor($callable);
         $nodeTraverser->addVisitor($callableNodeVisitor);
 
-        if ($this->shouldConnectParent($node)) {
-            $nodeTraverser->addVisitor(new ParentConnectingVisitor());
-        }
-
         $nodes = $node instanceof Node ? [$node] : $node;
         $nodeTraverser->traverse($nodes);
-    }
-
-    /**
-     * @param Node|Node[] $node
-     */
-    private function shouldConnectParent(Node | array $node): bool
-    {
-        if ($node instanceof Node) {
-            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-            return $parentNode instanceof Node;
-        }
-
-        // usage mostly by pass $node->stmts which parent node is the node
-        return true;
     }
 }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3519

As far as the node that passed to `traverseNodesWithCallable()` is part of `Node` to be transformed,eg:

- `$node->stmts` from `$node` of original node, then return `$node`.
- `$node` itself of original node, then return `$node`

the parent connecting will be taken care on `AbstractRector` after node transformed.
