### PR TITLE
[CodingStyle] Remove previous node attribute on TernaryConditionVariableAssignmentRector

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -192,4 +192,9 @@ final class AttributeKey
      * @var string
      */
     public const NEWLINED_ARRAY_PRINT = 'newlined_array_print';
+
+    /**
+     * @var string
+     */
+    public const ASSIGNED_TO = 'assigned_to';
 }

--- a/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
+++ b/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
@@ -79,8 +79,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($previousNode instanceof Node) {
+        $assignedTo = $node->getAttribute(AttributeKey::ASSIGNED_TO);
+        if ($assignedTo instanceof Node) {
             return null;
         }
 


### PR DESCRIPTION
Replace `previous` with `assigned_to` attribute on the ternary.