### PR TITLE
Revert Improve ArraySpreadInsteadOfArrayMergeRector (#3568)

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -149,9 +149,6 @@ final class RectorConfig extends ContainerConfigurator
         }
     }
 
-    /**
-     * @param PhpVersion::* $phpVersion
-     */
     public function phpVersion(int $phpVersion): void
     {
         $parameters = $this->parameters();

--- a/packages/PHPStanStaticTypeMapper/Contract/TypeMapperInterface.php
+++ b/packages/PHPStanStaticTypeMapper/Contract/TypeMapperInterface.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Type;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 
 /**
  * @template TType of Type
@@ -24,13 +23,11 @@ interface TypeMapperInterface
 
     /**
      * @param TType $type
-     * @param TypeKind::* $typeKind
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode;
 
     /**
      * @param TType $type
-     * @param TypeKind::* $typeKind
      * @return Name|ComplexType|Identifier|null
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node;

--- a/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -14,7 +14,6 @@ use PHPStan\Type\ConditionalType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 
 final class PHPStanStaticTypeMapper
 {
@@ -26,9 +25,6 @@ final class PHPStanStaticTypeMapper
     ) {
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode
     {
         foreach ($this->typeMappers as $typeMapper) {
@@ -54,9 +50,6 @@ final class PHPStanStaticTypeMapper
         throw new NotImplementedYetException(__METHOD__ . ' for ' . $type::class);
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     public function mapToPhpParserNode(Type $type, string $typeKind): Name | ComplexType | Identifier | null
     {
         foreach ($this->typeMappers as $typeMapper) {

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
@@ -82,7 +82,6 @@ final class ArrayTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param ArrayType $type
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode
@@ -126,9 +125,6 @@ final class ArrayTypeMapper implements TypeMapperInterface
         return new Identifier('array');
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function createArrayTypeNodeFromUnionType(
         UnionType $unionType,
         string $typeKind
@@ -186,9 +182,6 @@ final class ArrayTypeMapper implements TypeMapperInterface
         return false;
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function createGenericArrayType(
         ArrayType $arrayType,
         string $typeKind,
@@ -254,9 +247,6 @@ final class ArrayTypeMapper implements TypeMapperInterface
         return ! $arrayType->getItemType() instanceof ArrayType;
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function narrowConstantArrayTypeOfUnionType(
         ArrayType $arrayType,
         Type $itemType,
@@ -281,9 +271,6 @@ final class ArrayTypeMapper implements TypeMapperInterface
         return null;
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function createTypeNodeFromGenericClassStringType(
         GenericClassStringType $genericClassStringType,
         string $typeKind

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/CallableTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/CallableTypeMapper.php
@@ -39,7 +39,6 @@ final class CallableTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param CallableType $type
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode
@@ -50,7 +49,6 @@ final class CallableTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param CallableType|ClosureType $type
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ClosureTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ClosureTypeMapper.php
@@ -55,7 +55,6 @@ final class ClosureTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param ClosureType $type
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
@@ -74,7 +73,6 @@ final class ClosureTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @return CallableTypeParameterNode[]
      */
     private function createCallableTypeParameterNodes(ClosureType $closureType, string $typeKind): array

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ConditionalTypeForParameterMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ConditionalTypeForParameterMapper.php
@@ -9,7 +9,6 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\Type;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -36,7 +35,6 @@ final class ConditionalTypeForParameterMapper implements TypeMapperInterface
 
     /**
      * @param ConditionalTypeForParameter $type
-     * @param TypeKind::* $typeKind
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode
     {
@@ -45,7 +43,6 @@ final class ConditionalTypeForParameterMapper implements TypeMapperInterface
 
     /**
      * @param ConditionalTypeForParameter $type
-     * @param TypeKind::* $typeKind
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
     {

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/NeverTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/NeverTypeMapper.php
@@ -26,7 +26,6 @@ final class NeverTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param NeverType $type
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
@@ -35,7 +35,6 @@ final class NullTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param NullType $type
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -16,7 +16,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedGenericObjectType;
@@ -111,9 +110,6 @@ final class ObjectTypeMapper implements TypeMapperInterface
         $this->phpStanStaticTypeMapper = $phpStanStaticTypeMapper;
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function mapGenericObjectType(GenericObjectType $genericObjectType, string $typeKind): TypeNode
     {
         $name = $this->resolveGenericObjectTypeName($genericObjectType);

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/OversizedArrayTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/OversizedArrayTypeMapper.php
@@ -12,7 +12,6 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Accessory\OversizedArrayType;
 use PHPStan\Type\Type;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 
 /**
  * @implements TypeMapperInterface<OversizedArrayType>
@@ -28,7 +27,6 @@ final class OversizedArrayTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param OversizedArrayType $type
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type, string $typeKind): TypeNode
@@ -37,7 +35,6 @@ final class OversizedArrayTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param OversizedArrayType $type
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -33,7 +33,6 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\BoolUnionTypeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeAnalyzer;
@@ -184,9 +183,6 @@ final class UnionTypeMapper implements TypeMapperInterface
         return new PhpParserUnionType($types);
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function mapNullabledType(Type $nullabledType, string $typeKind): ?Node
     {
         // void cannot be nullable
@@ -278,7 +274,6 @@ final class UnionTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @return Name|FullyQualified|ComplexType|Identifier|null
      */
     private function matchTypeForUnionedObjectTypes(UnionType $unionType, string $typeKind): ?Node
@@ -339,9 +334,6 @@ final class UnionTypeMapper implements TypeMapperInterface
         return new FullyQualified($compatibleObjectType->getClassName());
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function matchPhpParserUnionType(
         UnionType $unionType,
         string $typeKind
@@ -380,9 +372,6 @@ final class UnionTypeMapper implements TypeMapperInterface
         return $this->resolveTypeWithNullablePHPParserUnionType(new PhpParserUnionType($phpParserUnionedTypes));
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function resolveAllowedStandaloneTypeInUnionType(
         Type $unionedType,
         string $typeKind
@@ -487,9 +476,6 @@ final class UnionTypeMapper implements TypeMapperInterface
         return new Identifier('int');
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     private function narrowBoolType(
         UnionType $unionType,
         PhpParserUnionType $phpParserUnionType,

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
@@ -47,7 +47,6 @@ final class VoidTypeMapper implements TypeMapperInterface
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @param VoidType $type
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -23,7 +23,6 @@ use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;
@@ -51,16 +50,12 @@ final class StaticTypeMapper
     ) {
     }
 
-    /**
-     * @param TypeKind::* $typeKind
-     */
     public function mapPHPStanTypeToPHPStanPhpDocTypeNode(Type $phpStanType, string $typeKind): TypeNode
     {
         return $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($phpStanType, $typeKind);
     }
 
     /**
-     * @param TypeKind::* $typeKind
      * @return Name|ComplexType|Identifier|null
      */
     public function mapPHPStanTypeToPhpParserNode(Type $phpStanType, string $typeKind): ?Node

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -175,9 +175,13 @@ final class ClassMethodReturnTypeOverrideGuard
             }
 
             $childReturnType = $this->returnTypeInferer->inferFunctionLike($method);
-            if ($returnType->isVoid()->yes() && ! $childReturnType->isVoid()->yes()) {
-                return true;
+            if (!$returnType->isVoid()->yes()) {
+                continue;
             }
+            if ($childReturnType->isVoid()->yes()) {
+                continue;
+            }
+            return true;
         }
 
         return false;

--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -178,9 +178,11 @@ final class ClassMethodReturnTypeOverrideGuard
             if (!$returnType->isVoid()->yes()) {
                 continue;
             }
+
             if ($childReturnType->isVoid()->yes()) {
                 continue;
             }
+
             return true;
         }
 

--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/integer_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/integer_keys.php.inc
@@ -6,8 +6,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two', 3 => 'four'];
-        $iter2 = [5 => 'six', 7 => 'eight'];
+        $iter1 = [0 => 'two'];
+        $iter2 = [1 => 'four'];
 
         return array_merge($iter1, $iter2);
     }
@@ -23,8 +23,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two', 3 => 'four'];
-        $iter2 = [5 => 'six', 7 => 'eight'];
+        $iter1 = [0 => 'two'];
+        $iter2 = [1 => 'four'];
 
         return [...$iter1, ...$iter2];
     }

--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/skip_string_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/skip_string_keys.php.inc
@@ -6,16 +6,16 @@ class SkipStringKeys
 {
     public function run()
     {
-        $iter1 = ['one' => 'two', 'three' => 'four'];
-        $iter2 = ['five' => 'six', 'seven' => 'eight'];
+        $iter1 = ['one' => 'two'];
+        $iter2 = ['three' => 'four'];
 
         return array_merge($iter1, $iter2);
     }
 
     public function go()
     {
-        $iter1 = [1 => 'two', 3 => 'four'];
-        $iter2 = ['five' => 'six', 'seven' => 'eight'];
+        $iter1 = [1 => 'two'];
+        $iter2 = ['three' => 'four'];
 
         return array_merge($iter1, $iter2);
     }

--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/integer_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/integer_keys.php.inc
@@ -6,8 +6,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two', 3 => 'four'];
-        $iter2 = [5 => 'six', 7 => 'eight'];
+        $iter1 = [0 => 'two'];
+        $iter2 = [1 => 'four'];
 
         return array_merge($iter1, $iter2);
     }
@@ -23,8 +23,8 @@ class IntegerKeys
 {
     public function run()
     {
-        $iter1 = [0 => 'two', 3 => 'four'];
-        $iter2 = [5 => 'six', 7 => 'eight'];
+        $iter1 = [0 => 'two'];
+        $iter2 = [1 => 'four'];
 
         return [...$iter1, ...$iter2];
     }

--- a/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/string_keys.php.inc
+++ b/rules-tests/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp81/string_keys.php.inc
@@ -6,16 +6,16 @@ class StringKeys
 {
     public function run()
     {
-        $iter1 = ['one' => 'two', 'three' => 'four'];
-        $iter2 = ['five' => 'six', 'seven' => 'eight'];
+        $iter1 = ['one' => 'two'];
+        $iter2 = ['three' => 'four'];
 
         return array_merge($iter1, $iter2);
     }
 
     public function go()
     {
-        $iter1 = [1 => 'two', 3 => 'four'];
-        $iter2 = ['five' => 'six', 'seven' => 'eight'];
+        $iter1 = [1 => 'two'];
+        $iter2 = ['three' => 'four'];
 
         return array_merge($iter1, $iter2);
     }
@@ -30,16 +30,16 @@ class StringKeys
 {
     public function run()
     {
-        $iter1 = ['one' => 'two', 'three' => 'four'];
-        $iter2 = ['five' => 'six', 'seven' => 'eight'];
+        $iter1 = ['one' => 'two'];
+        $iter2 = ['three' => 'four'];
 
         return [...$iter1, ...$iter2];
     }
 
     public function go()
     {
-        $iter1 = [1 => 'two', 3 => 'four'];
-        $iter2 = ['five' => 'six', 'seven' => 'eight'];
+        $iter1 = [1 => 'two'];
+        $iter2 = ['three' => 'four'];
 
         return [...$iter1, ...$iter2];
     }

--- a/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -133,9 +133,6 @@ CODE_SAMPLE
         return $this->nodeFactory->createStaticCall($objectReference, $methodName, $node->args);
     }
 
-    /**
-     * @return ObjectReference::STATIC|ObjectReference::SELF
-     */
     private function resolveClassSelf(MethodCall $methodCall): string
     {
         $classLike = $this->betterNodeFinder->findParentType($methodCall, Class_::class);

--- a/rules/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/Php74/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -13,6 +13,8 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -148,17 +150,18 @@ CODE_SAMPLE
 
     private function isArrayKeyTypeAllowed(ArrayType $arrayType): bool
     {
-        if ($arrayType->getKeyType()->isInteger()->yes()) {
-            return true;
+        $allowedKeyTypes = [IntegerType::class];
+        if ($this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_SPREAD_STRING_KEYS)) {
+            $allowedKeyTypes[] = StringType::class;
         }
 
-        if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_SPREAD_STRING_KEYS)) {
-            return false;
+        foreach ($allowedKeyTypes as $allowedKeyType) {
+            if ($arrayType->getKeyType() instanceof $allowedKeyType) {
+                return true;
+            }
         }
 
-        return $arrayType->getKeyType()
-            ->isString()
-            ->yes();
+        return false;
     }
 
     private function resolveValue(Expr $expr): Expr

--- a/rules/Php80/ValueObject/CondAndExpr.php
+++ b/rules/Php80/ValueObject/CondAndExpr.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Rector\Php80\ValueObject;
 
 use PhpParser\Node\Expr;
-use Rector\Php80\Enum\MatchKind;
 
 final class CondAndExpr
 {
     /**
      * @param Expr[]|null $condExprs
-     * @param MatchKind::* $matchKind
      */
     public function __construct(
         private readonly array|null $condExprs,
@@ -38,17 +36,11 @@ final class CondAndExpr
         return $this->condExprs;
     }
 
-    /**
-     * @return MatchKind::*
-     */
     public function getMatchKind(): string
     {
         return $this->matchKind;
     }
 
-    /**
-     * @param MatchKind::* $matchKind
-     */
     public function equalsMatchKind(string $matchKind): bool
     {
         return $this->matchKind === $matchKind;

--- a/rules/Transform/ValueObject/ArrayFuncCallToMethodCall.php
+++ b/rules/Transform/ValueObject/ArrayFuncCallToMethodCall.php
@@ -9,12 +9,6 @@ use Rector\Transform\Contract\ValueObject\ArgumentFuncCallToMethodCallInterface;
 
 final class ArrayFuncCallToMethodCall implements ArgumentFuncCallToMethodCallInterface
 {
-    /**
-     * @param non-empty-string $function
-     * @param non-empty-string $class
-     * @param non-empty-string $arrayMethod
-     * @param non-empty-string $nonArrayMethod
-     */
     public function __construct(
         private readonly string $function,
         private readonly string $class,

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
@@ -94,9 +94,6 @@ CODE_SAMPLE
         return $node;
     }
 
-    /**
-     * @return PhpVersion::*
-     */
     public function provideMinPhpVersion(): int
     {
         return PhpVersion::PHP_70;

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -130,9 +130,6 @@ final class ProcessCommand extends AbstractProcessCommand
         }
     }
 
-    /**
-     * @return ExitCode::*
-     */
     private function resolveReturnCode(ProcessResult $processResult, Configuration $configuration): int
     {
         // some system errors were found → fail

--- a/src/Php/PhpVersionProvider.php
+++ b/src/Php/PhpVersionProvider.php
@@ -30,9 +30,6 @@ final class PhpVersionProvider
     ) {
     }
 
-    /**
-     * @return PhpVersion::*
-     */
     public function provide(): int
     {
         $phpVersionFeatures = $this->parameterProvider->provideParameter(Option::PHP_VERSION_FEATURES);

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -266,7 +266,6 @@ final class NodeFactory
     }
 
     /**
-     * @param string|ObjectReference::* $class
      * @param Node[] $args
      */
     public function createStaticCall(string $class, string $method, array $args = []): StaticCall
@@ -343,7 +342,6 @@ final class NodeFactory
 
     /**
      * @api phpunit
-     * @param string|ObjectReference::* $constantName
      */
     public function createClassConstFetchFromName(Name $className, string $constantName): ClassConstFetch
     {
@@ -448,9 +446,6 @@ final class NodeFactory
         return $booleanAnd;
     }
 
-    /**
-     * @param string|ObjectReference::* $className
-     */
     private function createName(string $className): Name|FullyQualified
     {
         if (in_array($className, [ObjectReference::PARENT, ObjectReference::SELF, ObjectReference::STATIC], true)) {


### PR DESCRIPTION
This reverts commit 073f2d62a5beb49e270b2eab2433b60adb974cb6.

@TomasVotruba @yguedidi the issue seems not adding `is*` types ,but on ArraySpreadInsteadOfArrayMergeRector