### PR TITLE
[TypeDeclaration] Remove parent lookup on ReturnedNodesReturnTypeInfererTypeInferer

### DIFF
--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -17,7 +17,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v91';
+    private const CACHE_KEY = 'v92';
 
     private ContainerInterface|null $container = null;
 


### PR DESCRIPTION
Compare ClassReflection from ReflectionResolver instead of parent lookup.

Ref https://github.com/rectorphp/rector/issues/7947