### PR TITLE
[NodeManipulator] Reduce parent lookup on PropertyFetchAssignManipulator

### DIFF
--- a/src/NodeManipulator/PropertyFetchAssignManipulator.php
+++ b/src/NodeManipulator/PropertyFetchAssignManipulator.php
@@ -6,8 +6,10 @@ namespace Rector\Core\NodeManipulator;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeTraverser;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
@@ -43,17 +45,17 @@ final class PropertyFetchAssignManipulator
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $classMethod->getStmts(),
-            function (Node $node) use ($propertyName, $classLike, &$count): ?int {
+            function (Node $node) use ($propertyName, &$count): ?int {
+                // skip anonymous classes and inner function
+                if ($node instanceof Class_ || $node instanceof Function_) {
+                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                }
+
                 if (! $node instanceof Assign) {
                     return null;
                 }
 
                 if (! $this->propertyFetchAnalyzer->isLocalPropertyFetchName($node->var, $propertyName)) {
-                    return null;
-                }
-
-                $parentClassLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
-                if ($parentClassLike !== $classLike) {
                     return null;
                 }
 


### PR DESCRIPTION
same with PR:

- https://github.com/rectorphp/rector-src/pull/4034


when looking `PropertyFetch` via `simpleCallableNodeTraverser`, don't traverse on inner class and inner function.
