### PR TITLE
[1.0] Replace NodeConnectingVisitor with ParentConnectingVisitor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/inflector": "^2.0.6",
         "fidry/cpu-core-counter": "^0.5.1",
         "nette/neon": "^3.4",
-        "nette/utils": "^3.2.9",
+        "nette/utils": "^3.2",
         "nikic/php-parser": "^4.15.4",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.20.3",

--- a/config/config.php
+++ b/config/config.php
@@ -11,7 +11,7 @@ use PhpParser\ConstExprEvaluator;
 use PhpParser\Lexer;
 use PhpParser\NodeFinder;
 use PhpParser\NodeVisitor\CloningVisitor;
-use PhpParser\NodeVisitor\NodeConnectingVisitor;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeFactory;
 use PHPStan\Dependency\DependencyResolver;
@@ -156,7 +156,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $services->set(BuilderFactory::class);
     $services->set(CloningVisitor::class);
-    $services->set(NodeConnectingVisitor::class);
+    $services->set(ParentConnectingVisitor::class);
     $services->set(NodeFinder::class);
 
     $services->set(RectorConsoleOutputStyle::class)

--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -4,7 +4,7 @@ parameters:
         disableRuntimeReflectionProvider: false
 
 conditionalTags:
-    PhpParser\NodeVisitor\NodeConnectingVisitor:
+    PhpParser\NodeVisitor\ParentConnectingVisitor:
         phpstan.parser.richParserNodeVisitor: true
 
 services:

--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -11,6 +11,7 @@ services:
     - Rector\NodeTypeResolver\Reflection\BetterReflection\RectorBetterReflectionSourceLocatorFactory
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocator\IntermediateSourceLocator
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider
+    - PhpParser\NodeVisitor\ParentConnectingVisitor
 
     # basically decorates native PHPStan source locator with a dynamic source locator that is also available in Rector DI
     betterReflectionSourceLocator:

--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -77,6 +77,7 @@ final class AttributeKey
     public const PARENT_NODE = 'parent';
 
     /**
+     * @api
      * @internal of php-parser, do not change
      * @deprecated Use StmtsAwareInterface instead
      *
@@ -86,6 +87,7 @@ final class AttributeKey
     public const PREVIOUS_NODE = 'previous';
 
     /**
+     * @api
      * @internal of php-parser, do not change
      * @deprecated Use StmtsAwareInterface instead
      *

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -27,9 +27,7 @@ final class NodeScopeAndMetadataDecorator
         // needed also for format preserving printing
         $this->nodeTraverser->addVisitor($cloningVisitor);
 
-        // this one has to be run again to re-connect nodes with new attributes
-
-        // parent attribute is needed to resolve Scope
+        // this one has to be run again to re-connect parent nodes with new attributes
         $this->nodeTraverser->addVisitor($parentConnectingVisitor);
 
         $this->nodeTraverser->addVisitor($functionLikeParamArgPositionNodeVisitor);

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -7,7 +7,7 @@ namespace Rector\NodeTypeResolver;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
-use PhpParser\NodeVisitor\NodeConnectingVisitor;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionLikeParamArgPositionNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
@@ -19,7 +19,7 @@ final class NodeScopeAndMetadataDecorator
     public function __construct(
         CloningVisitor $cloningVisitor,
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
-        NodeConnectingVisitor $nodeConnectingVisitor,
+        ParentConnectingVisitor $parentConnectingVisitor,
         FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
     ) {
         $this->nodeTraverser = new NodeTraverser();
@@ -28,7 +28,10 @@ final class NodeScopeAndMetadataDecorator
         $this->nodeTraverser->addVisitor($cloningVisitor);
 
         // this one has to be run again to re-connect nodes with new attributes
-        $this->nodeTraverser->addVisitor($nodeConnectingVisitor);
+
+        // parent attribute is needed to resolve Scope
+        $this->nodeTraverser->addVisitor($parentConnectingVisitor);
+
         $this->nodeTraverser->addVisitor($functionLikeParamArgPositionNodeVisitor);
     }
 

--- a/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
+++ b/src/PhpParser/NodeTraverser/NodeConnectingTraverser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\PhpParser\NodeTraverser;
 
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NodeConnectingVisitor;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 
 final class NodeConnectingTraverser extends NodeTraverser
 {
@@ -13,6 +13,6 @@ final class NodeConnectingTraverser extends NodeTraverser
     {
         parent::__construct();
 
-        $this->addVisitor(new NodeConnectingVisitor());
+        $this->addVisitor(new ParentConnectingVisitor());
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -348,7 +348,7 @@ CODE_SAMPLE;
             $this->mirrorComments($firstNode, $originalNode);
 
             $this->updateParentNodes($refactoredNode, $parentNode);
-            $this->connectNodes($refactoredNode, $node);
+            $this->nodeConnectingTraverser->traverse($refactoredNode);
             $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
             $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
@@ -362,7 +362,7 @@ CODE_SAMPLE;
             : $refactoredNode;
 
         $this->updateParentNodes($refactoredNode, $parentNode);
-        $this->connectNodes([$refactoredNode], $node);
+        $this->nodeConnectingTraverser->traverse([$refactoredNode]);
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
         $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
@@ -430,34 +430,6 @@ CODE_SAMPLE;
             // update parents relations
             $node->setAttribute(AttributeKey::PARENT_NODE, $parentNode);
         }
-    }
-
-    /**
-     * @param non-empty-array<Node> $nodes
-     */
-    private function connectNodes(array $nodes, Node $node): void
-    {
-        $firstNode = current($nodes);
-        $firstNodePreviousNode = $firstNode->getAttribute(AttributeKey::PREVIOUS_NODE);
-
-        if (! $firstNodePreviousNode instanceof Node && $node->hasAttribute(AttributeKey::PREVIOUS_NODE)) {
-            /** @var Node $previousNode */
-            $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
-
-            $nodes = [$previousNode, ...$nodes];
-        }
-
-        $lastNode = end($nodes);
-        $lastNodeNextNode = $lastNode->getAttribute(AttributeKey::NEXT_NODE);
-
-        if (! $lastNodeNextNode instanceof Node && $node->hasAttribute(AttributeKey::NEXT_NODE)) {
-            /** @var Node $nextNode */
-            $nextNode = $node->getAttribute(AttributeKey::NEXT_NODE);
-
-            $nodes = [...$nodes, $nextNode];
-        }
-
-        $this->nodeConnectingTraverser->traverse($nodes);
     }
 
     private function printCurrentFileAndRule(): void


### PR DESCRIPTION
@TomasVotruba @staabm `parent` attribute can be reduced, but seems can't be removed completely to resolve Scope.

This to be `ParentConnectingVisitor` and remove `NodeConnectingVisitor` when all prev and next node attribute removed.