### PR TITLE
Allow to use a dedicated process for each job

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -50,7 +50,7 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL, false);
     }
 
-    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20): void
+    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20, bool $useSeparateProcessPerJob = false): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
@@ -58,6 +58,7 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $seconds);
         $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $maxNumberOfProcess);
         $parameters->set(Option::PARALLEL_JOB_SIZE, $jobSize);
+        $parameters->set(Option::PARALLEL_USE_SEPARATE_PROCESS_PER_JOB, $useSeparateProcessPerJob);
     }
 
     public function noDiffs(): void

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -158,15 +158,10 @@ final class ParallelFileProcessor
         $onExitCallableProvider = function (string $processIdentifier) use (&$systemErrors): callable {
             return function ($exitCode, string $stdErr) use (&$systemErrors, $processIdentifier): void {
                 $this->processPool->tryQuitProcess($processIdentifier);
-                if ($exitCode === Command::SUCCESS) {
-                    return;
-                }
 
-                if ($exitCode === null) {
-                    return;
+                if ($exitCode !== Command::SUCCESS && $exitCode !== null) {
+                    $systemErrors[] = new SystemError('Child process error: ' . $stdErr);
                 }
-
-                $systemErrors[] = new SystemError('Child process error: ' . $stdErr);
             };
         };
 

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -197,6 +197,12 @@ final class Option
     public const PARALLEL_JOB_TIMEOUT_IN_SECONDS = 'parallel-job-timeout-in-seconds';
 
     /**
+     * @internal Use @see \Rector\Config\RectorConfig::parallel() instead with pass bool $useSeparateProcessPerJob parameter
+     * @var string
+     */
+    public const PARALLEL_USE_SEPARATE_PROCESS_PER_JOB = 'parallel-use-separate-process-per-job';
+
+    /**
      * @var string
      */
     public const MEMORY_LIMIT = 'memory-limit';

--- a/src/ValueObject/Parallel/ParallelProcessWithIdentifier.php
+++ b/src/ValueObject/Parallel/ParallelProcessWithIdentifier.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\ValueObject\Parallel;
+
+use Symplify\EasyParallel\ValueObject\ParallelProcess;
+
+final class ParallelProcessWithIdentifier
+{
+    public function __construct(
+        private readonly string $identifier,
+        private readonly ParallelProcess $parallelProcess,
+    ) {
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getParallelProcess(): ParallelProcess
+    {
+        return $this->parallelProcess;
+    }
+}


### PR DESCRIPTION
~~**Disclaimer**: as the title says, this is a proof of concept, to open the discussion. It's of course not aim to be merged as is!~~

### The story

I'm running Rector on a big project, and often it breaks because of no more memory...
It's impossible to run a full configuration on the project to clean it entirely based on the rules we decided to use.
We could argue that as a refactoring tool, rector aim to be run in one shot to do a just few rules migrations, and it actually work.
But still I find myself obliged to close PhpStorm and Chrome to free some memory for Rector.

### The challenge

I challenged myself to be able to run Rector without memory issues until the end, with PhpStorm and Chrome still opened!
Here actual system monitoring before running Rector (there are other stuff needed for the project like Docker that are running too):

![image](https://user-images.githubusercontent.com/1480128/229943352-70bdd3ba-e8ba-45bd-b614-5dba4ba8464e.png)

### The investigation

I realized that Rector starts the configured number of processes and keep using them for each job.
So I thought about the idea of killing them after they finished their job, so one process = one parallel job.

### The first results

On rector-src at master, on my machine with a configuration to use 3 threads and job size of 10, it takes around 5m 10s to run.
But it consume a lot of memory!

On this branch, with the same configuration it takes around 15min 20s!!! 3 times the initial time!
But changing the job size to 150 it's down to around 5m 20s, not that bad to me, when on master it takes around 4m 30s.

It has a cost to start processes!

### The balance

The alternative don't fit for a parallel configuration with lots of small jobs, as it will lead to lots of processes to be created, and so exploding the time to run.
But being tweaked with a bigger job size, so less processes to run, it's not that bad from a time prespective.

So parallel configuration could depend on the project size, the number of rules configured, the running intentions of the developer.

### The proposal

Have is alternative way of running parallel jobs available through configuration so it's up to the developers to decide what fits best their project and intention.

### Random ideas

- Have it configurable with a fourth boolean parameter `$useSeparateProcessPerJob` that default to `false` in `->parallel()`
- Show a warning when `true` and the number of jobs is high

---

@TomasVotruba @samsonasik what do you think?
With https://github.com/rectorphp/rector/issues/7806 @keulinho you may be interested by this too