### PR TITLE
[CodingStyle] Remove parent attribute on NewlineAfterStatementRector

### DIFF
--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -151,7 +151,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($this->isRemoved($nextStmt, $stmt)) {
+            if ($this->isRemoved($stmt)) {
                 continue;
             }
 
@@ -204,18 +204,9 @@ CODE_SAMPLE
         return ! isset($comments[0]);
     }
 
-    private function isRemoved(Stmt $nextStmt, Stmt $stmt): bool
+    private function isRemoved(Stmt $stmt): bool
     {
-        if ($this->nodesToRemoveCollector->isNodeRemoved($stmt)) {
-            return true;
-        }
-        
-        return false;
-        
-        $parentCurrentNode = $stmt->getAttribute(AttributeKey::PARENT_NODE);
-        $parentnextStmt = $nextStmt->getAttribute(AttributeKey::PARENT_NODE);
-
-        return $parentnextStmt !== $parentCurrentNode;
+        return $this->nodesToRemoveCollector->isNodeRemoved($stmt);
     }
 
     private function shouldSkip(Stmt $stmt): bool

--- a/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
+++ b/rules/CodingStyle/Rector/Stmt/NewlineAfterStatementRector.php
@@ -209,7 +209,9 @@ CODE_SAMPLE
         if ($this->nodesToRemoveCollector->isNodeRemoved($stmt)) {
             return true;
         }
-
+        
+        return false;
+        
         $parentCurrentNode = $stmt->getAttribute(AttributeKey::PARENT_NODE);
         $parentnextStmt = $nextStmt->getAttribute(AttributeKey::PARENT_NODE);
 


### PR DESCRIPTION
Since we use StmtsAwareInterface, different parent with next stmt should not happened.