### PR TITLE
Defer type-resolving in UseIdenticalOverEqualWithSameTypeRector

### DIFF
--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -73,7 +73,6 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $leftStaticType = $this->getType($node->left);
-        $rightStaticType = $this->getType($node->right);
 
         // objects can be different by content
         if ($leftStaticType instanceof ObjectType) {
@@ -84,6 +83,7 @@ CODE_SAMPLE
             return null;
         }
 
+        $rightStaticType = $this->getType($node->right);
         if ($rightStaticType instanceof MixedType) {
             return null;
         }


### PR DESCRIPTION
type resolving is the slowest part in rector profiles

<img width="508" alt="grafik" src="https://user-images.githubusercontent.com/120441/236693964-6249f9c9-7efc-44ac-8e25-c7de119cbd04.png">

we try to not trigger resolving when possible