### PR TITLE
[Core] No need reindex FileWithoutNamespace on AbstractRector::beforeTraverse

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -186,11 +186,7 @@ CODE_SAMPLE;
             if (! $childStmt instanceof FileWithoutNamespace) {
                 $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
                 continue;
-            }
-
-            foreach ($childStmt->stmts as $keyChildStmt => $childStmtStmt) {
-                $childStmtStmt->setAttribute(AttributeKey::STMT_KEY, $keyChildStmt);
-            }
+            }   
         }
 
         return parent::beforeTraverse($nodes);


### PR DESCRIPTION
Since reindex happen even on reprint PR:

- https://github.com/rectorphp/rector-src/pull/4030

FileWithoutNamespace seems no longer need reindex. 

Left namespace part as it can have declare before it, or multi namespace.