### PR TITLE
[NodeTraverser] Add NodeConnectingTraverser

### DIFF
--- a/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
+++ b/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\PhpParser\NodeTraverser;
+
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NodeConnectingVisitor;
+
+final class NodeConnectingTraverser extends NodeTraverser
+{
+    public function __construct()
+    {
+        $this->addVisitor(new NodeConnectingVisitor());
+    }
+}

--- a/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
+++ b/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
@@ -11,6 +11,8 @@ final class NodeConnectingTraverser extends NodeTraverser
 {
     public function __construct()
     {
+        parent::__construct();
+        
         $this->addVisitor(new NodeConnectingVisitor());
     }
 }

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -10,12 +10,13 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use Rector\Core\PhpParser\NodeTraverser\NodeConnectingTraverser;
 
 final class SimplePhpParser
 {
     private readonly Parser $phpParser;
 
-    public function __construct()
+    public function __construct(private readonly NodeConnectingTraverser $nodeConnectingTraverser)
     {
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);
@@ -41,9 +42,6 @@ final class SimplePhpParser
             return [];
         }
 
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor(new NodeConnectingVisitor());
-
-        return $nodeTraverser->traverse($stmts);
+        $this->nodeConnectingTraverser->traverse($stmts);
     }
 }

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -6,8 +6,6 @@ namespace Rector\Core\PhpParser\Parser;
 
 use Nette\Utils\FileSystem;
 use PhpParser\Node\Stmt;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use Rector\Core\PhpParser\NodeTraverser\NodeConnectingTraverser;

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -40,6 +40,6 @@ final class SimplePhpParser
             return [];
         }
 
-        $this->nodeConnectingTraverser->traverse($stmts);
+        return $this->nodeConnectingTraverser->traverse($stmts);
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -11,8 +11,6 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\ObjectType;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -32,6 +32,7 @@ use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
+use Rector\Core\PhpParser\NodeTraverser\NodeConnectingTraverser;
 use Rector\Core\ProcessAnalyzer\RectifiedAnalyzer;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -115,6 +116,8 @@ CODE_SAMPLE;
 
     private DocBlockUpdater $docBlockUpdater;
 
+    private NodeConnectingTraverser $nodeConnectingTraverser;
+
     #[Required]
     public function autowire(
         NodesToRemoveCollector $nodesToRemoveCollector,
@@ -137,7 +140,8 @@ CODE_SAMPLE;
         ChangedNodeScopeRefresher $changedNodeScopeRefresher,
         RectorOutputStyle $rectorOutputStyle,
         FilePathHelper $filePathHelper,
-        DocBlockUpdater $docBlockUpdater
+        DocBlockUpdater $docBlockUpdater,
+        NodeConnectingTraverser $nodeConnectingTraverser
     ): void {
         $this->nodesToRemoveCollector = $nodesToRemoveCollector;
         $this->nodeRemover = $nodeRemover;
@@ -160,6 +164,7 @@ CODE_SAMPLE;
         $this->rectorOutputStyle = $rectorOutputStyle;
         $this->filePathHelper = $filePathHelper;
         $this->docBlockUpdater = $docBlockUpdater;
+        $this->nodeConnectingTraverser = $nodeConnectingTraverser;
     }
 
     /**
@@ -435,9 +440,7 @@ CODE_SAMPLE;
             $nodes = [...$nodes, $nextNode];
         }
 
-        $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor(new NodeConnectingVisitor());
-        $nodeTraverser->traverse($nodes);
+        $this->nodeConnectingTraverser->traverse($nodes);
     }
 
     private function printDebugCurrentFileAndRule(): void


### PR DESCRIPTION
instead of repetitive create object of `NodeTraverser` and add `NodeConnectingVisitor` as visitor, this PR create new service `NodeConnectingTraverser` which as shared service, once instantiated, it can be re-used.