### PR TITLE
[NodeTypeResolver] Handle crash after next exit() on no namespaced code after removal next attribute

### DIFF
--- a/packages/FileSystemRector/Parser/FileInfoParser.php
+++ b/packages/FileSystemRector/Parser/FileInfoParser.php
@@ -30,8 +30,6 @@ final class FileInfoParser
     public function parseFileInfoToNodesAndDecorate(string $filePath): array
     {
         $stmts = $this->rectorParser->parseFile($filePath);
-        $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
-
         $file = new File($filePath, FileSystem::read($filePath));
 
         return $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);

--- a/packages/FileSystemRector/Parser/FileInfoParser.php
+++ b/packages/FileSystemRector/Parser/FileInfoParser.php
@@ -30,6 +30,8 @@ final class FileInfoParser
     public function parseFileInfoToNodesAndDecorate(string $filePath): array
     {
         $stmts = $this->rectorParser->parseFile($filePath);
+        $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
+
         $file = new File($filePath, FileSystem::read($filePath));
 
         return $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -108,8 +108,7 @@ final class PHPStanNodeScopeResolver
          */
 
         Assert::allIsInstanceOf($stmts, Stmt::class);
-
-        $stmts = $this->nodeTraverser->traverse($stmts);
+        $this->nodeTraverser->traverse($stmts);
 
         if (! $isScopeRefreshing) {
             $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -110,10 +110,13 @@ final class PHPStanNodeScopeResolver
         Assert::allIsInstanceOf($stmts, Stmt::class);
 
         $stmts = $this->nodeTraverser->traverse($stmts);
-        $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
 
-        if (count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace) {
-            $stmts = $stmts[0]->stmts;
+        if (! $isScopeRefreshing) {
+            $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
+
+            if (count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace) {
+                $stmts = $stmts[0]->stmts;
+            }
         }
 
         $scope = $formerMutatingScope ?? $this->scopeFactory->createFromFile($filePath);

--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/after_exit.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/after_exit.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+// no namespace on purpose to cover crash on FileWithoutNamespace
+exit();
+
+// this part is needed to produce crash
+echo 'some statement';
+
+function run2()
+{
+    preg_split('#a#', null);
+}
+
+?>
+-----
+<?php
+
+// no namespace on purpose to cover crash on FileWithoutNamespace
+exit();
+
+// this part is needed to produce crash
+echo 'some statement';
+
+function run2()
+{
+    preg_split('#a#', '');
+}
+
+?>

--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/after_exit_namespaced.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/after_exit_namespaced.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+exit();
+
+echo 'some statement';
+
+function run2()
+{
+    preg_split('#a#', null);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+exit();
+
+echo 'some statement';
+
+function run2()
+{
+    preg_split('#a#', '');
+}
+
+?>

--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -17,7 +17,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v54';
+    private const CACHE_KEY = 'v55';
 
     private ContainerInterface|null $container = null;
 


### PR DESCRIPTION
After removal of `next` attribute, on no namespaced code, the stmts collected via `FileWithoutNamespaceNodeTraverser` which seems late detect the `UnreachableStatementNode` next stmt handling cause crash.

This PR try to fix https://github.com/rectorphp/rector/issues/7972