### PR TITLE
Performance: Prevent sorting of files in PhpFilesFinder

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -45,7 +45,7 @@ final class FilesFinder
      * @param string[] $suffixes
      * @return string[]
      */
-    private function findInDirectories(array $directories, array $suffixes, bool $sortByName = false): array
+    private function findInDirectories(array $directories, array $suffixes, bool $sortByName = true): array
     {
         if ($directories === []) {
             return [];

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -28,7 +28,7 @@ final class FilesFinder
      * @param string[] $suffixes
      * @return string[]
      */
-    public function findInDirectoriesAndFiles(array $source, array $suffixes = []): array
+    public function findInDirectoriesAndFiles(array $source, array $suffixes = [], bool $sortByName = true): array
     {
         $filesAndDirectories = $this->filesystemTweaker->resolveWithFnmatch($source);
 
@@ -37,7 +37,7 @@ final class FilesFinder
 
         $currentAndDependentFilePaths = $this->unchangedFilesFilter->filterAndJoinWithDependentFileInfos($filePaths);
 
-        return array_merge($currentAndDependentFilePaths, $this->findInDirectories($directories, $suffixes));
+        return array_merge($currentAndDependentFilePaths, $this->findInDirectories($directories, $suffixes, $sortByName));
     }
 
     /**
@@ -45,7 +45,7 @@ final class FilesFinder
      * @param string[] $suffixes
      * @return string[]
      */
-    private function findInDirectories(array $directories, array $suffixes): array
+    private function findInDirectories(array $directories, array $suffixes, bool $sortByName = false): array
     {
         if ($directories === []) {
             return [];
@@ -55,8 +55,11 @@ final class FilesFinder
             ->files()
             // skip empty files
             ->size('> 0')
-            ->in($directories)
-            ->sortByName();
+            ->in($directories);
+
+        if ($sortByName) {
+            $finder->sortByName();
+        }
 
         if ($suffixes !== []) {
             $suffixesPattern = $this->normalizeSuffixesToPattern($suffixes);

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -20,7 +20,7 @@ final class PhpFilesFinder
      */
     public function findInPaths(array $paths): array
     {
-        $filePaths = $this->filesFinder->findInDirectoriesAndFiles($paths, ['php']);
+        $filePaths = $this->filesFinder->findInDirectoriesAndFiles($paths, ['php'], false);
 
         // filter out non-PHP files
         foreach ($filePaths as $key => $filePath) {


### PR DESCRIPTION
From my understanding the order in which PhpFilesFinder gets its files from sfFinder is not relevant for the final result.

with this PR, I get 25% faster rector run with a 7% safe in memory

<img width="519" alt="grafik" src="https://github.com/rectorphp/rector-src/assets/120441/035b8bfd-299b-41f0-bc2a-f10cc7e7a507">
