### PR TITLE
[CI] Enable zend.assertions=1 on CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,6 +37,8 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     coverage: none
+                    # to display warning when assert() is called, eg: on direct getArgs() on CallLike
+                    # and check against first class callable strlen(...)
                     ini-values: zend.assertions=1
 
             -   uses: "ramsey/composer-install@v2"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,6 +37,7 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     coverage: none
+                    ini-values: zend.assertions=1
 
             -   uses: "ramsey/composer-install@v2"
 

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Renaming\Helper\RenameClassCallbackHandler;


### PR DESCRIPTION
To show assert warning early when found, eg on direct `getArgs()` usage on PR:

- https://github.com/rectorphp/rector-src/pull/3822#discussion_r1193003535