### PR TITLE
[Traverser] No need traverse connect after refactor() on single nodes as already connected on refresh scope

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -537,10 +537,6 @@ final class BetterNodeFinder
             return null;
         }
 
-        if ($previousNode === $node) {
-            return null;
-        }
-
         $foundNode = $this->findFirst($previousNode, $filter);
 
         // we found what we need

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -474,7 +474,8 @@ CODE_SAMPLE;
          *
          * Except Else_, ElseIf_, Catch_, Finally_ which they are a didicated Stmt while inside If_ or TryCatch_
          */
-        if (count($nodes) === 1 && ! in_array($nodes[0]::class, [Else_::class, ElseIf_::class, Catch_::class, Finally_::class], true)) {
+        if (count($nodes) === 1 &&
+            ! in_array($nodes[0]::class, [Else_::class, ElseIf_::class, Catch_::class, Finally_::class], true)) {
             return;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -8,7 +8,11 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Else_;
+use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeVisitorAbstract;
@@ -458,6 +462,20 @@ CODE_SAMPLE;
             $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
 
             $nodes = [...$nodes, $nextNode];
+        }
+
+        /**
+         * on refresh scope, the nodes inside single node are connected there
+         * with config in config/phpstan/static-reflection.neon
+         *
+         * conditionalTags:
+         *       PhpParser\NodeVisitor\NodeConnectingVisitor:
+         *           phpstan.parser.richParserNodeVisitor: true
+         *
+         * Except Else_, ElseIf_, Catch_, Finally_ which they are a didicated Stmt while inside If_ or TryCatch_
+         */
+        if (count($nodes) === 1 && ! in_array($nodes[0]::class, [Else_::class, ElseIf_::class, Catch_::class, Finally_::class], true)) {
+            return;
         }
 
         $this->nodeConnectingTraverser->traverse($nodes);


### PR DESCRIPTION
@TomasVotruba  @staabm after `refactor()` called, on refresh scope, the nodes inside single node are connected there with config in config/phpstan/static-reflection.neon, so no need to re-connect again.

https://github.com/rectorphp/rector-src/blob/1828db5f0f3b8424ac0183a5672f58c6689d3233/config/phpstan/static-reflection.neon#L6-L8
 
Except `Else_`, `ElseIf_`, `Catch_`, `Finally_` which they are a didicated `Stmt` while inside `If_` or `TryCatch_`