### PR TITLE
[Printer] Remove BetterStandarPrinter::cleanSurplusTag() and cleanEndWithPHPOpenTag()

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -73,9 +73,6 @@ return static function (RectorConfig $rectorConfig): void {
         '**/Expected*',
         __DIR__ . '/tests/PhpUnit/MultipleFilesChangedTrait/MultipleFilesChangedTraitTest.php',
 
-        // ignore for now, as printer cleans duplicate string of itself
-        __DIR__ . '/src/PhpParser/Printer/BetterStandardPrinter.php',
-
         // to keep original API from PHPStan untouched
         __DIR__ . '/packages/Caching/ValueObject/Storage/FileCacheStorage.php',
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -114,8 +114,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             $content .= $this->nl;
         }
 
-        $content = $this->cleanSurplusTag($content);
-        return $this->cleanEndWithPHPOpenTag($content);
+        return $content;
     }
 
     /**
@@ -516,35 +515,6 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
             . ($param->variadic ? '...' : '')
             . $this->p($param->var)
             . ($param->default instanceof Expr ? ' = ' . $this->p($param->default) : '');
-    }
-
-    private function cleanEndWithPHPOpenTag(string $content): string
-    {
-        if (str_ends_with($content, "<?php \n")) {
-            return substr($content, 0, -7);
-        }
-
-        if (str_ends_with($content, '<?php ')) {
-            return substr($content, 0, -6);
-        }
-
-        return $content;
-    }
-
-    private function cleanSurplusTag(string $content): string
-    {
-        $content = str_replace('<?php <?php', '<?php', $content);
-        $content = str_replace('?>?>', '?>', $content);
-
-        if (str_starts_with($content, "?>\n")) {
-            return substr($content, 3);
-        }
-
-        if (str_starts_with($content, "<?php\n\n?>")) {
-            return substr($content, 10);
-        }
-
-        return $content;
     }
 
     private function shouldPrintNewRawValue(LNumber|DNumber $lNumber): bool


### PR DESCRIPTION
Since `MixPhpHtmlDecorator` removed at PR:

- https://github.com/rectorphp/rector-src/pull/4054

The `cleanSurplusTag()` and `cleanEndWithPHPOpenTag()` will randomly change file for no reason, as it may change file with have that code on purpose, as previously have `disableIsRequireReprintInlineHTML` flag for reason to clean up tag.

This PR remove the methods.