### PR TITLE
Revert [NodeTypeResolver] Remove parent attribute usage on PHPStanNodeScopeResolver for next UnreachableStatementNode detection (#3970)

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -20,6 +20,8 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\EnumCase;
 use PhpParser\Node\Stmt\Expression;
@@ -237,7 +239,7 @@ final class PHPStanNodeScopeResolver
             return;
         }
 
-        if (! $stmt instanceof StmtsAwareInterface) {
+        if (! $stmt instanceof StmtsAwareInterface && ! $stmt instanceof ClassLike && ! $stmt instanceof Declare_) {
             return;
         }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -219,7 +219,7 @@ final class PHPStanNodeScopeResolver
             }
 
             if ($node instanceof Stmt) {
-                $this->setChildOfUnreachableStatementNodeAttribute($node);
+                $this->setChildOfUnreachableStatementNodeAttribute($node, $mutatingScope);
             }
 
             // special case for unreachable nodes
@@ -233,7 +233,7 @@ final class PHPStanNodeScopeResolver
         return $this->processNodesWithDependentFiles($filePath, $stmts, $scope, $nodeCallback);
     }
 
-    private function setChildOfUnreachableStatementNodeAttribute(Stmt $stmt): void
+    private function setChildOfUnreachableStatementNodeAttribute(Stmt $stmt, MutatingScope $mutatingScope): void
     {
         if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) !== true) {
             return;
@@ -249,6 +249,7 @@ final class PHPStanNodeScopeResolver
 
         foreach ($stmt->stmts as $childStmt) {
             $childStmt->setAttribute(AttributeKey::IS_UNREACHABLE, true);
+            $childStmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
         }
     }
 
@@ -321,8 +322,7 @@ final class PHPStanNodeScopeResolver
         $this->processNodes([$originalStmt], $filePath, $mutatingScope);
 
         $parentNode = $unreachableStatementNode->getAttribute(AttributeKey::PARENT_NODE);
-
-        if (! $parentNode instanceof StmtsAwareInterface) {
+        if (! $parentNode instanceof StmtsAwareInterface && ! $parentNode instanceof ClassLike && ! $parentNode instanceof Declare_) {
             return;
         }
 

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_after_infinite_loop.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/skip_after_infinite_loop.php.inc
@@ -13,10 +13,6 @@ final class SkipAfterInfiniteLoop
 
         if ($b = $yes) {
             $a[] = 'test';
-
-            if ($x = 'true') {
-                $yyy = 'test';
-            }
         }
 
         return $a;


### PR DESCRIPTION
This reverts commit dde521123623a81766e43d35f418be416340b01f.

Revert of https://github.com/rectorphp/rector-src/pull/3970