### PR TITLE
[CodeQuality] Reduce parent lookup for inside Closure BindTo on LocalPropertyAnalyzer

### DIFF
--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -134,6 +134,7 @@ final class LocalPropertyAnalyzer
         if ($this->isPartOfClosureBind($propertyFetch)) {
             return true;
         }
+
         return $propertyFetch->name instanceof Variable;
     }
 

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -134,12 +134,7 @@ final class LocalPropertyAnalyzer
         if ($this->isPartOfClosureBind($propertyFetch)) {
             return true;
         }
-
-        if ($propertyFetch->name instanceof Variable) {
-            return true;
-        }
-
-        return $this->isPartOfClosureBindTo($propertyFetch);
+        return $propertyFetch->name instanceof Variable;
     }
 
     /**
@@ -183,19 +178,5 @@ final class LocalPropertyAnalyzer
         }
 
         return $scope->isInClosureBind();
-    }
-
-    private function isPartOfClosureBindTo(PropertyFetch $propertyFetch): bool
-    {
-        $parentMethodCall = $this->betterNodeFinder->findParentType($propertyFetch, MethodCall::class);
-        if (! $parentMethodCall instanceof MethodCall) {
-            return false;
-        }
-
-        if (! $parentMethodCall->var instanceof Closure) {
-            return false;
-        }
-
-        return $this->nodeNameResolver->isName($parentMethodCall->name, 'bindTo');
     }
 }


### PR DESCRIPTION
The `$scope->isInClosureBind()` detect `bindTo()` as well.