### PR TITLE
[PostRector] Improve performance NameImportingPostRector

### DIFF
--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -19,6 +19,7 @@ use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\CodingStyle\Node\NameImporter;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\ParameterProvider;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Naming\Naming\AliasNameResolver;
@@ -54,13 +55,8 @@ final class NameImportingPostRector extends AbstractPostRector
             return null;
         }
 
-        $currentStmt = current($file->getOldStmts());
-        if ($currentStmt instanceof InlineHTML) {
-            return null;
-        }
-
         $currentStmt = current($file->getNewStmts());
-        if ($currentStmt instanceof InlineHTML) {
+        if ($currentStmt instanceof FileWithoutNamespace && current($currentStmt->stmts) instanceof InlineHTML) {
             return null;
         }
 


### PR DESCRIPTION
When first stmt is `InlineHTML`, it never be namespaced, see https://3v4l.org/IQug0 , only looking up new stmts should be ok.