### PR TITLE
[Php56] Move collect checked variables on Node not a Variable on UndefinedVariableResolver

### DIFF
--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -66,7 +66,6 @@ final class UndefinedVariableResolver
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
-            $checkedVariables = $this->resolveCheckedVariables($node, $checkedVariables);
             if ($node instanceof Case_) {
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
@@ -76,6 +75,7 @@ final class UndefinedVariableResolver
             }
 
             if (! $node instanceof Variable) {
+                $checkedVariables = $this->resolveCheckedVariables($node, $checkedVariables);
                 return null;
             }
 


### PR DESCRIPTION
Reduce unnecessary method calls to collect checked variables when possible.