### PR TITLE
[Traverser] Remove beforeTraverse() in StmtKeyNodeVisitor

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -5,12 +5,8 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Declare_;
-use PhpParser\Node\Stmt\Else_;
-use PhpParser\Node\Stmt\ElseIf_;
-use PhpParser\Node\Stmt\Finally_;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -18,24 +14,6 @@ use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNode
 
 final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
-    /**
-     * @param Node[] $nodes
-     * @return Node[]
-     */
-    public function beforeTraverse(array $nodes): array
-    {
-        foreach ($nodes as $key => $node) {
-            $currentStmtKey = $node->getAttribute(AttributeKey::STMT_KEY);
-            if ($currentStmtKey !== null) {
-                continue;
-            }
-
-            $node->setAttribute(AttributeKey::STMT_KEY, $key);
-        }
-
-        return $nodes;
-    }
-
     public function enterNode(Node $node): ?Node
     {
         if (! $node instanceof StmtsAwareInterface && ! $node instanceof ClassLike && ! $node instanceof Declare_) {
@@ -49,10 +27,6 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         // re-index stmt key under current node
         foreach ($node->stmts as $key => $childStmt) {
             $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
-        }
-
-        if ($node instanceof Else_ || $node instanceof ElseIf_ || $node instanceof Catch_ || $node instanceof Finally_) {
-            $node->setAttribute(AttributeKey::STMT_KEY, 0);
         }
 
         return null;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -29,6 +29,7 @@ use Rector\Core\Logging\CurrentRectorProvider;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\PhpParser\NodeTraverser\NodeConnectingTraverser;
@@ -180,6 +181,17 @@ CODE_SAMPLE;
         }
 
         $this->file = $file;
+
+        foreach ($nodes as $key => $childStmt) {
+            if (! $childStmt instanceof FileWithoutNamespace) {
+                $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
+                continue;
+            }
+
+            foreach ($childStmt->stmts as $keyChildStmt => $childStmtStmt) {
+                $childStmtStmt->setAttribute(AttributeKey::STMT_KEY, $keyChildStmt);
+            }
+        }
 
         return parent::beforeTraverse($nodes);
     }
@@ -365,27 +377,12 @@ CODE_SAMPLE;
             ? new Expression($refactoredNode)
             : $refactoredNode;
 
-        $this->mapStmtKey($originalNode, $refactoredNode);
-
         $this->updateParentNodes($refactoredNode, $parentNode);
         $this->nodeConnectingTraverser->traverse([$refactoredNode]);
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
         $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
         return $refactoredNode;
-    }
-
-    private function mapStmtKey(Node $originalNode, Node $refactoredNode): void
-    {
-        if ($originalNode instanceof Stmt) {
-            $refactoredNode->setAttribute(AttributeKey::STMT_KEY, $originalNode->getAttribute(AttributeKey::STMT_KEY));
-            return;
-        }
-
-        $currentStmt = $this->betterNodeFinder->resolveCurrentStatement($originalNode);
-        if ($currentStmt instanceof Stmt) {
-            $refactoredNode->setAttribute(AttributeKey::STMT_KEY, $currentStmt->getAttribute(AttributeKey::STMT_KEY));
-        }
     }
 
     /**


### PR DESCRIPTION
Re-index stmt_key on `StmtKeyNodeVisitor::beforeTraverse()` is invalid, as it may be a refactored node, which parts of collection of stmts, which if only once, it will got `0` index.

Instead, move to `AbstractRector::beforeTraverse()`.