### PR TITLE
Drop AttributeKey::SCOPE in ArrayCallableMethodMatcher

### DIFF
--- a/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
+++ b/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
-        $arrayCallable = $this->arrayCallableMethodMatcher->match($node);
+        $arrayCallable = $this->arrayCallableMethodMatcher->match($node, $scope);
         if (! $arrayCallable instanceof ArrayCallable) {
             return null;
         }

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -34,7 +35,7 @@ final class IsClassMethodUsedAnalyzer
     ) {
     }
 
-    public function isClassMethodUsed(ClassMethod $classMethod): bool
+    public function isClassMethodUsed(ClassMethod $classMethod, Scope $scope): bool
     {
         $class = $this->betterNodeFinder->findParentType($classMethod, Class_::class);
         if (! $class instanceof Class_) {
@@ -54,7 +55,7 @@ final class IsClassMethodUsedAnalyzer
         }
 
         // 3. magic array calls!
-        if ($this->isClassMethodCalledInLocalArrayCall($class, $classMethod)) {
+        if ($this->isClassMethodCalledInLocalArrayCall($class, $classMethod, $scope)) {
             return true;
         }
 
@@ -108,7 +109,7 @@ final class IsClassMethodUsedAnalyzer
         return $class->getMethod($value) instanceof ClassMethod;
     }
 
-    private function isClassMethodCalledInLocalArrayCall(Class_ $class, ClassMethod $classMethod): bool
+    private function isClassMethodCalledInLocalArrayCall(Class_ $class, ClassMethod $classMethod, Scope $scope): bool
     {
         /** @var Array_[] $arrays */
         $arrays = $this->betterNodeFinder->findInstanceOf($class, Array_::class);
@@ -118,7 +119,7 @@ final class IsClassMethodUsedAnalyzer
                 return true;
             }
 
-            $arrayCallable = $this->arrayCallableMethodMatcher->match($array);
+            $arrayCallable = $this->arrayCallableMethodMatcher->match($array, $scope);
             if ($arrayCallable instanceof ArrayCallableDynamicMethod) {
                 return true;
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -9,8 +9,10 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\MethodName;
 use Rector\DeadCode\NodeAnalyzer\IsClassMethodUsedAnalyzer;
@@ -20,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\RemoveUnusedPrivateMethodRectorTest
  */
-final class RemoveUnusedPrivateMethodRector extends AbstractRector
+final class RemoveUnusedPrivateMethodRector extends AbstractScopeAwareRector
 {
     public function __construct(
         private readonly IsClassMethodUsedAnalyzer $isClassMethodUsedAnalyzer,
@@ -71,13 +73,13 @@ CODE_SAMPLE
     /**
      * @param ClassMethod $node
      */
-    public function refactor(Node $node): ?Node
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
         if ($this->shouldSkip($node)) {
             return null;
         }
 
-        if ($this->isClassMethodUsedAnalyzer->isClassMethodUsed($node)) {
+        if ($this->isClassMethodUsedAnalyzer->isClassMethodUsed($node, $scope)) {
             return null;
         }
 

--- a/rules/Php81/Rector/Array_/FirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/FirstClassCallableRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
      */
     public function refactorWithScope(Node $node, Scope $scope)
     {
-        $arrayCallable = $this->arrayCallableMethodMatcher->match($node);
+        $arrayCallable = $this->arrayCallableMethodMatcher->match($node, $scope);
         if (! $arrayCallable instanceof ArrayCallable) {
             return null;
         }


### PR DESCRIPTION
rector-symfony fixes in https://github.com/rectorphp/rector-symfony/pull/398