### PR TITLE
Fix broken scoped build with double quotes in commit messages

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -108,7 +108,7 @@ jobs:
                 id: git-log
                 run: |
                     echo "log<<EOF" >> $GITHUB_OUTPUT
-                    echo "$(git log ${{ github.event.before }}..${{ github.event.after }} --reverse --pretty='%H %s' | sed -e 's/^/https:\/\/github.com\/rectorphp\/rector-src\/commit\//')" >> $GITHUB_OUTPUT
+                    echo "$(git log ${{ github.event.before }}..${{ github.event.after }} --reverse --pretty='https://github.com/rectorphp/rector-src/commit/%H %s')" >> $GITHUB_OUTPUT
                     echo 'EOF' >> $GITHUB_OUTPUT
 
             # 8.A publish it to remote repository without tag


### PR DESCRIPTION
blindly applying the fix from phpstan-src

https://github.com/phpstan/phpstan-src/blob/613c57c3d2301402ca474338959ad8e3bd204000/.github/workflows/phar.yml#L180-L186


-----

refs https://github.com/rectorphp/rector-src/pull/4164#issuecomment-1585862821