### PR TITLE
[BetterPhpdocParser] Remove getTokens() method on BetterTokenIterator

### DIFF
--- a/packages/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
+++ b/packages/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
@@ -102,14 +102,6 @@ final class BetterTokenIterator extends TokenIterator
         return $this->privatesAccessor->getPrivateProperty($this, self::INDEX);
     }
 
-    /**
-     * @return array<int, array{string, int, int}>
-     */
-    public function getTokens(): array
-    {
-        return $this->privatesAccessor->getPrivateProperty($this, self::TOKENS);
-    }
-
     public function count(): int
     {
         return count($this->getTokens());


### PR DESCRIPTION
@staabm since new php-doc-parser already has method `getTokens()` on `TokenIterator`, this method can be removed.

https://github.com/phpstan/phpdoc-parser/commit/900bd69a93e9bd51a11a0bdc6915c4bd813b25c3#diff-62d19c66cc22434f96724388acd962198a200c0c0ced48aeace88157ae658586