### PR TITLE
Prevent unnecessary IO in ChangedFilesDetector

### DIFF
--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -35,11 +35,15 @@ final class ChangedFilesDetector
 
     public function hasFileChanged(string $filePath): bool
     {
-        $currentFileHash = $this->hashFile($filePath);
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
-
         $cachedValue = $this->cache->load($fileInfoCacheKey, CacheKey::FILE_HASH_KEY);
-        return $currentFileHash !== $cachedValue;
+
+        if ($cachedValue !== null) {
+            $currentFileHash = $this->hashFile($filePath);
+            return $currentFileHash !== $cachedValue;
+        }
+
+        return true;
     }
 
     public function invalidateFile(string $filePath): void

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -43,6 +43,7 @@ final class ChangedFilesDetector
             return $currentFileHash !== $cachedValue;
         }
 
+        // we don't have a value to compare against. Be defensive and assume its changed
         return true;
     }
 


### PR DESCRIPTION
when no data is cached yet, we don't need to compure sha1_file() which is a hot function in profiles:

<img width="519" alt="grafik" src="https://user-images.githubusercontent.com/120441/233773986-1001732d-030f-45a1-8557-9ade40bd672b.png">
