### PR TITLE
[NodeManipulator] Reduce parent attribute usage on VariableManipulator

### DIFF
--- a/src/NodeManipulator/VariableManipulator.php
+++ b/src/NodeManipulator/VariableManipulator.php
@@ -198,7 +198,7 @@ final class VariableManipulator
                 if ($node instanceof Arg && $node->value instanceof Variable && ! $this->variableToConstantGuard->isReadArg(
                     $node
                 )) {
-                    $variables[] = $node;
+                    $variables = [$node];
                     return NodeTraverser::STOP_TRAVERSAL;
                 }
 


### PR DESCRIPTION
Previously, it look up variable, check parent is equal to assign, then continue lookup. This PR remove parent lookup by direct check on node is assign, then don't traverse current and children.