### PR TITLE
[Performance] Remove findFirst on AliasUsesResolver and UsedImportsResolver

### DIFF
--- a/rules/CodingStyle/ClassNameImport/AliasUsesResolver.php
+++ b/rules/CodingStyle/ClassNameImport/AliasUsesResolver.php
@@ -32,6 +32,7 @@ final class AliasUsesResolver
 
             $node = current($namespaces);
         }
+
         return $this->resolveFromStmts($node->stmts);
     }
 

--- a/rules/CodingStyle/ClassNameImport/AliasUsesResolver.php
+++ b/rules/CodingStyle/ClassNameImport/AliasUsesResolver.php
@@ -9,13 +9,11 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\UseUse;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 
 final class AliasUsesResolver
 {
     public function __construct(
-        private readonly UseImportsTraverser $useImportsTraverser,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly UseImportsTraverser $useImportsTraverser
     ) {
     }
 
@@ -28,24 +26,13 @@ final class AliasUsesResolver
         if (! $node instanceof Namespace_) {
             /** @var Namespace_[] $namespaces */
             $namespaces = array_filter($stmts, static fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
-            foreach ($namespaces as $namespace) {
-                $isFoundInNamespace = (bool) $this->betterNodeFinder->findFirst(
-                    $namespace,
-                    static fn (Node $subNode): bool => $subNode === $node
-                );
-
-                if ($isFoundInNamespace) {
-                    $node = $namespace;
-                    break;
-                }
+            if (count($namespaces) !== 1) {
+                return [];
             }
-        }
 
-        if ($node instanceof Namespace_) {
-            return $this->resolveFromStmts($node->stmts);
+            $node = current($namespaces);
         }
-
-        return [];
+        return $this->resolveFromStmts($node->stmts);
     }
 
     /**

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -106,7 +106,7 @@ final class UsedImportsResolver
         $namespaces = array_filter($stmts, static fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
 
         if (count($namespaces) !== 1) {
-            return [];
+            return null;
         }
 
         return current($namespaces);

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -27,30 +27,6 @@ final class UsedImportsResolver
     ) {
     }
 
-    private function resolveCurrentNamespaceForNode(Node $node): ?Namespace_
-    {
-        if ($node instanceof Namespace_) {
-            return $node;
-        }
-
-        $file = $this->currentFileProvider->getFile();
-        if (! $file instanceof File) {
-            return null;
-        }
-
-        $stmts = $file->getNewStmts();
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof Namespace_) {
-                $foundNode = $this->betterNodeFinder->findFirst($stmt, static fn(Node $subNode): bool => $subNode === $node);
-                if ($foundNode instanceof Node) {
-                    return $stmt;
-                }
-            }
-        }
-
-        return null;
-    }
-
     /**
      * @return array<FullyQualifiedObjectType|AliasedObjectType>
      */
@@ -113,6 +89,27 @@ final class UsedImportsResolver
         });
 
         return $usedFunctionImports;
+    }
+
+    private function resolveCurrentNamespaceForNode(Node $node): ?Namespace_
+    {
+        if ($node instanceof Namespace_) {
+            return $node;
+        }
+
+        $file = $this->currentFileProvider->getFile();
+        if (! $file instanceof File) {
+            return null;
+        }
+
+        $stmts = $file->getNewStmts();
+        $namespaces = array_filter($stmts, static fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
+
+        if (count($namespaces) !== 1) {
+            return [];
+        }
+
+        return current($namespaces);
     }
 
     /**


### PR DESCRIPTION
Multiple namespaces on auto import is not supported, so better to not need verify current node exists in Namespace_, just check the File has namespace should be enough.