### PR TITLE
[Console] Allow https url instead of git@ on SetupCICommand

### DIFF
--- a/src/Console/Command/SetupCICommand.php
+++ b/src/Console/Command/SetupCICommand.php
@@ -18,9 +18,9 @@ final class SetupCICommand extends Command
 {
     /**
      * @var string
-     * @see https://regex101.com/r/etcmog/1
+     * @see https://regex101.com/r/etcmog/2
      */
-    private const GITHUB_REPOSITORY_REGEX = '#github\.com:(?<repository_name>.*?)\.git#';
+    private const GITHUB_REPOSITORY_REGEX = '#github\.com[:\/](?<repository_name>.*?)\.git#';
 
     public function __construct(
         private readonly SymfonyStyle $symfonyStyle


### PR DESCRIPTION
It previously only support `git@` usage, eg:

```
[remote "origin"]
        url = git@github.com:rectorphp/rector-src.git
        fetch = +refs/heads/*:refs/remotes/origin/*
```

This PR support https url as well:

```
[remote "origin"]
        url = https://github.com/samsonasik/ErrorHeroModule.git
        fetch = +refs/heads/*:refs/remotes/origin/*
```

**Before**

```
bin/rector setup-ci
                                                                                                                        
 [ERROR] Current repository name could not be resolved                                                                  
```                                                                                                                        


**After**


```
bin/rector setup-ci
                                                                                                                        
                                                                                                                        
 [OK] The ".github/workflows/rector.yaml" file was added                                                                
                                                                                                                                                                                       
```

Fixes https://github.com/rectorphp/rector/issues/7931