### PR TITLE
Add missing test case for native call

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_once_type_and_native_call_first.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_once_type_and_native_call_first.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SkipOnceTypeAndNativeCallFirst
+{
+    public function getData()
+    {
+        if (false) {
+            return array_map(function ($i) {
+                return $i;
+            }, []);
+        }
+
+        return $this->getString();
+    }
+
+    private function getString()
+    {
+        return '...';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_once_type_and_native_call_second.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_once_type_and_native_call_second.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SkipOnceTypeAndNativeCallSecond
+{
+    public function getData()
+    {
+        if (false) {
+            return $this->getString();
+        }
+
+        return array_map(function ($i) {
+            return $i;
+        }, []);
+    }
+
+    private function getString()
+    {
+        return '...';
+    }
+}


### PR DESCRIPTION
Hi ! 

I spotted a bug today. Here is a failling test :)

When using a native call and returning first, here `array_map`, the `ReturnTypeFromStrictTypedCallRector` uses it directly and doesn't check that later `return` might return another type.

I suspect this is because if the `if`. With a debugger we can see that [`findCurrentScopeReturns`](https://github.com/rectorphp/rector-src/blob/main/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php#L113) only sees the return in the `if` scope.

My contribution stops here, I don't know how what would be a good fix for this :)

Have a good day.



