### PR TITLE
[NodeTypeResolver] Flip getAttribute call after instanceof check on PHPStanNodeScopeResolver

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -254,11 +254,11 @@ final class PHPStanNodeScopeResolver
 
     private function setChildOfUnreachableStatementNodeAttribute(Stmt $stmt, MutatingScope $mutatingScope): void
     {
-        if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) !== true) {
+        if (! $stmt instanceof StmtsAwareInterface && ! $stmt instanceof ClassLike && ! $stmt instanceof Declare_) {
             return;
         }
 
-        if (! $stmt instanceof StmtsAwareInterface && ! $stmt instanceof ClassLike && ! $stmt instanceof Declare_) {
+        if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) !== true) {
             return;
         }
 


### PR DESCRIPTION
Flip check, instanceof check first, then getAttribute call