### PR TITLE
Bump nikic/php-parser to 4.16.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/container": "^10.13",
         "nette/neon": "^3.4",
         "nette/utils": "^3.2",
-        "nikic/php-parser": "^4.15.4",
+        "nikic/php-parser": "^4.16.0",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.21.3",
         "phpstan/phpstan": "^1.10.20",

--- a/packages/PhpAttribute/NodeFactory/PhpNestedAttributeGroupFactory.php
+++ b/packages/PhpAttribute/NodeFactory/PhpNestedAttributeGroupFactory.php
@@ -235,7 +235,7 @@ final class PhpNestedAttributeGroupFactory
                     $annotationPropertyToAttributeClass
                 );
 
-                if ($annotationPropertyToAttributeClass->doesNeedNewImport() && count($attributeName->parts) === 1) {
+                if ($annotationPropertyToAttributeClass->doesNeedNewImport() && count($attributeName->getParts()) === 1) {
                     $attributeName->setAttribute(
                         AttributeKey::EXTRA_USE_IMPORT,
                         $annotationPropertyToAttributeClass->getAttributeClass()

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -165,11 +165,11 @@ final class NameImporter
         }
 
         if ($parentNode instanceof ConstFetch) {
-            return count($name->parts) === 1;
+            return count($name->getParts()) === 1;
         }
 
         if ($parentNode instanceof FuncCall) {
-            return count($name->parts) === 1;
+            return count($name->getParts()) === 1;
         }
 
         return false;

--- a/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
+++ b/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
@@ -170,8 +170,8 @@ CODE_SAMPLE
     {
         $nodeName = $this->getName($name);
         return $name instanceof FullyQualified
-            ? new FullyQualified(explode('_', $nodeName))
-            : new Name(explode('_', $nodeName));
+            ? new FullyQualified(explode('_', $nodeName), $name->getAttributes())
+            : new Name(explode('_', $nodeName), $name->getAttributes());
     }
 
     private function processIdentifier(Identifier $identifier): ?Identifier

--- a/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
+++ b/rules/Renaming/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
@@ -168,9 +169,9 @@ CODE_SAMPLE
     private function processName(Name $name): Name
     {
         $nodeName = $this->getName($name);
-        $name->parts = explode('_', $nodeName);
-
-        return $name;
+        return $name instanceof FullyQualified
+            ? new FullyQualified(explode('_', $nodeName))
+            : new Name(explode('_', $nodeName));
     }
 
     private function processIdentifier(Identifier $identifier): ?Identifier


### PR DESCRIPTION
php-parser 4.16.0 releaesed with deprecating `Name::$parts`, this PR update it to use `getParts()`  instead.

https://github.com/nikic/PHP-Parser/releases/tag/v4.16.0