### PR TITLE
[NodeTypeResolver] Make NodeTraverser as property on NodeScopeAndMetadataDecorator

### DIFF
--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -14,13 +14,13 @@ use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
 
 final class NodeScopeAndMetadataDecorator
 {
-    private NodeTraverser $nodeTraverser;
+    private readonly NodeTraverser $nodeTraverser;
 
     public function __construct(
-        private CloningVisitor $cloningVisitor,
+        CloningVisitor $cloningVisitor,
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
-        private NodeConnectingVisitor $nodeConnectingVisitor,
-        private FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
+        NodeConnectingVisitor $nodeConnectingVisitor,
+        FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
     ) {
         $this->nodeTraverser = new NodeTraverser();
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3531

this PR make `NodeTraverser` instance as property in `NodeScopeAndMetadataDecorator` and assign in `__construct()` early to avoid repetitive creation.