### PR TITLE
Use faster paratest in "complete-check" composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
             "@check-cs",
             "@phpstan",
             "@docs",
-            "phpunit"
+            "paratest"
         ],
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",


### PR DESCRIPTION
I don't see a reason why "complete check" uses the slower phpunit instead of paratest