### PR TITLE
[NodeAnalyzer] Remove unused $this->reflectionProvider->hasClass($className) check on PropertyPresenceChecker::getClassContextProperty()

### DIFF
--- a/src/NodeAnalyzer/PropertyPresenceChecker.php
+++ b/src/NodeAnalyzer/PropertyPresenceChecker.php
@@ -46,10 +46,6 @@ final class PropertyPresenceChecker
             return null;
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
-            return null;
-        }
-
         $property = $class->getProperty($propertyMetadata->getName());
         if ($property instanceof Property) {
             return $property;


### PR DESCRIPTION
The method `PropertyPresenceChecker::getClassContextProperty()` doesn't get ClassReflection, as it pull directly from `Class_` node, so no need to check `->hasClass()` on ReflectionProvider. 