### PR TITLE
Revert "[Performance] Reduce callable traverser on ContextNodeVisitor"

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ContextNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ContextNodeVisitor.php
@@ -9,19 +9,22 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Unset_;
 use PhpParser\Node\Stmt\While_;
+use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
@@ -112,30 +115,21 @@ final class ContextNodeVisitor extends NodeVisitorAbstract implements ScopeResol
         }
     }
 
-    /**
-     * @param Stmt[] $node
-     */
-    private function processContextInLoop(For_|Foreach_|While_|Do_|array $node): void
+    private function processContextInLoop(For_|Foreach_|While_|Do_ $node): void
     {
-        $stmts = $node instanceof Stmt ? $node->stmts : $node;
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof Break_) {
-                $stmt->setAttribute(AttributeKey::IS_IN_LOOP, true);
-                continue;
-            }
-
-            if ($stmt instanceof If_) {
-                $stmt->setAttribute(AttributeKey::IS_IN_LOOP, true);
-                $this->processContextInLoop($stmt->stmts);
-
-                foreach ($stmt->elseifs as $elseif) {
-                    $this->processContextInLoop($elseif->stmts);
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+            $node->stmts,
+            static function (Node $subNode): ?int {
+                if ($subNode instanceof Class_ || $subNode instanceof Function_ || $subNode instanceof Closure) {
+                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
-                if ($stmt->else instanceof Else_) {
-                    $this->processContextInLoop($stmt->else->stmts);
+                if ($subNode instanceof If_ || $subNode instanceof Break_) {
+                    $subNode->setAttribute(AttributeKey::IS_IN_LOOP, true);
                 }
+
+                return null;
             }
-        }
+        );
     }
 }


### PR DESCRIPTION
Reverts rectorphp/rector-src#4357
It cause issue inside try catch:

```diff
➜  ErrorHeroModule git:(master) time bin/rector process --clear-cache
 58/58 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) src/Handler/Logging.php:214

    ---------- begin diff ----------
@@ @@
                     if ($handlerWriterDb->isExists($errorFile, $errorLine, $errorMessage, $url, $errorType)) {
                         return true;
                     }
-
-                    break;
                 } catch (RuntimeException $runtimeException) {
                     // use \Laminas\Db\Adapter\Exception\RuntimeException but do here
                     // to avoid too much deep trace from Laminas\Db classes
    ----------- end diff -----------

Applied rules:
 * BreakNotInLoopOrSwitchToReturnRector (https://stackoverflow.com/questions/3618030/php-fatal-error-cannot-break-continue https://stackoverflow.com/questions/11988281/why-does-cannot-break-continue-1-level-comes-in-php)


                                                                                                                        
 [OK] 1 file has been changed by Rector                                                                                 
                                                                                                                        

bin/rector process --clear-cache  16.98s user 0.75s system 184% cpu 9.595 total
```