### PR TITLE
[Traverser] Remove next attribute in BetterNodeFinder

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -63,6 +63,11 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return null;
         }
 
+        // covered in beforeTraverse() and afterTraverse() as top level node handling
+        if ($node instanceof Namespace_ || $node instanceof FileWithoutNamespace) {
+            return null;
+        }
+
         if ($node->stmts === null) {
             return null;
         }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -46,12 +46,11 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
      */
     public function afterTraverse(array $nodes): array
     {
-        $currentNode = current($nodes);
-        if (! $currentNode instanceof Namespace_) {
-            return $nodes;
-        }
-
         foreach ($nodes as $key => $node) {
+            if (! $node instanceof Namespace_) {
+                return $nodes;
+            }
+
             $node->setAttribute(AttributeKey::STMT_KEY, $key);
         }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
@@ -16,8 +15,8 @@ use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNode
 final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
     /**
-     * @param Stmt[] $nodes
-     * @return Stmt[]
+     * @param Node[] $nodes
+     * @return Node[]
      */
     public function beforeTraverse(array $nodes): array
     {
@@ -41,8 +40,8 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
     }
 
     /**
-     * @param Stmt[] $nodes
-     * @return Stmt[]
+     * @param Node[] $nodes
+     * @return Node[]
      */
     public function afterTraverse(array $nodes): array
     {

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -16,8 +16,8 @@ use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNode
 final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
     /**
-     * @param Node[] $nodes
-     * @return Node[]
+     * @param Stmt[] $nodes
+     * @return Stmt[]
      */
     public function beforeTraverse(array $nodes): array
     {
@@ -41,8 +41,8 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
     }
 
     /**
-     * @param Node[] $nodes
-     * @return Node[]
+     * @param Stmt[] $nodes
+     * @return Stmt[]
      */
     public function afterTraverse(array $nodes): array
     {

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -21,6 +21,7 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
      */
     public function beforeTraverse(array $nodes): array
     {
+        // count = 1 is essential here as FileWithoutNamespace can merge with other Stmt
         if (count($nodes) === 1) {
             $currentNode = current($nodes);
             if ($currentNode instanceof FileWithoutNamespace) {
@@ -47,11 +48,13 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
      */
     public function afterTraverse(array $nodes): array
     {
+        $currentNode = current($nodes);
+        if (! $currentNode instanceof Namespace_) {
+            return $nodes;
+        }
+
         foreach ($nodes as $key => $node) {
-            // multiple namespace is allowed
-            if ($node instanceof Namespace_) {
-                $node->setAttribute(AttributeKey::STMT_KEY, $key);
-            }
+            $node->setAttribute(AttributeKey::STMT_KEY, $key);
         }
 
         return $nodes;

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -21,7 +21,7 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
      */
     public function beforeTraverse(array $nodes): array
     {
-        if ($nodes !== []) {
+        if (count($nodes) === 1) {
             $currentNode = current($nodes);
             if (! $currentNode instanceof Namespace_ && ! $currentNode instanceof FileWithoutNamespace) {
                 return $nodes;

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -34,9 +34,7 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         }
 
         foreach ($nodes as $key => $node) {
-            if ($node instanceof Stmt) {
-                $node->setAttribute(AttributeKey::STMT_KEY, $key);
-            }
+            $node->setAttribute(AttributeKey::STMT_KEY, $key);
         }
 
         return $nodes;

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
 
@@ -17,10 +21,32 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
      * @param Node[] $nodes
      * @return Node[]
      */
+    public function beforeTraverse(array $nodes): array
+    {
+        if (count($nodes) == 1) {
+            $currentNode = current($nodes);
+            if (! $currentNode instanceof Namespace_ && ! $currentNode instanceof FileWithoutNamespace) {
+                return $nodes;
+            }
+        }
+
+        foreach ($nodes as $key => $node) {
+            if ($node instanceof Stmt) {
+                $node->setAttribute(AttributeKey::STMT_KEY, $key);
+            }
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * @param Node[] $nodes
+     * @return Node[]
+     */
     public function afterTraverse(array $nodes): array
     {
         foreach ($nodes as $key => $node) {
-            if ($node instanceof Stmt) {
+            if ($node instanceof Namespace_ || $node instanceof FileWithoutNamespace) {
                 $node->setAttribute(AttributeKey::STMT_KEY, $key);
             }
         }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -62,8 +62,8 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return null;
         }
 
-        // covered in beforeTraverse() and afterTraverse() as top level node handling
-        if ($node instanceof Namespace_ || $node instanceof FileWithoutNamespace) {
+        // covered on beforeTraverse() as top level node handling
+        if ($node instanceof FileWithoutNamespace) {
             return null;
         }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
@@ -23,7 +21,7 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
      */
     public function beforeTraverse(array $nodes): array
     {
-        if (count($nodes) == 1) {
+        if (count($nodes) === 1) {
             $currentNode = current($nodes);
             if (! $currentNode instanceof Namespace_ && ! $currentNode instanceof FileWithoutNamespace) {
                 return $nodes;

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -21,7 +21,7 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
      */
     public function beforeTraverse(array $nodes): array
     {
-        if (count($nodes) === 1) {
+        if ($nodes !== []) {
             $currentNode = current($nodes);
             if (! $currentNode instanceof Namespace_ && ! $currentNode instanceof FileWithoutNamespace) {
                 return $nodes;

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -23,9 +23,13 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
     {
         if (count($nodes) === 1) {
             $currentNode = current($nodes);
-            if (! $currentNode instanceof Namespace_ && ! $currentNode instanceof FileWithoutNamespace) {
-                return $nodes;
+            if ($currentNode instanceof FileWithoutNamespace) {
+                foreach ($currentNode->stmts as $key => $stmt) {
+                    $stmt->setAttribute(AttributeKey::STMT_KEY, $key);
+                }
             }
+
+            return $nodes;
         }
 
         foreach ($nodes as $key => $node) {
@@ -44,7 +48,8 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
     public function afterTraverse(array $nodes): array
     {
         foreach ($nodes as $key => $node) {
-            if ($node instanceof Namespace_ || $node instanceof FileWithoutNamespace) {
+            // multiple namespace is allowed
+            if ($node instanceof Namespace_) {
                 $node->setAttribute(AttributeKey::STMT_KEY, $key);
             }
         }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -549,9 +549,13 @@ final class BetterNodeFinder
                 return null;
             }
 
-            // todo: use +1 key once all next node attribute reference and NodeConnectingVisitor removed
-            // left with add SlimNodeConnectingVisitor for only lookup parent
-            $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
+            $currentStmtKey = $node->getAttribute(AttributeKey::STMT_KEY);
+            $nextNode = $parentNode->stmts[$currentStmtKey + 1] ?? null;
+
+            // node just removed
+            if ($nextNode instanceof Node && $nextNode->getAttribute(AttributeKey::STMT_KEY) === $currentStmtKey) {
+                $nextNode = $node;
+            }
         } else {
             $nextNode = $this->resolveNextNodeFromOtherNode($node);
         }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -534,6 +534,23 @@ final class BetterNodeFinder
         return null;
     }
 
+    private function resolveNeigborStmt(StmtsAwareInterface $stmtsAware, Stmt $node, int $key, bool $isPrevious = true): ?Node
+    {
+        if ($isPrevious) {
+            if (isset($stmtsAware->stmts[$key + 1]) && $stmtsAware->stmts[$key + 1]->getStartTokenPos() === $node->getStartTokenPos()) {
+                return $node;
+            }
+
+            return $stmtsAware->stmts[$key - 1] ?? null;
+        }
+
+        if (isset($stmtsAware->stmts[$key - 1]) && $stmtsAware->stmts[$key - 1]->getStartTokenPos() === $node->getStartTokenPos()) {
+            return $node;
+        }
+
+        return $stmtsAware->stmts[$key + 1] ?? null;
+    }
+
     /**
      * Only search in next Node/Stmt
      *
@@ -550,7 +567,7 @@ final class BetterNodeFinder
             }
 
             $currentStmtKey = $node->getAttribute(AttributeKey::STMT_KEY);
-            $nextNode = $parentNode->stmts[$currentStmtKey + 1] ?? null;
+            $nextNode = $this->resolveNeigborStmt($parentNode, $node, $currentStmtKey, false);
         } else {
             $nextNode = $this->resolveNextNodeFromOtherNode($node);
         }
@@ -733,7 +750,7 @@ final class BetterNodeFinder
                 return $this->findFirstInTopLevelStmtsAware($parentNode, $filter);
             }
 
-            $previousNode = $parentNode->stmts[$currentStmtKey - 1];
+            $previousNode = $this->resolveNeigborStmt($parentNode, $node, $currentStmtKey, true);
         } else {
             $previousNode = $this->resolvePreviousNodeFromOtherNode($node);
         }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -547,12 +547,15 @@ final class BetterNodeFinder
 
             return $stmtsAware->stmts[$key - 1] ?? null;
         }
+
         if (!isset($stmtsAware->stmts[$key - 1])) {
             return $stmtsAware->stmts[$key + 1] ?? null;
         }
+
         if ($stmtsAware->stmts[$key - 1]->getStartTokenPos() !== $stmt->getStartTokenPos()) {
             return $stmtsAware->stmts[$key + 1] ?? null;
         }
+
         return $stmt;
     }
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -534,18 +534,10 @@ final class BetterNodeFinder
         return null;
     }
 
-    private function resolveNeigborStmt(StmtsAwareInterface $stmtsAware, Stmt $stmt, ?int $key, bool $isPrevious = true): ?Node
+    private function resolveNeighborNextStmt(StmtsAwareInterface $stmtsAware, Stmt $stmt, ?int $key): ?Node
     {
         if ($key === null) {
             $key = 0;
-        }
-
-        if ($isPrevious) {
-            if (isset($stmtsAware->stmts[$key + 1]) && $stmtsAware->stmts[$key + 1]->getStartTokenPos() === $stmt->getStartTokenPos()) {
-                return $stmt;
-            }
-
-            return $stmtsAware->stmts[$key - 1] ?? null;
         }
 
         if (!isset($stmtsAware->stmts[$key - 1])) {
@@ -575,7 +567,7 @@ final class BetterNodeFinder
             }
 
             $currentStmtKey = $node->getAttribute(AttributeKey::STMT_KEY);
-            $nextNode = $this->resolveNeigborStmt($parentNode, $node, $currentStmtKey, false);
+            $nextNode = $this->resolveNeighborNextStmt($parentNode, $node, $currentStmtKey);
         } else {
             $nextNode = $this->resolveNextNodeFromOtherNode($node);
         }
@@ -758,7 +750,7 @@ final class BetterNodeFinder
                 return $this->findFirstInTopLevelStmtsAware($parentNode, $filter);
             }
 
-            $previousNode = $this->resolveNeigborStmt($parentNode, $node, $currentStmtKey, true);
+            $previousNode = $parentNode->stmts[$currentStmtKey - 1] ?? null;
         } else {
             $previousNode = $this->resolvePreviousNodeFromOtherNode($node);
         }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -534,25 +534,26 @@ final class BetterNodeFinder
         return null;
     }
 
-    private function resolveNeigborStmt(StmtsAwareInterface $stmtsAware, Stmt $node, ?int $key, bool $isPrevious = true): ?Node
+    private function resolveNeigborStmt(StmtsAwareInterface $stmtsAware, Stmt $stmt, ?int $key, bool $isPrevious = true): ?Node
     {
         if ($key === null) {
             $key = 0;
         }
 
         if ($isPrevious) {
-            if (isset($stmtsAware->stmts[$key + 1]) && $stmtsAware->stmts[$key + 1]->getStartTokenPos() === $node->getStartTokenPos()) {
-                return $node;
+            if (isset($stmtsAware->stmts[$key + 1]) && $stmtsAware->stmts[$key + 1]->getStartTokenPos() === $stmt->getStartTokenPos()) {
+                return $stmt;
             }
 
             return $stmtsAware->stmts[$key - 1] ?? null;
         }
-
-        if (isset($stmtsAware->stmts[$key - 1]) && $stmtsAware->stmts[$key - 1]->getStartTokenPos() === $node->getStartTokenPos()) {
-            return $node;
+        if (!isset($stmtsAware->stmts[$key - 1])) {
+            return $stmtsAware->stmts[$key + 1] ?? null;
         }
-
-        return $stmtsAware->stmts[$key + 1] ?? null;
+        if ($stmtsAware->stmts[$key - 1]->getStartTokenPos() !== $stmt->getStartTokenPos()) {
+            return $stmtsAware->stmts[$key + 1] ?? null;
+        }
+        return $stmt;
     }
 
     /**

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -537,7 +537,7 @@ final class BetterNodeFinder
     private function resolveNeigborStmt(StmtsAwareInterface $stmtsAware, Stmt $node, ?int $key, bool $isPrevious = true): ?Node
     {
         if ($key === null) {
-            return null;
+            $key = 0;
         }
 
         if ($isPrevious) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
@@ -551,11 +552,6 @@ final class BetterNodeFinder
 
             $currentStmtKey = $node->getAttribute(AttributeKey::STMT_KEY);
             $nextNode = $parentNode->stmts[$currentStmtKey + 1] ?? null;
-
-            // node just removed
-            if ($nextNode instanceof Node && $nextNode->getAttribute(AttributeKey::STMT_KEY) === $currentStmtKey) {
-                $nextNode = $node;
-            }
         } else {
             $nextNode = $this->resolveNextNodeFromOtherNode($node);
         }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -534,8 +534,12 @@ final class BetterNodeFinder
         return null;
     }
 
-    private function resolveNeigborStmt(StmtsAwareInterface $stmtsAware, Stmt $node, int $key, bool $isPrevious = true): ?Node
+    private function resolveNeigborStmt(StmtsAwareInterface $stmtsAware, Stmt $node, ?int $key, bool $isPrevious = true): ?Node
     {
+        if ($key === null) {
+            return null;
+        }
+
         if ($isPrevious) {
             if (isset($stmtsAware->stmts[$key + 1]) && $stmtsAware->stmts[$key + 1]->getStartTokenPos() === $node->getStartTokenPos()) {
                 return $node;


### PR DESCRIPTION
@TomasVotruba @staabm I think I finally found a solution for removing `next` attribute usage on `BetterNodeFinder` on node just removed by verify current stmt_key + 1 value is equal with current stmt_key, which due to overlapped just removed node.

Closes https://github.com/rectorphp/rector/issues/7940