### PR TITLE
[Test] Enable displayDetailsOnTestsThatTriggerWarnings to true in tests to show warning

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
     colors="true"
     executionOrder="defects"
     defaultTestSuite="main"
+    displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <testsuites>
         <testsuite name="main">

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -116,7 +116,7 @@ final class UseImportsAdder
             return;
         }
 
-        if ($stmts[$indexStmt] instanceof Use_) {
+        if (isset($stmts[$indexStmt]) && $stmts[$indexStmt] instanceof Use_) {
             $comments = (array) $stmts[$indexStmt]->getAttribute(AttributeKey::COMMENTS);
 
             if ($comments !== []) {


### PR DESCRIPTION
To properly show erorrs:

```
vendor/bin/phpunit tests/Issues                                                                           
PHPUnit 10.1.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.5
Configuration: /Users/samsonasik/www/rector-src/phpunit.xml

...............................................................  63 / 179 ( 35%)
.............W..W.............................................. 126 / 179 ( 70%)
.....................................................           179 / 179 (100%)

Time: 00:19.685, Memory: 1.18 GB

2 tests triggered 2 PHP warnings:

1) Rector\Core\Tests\Issues\Issue6496\AutoImportDocBlockTest::test with data set #1
Undefined array key 0
/Users/samsonasik/www/rector-src/rules/CodingStyle/Application/UseImportsAdder.php:119

/Users/samsonasik/www/rector-src/tests/Issues/Issue6496/AutoImportDocBlockTest.php:14

2) Rector\Core\Tests\Issues\Issue6496\AutoImportDocBlockTest::test with data set #2
Undefined array key 0
/Users/samsonasik/www/rector-src/rules/CodingStyle/Application/UseImportsAdder.php:119

/Users/samsonasik/www/rector-src/tests/Issues/Issue6496/AutoImportDocBlockTest.php:14

OK, but there are issues!
Tests: 179, Assertions: 191, Warnings: 2.
```

Ref https://github.com/rectorphp/rector/issues/7958