### PR TITLE
[CodingStyle] Remove parent lookup on ShortNameResolver

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
@@ -28,7 +28,7 @@ final class ClassLikeNameClassNameImportSkipVoter implements ClassNameImportSkip
 
     public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
     {
-        $classLikeNames = $this->shortNameResolver->resolveShortClassLikeNamesForNode($node);
+        $classLikeNames = $this->shortNameResolver->resolveShortClassLikeNames($file);
         if ($classLikeNames === []) {
             return false;
         }

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -84,13 +84,18 @@ final class ShortNameResolver
      * Collects all "class <SomeClass>", "trait <SomeTrait>" and "interface <SomeInterface>"
      * @return string[]
      */
-    public function resolveShortClassLikeNamesForNode(Node $node): array
+    public function resolveShortClassLikeNames(File $file): array
     {
-        $namespace = $this->betterNodeFinder->findParentType($node, Namespace_::class);
-        if (! $namespace instanceof Namespace_) {
-            // only handle namespace nodes
+        $newStmts = $file->getNewStmts();
+
+        /** @var Namespace_[] $namespaces */
+        $namespaces = array_filter($newStmts, static fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
+        if (count($namespaces) !== 1) {
+            // only handle single namespace nodes
             return [];
         }
+
+        $namespace = current($namespaces);
 
         /** @var ClassLike[] $classLikes */
         $classLikes = $this->betterNodeFinder->findInstanceOf($namespace, ClassLike::class);


### PR DESCRIPTION
We don't support multiple namespaces imports uses, so using locate first namespace from file should be enough.