### PR TITLE
Get rid of `AttributeKey::SCOPE` in the NodeNameResolver subsystem

### DIFF
--- a/packages/NodeNameResolver/Contract/NodeNameResolverInterface.php
+++ b/packages/NodeNameResolver/Contract/NodeNameResolverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeNameResolver\Contract;
 
 use PhpParser\Node;
+use PHPStan\Analyser\Scope;
 
 /**
  * @template TNode as Node
@@ -19,5 +20,5 @@ interface NodeNameResolverInterface
     /**
      * @param TNode $node
      */
-    public function resolve(Node $node): ?string;
+    public function resolve(Node $node, ?Scope $scope): ?string;
 }

--- a/packages/NodeNameResolver/NodeNameResolver/ClassConstFetchNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/ClassConstFetchNameResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeNameResolver\NodeNameResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -31,7 +32,7 @@ final class ClassConstFetchNameResolver implements NodeNameResolverInterface
     /**
      * @param ClassConstFetch $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         $class = $this->nodeNameResolver->getName($node->class);
         $name = $this->nodeNameResolver->getName($node->name);

--- a/packages/NodeNameResolver/NodeNameResolver/ClassConstNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/ClassConstNameResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeNameResolver\NodeNameResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassConst;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -31,7 +32,7 @@ final class ClassConstNameResolver implements NodeNameResolverInterface
     /**
      * @param ClassConst $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         if ($node->consts === []) {
             return null;

--- a/packages/NodeNameResolver/NodeNameResolver/ClassNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/ClassNameResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassLike;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -33,7 +34,7 @@ final class ClassNameResolver implements NodeNameResolverInterface
     /**
      * @param ClassLike $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         if ($node->namespacedName instanceof Name) {
             return $node->namespacedName->toString();

--- a/packages/NodeNameResolver/NodeNameResolver/EmptyNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/EmptyNameResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeNameResolver\NodeNameResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Empty_;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 
 /**
@@ -21,7 +22,7 @@ final class EmptyNameResolver implements NodeNameResolverInterface
     /**
      * @param Empty_ $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         return 'empty';
     }

--- a/packages/NodeNameResolver/NodeNameResolver/FuncCallNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/FuncCallNameResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -33,7 +34,7 @@ final class FuncCallNameResolver implements NodeNameResolverInterface
      *
      * @param FuncCall $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         if ($node->name instanceof Expr) {
             return null;

--- a/packages/NodeNameResolver/NodeNameResolver/FunctionNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/FunctionNameResolver.php
@@ -23,11 +23,10 @@ final class FunctionNameResolver implements NodeNameResolverInterface
     /**
      * @param Function_ $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         $bareName = (string) $node->name;
 
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
         if (! $scope instanceof Scope) {
             return $bareName;
         }

--- a/packages/NodeNameResolver/NodeNameResolver/NameNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/NameNameResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -29,12 +30,12 @@ final class NameNameResolver implements NodeNameResolverInterface
     /**
      * @param Name $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         // possible function parent
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
         if ($parentNode instanceof FuncCall) {
-            return $this->funcCallNameResolver->resolve($parentNode);
+            return $this->funcCallNameResolver->resolve($parentNode, $scope);
         }
 
         $resolvedName = $node->getAttribute(AttributeKey::RESOLVED_NAME);

--- a/packages/NodeNameResolver/NodeNameResolver/ParamNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/ParamNameResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeNameResolver\NodeNameResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Param;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -31,7 +32,7 @@ final class ParamNameResolver implements NodeNameResolverInterface
     /**
      * @param Param $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         return $this->nodeNameResolver->getName($node->var);
     }

--- a/packages/NodeNameResolver/NodeNameResolver/PropertyNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/PropertyNameResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeNameResolver\NodeNameResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -31,7 +32,7 @@ final class PropertyNameResolver implements NodeNameResolverInterface
     /**
      * @param Property $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         if ($node->props === []) {
             return null;

--- a/packages/NodeNameResolver/NodeNameResolver/UseNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/UseNameResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeNameResolver\NodeNameResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Use_;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -31,7 +32,7 @@ final class UseNameResolver implements NodeNameResolverInterface
     /**
      * @param Use_ $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         if ($node->uses === []) {
             return null;

--- a/packages/NodeNameResolver/NodeNameResolver/VariableNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver/VariableNameResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -24,7 +25,7 @@ final class VariableNameResolver implements NodeNameResolverInterface
     /**
      * @param Variable $node
      */
-    public function resolve(Node $node): ?string
+    public function resolve(Node $node, ?Scope $scope): ?string
     {
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 

--- a/rules/Php82/Rector/New_/FilesystemIteratorSkipDotsRector.php
+++ b/rules/Php82/Rector/New_/FilesystemIteratorSkipDotsRector.php
@@ -108,6 +108,6 @@ final class FilesystemIteratorSkipDotsRector extends AbstractRector implements M
             return true;
         }
 
-        return $this->classConstFetchNameResolver->resolve($expr) === 'FilesystemIterator::SKIP_DOTS';
+        return $this->classConstFetchNameResolver->resolve($expr, null) === 'FilesystemIterator::SKIP_DOTS';
     }
 }


### PR DESCRIPTION
A first step of a ongoing refactoring

refs https://github.com/rectorphp/rector/discussions/7924