### PR TITLE
Add SwapMethodCallArgumentsRector

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,10 +1,10 @@
-# 420 Rules Overview
+# 421 Rules Overview
 
 <br>
 
 ## Categories
 
-- [Arguments](#arguments) (5)
+- [Arguments](#arguments) (6)
 
 - [CodeQuality](#codequality) (79)
 
@@ -258,6 +258,49 @@ return static function (RectorConfig $rectorConfig): void {
      {
 -        return some_function('one', 'two', 'three');
 +        return some_function('three', 'two', 'one');
+     }
+ }
+```
+
+<br>
+
+### SwapMethodCallArgumentsRector
+
+Reorder arguments in method calls
+
+:wrench: **configure it!**
+
+- class: [`Rector\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector`](../rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Rector\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector;
+use Rector\Arguments\ValueObject\SwapMethodCallArguments;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(SwapMethodCallArgumentsRector::class, [
+        new SwapMethodCallArguments('Caller', 'call', [
+            2,
+            1,
+            0,
+        ]),
+    ]);
+};
+```
+
+↓
+
+```diff
+ final class SomeClass
+ {
+     public function run(Caller $caller)
+     {
+-        return $caller->call('one', 'two', 'three');
++        return $caller->call('three', 'two', 'one');
      }
  }
 ```

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/dynamic_call.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/dynamic_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class Fixture
+{
+    public function run(MethodCaller $caller)
+    {
+        $caller->someCall($one, $two, $three);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class Fixture
+{
+    public function run(MethodCaller $caller)
+    {
+        $caller->someCall($three, $two, $one);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/dynamic_call_immediate_return.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/dynamic_call_immediate_return.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class Fixture
+{
+    public function run(MethodCaller $caller)
+    {
+        return $caller->someCall($one, $two, $three);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class Fixture
+{
+    public function run(MethodCaller $caller)
+    {
+        return $caller->someCall($three, $two, $one);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/static_call_with_parent.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/static_call_with_parent.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class ParentCall extends MethodCaller
+{
+    public function run()
+    {
+        parent::someCall($one, $two, $three);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class ParentCall extends MethodCaller
+{
+    public function run()
+    {
+        parent::someCall($three, $two, $one);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/static_call_with_self.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/static_call_with_self.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class SelfCall extends MethodCaller
+{
+    public function run()
+    {
+        self::someCall($one, $two, $three);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+final class SelfCall extends MethodCaller
+{
+    public function run()
+    {
+        self::someCall($three, $two, $one);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/static_call_with_static.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Fixture/static_call_with_static.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+class StaticCall extends MethodCaller
+{
+    public function run()
+    {
+        static::someCall($one, $two, $three);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+class StaticCall extends MethodCaller
+{
+    public function run()
+    {
+        static::someCall($three, $two, $one);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Source/MethodCaller.php
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/Source/MethodCaller.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source;
+
+class MethodCaller
+{
+
+}

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/SwapMethodCallArgumentsRectorTest.php
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/SwapMethodCallArgumentsRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SwapMethodCallArgumentsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        foreach (self::yieldFilesFromDirectory(__DIR__ . '/Fixture') as $filePath) {
+            yield basename($filePath[0]) => $filePath;
+        }
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector;
+use Rector\Arguments\ValueObject\SwapMethodCallArguments;
+use Rector\Config\RectorConfig;
+use Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\Source\MethodCaller;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(SwapMethodCallArgumentsRector::class, [
+        new SwapMethodCallArguments(MethodCaller::class, 'someCall', [2, 1, 0]),
+    ]);
+};

--- a/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
+++ b/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
@@ -75,7 +75,7 @@ CODE_SAMPLE
         }
 
         if ($node->isFirstClassCallable()) {
-            return [];
+            return null;
         }
 
         $args = $node->getArgs();

--- a/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
+++ b/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Arguments\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Type\ObjectType;
+use Rector\Arguments\ValueObject\SwapMethodCallArguments;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\SwapMethodCallArgumentsRectorTest
+ */
+class SwapMethodCallArgumentsRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    private const JUST_SWAPPED = 'just_swapped';
+
+    /**
+     * @var SwapMethodCallArguments[]
+     */
+    private array $methodArgumentSwaps = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Reorder arguments in method calls', [
+            new ConfiguredCodeSample(<<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function run(Caller $caller)
+    {
+        return $caller->call('one', 'two', 'three');
+    }
+}
+CODE_SAMPLE
+                , <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function run(Caller $caller)
+    {
+        return $caller->call('three', 'two', 'one');
+    }
+}
+CODE_SAMPLE
+                , [new SwapMethodCallArguments('Caller', 'call', [2, 1, 0])]),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): MethodCall|StaticCall|null
+    {
+        $isJustSwapped = (bool) $node->getAttribute(self::JUST_SWAPPED, false);
+        if ($isJustSwapped) {
+            return null;
+        }
+
+        foreach ($this->methodArgumentSwaps as $methodArgumentSwap) {
+            if (! $this->isName($node->name, $methodArgumentSwap->getMethod())) {
+                continue;
+            }
+
+            if (! $this->isObjectTypeMatch($node, $methodArgumentSwap->getObjectType())) {
+                continue;
+            }
+
+            $newArguments = $this->resolveNewArguments($methodArgumentSwap, $node);
+            if ($newArguments === []) {
+                return null;
+            }
+
+            foreach ($newArguments as $newPosition => $argument) {
+                $node->args[$newPosition] = $argument;
+            }
+
+            $node->setAttribute(self::JUST_SWAPPED, true);
+
+            return $node;
+        }
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, SwapMethodCallArguments::class);
+        $this->methodArgumentSwaps = $configuration;
+    }
+
+    private function isObjectTypeMatch(MethodCall|StaticCall $node, ObjectType $objectType): bool
+    {
+        if ($node instanceof MethodCall) {
+            return $this->isObjectType($node->var, $objectType);
+        }
+        return $this->isObjectType($node->class, $objectType);
+    }
+
+    /**
+     * @return array<int, Arg>
+     */
+    private function resolveNewArguments(
+        SwapMethodCallArguments $swapMethodCallArguments,
+        MethodCall|StaticCall $call
+    ): array {
+        $newArguments = [];
+        foreach ($swapMethodCallArguments->getOrder() as $oldPosition => $newPosition) {
+            if (! isset($call->getArgs()[$oldPosition])) {
+                continue;
+            }
+
+            if (! isset($call->getArgs()[$newPosition])) {
+                continue;
+            }
+
+            $newArguments[$newPosition] = $call->getArgs()[$oldPosition];
+        }
+
+        return $newArguments;
+    }
+}

--- a/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
+++ b/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
@@ -120,6 +120,9 @@ CODE_SAMPLE
         SwapMethodCallArguments $swapMethodCallArguments,
         MethodCall|StaticCall $call
     ): array {
+        if ($call->isFirstClassCallable()) {
+            return [];
+        }
         $newArguments = [];
         foreach ($swapMethodCallArguments->getOrder() as $oldPosition => $newPosition) {
             if (! isset($call->getArgs()[$oldPosition])) {

--- a/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
+++ b/rules/Arguments/Rector/MethodCall/SwapMethodCallArgumentsRector.php
@@ -19,7 +19,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\Tests\Arguments\Rector\MethodCall\SwapMethodCallArgumentsRector\SwapMethodCallArgumentsRectorTest
  */
-class SwapMethodCallArgumentsRector extends AbstractRector implements ConfigurableRectorInterface
+final class SwapMethodCallArgumentsRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
      * @var string
@@ -74,6 +74,12 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+
         foreach ($this->methodArgumentSwaps as $methodArgumentSwap) {
             if (! $this->isName($node->name, $methodArgumentSwap->getMethod())) {
                 continue;
@@ -83,7 +89,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $newArguments = $this->resolveNewArguments($methodArgumentSwap, $node);
+            $newArguments = $this->resolveNewArguments($methodArgumentSwap, $args);
             if ($newArguments === []) {
                 return null;
             }
@@ -96,6 +102,7 @@ CODE_SAMPLE
 
             return $node;
         }
+
         return null;
     }
 
@@ -110,30 +117,27 @@ CODE_SAMPLE
         if ($node instanceof MethodCall) {
             return $this->isObjectType($node->var, $objectType);
         }
+
         return $this->isObjectType($node->class, $objectType);
     }
 
     /**
+     * @param Arg[] $args
      * @return array<int, Arg>
      */
-    private function resolveNewArguments(
-        SwapMethodCallArguments $swapMethodCallArguments,
-        MethodCall|StaticCall $call
-    ): array {
-        if ($call->isFirstClassCallable()) {
-            return [];
-        }
+    private function resolveNewArguments(SwapMethodCallArguments $swapMethodCallArguments, array $args): array
+    {
         $newArguments = [];
         foreach ($swapMethodCallArguments->getOrder() as $oldPosition => $newPosition) {
-            if (! isset($call->getArgs()[$oldPosition])) {
+            if (! isset($args[$oldPosition])) {
                 continue;
             }
 
-            if (! isset($call->getArgs()[$newPosition])) {
+            if (! isset($args[$newPosition])) {
                 continue;
             }
 
-            $newArguments[$newPosition] = $call->getArgs()[$oldPosition];
+            $newArguments[$newPosition] = $args[$oldPosition];
         }
 
         return $newArguments;

--- a/rules/Arguments/ValueObject/SwapMethodCallArguments.php
+++ b/rules/Arguments/ValueObject/SwapMethodCallArguments.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Arguments\ValueObject;
+
+use PHPStan\Type\ObjectType;
+use Rector\Core\Validation\RectorAssert;
+
+final class SwapMethodCallArguments
+{
+    /**
+     * @param array<int, int> $order
+     */
+    public function __construct(
+        private readonly string $class,
+        private readonly string $method,
+        private readonly array $order,
+    ) {
+        RectorAssert::className($class);
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->class);
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function getOrder(): array
+    {
+        return $this->order;
+    }
+}


### PR DESCRIPTION
I was missing this feature during the development. Tell me if i forgot something or if I need to open an issue.

I was inspired by `SwapFuncCallArgumentsRector` to write this rector, so there is a bit of code duplication. I was hesitating to get out the `SwapMethodCallArgumentsRector::resolveNewArguments` method but didn't find a suited name neither namespace for a class. If you have any idea I'll be glad to refactor this.