### PR TITLE
[Php80] Handle crash leaveNode() returned invalid value of type integer on TokenGetAllToObjectRector

### DIFF
--- a/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/not_array_first2.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/not_array_first2.php.inc
@@ -33,7 +33,7 @@ final class NotArrayFirst2
         $tokens = \PhpToken::tokenize($code);
         $this->tokens = [];
         foreach ($tokens as $token) {
-            if ($token[0] !== T_WHITESPACE && $token[0] !== T_INLINE_HTML) {
+            if (! $token->is(T_WHITESPACE) && ! $token->is(T_INLINE_HTML)) {
                 $this->tokens = $token->text;
             }
         }

--- a/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/not_array_first2.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/not_array_first2.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\TokenGetAllToObjectRector\Fixture;
+
+final class NotArrayFirst2
+{
+    public function run()
+    {
+        $code = '<?php echo 1;';
+
+        $tokens = token_get_all($code);
+        $this->tokens = [];
+        foreach ($tokens as $token) {
+            if (!is_array($token) || ($token[0] !== T_WHITESPACE && $token[0] !== T_INLINE_HTML)) {
+                $this->tokens = $token;
+            }
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\TokenGetAllToObjectRector\Fixture;
+
+final class NotArrayFirst2
+{
+    public function run()
+    {
+        $code = '<?php echo 1;';
+
+        $tokens = \PhpToken::tokenize($code);
+        $this->tokens = [];
+        foreach ($tokens as $token) {
+            if ($token[0] !== T_WHITESPACE && $token[0] !== T_INLINE_HTML) {
+                $this->tokens = $token->text;
+            }
+        }
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/not_array_first2.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/TokenGetAllToObjectRector/Fixture/not_array_first2.php.inc
@@ -33,7 +33,7 @@ final class NotArrayFirst2
         $tokens = \PhpToken::tokenize($code);
         $this->tokens = [];
         foreach ($tokens as $token) {
-            if (! $token->is(T_WHITESPACE) && ! $token->is(T_INLINE_HTML)) {
+            if (!$token->is(T_WHITESPACE) && !$token->is(T_INLINE_HTML)) {
                 $this->tokens = $token->text;
             }
         }

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -377,9 +377,11 @@ final class TokenManipulator
         if ($parentNode->right !== $funcCall) {
             return $funcCall;
         }
+
         if (!$isLeftValueTrue) {
             return $funcCall;
         }
+
         return $parentNode;
     }
 }

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -359,16 +359,18 @@ final class TokenManipulator
     private function matchParentNodeInCaseOfIdenticalTrue(FuncCall $funcCall): Identical | FuncCall
     {
         $parentNode = $funcCall->getAttribute(AttributeKey::PARENT_NODE);
-        if ($parentNode instanceof Identical) {
-            $isRightValueTrue = $this->valueResolver->isValue($parentNode->right, true);
-            if ($parentNode->left === $funcCall && $isRightValueTrue) {
-                return $parentNode;
-            }
+        if (! $parentNode instanceof Identical) {
+            return $funcCall;
+        }
 
-            $isLeftValueTrue = $this->valueResolver->isValue($parentNode->left, true);
-            if ($parentNode->right === $funcCall && $isLeftValueTrue) {
-                return $parentNode;
-            }
+        $isRightValueTrue = $this->valueResolver->isValue($parentNode->right, true);
+        if ($parentNode->left === $funcCall && $isRightValueTrue) {
+            return $parentNode;
+        }
+
+        $isLeftValueTrue = $this->valueResolver->isValue($parentNode->left, true);
+        if ($parentNode->right === $funcCall && $isLeftValueTrue) {
+            return $parentNode;
         }
 
         return $funcCall;

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -130,6 +130,11 @@ final class TokenManipulator
         });
     }
 
+    private function isIdenticalOrNotIdentical(Node $node): bool
+    {
+        return $node instanceof Identical || $node instanceof NotIdentical;
+    }
+
     /**
      * @param Node[] $nodes
      */
@@ -138,10 +143,11 @@ final class TokenManipulator
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, function (Node $node) use (
             $singleTokenVariable
         ): null|MethodCall|BooleanNot {
-            if (! $node instanceof Identical && ! $node instanceof NotIdentical) {
+            if (! $this->isIdenticalOrNotIdentical($node)) {
                 return null;
             }
 
+            /** @var Identical|NotIdentical $node */
             $arrayDimFetchAndConstFetch = $this->matchArrayDimFetchAndConstFetch($node);
             if (! $arrayDimFetchAndConstFetch instanceof ArrayDimFetchAndConstFetch) {
                 return null;

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -374,10 +374,12 @@ final class TokenManipulator
         }
 
         $isLeftValueTrue = $this->valueResolver->isValue($parentNode->left, true);
-        if ($parentNode->right === $funcCall && $isLeftValueTrue) {
-            return $parentNode;
+        if ($parentNode->right !== $funcCall) {
+            return $funcCall;
         }
-
-        return $funcCall;
+        if (!$isLeftValueTrue) {
+            return $funcCall;
+        }
+        return $parentNode;
     }
 }

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -130,11 +130,6 @@ final class TokenManipulator
         });
     }
 
-    private function isIdenticalOrNotIdentical(Node $node): bool
-    {
-        return $node instanceof Identical || $node instanceof NotIdentical;
-    }
-
     /**
      * @param Node[] $nodes
      */
@@ -164,11 +159,7 @@ final class TokenManipulator
                 return null;
             }
 
-            $constName = $this->nodeNameResolver->getName($constFetch);
-            if ($constName === null) {
-                return null;
-            }
-
+            $constName = (string) $this->nodeNameResolver->getName($constFetch);
             if (! StringUtils::isMatch($constName, '#^T_#')) {
                 return null;
             }
@@ -240,6 +231,11 @@ final class TokenManipulator
             $this->nodesToRemoveCollector->addNodeToRemove($nodeToRemove);
             return $node;
         });
+    }
+
+    private function isIdenticalOrNotIdentical(Node $node): bool
+    {
+        return $node instanceof Identical || $node instanceof NotIdentical;
     }
 
     private function replaceTernary(Ternary $ternary): void
@@ -384,7 +380,7 @@ final class TokenManipulator
             return $funcCall;
         }
 
-        if (!$isLeftValueTrue) {
+        if (! $isLeftValueTrue) {
             return $funcCall;
         }
 

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -220,10 +220,6 @@ final class TokenManipulator
                 return $node;
             }
 
-            if (! $parentNode instanceof Node) {
-                return null;
-            }
-
             if ($parentNode instanceof BooleanNot) {
                 $parentOfParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
                 if ($parentOfParentNode instanceof BinaryOp) {

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -137,7 +137,7 @@ final class TokenManipulator
     {
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, function (Node $node) use (
             $singleTokenVariable
-        ): ?MethodCall {
+        ): null|MethodCall|BooleanNot {
             if (! $node instanceof Identical && ! $node instanceof NotIdentical) {
                 return null;
             }
@@ -167,10 +167,16 @@ final class TokenManipulator
                 return null;
             }
 
-            return $this->createIsTConstTypeMethodCall(
+            $isTConstTypeMethodCall = $this->createIsTConstTypeMethodCall(
                 $arrayDimFetch,
                 $arrayDimFetchAndConstFetch->getConstFetch()
             );
+
+            if ($node instanceof Identical) {
+                return $isTConstTypeMethodCall;
+            }
+
+            return new BooleanNot($isTConstTypeMethodCall);
         });
     }
 

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -220,12 +220,15 @@ final class TokenManipulator
                 return $node;
             }
 
-            if ($parentNode instanceof BooleanNot) {
-                $parentOfParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-                if ($parentOfParentNode instanceof BinaryOp) {
-                    $this->nodesToRemoveCollector->addNodeToRemove($parentNode);
-                    return $node;
-                }
+            if (! $parentNode instanceof BooleanNot) {
+                $this->nodesToRemoveCollector->addNodeToRemove($nodeToRemove);
+                return $node;
+            }
+
+            $parentOfParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
+            if ($parentOfParentNode instanceof BinaryOp) {
+                $this->nodesToRemoveCollector->addNodeToRemove($parentNode);
+                return $node;
             }
 
             $this->nodesToRemoveCollector->addNodeToRemove($nodeToRemove);

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
@@ -137,7 +138,7 @@ final class TokenManipulator
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, function (Node $node) use (
             $singleTokenVariable
         ): ?MethodCall {
-            if (! $node instanceof Identical) {
+            if (! $node instanceof Identical && ! $node instanceof NotIdentical) {
                 return null;
             }
 
@@ -311,7 +312,7 @@ final class TokenManipulator
         return $this->valueResolver->isValue($arrayDimFetch->dim, $value);
     }
 
-    private function matchArrayDimFetchAndConstFetch(Identical $identical): ?ArrayDimFetchAndConstFetch
+    private function matchArrayDimFetchAndConstFetch(Identical|NotIdentical $identical): ?ArrayDimFetchAndConstFetch
     {
         if ($identical->left instanceof ArrayDimFetch && $identical->right instanceof ConstFetch) {
             return new ArrayDimFetchAndConstFetch($identical->left, $identical->right);

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -345,12 +345,14 @@ final class TokenManipulator
             return true;
         }
 
-        if ($parentNode instanceof BooleanNot) {
-            $parentParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-            if ($parentParentNode instanceof If_) {
-                $parentParentNode->cond = $parentNode;
-                return true;
-            }
+        if (! $parentNode instanceof BooleanNot) {
+            return false;
+        }
+
+        $parentParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
+        if ($parentParentNode instanceof If_) {
+            $parentParentNode->cond = $parentNode;
+            return true;
         }
 
         return false;

--- a/rules/Php80/NodeManipulator/TokenManipulator.php
+++ b/rules/Php80/NodeManipulator/TokenManipulator.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\ConstFetch;
@@ -210,6 +211,18 @@ final class TokenManipulator
             if ($parentNode instanceof Ternary) {
                 $this->replaceTernary($parentNode);
                 return $node;
+            }
+
+            if (! $parentNode instanceof Node) {
+                return null;
+            }
+
+            if ($parentNode instanceof BooleanNot) {
+                $parentOfParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
+                if ($parentOfParentNode instanceof BinaryOp) {
+                    $this->nodesToRemoveCollector->addNodeToRemove($parentNode);
+                    return $node;
+                }
             }
 
             $this->nodesToRemoveCollector->addNodeToRemove($nodeToRemove);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7892
Ref https://getrector.com/demo/c6334ce9-fdf7-4bd0-9ed6-94ce626c3e28