### PR TITLE
[DeadCode] Remove parent lookup on IsClassMethodUsedAnalyzer::isInArrayMap()

### DIFF
--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\NodeAnalyzer;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\ArrayMapArgVisitor;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
@@ -78,12 +79,7 @@ final class IsClassMethodUsedAnalyzer
 
     private function isInArrayMap(Class_ $class, Array_ $array): bool
     {
-        $parentFuncCall = $this->betterNodeFinder->findParentType($array, FuncCall::class);
-        if (! $parentFuncCall instanceof FuncCall) {
-            return false;
-        }
-
-        if (! $this->nodeNameResolver->isName($parentFuncCall->name, 'array_map')) {
+        if (! $array->getAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME) instanceof Arg) {
             return false;
         }
 


### PR DESCRIPTION
There is already PHPStan node visitor for that: `ArrayMapArgVisitor` see 

https://github.com/phpstan/phpstan-src/blob/b944b111c5bfdff2f8350b0d20a7d3b4c76bc15b/src/Parser/ArrayMapArgVisitor.php#L10