### PR TITLE
add symfony contracts for trigger_deprecation function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "sebastian/diff": "^5.0",
         "symfony/config": "^6.2",
         "symfony/console": "^6.2.2",
+        "symfony/contracts": "^3.2",
         "symfony/dependency-injection": "6.1.*",
         "symfony/finder": "^6.2",
         "symfony/process": "^6.2",


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-src/actions/runs/5098183091/jobs/9165174937, symfony/contracts are needed after all 