### PR TITLE
Find slow phpunit tests in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     "require-dev": {
         "cweagans/composer-patches": "^1.7.2",
         "icanhazstring/composer-unused": "^0.8.5",
+        "johnkary/phpunit-speedtrap": "^1.0",
         "myclabs/php-enum": "^1.8.4",
         "nategood/httpful": "^0.3.2",
         "phpstan/extension-installer": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7.2",
+        "ergebnis/phpunit-slow-test-detector": "^2.1",
         "icanhazstring/composer-unused": "^0.8.5",
-        "johnkary/phpunit-speedtrap": "^1.0",
         "myclabs/php-enum": "^1.8.4",
         "nategood/httpful": "^0.3.2",
         "phpstan/extension-installer": "^1.2",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" executionOrder="defects" cacheDirectory=".phpunit.cache">
-    <extensions>
-        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap" />
-    </extensions>
+
   <testsuites>
     <testsuite name="main">
       <directory>tests</directory>
@@ -14,4 +12,8 @@
   <php>
     <ini name="memory_limit" value="-1"/>
   </php>
+
+    <extensions>
+               <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+            </extensions>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" executionOrder="defects" cacheDirectory=".phpunit.cache">
+    <extensions>
+        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap" />
+    </extensions>
   <testsuites>
     <testsuite name="main">
       <directory>tests</directory>


### PR DESCRIPTION
using https://github.com/ergebnis/phpunit-slow-test-detector

adds a bit of information after each test run which tests were slow, e.g.

```

Detected 2 tests that took longer than expected.

1. 1.113 (0.500) Rector\Tests\CodingStyle\Rector\MethodCall\PreferThisOrSelfMethodCallRector\PreferThisOrSelfMethodCallRectorTest::test#7
2. 0.806 (0.500) Rector\Tests\CodingStyle\Rector\MethodCall\PreferThisOrSelfMethodCallRector\PreferThisOrSelfMethodCallRectorTest::test#2
```