### PR TITLE
[NodeManipulator] Remove parent lookup on ClassMethodPropertyFetchManipulator

### DIFF
--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -17,7 +17,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v90';
+    private const CACHE_KEY = 'v91';
 
     private ContainerInterface|null $container = null;
 

--- a/src/NodeManipulator/ClassMethodPropertyFetchManipulator.php
+++ b/src/NodeManipulator/ClassMethodPropertyFetchManipulator.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeTraverser;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -43,7 +44,11 @@ final class ClassMethodPropertyFetchManipulator
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $classMethod->stmts,
-            function (Node $node) use ($propertyName, &$assignedParamName, $classMethod): ?int {
+            function (Node $node) use ($propertyName, &$assignedParamName): ?int {
+                if ($node instanceof Class_) {
+                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                }
+
                 if (! $node instanceof Assign) {
                     return null;
                 }
@@ -57,11 +62,6 @@ final class ClassMethodPropertyFetchManipulator
                 }
 
                 if ($node->expr instanceof MethodCall || $node->expr instanceof StaticCall) {
-                    return null;
-                }
-
-                $parentClassMethod = $this->betterNodeFinder->findParentType($node, ClassMethod::class);
-                if ($parentClassMethod !== $classMethod) {
                     return null;
                 }
 
@@ -104,7 +104,11 @@ final class ClassMethodPropertyFetchManipulator
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $classMethod->stmts,
-            function (Node $node) use ($propertyName, &$assignExprs, $paramNames, $classMethod): ?int {
+            function (Node $node) use ($propertyName, &$assignExprs, $paramNames): ?int {
+                if ($node instanceof Class_) {
+                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                }
+
                 if (! $node instanceof Assign) {
                     return null;
                 }
@@ -119,11 +123,6 @@ final class ClassMethodPropertyFetchManipulator
 
                 // skip param assigns
                 if ($this->nodeNameResolver->isNames($node->expr, $paramNames)) {
-                    return null;
-                }
-
-                $parentClassMethod = $this->betterNodeFinder->findParentType($node, ClassMethod::class);
-                if ($parentClassMethod !== $classMethod) {
                     return null;
                 }
 

--- a/src/NodeManipulator/ClassMethodPropertyFetchManipulator.php
+++ b/src/NodeManipulator/ClassMethodPropertyFetchManipulator.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeTraverser;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
@@ -24,7 +23,6 @@ final class ClassMethodPropertyFetchManipulator
     public function __construct(
         private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
         private readonly FunctionLikeManipulator $functionLikeManipulator
     ) {
     }


### PR DESCRIPTION
Don't traverse current and children when passed node is anonymous class.

Ref https://github.com/rectorphp/rector/issues/7947