### PR TITLE
[Php81] Remove cast check on NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -7,7 +7,6 @@ namespace Rector\Php81\Rector\FuncCall;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Cast\String_ as CastString_;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
@@ -486,10 +485,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isCastedReassign($argValue)) {
-            return null;
-        }
-
         $args[$position]->value = new CastString_($argValue);
         $funcCall->args = $args;
 
@@ -515,21 +510,6 @@ CODE_SAMPLE
         }
 
         return true;
-    }
-
-    private function isCastedReassign(Expr $expr): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirstPrevious($expr, function (Node $subNode) use ($expr): bool {
-            if (! $subNode instanceof Assign) {
-                return false;
-            }
-
-            if (! $this->nodeComparator->areNodesEqual($subNode->var, $expr)) {
-                return false;
-            }
-
-            return $subNode->expr instanceof CastString_;
-        });
     }
 
     private function isAnErrorTypeFromParentScope(Expr $expr, Scope $scope): bool


### PR DESCRIPTION
The `$type->isString()->yes()` seems already cover it, so `findFirstPrevious()` is not needed to get casted variable.