### PR TITLE
[Core] Remove manual reindex stmt_key on ChangedNodeScopeRefresher::reIndexNodeAttributes()

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -53,6 +53,8 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return null;
         }
 
+        $node->stmts = array_values($node->stmts);
+
         // re-index stmt key under current node
         foreach ($node->stmts as $key => $childStmt) {
             $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -98,15 +98,6 @@ final class ChangedNodeScopeRefresher
 
     public function reIndexNodeAttributes(Node $node): void
     {
-        if ($this->hasArrayStmtsNode($node)) {
-            /**
-             * @var StmtsAwareInterface|ClassLike|Declare_ $node
-             * @var Stmt[] $stmts
-             */
-            $stmts = $node->stmts;
-            $node->stmts = array_values($stmts);
-        }
-
         if ($node instanceof FunctionLike) {
             /** @var ClassMethod|Function_|Closure $node */
             $node->params = array_values($node->params);

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -17,9 +17,7 @@ use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
@@ -27,7 +25,6 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use PHPStan\Analyser\MutatingScope;
-use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\Core\Provider\CurrentFileProvider;
@@ -123,11 +120,6 @@ final class ChangedNodeScopeRefresher
         if ($node instanceof Switch_) {
             $node->cases = array_values($node->cases);
         }
-    }
-
-    private function hasArrayStmtsNode(Node $node): bool
-    {
-        return ($node instanceof ClassLike || $node instanceof StmtsAwareInterface || $node instanceof Declare_) && $node->stmts !== null;
     }
 
     /**

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -105,10 +105,6 @@ final class ChangedNodeScopeRefresher
              */
             $stmts = $node->stmts;
             $node->stmts = array_values($stmts);
-
-            foreach ($node->stmts as $key => $stmt) {
-                $stmt->setAttribute(AttributeKey::STMT_KEY, $key);
-            }
         }
 
         if ($node instanceof FunctionLike) {


### PR DESCRIPTION
Since we no longer have `removeNode()` that may overlap with PostRector, the manual reindex stmt_key on `ChangedNodeScopeRefresher::reIndexNodeAttributes()` seems no longer needed, and we can rely on `StmtKeyNodeVisitor` instead.