### PR TITLE
 [PostRector] Skip remove unused used at @see for Generic tag 

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -6,6 +6,7 @@ namespace Rector\BetterPhpDocParser\PhpDocInfo;
 
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
@@ -446,6 +447,23 @@ final class PhpDocInfo
 
         foreach ($identifierTypeNodes as $identifierTypeNode) {
             $resolvedClasses[] = ltrim($identifierTypeNode->name, '@');
+        }
+
+        return $resolvedClasses;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getGenericTagClassNames(): array
+    {
+        /** @var GenericTagValueNode[] $genericTagValueNodes */
+        $genericTagValueNodes = $this->phpDocNodeByTypeFinder->findByType($this->phpDocNode, GenericTagValueNode::class);
+
+        $resolvedClasses = [];
+
+        foreach ($genericTagValueNodes as $genericTagValueNode) {
+            $resolvedClasses[] = ltrim($genericTagValueNode->value, '@');
         }
 
         return $resolvedClasses;

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -463,7 +463,7 @@ final class PhpDocInfo
         $resolvedClasses = [];
 
         foreach ($genericTagValueNodes as $genericTagValueNode) {
-            $resolvedClasses[] = ltrim($genericTagValueNode->value, '@');
+            $resolvedClasses[] = $genericTagValueNode->value;
         }
 
         return $resolvedClasses;

--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -162,6 +162,9 @@ CODE_SAMPLE
 
             $constFetchNodeNames = $phpDocInfo->getConstFetchNodeClassNames();
             $names = array_merge($names, $constFetchNodeNames);
+
+            $genericTagClassNames = $phpDocInfo->getGenericTagClassNames();
+            $names = array_merge($names, $genericTagClassNames);
         });
 
         return $names;

--- a/tests/Issues/NamespacedUse/Fixture/skip_used_see.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_used_see.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+/**
+ * @see RenameClassRector
+ */
+final class SkipUsedSee
+{
+}


### PR DESCRIPTION
The following code should be skipped from remove unused use:

```php
namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;

use Rector\Renaming\Rector\Name\RenameClassRector;

/**
 * @see RenameClassRector
 */
final class SkipUsedSee
{
}
```