### PR TITLE
[DependencyInjection] Remove deprecated constants support on ConfigureCallValuesCollector

### DIFF
--- a/src/Console/Style/SymfonyStyleFactory.php
+++ b/src/Console/Style/SymfonyStyleFactory.php
@@ -18,6 +18,9 @@ final class SymfonyStyleFactory
     ) {
     }
 
+    /**
+     * @api
+     */
     public function create(): SymfonyStyle
     {
         // to prevent missing argv indexes

--- a/src/DependencyInjection/Collector/ConfigureCallValuesCollector.php
+++ b/src/DependencyInjection/Collector/ConfigureCallValuesCollector.php
@@ -4,13 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Core\DependencyInjection\Collector;
 
-use Rector\Core\Console\Style\SymfonyStyleFactory;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Util\ArrayParametersMerger;
-use Rector\Core\Util\Reflection\PrivatesAccessor;
-use ReflectionClass;
-use ReflectionClassConstant;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Definition;
 
 final class ConfigureCallValuesCollector
@@ -22,13 +17,9 @@ final class ConfigureCallValuesCollector
 
     private readonly ArrayParametersMerger $arrayParametersMerger;
 
-    private readonly SymfonyStyle $symfonyStyle;
-
     public function __construct()
     {
         $this->arrayParametersMerger = new ArrayParametersMerger();
-        $symfonyStyleFactory = new SymfonyStyleFactory(new PrivatesAccessor());
-        $this->symfonyStyle = $symfonyStyleFactory->create();
     }
 
     /**
@@ -60,42 +51,6 @@ final class ConfigureCallValuesCollector
     private function addConfigureCallValues(string $rectorClass, array $configureValues): void
     {
         foreach ($configureValues as $configureValue) {
-            // is nested or unnested value?
-            if (is_array($configureValue) && count($configureValue) === 1) {
-                $firstKey = array_key_first($configureValue);
-
-                if (is_string($firstKey) && is_array($configureValue[$firstKey])) {
-                    // has class some public constants?
-                    // fixes bug when 1 item is unwrapped and treated as constant key, without rule having public constant
-                    $classReflection = new ReflectionClass($rectorClass);
-
-                    $constantNamesToValues = $classReflection->getConstants(ReflectionClassConstant::IS_PUBLIC);
-                    foreach ($constantNamesToValues as $constantName => $constantValue) {
-                        if ($constantValue === $firstKey) {
-                            $reflectionConstant = $classReflection->getReflectionConstant($constantName);
-                            if ($reflectionConstant === false) {
-                                continue;
-                            }
-
-                            if (! str_contains((string) $reflectionConstant->getDocComment(), '@deprecated')) {
-                                continue;
-                            }
-
-                            $warningMessage = sprintf(
-                                'The constant for "%s::%s" is deprecated.%sUse "$rectorConfig->ruleWithConfiguration()" instead.',
-                                $rectorClass,
-                                $constantName,
-                                PHP_EOL
-                            );
-                            $this->symfonyStyle->warning($warningMessage);
-
-                            $configureValue = $configureValue[$firstKey];
-                            break;
-                        }
-                    }
-                }
-            }
-
             if (! isset($this->configureCallValuesByRectorClass[$rectorClass])) {
                 $this->configureCallValuesByRectorClass[$rectorClass] = $configureValue;
             } else {


### PR DESCRIPTION
`$rectorConfig->ruleWithConfiguration()` is exists in long time, and the deprecation notice exists since 2 years. 

I think this deprecated constants usage can be removed.