### PR TITLE
[Test] Remove XDEBUG_MODE=coverage on phpunit.xml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,7 @@ jobs:
                     - tests
                     - rules-tests
                     - packages-tests
+                    - utils-tests
 
         name: PHP ${{ matrix.php }} tests for ${{ matrix.path }}
         steps:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,5 @@
   </testsuites>
   <php>
     <ini name="memory_limit" value="-1"/>
-    <env name="XDEBUG_MODE" value="coverage"/>
   </php>
 </phpunit>


### PR DESCRIPTION
Since we don't enable coverage on workflow test 

https://github.com/rectorphp/rector-src/blob/b11c28e22b0e0e6e696a0e92d24d3d903f8020d5/.github/workflows/tests.yaml#L37

I think `XDEBUG_MODE=coverage` can just be removed.