### PR TITLE
[Parser] Fix key negative on BetterNodeFinder locate stmt on FileWithoutNamespace lookup Declare_

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -663,6 +663,7 @@ final class BetterNodeFinder
 
         $currentStmtKey = $node->getAttribute(AttributeKey::STMT_KEY);
         $stmtKey = $isPrevious ? $currentStmtKey - 1 : $currentStmtKey + 1;
+        $stmtKey = $stmtKey === -1 ? 0 : $stmtKey;
 
         if ($isPrevious) {
             return $newStmts[$stmtKey] ?? null;


### PR DESCRIPTION
**Before**

```diff
--- Expected
+++ Actual
@@ @@
 '<?php
 
-declare(strict_types=1);
-
```

**After**

```diff
--- Expected
+++ Actual
@@ @@
 '<?php
 
 declare(strict_types=1);
-
```