### PR TITLE
[NodeManipulator] Clean up AssignManipulator take 2

### DIFF
--- a/rules/CodeQuality/NodeAnalyzer/ForAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/ForAnalyzer.php
@@ -157,7 +157,7 @@ final class ForAnalyzer
             return false;
         }
 
-        if ($this->assignManipulator->isNodePartOfAssign($parentNode)) {
+        if ($this->assignManipulator->isLeftPartOfAssign($arrayDimFetch)) {
             return true;
         }
 

--- a/src/NodeManipulator/AssignManipulator.php
+++ b/src/NodeManipulator/AssignManipulator.php
@@ -20,9 +20,7 @@ use PhpParser\Node\Expr\PreInc;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt\Expression;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
-use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Util\MultiInstanceofChecker;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -44,7 +42,6 @@ final class AssignManipulator
 
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly NodeComparator $nodeComparator,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly MultiInstanceofChecker $multiInstanceofChecker

--- a/src/NodeManipulator/AssignManipulator.php
+++ b/src/NodeManipulator/AssignManipulator.php
@@ -70,15 +70,12 @@ final class AssignManipulator
     public function isLeftPartOfAssign(Node $node): bool
     {
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if ($parentNode instanceof Assign || $parentNode instanceof AssignOp) {
-            return $this->nodeComparator->areNodesEqual($parentNode->var, $node);
-        }
-
         if ($parentNode instanceof Node && $this->multiInstanceofChecker->isInstanceOf(
             $parentNode,
-            self::MODIFYING_NODE_TYPES
+            [Assign::class, ...self::MODIFYING_NODE_TYPES]
         )) {
-            return true;
+            /** @var Assign|AssignOp|PreDec|PostDec|PreInc|PostInc $parentNode */
+            return $parentNode->var === $node;
         }
 
         if ($this->isOnArrayDestructuring($parentNode)) {
@@ -100,26 +97,6 @@ final class AssignManipulator
                 /** @var Assign|AssignOp|PreDec|PostDec|PreInc|PostInc $parentNode */
                 return $parentNode->var === $previousParent;
             }
-        }
-
-        return false;
-    }
-
-    public function isNodePartOfAssign(Node $node): bool
-    {
-        $previousNode = $node;
-        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-
-        while ($parentNode instanceof Node && ! $parentNode instanceof Expression) {
-            if ($parentNode instanceof Assign && $this->nodeComparator->areNodesEqual(
-                $parentNode->var,
-                $previousNode
-            )) {
-                return true;
-            }
-
-            $previousNode = $parentNode;
-            $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
         }
 
         return false;

--- a/src/NodeManipulator/AssignManipulator.php
+++ b/src/NodeManipulator/AssignManipulator.php
@@ -127,6 +127,14 @@ final class AssignManipulator
         }
 
         $node = $parentArrayItem->getAttribute(AttributeKey::PARENT_NODE);
-        return $node instanceof Assign && $node->var === $parentArrayItem;
+        if (! $this->multiInstanceofChecker->isInstanceOf(
+            $node,
+            self::MODIFYING_NODE_TYPES
+        )) {
+            return false;
+        }
+
+        /** @var Assign|AssignOp|PreDec|PostDec|PreInc|PostInc $parentArrayItem */
+        return $node->var === $parentArrayItem;
     }
 }

--- a/src/NodeManipulator/AssignManipulator.php
+++ b/src/NodeManipulator/AssignManipulator.php
@@ -34,6 +34,7 @@ final class AssignManipulator
      * @var array<class-string<Expr>>
      */
     private const MODIFYING_NODE_TYPES = [
+        Assign::class,
         AssignOp::class,
         PreDec::class,
         PostDec::class,
@@ -72,7 +73,7 @@ final class AssignManipulator
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
         if ($parentNode instanceof Node && $this->multiInstanceofChecker->isInstanceOf(
             $parentNode,
-            [Assign::class, ...self::MODIFYING_NODE_TYPES]
+            self::MODIFYING_NODE_TYPES
         )) {
             /** @var Assign|AssignOp|PreDec|PostDec|PreInc|PostInc $parentNode */
             return $parentNode->var === $node;
@@ -92,7 +93,7 @@ final class AssignManipulator
 
             if ($parentNode instanceof Node && $this->multiInstanceofChecker->isInstanceOf(
                 $parentNode,
-                [Assign::class, ...self::MODIFYING_NODE_TYPES]
+                self::MODIFYING_NODE_TYPES
             )) {
                 /** @var Assign|AssignOp|PreDec|PostDec|PreInc|PostInc $parentNode */
                 return $parentNode->var === $previousParent;

--- a/src/NodeManipulator/AssignManipulator.php
+++ b/src/NodeManipulator/AssignManipulator.php
@@ -127,14 +127,6 @@ final class AssignManipulator
         }
 
         $node = $parentArrayItem->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $this->multiInstanceofChecker->isInstanceOf(
-            $node,
-            self::MODIFYING_NODE_TYPES
-        )) {
-            return false;
-        }
-
-        /** @var Assign|AssignOp|PreDec|PostDec|PreInc|PostInc $parentArrayItem */
-        return $node->var === $parentArrayItem;
+        return $node instanceof Assign && $node->var === $parentArrayItem;
     }
 }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/3695

this PR clean up unnecessary method `isNodePartOfAssign()` that should can be handled by `isLeftPartOfAssign()` method, and optimize it by re-use `MODIFYING_NODE_TYPES` constant.