### PR TITLE
[CodingStyle] Skip concat on first arg on ConsistentImplodeRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentImplodeRector/Fixture/skip_concat_on_first_arg.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentImplodeRector/Fixture/skip_concat_on_first_arg.php.inc
@@ -2,11 +2,11 @@
 
 namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentImplodeRector\Fixture;
 
-final class DemoFile
+final class SkipConcatOnFirstArg
 {
     public function run()
     {
-        implode('|' . ' ', 'should not be changed?');
+        implode('|' . ' ', 'should not be changed');
     }
 }
 

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentImplodeRector/Fixture/string_arguments.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentImplodeRector/Fixture/string_arguments.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentImplodeRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        implode('|' . ' ', 'should not be changed?');
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentImplodeRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentImplodeRector.php
@@ -95,7 +95,9 @@ CODE_SAMPLE
         /** @var Arg $arg0 */
         $arg0 = $node->args[0];
         $firstArgumentValue = $arg0->value;
-        if ($firstArgumentValue instanceof String_) {
+
+        $firstArgumentType = $this->getType($firstArgumentValue);
+        if ($firstArgumentType->isString()->yes()) {
             return null;
         }
 


### PR DESCRIPTION
# Failing Test for ConsistentImplodeRector

Based on https://getrector.com/demo/ec054f63-0f4e-489d-a3da-fa87581814f0

Reported in https://github.com/rectorphp/rector/issues/7903
Closes https://github.com/rectorphp/rector/issues/7903