### PR TITLE
[PostRector] Skip remove unused use on used in Attribute in php 7.x

### DIFF
--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -172,14 +172,6 @@ CODE_SAMPLE
     /**
      * @return string[]
      */
-    public function findAttributeNames(Namespace_|FileWithoutNamespace $namespace): array
-    {
-        return $this->phpAttributeAnalyzer->getClassNames($namespace);
-    }
-
-    /**
-     * @return string[]
-     */
     private function resolveUsedPhpAndDocNames(Namespace_|FileWithoutNamespace $namespace): array
     {
         $phpNames = $this->findNonUseImportNames($namespace);

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -17,6 +17,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Configuration\RectorConfigProvider;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -26,7 +27,8 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     public function __construct(
         private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly RectorConfigProvider $rectorConfigProvider
+        private readonly RectorConfigProvider $rectorConfigProvider,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -170,12 +172,21 @@ CODE_SAMPLE
     /**
      * @return string[]
      */
+    public function findAttributeNames(Namespace_|FileWithoutNamespace $namespace): array
+    {
+        return $this->phpAttributeAnalyzer->getClassNames($namespace);
+    }
+
+    /**
+     * @return string[]
+     */
     private function resolveUsedPhpAndDocNames(Namespace_|FileWithoutNamespace $namespace): array
     {
         $phpNames = $this->findNonUseImportNames($namespace);
         $docBlockNames = $this->findNamesInDocBlocks($namespace);
+        $attributeNames = $this->phpAttributeAnalyzer->getClassNames($namespace);
 
-        $names = array_merge($phpNames, $docBlockNames);
+        $names = array_merge($phpNames, $docBlockNames, $attributeNames);
         return array_unique($names);
     }
 

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -23,7 +23,6 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpAttribute\Enum\DocTagNodeState;
-use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
 final class PhpAttributeAnalyzer
 {

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -19,10 +19,10 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\PhpParser\AstResolver;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpAttribute\Enum\DocTagNodeState;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
 final class PhpAttributeAnalyzer
 {
@@ -30,7 +30,7 @@ final class PhpAttributeAnalyzer
         private readonly AstResolver $astResolver,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly ReflectionProvider $reflectionProvider,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
     ) {
     }
 
@@ -41,15 +41,14 @@ final class PhpAttributeAnalyzer
     {
         $classNames = [];
 
-        $this->betterNodeFinder->find(
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $namespace->stmts,
-            static function (Node $subNode) use (&$classNames) : bool {
+            static function (Node $subNode) use (&$classNames) {
                 if ($subNode instanceof Attribute) {
                     $classNames[] = $subNode->name->toString();
-                    return true;
                 }
 
-                return false;
+                return null;
             }
         );
 

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -43,12 +43,11 @@ final class PhpAttributeAnalyzer
 
         $this->betterNodeFinder->find(
             $namespace->stmts,
-            function (Node $subNode) use (&$classNames): bool {
+            static function (Node $subNode) use (&$classNames) : bool {
                 if ($subNode instanceof Attribute) {
                     $classNames[] = $subNode->name->toString();
                     return true;
                 }
-
                 return false;
             }
         );

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -48,6 +48,7 @@ final class PhpAttributeAnalyzer
                     $classNames[] = $subNode->name->toString();
                     return true;
                 }
+
                 return false;
             }
         );

--- a/tests/Issues/NamespacedUse/Fixture/skip_used_in_attribute.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_used_in_attribute.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+
+use ReturnTypeWillChange;
+
+class SkipUsedInAttribute implements \ArrayAccess
+{
+    #[ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+    }
+}


### PR DESCRIPTION
I tried in kahlan in php 7.2, and it show removed 

```php
use ReturnTypeWillChange;
```

see https://github.com/kahlan/kahlan/actions/runs/4448615448/jobs/7811656219

which used in attribute. This PR try to not remove it when used in php 7.2