### PR TITLE
Fix ExplicitMethodCallOverMagicGetSetRector with a protected method

### DIFF
--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_protected_methods.php.inc
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Fixture/skip_protected_methods.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source\ObjectWithMagicCallsProtectedMethods;
+
+final class SkipProtectedMethods
+{
+    public function run(ObjectWithMagicCallsProtectedMethods $object)
+    {
+        return $object->name;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsProtectedMethods.php
+++ b/rules-tests/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector/Source/ObjectWithMagicCallsProtectedMethods.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\PropertyFetch\ExplicitMethodCallOverMagicGetSetRector\Source;
+
+use Nette\SmartObject;
+
+final class ObjectWithMagicCallsProtectedMethods
+{
+    // adds magic __get() and __set() methods
+    use SmartObject;
+
+    private $name;
+
+    protected function getName()
+    {
+        return $this->name;
+    }
+
+    protected function setName(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
+++ b/rules/CodeQuality/Rector/PropertyFetch/ExplicitMethodCallOverMagicGetSetRector.php
@@ -167,6 +167,10 @@ CODE_SAMPLE
 
             $methodReflection = $callerType->getMethod($possibleGetterMethodName, $scope);
 
+            if (! $methodReflection->isPublic()) {
+                continue;
+            }
+
             $variant = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
             $returnType = $variant->getReturnType();
 


### PR DESCRIPTION
The `ExplicitMethodCallOverMagicGetSetRector` changes magic get calls to method calls even though they are not public.