### PR TITLE
[Php81] Add $hasChanged flag to only return node on changed params on NewInInitializerRector

### DIFF
--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -97,6 +97,7 @@ CODE_SAMPLE
             return null;
         }
 
+        $hasChanged = false;
         foreach ($params as $param) {
             /** @var string $paramName */
             $paramName = $this->getName($param->var);
@@ -126,10 +127,16 @@ CODE_SAMPLE
 
                 $this->removeNode($toPropertyAssign);
                 $this->processPropertyPromotion($node, $param, $paramName);
+
+                $hasChanged = true;
             }
         }
 
-        return $node;
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
-        foreach ($node->params as $param) {
+        foreach ($params as $param) {
             /** @var string $paramName */
             $paramName = $this->getName($param->var);
 

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -84,21 +84,13 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isLegalClass($node)) {
-            return null;
-        }
-
-        $params = $this->matchConstructorParams($node);
+        $params = $this->resolveParams($node);
         if ($params === []) {
             return null;
         }
 
-        if ($this->isOverrideAbstractMethod($node)) {
-            return null;
-        }
-
         $hasChanged = false;
-        foreach ($params as $param) {
+        foreach ($node->params as $param) {
             /** @var string $paramName */
             $paramName = $this->getName($param->var);
 
@@ -142,6 +134,27 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::NEW_INITIALIZERS;
+    }
+
+    /**
+     * @return Param[]
+     */
+    private function resolveParams(ClassMethod $classMethod): array
+    {
+        if (! $this->isLegalClass($classMethod)) {
+            return [];
+        }
+
+        $params = $this->matchConstructorParams($classMethod);
+        if ($params === []) {
+            return [];
+        }
+
+        if ($this->isOverrideAbstractMethod($classMethod)) {
+            return [];
+        }
+
+        return $params;
     }
 
     private function isOverrideAbstractMethod(ClassMethod $classMethod): bool


### PR DESCRIPTION
To avoid show unrelated rules defined in the list.