### PR TITLE
[Php56] Remove parent lookup on UndefinedVariableResolver

### DIFF
--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -17,7 +17,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v85';
+    private const CACHE_KEY = 'v86';
 
     private ContainerInterface|null $container = null;
 


### PR DESCRIPTION
Get current stmt via passed `Node` as `Stmt` inside `traverseNodesWithCallable()` instead of parent lookup via `BetterNodeFinder` on found variable.