### PR TITLE
NodeTypeResolver: cheap checks first in isObjectTypeOfObjectType()

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -341,11 +341,11 @@ final class NodeTypeResolver
 
     private function isObjectTypeOfObjectType(ObjectType $resolvedObjectType, ObjectType $requiredObjectType): bool
     {
-        if ($resolvedObjectType->isInstanceOf($requiredObjectType->getClassName())->yes()) {
+        if ($resolvedObjectType->getClassName() === $requiredObjectType->getClassName()) {
             return true;
         }
 
-        if ($resolvedObjectType->getClassName() === $requiredObjectType->getClassName()) {
+        if ($resolvedObjectType->isInstanceOf($requiredObjectType->getClassName())->yes()) {
             return true;
         }
 


### PR DESCRIPTION
do checks first which don't require type-system deep inspections

spotted in https://github.com/rectorphp/rector/issues/7806#issuecomment-1473547832