### PR TITLE
[Performance] Remove parent lookup on StmtKeyNodeVisitor

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -6,13 +6,9 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Provider\CurrentFileProvider;
-use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
 
@@ -26,13 +22,11 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
     /**
      * @param Node[] $nodes
      * @return Node[]
-     *
-     * It used on namespace renaming
      */
-    public function beforeTraverse(array $nodes): array
+    public function afterTraverse(array $nodes): array
     {
         foreach ($nodes as $key => $node) {
-            if ($node instanceof Namespace_ || $node instanceof FileWithoutNamespace) {
+            if ($node instanceof Stmt) {
                 $node->setAttribute(AttributeKey::STMT_KEY, $key);
             }
         }
@@ -42,48 +36,17 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
 
     public function enterNode(Node $node): ?Node
     {
-        // need direct Stmt instance check to got every Stmt
-        if (! $node instanceof Stmt || $node instanceof ClassLike) {
+        if (! $node instanceof StmtsAwareInterface) {
             return null;
         }
 
         // re-index stmt key under current node
-        if ($node->getAttribute(AttributeKey::STMT_KEY) !== null) {
-            $this->setStmtKeyAttribute($node);
-            return null;
-        }
-
-        $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-
-        // parent node of Stmt must be Node, except on top level namespace or file without namespace
-        if (! $parentNode instanceof Node) {
-            // on __construct(), $file not yet a File object
-            $file = $this->currentFileProvider->getFile();
-            if ($file instanceof File) {
-                $newStmts = $file->getNewStmts();
-                foreach ($newStmts as $key => $childStmt) {
-                    $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
-                }
-            }
-
-            return null;
-        }
-
-        if (! $parentNode instanceof StmtsAwareInterface) {
-            return null;
-        }
-
-        // re-index stmt key under parent node
-        $this->setStmtKeyAttribute($parentNode);
+        $this->setStmtKeyAttribute($node);
         return null;
     }
 
-    private function setStmtKeyAttribute(Stmt|StmtsAwareInterface $stmt): void
+    private function setStmtKeyAttribute(StmtsAwareInterface $stmt): void
     {
-        if (! $stmt instanceof StmtsAwareInterface) {
-            return;
-        }
-
         if ($stmt->stmts === null) {
             return;
         }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -34,18 +34,12 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return null;
         }
 
-        // re-index stmt key under current node
-        $this->setStmtKeyAttribute($node);
-        return null;
-    }
-
-    private function setStmtKeyAttribute(StmtsAwareInterface $stmtsAware): void
-    {
-        if ($stmtsAware->stmts === null) {
+        if ($node->stmts === null) {
             return;
         }
 
-        foreach ($stmtsAware->stmts as $key => $childStmt) {
+        // re-index stmt key under current node
+        foreach ($node->stmts as $key => $childStmt) {
             $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
         }
     }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -8,17 +8,11 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
-use Rector\Core\Provider\CurrentFileProvider;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
 
 final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
-    public function __construct(
-        private readonly CurrentFileProvider $currentFileProvider
-    ) {
-    }
-
     /**
      * @param Node[] $nodes
      * @return Node[]
@@ -45,13 +39,13 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         return null;
     }
 
-    private function setStmtKeyAttribute(StmtsAwareInterface $stmt): void
+    private function setStmtKeyAttribute(StmtsAwareInterface $stmtsAware): void
     {
-        if ($stmt->stmts === null) {
+        if ($stmtsAware->stmts === null) {
             return;
         }
 
-        foreach ($stmt->stmts as $key => $childStmt) {
+        foreach ($stmtsAware->stmts as $key => $childStmt) {
             $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
         }
     }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -35,12 +35,14 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         }
 
         if ($node->stmts === null) {
-            return;
+            return null;
         }
 
         // re-index stmt key under current node
         foreach ($node->stmts as $key => $childStmt) {
             $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
@TomasVotruba @staabm here to improve `StmtKeyNodeVisitor` by remove `parent` lookup with utilize `afterTraverse()`