### PR TITLE
Try use of nette/utils fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "fidry/cpu-core-counter": "^0.5.1",
         "illuminate/container": "^10.13",
         "nette/neon": "^3.4",
-        "nette/utils": "^3.2",
+        "nette/utils": "dev-token as 3.2.10-dev",
         "nikic/php-parser": "^4.15.4",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.21.3",
@@ -173,5 +173,11 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/staabm/nette-utils/"
+        }
+    ]
 }

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -333,3 +333,4 @@ require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Parser/TypePa
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Printer/DiffElem.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Printer/Differ.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Printer/Printer.php';
+require_once __DIR__ . '/../../../vendor/nette/utils/src/Utils/Reflection.php';

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -333,4 +333,8 @@ require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Parser/TypePa
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Printer/DiffElem.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Printer/Differ.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Printer/Printer.php';
+
 require_once __DIR__ . '/../../../vendor/nette/utils/src/Utils/Reflection.php';
+
+class_alias('\Nette\Utils\Reflection', '\_PHPStan_dcc7b7cff\Nette\Utils\Reflection', false);
+

--- a/preload.php
+++ b/preload.php
@@ -333,3 +333,7 @@ require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Parser/TypeParser.php'
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Printer/DiffElem.php';
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Printer/Differ.php';
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Printer/Printer.php';
+
+require_once __DIR__ . '/vendor/nette/utils/src/Utils/Reflection.php';
+
+class_alias('\Nette\Utils\Reflection', '\_PHPStan_dcc7b7cff\Nette\Utils\Reflection', false);


### PR DESCRIPTION
experiment which tries to optimize nette/utils, see https://github.com/nette/utils/pull/296

atm this PR does not use the custom utils fork, because rector is somehow using a PHPStan prefixed version, and I don't know why - see https://github.com/rectorphp/rector/discussions/7981

any pointers are welcome