### PR TITLE
Use exception for system errors

### DIFF
--- a/src/Application/FileProcessor/ChainFileProcessor.php
+++ b/src/Application/FileProcessor/ChainFileProcessor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Application\FileProcessor;
+
+use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\ValueObject\Application\File;
+use Rector\Core\ValueObject\Configuration;
+use Rector\Core\ValueObject\Reporting\FileDiff;
+
+final class ChainFileProcessor
+{
+    /**
+     * @var string[]
+     */
+    private readonly array $supportedFileExtensions;
+
+    /**
+     * @param FileProcessorInterface[] $fileProcessors
+     */
+    public function __construct(
+        private readonly array $fileProcessors = [],
+    ) {
+        $supportedFileExtensions = [];
+
+        foreach ($this->fileProcessors as $fileProcessor) {
+            $supportedFileExtensions = array_merge(
+                $supportedFileExtensions,
+                $fileProcessor->getSupportedFileExtensions(),
+            );
+        }
+
+        $this->supportedFileExtensions = $supportedFileExtensions;
+    }
+
+    public function process(File $file, Configuration $configuration): ?FileDiff
+    {
+        foreach ($this->fileProcessors as $fileProcessor) {
+            if (! $fileProcessor->supports($file, $configuration)) {
+                continue;
+            }
+
+            $fileDiff = $fileProcessor->process($file, $configuration);
+
+            if ($fileDiff instanceof FileDiff) {
+                return $fileDiff;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedFileExtensions(): array
+    {
+        return $this->supportedFileExtensions;
+    }
+}

--- a/src/Contract/Processor/FileProcessorInterface.php
+++ b/src/Contract/Processor/FileProcessorInterface.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Core\Contract\Processor;
 
+use Rector\Core\Exception\ParsingException;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
-use Rector\Core\ValueObject\Error\SystemError;
 use Rector\Core\ValueObject\Reporting\FileDiff;
 
 interface FileProcessorInterface
@@ -14,9 +14,9 @@ interface FileProcessorInterface
     public function supports(File $file, Configuration $configuration): bool;
 
     /**
-     * @return array{system_errors: SystemError[], file_diffs: FileDiff[]}
+     * @throws ParsingException
      */
-    public function process(File $file, Configuration $configuration): array;
+    public function process(File $file, Configuration $configuration): ?FileDiff;
 
     /**
      * @return string[]

--- a/src/Exception/ParsingException.php
+++ b/src/Exception/ParsingException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Exception;
+
+use Exception;
+use Rector\Core\ValueObject\Error\SystemError;
+
+final class ParsingException extends Exception
+{
+    public function __construct(public readonly SystemError $systemError)
+    {
+        parent::__construct();
+    }
+
+    public function getSystemError(): SystemError
+    {
+        return $this->systemError;
+    }
+}

--- a/src/ValueObjectFactory/Application/FileFactory.php
+++ b/src/ValueObjectFactory/Application/FileFactory.php
@@ -6,7 +6,7 @@ namespace Rector\Core\ValueObjectFactory\Application;
 
 use Nette\Utils\FileSystem;
 use Rector\Caching\Detector\ChangedFilesDetector;
-use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\Application\FileProcessor\ChainFileProcessor;
 use Rector\Core\FileSystem\FilesFinder;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
@@ -16,13 +16,10 @@ use Rector\Core\ValueObject\Configuration;
  */
 final class FileFactory
 {
-    /**
-     * @param FileProcessorInterface[] $fileProcessors
-     */
     public function __construct(
         private readonly FilesFinder $filesFinder,
         private readonly ChangedFilesDetector $changedFilesDetector,
-        private readonly array $fileProcessors,
+        private readonly ChainFileProcessor $chainFileProcessor,
     ) {
     }
 
@@ -60,14 +57,7 @@ final class FileFactory
      */
     private function resolveSupportedFileExtensions(Configuration $configuration): array
     {
-        $supportedFileExtensions = [];
-
-        foreach ($this->fileProcessors as $fileProcessor) {
-            $supportedFileExtensions = array_merge(
-                $supportedFileExtensions,
-                $fileProcessor->getSupportedFileExtensions()
-            );
-        }
+        $supportedFileExtensions = $this->chainFileProcessor->getSupportedFileExtensions();
 
         // basic PHP extensions
         $supportedFileExtensions = array_merge($supportedFileExtensions, $configuration->getFileExtensions());


### PR DESCRIPTION
I believe this makes the API for some services cleaner, and it makes sense to use exceptions for errors and catch them at the right high level, not too soon

- [x] ~~#3740~~
- [x] #3741
- [x] make tests pass