### PR TITLE
[Php80] Remove parent attribute usage on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -205,7 +205,7 @@ final class PhpDocTypeChanger
         return in_array((string) $typeNode, self::ALLOWED_IDENTIFIER_TYPENODE_TYPES, true);
     }
 
-    public function copyPropertyDocToParam(Property $property, Param $param): void
+    public function copyPropertyDocToParam(ClassMethod $classMethod, Property $property, Param $param): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
         if (! $phpDocInfo instanceof PhpDocInfo) {
@@ -222,13 +222,7 @@ final class PhpDocTypeChanger
             return;
         }
 
-        $parentNode = $param->getAttribute(AttributeKey::PARENT_NODE);
         $paramVarName = $this->nodeNameResolver->getName($param->var);
-
-        if (! $parentNode instanceof ClassMethod) {
-            return;
-        }
-
         if (! $this->isAllowed($varTagValueNode->type)) {
             return;
         }
@@ -240,7 +234,7 @@ final class PhpDocTypeChanger
         $phpDocInfo->removeByType(VarTagValueNode::class);
         $param->setAttribute(AttributeKey::PHP_DOC_INFO, $phpDocInfo);
 
-        $phpDocInfo = $parentNode->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
         $paramType = $this->staticTypeMapper->mapPHPStanPhpDocTypeToPHPStanType($varTagValueNode, $property);
 
         $this->changeParamType($phpDocInfo, $paramType, $param, $paramVarName);

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -175,7 +175,7 @@ CODE_SAMPLE
             $param->attrGroups = array_merge($param->attrGroups, $property->attrGroups);
             $this->processNullableType($property, $param);
 
-            $this->phpDocTypeChanger->copyPropertyDocToParam($property, $param);
+            $this->phpDocTypeChanger->copyPropertyDocToParam($constructClassMethod, $property, $param);
         }
 
         return $node;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/7947