### PR TITLE
[NodeTraverser] Add custom NodeConnectingVisitor to handle after refactor() applied

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -537,10 +537,6 @@ final class BetterNodeFinder
             return null;
         }
 
-        if ($previousNode === $node) {
-            return null;
-        }
-
         $foundNode = $this->findFirst($previousNode, $filter);
 
         // we found what we need

--- a/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
+++ b/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\PhpParser\NodeTraverser;
 
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NodeConnectingVisitor;
+use Rector\Core\PhpParser\NodeVisitor\NodeConnectingVisitor;
 
 final class NodeConnectingTraverser extends NodeTraverser
 {

--- a/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
+++ b/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\PhpParser\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Visitor that connects a child node to its parent node
+ * as well as its sibling nodes, with verify previous node is not equal to current node.
+ *
+ * inspired by https://github.com/nikic/PHP-Parser/blob/0ffddce52d816f72d0efc4d9b02e276d3309ef01/lib/PhpParser/NodeVisitor/NodeConnectingVisitor.php
+ */
+final class NodeConnectingVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var Node[]
+     */
+    private $stack = [];
+
+    /**
+     * @var ?Node
+     */
+    private $previous;
+
+    public function beforeTraverse(array $nodes) {
+        $this->stack    = [];
+        $this->previous = null;
+    }
+
+    public function enterNode(Node $node) {
+        if (!empty($this->stack)) {
+            $node->setAttribute('parent', $this->stack[count($this->stack) - 1]);
+        }
+
+        if (! in_array($this->previous, [null, $node], true) && $this->previous->getAttribute('parent') === $node->getAttribute('parent')) {
+            $node->setAttribute('previous', $this->previous);
+            $this->previous->setAttribute('next', $node);
+        }
+
+        $this->stack[] = $node;
+    }
+
+    public function leaveNode(Node $node) {
+        $this->previous = $node;
+
+        array_pop($this->stack);
+    }
+}

--- a/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
+++ b/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
@@ -18,33 +18,30 @@ final class NodeConnectingVisitor extends NodeVisitorAbstract
     /**
      * @var Node[]
      */
-    private $stack = [];
+    private array $stack = [];
 
-    /**
-     * @var ?Node
-     */
-    private $previous;
+    private ?Node $node = null;
 
-    public function beforeTraverse(array $nodes) {
+    public function beforeTraverse(array $nodes): void {
         $this->stack    = [];
-        $this->previous = null;
+        $this->node = null;
     }
 
-    public function enterNode(Node $node) {
+    public function enterNode(Node $node): void {
         if (!empty($this->stack)) {
             $node->setAttribute('parent', $this->stack[count($this->stack) - 1]);
         }
 
-        if (! in_array($this->previous, [null, $node], true) && $this->previous->getAttribute('parent') === $node->getAttribute('parent')) {
-            $node->setAttribute('previous', $this->previous);
-            $this->previous->setAttribute('next', $node);
+        if (! in_array($this->node, [null, $node], true) && $this->node->getAttribute('parent') === $node->getAttribute('parent')) {
+            $node->setAttribute('previous', $this->node);
+            $this->node->setAttribute('next', $node);
         }
 
         $this->stack[] = $node;
     }
 
-    public function leaveNode(Node $node) {
-        $this->previous = $node;
+    public function leaveNode(Node $node): void {
+        $this->node = $node;
 
         array_pop($this->stack);
     }

--- a/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
+++ b/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
@@ -28,7 +28,7 @@ final class NodeConnectingVisitor extends NodeVisitorAbstract
     }
 
     public function enterNode(Node $node): void {
-        if (!empty($this->stack)) {
+        if ($this->stack !== []) {
             $node->setAttribute('parent', $this->stack[count($this->stack) - 1]);
         }
 

--- a/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
+++ b/src/PhpParser/NodeVisitor/NodeConnectingVisitor.php
@@ -6,6 +6,7 @@ namespace Rector\Core\PhpParser\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * Visitor that connects a child node to its parent node
@@ -22,27 +23,40 @@ final class NodeConnectingVisitor extends NodeVisitorAbstract
 
     private ?Node $node = null;
 
-    public function beforeTraverse(array $nodes): void {
-        $this->stack    = [];
+    public function beforeTraverse(array $nodes)
+    {
+        $this->stack = [];
         $this->node = null;
+
+        return null;
     }
 
-    public function enterNode(Node $node): void {
+    public function enterNode(Node $node)
+    {
         if ($this->stack !== []) {
-            $node->setAttribute('parent', $this->stack[count($this->stack) - 1]);
+            $node->setAttribute(AttributeKey::PARENT_NODE, $this->stack[count($this->stack) - 1]);
         }
 
-        if (! in_array($this->node, [null, $node], true) && $this->node->getAttribute('parent') === $node->getAttribute('parent')) {
-            $node->setAttribute('previous', $this->node);
-            $this->node->setAttribute('next', $node);
+        if ($this->node instanceof Node
+            && $this->node !== $node
+            && $this->node->getAttribute(AttributeKey::PARENT_NODE) === $node->getAttribute(
+                AttributeKey::PARENT_NODE
+            )) {
+            $node->setAttribute(AttributeKey::PREVIOUS_NODE, $this->node);
+            $this->node->setAttribute(AttributeKey::NEXT_NODE, $node);
         }
 
         $this->stack[] = $node;
+
+        return null;
     }
 
-    public function leaveNode(Node $node): void {
+    public function leaveNode(Node $node)
+    {
         $this->node = $node;
 
         array_pop($this->stack);
+
+        return null;
     }
 }

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -14,6 +14,7 @@ use PhpParser\ParserFactory;
 final class SimplePhpParser
 {
     private readonly NodeTraverser $nodeTraverser;
+
     private readonly Parser $phpParser;
 
     public function __construct()

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -6,19 +6,23 @@ namespace Rector\Core\PhpParser\Parser;
 
 use Nette\Utils\FileSystem;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NodeConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
-use Rector\Core\PhpParser\NodeTraverser\NodeConnectingTraverser;
 
 final class SimplePhpParser
 {
+    private readonly NodeTraverser $nodeTraverser;
     private readonly Parser $phpParser;
 
-    public function __construct(
-        private readonly NodeConnectingTraverser $nodeConnectingTraverser
-    ) {
+    public function __construct()
+    {
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+
+        $this->nodeTraverser = new NodeTraverser();
+        $this->nodeTraverser->addVisitor(new NodeConnectingVisitor());
     }
 
     /**
@@ -41,6 +45,6 @@ final class SimplePhpParser
             return [];
         }
 
-        return $this->nodeConnectingTraverser->traverse($stmts);
+        return $this->nodeTraverser->traverse($stmts);
     }
 }


### PR DESCRIPTION
Previously, we use hack check:

```php
        if ($previousNode === $node) {
            return null;
        }
```

to handle infinite loop on node just flipped position on PR:

- https://github.com/rectorphp/rector-src/pull/3484

on every single node previous check on `BetterNodeFinder::findFirstInlinedPrevious()`, which if the code is in deep, it will compare every single object passed.

https://github.com/rectorphp/rector-src/blob/5c1be93b80c3f7bfd8bd158ba0a55501a7acaefc/src/PhpParser/Node/BetterNodeFinder.php#L540-L542

This PR add dedicated custom `NodeConnectingVisitor` which verify previous data node is equal to node before set attribute on re-connect after `refactor()` applied only.