### PR TITLE
Don't calculate diffs when `--no-diffs` is given

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -84,7 +84,9 @@ final class ApplicationFileProcessor
 
             $systemErrorsAndFileDiffs = $this->processFiles($files, $configuration);
 
-            $this->fileDiffFileDecorator->decorate($files);
+            if ($configuration->shouldShowDiffs()) {
+                $this->fileDiffFileDecorator->decorate($files);
+            }
             $this->printFiles($files, $configuration);
         }
 

--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -186,7 +186,9 @@ final class PhpFileProcessor implements FileProcessorInterface
         }
 
         $file->changeFileContent($newContent);
-        $this->fileDiffFileDecorator->decorate([$file]);
+        if ($configuration->shouldShowDiffs()) {
+            $this->fileDiffFileDecorator->decorate([$file]);
+        }
     }
 
     private function notifyFile(File $file): void


### PR DESCRIPTION
the slowest part of running rector on a file with ~5000 lines of code is generating the diff afterwards

`php bin/rector.php -c rector-test.php --dry-run  -vvv --debug --no-diffs`

<img width="510" alt="grafik" src="https://user-images.githubusercontent.com/120441/235308060-c6fc62b3-9639-48f4-871b-9aa5c975b60d.png">

refs https://github.com/rectorphp/rector/issues/7899