### PR TITLE
[NodeTypeResolver] Remove findParentType() on ClassMethodOrClassConstTypeResolver

### DIFF
--- a/src/Kernel/RectorKernel.php
+++ b/src/Kernel/RectorKernel.php
@@ -17,7 +17,7 @@ final class RectorKernel
     /**
      * @var string
      */
-    private const CACHE_KEY = 'v110';
+    private const CACHE_KEY = 'v111';
 
     private ContainerInterface|null $container = null;
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/7947