### PR TITLE
[Php56] Reduce origNode check on UndefinedVariableResolver

### DIFF
--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -57,19 +57,11 @@ final class UndefinedVariableResolver
         ): ?int {
             // entering new scope - break!
             if ($node instanceof FunctionLike && ! $node instanceof ArrowFunction) {
-                return NodeTraverser::STOP_TRAVERSAL;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
             if ($node instanceof Foreach_) {
                 // handled above
-                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-            }
-
-            /**
-             * The Node that doesn't have origNode attribute yet
-             * means the Node is a replacement below other changed node
-             */
-            if (! $node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 


### PR DESCRIPTION
since we have always reindexed stmt_key, check origNode exists seems not needed.