### PR TITLE
[Ast] Improve AstResolver and ClassLikeAstResolver performance

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -76,10 +76,6 @@ final class AstResolver
     public function resolveClassMethodFromMethodReflection(MethodReflection $methodReflection): ?ClassMethod
     {
         $classReflection = $methodReflection->getDeclaringClass();
-
-        $classLikeName = $classReflection->getName();
-        $methodName = $methodReflection->getName();
-
         $fileName = $classReflection->getFileName();
 
         // probably native PHP method → un-parseable
@@ -91,6 +87,9 @@ final class AstResolver
         if ($nodes === []) {
             return null;
         }
+
+        $classLikeName = $classReflection->getName();
+        $methodName = $methodReflection->getName();
 
         $classMethod = null;
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
@@ -131,8 +130,6 @@ final class AstResolver
 
     public function resolveFunctionFromFunctionReflection(FunctionReflection $functionReflection): ?Function_
     {
-        $functionName = $functionReflection->getName();
-
         $fileName = $functionReflection->getFileName();
         if ($fileName === null) {
             return null;
@@ -143,7 +140,9 @@ final class AstResolver
             return null;
         }
 
+        $functionName = $functionReflection->getName();
         $functionNode = null;
+
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $nodes,
             function (Node $node) use ($functionName, &$functionNode): ?int {

--- a/src/PhpParser/ClassLikeAstResolver.php
+++ b/src/PhpParser/ClassLikeAstResolver.php
@@ -38,7 +38,6 @@ final class ClassLikeAstResolver
             return null;
         }
 
-        $className = $classReflection->getName();
         $fileName = $classReflection->getFileName();
 
         // probably internal class
@@ -51,6 +50,7 @@ final class ClassLikeAstResolver
             return null;
         }
 
+        $className = $classReflection->getName();
         /** @var Class_|Trait_|Interface_|Enum_|null $classLike */
         $classLike = $this->betterNodeFinder->findFirst(
             $stmts,


### PR DESCRIPTION
Avoid unnecessary method call on native PHP method that not parseable.