### PR TITLE
Improve ArraySpreadInsteadOfArrayMergeRector

### DIFF
--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/integer_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/integer_keys.php.inc
@@ -6,8 +6,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two'];
-        $iter2 = [1 => 'four'];
+        $iter1 = [0 => 'two', 3 => 'four'];
+        $iter2 = [5 => 'six', 7 => 'eight'];
 
         return array_merge($iter1, $iter2);
     }
@@ -23,8 +23,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two'];
-        $iter2 = [1 => 'four'];
+        $iter1 = [0 => 'two', 3 => 'four'];
+        $iter2 = [5 => 'six', 7 => 'eight'];
 
         return [...$iter1, ...$iter2];
     }

--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/skip_string_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/skip_string_keys.php.inc
@@ -6,16 +6,16 @@ class SkipStringKeys
 {
     public function run()
     {
-        $iter1 = ['one' => 'two'];
-        $iter2 = ['three' => 'four'];
+        $iter1 = ['one' => 'two', 'three' => 'four'];
+        $iter2 = ['five' => 'six', 'seven' => 'eight'];
 
         return array_merge($iter1, $iter2);
     }
 
     public function go()
     {
-        $iter1 = [1 => 'two'];
-        $iter2 = ['three' => 'four'];
+        $iter1 = [1 => 'two', 3 => 'four'];
+        $iter2 = ['five' => 'six', 'seven' => 'eight'];
 
         return array_merge($iter1, $iter2);
     }

--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/integer_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/integer_keys.php.inc
@@ -6,8 +6,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two'];
-        $iter2 = [1 => 'four'];
+        $iter1 = [0 => 'two', 3 => 'four'];
+        $iter2 = [5 => 'six', 7 => 'eight'];
 
         return array_merge($iter1, $iter2);
     }
@@ -23,8 +23,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two'];
-        $iter2 = [1 => 'four'];
+        $iter1 = [0 => 'two', 3 => 'four'];
+        $iter2 = [5 => 'six', 7 => 'eight'];
 
         return [...$iter1, ...$iter2];
     }

--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/string_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/string_keys.php.inc
@@ -6,16 +6,16 @@ class StringKeys
 {
     public function run()
     {
-        $iter1 = ['one' => 'two'];
-        $iter2 = ['three' => 'four'];
+        $iter1 = ['one' => 'two', 'three' => 'four'];
+        $iter2 = ['five' => 'six', 'seven' => 'eight'];
 
         return array_merge($iter1, $iter2);
     }
 
     public function go()
     {
-        $iter1 = [1 => 'two'];
-        $iter2 = ['three' => 'four'];
+        $iter1 = [1 => 'two', 3 => 'four'];
+        $iter2 = ['five' => 'six', 'seven' => 'eight'];
 
         return array_merge($iter1, $iter2);
     }
@@ -30,16 +30,16 @@ class StringKeys
 {
     public function run()
     {
-        $iter1 = ['one' => 'two'];
-        $iter2 = ['three' => 'four'];
+        $iter1 = ['one' => 'two', 'three' => 'four'];
+        $iter2 = ['five' => 'six', 'seven' => 'eight'];
 
         return [...$iter1, ...$iter2];
     }
 
     public function go()
     {
-        $iter1 = [1 => 'two'];
-        $iter2 = ['three' => 'four'];
+        $iter1 = [1 => 'two', 3 => 'four'];
+        $iter2 = ['five' => 'six', 'seven' => 'eight'];
 
         return [...$iter1, ...$iter2];
     }

--- a/rules/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -13,8 +13,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\StringType;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -150,18 +148,17 @@ CODE_SAMPLE
 
     private function isArrayKeyTypeAllowed(ArrayType $arrayType): bool
     {
-        $allowedKeyTypes = [IntegerType::class];
-        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_SPREAD_STRING_KEYS)) {
-            $allowedKeyTypes[] = StringType::class;
+        if ($arrayType->getKeyType()->isInteger()->yes()) {
+            return true;
         }
 
-        foreach ($allowedKeyTypes as $allowedKeyType) {
-            if ($arrayType->getKeyType() instanceof $allowedKeyType) {
-                return true;
-            }
+        if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_SPREAD_STRING_KEYS)) {
+            return false;
         }
 
-        return false;
+        return $arrayType->getKeyType()
+            ->isString()
+            ->yes();
     }
 
     private function resolveValue(Expr $expr): Expr


### PR DESCRIPTION
The issue is that such arrays are detected by PHPStan as an union of constant int or and union of constant string types.

Here direct link to the failing job: https://github.com/rectorphp/rector-src/actions/runs/4633226912/jobs/8198209532?pr=3568