### PR TITLE
[Printer] Remove pExpr_Yield override method

### DIFF
--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\EarlyReturn\Rector\Return_;
 
+use PHPStan\Analyser\Scope;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
@@ -72,7 +73,7 @@ CODE_SAMPLE
      * @param Return_ $node
      * @return null|Node[]
      */
-    public function refactorWithScope(Node $node, \PHPStan\Analyser\Scope $scope): ?array
+    public function refactorWithScope(Node $node, Scope $scope): ?array
     {
         if (! $node->expr instanceof BooleanOr) {
             return null;

--- a/src/PhpParser/Node/AssignAndBinaryMap.php
+++ b/src/PhpParser/Node/AssignAndBinaryMap.php
@@ -43,7 +43,6 @@ use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Cast\Bool_;
 use PHPStan\Analyser\Scope;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class AssignAndBinaryMap
 {

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -10,10 +10,8 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Ternary;
-use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
@@ -325,29 +323,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         }
 
         return Strings::replace($closureContent, self::USE_REGEX, '$1 (');
-    }
-
-    /**
-     * Do not add "()" on Expressions
-     * @see https://github.com/rectorphp/rector/pull/401#discussion_r181487199
-     */
-    protected function pExpr_Yield(Yield_ $yield): string
-    {
-        if (! $yield->value instanceof Expr) {
-            return 'yield';
-        }
-
-        $parentNode = $yield->getAttribute(AttributeKey::PARENT_NODE);
-        // brackets are needed only in case of assign, @see https://www.php.net/manual/en/language.generators.syntax.php
-        $shouldAddBrackets = $parentNode instanceof Assign;
-
-        return sprintf(
-            '%syield %s%s%s',
-            $shouldAddBrackets ? '(' : '',
-            $yield->key instanceof Expr ? $this->p($yield->key) . ' => ' : '',
-            $this->p($yield->value),
-            $shouldAddBrackets ? ')' : ''
-        );
     }
 
     /**


### PR DESCRIPTION
`Yield_` as Expr in node types seems no longer used in any rules, so I think it can be removed.