### PR TITLE
Improve string support in Doctrine Annotations

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParserTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParserTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use PhpParser\Node\Scalar\String_;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\TokenIteratorFactory;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParser;
 use Rector\Testing\PHPUnit\AbstractTestCase;
@@ -40,15 +41,15 @@ final class ArrayParserTest extends AbstractTestCase
 
     public static function provideData(): Iterator
     {
-        yield ['{key: "value"}', [new ArrayItemNode('value', 'key', String_::KIND_DOUBLE_QUOTED)]];
+        yield ['{key: "value"}', [new ArrayItemNode(new StringNode('value'), 'key')]];
 
         yield ['{"key": "value"}', [
-            new ArrayItemNode('value', 'key', String_::KIND_DOUBLE_QUOTED, String_::KIND_DOUBLE_QUOTED),
+            new ArrayItemNode(new StringNode('value'), new StringNode('key')),
         ]];
 
         yield ['{"value", "value2"}', [
-            new ArrayItemNode('value', null, String_::KIND_DOUBLE_QUOTED),
-            new ArrayItemNode('value2', null, String_::KIND_DOUBLE_QUOTED),
+            new ArrayItemNode(new StringNode('value')),
+            new ArrayItemNode(new StringNode('value2')),
         ]];
     }
 }

--- a/packages-tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/StaticDoctrineAnnotationParserTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/StaticDoctrineAnnotationParserTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use PhpParser\Node\Scalar\String_;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\TokenIteratorFactory;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
@@ -44,8 +45,8 @@ final class StaticDoctrineAnnotationParserTest extends AbstractTestCase
     public static function provideData(): Iterator
     {
         $curlyListNode = new CurlyListNode([
-            new ArrayItemNode('chalet', null, String_::KIND_DOUBLE_QUOTED),
-            new ArrayItemNode('apartment', null, String_::KIND_DOUBLE_QUOTED),
+            new ArrayItemNode(new StringNode('chalet')),
+            new ArrayItemNode(new StringNode('apartment')),
         ]);
         yield ['{"chalet", "apartment"}', $curlyListNode];
 

--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
@@ -56,8 +57,8 @@ final class TestModifyReprintTest extends AbstractTestCase
 
         // this will extended tokens of first node
         $methodsCurlyListNode = new CurlyListNode([
-            new ArrayItemNode('GET', null, String_::KIND_DOUBLE_QUOTED),
-            new ArrayItemNode('HEAD', null, String_::KIND_DOUBLE_QUOTED),
+            new ArrayItemNode(new StringNode('GET')),
+            new ArrayItemNode(new StringNode('HEAD')),
         ]);
         $doctrineAnnotationTagValueNode->values[] = new ArrayItemNode($methodsCurlyListNode, 'methods');
 

--- a/packages-tests/PhpAttribute/Printer/PhpAttributeGroupFactoryTest.php
+++ b/packages-tests/PhpAttribute/Printer/PhpAttributeGroupFactoryTest.php
@@ -7,6 +7,7 @@ namespace Rector\Tests\PhpAttribute\Printer;
 use PhpParser\Node\Arg;
 use PhpParser\Node\AttributeGroup;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\Testing\PHPUnit\AbstractTestCase;
 
@@ -36,8 +37,8 @@ final class PhpAttributeGroupFactoryTest extends AbstractTestCase
     public function testCreateArgsFromItems(): void
     {
         $args = $this->phpAttributeGroupFactory->createArgsFromItems([
-            new ArrayItemNode('/path', 'path'),
-            new ArrayItemNode('action', 'name'),
+            new ArrayItemNode(new StringNode('/path'), 'path'),
+            new ArrayItemNode(new StringNode('action'), 'name'),
         ], 'SomeClass');
 
         $this->assertCount(2, $args);

--- a/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
+++ b/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
@@ -13,16 +13,6 @@ final class ArrayItemNode implements PhpDocTagValueNode, Stringable
 {
     use NodeAttributes;
 
-    /**
-     * @deprecated
-     */
-    public int|null $kindValueQuoted = String_::KIND_DOUBLE_QUOTED;
-
-    /**
-     * @deprecated
-     */
-    public int|null $kindKeyQuoted = String_::KIND_DOUBLE_QUOTED;
-
     public function __construct(
         public mixed $value,
         public mixed $key = null,

--- a/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
+++ b/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
@@ -14,13 +14,18 @@ final class ArrayItemNode implements PhpDocTagValueNode, Stringable
     use NodeAttributes;
 
     /**
-     * @param String_::KIND_*|null $kindValueQuoted
+     * @deprecated
      */
+    public int|null $kindValueQuoted = String_::KIND_DOUBLE_QUOTED;
+
+    /**
+     * @deprecated
+     */
+    public int|null $kindKeyQuoted = String_::KIND_DOUBLE_QUOTED;
+
     public function __construct(
         public mixed $value,
-        public mixed $key,
-        public int|null $kindValueQuoted = null,
-        public int|null $kindKeyQuoted = null,
+        public mixed $key = null,
     ) {
     }
 
@@ -28,16 +33,11 @@ final class ArrayItemNode implements PhpDocTagValueNode, Stringable
     {
         $value = '';
 
-        if ($this->kindKeyQuoted === String_::KIND_DOUBLE_QUOTED) {
-            $value .= '"' . $this->key . '" = ';
-        } elseif ($this->key !== null) {
+        if ($this->key !== null) {
             $value .= $this->key . '=';
         }
 
-        // @todo depends on the context! possibly the top array is quting this stinrg already
-        if ($this->kindValueQuoted === String_::KIND_DOUBLE_QUOTED) {
-            $value .= '"' . $this->value . '"';
-        } elseif (is_array($this->value)) {
+        if (is_array($this->value)) {
             foreach ($this->value as $singleValue) {
                 $value .= $singleValue;
             }

--- a/packages/BetterPhpDocParser/PhpDoc/StringNode.php
+++ b/packages/BetterPhpDocParser/PhpDoc/StringNode.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\PhpDoc;
+
+use PhpParser\Node\Scalar\String_;
+use PHPStan\PhpDocParser\Ast\NodeAttributes;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Stringable;
+
+final class StringNode implements PhpDocTagValueNode, Stringable
+{
+    use NodeAttributes;
+
+    public function __construct(
+        public string $value,
+    ) {
+        $this->value = str_replace('""', '"', $this->value);
+
+        if (str_contains($this->value, "'") && ! str_contains($this->value, "\n")) {
+            $kind = String_::KIND_DOUBLE_QUOTED;
+        } else {
+            $kind = String_::KIND_SINGLE_QUOTED;
+        }
+
+        $this->setAttribute(AttributeKey::KIND, $kind);
+    }
+
+    public function __toString(): string
+    {
+        return '"' . str_replace('"', '""', $this->value) . '"';
+    }
+}

--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
@@ -62,7 +62,6 @@ final class PhpDocClassRenamer
         $classNameArrayItemNode = $callableCallbackArrayItems[0];
         $classNameStringNode = $classNameArrayItemNode->value;
 
-        // array is needed for callable
         if (! $classNameStringNode instanceof StringNode) {
             return;
         }
@@ -75,7 +74,6 @@ final class PhpDocClassRenamer
             $classNameStringNode->value = $newClass;
 
             // trigger reprint
-//            $classNameStringNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, null);
             $classNameArrayItemNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, null);
             break;
         }
@@ -130,7 +128,6 @@ final class PhpDocClassRenamer
                 );
 
                 $classNameArrayItemNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, null);
-//                $classNameStringNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, null);
             }
 
             $currentTypeArrayItemNode = $doctrineAnnotationTagValueNode->getValue('type');
@@ -182,7 +179,6 @@ final class PhpDocClassRenamer
             }
 
             $targetEntityStringNode->value = $newClass;
-//            $targetEntityStringNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, null);
             $targetEntityArrayItemNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, null);
         }
     }

--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
@@ -8,6 +8,7 @@ use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParser;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\PlainValueParser;
 use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
@@ -49,11 +50,11 @@ final class StaticDoctrineAnnotationParser
     /**
      * @api tests
      * @see https://github.com/doctrine/annotations/blob/c66f06b7c83e9a2a7523351a9d5a4b55f885e574/lib/Doctrine/Common/Annotations/DocParser.php#L1215-L1224
-     * @return CurlyListNode|string|array<mixed>|ConstExprNode|DoctrineAnnotationTagValueNode
+     * @return CurlyListNode|string|array<mixed>|ConstExprNode|DoctrineAnnotationTagValueNode|StringNode
      */
     public function resolveAnnotationValue(
         BetterTokenIterator $tokenIterator
-    ): CurlyListNode | string | array | ConstExprNode | DoctrineAnnotationTagValueNode {
+    ): CurlyListNode | string | array | ConstExprNode | DoctrineAnnotationTagValueNode | StringNode {
         // skips dummy tokens like newlines
         $tokenIterator->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 
@@ -118,11 +119,11 @@ final class StaticDoctrineAnnotationParser
     }
 
     /**
-     * @return CurlyListNode|string|array<mixed>|ConstExprNode|DoctrineAnnotationTagValueNode
+     * @return CurlyListNode|string|array<mixed>|ConstExprNode|DoctrineAnnotationTagValueNode|StringNode
      */
     private function parseValue(
         BetterTokenIterator $tokenIterator
-    ): CurlyListNode | string | array | ConstExprNode | DoctrineAnnotationTagValueNode {
+    ): CurlyListNode | string | array | ConstExprNode | DoctrineAnnotationTagValueNode | StringNode {
         if ($tokenIterator->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET)) {
             $items = $this->arrayParser->parseCurlyArray($tokenIterator);
             return new CurlyListNode($items);

--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 
 /**
@@ -181,20 +182,20 @@ final class ArrayParser
         $valueQuoteKind = $this->resolveQuoteKind($value);
         if (is_string($value) && $valueQuoteKind === String_::KIND_DOUBLE_QUOTED) {
             // give raw value
-            $value = trim($value, '"');
+            $value = new StringNode(substr($value, 1, strlen($value) - 2));
         }
 
         $keyQuoteKind = $this->resolveQuoteKind($key);
         if (is_string($key) && $keyQuoteKind === String_::KIND_DOUBLE_QUOTED) {
             // give raw value
-            $key = trim($key, '"');
+            $key = new StringNode(substr($key, 1, strlen($key) - 2));
         }
 
         if ($key !== null) {
-            return new ArrayItemNode($value, $key, $valueQuoteKind, $keyQuoteKind);
+            return new ArrayItemNode($value, $key);
         }
 
-        return new ArrayItemNode($value, null, $valueQuoteKind, $keyQuoteKind);
+        return new ArrayItemNode($value);
     }
 
     private function isQuotedWith(mixed $value, string $quotes): bool

--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
@@ -177,18 +177,22 @@ final class ArrayParser
         return null;
     }
 
-    private function createArrayItemFromKeyAndValue(mixed $key, mixed $value): ArrayItemNode
+    private function createArrayItemFromKeyAndValue(mixed $rawKey, mixed $rawValue): ArrayItemNode
     {
-        $valueQuoteKind = $this->resolveQuoteKind($value);
-        if (is_string($value) && $valueQuoteKind === String_::KIND_DOUBLE_QUOTED) {
+        $valueQuoteKind = $this->resolveQuoteKind($rawValue);
+        if (is_string($rawValue) && $valueQuoteKind === String_::KIND_DOUBLE_QUOTED) {
             // give raw value
-            $value = new StringNode(substr($value, 1, strlen($value) - 2));
+            $value = new StringNode(substr($rawValue, 1, strlen($rawValue) - 2));
+        } else {
+            $value = $rawValue;
         }
 
-        $keyQuoteKind = $this->resolveQuoteKind($key);
-        if (is_string($key) && $keyQuoteKind === String_::KIND_DOUBLE_QUOTED) {
+        $keyQuoteKind = $this->resolveQuoteKind($rawKey);
+        if (is_string($rawKey) && $keyQuoteKind === String_::KIND_DOUBLE_QUOTED) {
             // give raw value
-            $key = new StringNode(substr($key, 1, strlen($key) - 2));
+            $key = new StringNode(substr($rawKey, 1, strlen($rawKey) - 2));
+        } else {
+            $key = $rawKey;
         }
 
         if ($key !== null) {

--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/PlainValueParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/PlainValueParser.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\PhpDocParser\ClassAnnotationMatcher;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser;
 use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
@@ -42,11 +43,11 @@ final class PlainValueParser
     }
 
     /**
-     * @return string|mixed[]|ConstExprNode|DoctrineAnnotationTagValueNode
+     * @return string|mixed[]|ConstExprNode|DoctrineAnnotationTagValueNode|StringNode
      */
     public function parseValue(
         BetterTokenIterator $tokenIterator
-    ): string | array | ConstExprNode | DoctrineAnnotationTagValueNode {
+    ): string | array | ConstExprNode | DoctrineAnnotationTagValueNode | StringNode {
         $currentTokenValue = $tokenIterator->currentTokenValue();
 
         // temporary hackaround multi-line doctrine annotations
@@ -91,7 +92,7 @@ final class PlainValueParser
 
         $end = $tokenIterator->currentPosition();
         if ($start + 1 < $end) {
-            return $tokenIterator->printFromTo($start, $end);
+            return new StringNode($tokenIterator->printFromTo($start, $end));
         }
 
         return $currentTokenValue;

--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
@@ -7,6 +7,7 @@ namespace Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation;
 use PHPStan\PhpDocParser\Ast\NodeAttributes;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 
 abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
@@ -31,7 +32,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     public function removeValue(string $desiredKey): void
     {
         foreach ($this->values as $key => $value) {
-            if ($value->key !== $desiredKey) {
+            if (! $this->isValueKeyEquals($value, $desiredKey)) {
                 continue;
             }
 
@@ -75,7 +76,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
     public function getValue(string $desiredKey): ?ArrayItemNode
     {
         foreach ($this->values as $value) {
-            if ($value->key === $desiredKey) {
+            if ($this->isValueKeyEquals($value, $desiredKey)) {
                 return $value;
             }
         }
@@ -120,6 +121,15 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
         }
 
         return $itemContents;
+    }
+
+    private function isValueKeyEquals(ArrayItemNode $value, string $desiredKey): bool
+    {
+        if ($value->key instanceof StringNode) {
+            return $value->key->value === $desiredKey;
+        }
+
+        return $value->key === $desiredKey;
     }
 
     private function stringifyValue(mixed $value): string

--- a/packages/PhpAttribute/AnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper.php
@@ -6,8 +6,11 @@ namespace Rector\PhpAttribute;
 
 use PhpParser\BuilderHelpers;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
 use Rector\PhpAttribute\Enum\DocTagNodeState;
 
@@ -46,6 +49,12 @@ final class AnnotationToAttributeMapper
 
         if ($value instanceof ArrayItemNode) {
             return BuilderHelpers::normalizeValue((string) $value);
+        }
+
+        if ($value instanceof StringNode) {
+            return new String_($value->value, [
+                AttributeKey::KIND => $value->getAttribute(AttributeKey::KIND),
+            ]);
         }
 
         // fallback

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\Core\Validation\RectorAssert;
 use Rector\PhpAttribute\AnnotationToAttributeMapper;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
@@ -50,14 +51,8 @@ final class ArrayItemNodeAnnotationToAttributeMapper implements AnnotationToAttr
         }
 
         if ($arrayItemNode->key !== null) {
-            $keyValue = match ($arrayItemNode->kindKeyQuoted) {
-                String_::KIND_SINGLE_QUOTED => "'" . $arrayItemNode->key . "'",
-                String_::KIND_DOUBLE_QUOTED => '"' . $arrayItemNode->key . '"',
-                default => $arrayItemNode->key,
-            };
-
             /** @var Expr $keyExpr */
-            $keyExpr = $this->annotationToAttributeMapper->map($keyValue);
+            $keyExpr = $this->annotationToAttributeMapper->map($arrayItemNode->key);
         } else {
             if ($this->hasNoParenthesesAnnotation($arrayItemNode)) {
                 try {
@@ -81,7 +76,7 @@ final class ArrayItemNodeAnnotationToAttributeMapper implements AnnotationToAttr
 
     private function hasNoParenthesesAnnotation(ArrayItemNode $arrayItemNode): bool
     {
-        if (is_int($arrayItemNode->kindValueQuoted)) {
+        if ($arrayItemNode->value instanceof StringNode) {
             return false;
         }
 

--- a/packages/PhpAttribute/AnnotationToAttributeMapper/StringNodeAnnotationToAttributeMapper.php
+++ b/packages/PhpAttribute/AnnotationToAttributeMapper/StringNodeAnnotationToAttributeMapper.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PhpAttribute\AnnotationToAttributeMapper;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
+
+/**
+ * @implements AnnotationToAttributeMapperInterface<StringNode>
+ */
+final class StringNodeAnnotationToAttributeMapper implements AnnotationToAttributeMapperInterface
+{
+    public function isCandidate(mixed $value): bool
+    {
+        return $value instanceof StringNode;
+    }
+
+    /**
+     * @param StringNode $value
+     */
+    public function map($value): Expr
+    {
+        return new String_($value->value, [
+            AttributeKey::KIND => $value->getAttribute(AttributeKey::KIND),
+        ]);
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -744,3 +744,6 @@ parameters:
         -
             message: '#Method name "(get|has|set)Attribute\(\)" is used in multiple traits\. Make it unique to avoid conflicts#'
             path: packages/BetterPhpDocParser/PhpDoc/StringNode.php
+
+        # resolve later
+        - '#Cognitive complexity for "Rector\\BetterPhpDocParser\\PhpDocManipulator\\PhpDocClassRenamer\:\:processSerializerTypeTagValueNode\(\)" is 11, keep it under 10#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -739,3 +739,8 @@ parameters:
         -
             message: '#Offset 0 does not exist on array<PhpParser\\Node\\Stmt>\|null#'
             path: rules/CodingStyle/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
+
+        # looks like a bug in the PHPStan rule, see https://github.com/rectorphp/rector-src/pull/3645#issuecomment-1561294527
+        -
+            message: '#Method name "(get|has|set)Attribute\(\)" is used in multiple traits\. Make it unique to avoid conflicts#'
+            path: packages/BetterPhpDocParser/PhpDoc/StringNode.php

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Doctrine/preserve_int_key_defined.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\D
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\DiscriminatorMap({ "1" = "CostDetailEntity" })
+ * @ORM\DiscriminatorMap({ 1 = "CostDetailEntity" })
  */
 class PreserveIntKeyDefined
 {

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/preserve_quotes.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/preserve_quotes.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Symfony;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class MyEntity
+{
+    /**
+     * @Assert\Choice(callback="\MyApp\Path\To\My::callbackFunction", strict=true)
+     */
+    private string $type;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Symfony;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class MyEntity
+{
+    #[Assert\Choice(callback: '\MyApp\Path\To\My::callbackFunction', strict: true)]
+    private string $type;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/symfony_security.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/symfony_security.php.inc
@@ -24,7 +24,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 final class SymfonySecurity
 {
-    #[Security('is_granted(constant(\'\\\Rector\\\Tests\\\Php80\\\Rector\\\Class_\\\AnnotationToAttributeRector\\\Source\\\ConstantReference::FIRST_NAME\'))')]
+    #[Security("is_granted(constant('\\\\Rector\\\\Tests\\\\Php80\\\\Rector\\\\Class_\\\\AnnotationToAttributeRector\\\\Source\\\\ConstantReference::FIRST_NAME'))")]
     public function action()
     {
     }

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/validation_string_parameter.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/validation_string_parameter.php.inc
@@ -8,10 +8,10 @@ final class ValidationIntegerParameter
 {
     /**
      * @Assert\Length(
-     *     min=100,
-     *     max=255,
+     *     min="100",
+     *     max="255",
      *     maxMessage="some Message",
-     *     allowed=true
+     *     allowed="true"
      * )
      */
     public function action()
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 final class ValidationIntegerParameter
 {
-    #[Assert\Length(min: 100, max: 255, maxMessage: 'some Message', allowed: true)]
+    #[Assert\Length(min: '100', max: '255', maxMessage: 'some Message', allowed: 'true')]
     public function action()
     {
     }

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -35,6 +35,7 @@ return static function (RectorConfig $rectorConfig): void {
 
             // validation
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\All'),
+            new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Choice'),
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Length'),
 
             // JMS + Symfony

--- a/rules/Php80/NodeAnalyzer/AnnotationTargetResolver.php
+++ b/rules/Php80/NodeAnalyzer/AnnotationTargetResolver.php
@@ -6,6 +6,7 @@ namespace Rector\Php80\NodeAnalyzer;
 
 use PhpParser\Node\Expr\ClassConstFetch;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
+use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\Core\PhpParser\Node\NodeFactory;
 
 final class AnnotationTargetResolver
@@ -39,7 +40,11 @@ final class AnnotationTargetResolver
 
         foreach ($targetValues as $targetValue) {
             foreach (self::TARGET_TO_CONSTANT_MAP as $target => $constant) {
-                if ($target !== $targetValue->value) {
+                if (! $targetValue->value instanceof StringNode) {
+                    continue;
+                }
+
+                if ($target !== $targetValue->value->value) {
                     continue;
                 }
 


### PR DESCRIPTION
closes https://github.com/rectorphp/rector/issues/7890
closes https://github.com/rectorphp/rector-src/pull/3635

This PR adds a `StringNode` for PHPDoc that is used for `ArrayItemNode` key and value when relevant, to enforce preserving it as a string value, and not having it parsed for something else.
It also clean up the support for single quotes as [Doctrine annotation doesn't support it](https://github.com/doctrine/annotations/blob/2.0.x/lib/Doctrine/Common/Annotations/DocLexer.php#L103-L107).