### PR TITLE
Define default test-suite

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,7 +29,7 @@
     <ini name="memory_limit" value="-1"/>
   </php>
 
-    <extensions>
-               <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
-            </extensions>
+  <extensions>
+    <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+  </extensions>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" executionOrder="defects" cacheDirectory=".phpunit.cache">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    executionOrder="defects"
+    cacheDirectory=".phpunit.cache"
+    defaultTestSuite="main"
+>
 
   <testsuites>
     <testsuite name="main">


### PR DESCRIPTION
makes sure we don't run tests twice.

before this change rule tests would have run 2 times as all suites would have been executed on `vendor/bin/phpunit`  invocation


![grafik](https://github.com/rectorphp/rector-src/assets/120441/d7f583a2-9fe4-41b5-8a0c-2601497f5321)

