### PR TITLE
 [Php82] Do not reprint Class_ when no attribute on ReadOnlyClassRector 

### DIFF
--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_without_attribute.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_without_attribute.php.inc
@@ -13,7 +13,7 @@ final class ClassWithoutAttribute {
 namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
 
 final readonly class ClassWithoutAttribute {
-    private string $property;
+   private string $property;
 }
 
 ?>

--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_without_attribute.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_without_attribute.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final class ClassWithoutAttribute {
+   private readonly string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final readonly class ClassWithoutAttribute {
+    private string $property;
+}
+
+?>

--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/only_readonly_property.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/only_readonly_property.php.inc
@@ -15,7 +15,7 @@ namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
 
 final readonly class OnlyReadonlyProperty
 {
-    private string $property;
+   private string $property;
 }
 
 ?>

--- a/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
+++ b/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
 
         $this->visibilityManipulator->makeReadonly($node);
 
-        if ($node->attrGroups === []) {
+        if ($node->attrGroups !== []) {
             // invoke reprint with correct readonly newline
             $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }

--- a/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
+++ b/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
@@ -88,11 +88,6 @@ CODE_SAMPLE
 
         $this->visibilityManipulator->makeReadonly($node);
 
-        if ($node->attrGroups !== []) {
-            // invoke reprint with correct readonly newline
-            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-        }
-
         $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);
 
         if ($constructClassMethod instanceof ClassMethod) {
@@ -103,6 +98,11 @@ CODE_SAMPLE
 
         foreach ($node->getProperties() as $property) {
             $this->visibilityManipulator->removeReadonly($property);
+        }
+
+        if ($node->attrGroups !== []) {
+            // invoke reprint with correct readonly newline
+            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }
 
         return $node;

--- a/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
+++ b/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
@@ -88,8 +88,10 @@ CODE_SAMPLE
 
         $this->visibilityManipulator->makeReadonly($node);
 
-        // invoke reprint with correct readonly newline
-        $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        if ($node->attrGroups === []) {
+            // invoke reprint with correct readonly newline
+            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        }
 
         $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);
 


### PR DESCRIPTION
when `Class_` doesn't have attrGroups, no need to reprint.