### PR TITLE
Fix WorkerCommandLineFactoryTest

### DIFF
--- a/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -100,7 +100,8 @@ final class WorkerCommandLineFactoryTest extends TestCase
 
     private function prepareProcessCommandDefinition(): InputDefinition
     {
-        $inputDefinition = $this->processCommand->getDefinition();
+        // clone the object as we should not modify a taken from the DI container
+        $inputDefinition = clone $this->processCommand->getDefinition();
 
         // not sure why, but the 1st argument "command" is missing; this is needed for a command name
         $arguments = $inputDefinition->getArguments();

--- a/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -100,7 +100,7 @@ final class WorkerCommandLineFactoryTest extends TestCase
 
     private function prepareProcessCommandDefinition(): InputDefinition
     {
-        // clone the object as we should not modify a taken from the DI container
+        // clone the object as we should not modify a object taken from the DI container
         $inputDefinition = clone $this->processCommand->getDefinition();
 
         // not sure why, but the 1st argument "command" is missing; this is needed for a command name


### PR DESCRIPTION
Fixes

```
Runtime:       PHP 8.1.17
Configuration: /home/runner/work/rector-src/rector-src/phpunit.xml

...............................................................  63 / 248 ( 25%)
............................................................... 126 / 248 ( 50%)
............................................................... 189 / 248 ( 76%)
...........................EE..............................     248 / 248 (100%)

Time: 00:04.372, Memory: 241.06 MB

There were 2 errors:

1) Rector\Tests\Parallel\Command\WorkerCommandLineFactoryTest::test with data set #1
Symfony\Component\Console\Exception\LogicException: An argument with name "command" already exists.

/home/runner/work/rector-src/rector-src/vendor/symfony/console/Input/InputDefinition.php:100
/home/runner/work/rector-src/rector-src/vendor/symfony/console/Input/InputDefinition.php:89
/home/runner/work/rector-src/rector-src/vendor/symfony/console/Input/InputDefinition.php:77
/home/runner/work/rector-src/rector-src/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php:110
/home/runner/work/rector-src/rector-src/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php:50

2) Rector\Tests\Parallel\Command\WorkerCommandLineFactoryTest::test with data set #2
Symfony\Component\Console\Exception\LogicException: An argument with name "command" already exists.

/home/runner/work/rector-src/rector-src/vendor/symfony/console/Input/InputDefinition.php:100
/home/runner/work/rector-src/rector-src/vendor/symfony/console/Input/InputDefinition.php:89
/home/runner/work/rector-src/rector-src/vendor/symfony/console/Input/InputDefinition.php:77
/home/runner/work/rector-src/rector-src/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php:110
/home/runner/work/rector-src/rector-src/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php:50
```

when [re-using the container instead of re-compiling for each test](https://github.com/rectorphp/rector-src/pull/3809)