### PR TITLE
[NodeTraverser] Remove double apply FileWithoutNamespace, remove recursive lookup stmts on BetterStandardPrinter

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -110,7 +110,8 @@ final class PHPStanNodeScopeResolver
         Assert::allIsInstanceOf($stmts, Stmt::class);
         $this->nodeTraverser->traverse($stmts);
 
-        if (! $isScopeRefreshing) {
+        $isFileWithoutNamespace = count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace;
+        if (! $isScopeRefreshing && ! $isFileWithoutNamespace) {
             $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
 
             if (count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace) {

--- a/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
@@ -25,6 +25,10 @@ final class FileWithoutNamespaceNodeTraverser extends NodeTraverser
      */
     public function traverse(array $nodes): array
     {
+        if (current($nodes) instanceof FileWithoutNamespace) {
+            return $nodes;
+        }
+
         $hasNamespace = (bool) $this->nodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
         if (! $hasNamespace && $nodes !== []) {
             $fileWithoutNamespace = new FileWithoutNamespace($nodes);

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -531,7 +531,7 @@ final class BetterStandardPrinter extends Standard implements NodePrinterInterfa
         $stmts = array_values($stmts);
 
         if (count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace) {
-            return $this->resolveNewStmts($stmts[0]->stmts);
+            return $stmts[0]->stmts;
         }
 
         return $stmts;


### PR DESCRIPTION
If current node already `FileWithoutNamespace`, not need to wrap inside `FileWithoutNamespace` to avoid needed of recursive look stmts inside BetterStandardPrinter.