### PR TITLE
 [CodeQuality] Skip not regex on SimplifyRegexPatternRector 

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/skip_not_regex.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/skip_not_regex.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector\Fixture;
+
+use Nette\Utils\Strings;
+
+class SkipNotRegex
+{
+    public function run($value)
+    {
+        echo '[0-9] and \d are a bit different.';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/skip_not_regex.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/skip_not_regex.php.inc
@@ -2,8 +2,6 @@
 
 namespace Rector\Tests\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector\Fixture;
 
-use Nette\Utils\Strings;
-
 class SkipNotRegex
 {
     public function run($value)

--- a/rules/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector.php
@@ -8,6 +8,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeNameResolver\Regex\RegexPatternDetector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -29,6 +30,10 @@ final class SimplifyRegexPatternRector extends AbstractRector
         '[0-9A-Za-z_]' => '\w',
         '[\r\n\t\f\v ]' => '\s',
     ];
+
+    public function __construct(private readonly RegexPatternDetector $regexPatternDetector)
+    {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -70,6 +75,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if (! $this->regexPatternDetector->isRegexPattern($node->value)) {
+            return null;
+        }
+
         foreach (self::COMPLEX_PATTERN_TO_SIMPLE as $complexPattern => $simple) {
             $originalValue = $node->value;
             $simplifiedValue = Strings::replace(


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/7993

@kenjis let's start with detect not regex type before check of unicode identifier.