### PR TITLE
[Formatter] Improve $escapeDiffLine check on ColorConsoleDiffFormatter

### DIFF
--- a/src/Console/Formatter/ColorConsoleDiffFormatter.php
+++ b/src/Console/Formatter/ColorConsoleDiffFormatter.php
@@ -65,6 +65,7 @@ final class ColorConsoleDiffFormatter
         foreach ($escapedDiffLines as $key => $escapedDiffLine) {
             if ($escapedDiffLine === '--- Original') {
                 unset($escapedDiffLines[$key]);
+                continue;
             }
 
             if ($escapedDiffLine === '+++ New') {

--- a/src/Console/Formatter/ColorConsoleDiffFormatter.php
+++ b/src/Console/Formatter/ColorConsoleDiffFormatter.php
@@ -63,14 +63,11 @@ final class ColorConsoleDiffFormatter
 
         // remove description of added + remove; obvious on diffs
         foreach ($escapedDiffLines as $key => $escapedDiffLine) {
-            if ($escapedDiffLine === '--- Original') {
-                unset($escapedDiffLines[$key]);
+            if (! in_array($escapedDiffLine, ['--- Original', '+++ New'], true)) {
                 continue;
             }
 
-            if ($escapedDiffLine === '+++ New') {
-                unset($escapedDiffLines[$key]);
-            }
+            unset($escapedDiffLines[$key]);
         }
 
         $coloredLines = array_map(function (string $string): string {


### PR DESCRIPTION
`continue` early after first match `if` on compare `$escapeDiffLine` so no need another `if` compare after match, so continue to next iteration instead.