### PR TITLE
[DX] Better and extensible way to configure parallel settings

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -83,6 +83,7 @@ return static function (RectorConfig $rectorConfig): void {
     $services->load('Rector\\', __DIR__ . '/../packages')
         ->exclude([
             __DIR__ . '/../packages/Config/RectorConfig.php',
+            __DIR__ . '/../packages/Config/ParallelConfig.php',
             __DIR__ . '/../packages/*/{ValueObject,Contract,Exception}',
             __DIR__ . '/../packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php',
             __DIR__ . '/../packages/Testing/PHPUnit',

--- a/packages/Config/ParallelConfig.php
+++ b/packages/Config/ParallelConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Config;
+
+use Rector\Core\Configuration\Option;
+
+final class ParallelConfig
+{
+    public function __construct(
+        private readonly RectorConfig $rectorConfig
+    ) {
+    }
+
+    public function maxNumberOfProcess(int $numberOfProcess): self
+    {
+        $parameters = $this->rectorConfig->parameters();
+        $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $numberOfProcess);
+
+        return $this;
+    }
+
+    public function jobTimeout(int $seconds): self
+    {
+        $parameters = $this->rectorConfig->parameters();
+        $parameters->set(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $seconds);
+
+        return $this;
+    }
+
+    public function jobSize(int $size): self
+    {
+        $parameters = $this->rectorConfig->parameters();
+        $parameters->set(Option::PARALLEL_JOB_SIZE, $size);
+
+        return $this;
+    }
+}

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -55,7 +55,7 @@ final class RectorConfig extends ContainerConfigurator
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
 
-        $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
+        $parameters->set(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $seconds);
         $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $maxNumberOfProcess);
         $parameters->set(Option::PARALLEL_JOB_SIZE, $jobSize);
     }

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -50,14 +50,16 @@ final class RectorConfig extends ContainerConfigurator
         $parameters->set(Option::PARALLEL, false);
     }
 
-    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20): void
+    public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20): ParallelConfig
     {
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
 
-        $parameters->set(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $seconds);
-        $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $maxNumberOfProcess);
-        $parameters->set(Option::PARALLEL_JOB_SIZE, $jobSize);
+        $parallelConfig = new ParallelConfig($this);
+        $parallelConfig = $parallelConfig->jobTimeout($seconds);
+        $parallelConfig = $parallelConfig->maxNumberOfProcess($maxNumberOfProcess);
+
+        return $parallelConfig->jobSize($jobSize);
     }
 
     /**

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -127,7 +127,7 @@ final class ParallelFileProcessor
             $this->processPool->quitAll();
         };
 
-        $timeoutInSeconds = $this->parameterProvider->provideIntParameter(Option::PARALLEL_TIMEOUT_IN_SECONDS);
+        $timeoutInSeconds = $this->parameterProvider->provideIntParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS);
 
         for ($i = 0; $i < $numberOfProcesses; ++$i) {
             // nothing else to process, stop now

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -194,7 +194,7 @@ final class Option
      * @internal Use @see \Rector\Config\RectorConfig::parallel() instead with pass int $seconds parameter
      * @var string
      */
-    public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
+    public const PARALLEL_JOB_TIMEOUT_IN_SECONDS = 'parallel-job-timeout-in-seconds';
 
     /**
      * @var string


### PR DESCRIPTION
`->parallel()` is the only `RectorConfig` shortcut with more than two parameters.
Also, with the discussion opened in #3563, parallelization could get more settings.
Finally, I would like to also propose another parallel setting in another PR: job memory limit.

Before #3601, with memory limit being set in the command line, it always confused me that when you set a memory limit value it's the limit for **each** process, not a global limit, while it looks like it is.
If this get accepted, I plan to add a `->jobMemoryLimit($limit)` shortcut in `ParallelConfig` to be used by the worker command.
I think this will make things clearer.

Here the allowed syntax:

```php
$rectorConfig->parallel()->jobSize(50)->jobTimeout(300);
```

---

Other potential ideas on top of this:

- disable with `$rectorConfig->parallel()->disable();`
- a `$rectorConfig->parallel()->useAllProcesses();` shortcut
- a `$rectorConfig->parallel()->keepOneProcessFree();` shortcut, inspired by you @TomasVotruba ([blog post](https://tomasvotruba.com/blog/hidden-productivity-costs-of-parallel-run))
- use alternative way from #3563 with `$rectorConfig->parallel()->separateProcessPerJob();`