### PR TITLE
CI: separate rules-tests in 2 parallel jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,10 +22,11 @@ jobs:
             matrix:
                 php: ['8.1']
                 path:
-                    - tests
-                    - rules-tests
-                    - packages-tests
-                    - utils-tests
+                    - "tests/"
+                    - "rules-tests/"
+                    - "--test-suite php-rules"
+                    - "--test-suite other-rules"
+                    - "utils-tests/"
 
         name: PHP ${{ matrix.php }} tests for ${{ matrix.path }}
         steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,11 +22,11 @@ jobs:
             matrix:
                 php: ['8.1']
                 path:
-                    - "tests/"
+                    - "tests"
                     - "--testsuite p-rules"
                     - "--testsuite other-rules"
-                    - "packages-tests/"
-                    - "utils-tests/"
+                    - "packages-tests"
+                    - "utils-tests"
 
         name: PHP ${{ matrix.php }} tests for ${{ matrix.path }}
         steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
                 php: ['8.1']
                 path:
                     - "tests/"
-                    - "--testsuite php-rules"
+                    - "--testsuite p-rules"
                     - "--testsuite other-rules"
                     - "packages-tests/"
                     - "utils-tests/"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,8 +24,8 @@ jobs:
                 path:
                     - "tests/"
                     - "rules-tests/"
-                    - "--test-suite php-rules"
-                    - "--test-suite other-rules"
+                    - "--testsuite php-rules"
+                    - "--testsuite other-rules"
                     - "utils-tests/"
 
         name: PHP ${{ matrix.php }} tests for ${{ matrix.path }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
                 php: ['8.1']
                 path:
                     - "tests"
-                    - "--testsuite p-rules"
+                    - "--testsuite first-letter-p-rules"
                     - "--testsuite other-rules"
                     - "packages-tests"
                     - "utils-tests"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
                 php: ['8.1']
                 path:
                     - "tests"
-                    - "--testsuite first-letter-p-rules"
+                    - "--testsuite php-rules"
                     - "--testsuite other-rules"
                     - "packages-tests"
                     - "utils-tests"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,6 @@ jobs:
                 php: ['8.1']
                 path:
                     - "tests/"
-                    - "rules-tests/"
                     - "--testsuite php-rules"
                     - "--testsuite other-rules"
                     - "utils-tests/"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,7 @@ jobs:
                     - "tests/"
                     - "--testsuite php-rules"
                     - "--testsuite other-rules"
+                    - "packages-tests/"
                     - "utils-tests/"
 
         name: PHP ${{ matrix.php }} tests for ${{ matrix.path }}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,12 +9,12 @@
       <directory>utils-tests</directory>
     </testsuite>
     <!-- divide the rules-tests roughly in 2 equal sized groups -->
-    <testsuite name="first-letter-p-rules">
-        <directory>rules-tests/P*</directory>
+    <testsuite name="php-rules">
+        <directory>rules-tests/Php*</directory>
     </testsuite>
     <testsuite name="other-rules">
         <directory>rules-tests/</directory>
-        <exclude>rules-tests/P*</exclude>
+        <exclude>rules-tests/Php*</exclude>
     </testsuite>
   </testsuites>
   <php>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,7 @@
       <directory>packages-tests</directory>
       <directory>utils-tests</directory>
     </testsuite>
+    <!-- divide the rules-tests roughly in 2 equal sized groups -->
     <testsuite name="first-letter-p-rules">
         <directory>rules-tests/P*</directory>
     </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
       <directory>packages-tests</directory>
       <directory>utils-tests</directory>
     </testsuite>
-    <testsuite name="p-rules">
+    <testsuite name="first-letter-p-rules">
         <directory>rules-tests/P*</directory>
     </testsuite>
     <testsuite name="other-rules">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,12 +8,12 @@
       <directory>packages-tests</directory>
       <directory>utils-tests</directory>
     </testsuite>
-    <testsuite name="php-rules">
-        <directory>rules-tests/Php*</directory>
+    <testsuite name="p-rules">
+        <directory>rules-tests/P*</directory>
     </testsuite>
     <testsuite name="other-rules">
         <directory>rules-tests/</directory>
-        <exclude>rules-tests/Php*</exclude>
+        <exclude>rules-tests/P*</exclude>
     </testsuite>
   </testsuites>
   <php>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,7 @@
   <testsuites>
     <testsuite name="main">
       <directory>tests</directory>
+      <directory>rules-tests</directory>
       <directory>packages-tests</directory>
       <directory>utils-tests</directory>
     </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,9 +4,15 @@
   <testsuites>
     <testsuite name="main">
       <directory>tests</directory>
-      <directory>rules-tests</directory>
       <directory>packages-tests</directory>
       <directory>utils-tests</directory>
+    </testsuite>
+    <testsuite name="php-rules">
+        <directory>rules-tests/Php*</directory>
+    </testsuite>
+    <testsuite name="other-rules">
+        <directory>rules-tests/</directory>
+        <exclude>rules-tests/Php*</exclude>
     </testsuite>
   </testsuites>
   <php>


### PR DESCRIPTION
lets parallelize our CI a bit, so we can reduce wait time.

since previous approaches of using some parallel runners did not succeed lets try this easy way of parallelzation instead