### PR TITLE
[DX] Allow --no-diffs to be configured via configuration file

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -60,6 +60,12 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL_JOB_SIZE, $jobSize);
     }
 
+    public function noDiffs(): void
+    {
+        $parameters = $this->parameters();
+        $parameters->set(Option::NO_DIFFS, true);
+    }
+
     /**
      * @param array<int|string, mixed> $criteria
      */

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -40,7 +40,7 @@ final class ConfigurationFactory
         $outputFormat = (string) $input->getOption(Option::OUTPUT_FORMAT);
         $showProgressBar = $this->shouldShowProgressBar($input, $outputFormat);
 
-        $showDiffs = ! (bool) $input->getOption(Option::NO_DIFFS);
+        $showDiffs = $this->shouldShowDiffs($input);
 
         $paths = $this->resolvePaths($input);
 
@@ -80,6 +80,17 @@ final class ConfigurationFactory
         }
 
         return $outputFormat === ConsoleOutputFormatter::NAME;
+    }
+
+    private function shouldShowDiffs(InputInterface $input): bool
+    {
+        $noDiffs = (bool) $input->getOption(Option::NO_DIFFS);
+        if ($noDiffs) {
+            return false;
+        }
+
+        // fallback to parameter
+        return ! $this->parameterProvider->provideBoolParameter(Option::NO_DIFFS);
     }
 
     /**


### PR DESCRIPTION
Typical command I run on my projects when running a single rector over the whole code is: `vendor/bin/rector process --memory-limit=4G --no-diffs --clear-cache`
I'd like to improve the DX by just running `vendor/bin/rector`, so I started by the easiest one to support in configuration file :)