### PR TITLE
[Traverser] Add GlobalVariableNodeVisitor

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -201,4 +201,9 @@ final class AttributeKey
      * @var string
      */
     public const ASSIGNED_TO = 'assigned_to';
+
+    /**
+     * @var string
+     */
+    public const IS_GLOBAL_VAR = 'is_global_var';
 }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVariableVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVariableVisitor.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Global_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+
+final class GlobalVariableNodeVariableVisitor extends NodeVisitorAbstract
+{
+    public function __construct(
+        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+    ) {
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof StmtsAwareInterface) {
+            return null;
+        }
+
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        $globalVariableNames = [];
+
+        foreach ($node->stmts as $stmt) {
+            if (! $stmt instanceof Global_) {
+                if ($globalVariableNames !== []) {
+                    $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+                        $stmt,
+                        static function (Node $subNode) use ($globalVariableNames) {
+                            if ($subNode instanceof Class_) {
+                                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                            }
+
+                            if (! $subNode instanceof Variable) {
+                                return null;
+                            }
+
+                            if (! is_string($subNode->name)) {
+                                return null;
+                            }
+
+                            if (! in_array($subNode->name, $globalVariableNames, true)) {
+                                return null;
+                            }
+
+                            $subNode->setAttribute(AttributeKey::IS_GLOBAL_VAR, true);
+                            return $subNode;
+                        }
+                    );
+                }
+
+                continue;
+            }
+
+            foreach ($stmt->vars as $variable) {
+                if ($variable instanceof Variable && is_string($variable->name)) {
+                    $variable->setAttribute(AttributeKey::IS_GLOBAL_VAR, true);
+                    $globalVariableNames[] = $variable->name;
+                }
+            }
+        }
+    }
+}

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVisitor.php
@@ -38,7 +38,7 @@ final class GlobalVariableNodeVisitor extends NodeVisitorAbstract
                 if ($globalVariableNames !== []) {
                     $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
                         $stmt,
-                        static function (Node $subNode) use ($globalVariableNames) {
+                        static function (Node $subNode) use ($globalVariableNames): int|null|Variable {
                             if ($subNode instanceof Class_) {
                                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                             }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVisitor.php
@@ -14,7 +14,7 @@ use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
-final class GlobalVariableNodeVariableVisitor extends NodeVisitorAbstract
+final class GlobalVariableNodeVisitor extends NodeVisitorAbstract
 {
     public function __construct(
         private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/GlobalVariableNodeVisitor.php
@@ -71,5 +71,7 @@ final class GlobalVariableNodeVisitor extends NodeVisitorAbstract
                 }
             }
         }
+
+        return null;
     }
 }

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -51,6 +51,7 @@ use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\AssignedToNodeVisitor;
+use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\GlobalVariableNodeVariableVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\RemoveDeepChainMethodCallNodeVisitor;
 use Webmozart\Assert\Assert;
 
@@ -74,6 +75,7 @@ final class PHPStanNodeScopeResolver
         private readonly ReflectionProvider $reflectionProvider,
         RemoveDeepChainMethodCallNodeVisitor $removeDeepChainMethodCallNodeVisitor,
         AssignedToNodeVisitor $assignedToNodeVisitor,
+        GlobalVariableNodeVariableVisitor $globalVariableNodeVariableVisitor,
         private readonly ScopeFactory $scopeFactory,
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly NodeNameResolver $nodeNameResolver,
@@ -83,6 +85,7 @@ final class PHPStanNodeScopeResolver
         $this->nodeTraverser = new NodeTraverser();
         $this->nodeTraverser->addVisitor($removeDeepChainMethodCallNodeVisitor);
         $this->nodeTraverser->addVisitor($assignedToNodeVisitor);
+        $this->nodeTraverser->addVisitor($globalVariableNodeVariableVisitor);
     }
 
     /**

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -51,7 +51,7 @@ use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\AssignedToNodeVisitor;
-use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\GlobalVariableNodeVariableVisitor;
+use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\GlobalVariableNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\RemoveDeepChainMethodCallNodeVisitor;
 use Webmozart\Assert\Assert;
 
@@ -75,7 +75,7 @@ final class PHPStanNodeScopeResolver
         private readonly ReflectionProvider $reflectionProvider,
         RemoveDeepChainMethodCallNodeVisitor $removeDeepChainMethodCallNodeVisitor,
         AssignedToNodeVisitor $assignedToNodeVisitor,
-        GlobalVariableNodeVariableVisitor $globalVariableNodeVariableVisitor,
+        GlobalVariableNodeVisitor $globalVariableNodeVisitor,
         private readonly ScopeFactory $scopeFactory,
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly NodeNameResolver $nodeNameResolver,
@@ -85,7 +85,7 @@ final class PHPStanNodeScopeResolver
         $this->nodeTraverser = new NodeTraverser();
         $this->nodeTraverser->addVisitor($removeDeepChainMethodCallNodeVisitor);
         $this->nodeTraverser->addVisitor($assignedToNodeVisitor);
-        $this->nodeTraverser->addVisitor($globalVariableNodeVariableVisitor);
+        $this->nodeTraverser->addVisitor($globalVariableNodeVisitor);
     }
 
     /**

--- a/packages/Testing/PHPUnit/AbstractTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractTestCase.php
@@ -80,6 +80,7 @@ abstract class AbstractTestCase extends TestCase
             if ($hash === false) {
                 throw new ShouldNotHappenException(sprintf('File %s is not readable', $configFile));
             }
+
             $configHash .= $hash;
         }
 

--- a/rules/DeadCode/Comparator/CurrentAndParentClassMethodComparator.php
+++ b/rules/DeadCode/Comparator/CurrentAndParentClassMethodComparator.php
@@ -15,13 +15,11 @@ use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use Rector\Core\Enum\ObjectReference;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\DeadCode\Comparator\Parameter\ParameterDefaultsComparator;
 use Rector\DeadCode\Comparator\Parameter\ParameterTypeComparator;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class CurrentAndParentClassMethodComparator
 {

--- a/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
+++ b/rules/PSR4/Rector/FileWithoutNamespace/NormalizeNamespaceByPSR4ComposerAutoloadRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Namespace_;
 use PHPStan\Analyser\Scope;
 use Rector\Core\NodeAnalyzer\InlineHTMLAnalyzer;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\PSR4\Contract\PSR4AutoloadNamespaceMatcherInterface;
 use Rector\PSR4\NodeManipulator\FullyQualifyStmtsAnalyzer;

--- a/rules/Php71/NodeAnalyzer/CountableAnalyzer.php
+++ b/rules/Php71/NodeAnalyzer/CountableAnalyzer.php
@@ -11,9 +11,7 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
-use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -23,7 +21,6 @@ use PHPStan\Type\UnionType;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 

--- a/rules/Php71/Rector/FuncCall/CountOnNullRector.php
+++ b/rules/Php71/Rector/FuncCall/CountOnNullRector.php
@@ -26,7 +26,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Core\NodeAnalyzer\VariableAnalyzer;
 use Rector\Core\Php\PhpVersionProvider;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;

--- a/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
+++ b/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
@@ -24,7 +24,6 @@ use PHPStan\Type\TypeWithClassName;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Naming\Naming\PropertyNaming;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class TypeProvidingExprFromClassResolver
 {

--- a/rules/Transform/Rector/FuncCall/FuncCallToMethodCallRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToMethodCallRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Transform\NodeAnalyzer\FuncCallStaticCallToMethodCallAnalyzer;
 use Rector\Transform\ValueObject\FuncCallToMethodCall;

--- a/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Transform\NodeAnalyzer\FuncCallStaticCallToMethodCallAnalyzer;
 use Rector\Transform\ValueObject\StaticCallToMethodCall;

--- a/src/NodeAnalyzer/VariableAnalyzer.php
+++ b/src/NodeAnalyzer/VariableAnalyzer.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\ClosureUse;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Global_;
 use PhpParser\Node\Stmt\Static_;
 use PhpParser\Node\Stmt\StaticVar;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
@@ -26,28 +25,24 @@ final class VariableAnalyzer
 
     public function isStaticOrGlobal(Variable $variable): bool
     {
-        if ($this->isParentStaticOrGlobal($variable)) {
+        if ($variable->getAttribute(AttributeKey::IS_GLOBAL_VAR) === true) {
+            return true;
+        }
+
+        if ($this->isParentStatic($variable)) {
             return true;
         }
 
         return (bool) $this->betterNodeFinder->findFirstPrevious($variable, function (Node $node) use (
             $variable
         ): bool {
-            if (! in_array($node::class, [Static_::class, Global_::class], true)) {
+            if (! $node instanceof Static_) {
                 return false;
             }
 
-            /**
-             * @var Static_|Global_ $node
-             * @var StaticVar[]|Variable[] $vars
-             */
             $vars = $node->vars;
             foreach ($vars as $var) {
-                $staticVarVariable = $var instanceof StaticVar
-                    ? $var->var
-                    : $var;
-
-                if ($this->nodeComparator->areNodesEqual($staticVarVariable, $variable)) {
+                if ($this->nodeComparator->areNodesEqual($var->var, $variable)) {
                     return true;
                 }
             }
@@ -82,16 +77,12 @@ final class VariableAnalyzer
         });
     }
 
-    private function isParentStaticOrGlobal(Variable $variable): bool
+    private function isParentStatic(Variable $variable): bool
     {
         $parentNode = $variable->getAttribute(AttributeKey::PARENT_NODE);
 
         if (! $parentNode instanceof Node) {
             return false;
-        }
-
-        if ($parentNode instanceof Global_) {
-            return true;
         }
 
         if (! $parentNode instanceof StaticVar) {


### PR DESCRIPTION
@TomasVotruba @staabm this is `Node` flag `true` or `false` example that I meant. For this PR, is to detect that variable may be a `global` variable.

```php
$variable = 'value';

function foo()
{
       global $variable;

       echo $variable;
}
```

The detection is by create new `GlobalVariableNodeVariableVisitor` by loop the `StmtsAwareInterface` stmts if there is `Global_` stmt, then check on next stmt on loop.

This implementation is currently for `Global` detection on `VariableAnalyzer`

https://github.com/rectorphp/rector-src/pull/3816/files#diff-8b66a0350e903758d4d9cc4e625a0383881d1830a878ed3d37d3cbec801bce1c

if this is accepted, we can create detection for static one so no more `findFirstPrevious()` for this detection.