### PR TITLE
Revert [Tests] Remove RunTestsInSeparateProcesses in rules-tests

### DIFF
--- a/rules-tests/Naming/ValueObjectFactory/PropertyRenameFactory/PropertyRenameFactoryTest.php
+++ b/rules-tests/Naming/ValueObjectFactory/PropertyRenameFactory/PropertyRenameFactoryTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\FileSystemRector\Parser\FileInfoParser;
 use Rector\Naming\ExpectedNameResolver\MatchPropertyTypeExpectedNameResolver;
@@ -15,6 +16,7 @@ use Rector\Naming\ValueObject\PropertyRename;
 use Rector\Naming\ValueObjectFactory\PropertyRenameFactory;
 use Rector\Testing\PHPUnit\AbstractTestCase;
 
+#[RunTestsInSeparateProcesses]
 final class PropertyRenameFactoryTest extends AbstractTestCase
 {
     private PropertyRenameFactory $propertyRenameFactory;

--- a/rules-tests/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector/PseudoNamespaceToNamespaceRectorTest.php
+++ b/rules-tests/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector/PseudoNamespaceToNamespaceRectorTest.php
@@ -6,8 +6,10 @@ namespace Rector\Tests\Renaming\Rector\FileWithoutNamespace\PseudoNamespaceToNam
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+#[RunTestsInSeparateProcesses]
 final class PseudoNamespaceToNamespaceRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
@@ -6,8 +6,10 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+#[RunTestsInSeparateProcesses]
 final class RenameClassRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]


### PR DESCRIPTION
This reverts commit fdbe615da859227452bf06b86d72e63faf8d7700., 

@TomasVotruba sometime test still randomly failure on these tests so it needs to be reverted.