### PR TITLE
[NodeManipulator] Improve IfManipulator::collectNestedIfsWithNonBreaking() performance

### DIFF
--- a/src/NodeManipulator/IfManipulator.php
+++ b/src/NodeManipulator/IfManipulator.php
@@ -183,15 +183,14 @@ final class IfManipulator
             return [];
         }
 
-        $betterNodeFinderFindInstanceOf = $this->betterNodeFinder->findInstanceOf($currentIf->stmts, Return_::class);
+        $return = $this->betterNodeFinder->findFirstInstanceOf($currentIf->stmts, Return_::class);
 
-        if ($betterNodeFinderFindInstanceOf !== []) {
+        if ($return instanceof Return_) {
             return [];
         }
 
-        /** @var Exit_[] $exits */
-        $exits = $this->betterNodeFinder->findInstanceOf($currentIf->stmts, Exit_::class);
-        if ($exits !== []) {
+        $exit = $this->betterNodeFinder->findFirstInstanceOf($currentIf->stmts, Exit_::class);
+        if ($exit instanceof Exit_) {
             return [];
         }
 


### PR DESCRIPTION
Use `findFirstInstanceOf()` instead of `findInstanceOf()` when possible.