### PR TITLE
[DeadCode] Remove next attribute on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -234,7 +234,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $if = $parentNode->getAttribute(AttributeKey::NEXT_NODE);
+        $if = $this->betterNodeFinder->resolveNextNode($parentNode);
 
         // check if next node is if
         if (! $if instanceof If_) {

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -234,10 +234,10 @@ CODE_SAMPLE
             return null;
         }
 
-        $if = $this->betterNodeFinder->resolveNextNode($parentNode);
+        $node = $this->betterNodeFinder->resolveNextNode($parentNode);
 
         // check if next node is if
-        if (! $if instanceof If_) {
+        if (! $node instanceof If_) {
             if (
                 $assign->var instanceof Variable &&
                 ! $scope->hasVariableType((string) $this->getName($assign->var))
@@ -249,7 +249,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->conditionSearcher->hasIfAndElseForVariableRedeclaration($assign, $if)) {
+        if ($this->conditionSearcher->hasIfAndElseForVariableRedeclaration($assign, $node)) {
             $this->removeNode($assign);
             return $assign;
         }


### PR DESCRIPTION
@TomasVotruba @staabm this require : 

```diff
-$parentNode->getAttribute(AttributeKey::NEXT_NODE);
+$this->betterNodeFinder->resolveNextNode($parentNode)
```

as it need to get next of parent node.