### PR TITLE
Increase kernel cache key

### DIFF
--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -17,7 +17,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v87';
+    private const CACHE_KEY = 'v88';
 
     private ContainerInterface|null $container = null;
 


### PR DESCRIPTION
For removed `BetterNodeFinder` instance dependency on rector-downgrade-php's `NamedVariableFactory`, ref https://github.com/rectorphp/rector-downgrade-php/pull/106/files#diff-0e1e656d886663a4dc77a5e8b72305c5693d212e3f1851baaf365d259ee4be1b