### PR TITLE
[CodeQuality] Improve SimplifyIfElseToTernaryRector performance

### DIFF
--- a/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -181,8 +181,8 @@ CODE_SAMPLE
     private function haveNestedTernary(array $nodes): bool
     {
         foreach ($nodes as $node) {
-            $betterNodeFinderFindInstanceOf = $this->betterNodeFinder->findInstanceOf($node, Ternary::class);
-            if ($betterNodeFinderFindInstanceOf !== []) {
+            $ternary = $this->betterNodeFinder->findFirstInstanceOf($node, Ternary::class);
+            if ($ternary instanceof Ternary) {
                 return true;
             }
         }


### PR DESCRIPTION
Using `findFirstInstanceOf()` over `findInstanceOf()` when possible.