### PR TITLE
[CodeQuality] Skip deep append in if foreach before on ForeachItemsAssignToEmptyArrayToAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_deep_append_foreach.php.inc
+++ b/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_deep_append_foreach.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRector\Fixture;
+
+class SkipDeepAppendForeach
+{
+    public function run(array $items)
+    {
+        $items2 = [];
+
+        if (rand(0, 1)) {
+            foreach (['foo', 'bar'] as $item) {
+                $items2[] = $item;
+            }
+        }
+
+        foreach ($items as $item) {
+            $items2[] = $item;
+        }
+    }
+}
+

--- a/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
@@ -92,11 +92,11 @@ CODE_SAMPLE
                 $emptyArrayVariables[] = $variableName;
             }
 
-            if ($this->isAppend($stmt, $emptyArrayVariables)) {
-                return null;
-            }
-
             if (! $stmt instanceof Foreach_) {
+                if ($this->isAppend($stmt, $emptyArrayVariables)) {
+                    return null;
+                }
+
                 continue;
             }
 
@@ -128,10 +128,6 @@ CODE_SAMPLE
         $this->traverseNodesWithCallable(
             $stmt,
             function (Node $subNode) use ($emptyArrayVariables, &$isAppend): ?int {
-                if ($subNode instanceof Foreach_) {
-                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-                }
-
                 if ($subNode instanceof Assign && $subNode->var instanceof ArrayDimFetch) {
                     $isAppend = $this->isNames($subNode->var->var, $emptyArrayVariables);
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/4052

The following code should be skipped as well:

```php
        $items2 = [];

        if (rand(0, 1)) {
            foreach (['foo', 'bar'] as $item) {
                $items2[] = $item;
            }
        }

        foreach ($items as $item) {
            $items2[] = $item;
        }
```