### PR TITLE
[CodeQuality][Php56] Do not add unnecessary init value on ThrowWithPreviousExceptionRector+OptionalParametersAfterRequiredRector+AddDefaultValueForUndefinedVariableRector

### DIFF
--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -123,7 +123,7 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        // when parent Node origNode is null, it must parent Node just reprinted, so it can't be verified
+        // when parent Node origNode is null, it means parent Node just reprinted, so it can't be verified
         // so skip it
         return ! $parentNode->getAttribute(AttributeKey::ORIGINAL_NODE) instanceof Node;
     }

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Case_;
+use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Function_;
@@ -117,9 +118,19 @@ final class UndefinedVariableResolver
         return $currentStmt instanceof Stmt && $currentStmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true;
     }
 
-    private function issetOrUnsetOrEmptyParent(Node $parentNode): bool
+    private function shouldSkipWithParent(Node $parentNode, Variable $variable): bool
     {
-        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true);
+        if (in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true)) {
+            return true;
+        }
+
+        $originalNode = $variable->getAttribute(AttributeKey::ORIGINAL_NODE);
+        if (! $originalNode instanceof Node) {
+            return false;
+        }
+
+        $originalNodeParent = $originalNode->getAttribute(AttributeKey::PARENT_NODE);
+        return $originalNodeParent instanceof Catch_;
     }
 
     private function isAsCoalesceLeftOrAssignOpCoalesceVar(Node $parentNode, Variable $variable): bool
@@ -150,7 +161,7 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        if ($this->issetOrUnsetOrEmptyParent($parentNode)) {
+        if ($this->shouldSkipWithParent($parentNode, $variable)) {
             return true;
         }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Php56\NodeAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
@@ -118,9 +117,9 @@ final class UndefinedVariableResolver
         return $currentStmt instanceof Stmt && $currentStmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true;
     }
 
-    private function shouldSkipWithParent(Node $parentNode): bool
+    private function issetOrUnsetOrEmptyParent(Node $parentNode): bool
     {
-        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class, Arg::class], true);
+        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true);
     }
 
     private function isAsCoalesceLeftOrAssignOpCoalesceVar(Node $parentNode, Variable $variable): bool
@@ -151,7 +150,7 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        if ($this->shouldSkipWithParent($parentNode)) {
+        if ($this->issetOrUnsetOrEmptyParent($parentNode)) {
             return true;
         }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -129,8 +129,8 @@ final class UndefinedVariableResolver
             return false;
         }
 
-        $originalNodeParent = $originalNode->getAttribute(AttributeKey::PARENT_NODE);
-        return $originalNodeParent instanceof Catch_;
+        $node = $originalNode->getAttribute(AttributeKey::PARENT_NODE);
+        return $node instanceof Catch_;
     }
 
     private function isAsCoalesceLeftOrAssignOpCoalesceVar(Node $parentNode, Variable $variable): bool

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -123,6 +123,8 @@ final class UndefinedVariableResolver
             return true;
         }
 
+        // when parent Node origNode is null, it must parent Node just reprinted, so it can't be verified
+        // so skip it
         return ! $parentNode->getAttribute(AttributeKey::ORIGINAL_NODE) instanceof Node;
     }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -20,7 +20,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Case_;
-use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Function_;
@@ -118,19 +117,9 @@ final class UndefinedVariableResolver
         return $currentStmt instanceof Stmt && $currentStmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true;
     }
 
-    private function shouldSkipWithParent(Node $parentNode, Variable $variable): bool
+    private function issetOrUnsetOrEmptyParent(Node $parentNode): bool
     {
-        if (in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true)) {
-            return true;
-        }
-
-        $originalNode = $variable->getAttribute(AttributeKey::ORIGINAL_NODE);
-        if (! $originalNode instanceof Node) {
-            return false;
-        }
-
-        $originalNodeParent = $originalNode->getAttribute(AttributeKey::PARENT_NODE);
-        return $originalNodeParent instanceof Catch_;
+        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true);
     }
 
     private function isAsCoalesceLeftOrAssignOpCoalesceVar(Node $parentNode, Variable $variable): bool
@@ -161,7 +150,7 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        if ($this->shouldSkipWithParent($parentNode, $variable)) {
+        if ($this->issetOrUnsetOrEmptyParent($parentNode)) {
             return true;
         }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -129,8 +129,8 @@ final class UndefinedVariableResolver
             return false;
         }
 
-        $node = $originalNode->getAttribute(AttributeKey::PARENT_NODE);
-        return $node instanceof Catch_;
+        $originalNodeParent = $originalNode->getAttribute(AttributeKey::PARENT_NODE);
+        return $originalNodeParent instanceof Catch_;
     }
 
     private function isAsCoalesceLeftOrAssignOpCoalesceVar(Node $parentNode, Variable $variable): bool

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -117,9 +117,13 @@ final class UndefinedVariableResolver
         return $currentStmt instanceof Stmt && $currentStmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true;
     }
 
-    private function issetOrUnsetOrEmptyParent(Node $parentNode): bool
+    private function shouldSkipWithParent(Node $parentNode): bool
     {
-        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true);
+        if (in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true)) {
+            return true;
+        }
+
+        return ! $parentNode->getAttribute(AttributeKey::ORIGINAL_NODE) instanceof Node;
     }
 
     private function isAsCoalesceLeftOrAssignOpCoalesceVar(Node $parentNode, Variable $variable): bool
@@ -150,7 +154,7 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        if ($this->issetOrUnsetOrEmptyParent($parentNode)) {
+        if ($this->shouldSkipWithParent($parentNode)) {
             return true;
         }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Php56\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
@@ -117,9 +118,9 @@ final class UndefinedVariableResolver
         return $currentStmt instanceof Stmt && $currentStmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true;
     }
 
-    private function issetOrUnsetOrEmptyParent(Node $parentNode): bool
+    private function shouldSkipWithParent(Node $parentNode): bool
     {
-        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class], true);
+        return in_array($parentNode::class, [Unset_::class, UnsetCast::class, Isset_::class, Empty_::class, Arg::class], true);
     }
 
     private function isAsCoalesceLeftOrAssignOpCoalesceVar(Node $parentNode, Variable $variable): bool
@@ -150,7 +151,7 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        if ($this->issetOrUnsetOrEmptyParent($parentNode)) {
+        if ($this->shouldSkipWithParent($parentNode)) {
             return true;
         }
 

--- a/tests/Issues/DefaultValueOptionalThrow/DefaultValueOptionalThrowTest.php
+++ b/tests/Issues/DefaultValueOptionalThrow/DefaultValueOptionalThrowTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\DefaultValueOptionalThrow;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DefaultValueOptionalThrowTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DefaultValueOptionalThrow/Fixture/do_not_add_init_value.php.inc
+++ b/tests/Issues/DefaultValueOptionalThrow/Fixture/do_not_add_init_value.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\DefaultValueOptionalThrow\Fixture;
+
+use Exception;
+
+class DoNotAddInitValue
+{
+    public function run()
+    {
+        try {
+            return 1;
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\DefaultValueOptionalThrow\Fixture;
+
+use Exception;
+
+class DoNotAddInitValue
+{
+    public function run()
+    {
+        try {
+            return 1;
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}
+
+?>

--- a/tests/Issues/DefaultValueOptionalThrow/config/configured_rule.php
+++ b/tests/Issues/DefaultValueOptionalThrow/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector;
+use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
+use Rector\Config\RectorConfig;
+use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        OptionalParametersAfterRequiredRector::class,
+        ThrowWithPreviousExceptionRector::class,
+        AddDefaultValueForUndefinedVariableRector::class,
+    ]);
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7922
Ref https://getrector.com/demo/261db1ad-7154-40e3-be4d-eb89bda2f22f