### PR TITLE
NodeTypeResolver: remove unnecessary check

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -365,7 +365,7 @@ final class NodeTypeResolver
             }
         }
 
-        return $resolvedClassReflection->isSubclassOf($requiredClassName);
+        return false;
     }
 
     private function resolveObjectType(ObjectType $resolvedObjectType, ObjectType $requiredObjectType): bool


### PR DESCRIPTION
running `vendor/bin/phpunit` on rector-src 

before this PR: 177.64s
after this PR: 172.23s

----

after https://github.com/rectorphp/rector-src/pull/3627 is merged, there should be enough room to merge this without a need to refactor because of too much complexity