### PR TITLE
Use `FunctionLike` contract instead of union of function-like concrete implementations

### DIFF
--- a/rules/Naming/Contract/RenameParamValueObjectInterface.php
+++ b/rules/Naming/Contract/RenameParamValueObjectInterface.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\Naming\Contract;
 
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
 
 interface RenameParamValueObjectInterface extends RenameValueObjectInterface
 {
-    public function getFunctionLike(): ClassMethod | Function_ | Closure | ArrowFunction;
+    public function getFunctionLike(): FunctionLike;
 
     public function getParam(): Param;
 }

--- a/rules/Naming/ValueObject/ParamRename.php
+++ b/rules/Naming/ValueObject/ParamRename.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Naming\ValueObject;
 
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
 use Rector\Naming\Contract\RenameParamValueObjectInterface;
 
 final class ParamRename implements RenameParamValueObjectInterface
@@ -19,7 +16,7 @@ final class ParamRename implements RenameParamValueObjectInterface
         private readonly string $expectedName,
         private readonly Param $param,
         private readonly Variable $variable,
-        private readonly ClassMethod | Function_ | Closure | ArrowFunction $functionLike
+        private readonly FunctionLike $functionLike
     ) {
     }
 
@@ -33,7 +30,7 @@ final class ParamRename implements RenameParamValueObjectInterface
         return $this->expectedName;
     }
 
-    public function getFunctionLike(): ClassMethod | Function_ | Closure | ArrowFunction
+    public function getFunctionLike(): FunctionLike
     {
         return $this->functionLike;
     }

--- a/rules/Naming/ValueObjectFactory/ParamRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/ParamRenameFactory.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Naming\ValueObjectFactory;
 
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Error;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
 use Rector\Naming\ValueObject\ParamRename;
 use Rector\NodeNameResolver\NodeNameResolver;
 
@@ -21,7 +18,7 @@ final class ParamRenameFactory
     }
 
     public function createFromResolvedExpectedName(
-        ClassMethod|Function_|ArrowFunction|Closure $functionLike,
+        FunctionLike $functionLike,
         Param $param,
         string $expectedName
     ): ?ParamRename {

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 namespace Rector\Naming;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
 use PhpParser\NodeTraverser;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -31,7 +28,7 @@ final class VariableRenamer
     }
 
     public function renameVariableInFunctionLike(
-        ClassMethod | Function_ | Closure | ArrowFunction $functionLike,
+        Node\FunctionLike $functionLike,
         string $oldName,
         string $expectedName,
         ?Assign $assign = null


### PR DESCRIPTION
It does not make sense to use `ClassMethod | Function_ | Closure | ArrowFunction` because when consuming such contract it requires using `instanceof` anyway (same as with `FunctionLike` interface). Also, it forces custom rectors to use union too in the signatures, but if PHP 7.4 is used, there's no way to achieve it with native types and phpDoc has to be used instead.