### PR TITLE
Use a fixer autoloader suffix for the prefixed rector

### DIFF
--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -37,6 +37,7 @@ wget https://github.com/humbug/php-scoper/releases/download/0.17.7/php-scoper.ph
 php -d memory_limit=-1 php-scoper.phar add-prefix bin config src packages rules vendor composer.json --output-dir "../$RESULT_DIRECTORY" --config scoper.php --force --ansi --working-dir "$BUILD_DIRECTORY";
 
 note "Dumping Composer Autoload"
+composer config --working-dir "$RESULT_DIRECTORY" autoloader-suffix PrefixedRector
 composer dump-autoload --working-dir "$RESULT_DIRECTORY" --ansi --classmap-authoritative --no-dev
 
 rm -rf "$BUILD_DIRECTORY"


### PR DESCRIPTION
This makes the generation of the scoped repository more reproducible.

Note that this is not yet fully reproducible as the PHP-Scoper config uses the year+month as part of the suffix (so it is reproducible only during the same month)