### PR TITLE
[DX] Deprecate PARENT_NODE attribute, allow return of NodeTraverser::* in refactor() method

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -73,6 +73,9 @@ final class AttributeKey
     public const RESOLVED_NAME = 'resolvedName';
 
     /**
+     * @deprecated Refactor to a custom visitors/parent node instead,
+     * @see https://phpstan.org/blog/preprocessing-ast-for-custom-rules
+     *
      * @internal of php-parser, do not change
      * @see https://github.com/nikic/PHP-Parser/pull/681/files
      * @var string

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -767,3 +767,6 @@ parameters:
 
         - '#Cognitive complexity for "Rector\\TypeDeclaration\\Rector\\ClassMethod\\BoolReturnTypeFromStrictScalarReturnsRector\:\:hasOnlyBoolScalarReturnExprs\(\)" is 11, keep it under 10#'
         - '#Access to an undefined property PhpParser\\Node\\Stmt\\ClassLike\|PhpParser\\Node\\Stmt\\Declare_\|Rector\\Core\\Contract\\PhpParser\\Node\\StmtsAwareInterface\:\:\$stmts#'
+
+        # WIP
+        - '#Fetching deprecated class constant PARENT_NODE#'

--- a/rules-tests/CodeQuality/Rector/FuncCall/SetTypeToCastRector/Fixture/skip_args.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SetTypeToCastRector/Fixture/skip_args.php.inc
@@ -2,10 +2,12 @@
 
 namespace Rector\Tests\CodeQuality\Rector\FuncCall\SetTypeToCastRector\Fixture;
 
-class SkipAssign
+final class SkipArgs
 {
     public function run($foo)
     {
-        $result = settype($foo, 'string');
+        is_bool(settype($foo, 'string'));
+
+        settype($foo, settype($foo, 'string'));
     }
 }

--- a/rules-tests/CodeQuality/Rector/FuncCall/SetTypeToCastRector/Fixture/skip_array_items.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SetTypeToCastRector/Fixture/skip_array_items.php.inc
@@ -2,10 +2,11 @@
 
 namespace Rector\Tests\CodeQuality\Rector\FuncCall\SetTypeToCastRector\Fixture;
 
-class SkipAssign
+class SkipArrayItems
 {
     public function run($foo)
     {
-        $result = settype($foo, 'string');
+        $result = [settype($foo, 'string')];
+        $result = [0 => settype($foo, 'string')];
     }
 }

--- a/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -49,8 +50,8 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Expression[] $node
-     * @param Expression[]|null $node
+     * @param Expression $node
+     * @return Stmt[]|null
      */
     public function refactor(Node $node): ?array
     {

--- a/rules/CodeQuality/Rector/FuncCall/SetTypeToCastRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SetTypeToCastRector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\Rector\FuncCall;
 
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Arg;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
@@ -79,7 +81,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [FuncCall::class, Expression::class, Assign::class, Expr\ArrayItem::class, Node\Arg::class];
+        return [FuncCall::class, Expression::class, Assign::class, ArrayItem::class, Arg::class];
     }
 
     /**
@@ -87,7 +89,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node)
     {
-        if ($node instanceof Node\Arg || $node instanceof Expr\ArrayItem) {
+        if ($node instanceof Arg || $node instanceof ArrayItem) {
             if ($this->isSetTypeFuncCall($node->value)) {
                 return NodeTraverser::STOP_TRAVERSAL;
             }

--- a/rules/CodeQuality/Rector/FuncCall/SetTypeToCastRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SetTypeToCastRector.php
@@ -131,10 +131,7 @@ CODE_SAMPLE
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         // result of function or probably used
-        if ($parentNode instanceof Expr || $parentNode instanceof Arg) {
-            return null;
-        }
-
+//        skip_assign.php.inc
         if (isset(self::TYPE_TO_CAST[$typeValue])) {
             $castClass = self::TYPE_TO_CAST[$typeValue];
             $castNode = new $castClass($variable);

--- a/src/Contract/Rector/PhpRectorInterface.php
+++ b/src/Contract/Rector/PhpRectorInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\Contract\Rector;
 
 use PhpParser\Node;
+use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 
 interface PhpRectorInterface extends NodeVisitor, RectorInterface
@@ -19,7 +20,7 @@ interface PhpRectorInterface extends NodeVisitor, RectorInterface
 
     /**
      * Process Node of matched type
-     * @return Node|Node[]|null
+     * @return Node|Node[]|null|NodeTraverser::*
      */
     public function refactor(Node $node);
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -184,7 +184,7 @@ CODE_SAMPLE;
         return parent::beforeTraverse($nodes);
     }
 
-    final public function enterNode(Node $node): ?Node
+    final public function enterNode(Node $node)
     {
         $nodeClass = $node::class;
         if (! $this->isMatchingNodeType($nodeClass)) {
@@ -216,9 +216,13 @@ CODE_SAMPLE;
         }
 
         $refactoredNode = $this->refactor($node);
-
         if ($isDebug) {
             $this->printConsumptions($startTime, $previousMemory);
+        }
+
+        // @see NodeTravser::* codes, e.g. removal of node of stopping the traversing
+        if (is_int($refactoredNode)) {
+            return $refactoredNode;
         }
 
         // nothing to change or just removed via removeNode() → continue


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/7947