### PR TITLE
[Traverser] Add StaticVariableNodeVisitor

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -206,4 +206,9 @@ final class AttributeKey
      * @var string
      */
     public const IS_GLOBAL_VAR = 'is_global_var';
+
+    /**
+     * @var string
+     */
+    public const IS_STATIC_VAR = 'is_static_var';
 }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StaticVariableNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StaticVariableNodeVisitor.php
@@ -41,12 +41,10 @@ final class StaticVariableNodeVisitor extends NodeVisitorAbstract
                 continue;
             }
 
-            foreach ($stmt->vars as $staticVars) {
-                foreach ($staticVars as $staticVar) {
-                    if (is_string($staticVar->var->name)) {
-                        $staticVar->var->setAttribute(AttributeKey::IS_STATIC_VAR, true);
-                        $staticVariableNames[] = $staticVar->var->name;
-                    }
+            foreach ($stmt->vars as $staticVar) {
+                if (is_string($staticVar->var->name)) {
+                    $staticVar->var->setAttribute(AttributeKey::IS_STATIC_VAR, true);
+                    $staticVariableNames[] = $staticVar->var->name;
                 }
             }
         }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StaticVariableNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StaticVariableNodeVisitor.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Static_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+
+final class StaticVariableNodeVisitor extends NodeVisitorAbstract
+{
+    public function __construct(
+        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+    ) {
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof StmtsAwareInterface) {
+            return null;
+        }
+
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        /** @var string[] $staticVariableNames */
+        $staticVariableNames = [];
+
+        foreach ($node->stmts as $stmt) {
+            if (! $stmt instanceof Static_) {
+                $this->setIsStaticVarAttribute($stmt, $staticVariableNames);
+                continue;
+            }
+
+            foreach ($stmt->vars as $staticVars) {
+                foreach ($staticVars as $staticVar) {
+                    if (is_string($staticVar->var->name)) {
+                        $staticVar->var->setAttribute(AttributeKey::IS_STATIC_VAR, true);
+                        $staticVariableNames[] = $staticVar->var->name;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string[] $staticVariableNames
+     */
+    private function setIsStaticVarAttribute(Stmt $stmt, array $staticVariableNames): void
+    {
+        if ($staticVariableNames === []) {
+            return;
+        }
+
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+            $stmt,
+            static function (Node $subNode) use ($staticVariableNames): int|null|Variable {
+                if ($subNode instanceof Class_) {
+                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                }
+
+                if (! $subNode instanceof Variable) {
+                    return null;
+                }
+
+                if (! is_string($subNode->name)) {
+                    return null;
+                }
+
+                if (! in_array($subNode->name, $staticVariableNames, true)) {
+                    return null;
+                }
+
+                $subNode->setAttribute(AttributeKey::IS_STATIC_VAR, true);
+                return $subNode;
+            }
+        );
+    }
+}

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -53,6 +53,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\AssignedToNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\GlobalVariableNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\RemoveDeepChainMethodCallNodeVisitor;
+use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\StaticVariableNodeVisitor;
 use Webmozart\Assert\Assert;
 
 /**
@@ -76,6 +77,7 @@ final class PHPStanNodeScopeResolver
         RemoveDeepChainMethodCallNodeVisitor $removeDeepChainMethodCallNodeVisitor,
         AssignedToNodeVisitor $assignedToNodeVisitor,
         GlobalVariableNodeVisitor $globalVariableNodeVisitor,
+        StaticVariableNodeVisitor $staticVariableNodeVisitor,
         private readonly ScopeFactory $scopeFactory,
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly NodeNameResolver $nodeNameResolver,
@@ -86,6 +88,7 @@ final class PHPStanNodeScopeResolver
         $this->nodeTraverser->addVisitor($removeDeepChainMethodCallNodeVisitor);
         $this->nodeTraverser->addVisitor($assignedToNodeVisitor);
         $this->nodeTraverser->addVisitor($globalVariableNodeVisitor);
+        $this->nodeTraverser->addVisitor($staticVariableNodeVisitor);
     }
 
     /**

--- a/src/NodeAnalyzer/VariableAnalyzer.php
+++ b/src/NodeAnalyzer/VariableAnalyzer.php
@@ -9,8 +9,6 @@ use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\ClosureUse;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Static_;
-use PhpParser\Node\Stmt\StaticVar;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -29,26 +27,7 @@ final class VariableAnalyzer
             return true;
         }
 
-        if ($this->isParentStatic($variable)) {
-            return true;
-        }
-
-        return (bool) $this->betterNodeFinder->findFirstPrevious($variable, function (Node $node) use (
-            $variable
-        ): bool {
-            if (! $node instanceof Static_) {
-                return false;
-            }
-
-            $vars = $node->vars;
-            foreach ($vars as $var) {
-                if ($this->nodeComparator->areNodesEqual($var->var, $variable)) {
-                    return true;
-                }
-            }
-
-            return false;
-        });
+        return $variable->getAttribute(AttributeKey::IS_STATIC_VAR) === true;
     }
 
     public function isUsedByReference(Variable $variable): bool
@@ -75,22 +54,6 @@ final class VariableAnalyzer
 
             return $parentNode instanceof AssignRef;
         });
-    }
-
-    private function isParentStatic(Variable $variable): bool
-    {
-        $parentNode = $variable->getAttribute(AttributeKey::PARENT_NODE);
-
-        if (! $parentNode instanceof Node) {
-            return false;
-        }
-
-        if (! $parentNode instanceof StaticVar) {
-            return false;
-        }
-
-        $parentParentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-        return $parentParentNode instanceof Static_;
     }
 
     private function isParamReferenced(Node $node, Variable $variable): bool


### PR DESCRIPTION
@TomasVotruba @staabm this is continue of PR:

- https://github.com/rectorphp/rector-src/pull/3816

to remove `findFirstPrevious()` for static variable node detection.