### PR TITLE
LocallyCalledStaticMethodToNonStaticRector with method args

### DIFF
--- a/rules-tests/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/method_with_arg.php.inc
+++ b/rules-tests/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/method_with_arg.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\RemovingStatic\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture;
+
+class MethodWithArg
+{
+    public function run($arg)
+    {
+        self::someStatic($arg);
+    }
+
+    private static function someStatic($arg)
+    {
+    }
+}
+
+?>
+    -----
+<?php
+
+namespace Rector\Tests\RemovingStatic\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture;
+
+class MethodWithArg
+{
+    public function run($arg)
+    {
+        $this->someStatic($arg);
+    }
+
+    private function someStatic($arg)
+    {
+    }
+}
+
+?>

--- a/rules-tests/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/method_with_arg.php.inc
+++ b/rules-tests/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/method_with_arg.php.inc
@@ -15,7 +15,7 @@ class MethodWithArg
 }
 
 ?>
-    -----
+-----
 <?php
 
 namespace Rector\Tests\RemovingStatic\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture;

--- a/rules/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
+++ b/rules/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
@@ -136,7 +136,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            return new MethodCall(new Variable('this'), $classMethodName);
+            return new MethodCall(new Variable('this'), $classMethodName, $node->args);
         });
 
         // change static calls to non-static ones, but only if in non-static method!!!


### PR DESCRIPTION
* keep method args on refactoring

Fixes https://github.com/rectorphp/rector/issues/7992