### PR TITLE
Revert Fix broken scoped build with double quotes in commit messages (#4175)

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -108,7 +108,7 @@ jobs:
                 id: git-log
                 run: |
                     echo "log<<EOF" >> $GITHUB_OUTPUT
-                    echo "$(git log ${{ github.event.before }}..${{ github.event.after }} --reverse --pretty='https://github.com/rectorphp/rector-src/commit/%H %s')" >> $GITHUB_OUTPUT
+                    echo "$(git log ${{ github.event.before }}..${{ github.event.after }} --reverse --pretty='%H %s' | sed -e 's/^/https:\/\/github.com\/rectorphp\/rector-src\/commit\//')" >> $GITHUB_OUTPUT
                     echo 'EOF' >> $GITHUB_OUTPUT
 
             # 8.A publish it to remote repository without tag


### PR DESCRIPTION
@staabm this is revert of your PR: 

- https://github.com/rectorphp/rector-src/pull/4175

as not working see https://github.com/rectorphp/rector-src/actions/runs/5234281911/jobs/9450314156#step:22:13

This reverts commit 3e43e54aa5e99a3952208734da68e8e22d00872a.