### PR TITLE
[NodeTraverser] Traverse fill stmt_key after FileWithoutNamespaceNodeTraverser on PHPStanNodeScopeResolver

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -108,15 +108,22 @@ final class PHPStanNodeScopeResolver
          */
 
         Assert::allIsInstanceOf($stmts, Stmt::class);
-        $this->nodeTraverser->traverse($stmts);
 
+        $isInitFileWithoutNamespace = false;
         if (! $isScopeRefreshing && ! current($stmts) instanceof FileWithoutNamespace) {
             $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
 
             $currentStmt = current($stmts);
             if ($currentStmt instanceof FileWithoutNamespace) {
+                $this->nodeTraverser->traverse($stmts);
                 $stmts = $currentStmt->stmts;
+
+                $isInitFileWithoutNamespace = true;
             }
+        }
+
+        if (! $isInitFileWithoutNamespace) {
+            $this->nodeTraverser->traverse($stmts);
         }
 
         $scope = $formerMutatingScope ?? $this->scopeFactory->createFromFile($filePath);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -176,10 +176,6 @@ CODE_SAMPLE;
                 $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
                 continue;
             }
-
-            foreach ($childStmt->stmts as $keyChildStmt => $childStmtStmt) {
-                $childStmtStmt->setAttribute(AttributeKey::STMT_KEY, $keyChildStmt);
-            }
         }
 
         return parent::beforeTraverse($nodes);


### PR DESCRIPTION
Use collection of visitor with traverser after `FileWithoutNamespaceNodeTraverser` init.