### PR TITLE
[Traverser] Nullify previous node on PHPStanNodeScopeResolver on scope refreshing

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -108,6 +108,12 @@ final class PHPStanNodeScopeResolver
             $isScopeRefreshing,
             $filePath
         ): void {
+            // scope refreshing happen after refactor()
+            if ($isScopeRefreshing && $node->hasAttribute(AttributeKey::PREVIOUS_NODE)) {
+                // clean up previous node as always refilled with NodeConnectingVisitor via NodeConnectingTraverser
+                $node->setAttribute(AttributeKey::PREVIOUS_NODE, null);
+            }
+
             if ((
                 $node instanceof Expression ||
                 $node instanceof Return_ ||
@@ -162,7 +168,7 @@ final class PHPStanNodeScopeResolver
                 $node->name->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
-            if ($node instanceof Assign) {
+            if ($node instanceof Assign || $node instanceof AssignOp) {
                 // decorate value as well
                 $node->var->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -537,10 +537,6 @@ final class BetterNodeFinder
             return null;
         }
 
-        if ($previousNode === $node) {
-            return null;
-        }
-
         $foundNode = $this->findFirst($previousNode, $filter);
 
         // we found what we need


### PR DESCRIPTION
**Background**

The `$previousNode === $node` check was used to cover flipped `AssignOp` when downgrade null coalescing and json const, see:

- https://github.com/rectorphp/rector-src/pull/3484

when `left` and `right` flipped, the `previous` node is current node, and that cause infinite loop, so the solution was set `previous` node equal to current node, then stop search on `BetterNodeFinder`.

**Alternative solution**

This PR make alternative solution so it can happen in any node search usage, not only `findFirstPrevious()`, by set `previous` attribute to `null` before re-apply with `NodeConnectingVisitor` via `NodeConnectingTraverser` on `refactor()` method:

https://github.com/rectorphp/rector-src/blob/f604bf38cbb3b1053e0cec78423e82bd6e72b29d/src/Rector/AbstractRector.php#L419-L441 