### PR TITLE
[ChangesReporting] Added more efficient ConsoleFileDiffFactory

### DIFF
--- a/packages/ChangesReporting/ValueObjectFactory/ConsoleFileDiffFactory.php
+++ b/packages/ChangesReporting/ValueObjectFactory/ConsoleFileDiffFactory.php
@@ -5,18 +5,13 @@ declare(strict_types=1);
 namespace Rector\ChangesReporting\ValueObjectFactory;
 
 use Rector\Core\Console\Formatter\ConsoleDiffer;
-use Rector\Core\Differ\DefaultDiffer;
 use Rector\Core\FileSystem\FilePathHelper;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Reporting\FileDiff;
 
-/**
- * In case you only need console diffs and not default-diffs, you should use the more efficient ConsoleFileDiffFactory instead.
- */
-final class FileDiffFactory
+final class ConsoleFileDiffFactory
 {
     public function __construct(
-        private readonly DefaultDiffer $defaultDiffer,
         private readonly ConsoleDiffer $consoleDiffer,
         private readonly FilePathHelper $filePathHelper,
     ) {
@@ -29,7 +24,7 @@ final class FileDiffFactory
         // always keep the most recent diff
         return new FileDiff(
             $relativeFilePath,
-            $this->defaultDiffer->diff($oldContent, $newContent),
+            '', // computing the diff can be slow, therefore we only compute what we need
             $this->consoleDiffer->diff($oldContent, $newContent),
             $file->getRectorWithLineChanges()
         );

--- a/src/Application/FileDecorator/FileDiffFileDecorator.php
+++ b/src/Application/FileDecorator/FileDiffFileDecorator.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Core\Application\FileDecorator;
 
+use Rector\ChangesReporting\ValueObjectFactory\ConsoleFileDiffFactory;
 use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
 use Rector\Core\ValueObject\Application\File;
 
 final class FileDiffFileDecorator
 {
     public function __construct(
-        private readonly FileDiffFactory $fileDiffFactory
+        private readonly ConsoleFileDiffFactory $fileDiffFactory
     ) {
     }
 

--- a/src/NonPhpFile/NonPhpFileProcessor.php
+++ b/src/NonPhpFile/NonPhpFileProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\NonPhpFile;
 
+use Rector\ChangesReporting\ValueObjectFactory\ConsoleFileDiffFactory;
 use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesCollector;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
@@ -23,7 +24,7 @@ final class NonPhpFileProcessor implements FileProcessorInterface
      */
     public function __construct(
         private readonly array $nonPhpRectors,
-        private readonly FileDiffFactory $fileDiffFactory,
+        private readonly ConsoleFileDiffFactory $fileDiffFactory,
         private readonly Filesystem $filesystem,
         private readonly RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
     ) {


### PR DESCRIPTION
The idea of this PR is, that we no longer create the "default-diff" but only the "console-diff".
thats the only thing we actually use later on.

This improves diff printing by 12% as we do less unncessary work:
<img width="536" alt="grafik" src="https://user-images.githubusercontent.com/120441/233825163-c660210a-bc4e-494b-8b04-fd68163666a9.png">


See the investigation in https://github.com/rectorphp/rector/issues/7899