### PR TITLE
Added a NodeTypeResolver cache

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -16,6 +16,7 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeFactory;
 use PHPStan\Dependency\DependencyResolver;
 use PHPStan\File\FileHelper;
+use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Parser\Parser;
 use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
@@ -189,6 +190,9 @@ return static function (RectorConfig $rectorConfig): void {
         ->factory([service(PHPStanServicesFactory::class), 'createDependencyResolver']);
     $services->set(FileHelper::class)
         ->factory([service(PHPStanServicesFactory::class), 'createFileHelper']);
+
+    $services->set(ExprPrinter::class)
+        ->factory([service(PHPStanServicesFactory::class), 'createExprPrinter']);
 
     $services->set(Cache::class)
         ->factory([service(CacheFactory::class), 'create']);

--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -11,8 +11,6 @@ services:
     - Rector\NodeTypeResolver\Reflection\BetterReflection\RectorBetterReflectionSourceLocatorFactory
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocator\IntermediateSourceLocator
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider
-    - PHPStan\Node\Printer\ExprPrinter
-    - PHPStan\Node\Printer\Printer
 
     # basically decorates native PHPStan source locator with a dynamic source locator that is also available in Rector DI
     betterReflectionSourceLocator:

--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -11,6 +11,8 @@ services:
     - Rector\NodeTypeResolver\Reflection\BetterReflection\RectorBetterReflectionSourceLocatorFactory
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocator\IntermediateSourceLocator
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider
+    - PHPStan\Node\Printer\ExprPrinter
+    - PHPStan\Node\Printer\Printer
 
     # basically decorates native PHPStan source locator with a dynamic source locator that is also available in Rector DI
     betterReflectionSourceLocator:

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -11,6 +11,7 @@ use PHPStan\Dependency\DependencyResolver;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\ContainerFactory;
 use PHPStan\File\FileHelper;
+use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Parser\Parser;
 use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\Reflection\ReflectionProvider;
@@ -112,6 +113,14 @@ final class PHPStanServicesFactory
     public function createDependencyResolver(): DependencyResolver
     {
         return $this->container->getByType(DependencyResolver::class);
+    }
+
+    /**
+     * @api
+     */
+    public function createExprPrinter(): ExprPrinter
+    {
+        return $this->container->getByType(ExprPrinter::class);
     }
 
     /**

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -125,13 +125,23 @@ final class NodeTypeResolver
 
     public function getType(Node $node): Type
     {
-        $key = $this->getNodeKey($node);
+        if ($node instanceof Expr) {
+            $key = $this->getNodeKey($node);
 
-        if (! array_key_exists($key, $this->resolvedTypes)) {
-            $this->resolvedTypes[$key] = $this->resolveType($node);
+            $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+            if (! array_key_exists($key, $this->resolvedTypes) ||
+                ! $originalNode instanceof Node ||
+                $originalNode->getStartTokenPos() !== $node->getStartTokenPos() ||
+                $originalNode->getEndTokenPos() !== $node->getEndTokenPos()
+            ) {
+
+                $this->resolvedTypes[$key] = $this->resolveType($node);
+            }
+
+            return $this->resolvedTypes[$key];
         }
 
-        return $this->resolvedTypes[$key];
+        return $this->resolveType($node);
     }
 
     private function resolveType(Node $node): Type

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -129,7 +129,12 @@ final class NodeTypeResolver
             $key = $this->getNodeKey($node);
 
             $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+            // re-resolve type when
+            // - it was not resolved yet
+            // - it was just created by rector
+            // - the node was just changed/rectified
             if (! array_key_exists($key, $this->resolvedTypes) ||
+                $node->hasAttribute(AttributeKey::CREATED_BY_RULE) ||
                 ! $originalNode instanceof Node ||
                 $originalNode->getStartTokenPos() !== $node->getStartTokenPos() ||
                 $originalNode->getEndTokenPos() !== $node->getEndTokenPos()

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -21,6 +21,8 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\ClassAutoloadingException;
+use PHPStan\Node\Printer\ExprPrinter;
+use PHPStan\Parser\ArrayMapArgVisitor;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -53,6 +55,11 @@ final class NodeTypeResolver
     private array $nodeTypeResolvers = [];
 
     /**
+     * @var array<string, Type>
+     */
+    private array $resolvedTypes = [];
+
+    /**
      * @param NodeTypeResolverInterface[] $nodeTypeResolvers
      */
     public function __construct(
@@ -64,6 +71,7 @@ final class NodeTypeResolver
         private readonly AccessoryNonEmptyStringTypeCorrector $accessoryNonEmptyStringTypeCorrector,
         private readonly IdentifierTypeResolver $identifierTypeResolver,
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
+        private readonly ExprPrinter $exprPrinter,
         array $nodeTypeResolvers
     ) {
         foreach ($nodeTypeResolvers as $nodeTypeResolver) {
@@ -116,6 +124,17 @@ final class NodeTypeResolver
     }
 
     public function getType(Node $node): Type
+    {
+        $key = $this->getNodeKey($node);
+
+        if (! array_key_exists($key, $this->resolvedTypes)) {
+            $this->resolvedTypes[$key] = $this->resolveType($node);
+        }
+
+        return $this->resolvedTypes[$key];
+    }
+
+    private function resolveType(Node $node): Type
     {
         if ($node instanceof Property && $node->type instanceof NullableType) {
             return $this->getType($node->type);
@@ -404,5 +423,23 @@ final class NodeTypeResolver
         }
 
         return new MixedType();
+    }
+
+    /**
+     * Stolen from phpstan-src getNodeKey->getNodeKey()
+     */
+    private function getNodeKey(Expr $node): string
+    {
+        $key = $this->exprPrinter->printExpr($node);
+
+        if (
+            $node instanceof Node\FunctionLike
+            && $node->hasAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME)
+            && $node->hasAttribute('startFilePos')
+        ) {
+            $key .= '/*' . $node->getAttribute('startFilePos') . '*/';
+        }
+
+        return $key;
     }
 }


### PR DESCRIPTION
> See the trace here: [blackfire.io/profiles/c7c3b1b3-66bc-4a75-821d-c5176c2f2536/graph](https://blackfire.io/profiles/c7c3b1b3-66bc-4a75-821d-c5176c2f2536/graph)

I think the profile in https://github.com/rectorphp/rector/issues/7806#issuecomment-1473547832 shows, that `NodeTypeResolver` could benefit from caching the result, because 1234x calls of `ReturnTypeDeclarationRector` explode into ~380.000x calls to `NodeTypeResolver->getType/resolveObjectType`.

<img width="1186" alt="grafik" src="https://user-images.githubusercontent.com/120441/232321844-2ca5235d-eebd-4105-92fc-ba86c9ffc2b9.png">

the implementation takes inspiration from phpstan-src

https://github.com/phpstan/phpstan-src/blob/0745fbd69a92d1dc164992601a1f28548f096d42/src/Analyser/MutatingScope.php#L646-L651

