### PR TITLE
Fix StaticCallOnNonStaticToInstanceCallRector to skip parent's parent…

### DIFF
--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/keep_parent_parent_method.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/keep_parent_parent_method.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class Grandpa
+{
+    protected function test()
+    {
+    }
+}
+
+class Father extends Grandpa
+{
+    protected function test()
+    {
+        parent::test();
+    }
+}
+
+class Son extends Father
+{
+    protected function test()
+    {
+        Grandpa::test();
+    }
+}


### PR DESCRIPTION
…'s method calls.

[Issue 7974](https://github.com/rectorphp/rector/issues/7974)