### PR TITLE
[Caching] Fix dependent files not yet exists on ChangedFilesDetector::cacheFileWithDependencies()

### DIFF
--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -51,6 +51,11 @@ final class ChangedFilesDetector
         $hash = $this->hashFile($filePath);
 
         $this->cache->save($filePathCacheKey, CacheKey::FILE_HASH_KEY, $hash);
+
+        if (! isset($this->dependentFiles[$filePathCacheKey])) {
+            return;
+        }
+
         $this->cache->save(
             $filePathCacheKey . '_files',
             CacheKey::DEPENDENT_FILES_KEY,


### PR DESCRIPTION
@yguedidi this should fix https://github.com/rectorphp/rector/issues/7919