### PR TITLE
Added failling RemoveUnusedPrivatePropertyRector test-case

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/Fixture/cron_controller.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/Fixture/cron_controller.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+final class CronController
+{
+
+    protected $_distributoradaids = [];
+
+    private $_max_fileage = 3600; // 1h
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+final class CronController
+{
+
+    protected $_distributoradaids = [];
+}
+
+?>


### PR DESCRIPTION
rector moved a comment related to a propery beeing removed to a different property.
I think the comment should also be removed when on the same line as the property beeing removed

from https://getrector.com/demo/0772a67b-072b-47c0-b268-db16502bca38