### PR TITLE
[PHPStanStaticTypeMapper] Improve UnionTypeMapper performance take 2

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -267,7 +267,7 @@ final class UnionTypeMapper implements TypeMapperInterface
 
         $phpParserUnionType->types = array_filter(
             $phpParserUnionType->types,
-            fn (Node $node): bool => ! $node instanceof Identifier || $node->toString() !== 'false'
+            static fn(Node $node): bool => ! $node instanceof Identifier || $node->toString() !== 'false'
         );
         $phpParserUnionType->types = array_values($phpParserUnionType->types);
 

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -245,7 +245,7 @@ final class UnionTypeMapper implements TypeMapperInterface
         if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_TYPES)) {
             return null;
         }
-        
+
         if (count($phpParserUnionType->types) === 2) {
             return $phpParserUnionType;
         }
@@ -256,23 +256,20 @@ final class UnionTypeMapper implements TypeMapperInterface
                 $identifierNames[] = $type->toString();
             }
         }
-        
+
         if (! in_array('bool', $identifierNames, true)) {
             return $phpParserUnionType;
         }
-        
+
         if (! in_array('false', $identifierNames, true)) {
             return $phpParserUnionType;
         }
 
-        foreach ($phpParserUnionType->types as $key => $type) {
-            if ($type instanceof Identifier && $type->toString() === 'false') {
-                unset($phpParserUnionType->types[$key]);
-                $phpParserUnionType->types = array_values($phpParserUnionType->types);
-
-                return $phpParserUnionType;
-            }
-        }
+        $phpParserUnionType->types = array_filter(
+            $phpParserUnionType->types,
+            fn (Node $node): bool => ! $node instanceof Identifier || $node->toString() !== 'false'
+        );
+        $phpParserUnionType->types = array_values($phpParserUnionType->types);
 
         return $phpParserUnionType;
     }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -245,6 +245,10 @@ final class UnionTypeMapper implements TypeMapperInterface
         if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_TYPES)) {
             return null;
         }
+        
+        if (count($phpParserUnionType->types) === 2) {
+            return $phpParserUnionType;
+        }
 
         $identifierNames = [];
         foreach ($phpParserUnionType->types as $type) {


### PR DESCRIPTION
No need to verify bool and false exists when count types only 2 as already verified previously for all bool