### PR TITLE
[Performance] Use STOP_TRAVERSAL inside SimpleCallableNodeTraverser on ConstructorAssignDetector

### DIFF
--- a/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
+++ b/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
@@ -66,7 +66,7 @@ final class ConstructorAssignDetector
 
                 $isAssignedInConstructor = true;
 
-                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                return NodeTraverser::STOP_TRAVERSAL;
             });
         }
 


### PR DESCRIPTION
`SimpleCallableNodeTraverser` is different process, so it is ok to doing `STOP_TRAVERSAL`