### PR TITLE
Revert [Core] No need reindex FileWithoutNamespace on AbstractRector::beforeTraverse

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -186,7 +186,11 @@ CODE_SAMPLE;
             if (! $childStmt instanceof FileWithoutNamespace) {
                 $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
                 continue;
-            }   
+            }
+
+            foreach ($childStmt->stmts as $keyChildStmt => $childStmtStmt) {
+                $childStmtStmt->setAttribute(AttributeKey::STMT_KEY, $keyChildStmt);
+            }
         }
 
         return parent::beforeTraverse($nodes);


### PR DESCRIPTION
Reverts rectorphp/rector-src#4043