### PR TITLE
[#8015] Failing Tests for RemoveUnusedConstructorParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/unused_followed_by_other_used_params_multiline.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/unused_followed_by_other_used_params_multiline.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class UnusedFollowedByOtherUsedParamsMultiline
+{
+    private ExampleOne $paramOne;
+    private ExampleTwo $paramTwo;
+    private ExampleThree $paramThree;
+
+    public function __construct(
+        ExampleOne $paramOne,
+        ExampleTwo $paramTwo,
+        ExampleThree $paramThree
+    ) {
+        $this->paramOne = $paramOne;
+        $this->paramThree = $paramThree;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class UnusedFollowedByOtherUsedParamsMultiline
+{
+    private ExampleOne $paramOne;
+    private ExampleTwo $paramTwo;
+    private ExampleThree $paramThree;
+
+    public function __construct(
+        ExampleOne $paramOne,
+        ExampleThree $paramThree
+    ) {
+        $this->paramOne = $paramOne;
+        $this->paramThree = $paramThree;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/unused_followed_by_other_used_params_single_line.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/unused_followed_by_other_used_params_single_line.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class UnusedFollowedByOtherUsedParamsSingleLine
+{
+    private ExampleOne $paramOne;
+    private ExampleTwo $paramTwo;
+    private ExampleThree $paramThree;
+
+    public function __construct(ExampleOne $paramOne, ExampleTwo $paramTwo, ExampleThree $paramThree)
+    {
+        $this->paramOne = $paramOne;
+        $this->paramThree = $paramThree;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class UnusedFollowedByOtherUsedParamsSingleLine
+{
+    private ExampleOne $paramOne;
+    private ExampleTwo $paramTwo;
+    private ExampleThree $paramThree;
+
+    public function __construct(ExampleOne $paramOne, ExampleThree $paramThree)
+    {
+        $this->paramOne = $paramOne;
+        $this->paramThree = $paramThree;
+    }
+}
+
+?>


### PR DESCRIPTION
I created https://github.com/rectorphp/rector/issues/8015 and have now added tests that fail for the scenario I have described