### PR TITLE
[Php70] Skip curly named variable on ThisCallOnStaticMethodToStaticCallRector

### DIFF
--- a/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/skip_named_curly_variable.php.inc
+++ b/rules-tests/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector/Fixture/skip_named_curly_variable.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector\Fixture;
+
+final class SkipNamedCurlyVariable
+{
+    public static function macro()
+    {
+    }
+
+    public function run()
+    {
+        $macros = ['whateverName'];
+        $attributes = ['attribute1' => 'test', 'whateverName' => 'macro code example'];
+
+        foreach (array_keys($macros) as $macro) {
+            if (isset($attributes[$macro])) {
+                is_array($attributes[$macro]) ? $this->{$macro}($attributes[$macro]) : $this->{$macro}([]);
+                continue;
+            }
+        }
+    }
+}

--- a/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -7,6 +7,7 @@ namespace Rector\Php70\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Reflection\Php\PhpMethodReflection;
@@ -95,6 +96,10 @@ CODE_SAMPLE
         }
 
         if (! $this->nodeNameResolver->isName($node->var, 'this')) {
+            return null;
+        }
+
+        if (! $node->name instanceof Identifier) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7921