### PR TITLE
Revert Performance: Early return in PhpDocNode refactoring for class renames (#3509)

### DIFF
--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -100,11 +100,6 @@ final class ClassRenamer
      */
     private function refactorPhpDoc(Node $node, array $oldToNewTypes, array $oldToNewClasses): void
     {
-        if (!$this->hasOriginalNodePhpDoc($node)) {
-            // no need to create empty PHPDoc nodes and traverse over those, if the code had no PHPDoc in the first place
-            return;
-        }
-
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if (! $phpDocInfo->hasByTypes(NodeTypes::TYPE_AWARE_NODES) && ! $phpDocInfo->hasByAnnotationClasses(
             NodeTypes::TYPE_AWARE_DOCTRINE_ANNOTATION_CLASSES
@@ -491,18 +486,5 @@ final class ClassRenamer
     private function resolveOldToNewClassCallbacks(Node $node, array $oldToNewClasses): array
     {
         return [...$oldToNewClasses, ...$this->renameClassCallbackHandler->getOldToNewClassesFromNode($node)];
-    }
-
-    /**
-     * Checks whether the original node has any PHPDoc comments.
-     */
-    private function hasOriginalNodePhpDoc(Node $node): bool
-    {
-        $origNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-        if ($origNode instanceof Node && $origNode->getDocComment() === null && $origNode->getComments() === []) {
-            return false;
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
This reverts commit 48e431b52386ed8a200bc5f6e697fcf6f3a2db8f.

@keulinho this needs to revert PR https://github.com/rectorphp/rector-src/pull/3509 as cause error on latest main branch 

https://github.com/rectorphp/rector-src/actions/runs/4902565356/jobs/8754485599
