### PR TITLE
[Preload] Add preload-split-package.php to bin/rector.php to fix overlap php-doc-parser

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -121,6 +121,11 @@ if (file_exists(__DIR__ . '/../preload.php') && is_dir(__DIR__ . '/../vendor')) 
     require_once __DIR__ . '/../preload.php';
 }
 
+// require rector-src on split packages
+if (file_exists(__DIR__ . '/../preload-split-package.php') && is_dir(__DIR__ . '/../../../../vendor')) {
+    require_once __DIR__ . '/../preload-split-package.php';
+}
+
 require_once __DIR__ . '/../src/constants.php';
 
 $autoloadIncluder->loadIfExistsAndNotLoadedYet(__DIR__ . '/../vendor/scoper-autoload.php');


### PR DESCRIPTION
@JohJohan @TomasVotruba this to make work on rector packages run `vendor/bin/rector` due to overlapped php-doc-parser with phpstan.phar scoped vendor 

https://github.com/rectorphp/rector-symfony/pull/394