### PR TITLE
[DX] Allow --clear-cache to be configured via configuration file

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -209,6 +209,12 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::NESTED_CHAIN_METHOD_CALL_LIMIT, $limit);
     }
 
+    public function clearCache(): void
+    {
+        $parameters = $this->parameters();
+        $parameters->set(Option::CLEAR_CACHE, true);
+    }
+
     public function cacheDirectory(string $directoryPath): void
     {
         // cache directory path is created via mkdir in CacheFactory

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -35,7 +35,7 @@ final class ConfigurationFactory
     public function createFromInput(InputInterface $input): Configuration
     {
         $isDryRun = (bool) $input->getOption(Option::DRY_RUN);
-        $shouldClearCache = (bool) $input->getOption(Option::CLEAR_CACHE);
+        $shouldClearCache = $this->shouldClearCache($input);
 
         $outputFormat = (string) $input->getOption(Option::OUTPUT_FORMAT);
         $showProgressBar = $this->shouldShowProgressBar($input, $outputFormat);
@@ -66,6 +66,17 @@ final class ConfigurationFactory
             $isParallel,
             $memoryLimit
         );
+    }
+
+    private function shouldClearCache(InputInterface $input): bool
+    {
+        $clearCache = (bool) $input->getOption(Option::CLEAR_CACHE);
+        if ($clearCache) {
+            return true;
+        }
+
+        // fallback to parameter
+        return $this->parameterProvider->provideBoolParameter(Option::CLEAR_CACHE);
     }
 
     private function shouldShowProgressBar(InputInterface $input, string $outputFormat): bool


### PR DESCRIPTION
Typical command I run on my projects when running a single rector over the whole code is: `vendor/bin/rector process --memory-limit=4G --no-diffs --clear-cache`
I'd like to improve the DX by just running `vendor/bin/rector`. so after #3598 I continued by the second easiest one to support in configuration file :)