### PR TITLE
Skip rewindable generator

### DIFF
--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/skip_rewindable_generator.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/skip_rewindable_generator.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+
+final class SkipRewindableGenerator
+{
+    public function __construct(RewindableGenerator $items)
+    {
+    }
+}

--- a/rules/Naming/Guard/BreakingVariableRenameGuard.php
+++ b/rules/Naming/Guard/BreakingVariableRenameGuard.php
@@ -126,6 +126,10 @@ final class BreakingVariableRenameGuard
             return true;
         }
 
+        if ($this->isGenerator($param)) {
+            return true;
+        }
+
         if ($this->isDateTimeAtNamingConvention($param)) {
             return true;
         }
@@ -222,17 +226,11 @@ final class BreakingVariableRenameGuard
         return false;
     }
 
-    /**
-     * @TODO Remove once ParamRenamer created
-     */
     private function isRamseyUuidInterface(Param $param): bool
     {
         return $this->nodeTypeResolver->isObjectType($param, new ObjectType('Ramsey\Uuid\UuidInterface'));
     }
 
-    /**
-     * @TODO Remove once ParamRenamer created
-     */
     private function isDateTimeAtNamingConvention(Param $param): bool
     {
         $type = $this->nodeTypeResolver->getType($param);
@@ -248,5 +246,13 @@ final class BreakingVariableRenameGuard
         /** @var string $currentName */
         $currentName = $this->nodeNameResolver->getName($param);
         return StringUtils::isMatch($currentName, self::AT_NAMING_REGEX . '');
+    }
+
+    private function isGenerator(Param $param): bool
+    {
+        return $this->nodeTypeResolver->isObjectType(
+            $param,
+            new ObjectType('Symfony\Component\DependencyInjection\Argument\RewindableGenerator')
+        );
     }
 }

--- a/rules/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector.php
+++ b/rules/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector.php
@@ -103,9 +103,13 @@ CODE_SAMPLE
                 return null;
             }
 
-            $hasChanged = true;
+            $propertyFetch = $this->matchLocalPropertyFetchInGetterMethod($classMethod);
+            if (! $propertyFetch instanceof PropertyFetch) {
+                return null;
+            }
 
-            return $this->matchLocalPropertyFetchInGetterMethod($classMethod);
+            $hasChanged = true;
+            return $propertyFetch;
         });
 
         if ($hasChanged) {


### PR DESCRIPTION
- avoid early change in privatize local getter to property
- skip rewindable generator from type rename
