### PR TITLE
CI: make linting errors appear in PRs 'Files Changed' tab

### DIFF
--- a/.github/workflows/php_linter.yaml
+++ b/.github/workflows/php_linter.yaml
@@ -20,7 +20,8 @@ jobs:
                 with:
                     php-version: 8.1
                     coverage: none
+                    tools: cs2pr
 
             -   run: composer global require php-parallel-lint/php-parallel-lint --ansi
 
-            -   run: /home/runner/.composer/vendor/bin/parallel-lint src bin/rector config tests packages rules --colors --exclude rules/psr4/tests/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/Source --exclude packages/node-type-resolver/tests/PerNodeTypeResolver/PropertyFetchTypeResolver/Source --exclude rules/nette-kdyby/tests/Rector/MethodCall/ReplaceEventManagerWithEventSubscriberRector/Source/ExpectedSomeClassCopyEvent.php --exclude rules/nette-kdyby/tests/Rector/MethodCall/ReplaceMagicPropertyEventWithEventClassRector/Source --exclude rules/type-declaration/tests/Rector/ClassMethod/ParamTypeFromStrictTypedPropertyRector/Source
+            -   run: /home/runner/.composer/vendor/bin/parallel-lint src bin/rector config tests packages rules --colors --exclude rules/psr4/tests/Rector/Namespace_/MultipleClassFileToPsr4ClassesRector/Source --exclude packages/node-type-resolver/tests/PerNodeTypeResolver/PropertyFetchTypeResolver/Source --exclude rules/nette-kdyby/tests/Rector/MethodCall/ReplaceEventManagerWithEventSubscriberRector/Source/ExpectedSomeClassCopyEvent.php --exclude rules/nette-kdyby/tests/Rector/MethodCall/ReplaceMagicPropertyEventWithEventClassRector/Source --exclude rules/type-declaration/tests/Rector/ClassMethod/ParamTypeFromStrictTypedPropertyRector/Source --checkstyle | cs2pr


### PR DESCRIPTION
example (with phpunit error message):

![phpunit-printer-context](https://user-images.githubusercontent.com/120441/236210047-0d2ebdb6-5b6c-4e29-b671-b87af2feab36.png)

using https://github.com/staabm/annotate-pull-request-from-checkstyle