### PR TITLE
Ease finding slow files

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -234,6 +234,14 @@ CODE_SAMPLE;
             throw new ShouldNotHappenException($errorMessage);
         }
 
+        return $this->postRefactorProcess($originalNode, $node, $refactoredNode);
+    }
+
+    /**
+     * @param Node|Node[] $refactoredNode
+     */
+    private function postRefactorProcess(Node|null $originalNode, Node $node, Node|array $refactoredNode): Node
+    {
         $originalNode ??= $node;
 
         /** @var non-empty-array<Node>|Node $refactoredNode */

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -468,7 +468,12 @@ CODE_SAMPLE;
         $elapsedTime = microtime(true) - $startTime;
         $currentTotalMemory = memory_get_peak_usage(true);
 
-        $this->rectorOutputStyle->writeln(sprintf('--- consumed %s, total %s, took %.2f s', BytesHelper::bytes($currentTotalMemory - $previousMemory), BytesHelper::bytes($currentTotalMemory), $elapsedTime));
+        $consumed = sprintf(
+            '--- consumed %s, total %s, took %.2f s',
+            BytesHelper::bytes($currentTotalMemory - $previousMemory),
+            BytesHelper::bytes($currentTotalMemory), $elapsedTime
+        );
+        $this->rectorOutputStyle->writeln($consumed);
         $this->rectorOutputStyle->newLine(1);
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -198,23 +198,31 @@ CODE_SAMPLE;
             return null;
         }
 
+        $isDebug = $this->rectorOutputStyle->isDebug();
+
         $this->currentRectorProvider->changeCurrentRector($this);
         // for PHP doc info factory and change notifier
         $this->currentNodeProvider->setNode($node);
 
-        $this->printDebugCurrentFileAndRule();
+        if ($isDebug) {
+            $this->printCurrentFileAndRule();
+        }
 
         $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
         if ($originalNode instanceof Node) {
             $this->changedNodeScopeRefresher->reIndexNodeAttributes($node);
         }
 
-        $startTime = microtime(true);
-        $previousMemory = memory_get_peak_usage(true);
+        if ($isDebug) {
+            $startTime = microtime(true);
+            $previousMemory = memory_get_peak_usage(true);
+        }
 
         $refactoredNode = $this->refactor($node);
 
-        $this->printDebugConsumptions($startTime, $previousMemory);
+        if ($isDebug) {
+            $this->printConsumptions($startTime, $previousMemory);
+        }
 
         // nothing to change or just removed via removeNode() → continue
         if ($refactoredNode === null) {
@@ -447,24 +455,16 @@ CODE_SAMPLE;
         $this->nodeConnectingTraverser->traverse($nodes);
     }
 
-    private function printDebugCurrentFileAndRule(): void
+    private function printCurrentFileAndRule(): void
     {
-        if (! $this->rectorOutputStyle->isDebug()) {
-            return;
-        }
-
         $relativeFilePath = $this->filePathHelper->relativePath($this->file->getFilePath());
 
         $this->rectorOutputStyle->writeln('[file] ' . $relativeFilePath);
         $this->rectorOutputStyle->writeln('[rule] ' . static::class);
     }
 
-    private function printDebugConsumptions(float $startTime, int $previousMemory): void
+    private function printConsumptions(float $startTime, int $previousMemory): void
     {
-        if (! $this->rectorOutputStyle->isDebug()) {
-            return;
-        }
-
         $elapsedTime = microtime(true) - $startTime;
         $currentTotalMemory = memory_get_peak_usage(true);
 


### PR DESCRIPTION
To ease finding the slowest files within a project, so we get a starting point what to profile I have added debug output in a similar way its done in PHPStan.

----

Run rector across your project:
```
vendor/bin/rector -vvv --debug --no-diffs | tee rector.log
```

Analyse the generated `rector.log` file with `parse.php`...
```
php parse.php
```

.. and you get a list of files sorted by the time it took rector to refactor it:

```
Slowest files
4.90 seconds: [file] packages/Testing/PHPUnit/AbstractRectorTestCase.php
4.07 seconds: [file] packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
2.99 seconds: [file] packages/Caching/ValueObject/CacheFilePaths.php
2.95 seconds: [file] packages/BetterPhpDocParser/Attributes/AttributeMirrorer.php
2.93 seconds: [file] packages/BetterPhpDocParser/PhpDocNodeVisitor/TemplatePhpDocNodeVisitor.php
2.68 seconds: [file] packages/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
2.61 seconds: [file] packages/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
2.53 seconds: [file] packages/PHPStanStaticTypeMapper/TypeMapper/OversizedArrayTypeMapper.php
2.07 seconds: [file] packages/BetterPhpDocParser/ValueObject/PhpDocAttributeKey.php
1.71 seconds: [file] bin/clean-phpstan.php
1.52 seconds: [file] config/set/php80.php
1.18 seconds: [file] packages/PhpAttribute/NodeAnalyzer/ExprParameterReflectionTypeCorrector.php
1.01 seconds: [file] packages/Testing/PHPUnit/AbstractRectorTestCase.php
0.97 seconds: [file] config/set/php52.php
0.89 seconds: [file] packages/BetterPhpDocParser/PhpDocNodeVisitor/TemplatePhpDocNodeVisitor.php
0.83 seconds: [file] packages/PHPStanStaticTypeMapper/TypeMapper/ResourceTypeMapper.php
0.83 seconds: [file] packages/Caching/ValueObject/Storage/MemoryCacheStorage.php
0.78 seconds: [file] config/set/php80.php
0.69 seconds: [file] packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
0.63 seconds: [file] packages/StaticTypeMapper/PhpDocParser/NullableTypeMapper.php
0.62 seconds: [file] rules/CodingStyle/Rector/ClassConst/VarConstantCommentRector.php
0.60 seconds: [file] packages/PhpAttribute/NodeAnalyzer/ExprParameterReflectionTypeCorrector.php
0.56 seconds: [file] packages/PhpAttribute/AnnotationToAttributeMapper/ArrayItemNodeAnnotationToAttributeMapper.php
0.45 seconds: [file] packages/Testing/PHPUnit/AbstractRectorTestCase.php
0.38 seconds: [file] rules/CodeQuality/Rector/ClassMethod/NarrowUnionTypeDocRector.php
0.35 seconds: [file] packages-tests/Comments/CommentRemover/CommentRemoverTest.php
0.34 seconds: [file] packages/PhpAttribute/Enum/DocTagNodeState.php
0.34 seconds: [file] packages/PostRector/Collector/NodesToAddCollector.php
0.32 seconds: [file] packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
0.31 seconds: [file] packages/BetterPhpDocParser/PhpDocNodeVisitor/TemplatePhpDocNode
...
```

Starting from here you can use your favorite profiler to analyse the slowest ones


-----

```php
<?php // parse.php
declare(strict_types=1);

// 
// inspired and adopted from https://gist.github.com/ruudk/41897eb59ff497b271fc9fa3c7d5fb27

$log = new SplFileObject("rector.log");

$logs = [];
$file = null;
while (! $log->eof()) {
    $line = trim($log->fgets());
    if ($line === '') {
        continue;
    }

    if (str_starts_with($line, '[file]')) {
        $file = $line;
        continue;
    }

    if ($file === null) {
        continue;
    }
    if (preg_match('/took (?<seconds>[\d.]+) s/', $line, $matches) === 1) {
        $accu = 0.0;
        if (array_key_exists($file, $logs)) {
            $accu = $logs[$file][0];
        }
        $logs[$file] = [$accu + ((float) $matches['seconds']), $file];
        $file = null;
    }
}

usort($logs, fn(array $left, array $right) => $right[0] <=> $left[0]);
$logs = array_slice($logs, 0, 100);

echo "Slowest files" . PHP_EOL;
foreach ($logs as $log) {
    echo sprintf("%.2f seconds: %s", $log[0], $log[1]) . PHP_EOL;
}
```
