### PR TITLE
[NodeTypeResolver] Remove next node attribute on PHPStanNodeScopeResolver

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -44,6 +44,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Caching\FileSystem\DependencyResolver;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -325,12 +326,22 @@ final class PHPStanNodeScopeResolver
 
         $this->processNodes([$originalStmt], $filePath, $mutatingScope);
 
-        $nextNode = $originalStmt->getAttribute(AttributeKey::NEXT_NODE);
-        while ($nextNode instanceof Stmt) {
-            $nextNode->setAttribute(AttributeKey::IS_UNREACHABLE, true);
+        $parentNode = $unreachableStatementNode->getAttribute(AttributeKey::PARENT_NODE);
 
-            $this->processNodes([$nextNode], $filePath, $mutatingScope);
-            $nextNode = $nextNode->getAttribute(AttributeKey::NEXT_NODE);
+        if (! $parentNode instanceof StmtsAwareInterface) {
+            return;
+        }
+
+        $stmtKey = $unreachableStatementNode->getAttribute(AttributeKey::STMT_KEY);
+        $totalKeys = $parentNode->stmts === null ? 0 : count($parentNode->stmts);
+
+        for ($key = $stmtKey + 1; $key < $totalKeys; ++$key) {
+            if (! isset($parentNode->stmts[$key])) {
+                continue;
+            }
+
+            $parentNode->stmts[$key]->setAttribute(AttributeKey::IS_UNREACHABLE, true);
+            $this->processNodes([$parentNode->stmts[$key]], $filePath, $mutatingScope);
         }
     }
 


### PR DESCRIPTION
Utilize `stmt_key` attribute + 1 to get next node.