### PR TITLE
regular terminating and respawning of processes

### DIFF
--- a/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -34,13 +34,21 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
 
     public function report(ProcessResult $processResult, Configuration $configuration): void
     {
+        $errors = $processResult->getErrors();
+
+        // only show 100% when no errors
+        if ($errors === [] && $configuration->shouldShowProgressBar()) {
+            $this->rectorOutputStyle->progressFinish();
+        }
+
+        // show diff after progress bar
         if ($configuration->shouldShowDiffs()) {
             $this->reportFileDiffs($processResult->getFileDiffs());
         }
 
         $this->reportErrors($processResult->getErrors());
 
-        if ($processResult->getErrors() !== []) {
+        if ($errors !== []) {
             return;
         }
 

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -42,7 +42,7 @@ final class ParallelFileProcessor
      */
     private const SYSTEM_ERROR_LIMIT = 50;
 
-    private int $maxProcessIterations = 10;
+    private const MAX_PROCESS_ITERATIONS = 10;
 
     private ProcessPool|null $processPool = null;
 
@@ -190,7 +190,7 @@ final class ParallelFileProcessor
                     if (!isset($this->processRunCounter[$processIdentifier])) {
                         $this->processRunCounter[$processIdentifier] = 0;
                     }
-                    if ($this->processRunCounter[$processIdentifier] >= $this->maxProcessIterations) {
+                    if ($this->processRunCounter[$processIdentifier] >= self::MAX_PROCESS_ITERATIONS) {
                         $this->processPool->quitProcess($processIdentifier);
                         if (is_callable($this->processSpawner)){
                             ($this->processSpawner)();

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -42,6 +42,8 @@ final class ParallelFileProcessor
      */
     private const SYSTEM_ERROR_LIMIT = 50;
 
+    private int $maxProcessIterations = 10;
+
     private ProcessPool|null $processPool = null;
 
     private $processSpawner = null;
@@ -183,7 +185,7 @@ final class ParallelFileProcessor
                     if (!isset($processRunCounter[$processIdentifier])) {
                         $processRunCounter[$processIdentifier] = 0;
                     }
-                    if ($processRunCounter[$processIdentifier] >= 2) {
+                    if ($processRunCounter[$processIdentifier] >= $this->maxProcessIterations) {
                         $this->processPool->quitProcess($processIdentifier);
                         ($this->processSpawner)();
                     }

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -196,7 +196,7 @@ final class ParallelFileProcessor
                             ($this->processSpawner)();
                         }
                     }
-                    $this->processRunCounter[$processIdentifier] = $this->processRunCounter[$processIdentifier] + 1;
+                    ++$this->processRunCounter[$processIdentifier];;
                     $job = array_pop($jobs);
                     $parallelProcess->request([
                         ReactCommand::ACTION => Action::MAIN,

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Parallel\Application;
 
+use Closure;
 use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
 use Nette\Utils\Random;
@@ -47,9 +48,9 @@ final class ParallelFileProcessor
     private ProcessPool|null $processPool = null;
 
     /**
-     * @var \Closure():void|null
+     * @var Closure():void|null
      */
-    private \Closure|null $processSpawner = null;
+    private Closure|null $processSpawner = null;
 
     /**
      * @var int[]
@@ -185,15 +186,18 @@ final class ParallelFileProcessor
                         $this->processPool->quitProcess($processIdentifier);
                         return;
                     }
+
                     if (!isset($this->processRunCounter[$processIdentifier])) {
                         $this->processRunCounter[$processIdentifier] = 0;
                     }
+
                     if ($this->processRunCounter[$processIdentifier] >= self::MAX_PROCESS_ITERATIONS) {
                         $this->processPool->quitProcess($processIdentifier);
                         if (is_callable($this->processSpawner)){
                             ($this->processSpawner)();
                         }
                     }
+
                     ++$this->processRunCounter[$processIdentifier];;
                     $job = array_pop($jobs);
                     $parallelProcess->request([

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -180,18 +180,6 @@ final class ParallelFileProcessor
                         $this->processPool->quitProcess($processIdentifier);
                         return;
                     }
-//                    file_put_contents('/work/sandbox/test.log',
-//                        PHP_EOL.`####`.var_export([
-//                            'call onData',
-//                            'getmypid()'=>getmypid(),
-//                            '$processIdentifier'=>
-//                                $processIdentifier,
-//                            '$processRunCounter[$processIdentifier]' => $processRunCounter[$processIdentifier],
-//                            'count($jobs)'=>
-//                                count($jobs),
-//                        ],true),
-//                        FILE_APPEND);
-
                     if (!isset($processRunCounter[$processIdentifier])) {
                         $processRunCounter[$processIdentifier] = 0;
                     }
@@ -241,18 +229,6 @@ final class ParallelFileProcessor
                 }
 
                 $processIdentifier = $data[Option::PARALLEL_IDENTIFIER];
-
-                //var_dump($jobs);
-
-//                file_put_contents('/work/sandbox/test.log',
-//                    PHP_EOL.`####`.var_export([
-//                        'onData',
-//                        'getmypid()'=>getmypid(),
-//                        '$processRunCounter[$processIdentifier]' => $processRunCounter[$processIdentifier],
-//                        '$processIdentifier'=>
-//                            $processIdentifier,
-//                    ],true),
-//                    FILE_APPEND);
                 $parallelProcess = $this->processPool->getProcess($processIdentifier);
                 $parallelProcess->bindConnection($inDecoder, $outEncoder);
 

--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -119,10 +119,8 @@ final class ParallelFileProcessor
 
         $timeoutInSeconds = SimpleParameterProvider::provideIntParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS);
 
-        $workerCommandLineFactory = $this->workerCommandLineFactory;
         $this->processSpawner = function(
         ) use (
-            $workerCommandLineFactory,
             &$systemErrors,
             &$fileDiffs,
             &$jobs,
@@ -138,7 +136,7 @@ final class ParallelFileProcessor
         ): void {
 
             $processIdentifier = Random::generate();
-            $workerCommandLine = $workerCommandLineFactory->create(
+            $workerCommandLine = $this->workerCommandLineFactory->create(
                 $mainScript,
                 ProcessCommand::class,
                 'worker',

--- a/src/Console/Output/RectorOutputStyle.php
+++ b/src/Console/Output/RectorOutputStyle.php
@@ -28,6 +28,11 @@ final class RectorOutputStyle implements OutputStyleInterface
         $this->rectorConsoleOutputStyle->progressAdvance($step);
     }
 
+    public function progressFinish(): void
+    {
+        $this->rectorConsoleOutputStyle->progressFinish();
+    }
+
     public function error(string $message): void
     {
         $this->rectorConsoleOutputStyle->error($message);

--- a/src/Console/Style/RectorConsoleOutputStyle.php
+++ b/src/Console/Style/RectorConsoleOutputStyle.php
@@ -81,4 +81,15 @@ final class RectorConsoleOutputStyle extends SymfonyStyle
     {
         return $this->progressBar ?? throw new RuntimeException('The ProgressBar is not started.');
     }
+
+    public function progressFinish(): void
+    {
+        // hide progress bar in tests
+        if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+            return;
+        }
+
+        $progressBar = $this->getProgressBar();
+        $progressBar->finish();
+    }
 }

--- a/src/Contract/Console/OutputStyleInterface.php
+++ b/src/Contract/Console/OutputStyleInterface.php
@@ -34,4 +34,6 @@ interface OutputStyleInterface
     public function progressStart(int $fileCount): void;
 
     public function progressAdvance(int $step = 1): void;
+
+    public function progressFinish(): void;
 }


### PR DESCRIPTION
## Context
As described here https://github.com/rectorphp/rector/discussions/7891
I had some issues with memory usage, which caused some issues on a very large project.

I tried out this PR https://github.com/rectorphp/rector-src/pull/3563 but as described in https://github.com/rectorphp/rector-src/pull/3563#issuecomment-1519941646 it was not enough for my usecase.

## What is this PR doing

This PR introduces the ability to "restart" spawned workers to reset their memory usage.
In the current Draft it is doing this hardcoded after 10 Iterations. Which should be high enough to not affect the normal usage, but low enough to improve the situation for big projects.
And its abstracted into a property, so adding a setting later is relatively easy. (later, because it opens up questions on how to configure the parallelization properly, especially the conditions for the restarting)

## What I changed

I basically just added the lines 186-195 and moved the process spawning into an own callable, so it can get called repeatedly.

I would like to move more into class properties and methods, but thats not so easy and might make the Review harder

## Performance comparison

files per restart = jobsize * (onData iterations till restart)

First one comparison extended with the previously linked PR
https://github.com/rectorphp/rector-src/pull/3563#issuecomment-1519941646

|-|Run A|| Run B|Run C||
|- | -- | -- | -- | -- | -- |
|version|last release|last release| PR 3563|this draft|this draft|
|parallelization|1|3|3|3|6|
|files per restart|X|X|X|200|200|
|Time Real|2m 17s| 1m 15s| 12m 58s|2m 35s| 1m 51s|
|Time User|2m 02s| 2m 43s | 32m 23s|6m 28s| 8m 34s |
|totalmemory max| ~4G |~6G | ~0.5G | ~3-4G |~5G |



But now also one Run for the Full project (19.943 files), not only a subset

|-|Run D|||
|- | -- | -- | -- |
|version|this draft|this draft| ### |
|parallelization|6|6|3|
|files per restart|1000|500||
|Time Real|X| 8m 50s| ###|
|Time User|X| 45m 12s | ###|
|totalmemory max| ~18G |~11G | ### |

With 1.000 Files per restart, it still exceeded to much my available memory, but with 500 it did fit into memory and I was able to use 100% of my available CPUs, drastically cutting down the needed Real Time.

### updated performance test


Setup:
WSL2, Linux, php 8.1
cpu: physical cores 6, logical 12
Ram: 32 GB (25GB allowed for WSL2)


used config:
```php
return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths([
        __DIR__ . '/src',
        __DIR__ . '/../symfony',
    ]);

    // usual config
    //$rectorConfig->parallel(120*30,12,200);
    // config for yguedidi
    $rectorConfig->parallel(120*30,12,500, true);

    $rectorConfig->rule(\Rector\Php74\Rector\Ternary\ParenthesizeNestedTernaryRector::class);
};
```


On a current symfony/symfony checkout, 9629 files
last release: rector 1.6.0


| -                 | Run A        | Run B        | Run C                        | Run D        | Run E     | Run F       | Run G       | Run H       |
|:------------------|:-------------|:-------------|:-----------------------------|:-------------|:----------|-------------|-------------|-------------|
| version           | last release | last release | last release                 | last release | pr-3563   | pr-3563     | pr-3722     | pr-3722     |
| special commands  |              |              | --no-diffs --no-progress-bar |              |           |             |             |             |
| parallelization   | 16           | 6            | 6                            | 12           | 12        | 12          | 12          | 12          |
| job size          | 20           | 20           | 20                           | 500          | 500       | 200         | 20          | 10          |
| files per restart | X            | X            | X                            | x            | x         | x           | 200         | 100         |
| Time Real         | 02m 28s      | 02m 04s      | 02m 06s                      | 01m 40s      | 01m 54s   | 02m 12s     | 01m 55s     | 02m 21s     |
| Time User         | 26m 49s      | 11m 48s      | 12m 02s                      | 14m 44s      | 17m 28s   | 22m 39s     | 21m 24s     | 26m 12s     |
| process memory    | 2G           | 2G ~ 4G      | 2G ~ 4G                      | 0.6G ~ 3G    | 0.3G ~ 3G | 0.2G ~ 2.8G | 0.2G ~ 1.8G | 0.2G - 0.7G |
| totalmemory max   | ~24G         | ~18G         | ~18G                         | ~14G         | ~9G       | 5GB         | 5G          | 4G          |

and this one is after merging in the changes from the last release

| -                 | Run J           |
|:------------------|-----------------|
| version           | pr-3722 updated |
| special commands  |                 |
| parallelization   | 12              |
| job size          | 20              |
| files per restart | 200             |
| Time Real         | 02m 16s         |
| Time User         | 25m 14s         |
| process memory    | 0.2G ~ 0.9G     |
| totalmemory max   | 6G              |


