### PR TITLE
[Testing] Reduce IO on AbstractRectorTestCase::doTestFile()

### DIFF
--- a/packages/Testing/Fixture/FixtureSplitter.php
+++ b/packages/Testing/Fixture/FixtureSplitter.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace Rector\Testing\Fixture;
 
-use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
-use Webmozart\Assert\Assert;
 
 /**
  * @api
@@ -27,10 +25,8 @@ final class FixtureSplitter
     /**
      * @return array<string, string>
      */
-    public static function split(string $filePath): array
+    public static function split(string $fixtureFileContents): array
     {
-        $fixtureFileContents = FileSystem::read($filePath);
-
         return Strings::split($fixtureFileContents, self::SPLIT_LINE_REGEX);
     }
 }

--- a/packages/Testing/Fixture/FixtureSplitter.php
+++ b/packages/Testing/Fixture/FixtureSplitter.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Rector\Testing\Fixture;
 
+use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 
 /**
@@ -25,7 +26,17 @@ final class FixtureSplitter
     /**
      * @return array<string, string>
      */
-    public static function split(string $fixtureFileContents): array
+    public static function split(string $filePath): array
+    {
+        $fixtureFileContents = FileSystem::read($filePath);
+
+        return Strings::split($fixtureFileContents, self::SPLIT_LINE_REGEX);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function splitFixtureFileContents(string $fixtureFileContents): array
     {
         return Strings::split($fixtureFileContents, self::SPLIT_LINE_REGEX);
     }

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -107,7 +107,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
 
         if (FixtureSplitter::containsSplit($fixtureFileContents)) {
             // changed content
-            [$inputFileContents, $expectedFileContents] = FixtureSplitter::split($fixtureFileContents);
+            [$inputFileContents, $expectedFileContents] = FixtureSplitter::splitFixtureFileContents($fixtureFileContents);
         } else {
             // no change
             $inputFileContents = $fixtureFileContents;

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -107,7 +107,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
 
         if (FixtureSplitter::containsSplit($fixtureFileContents)) {
             // changed content
-            [$inputFileContents, $expectedFileContents] = FixtureSplitter::split($fixtureFilePath);
+            [$inputFileContents, $expectedFileContents] = FixtureSplitter::split($fixtureFileContents);
         } else {
             // no change
             $inputFileContents = $fixtureFileContents;


### PR DESCRIPTION
`FileSystem::read()` already call early,  so I added new method `FixtureSplitter::splitFixtureFileContents()` for direct already defined content.