### PR TITLE
[Util]: Use `instanceof` instead of `is_a()`

### DIFF
--- a/src/Util/MultiInstanceofChecker.php
+++ b/src/Util/MultiInstanceofChecker.php
@@ -9,10 +9,10 @@ final class MultiInstanceofChecker
     /**
      * @param array<class-string> $types
      */
-    public function isInstanceOf(object | string $object, array $types): bool
+    public function isInstanceOf(object $object, array $types): bool
     {
         foreach ($types as $type) {
-            if (is_a($object, $type, true)) {
+            if ($object instanceof $type) {
                 return true;
             }
         }


### PR DESCRIPTION
`is_a()` is a runtime concept which should not be used in static analysis context