### PR TITLE
[NodeTypeResolver] Add AssignedToNodeVisitor

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\NodeVisitorAbstract;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+/**
+ * Inspired by https://github.com/phpstan/phpstan-src/blob/1.7.x/src/Parser/NewAssignedToPropertyVisitor.php
+ */
+final class AssignedToNodeVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof Assign) {
+            return null;
+        }
+
+        $node->expr->setAttribute(AttributeKey::ASSIGNED_TO, $node->var);
+        return null;
+    }
+}

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -50,6 +50,7 @@ use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\AssignedToNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\RemoveDeepChainMethodCallNodeVisitor;
 use Webmozart\Assert\Assert;
 
@@ -72,6 +73,7 @@ final class PHPStanNodeScopeResolver
         private readonly NodeScopeResolver $nodeScopeResolver,
         private readonly ReflectionProvider $reflectionProvider,
         RemoveDeepChainMethodCallNodeVisitor $removeDeepChainMethodCallNodeVisitor,
+        AssignedToNodeVisitor $assignedToNodeVisitor,
         private readonly ScopeFactory $scopeFactory,
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly NodeNameResolver $nodeNameResolver,
@@ -80,6 +82,7 @@ final class PHPStanNodeScopeResolver
     ) {
         $this->nodeTraverser = new NodeTraverser();
         $this->nodeTraverser->addVisitor($removeDeepChainMethodCallNodeVisitor);
+        $this->nodeTraverser->addVisitor($assignedToNodeVisitor);
     }
 
     /**


### PR DESCRIPTION
@TomasVotruba I found a bug on scoped rector/rector when using `assigned_to` attribute, which never exists if no require `symplify/phpstan-rules` in require.

The `symplify/phpstan-rules` is in require-dev which loaded that's why it works on https://github.com/rectorphp/rector-src/pull/3540

On this PR, I copy and add dedicated `AssignedToNodeVisitor` to make assign as `assigned_to` attribute on expr.