### PR TITLE
Rename PARALLEL_TIMEOUT_IN_SECONDS to PARALLEL_JOB_TIMEOUT_IN_SECONDS

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -55,7 +55,7 @@ final class RectorConfig extends ContainerConfigurator
         $parameters = $this->parameters();
         $parameters->set(Option::PARALLEL, true);
 
-        $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, $seconds);
+        $parameters->set(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $seconds);
         $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $maxNumberOfProcess);
         $parameters->set(Option::PARALLEL_JOB_SIZE, $jobSize);
     }

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -127,7 +127,7 @@ final class ParallelFileProcessor
             $this->processPool->quitAll();
         };
 
-        $timeoutInSeconds = $this->parameterProvider->provideIntParameter(Option::PARALLEL_TIMEOUT_IN_SECONDS);
+        $timeoutInSeconds = $this->parameterProvider->provideIntParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS);
 
         for ($i = 0; $i < $numberOfProcesses; ++$i) {
             // nothing else to process, stop now

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -194,7 +194,7 @@ final class Option
      * @internal Use @see \Rector\Config\RectorConfig::parallel() instead with pass int $seconds parameter
      * @var string
      */
-    public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
+    public const PARALLEL_JOB_TIMEOUT_IN_SECONDS = 'parallel-job-timeout-in-seconds';
 
     /**
      * @var string


### PR DESCRIPTION
A more precise name that express this configured timeout is per job