### PR TITLE
[Printer] Reduce parent attribute usage on BetterStandardPrinter on print ArrowFunction comment

### DIFF
--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
@@ -8,6 +8,7 @@ function() {
 -----
 <?php
 
-fn() => /** @psalm-suppress UndefinedFunction */
+fn() =>
+    /** @psalm-suppress UndefinedFunction */
     ff();
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
@@ -9,5 +9,5 @@ function() {
 <?php
 
 fn() => /** @psalm-suppress UndefinedFunction */
-ff();
+    ff();
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return2.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return2.php.inc
@@ -8,6 +8,7 @@ function() {
 -----
 <?php
 
-fn() => // @psalm-suppress UndefinedFunction
+fn() =>
+    // @psalm-suppress UndefinedFunction
     ff();
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return2.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return2.php.inc
@@ -9,5 +9,5 @@ function() {
 <?php
 
 fn() => // @psalm-suppress UndefinedFunction
-ff();
+    ff();
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return3.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return3.php.inc
@@ -12,7 +12,8 @@ function() {
 -----
 <?php
 
-fn() => /**
+fn() =>
+    /**
      * comment
      */
     // something

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return3.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return3.php.inc
@@ -15,7 +15,7 @@ function() {
 fn() => /**
      * comment
      */
-// something
-// @psalm-suppress UndefinedFunction
-ff();
+    // something
+    // @psalm-suppress UndefinedFunction
+    ff();
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return4.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return4.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+function deep() {
+    function() {
+        /**
+         * comment
+         */
+        // something
+        // @psalm-suppress UndefinedFunction
+        return ff();
+    };
+}
+?>
+-----
+<?php
+
+function deep() {
+    fn() =>
+        /**
+         * comment
+         */
+        // something
+        // @psalm-suppress UndefinedFunction
+        ff();
+}
+?>

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -195,7 +195,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
 
         $indent = str_repeat($this->tabOrSpaceIndentCharacter, $this->rectorConfigProvider->getIndentSize());
 
-        $text = '';
+        $text = "\n" . $indent;
         foreach ($comments as $key => $comment) {
             $commentText = $key > 0 ? $indent . $comment->getText() : $comment->getText();
             $text .= $commentText . "\n";
@@ -206,7 +206,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             . 'fn' . ($arrowFunction->byRef ? '&' : '')
             . '(' . $this->pCommaSeparated($arrowFunction->params) . ')'
             . ($arrowFunction->returnType !== null ? ': ' . $this->p($arrowFunction->returnType) : '')
-            . ' => '
+            . ' =>'
             . $text
             . $indent
             . $this->p($arrowFunction->expr);

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -169,6 +169,15 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         return ltrim($content);
     }
 
+    protected function p(Node $node, $parentFormatPreserved = false): string
+    {
+        $content = parent::p($node, $parentFormatPreserved);
+
+        return $node->getAttribute(AttributeKey::WRAPPED_IN_PARENTHESES) === true
+            ? ('(' . $content . ')')
+            : $content;
+    }
+
     protected function pExpr_ArrowFunction(ArrowFunction $arrowFunction): string
     {
         if (! $arrowFunction->hasAttribute(AttributeKey::COMMENT_CLOSURE_RETURN_MIRRORED)) {
@@ -193,19 +202,10 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             . ($arrowFunction->static ? 'static ' : '')
             . 'fn' . ($arrowFunction->byRef ? '&' : '')
             . '(' . $this->pCommaSeparated($arrowFunction->params) . ')'
-            . (null !== $arrowFunction->returnType ? ': ' . $this->p($arrowFunction->returnType) : '')
+            . ($arrowFunction->returnType !== null ? ': ' . $this->p($arrowFunction->returnType) : '')
             . ' => '
             . $text
             . $this->p($arrowFunction->expr);
-    }
-
-    protected function p(Node $node, $parentFormatPreserved = false): string
-    {
-        $content = parent::p($node, $parentFormatPreserved);
-
-        return $node->getAttribute(AttributeKey::WRAPPED_IN_PARENTHESES) === true
-            ? ('(' . $content . ')')
-            : $content;
     }
 
     /**

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -193,9 +193,12 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return parent::pExpr_ArrowFunction($arrowFunction);
         }
 
+        $indent = str_repeat($this->tabOrSpaceIndentCharacter, $this->rectorConfigProvider->getIndentSize());
+
         $text = '';
-        foreach ($comments as $comment) {
-            $text .= $comment->getText() . "\n";
+        foreach ($comments as $key => $comment) {
+            $commentText = $key > 0 ? $indent . $comment->getText() : $comment->getText();
+            $text .= $commentText . "\n";
         }
 
         return $this->pAttrGroups($arrowFunction->attrGroups, true)
@@ -205,6 +208,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             . ($arrowFunction->returnType !== null ? ': ' . $this->p($arrowFunction->returnType) : '')
             . ' => '
             . $text
+            . $indent
             . $this->p($arrowFunction->expr);
     }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -193,7 +193,8 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return parent::pExpr_ArrowFunction($arrowFunction);
         }
 
-        $indent = str_repeat(' ', $this->indentLevel) . str_repeat($this->tabOrSpaceIndentCharacter, $this->rectorConfigProvider->getIndentSize());
+        $indent = str_repeat($this->tabOrSpaceIndentCharacter, $this->indentLevel) .
+            str_repeat($this->tabOrSpaceIndentCharacter, $this->rectorConfigProvider->getIndentSize());
 
         $text = "\n" . $indent;
         foreach ($comments as $key => $comment) {

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -169,13 +169,39 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         return ltrim($content);
     }
 
+    protected function pExpr_ArrowFunction(ArrowFunction $arrowFunction): string
+    {
+        if (! $arrowFunction->hasAttribute(AttributeKey::COMMENT_CLOSURE_RETURN_MIRRORED)) {
+            return parent::pExpr_ArrowFunction($arrowFunction);
+        }
+
+        $expr = $arrowFunction->expr;
+
+        /** @var Comment[] $comments */
+        $comments = $expr->getAttribute(AttributeKey::COMMENTS) ?? [];
+
+        if ($comments === []) {
+            return parent::pExpr_ArrowFunction($arrowFunction);
+        }
+
+        $text = '';
+        foreach ($comments as $comment) {
+            $text .= $comment->getText() . "\n";
+        }
+
+        return $this->pAttrGroups($arrowFunction->attrGroups, true)
+            . ($arrowFunction->static ? 'static ' : '')
+            . 'fn' . ($arrowFunction->byRef ? '&' : '')
+            . '(' . $this->pCommaSeparated($arrowFunction->params) . ')'
+            . (null !== $arrowFunction->returnType ? ': ' . $this->p($arrowFunction->returnType) : '')
+            . ' => '
+            . $text
+            . $this->p($arrowFunction->expr);
+    }
+
     protected function p(Node $node, $parentFormatPreserved = false): string
     {
         $content = parent::p($node, $parentFormatPreserved);
-
-        if ($node instanceof Expr) {
-            $content = $this->resolveContentOnExpr($node, $content);
-        }
 
         return $node->getAttribute(AttributeKey::WRAPPED_IN_PARENTHESES) === true
             ? ('(' . $content . ')')
@@ -533,36 +559,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
     private function shouldPrintNewRawValue(LNumber|DNumber $lNumber): bool
     {
         return $lNumber->getAttribute(AttributeKey::REPRINT_RAW_VALUE) === true;
-    }
-
-    private function resolveContentOnExpr(Expr $expr, string $content): string
-    {
-        $parentNode = $expr->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parentNode instanceof ArrowFunction) {
-            return $content;
-        }
-
-        if ($parentNode->expr !== $expr) {
-            return $content;
-        }
-
-        if (! $parentNode->hasAttribute(AttributeKey::COMMENT_CLOSURE_RETURN_MIRRORED)) {
-            return $content;
-        }
-
-        /** @var Comment[] $comments */
-        $comments = $expr->getAttribute(AttributeKey::COMMENTS) ?? [];
-
-        if ($comments === []) {
-            return $content;
-        }
-
-        $text = '';
-        foreach ($comments as $comment) {
-            $text .= $comment->getText() . "\n";
-        }
-
-        return $content = $text . $content;
     }
 
     /**

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -193,7 +193,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             return parent::pExpr_ArrowFunction($arrowFunction);
         }
 
-        $indent = str_repeat($this->tabOrSpaceIndentCharacter, $this->rectorConfigProvider->getIndentSize());
+        $indent = str_repeat(' ', $this->indentLevel) . str_repeat($this->tabOrSpaceIndentCharacter, $this->rectorConfigProvider->getIndentSize());
 
         $text = "\n" . $indent;
         foreach ($comments as $key => $comment) {


### PR DESCRIPTION
`parent` attribute 

```php
$parentNode = $expr->getAttribute(AttributeKey::PARENT_NODE);
```

was used to keep comment on code from:

```php
function() {
    /** @psalm-suppress UndefinedFunction */
    return ff();
};
```

to:

```php
fn() => /** @psalm-suppress UndefinedFunction */
ff();
```

at PR:

- https://github.com/rectorphp/rector-src/pull/1677

There is a `pExpr_ArrowFunction()` that can be override instead so can directly print from there.