### PR TITLE
[NodeTypeResolver] Simplify NodeTypeResolver: remove IdentifierTypeResolver dependency

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -40,7 +40,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeCorrector\AccessoryNonEmptyStringTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeCorrector\GenericClassStringTypeCorrector;
 use Rector\NodeTypeResolver\NodeTypeCorrector\HasOffsetTypeCorrector;
-use Rector\NodeTypeResolver\NodeTypeResolver\IdentifierTypeResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\TypeDeclaration\PHPStan\ObjectTypeSpecifier;
@@ -62,7 +61,6 @@ final class NodeTypeResolver
         private readonly ReflectionProvider $reflectionProvider,
         private readonly HasOffsetTypeCorrector $hasOffsetTypeCorrector,
         private readonly AccessoryNonEmptyStringTypeCorrector $accessoryNonEmptyStringTypeCorrector,
-        private readonly IdentifierTypeResolver $identifierTypeResolver,
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
         array $nodeTypeResolvers
     ) {
@@ -173,19 +171,10 @@ final class NodeTypeResolver
                 }
             }
 
-            if ($node instanceof Identifier) {
-                return $this->identifierTypeResolver->resolve($node);
-            }
-
             return new MixedType();
         }
 
         if (! $node instanceof Expr) {
-            // scalar type, e.g. from param type name
-            if ($node instanceof Identifier) {
-                return $this->identifierTypeResolver->resolve($node);
-            }
-
             return new MixedType();
         }
 

--- a/packages/NodeTypeResolver/NodeTypeResolver/IdentifierTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/IdentifierTypeResolver.php
@@ -11,6 +11,9 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 
+/**
+ * @implements NodeTypeResolverInterface<Identifier>
+ */
 final class IdentifierTypeResolver
 {
     public function resolve(Identifier $identifier): StringType | BooleanType | IntegerType | FloatType | MixedType

--- a/packages/NodeTypeResolver/NodeTypeResolver/IdentifierTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/IdentifierTypeResolver.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\NodeTypeResolver;
 
+use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 
 /**

--- a/packages/NodeTypeResolver/NodeTypeResolver/IdentifierTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/IdentifierTypeResolver.php
@@ -10,27 +10,40 @@ use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
+use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 
 /**
  * @implements NodeTypeResolverInterface<Identifier>
  */
-final class IdentifierTypeResolver
+final class IdentifierTypeResolver implements NodeTypeResolverInterface
 {
-    public function resolve(Identifier $identifier): StringType | BooleanType | IntegerType | FloatType | MixedType
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeClasses(): array
     {
-        if ($identifier->toLowerString() === 'string') {
+        return [Identifier::class];
+    }
+
+    /**
+     * @param Identifier $node
+     * @return StringType|BooleanType|IntegerType|FloatType|MixedType
+     */
+    public function resolve(Node $node): Type
+    {
+        if ($node->toLowerString() === 'string') {
             return new StringType();
         }
 
-        if ($identifier->toLowerString() === 'bool') {
+        if ($node->toLowerString() === 'bool') {
             return new BooleanType();
         }
 
-        if ($identifier->toLowerString() === 'int') {
+        if ($node->toLowerString() === 'int') {
             return new IntegerType();
         }
 
-        if ($identifier->toLowerString() === 'float') {
+        if ($node->toLowerString() === 'float') {
             return new FloatType();
         }
 


### PR DESCRIPTION
`IdentifierTypeResolver` already included inside `nodeTypeResolvers` params in `__construct()`:

https://github.com/rectorphp/rector-src/blob/657ec2e5af81361107cafc9c842b1d9cdf4ed760/packages/NodeTypeResolver/NodeTypeResolver.php#L67

then, it called early:

https://github.com/rectorphp/rector-src/blob/657ec2e5af81361107cafc9c842b1d9cdf4ed760/packages/NodeTypeResolver/NodeTypeResolver.php#L151

Make `IdentifierTypeResolver` implemenst `NodeTypeResolverInterface` so no need to double check it.

so no need to double check it.