### PR TITLE
[PhpParser] Remove parent lookup on BetterNodeFinder::findFirstInFunctionLikeScoped()

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -401,6 +401,7 @@ final class BetterNodeFinder
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
+                // Expr is part of Stmt, so only collect Stmt only to be filtered
                 if (! $subNode instanceof Stmt) {
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -396,16 +396,14 @@ final class BetterNodeFinder
         $nodes = [];
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $functionLike->stmts,
-            function (Node $subNode) use (&$nodes) {
+            static function (Node $subNode) use (&$nodes) : ?int {
                 if ($subNode instanceof Class_ || $subNode instanceof Function_ || $subNode instanceof Closure) {
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
-
                 // Expr is part of Stmt, so only collect Stmt only to be filtered
                 if (! $subNode instanceof Stmt) {
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
-
                 $nodes[] = $subNode;
                 return null;
             });

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -400,10 +400,12 @@ final class BetterNodeFinder
                 if ($subNode instanceof Class_ || $subNode instanceof Function_ || $subNode instanceof Closure) {
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
+
                 // Expr is part of Stmt, so only collect Stmt only to be filtered
                 if (! $subNode instanceof Stmt) {
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
+
                 $nodes[] = $subNode;
                 return null;
             });

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -396,7 +396,7 @@ final class BetterNodeFinder
         $nodes = [];
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $functionLike->stmts,
-            function (Node $subNode) use ($nodes) {
+            function (Node $subNode) use (&$nodes) {
                 if ($subNode instanceof Class_ || $subNode instanceof Function_ || $subNode instanceof Closure) {
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }


### PR DESCRIPTION
Check with `SimpleCallableNodeTraverser` to not traverse below when found anonymous class, function, or closure inside another `ClassMethod | Function_ | Closure`.

Ref https://github.com/rectorphp/rector/issues/7947