### PR TITLE
Improve LocalMethodCallFinder performance

### DIFF
--- a/src/PhpParser/NodeFinder/LocalMethodCallFinder.php
+++ b/src/PhpParser/NodeFinder/LocalMethodCallFinder.php
@@ -44,16 +44,16 @@ final class LocalMethodCallFinder
         $matchingMethodCalls = [];
 
         foreach ($methodCalls as $methodCall) {
+            if (! $this->nodeNameResolver->isName($methodCall->name, $classMethodName)) {
+                continue;
+            }
+
             $callerType = $this->nodeTypeResolver->getType($methodCall->var);
             if (! $callerType instanceof TypeWithClassName) {
                 continue;
             }
 
             if ($callerType->getClassName() !== $className) {
-                continue;
-            }
-
-            if (! $this->nodeNameResolver->isName($methodCall->name, $classMethodName)) {
                 continue;
             }
 


### PR DESCRIPTION
leads to a 86% faster analysis when running rector on a folder of the phpstan-src codebase

<img width="724" alt="grafik" src="https://user-images.githubusercontent.com/120441/233792138-5927fd77-916f-4939-9efa-8302647a2cda.png">
