### PR TITLE
[Traverser] Using bool value for assigned_to attribute on variable assign

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -200,7 +200,7 @@ final class AttributeKey
     /**
      * @var string
      */
-    public const ASSIGNED_TO = 'assigned_to';
+    public const IS_ASSIGNED_TO = 'is_assigned_to';
 
     /**
      * @var string

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
@@ -21,7 +21,7 @@ final class AssignedToNodeVisitor extends NodeVisitorAbstract implements ScopeRe
             return null;
         }
 
-        $node->expr->setAttribute(AttributeKey::ASSIGNED_TO, $node->var);
+        $node->expr->setAttribute(AttributeKey::ASSIGNED_TO, true);
         return null;
     }
 }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
@@ -21,7 +21,7 @@ final class AssignedToNodeVisitor extends NodeVisitorAbstract implements ScopeRe
             return null;
         }
 
-        $node->expr->setAttribute(AttributeKey::ASSIGNED_TO, true);
+        $node->expr->setAttribute(AttributeKey::IS_ASSIGNED_TO, true);
         return null;
     }
 }

--- a/packages/ReadWrite/NodeFinder/NodeUsageFinder.php
+++ b/packages/ReadWrite/NodeFinder/NodeUsageFinder.php
@@ -49,7 +49,7 @@ final class NodeUsageFinder
             }
 
             $assignedTo = $node->getAttribute(AttributeKey::ASSIGNED_TO);
-            return ! $assignedTo instanceof Node;
+            return $assignedTo === null;
         });
     }
 

--- a/packages/ReadWrite/NodeFinder/NodeUsageFinder.php
+++ b/packages/ReadWrite/NodeFinder/NodeUsageFinder.php
@@ -48,7 +48,7 @@ final class NodeUsageFinder
                 return false;
             }
 
-            $assignedTo = $node->getAttribute(AttributeKey::ASSIGNED_TO);
+            $assignedTo = $node->getAttribute(AttributeKey::IS_ASSIGNED_TO);
             return $assignedTo === null;
         });
     }

--- a/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
+++ b/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
@@ -80,7 +80,7 @@ CODE_SAMPLE
         }
 
         $assignedTo = $node->getAttribute(AttributeKey::ASSIGNED_TO);
-        if ($assignedTo instanceof Node) {
+        if ($assignedTo === true) {
             return null;
         }
 

--- a/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
+++ b/rules/CodingStyle/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
@@ -79,7 +79,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $assignedTo = $node->getAttribute(AttributeKey::ASSIGNED_TO);
+        $assignedTo = $node->getAttribute(AttributeKey::IS_ASSIGNED_TO);
         if ($assignedTo === true) {
             return null;
         }


### PR DESCRIPTION
The `assigned_to` attribute flag seems only be used to verify it is assigned, so no need to fill with object, only true flag.