### PR TITLE
[Performance] Reduce parent lookup on PropertyFetchAnalyzer

### DIFF
--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -17,8 +17,10 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
+use PhpParser\NodeTraverser;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
 use Rector\Core\Enum\ObjectReference;
@@ -94,21 +96,16 @@ final class PropertyFetchAnalyzer
             $propertyName,
             &$total
         ): ?Node {
+            // skip anonymous classes and inner function
+            if ($subNode instanceof Class_ || $subNode instanceof Function_) {
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
             if (! $this->isLocalPropertyFetchName($subNode, $propertyName)) {
                 return null;
             }
 
-            $parentClassLike = $this->betterNodeFinder->findParentType($subNode, ClassLike::class);
-
-            // property fetch in Trait cannot get parent ClassLike
-            if (! $parentClassLike instanceof ClassLike) {
-                ++$total;
-            }
-
-            if ($parentClassLike === $class) {
-                ++$total;
-            }
-
+            ++$total;
             return $subNode;
         });
 

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -91,7 +91,7 @@ final class PropertyFetchAnalyzer
     {
         $total = 0;
 
-        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($class->stmts, function (Node $subNode) use (
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($class->getMethods(), function (Node $subNode) use (
             $class,
             $propertyName,
             &$total

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -92,7 +92,6 @@ final class PropertyFetchAnalyzer
         $total = 0;
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($class->getMethods(), function (Node $subNode) use (
-            $class,
             $propertyName,
             &$total
         ): int|null|Node {

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -95,7 +95,7 @@ final class PropertyFetchAnalyzer
             $class,
             $propertyName,
             &$total
-        ): ?Node {
+        ): int|null|Node {
             // skip anonymous classes and inner function
             if ($subNode instanceof Class_ || $subNode instanceof Function_) {
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;


### PR DESCRIPTION
when looking `PropertyFetch` via `simpleCallableNodeTraverser`, don't traverse on inner class and inner function.