### PR TITLE
Add sleep after processPool->quitAll() to give time for all child processes to terminate

### DIFF
--- a/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/Parallel/Application/ParallelFileProcessor.php
@@ -125,6 +125,11 @@ final class ParallelFileProcessor
             ++$systemErrorsCount;
             $reachedSystemErrorsCountLimit = true;
             $this->processPool->quitAll();
+
+            // This sleep has to be here, because event though we have called $this->processPool->quitAll(),
+            // it takes some time for the child processes to actually die, during which they can still write to cache
+            // @see https://github.com/rectorphp/rector-src/pull/3834/files#r1231696531
+            sleep(1);
         };
 
         $timeoutInSeconds = $this->parameterProvider->provideIntParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS);


### PR DESCRIPTION
Based on request from https://github.com/rectorphp/rector-src/pull/3834/files#r1231696531