### PR TITLE
[Testing] Remove require_once on TestingParser::parseFileToDecoratedNodes()

### DIFF
--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -39,9 +39,6 @@ final class TestingParser
      */
     public function parseFileToDecoratedNodes(string $filePath): array
     {
-        // autoload file
-        require_once $filePath;
-
         $this->parameterProvider->changeParameter(Option::SOURCE, [$filePath]);
 
         $nodes = $this->rectorParser->parseFile($filePath);


### PR DESCRIPTION
`require_once` seems not needed.