### PR TITLE
Fix command to configure rector

### DIFF
--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -36,7 +36,7 @@ There are 2 main ways to use Rector:
 To use them, create a `rector.php` in your root directory:
 
 ```bash
-vendor/bin/rector init
+vendor/bin/rector
 ```
 
 And modify it:


### PR DESCRIPTION
### Fixed

- The `init` command no longer exists (see https://github.com/rectorphp/rector/issues/8010), it should be omitted