### PR TITLE
[1.0] Add public method BetterNodeFinder::resolvePreviousNode() and BetterNodeFinder::resolveNextNode()

### DIFF
--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -17,7 +17,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v16';
+    private const CACHE_KEY = 'v17';
 
     private ContainerInterface|null $container = null;
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -716,11 +716,7 @@ final class BetterNodeFinder
     /**
      * @api
      *
-<<<<<<< HEAD
-     * Resolve previous node from not an Stmt, eg: Expr, Identifier, Name, etc
-=======
      * Resolve previous node from any Node, eg: Expr, Identifier, Name, etc
->>>>>>> 17608b3d75 (comment)
      */
     public function resolvePreviousNode(Node $node): ?Node
     {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -584,7 +584,7 @@ final class BetterNodeFinder
             /** @var StmtsAwareInterface|ClassLike|Declare_ $parentNode */
             $nextNode = $this->resolveNeighborNextStmt($parentNode, $node, $currentStmtKey);
         } else {
-            $nextNode = $this->resolveNextNodeFromOtherNode($node);
+            $nextNode = $this->resolveNextNode($node);
         }
 
         if (! $nextNode instanceof Node) {
@@ -714,9 +714,11 @@ final class BetterNodeFinder
     }
 
     /**
+     * @api
+     *
      * Resolve previous node from not an Stmt, eg: Expr, Identifier, Name, etc
      */
-    private function resolvePreviousNodeFromOtherNode(Node $node): ?Node
+    public function resolvePreviousNode(Node $node): ?Node
     {
         $currentStmt = $this->resolveCurrentStatement($node);
 
@@ -750,9 +752,11 @@ final class BetterNodeFinder
     }
 
     /**
+     * @api
+     *
      * Resolve next node from not an Stmt, eg: Expr, Identifier, Name, etc
      */
-    private function resolveNextNodeFromOtherNode(Node $node): ?Node
+    public function resolveNextNode(Node $node): ?Node
     {
         $currentStmt = $this->resolveCurrentStatement($node);
 
@@ -811,7 +815,7 @@ final class BetterNodeFinder
             /** @var StmtsAwareInterface|ClassLike|Declare_ $parentNode */
             $previousNode = $parentNode->stmts[$currentStmtKey - 1] ?? null;
         } else {
-            $previousNode = $this->resolvePreviousNodeFromOtherNode($node);
+            $previousNode = $this->resolvePreviousNode($node);
         }
 
         if (! $previousNode instanceof Node) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -716,7 +716,11 @@ final class BetterNodeFinder
     /**
      * @api
      *
+<<<<<<< HEAD
      * Resolve previous node from not an Stmt, eg: Expr, Identifier, Name, etc
+=======
+     * Resolve previous node from any Node, eg: Expr, Identifier, Name, etc
+>>>>>>> 17608b3d75 (comment)
      */
     public function resolvePreviousNode(Node $node): ?Node
     {
@@ -754,7 +758,7 @@ final class BetterNodeFinder
     /**
      * @api
      *
-     * Resolve next node from not an Stmt, eg: Expr, Identifier, Name, etc
+     * Resolve next node from any Node, eg: Expr, Identifier, Name, etc
      */
     public function resolveNextNode(Node $node): ?Node
     {

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\Parser;
 
+use PhpParser\Node\Expr\Variable;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use PhpParser\Node\Expr;
@@ -14,9 +15,7 @@ use PhpParser\Node\Stmt;
 use Rector\Core\Contract\PhpParser\NodePrinterInterface;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
-use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\Util\StringUtils;
-use Rector\Core\ValueObject\Application\File;
 
 final class InlineCodeParser
 {
@@ -150,7 +149,7 @@ final class InlineCodeParser
 
         if ($concat->right instanceof String_ && str_starts_with($concat->right->value, '($')) {
             $node = $this->betterNodeFinder->resolveNextNode($concat);
-            if ($node instanceof Expr\Variable) {
+            if ($node instanceof Variable) {
                 $concat->right->value .= '.';
             }
         }


### PR DESCRIPTION
@TomasVotruba @staabm previously, I created private method `resolveNextNodeFromOtherNode()` and `resolvePreviousNodeFromOtherNode()` which utilize to replace:

```diff
-$node->getAttribute(AttributeKey::NEXT_NODE);
+$this->resolveNextNodeFromOtherNode($node);

-$node->getAttribute(AttributeKey::PREVIOUS_NODE);
+$this->resolvePreviousNodeFromOtherNode($node);
```

internally which the `Node` is not `Stmt`, which can be: `Expr`, `Identifier`, `Name`, which this can't be handled directly via `StmtsAwareInterface`, with the following strategy:

1. Resolve current stmt
2. Find in current stmt with verify `"start token pos"` or `"end token pos"` to get nearest next/previous node.
3. Find Previous Stmt or Next Stmt with got "stmt_key" if already at the end of stmt or start of stmt passed.

With make it `public method`, and rename to `resolveNextNode()` and `resolvePreviousNode()`, we can utilize it on a code that can't use `StmtsAwareInterface` or need jump anoter parent of it, eg, this following downgrade code:

```php
    private function processForStringOrVariableOrProperty(
        String_ | Variable | PropertyFetch | StaticPropertyFetch $expr
    ): ?Expr {
        $nextNode = $expr->getAttribute(AttributeKey::NEXT_NODE);
        if (! $nextNode instanceof UnaryMinus) {
            return null;
        }
```

which it can't rely on `StmtsAwareInterface`, see 

https://github.com/rectorphp/rector-downgrade-php/blob/edea6f89987c3c5ac465382195ef7b5216987745/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php#L69-L72

that to be:

```diff
-$nextNode = $expr->getAttribute(AttributeKey::NEXT_NODE);
+$nextNode = $this->betterNodeFinder->resolveNextNode($expr);
```

This also help user to migrate their code easier when upgrade to 1.0.