### PR TITLE
[NodeRemover] Use return null after $this->removeNode()

### DIFF
--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -109,7 +109,7 @@ CODE_SAMPLE
         }
 
         $this->removeNode($node);
-        return $node;
+        return null;
     }
 
     private function cleanCastedExpr(Expr $expr): Expr

--- a/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        return $node;
+        return null;
     }
 
     private function shouldSkipNonFinalNonPrivateClassMethod(Class_ $class, ClassMethod $classMethod): bool

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -87,7 +87,7 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        return $node;
+        return null;
     }
 
     private function shouldSkip(ClassMethod $classMethod): bool

--- a/rules/DeadCode/Rector/For_/RemoveDeadLoopRector.php
+++ b/rules/DeadCode/Rector/For_/RemoveDeadLoopRector.php
@@ -66,6 +66,6 @@ CODE_SAMPLE
         }
 
         $this->removeNode($node);
-        return $node;
+        return null;
     }
 }

--- a/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveEmptyMethodCallRector.php
@@ -127,7 +127,7 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        return $node;
+        return null;
     }
 
     private function resolveClassLike(MethodCall $methodCall): ?ClassLike

--- a/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
+++ b/rules/DeadCode/Rector/TryCatch/RemoveDeadTryCatchRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
 
         if ($this->isEmpty($node->stmts)) {
             $this->removeNode($node);
-            return $node;
+            return null;
         }
 
         if (count($node->catches) !== 1) {

--- a/rules/Php70/Rector/Break_/BreakNotInLoopOrSwitchToReturnRector.php
+++ b/rules/Php70/Rector/Break_/BreakNotInLoopOrSwitchToReturnRector.php
@@ -97,6 +97,6 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        return $node;
+        return null;
     }
 }

--- a/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
+++ b/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
@@ -130,7 +130,8 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        return null;
+        // change next node before remove, so it needs to return the Node
+        return $node;
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
+++ b/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
@@ -130,7 +130,7 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        return $node;
+        return null;
     }
 
     public function provideMinPhpVersion(): int

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -56,10 +56,10 @@ A) Return null for no change:
 
     return null;
 
-B) Remove the Node:
+B) Remove the Node and return null:
 
     \$this->removeNode(\$node);
-    return \$node;
+    return null;
 CODE_SAMPLE;
 
     protected NodeNameResolver $nodeNameResolver;
@@ -210,7 +210,7 @@ CODE_SAMPLE;
 
         $refactoredNode = $this->refactor($node);
 
-        // nothing to change → continue
+        // nothing to change or just removed via removeNode() → continue
         if ($refactoredNode === null) {
             return null;
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -52,11 +52,11 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
     private const EMPTY_NODE_ARRAY_MESSAGE = <<<CODE_SAMPLE
 Array of nodes cannot be empty. Ensure "%s->refactor()" returns non-empty array for Nodes.
 
-A) Return null for no change:
+A) Direct return null for no change:
 
     return null;
 
-B) Remove the Node and return null:
+B) Remove the Node:
 
     \$this->removeNode(\$node);
     return null;


### PR DESCRIPTION
The `removeNode()` method calls:

```php
        $this->nodesToRemoveCollector->addNodeToRemove($node);
        $this->rectorChangeCollector->notifyNodeFileInfo($node);
```

which:

- no need to connect prev-parent-next for removed node
- already apply `RectorWithLineChange` via `notifyNodeFileInfo()`