### PR TITLE
[Core] Ensure reindex node attributes even on re-print

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -217,10 +217,7 @@ CODE_SAMPLE;
             $this->printCurrentFileAndRule();
         }
 
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-        if ($originalNode instanceof Node) {
-            $this->changedNodeScopeRefresher->reIndexNodeAttributes($node);
-        }
+        $this->changedNodeScopeRefresher->reIndexNodeAttributes($node);
 
         if ($isDebug) {
             $startTime = microtime(true);
@@ -247,6 +244,7 @@ CODE_SAMPLE;
             throw new ShouldNotHappenException($errorMessage);
         }
 
+        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
         return $this->postRefactorProcess($originalNode, $node, $refactoredNode);
     }
 


### PR DESCRIPTION
re-print may need reindex stmt_key, so better to always reindex before refactor to avoid race condition.