### PR TITLE
[Traverser] Utilize statementDepth attribute on StmtKeyNodeVisitor to fill stmt_key in root of stmts

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -216,4 +216,9 @@ final class AttributeKey
      * @var string
      */
     public const IS_MULTI_ASSIGN = 'is_multi_assign';
+
+    /**
+     * @var string
+     */
+    public const STATEMENT_DEPTH = 'statementDepth';
 }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\NodeVisitorAbstract;
@@ -14,6 +15,27 @@ use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNode
 
 final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
+    /**
+     * @param Stmt[] $nodes
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        $currentNode = current($nodes);
+
+        if (! $currentNode instanceof Stmt) {
+            return $nodes;
+        }
+
+        $statementDepth = $currentNode->getAttribute(AttributeKey::STATEMENT_DEPTH);
+        if ($statementDepth > 0) {
+            return $nodes;
+        }
+
+        foreach ($nodes as $key => $node) {
+            $node->setAttribute(AttributeKey::STMT_KEY, $key);
+        }
+    }
+
     public function enterNode(Node $node): ?Node
     {
         if (! $node instanceof StmtsAwareInterface && ! $node instanceof ClassLike && ! $node instanceof Declare_) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -23,17 +23,17 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         $currentNode = current($nodes);
 
         if (! $currentNode instanceof Stmt) {
-            return $nodes;
+            return null;
         }
 
         $statementDepth = $currentNode->getAttribute(AttributeKey::STATEMENT_DEPTH);
         if ($statementDepth > 0) {
-            return $nodes;
+            return null;
         }
 
         // on target node or no other root stmt, eg: only namespace without declare, no need reindex
         if (count($nodes) === 1) {
-            return $nodes;
+            return null;
         }
 
         foreach ($nodes as $key => $node) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -31,6 +31,11 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return $nodes;
         }
 
+        // on target node, no need reindex
+        if (count($nodes) === 1) {
+            return $nodes;
+        }
+
         foreach ($nodes as $key => $node) {
             $node->setAttribute(AttributeKey::STMT_KEY, $key);
         }

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -16,7 +16,7 @@ use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNode
 final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
     /**
-     * @param Stmt[] $nodes
+     * @param Node[] $nodes
      */
     public function beforeTraverse(array $nodes)
     {
@@ -39,6 +39,8 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         foreach ($nodes as $key => $node) {
             $node->setAttribute(AttributeKey::STMT_KEY, $key);
         }
+
+        return $nodes;
     }
 
     public function enterNode(Node $node): ?Node

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -27,7 +27,7 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         }
 
         $statementDepth = $currentNode->getAttribute(AttributeKey::STATEMENT_DEPTH);
-        if ($statementDepth > 0) {
+        if ($statementDepth > 0 || $statementDepth === null) {
             return null;
         }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -31,7 +31,7 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return $nodes;
         }
 
-        // on target node, no need reindex
+        // on target node or no other root stmt, eg: only namespace without declare, no need reindex
         if (count($nodes) === 1) {
             return $nodes;
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -30,7 +30,6 @@ use Rector\Core\Logging\CurrentRectorProvider;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\PhpParser\NodeTraverser\NodeConnectingTraverser;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -171,13 +171,6 @@ CODE_SAMPLE;
 
         $this->file = $file;
 
-        foreach ($nodes as $key => $childStmt) {
-            if (! $childStmt instanceof FileWithoutNamespace) {
-                $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
-                continue;
-            }
-        }
-
         return parent::beforeTraverse($nodes);
     }
 


### PR DESCRIPTION
By this, no more loop root nodes on `AbstractRector::beforeTraverse()`