### PR TITLE
[DX] Allow --memory-limit to be configured via configuration file

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -66,6 +66,12 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::NO_DIFFS, true);
     }
 
+    public function memoryLimit(string $memoryLimit): void
+    {
+        $parameters = $this->parameters();
+        $parameters->set(Option::MEMORY_LIMIT, $memoryLimit);
+    }
+
     /**
      * @param array<int|string, mixed> $criteria
      */

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -50,8 +50,7 @@ final class ConfigurationFactory
         $parallelPort = (string) $input->getOption(Option::PARALLEL_PORT);
         $parallelIdentifier = (string) $input->getOption(Option::PARALLEL_IDENTIFIER);
 
-        /** @var string|null $memoryLimit */
-        $memoryLimit = $input->getOption(Option::MEMORY_LIMIT);
+        $memoryLimit = $this->resolveMemoryLimit($input);
 
         return new Configuration(
             $isDryRun,
@@ -123,5 +122,19 @@ final class ConfigurationFactory
 
         // fallback to parameter
         return $this->parameterProvider->provideArrayParameter(Option::PATHS);
+    }
+
+    private function resolveMemoryLimit(InputInterface $input): string | null
+    {
+        $memoryLimit = $input->getOption(Option::MEMORY_LIMIT);
+        if ($memoryLimit !== null) {
+            return (string) $memoryLimit;
+        }
+
+        if (! $this->parameterProvider->hasParameter(Option::MEMORY_LIMIT)) {
+            return null;
+        }
+
+        return $this->parameterProvider->provideStringParameter(Option::MEMORY_LIMIT);
     }
 }


### PR DESCRIPTION
Typical command I run on my projects when running a single rector over the whole code is: `vendor/bin/rector process --memory-limit=4G --no-diffs --clear-cache`
I'd like to improve the DX by just running `vendor/bin/rector`. so after #3598 and #3599 here the final one :)