### PR TITLE
Fix StaticCallOnNonStaticToInstanceCallRector to skip parent's parent…

### DIFF
--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/keep_parent_parent_method.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/keep_parent_parent_method.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class Grandpa
+{
+    protected function test()
+    {
+    }
+}
+
+class Father extends Grandpa
+{
+    protected function test()
+    {
+        parent::test();
+    }
+}
+
+class Son extends Father
+{
+    protected function test()
+    {
+        Grandpa::test();
+    }
+}

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
@@ -164,6 +165,11 @@ CODE_SAMPLE
 
         $isStaticMethod = $this->staticAnalyzer->isStaticMethod($classReflection, $methodName);
         if ($isStaticMethod) {
+            return true;
+        }
+
+        $reflection = $scope->getClassReflection();
+        if ($reflection instanceof ClassReflection && $reflection->isSubclassOf($className)) {
             return true;
         }
 


### PR DESCRIPTION
…'s method calls.

[Issue 7974](https://github.com/rectorphp/rector/issues/7974)