### PR TITLE
[CodeQuality] Skip empty cases on SwitchTrueToIfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToIfRector/Fixture/skip_empty_cases.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToIfRector/Fixture/skip_empty_cases.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToIfRector\Fixture;
+
+class SkipEmtyCases
+{
+    public function run()
+    {
+        switch (true) {
+        }
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToIfRector/Fixture/skip_empty_cases.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToIfRector/Fixture/skip_empty_cases.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToIfRector\Fixture;
 
-class SkipEmtyCases
+class SkipEmptyCases
 {
     public function run()
     {

--- a/rules/CodeQuality/Rector/Switch_/SwitchTrueToIfRector.php
+++ b/rules/CodeQuality/Rector/Switch_/SwitchTrueToIfRector.php
@@ -99,7 +99,11 @@ CODE_SAMPLE
         }
 
         if ($defaultCase instanceof Case_) {
-            return array_merge($newStmts, $defaultCase->stmts);
+            $newStmts = array_merge($newStmts, $defaultCase->stmts);
+        }
+
+        if ($newStmts === []) {
+            return null;
         }
 
         return $newStmts;


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/3535#discussion_r1155377994, if empty cases not skipped, it will got error:

```
There was 1 error:

1) Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToIfRector\SwitchTrueToIfRectorTest::test with data set #1
Rector\Core\Exception\ShouldNotHappenException: Array of nodes cannot be empty. Ensure "Rector\CodeQuality\Rector\Switch_\SwitchTrueToIfRector->refactor()" returns non-empty array for Nodes.

A) Return null for no change:

    return null;

B) Remove the Node:

    $this->removeNode($node);
    return $node;
```