### PR TITLE
Remove unused imports

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver/ClassMethodOrClassConstTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/ClassMethodOrClassConstTypeResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\NodeTypeResolver;
 
 use PhpParser\Node;
-use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;

--- a/packages/NodeTypeResolver/NodeTypeResolver/VariableTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/VariableTypeResolver.php
@@ -6,7 +6,6 @@ namespace Rector\NodeTypeResolver\NodeTypeResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Param;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -39,7 +39,6 @@ use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\BoolUnionTypeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeCommonTypeNarrower;
 use Rector\PHPStanStaticTypeMapper\ValueObject\UnionTypeAnalysis;
-use function Symfony\Component\String\b;
 use Symfony\Contracts\Service\Attribute\Required;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;

--- a/packages/ReadWrite/ReadNodeAnalyzer/LocalPropertyFetchReadNodeAnalyzer.php
+++ b/packages/ReadWrite/ReadNodeAnalyzer/LocalPropertyFetchReadNodeAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\ReadWrite\ReadNodeAnalyzer;
 
-use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;

--- a/packages/VersionBonding/Contract/MinPhpVersionInterface.php
+++ b/packages/VersionBonding/Contract/MinPhpVersionInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\VersionBonding\Contract;
 
-use Rector\Core\Contract\Rector\RectorInterface;
-use Rector\Core\ValueObject\PhpVersion;
-
 /**
  * Can be implemented by @see RectorInterface
  * All rules that do not meet this PHP version will not be run and user will be warned about it.

--- a/packages/VersionBonding/Contract/MinPhpVersionInterface.php
+++ b/packages/VersionBonding/Contract/MinPhpVersionInterface.php
@@ -16,7 +16,7 @@ interface MinPhpVersionInterface
 {
     /**
      * @todo upgrade to Enum and return of Enum object in the future.
-     * Requires refactoring of \Rector\Core\ValueObject\PhpVersion and PhpVersionFeatures object at the same time.
+     * Requires refactoring of \Rector\Core\ValueObject\PhpVersion and \Rector\Core\ValueObject\PhpVersionFeature object at the same time.
      */
     public function provideMinPhpVersion(): int;
 }

--- a/packages/VersionBonding/Contract/MinPhpVersionInterface.php
+++ b/packages/VersionBonding/Contract/MinPhpVersionInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\VersionBonding\Contract;
 
 /**
- * Can be implemented by @see RectorInterface
+ * Can be implemented by @see \Rector\Core\Contract\Rector\RectorInterface
  * All rules that do not meet this PHP version will not be run and user will be warned about it.
  * They can either:
  *      - exclude rule,
@@ -16,7 +16,7 @@ interface MinPhpVersionInterface
 {
     /**
      * @todo upgrade to Enum and return of Enum object in the future.
-     * Requires refactoring of PhpVersion and PhpVersionFeatures object at the same time.
+     * Requires refactoring of \Rector\Core\ValueObject\PhpVersion and PhpVersionFeatures object at the same time.
      */
     public function provideMinPhpVersion(): int;
 }

--- a/rector.php
+++ b/rector.php
@@ -57,6 +57,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->importNames();
+    $rectorConfig->removeUnusedImports();
     $rectorConfig->parallel();
 
     $rectorConfig->skip([

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -7,7 +7,6 @@ namespace Rector\CodeQuality\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use Rector\CodeQuality\NodeAnalyzer\ConstructorPropertyDefaultExprResolver;
 use Rector\Core\Rector\AbstractRector;

--- a/rules/DeadCode/PhpDoc/TagRemover/ReturnTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/ReturnTagRemover.php
@@ -6,7 +6,6 @@ namespace Rector\DeadCode\PhpDoc\TagRemover;
 
 use PhpParser\Node\FunctionLike;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\DeadCode\PhpDoc\DeadReturnTagValueNodeAnalyzer;
 

--- a/rules/Naming/ParamRenamer/ParamRenamer.php
+++ b/rules/Naming/ParamRenamer/ParamRenamer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Naming\ParamRenamer;
 
-use PhpParser\Node\Param;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PropertyDocBlockManipulator;
 use Rector\Naming\ValueObject\ParamRename;
 use Rector\Naming\VariableRenamer;

--- a/rules/Restoration/Rector/ClassLike/UpdateFileNameByClassNameFileSystemRector.php
+++ b/rules/Restoration/Rector/ClassLike/UpdateFileNameByClassNameFileSystemRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesCollector;
 use Rector\Core\Rector\AbstractRector;
-use Rector\Core\ValueObject\Application\File;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnFilter/ExclusiveNativeCallLikeReturnMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnFilter/ExclusiveNativeCallLikeReturnMatcher.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\NodeAnalyzer\ReturnFilter;
 
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;

--- a/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
+++ b/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
@@ -21,7 +21,6 @@ use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\StaticTypeMapper\Naming\NameScopeFactory;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\NonExistingObjectType;

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/GetterTypeDeclarationPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/GetterTypeDeclarationPropertyTypeInferer.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\TypeDeclaration\FunctionLikeReturnTypeResolver;
 use Rector\TypeDeclaration\NodeAnalyzer\ClassMethodAndPropertyAnalyzer;

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/GetterTypeDeclarationPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/GetterTypeDeclarationPropertyTypeInferer.php
@@ -17,8 +17,7 @@ final class GetterTypeDeclarationPropertyTypeInferer
     public function __construct(
         private readonly FunctionLikeReturnTypeResolver $functionLikeReturnTypeResolver,
         private readonly ClassMethodAndPropertyAnalyzer $classMethodAndPropertyAnalyzer,
-        private readonly NodeNameResolver $nodeNameResolver,
-        //private readonly BetterNodeFinder $betterNodeFinder
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeManipulator/MagicPropertyFetchAnalyzer.php
+++ b/src/NodeManipulator/MagicPropertyFetchAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeManipulator;
 
-use PhpParser\Node;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PHPStan\Analyser\Scope;

--- a/src/ValueObjectFactory/ProcessResultFactory.php
+++ b/src/ValueObjectFactory/ProcessResultFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\ValueObjectFactory;
 
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesCollector;
-use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Error\SystemError;
 use Rector\Core\ValueObject\ProcessResult;
 use Rector\Core\ValueObject\Reporting\FileDiff;

--- a/tests/Issues/PhpTagsAddedToBlade/PhpTagsAddedToBladeTest.php
+++ b/tests/Issues/PhpTagsAddedToBlade/PhpTagsAddedToBladeTest.php
@@ -7,7 +7,6 @@ namespace Rector\Core\Tests\Issues\PhpTagsAddedToBlade;
 use Nette\Utils\FileSystem;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\Core\Application\ApplicationFileProcessor;
-use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
 use Rector\Parallel\ValueObject\Bridge;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/utils/ChangelogGenerator/Command/GenerateChangelogCommand.php
+++ b/utils/ChangelogGenerator/Command/GenerateChangelogCommand.php
@@ -11,7 +11,6 @@ use Rector\Utils\ChangelogGenerator\Enum\Option;
 use Rector\Utils\ChangelogGenerator\Enum\RepositoryName;
 use Rector\Utils\ChangelogGenerator\GithubApiCaller;
 use Rector\Utils\ChangelogGenerator\GitResolver;
-use Rector\Utils\ChangelogGenerator\ValueObject\Commit;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
@TomasVotruba let's enable `$rectorConfig->removeUnusedImports();` to clean up unused imports on the code base.