### PR TITLE
[NodeTraverser] Add CleanVisitorNodeTraverser

### DIFF
--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -8,8 +8,6 @@ use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
-use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
-use Rector\Core\PhpParser\Parser\SimplePhpParser;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionLikeParamArgPositionNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
@@ -20,9 +18,7 @@ final class NodeScopeAndMetadataDecorator
         private readonly CloningVisitor $cloningVisitor,
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         private readonly NodeConnectingVisitor $nodeConnectingVisitor,
-        private readonly FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
-        private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser,
-        private readonly SimplePhpParser $simplePhpParser
+        private readonly FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor
     ) {
     }
 
@@ -43,16 +39,5 @@ final class NodeScopeAndMetadataDecorator
         $nodeTraverser->addVisitor($this->functionLikeParamArgPositionNodeVisitor);
 
         return $nodeTraverser->traverse($stmts);
-    }
-
-    /**
-     * @return Stmt[]
-     */
-    public function decorateStmtsFromString(string $content): array
-    {
-        $stmts = $this->simplePhpParser->parseString($content);
-
-        $this->cleanVisitorNodeTraverser->addVisitor($this->nodeConnectingVisitor);
-        return $this->cleanVisitorNodeTraverser->traverse($stmts);
     }
 }

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -18,7 +18,7 @@ final class NodeScopeAndMetadataDecorator
         private readonly CloningVisitor $cloningVisitor,
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         private readonly NodeConnectingVisitor $nodeConnectingVisitor,
-        private readonly FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor
+        private readonly FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
     ) {
     }
 

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -9,6 +9,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
+use Rector\Core\PhpParser\Parser\SimplePhpParser;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionLikeParamArgPositionNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
@@ -20,7 +21,8 @@ final class NodeScopeAndMetadataDecorator
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         private readonly NodeConnectingVisitor $nodeConnectingVisitor,
         private readonly FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
-        private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser
+        private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser,
+        private readonly SimplePhpParser $simplePhpParser
     ) {
     }
 
@@ -44,11 +46,12 @@ final class NodeScopeAndMetadataDecorator
     }
 
     /**
-     * @param Stmt[] $stmts
      * @return Stmt[]
      */
-    public function decorateNodesFromStmts(array $stmts): array
+    public function decorateStmtsFromString(string $content): array
     {
+        $stmts = $this->simplePhpParser->parseString($content);
+
         $this->cleanVisitorNodeTraverser->addVisitor($this->nodeConnectingVisitor);
         return $this->cleanVisitorNodeTraverser->traverse($stmts);
     }

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -47,7 +47,7 @@ final class NodeScopeAndMetadataDecorator
      * @param Stmt[] $stmts
      * @return Stmt[]
      */
-    public function decorateStmtsFromString(array $stmts): array
+    public function decorateNodesFromStmts(array $stmts): array
     {
         $this->cleanVisitorNodeTraverser->addVisitor($this->nodeConnectingVisitor);
         return $this->cleanVisitorNodeTraverser->traverse($stmts);

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
+use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionLikeParamArgPositionNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
@@ -19,6 +20,7 @@ final class NodeScopeAndMetadataDecorator
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         private readonly NodeConnectingVisitor $nodeConnectingVisitor,
         private readonly FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
+        private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser
     ) {
     }
 
@@ -47,9 +49,7 @@ final class NodeScopeAndMetadataDecorator
      */
     public function decorateStmtsFromString(array $stmts): array
     {
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor($this->nodeConnectingVisitor);
-
-        return $nodeTraverser->traverse($stmts);
+        $this->cleanVisitorNodeTraverser->addVisitor($this->nodeConnectingVisitor);
+        return $this->cleanVisitorNodeTraverser->traverse($stmts);
     }
 }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -46,6 +46,7 @@ use Rector\Caching\FileSystem\DependencyResolver;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -73,7 +74,8 @@ final class PHPStanNodeScopeResolver
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ClassAnalyzer $classAnalyzer
+        private readonly ClassAnalyzer $classAnalyzer,
+        private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser
     ) {
     }
 
@@ -376,9 +378,8 @@ final class PHPStanNodeScopeResolver
      */
     private function removeDeepChainMethodCallNodes(array $nodes): void
     {
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor($this->removeDeepChainMethodCallNodeVisitor);
-        $nodeTraverser->traverse($nodes);
+        $this->cleanVisitorNodeTraverser->addVisitor($this->removeDeepChainMethodCallNodeVisitor);
+        $this->cleanVisitorNodeTraverser->traverse($nodes);
     }
 
     private function resolveClassOrInterfaceScope(

--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\PhpDocParser\NodeTraverser;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
+use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 use Rector\PhpDocParser\NodeVisitor\CallableNodeVisitor;
 
 /**
@@ -13,6 +13,10 @@ use Rector\PhpDocParser\NodeVisitor\CallableNodeVisitor;
  */
 final class SimpleCallableNodeTraverser
 {
+    public function __construct(private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser)
+    {
+    }
+
     /**
      * @param callable(Node $node): (int|Node|null) $callable
      * @param Node|Node[]|null $node
@@ -27,11 +31,10 @@ final class SimpleCallableNodeTraverser
             return;
         }
 
-        $nodeTraverser = new NodeTraverser();
         $callableNodeVisitor = new CallableNodeVisitor($callable);
-        $nodeTraverser->addVisitor($callableNodeVisitor);
+        $this->cleanVisitorNodeTraverser->addVisitor($callableNodeVisitor);
 
         $nodes = $node instanceof Node ? [$node] : $node;
-        $nodeTraverser->traverse($nodes);
+        $this->cleanVisitorNodeTraverser->traverse($nodes);
     }
 }

--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\PhpDocParser\NodeTraverser;
 
 use PhpParser\Node;
+use PhpParser\NodeTraverser;
 use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 use Rector\PhpDocParser\NodeVisitor\CallableNodeVisitor;
 
@@ -13,10 +14,6 @@ use Rector\PhpDocParser\NodeVisitor\CallableNodeVisitor;
  */
 final class SimpleCallableNodeTraverser
 {
-    public function __construct(private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser)
-    {
-    }
-
     /**
      * @param callable(Node $node): (int|Node|null) $callable
      * @param Node|Node[]|null $node
@@ -31,10 +28,11 @@ final class SimpleCallableNodeTraverser
             return;
         }
 
+        $nodeTraverser = new NodeTraverser();
         $callableNodeVisitor = new CallableNodeVisitor($callable);
-        $this->cleanVisitorNodeTraverser->addVisitor($callableNodeVisitor);
+        $nodeTraverser->addVisitor($callableNodeVisitor);
 
         $nodes = $node instanceof Node ? [$node] : $node;
-        $this->cleanVisitorNodeTraverser->traverse($nodes);
+        $nodeTraverser->traverse($nodes);
     }
 }

--- a/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -6,7 +6,6 @@ namespace Rector\PhpDocParser\NodeTraverser;
 
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
-use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 use Rector\PhpDocParser\NodeVisitor\CallableNodeVisitor;
 
 /**

--- a/packages/PostRector/Application/PostFileProcessor.php
+++ b/packages/PostRector/Application/PostFileProcessor.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Rector\PostRector\Application;
 
 use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Logging\CurrentRectorProvider;
+use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\PostRector\Contract\Rector\PostRectorDependencyInterface;
@@ -28,6 +28,7 @@ final class PostFileProcessor
         private readonly Skipper $skipper,
         private readonly CurrentFileProvider $currentFileProvider,
         private readonly CurrentRectorProvider $currentRectorProvider,
+        private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser,
         array $postRectors
     ) {
         $this->postRectors = $this->sortByPriority($postRectors);
@@ -46,9 +47,8 @@ final class PostFileProcessor
 
             $this->currentRectorProvider->changeCurrentRector($postRector);
 
-            $nodeTraverser = new NodeTraverser();
-            $nodeTraverser->addVisitor($postRector);
-            $stmts = $nodeTraverser->traverse($stmts);
+            $this->cleanVisitorNodeTraverser->addVisitor($postRector);
+            $stmts = $this->cleanVisitorNodeTraverser->traverse($stmts);
         }
 
         return $stmts;

--- a/src/PhpParser/NodeTraverser/CleanVisitorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/CleanVisitorNodeTraverser.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\PhpParser\NodeTraverser;
+
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+
+final class CleanVisitorNodeTraverser extends NodeTraverser
+{
+    public function addVisitor(NodeVisitor $visitor)
+    {
+        $this->visitors = [];
+        $this->visitors[] = $visitor;
+    }
+}

--- a/src/PhpParser/NodeTraverser/CleanVisitorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/CleanVisitorNodeTraverser.php
@@ -11,7 +11,6 @@ final class CleanVisitorNodeTraverser extends NodeTraverser
 {
     public function addVisitor(NodeVisitor $nodeVisitor): void
     {
-        $this->visitors = [];
-        $this->visitors[] = $nodeVisitor;
+        $this->visitors = [$nodeVisitor];
     }
 }

--- a/src/PhpParser/NodeTraverser/CleanVisitorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/CleanVisitorNodeTraverser.php
@@ -9,9 +9,9 @@ use PhpParser\NodeVisitor;
 
 final class CleanVisitorNodeTraverser extends NodeTraverser
 {
-    public function addVisitor(NodeVisitor $visitor)
+    public function addVisitor(NodeVisitor $nodeVisitor): void
     {
         $this->visitors = [];
-        $this->visitors[] = $visitor;
+        $this->visitors[] = $nodeVisitor;
     }
 }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -16,7 +16,6 @@ use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Util\StringUtils;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 
 final class InlineCodeParser
 {
@@ -64,7 +63,6 @@ final class InlineCodeParser
 
     public function __construct(
         private readonly NodePrinterInterface $nodePrinter,
-        private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly SimplePhpParser $simplePhpParser,
         private readonly ValueResolver $valueResolver
     ) {

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -85,7 +85,7 @@ final class InlineCodeParser
         $content = StringUtils::isMatch($content, self::ENDING_SEMI_COLON_REGEX) ? $content : $content . ';';
 
         $stmts = $this->simplePhpParser->parseString($content);
-        return $this->nodeScopeAndMetadataDecorator->decorateStmtsFromString($stmts);
+        return $this->nodeScopeAndMetadataDecorator->decorateNodesFromStmts($stmts);
     }
 
     public function stringify(Expr $expr): string

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -65,7 +65,8 @@ final class InlineCodeParser
     public function __construct(
         private readonly NodePrinterInterface $nodePrinter,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
-        private readonly ValueResolver $valueResolver
+        private readonly SimplePhpParser $simplePhpParser,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 
@@ -83,7 +84,7 @@ final class InlineCodeParser
         $content = StringUtils::isMatch($content, self::OPEN_PHP_TAG_REGEX) ? $content : '<?php ' . $content;
         $content = StringUtils::isMatch($content, self::ENDING_SEMI_COLON_REGEX) ? $content : $content . ';';
 
-        return $this->nodeScopeAndMetadataDecorator->decorateStmtsFromString($content);
+        return $this->simplePhpParser->parseString($content);
     }
 
     public function stringify(Expr $expr): string

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -66,7 +66,7 @@ final class InlineCodeParser
         private readonly NodePrinterInterface $nodePrinter,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly SimplePhpParser $simplePhpParser,
-        private readonly ValueResolver $valueResolver,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -65,7 +65,6 @@ final class InlineCodeParser
     public function __construct(
         private readonly NodePrinterInterface $nodePrinter,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
-        private readonly SimplePhpParser $simplePhpParser,
         private readonly ValueResolver $valueResolver
     ) {
     }
@@ -84,8 +83,7 @@ final class InlineCodeParser
         $content = StringUtils::isMatch($content, self::OPEN_PHP_TAG_REGEX) ? $content : '<?php ' . $content;
         $content = StringUtils::isMatch($content, self::ENDING_SEMI_COLON_REGEX) ? $content : $content . ';';
 
-        $stmts = $this->simplePhpParser->parseString($content);
-        return $this->nodeScopeAndMetadataDecorator->decorateNodesFromStmts($stmts);
+        return $this->nodeScopeAndMetadataDecorator->decorateStmtsFromString($content);
     }
 
     public function stringify(Expr $expr): string

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -16,8 +16,10 @@ final class SimplePhpParser
 {
     private readonly Parser $phpParser;
 
-    public function __construct(private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser)
-    {
+    public function __construct(
+        private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser,
+        private readonly NodeConnectingVisitor $nodeConnectingVisitor
+    ) {
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);
     }
@@ -42,7 +44,7 @@ final class SimplePhpParser
             return [];
         }
 
-        $this->cleanVisitorNodeTraverser->addVisitor(new NodeConnectingVisitor());
+        $this->cleanVisitorNodeTraverser->addVisitor($this->nodeConnectingVisitor);
         return $this->cleanVisitorNodeTraverser->traverse($stmts);
     }
 }

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -10,12 +10,13 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 
 final class SimplePhpParser
 {
     private readonly Parser $phpParser;
 
-    public function __construct()
+    public function __construct(private readonly CleanVisitorNodeTraverser $cleanVisitorNodeTraverser)
     {
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);
@@ -41,9 +42,7 @@ final class SimplePhpParser
             return [];
         }
 
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor(new NodeConnectingVisitor());
-
-        return $nodeTraverser->traverse($stmts);
+        $this->cleanVisitorNodeTraverser->addVisitor(new NodeConnectingVisitor());
+        return $this->cleanVisitorNodeTraverser->traverse($stmts);
     }
 }

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -6,7 +6,6 @@ namespace Rector\Core\PhpParser\Parser;
 
 use Nette\Utils\FileSystem;
 use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -32,6 +32,7 @@ use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
+use Rector\Core\PhpParser\NodeTraverser\CleanVisitorNodeTraverser;
 use Rector\Core\ProcessAnalyzer\RectifiedAnalyzer;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -115,6 +116,8 @@ CODE_SAMPLE;
 
     private DocBlockUpdater $docBlockUpdater;
 
+    private CleanVisitorNodeTraverser $cleanVisitorNodeTraverser;
+
     #[Required]
     public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
@@ -137,7 +140,8 @@ CODE_SAMPLE;
         ChangedNodeScopeRefresher $changedNodeScopeRefresher,
         RectorOutputStyle $rectorOutputStyle,
         FilePathHelper $filePathHelper,
-        DocBlockUpdater $docBlockUpdater
+        DocBlockUpdater $docBlockUpdater,
+        CleanVisitorNodeTraverser $cleanVisitorNodeTraverser
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
         $this->nodeRemover = $nodeRemover;
@@ -160,6 +164,7 @@ CODE_SAMPLE;
         $this->rectorOutputStyle = $rectorOutputStyle;
         $this->filePathHelper = $filePathHelper;
         $this->docBlockUpdater = $docBlockUpdater;
+        $this->cleanVisitorNodeTraverser = $cleanVisitorNodeTraverser;
     }
 
     /**
@@ -435,9 +440,8 @@ CODE_SAMPLE;
             $nodes = [...$nodes, $nextNode];
         }
 
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor(new NodeConnectingVisitor());
-        $nodeTraverser->traverse($nodes);
+        $this->cleanVisitorNodeTraverser->addVisitor(new NodeConnectingVisitor());
+        $this->cleanVisitorNodeTraverser->traverse($nodes);
     }
 
     private function printDebugCurrentFileAndRule(): void

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -118,6 +118,8 @@ CODE_SAMPLE;
 
     private CleanVisitorNodeTraverser $cleanVisitorNodeTraverser;
 
+    private NodeConnectingVisitor $nodeConnectingVisitor;
+
     #[Required]
     public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
@@ -141,7 +143,8 @@ CODE_SAMPLE;
         RectorOutputStyle $rectorOutputStyle,
         FilePathHelper $filePathHelper,
         DocBlockUpdater $docBlockUpdater,
-        CleanVisitorNodeTraverser $cleanVisitorNodeTraverser
+        CleanVisitorNodeTraverser $cleanVisitorNodeTraverser,
+        NodeConnectingVisitor $nodeConnectingVisitor
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
         $this->nodeRemover = $nodeRemover;
@@ -165,6 +168,7 @@ CODE_SAMPLE;
         $this->filePathHelper = $filePathHelper;
         $this->docBlockUpdater = $docBlockUpdater;
         $this->cleanVisitorNodeTraverser = $cleanVisitorNodeTraverser;
+        $this->nodeConnectingVisitor = $nodeConnectingVisitor;
     }
 
     /**
@@ -440,7 +444,7 @@ CODE_SAMPLE;
             $nodes = [...$nodes, $nextNode];
         }
 
-        $this->cleanVisitorNodeTraverser->addVisitor(new NodeConnectingVisitor());
+        $this->cleanVisitorNodeTraverser->addVisitor($this->nodeConnectingVisitor);
         $this->cleanVisitorNodeTraverser->traverse($nodes);
     }
 


### PR DESCRIPTION
There are various places which `NodeTraverser` instantiated to add visitors, and that happen repetitively. 

This PR add `CleanVisitorNodeTraverser` which clean the visitor during `addVisitor`

and mark as service so:

- no need repetive `new NodeTraverser()`
- visitors is cleared before add so avoid duplicated visitors.