### PR TITLE
[Core] Change ChangedNodeScopeRefresher modifier to private on AbstractRector

### DIFF
--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -78,13 +78,9 @@ final class ScopeAnalyzer
         }
 
         /**
-         * Node and parent Node doesn't has Scope, and node and/or parent Node Start token pos is < 0,
+         * Node and parent Node doesn't has Scope, and Node Start token pos is < 0,
          * it means the node and parent node just re-printed, the Scope need to be resolved from file
          */
-        if ($parentNode->getStartTokenPos() < 0) {
-            return $this->scopeFactory->createFromFile($filePath);
-        }
-
         if ($node->getStartTokenPos() < 0) {
             return $this->scopeFactory->createFromFile($filePath);
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE;
 
     protected File $file;
 
-    protected ChangedNodeScopeRefresher $changedNodeScopeRefresher;
+    private ChangedNodeScopeRefresher $changedNodeScopeRefresher;
 
     private NodesToRemoveCollector $nodesToRemoveCollector;
 

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -37,10 +37,6 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
 
         if (! $currentScope instanceof MutatingScope) {
             $currentScope = $this->scopeAnalyzer->resolveScope($node, $this->file->getFilePath());
-
-            if ($currentScope instanceof MutatingScope) {
-                $this->changedNodeScopeRefresher->refresh($node, $currentScope, $this->file->getFilePath());
-            }
         }
 
         if (! $currentScope instanceof Scope) {


### PR DESCRIPTION
Change `ChangedNodeScopeRefresher` modifier to private to only be used on `AbstractRector` on after `refactor()` called only.

Also reduce parent node check on start token check < 0 on `ScopeAnalyzer` as direct check on `Node` is already working instead of parent, same with in `RectifiedAnalyzer`:

https://github.com/rectorphp/rector-src/blob/2406dc813a3eba3e25522fcb69af879fbc4a60cd/src/ProcessAnalyzer/RectifiedAnalyzer.php#L66-L73