### PR TITLE
Revert Cache on successful file processing (#3604)

### DIFF
--- a/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/packages-tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -32,7 +32,7 @@ final class ChangedFilesDetectorTest extends AbstractRectorTestCase
         $filePath = __DIR__ . '/Source/file.php';
 
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
-        $this->changedFilesDetector->addFileWithDependencies($filePath);
+        $this->changedFilesDetector->addFileWithDependencies($filePath, []);
 
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
         $this->changedFilesDetector->invalidateFile($filePath);
@@ -46,9 +46,7 @@ final class ChangedFilesDetectorTest extends AbstractRectorTestCase
     #[DataProvider('provideData')]
     public function testGetDependentFileInfos(string $filePath, array $dependantFiles): void
     {
-        $this->changedFilesDetector->addFileDependentFiles($filePath, $dependantFiles);
-        $this->changedFilesDetector->addFileWithDependencies($filePath);
-
+        $this->changedFilesDetector->addFileWithDependencies($filePath, $dependantFiles);
         $dependantFilePaths = $this->changedFilesDetector->getDependentFilePaths($filePath);
 
         $dependantFilesCount = count($dependantFiles);

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -15,11 +15,6 @@ use Rector\Caching\Enum\CacheKey;
  */
 final class ChangedFilesDetector
 {
-    /**
-     * @var array<string, string[]>
-     */
-    private array $dependentFiles = [];
-
     public function __construct(
         private readonly FileHashComputer $fileHashComputer,
         private readonly Cache $cache
@@ -29,23 +24,13 @@ final class ChangedFilesDetector
     /**
      * @param string[] $dependentFiles
      */
-    public function addFileDependentFiles(string $filePath, array $dependentFiles): void
-    {
-        $filePathCacheKey = $this->getFilePathCacheKey($filePath);
-        $this->dependentFiles[$filePathCacheKey] = $dependentFiles;
-    }
-
-    public function addFileWithDependencies(string $filePath): void
+    public function addFileWithDependencies(string $filePath, array $dependentFiles): void
     {
         $filePathCacheKey = $this->getFilePathCacheKey($filePath);
         $hash = $this->hashFile($filePath);
 
         $this->cache->save($filePathCacheKey, CacheKey::FILE_HASH_KEY, $hash);
-        $this->cache->save(
-            $filePathCacheKey . '_files',
-            CacheKey::DEPENDENT_FILES_KEY,
-            $this->dependentFiles[$filePathCacheKey],
-        );
+        $this->cache->save($filePathCacheKey . '_files', CacheKey::DEPENDENT_FILES_KEY, $dependentFiles);
     }
 
     public function hasFileChanged(string $filePath): bool

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -431,6 +431,6 @@ final class PHPStanNodeScopeResolver
             }
         }
 
-        $this->changedFilesDetector->addFileDependentFiles($filePath, $dependentFiles);
+        $this->changedFilesDetector->addFileWithDependencies($filePath, $dependentFiles);
     }
 }

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -7,7 +7,6 @@ namespace Rector\Parallel;
 use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
 use Nette\Utils\FileSystem;
-use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Core\Application\ApplicationFileProcessor;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesProcessor;
 use Rector\Core\Console\Style\RectorConsoleOutputStyle;
@@ -42,8 +41,7 @@ final class WorkerRunner
         private readonly RectorConsoleOutputStyle $rectorConsoleOutputStyle,
         private readonly RemovedAndAddedFilesProcessor $removedAndAddedFilesProcessor,
         private readonly ApplicationFileProcessor $applicationFileProcessor,
-        private readonly ChangedFilesDetector $changedFilesDetector,
-        private readonly array $fileProcessors = [],
+        private readonly array $fileProcessors = []
     ) {
     }
 
@@ -87,24 +85,14 @@ final class WorkerRunner
             $this->applicationFileProcessor->configurePHPStanNodeScopeResolver($filePaths, $configuration);
 
             foreach ($filePaths as $filePath) {
-                $file = null;
-
                 try {
                     $file = new File($filePath, FileSystem::read($filePath));
                     $this->currentFileProvider->setFile($file);
 
                     $errorAndFileDiffs = $this->processFiles($file, $configuration, $errorAndFileDiffs);
-
-                    if ($errorAndFileDiffs[Bridge::SYSTEM_ERRORS] !== []) {
-                        $this->changedFilesDetector->invalidateFile($file->getFilePath());
-                    } else {
-                        $this->changedFilesDetector->addFileWithDependencies($file->getFilePath());
-                    }
                 } catch (Throwable $throwable) {
                     ++$systemErrorsCount;
                     $systemErrors = $this->collectSystemErrors($systemErrors, $throwable, $filePath);
-
-                    $this->invalidateFile($file);
                 }
             }
 
@@ -169,14 +157,5 @@ final class WorkerRunner
         $systemErrors[] = new SystemError($errorMessage, $filePath, $throwable->getLine());
 
         return $systemErrors;
-    }
-
-    private function invalidateFile(?File $file): void
-    {
-        if ($file === null) {
-            return;
-        }
-
-        $this->changedFilesDetector->invalidateFile($file->getFilePath());
     }
 }

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\Application;
 
 use PHPStan\Analyser\NodeScopeResolver;
-use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Core\Application\FileDecorator\FileDiffFileDecorator;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesProcessor;
 use Rector\Core\Configuration\Option;
@@ -53,8 +52,7 @@ final class ApplicationFileProcessor
         private readonly ParameterProvider $parameterProvider,
         private readonly ScheduleFactory $scheduleFactory,
         private readonly CpuCoreCountProvider $cpuCoreCountProvider,
-        private readonly ChangedFilesDetector $changedFilesDetector,
-        private readonly array $fileProcessors = [],
+        private readonly array $fileProcessors = []
     ) {
     }
 
@@ -128,12 +126,6 @@ final class ApplicationFileProcessor
 
                 $result = $fileProcessor->process($file, $configuration);
                 $systemErrorsAndFileDiffs = $this->arrayParametersMerger->merge($systemErrorsAndFileDiffs, $result);
-            }
-
-            if ($systemErrorsAndFileDiffs[Bridge::SYSTEM_ERRORS] !== []) {
-                $this->changedFilesDetector->invalidateFile($file->getFilePath());
-            } else {
-                $this->changedFilesDetector->addFileWithDependencies($file->getFilePath());
             }
 
             // progress bar +1

--- a/src/ValueObject/ProcessResult.php
+++ b/src/ValueObject/ProcessResult.php
@@ -63,4 +63,17 @@ final class ProcessResult
     {
         return $this->removedNodeCount;
     }
+
+    /**
+     * @return string[]
+     */
+    public function getChangedFilePaths(): array
+    {
+        $fileInfos = [];
+        foreach ($this->fileDiffs as $fileDiff) {
+            $fileInfos[] = $fileDiff->getRelativeFilePath();
+        }
+
+        return array_unique($fileInfos);
+    }
 }


### PR DESCRIPTION
This reverts commit 4c56874ee79f5dd3ea2e97ea12e13335ebd6765b.

@TomasVotruba @yguedidi I need to immediatelly revert it as double `--dry-run` no longer working after PR:

- https://github.com/rectorphp/rector-src/pull/3604

![Screen Shot 2023-04-11 at 15 17 59](https://user-images.githubusercontent.com/459648/231100194-ea553452-c7f1-44f1-a3e5-9c0a26b348b7.png)
