### PR TITLE
[NodeTypeResolver] Make NodeTraverser as property on PHPStanNodeScopeResolver

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -70,7 +70,7 @@ final class PHPStanNodeScopeResolver
         private readonly DependencyResolver $dependencyResolver,
         private readonly NodeScopeResolver $nodeScopeResolver,
         private readonly ReflectionProvider $reflectionProvider,
-        private RemoveDeepChainMethodCallNodeVisitor $removeDeepChainMethodCallNodeVisitor,
+        RemoveDeepChainMethodCallNodeVisitor $removeDeepChainMethodCallNodeVisitor,
         private readonly ScopeFactory $scopeFactory,
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly NodeNameResolver $nodeNameResolver,


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3531

this PR make `NodeTraverser` instance as property in `PHPStanNodeScopeResolver` and assign in `__construct()` early to avoid repetitive creation.