### PR TITLE
[NodeTypeResolver] Remove NodeScopeAndMetadataDecorator::decorateStmtsFromString() method

### DIFF
--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -40,16 +40,4 @@ final class NodeScopeAndMetadataDecorator
 
         return $nodeTraverser->traverse($stmts);
     }
-
-    /**
-     * @param Stmt[] $stmts
-     * @return Stmt[]
-     */
-    public function decorateStmtsFromString(array $stmts): array
-    {
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor($this->nodeConnectingVisitor);
-
-        return $nodeTraverser->traverse($stmts);
-    }
 }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -16,7 +16,6 @@ use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Util\StringUtils;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 
 final class InlineCodeParser
 {
@@ -64,7 +63,6 @@ final class InlineCodeParser
 
     public function __construct(
         private readonly NodePrinterInterface $nodePrinter,
-        private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly SimplePhpParser $simplePhpParser,
         private readonly ValueResolver $valueResolver
     ) {
@@ -84,8 +82,7 @@ final class InlineCodeParser
         $content = StringUtils::isMatch($content, self::OPEN_PHP_TAG_REGEX) ? $content : '<?php ' . $content;
         $content = StringUtils::isMatch($content, self::ENDING_SEMI_COLON_REGEX) ? $content : $content . ';';
 
-        $stmts = $this->simplePhpParser->parseString($content);
-        return $this->nodeScopeAndMetadataDecorator->decorateStmtsFromString($stmts);
+        return $this->simplePhpParser->parseString($content);
     }
 
     public function stringify(Expr $expr): string


### PR DESCRIPTION
`SimplePhpParser::parseString()` already cover it, no need to double traverse.