### PR TITLE
[Parser] Remove next attribute usage on InlineCodeParser

### DIFF
--- a/packages/Testing/PHPUnit/AbstractTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractTestCase.php
@@ -62,11 +62,11 @@ abstract class AbstractTestCase extends TestCase
 
         try {
             $object = self::$currentContainer->get($type);
-        } catch (Throwable $e) {
+        } catch (Throwable $throwable) {
             // clear compiled container cache, to trigger re-discovery
             RectorKernel::clearCache();
 
-            throw $e;
+            throw $throwable;
         }
 
         if ($object === null) {

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,7 @@ use Rector\Config\RectorConfig;
 use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
@@ -86,6 +87,10 @@ return static function (RectorConfig $rectorConfig): void {
         // race condition with stmts aware patch and PHPStan type
         \Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector::class => [
             __DIR__ . '/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php',
+        ],
+
+        ChangeReadOnlyPropertyWithDefaultValueToConstantRector::class => [
+            __DIR__ . '/src/Kernel/RectorKernel.php',
         ],
     ]);
 

--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryOrToEarlyReturnRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\EarlyReturn\Rector\Return_;
 
+use PHPStan\Analyser\Scope;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
@@ -72,7 +73,7 @@ CODE_SAMPLE
      * @param Return_ $node
      * @return null|Node[]
      */
-    public function refactorWithScope(Node $node, \PHPStan\Analyser\Scope $scope): ?array
+    public function refactorWithScope(Node $node, Scope $scope): ?array
     {
         if (! $node->expr instanceof BooleanOr) {
             return null;

--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -16,7 +16,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v7';
+    private const CACHE_KEY = 'v8';
 
     private ContainerInterface|null $container = null;
 

--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -22,10 +22,7 @@ final class RectorKernel
 
     private bool $dumpFileCache = false;
 
-    /**
-     * @var string|null
-     */
-    private static $defaultFilesHash;
+    private static ?string $defaultFilesHash = null;
 
     public function __construct()
     {
@@ -55,11 +52,7 @@ final class RectorKernel
             return $this->buildContainer([]);
         }
 
-        if ($this->dumpFileCache) {
-            $container = $this->buildCachedContainer($configFiles);
-        } else {
-            $container = $this->buildContainer($configFiles);
-        }
+        $container = $this->dumpFileCache ? $this->buildCachedContainer($configFiles) : $this->buildContainer($configFiles);
 
         return $this->container = $container;
     }

--- a/src/PhpParser/Node/AssignAndBinaryMap.php
+++ b/src/PhpParser/Node/AssignAndBinaryMap.php
@@ -43,7 +43,6 @@ use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Cast\Bool_;
 use PHPStan\Analyser\Scope;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class AssignAndBinaryMap
 {

--- a/tests/Validation/Collector/EmptyConfigurableRectorCollector/ConfigurableArrayMissingTest.php
+++ b/tests/Validation/Collector/EmptyConfigurableRectorCollector/ConfigurableArrayMissingTest.php
@@ -18,8 +18,8 @@ final class ConfigurableArrayMissingTest extends AbstractTestCase
     protected function setUp(): void
     {
         $rectorKernel = new RectorKernel();
-        $container = $rectorKernel->createBuilder([__DIR__ . '/config/configurable_array_missing.php']);
-        $this->emptyConfigurableRectorCollector = $container->get(EmptyConfigurableRectorCollector::class);
+        $containerBuilder = $rectorKernel->createBuilder([__DIR__ . '/config/configurable_array_missing.php']);
+        $this->emptyConfigurableRectorCollector = $containerBuilder->get(EmptyConfigurableRectorCollector::class);
     }
 
     public function test(): void

--- a/tests/Validation/Collector/EmptyConfigurableRectorCollector/EmptyConfigurableRectorCollectorTest.php
+++ b/tests/Validation/Collector/EmptyConfigurableRectorCollector/EmptyConfigurableRectorCollectorTest.php
@@ -15,8 +15,8 @@ final class EmptyConfigurableRectorCollectorTest extends AbstractTestCase
     protected function setUp(): void
     {
         $rectorKernel = new RectorKernel();
-        $container = $rectorKernel->createBuilder([__DIR__ . '/config/configurable_array_has_values.php']);
-        $this->emptyConfigurableRectorCollector = $container->get(EmptyConfigurableRectorCollector::class);
+        $containerBuilder = $rectorKernel->createBuilder([__DIR__ . '/config/configurable_array_has_values.php']);
+        $this->emptyConfigurableRectorCollector = $containerBuilder->get(EmptyConfigurableRectorCollector::class);
     }
 
     public function test(): void

--- a/tests/Validation/Collector/EmptyConfigurableRectorCollector/EmptyConfigureTest.php
+++ b/tests/Validation/Collector/EmptyConfigurableRectorCollector/EmptyConfigureTest.php
@@ -15,8 +15,8 @@ final class EmptyConfigureTest extends AbstractTestCase
     protected function setUp(): void
     {
         $rectorKernel = new RectorKernel();
-        $container = $rectorKernel->createBuilder([__DIR__ . '/config/empty_configure.php']);
-        $this->emptyConfigurableRectorCollector = $container->get(EmptyConfigurableRectorCollector::class);
+        $containerBuilder = $rectorKernel->createBuilder([__DIR__ . '/config/empty_configure.php']);
+        $this->emptyConfigurableRectorCollector = $containerBuilder->get(EmptyConfigurableRectorCollector::class);
     }
 
     public function test(): void


### PR DESCRIPTION
next attribute usage was used on PR:

- https://github.com/rectorphp/rector-src/pull/3300

on concat next variable usage:

```php

        $argL = func_get_args();
        $strFunc = array_shift($argL);
        $strArgs = join(', ',$argL);

        return create_function('$v', 'return '.$strFunc.'($v'.$strArgs.');');
```

This PR apply use `File` tokens to verify next variable.