### PR TITLE
[Naming] Remove parent lookup on UseImportsResolver

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
@@ -57,7 +57,7 @@ final class ClassAnnotationMatcher
 
         $tag = ltrim($tag, '@');
 
-        $uses = $this->useImportsResolver->resolveForNode($node);
+        $uses = $this->useImportsResolver->resolve();
         $fullyQualifiedClass = $this->resolveFullyQualifiedClass($uses, $node, $tag, $returnNullOnUnknownClass);
 
         if ($fullyQualifiedClass === null) {

--- a/packages/FileSystemRector/Parser/FileInfoParser.php
+++ b/packages/FileSystemRector/Parser/FileInfoParser.php
@@ -8,6 +8,7 @@ use Nette\Utils\FileSystem;
 use PhpParser\Node\Stmt;
 use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
 use Rector\Core\PhpParser\Parser\RectorParser;
+use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 
@@ -19,7 +20,8 @@ final class FileInfoParser
     public function __construct(
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser,
-        private readonly RectorParser $rectorParser
+        private readonly RectorParser $rectorParser,
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 
@@ -33,7 +35,11 @@ final class FileInfoParser
         $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
 
         $file = new File($filePath, FileSystem::read($filePath));
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
 
-        return $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
+        $file->hydrateStmtsAndTokens($stmts, $stmts, []);
+        $this->currentFileProvider->setFile($file);
+
+        return $stmts;
     }
 }

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
@@ -130,7 +130,7 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             return $name;
         }
 
-        $uses = $this->useImportsResolver->resolveForNode($phpParserNode);
+        $uses = $this->useImportsResolver->resolve();
         $scope = $phpParserNode->getAttribute(AttributeKey::SCOPE);
 
         if (! $scope instanceof Scope) {

--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -61,7 +61,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
         $filePath = $file->getFilePath();
         $objectTypes = $this->useImportTypesInFilePath[$filePath] ?? [];
 
-        $uses = $this->useImportsResolver->resolveForNode($node);
+        $uses = $this->useImportsResolver->resolve();
 
         foreach ($uses as $use) {
             $prefix = $this->useImportsResolver->resolvePrefix($use);

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
         }
 
         /** @var Use_[]|GroupUse[] $currentUses */
-        $currentUses = $this->useImportsResolver->resolveForNode($name);
+        $currentUses = $this->useImportsResolver->resolve();
 
         if ($this->shouldImportName($name, $currentUses)) {
             $nameInUse = $this->resolveNameInUse($name, $currentUses);

--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
         $useImportTypes = $this->filterOutNonNamespacedNames($useImportTypes);
 
         // then add, to prevent adding + removing false positive of same short use
-        return $this->useImportsAdder->addImportsToStmts($nodes, $useImportTypes, $functionUseImportTypes);
+        return $this->useImportsAdder->addImportsToStmts($namespace, $nodes, $useImportTypes, $functionUseImportTypes);
     }
 
     /**

--- a/packages/StaticTypeMapper/Naming/NameScopeFactory.php
+++ b/packages/StaticTypeMapper/Naming/NameScopeFactory.php
@@ -59,7 +59,7 @@ final class NameScopeFactory
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         $namespace = $scope instanceof Scope ? $scope->getNamespace() : null;
 
-        $uses = $this->useImportsResolver->resolveForNode($node);
+        $uses = $this->useImportsResolver->resolve();
         $usesAliasesToNames = $this->resolveUseNamesByAlias($uses);
 
         if ($scope instanceof Scope && $scope->getClassReflection() instanceof ClassReflection) {

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\ParameterProvider;
 use Rector\Core\PhpParser\Parser\RectorParser;
+use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 
@@ -21,6 +22,7 @@ final class TestingParser
         private readonly ParameterProvider $parameterProvider,
         private readonly RectorParser $rectorParser,
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 
@@ -30,6 +32,8 @@ final class TestingParser
 
         $stmts = $this->rectorParser->parseFile($filePath);
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
+
+        $this->currentFileProvider->setFile($file);
 
         return $file;
     }
@@ -44,6 +48,11 @@ final class TestingParser
         $nodes = $this->rectorParser->parseFile($filePath);
 
         $file = new File($filePath, FileSystem::read($filePath));
-        return $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $nodes);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $nodes);
+
+        $file->hydrateStmtsAndTokens($stmts, $stmts, []);
+        $this->currentFileProvider->setFile($file);
+
+        return $nodes;
     }
 }

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -53,6 +53,6 @@ final class TestingParser
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
         $this->currentFileProvider->setFile($file);
 
-        return $nodes;
+        return $stmts;
     }
 }

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -33,6 +33,7 @@ final class TestingParser
         $stmts = $this->rectorParser->parseFile($filePath);
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
 
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
         $this->currentFileProvider->setFile($file);
 
         return $file;
@@ -45,12 +46,12 @@ final class TestingParser
     {
         $this->parameterProvider->changeParameter(Option::SOURCE, [$filePath]);
 
-        $nodes = $this->rectorParser->parseFile($filePath);
+        $stmts = $this->rectorParser->parseFile($filePath);
 
         $file = new File($filePath, FileSystem::read($filePath));
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $nodes);
-
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
+
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
         $this->currentFileProvider->setFile($file);
 
         return $stmts;

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -31,9 +31,9 @@ final class TestingParser
         $file = new File($filePath, FileSystem::read($filePath));
 
         $stmts = $this->rectorParser->parseFile($filePath);
-        $file->hydrateStmtsAndTokens($stmts, $stmts, []);
-
         $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
+
+        $file->hydrateStmtsAndTokens($stmts, $stmts, []);
         $this->currentFileProvider->setFile($file);
 
         return $file;
@@ -49,9 +49,10 @@ final class TestingParser
         $stmts = $this->rectorParser->parseFile($filePath);
 
         $file = new File($filePath, FileSystem::read($filePath));
-        $file->hydrateStmtsAndTokens($stmts, $stmts, []);
 
         $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
+        $file->hydrateStmtsAndTokens($stmts, $stmts, []);
+
         $this->currentFileProvider->setFile($file);
 
         return $stmts;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -683,3 +683,7 @@ parameters:
 
         # for symfony configs check
         - '#Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\tagged_iterator not found#'
+
+        -
+            message: '#Parameters should use "PhpParser\\Node\\Expr\\Variable\|array" types as the only types passed to this method#'
+            path: src/PhpParser/Node/BetterNodeFinder.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -687,3 +687,5 @@ parameters:
         -
             message: '#Parameters should use "PhpParser\\Node\\Expr\\Variable\|array" types as the only types passed to this method#'
             path: src/PhpParser/Node/BetterNodeFinder.php
+
+        - '#The "Rector\\Core\\ValueObject\\Application\\File" class always calls "hydrateStmtsAndTokens\(\)" setters, better move it to constructor#'

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -40,7 +40,7 @@ final class UseImportsResolverTest extends AbstractTestCase
         $firstProperty = $this->betterNodeFinder->findFirstInstanceOf($nodes, Property::class);
         $this->assertInstanceOf(Property::class, $firstProperty);
 
-        $resolvedUses = $this->useImportsResolver->resolveForNode($firstProperty);
+        $resolvedUses = $this->useImportsResolver->resolve();
 
         $stringUses = [];
 

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Use_;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\Testing\Fixture\FixtureFileFinder;
 use Rector\Testing\PHPUnit\AbstractTestCase;
@@ -22,13 +23,16 @@ final class UseImportsResolverTest extends AbstractTestCase
 
     private TestingParser $testingParser;
 
+    private CurrentFileProvider $currentFileProvider;
+
     private BetterNodeFinder $betterNodeFinder;
 
     protected function setUp(): void
     {
         $this->boot();
-        $this->useImportsResolver = $this->getService(UseImportsResolver::class);
+
         $this->testingParser = $this->getService(TestingParser::class);
+        $this->currentFileProvider = $this->getService(CurrentFileProvider::class);
         $this->betterNodeFinder = $this->getService(BetterNodeFinder::class);
     }
 
@@ -40,7 +44,11 @@ final class UseImportsResolverTest extends AbstractTestCase
         $firstProperty = $this->betterNodeFinder->findFirstInstanceOf($nodes, Property::class);
         $this->assertInstanceOf(Property::class, $firstProperty);
 
-        $resolvedUses = $this->useImportsResolver->resolve();
+        $file = $this->testingParser->parseFilePathToFile($filePath);
+        $this->currentFileProvider->setFile($file);
+
+        $useImportsResolver = $this->getService(UseImportsResolver::class);
+        $resolvedUses = $useImportsResolver->resolve();
 
         $stringUses = [];
 

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Use_;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\Testing\Fixture\FixtureFileFinder;
 use Rector\Testing\PHPUnit\AbstractTestCase;
@@ -19,18 +18,17 @@ use Rector\Tests\Naming\Naming\UseImportsResolver\Source\SecondClass;
 
 final class UseImportsResolverTest extends AbstractTestCase
 {
-    private TestingParser $testingParser;
+    private UseImportsResolver $useImportsResolver;
 
-    private CurrentFileProvider $currentFileProvider;
+    private TestingParser $testingParser;
 
     private BetterNodeFinder $betterNodeFinder;
 
     protected function setUp(): void
     {
         $this->boot();
-
+        $this->useImportsResolver = $this->getService(UseImportsResolver::class);
         $this->testingParser = $this->getService(TestingParser::class);
-        $this->currentFileProvider = $this->getService(CurrentFileProvider::class);
         $this->betterNodeFinder = $this->getService(BetterNodeFinder::class);
     }
 
@@ -42,11 +40,7 @@ final class UseImportsResolverTest extends AbstractTestCase
         $firstProperty = $this->betterNodeFinder->findFirstInstanceOf($nodes, Property::class);
         $this->assertInstanceOf(Property::class, $firstProperty);
 
-        $file = $this->testingParser->parseFilePathToFile($filePath);
-        $this->currentFileProvider->setFile($file);
-
-        $useImportsResolver = $this->getService(UseImportsResolver::class);
-        $resolvedUses = $useImportsResolver->resolve();
+        $resolvedUses = $this->useImportsResolver->resolve();
 
         $stringUses = [];
 

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -19,8 +19,6 @@ use Rector\Tests\Naming\Naming\UseImportsResolver\Source\SecondClass;
 
 final class UseImportsResolverTest extends AbstractTestCase
 {
-    private UseImportsResolver $useImportsResolver;
-
     private TestingParser $testingParser;
 
     private CurrentFileProvider $currentFileProvider;

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Use_;
 use PHPStan\Type\ObjectType;
 use Rector\CodingStyle\ClassNameImport\UsedImportsResolver;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
@@ -32,7 +33,7 @@ final class UseImportsAdder
      * @param array<FullyQualifiedObjectType|AliasedObjectType> $functionUseImportTypes
      * @return Stmt[]
      */
-    public function addImportsToStmts(array $stmts, array $useImportTypes, array $functionUseImportTypes): array
+    public function addImportsToStmts(FileWithoutNamespace $fileWithoutNamespace, array $stmts, array $useImportTypes, array $functionUseImportTypes): array
     {
         $existingUseImportTypes = $this->usedImportsResolver->resolveForStmts($stmts);
         $existingFunctionUseImports = $this->usedImportsResolver->resolveFunctionImportsForStmts($stmts);
@@ -62,14 +63,20 @@ final class UseImportsAdder
 
                 array_splice($stmts, $key + 1, 0, $nodesToAdd);
 
-                return $stmts;
+                $fileWithoutNamespace->stmts = $stmts;
+                $fileWithoutNamespace->stmts = array_values($fileWithoutNamespace->stmts);
+
+                return $fileWithoutNamespace->stmts;
             }
         }
 
         $this->mirrorUseComments($stmts, $newUses);
 
         // make use stmts first
-        return array_merge($newUses, $stmts);
+        $fileWithoutNamespace->stmts = array_merge($newUses, $stmts);
+        $fileWithoutNamespace->stmts = array_values($fileWithoutNamespace->stmts);
+
+        return $fileWithoutNamespace->stmts;
     }
 
     /**
@@ -104,6 +111,7 @@ final class UseImportsAdder
         $this->mirrorUseComments($namespace->stmts, $newUses);
 
         $namespace->stmts = array_merge($newUses, $namespace->stmts);
+        $namespace->stmts = array_values($namespace->stmts);
     }
 
     /**

--- a/rules/Naming/Naming/AliasNameResolver.php
+++ b/rules/Naming/Naming/AliasNameResolver.php
@@ -16,7 +16,7 @@ final class AliasNameResolver
 
     public function resolveByName(Name $name): ?string
     {
-        $uses = $this->useImportsResolver->resolveForNode($name);
+        $uses = $this->useImportsResolver->resolve();
         $nameString = $name->toString();
 
         foreach ($uses as $use) {

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -29,7 +29,7 @@ final class UseImportsResolver
         }
 
         $newStmts = $file->getNewStmts();
-        $namespaces = array_filter($newStmts, fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
+        $namespaces = array_filter($newStmts, static fn(Stmt $stmt): bool => $stmt instanceof Namespace_);
 
         // multiple namespaces is not supported
         if (count($namespaces) > 1) {

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -25,7 +24,7 @@ final class UseImportsResolver
     {
         $file = $this->currentFileProvider->getFile();
         if (! $file instanceof File) {
-            return new ShouldNotHappenException();
+            null;
         }
 
         $newStmts = $file->getNewStmts();

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -24,7 +24,12 @@ final class UseImportsResolver
 
     private function resolveNamespace(): Namespace_|FileWithoutNamespace|null
     {
+        /** @var File|null $file */
         $file = $this->currentFileProvider->getFile();
+        if (! $file instanceof File) {
+            return null;
+        }
+
         $newStmts = $file->getNewStmts();
 
         if ($newStmts === []) {

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -9,25 +9,52 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\Core\Provider\CurrentFileProvider;
+use Rector\Core\ValueObject\Application\File;
 
 final class UseImportsResolver
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
+    }
+
+    private function resolveNamespace(): Namespace_|FileWithoutNamespace|null
+    {
+        $file = $this->currentFileProvider->getFile();
+        if (! $file instanceof File) {
+            return new ShouldNotHappenException();
+        }
+
+        $newStmts = $file->getNewStmts();
+        $namespaces = array_filter($newStmts, fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
+
+        // multiple namespaces is not supported
+        if (count($namespaces) > 1) {
+            return null;
+        }
+
+        $currentNamespace = current($namespaces);
+        if ($currentNamespace instanceof Namespace_) {
+            return $currentNamespace;
+        }
+
+        $currentStmt = current($newStmts);
+        if (! $currentStmt instanceof FileWithoutNamespace) {
+            return null;
+        }
+
+        return $currentStmt;
     }
 
     /**
      * @return Use_[]|GroupUse[]
      */
-    public function resolveForNode(Node $node): array
+    public function resolve(): array
     {
-        $namespace = $this->betterNodeFinder->findParentByTypes(
-            $node,
-            [Namespace_::class, FileWithoutNamespace::class]
-        );
+        $namespace = $this->resolveNamespace();
         if (! $namespace instanceof Node) {
             return [];
         }
@@ -42,12 +69,9 @@ final class UseImportsResolver
      * @api
      * @return Use_[]
      */
-    public function resolveBareUsesForNode(Node $node): array
+    public function resolveBareUses(): array
     {
-        $namespace = $this->betterNodeFinder->findParentByTypes(
-            $node,
-            [Namespace_::class, FileWithoutNamespace::class]
-        );
+        $namespace = $this->resolveNamespace();
         if (! $namespace instanceof Node) {
             return [];
         }

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -51,7 +51,10 @@ final class UseImportsResolver
         $currentStmt = current($newStmts);
         if (! $currentStmt instanceof FileWithoutNamespace) {
             $newStmts = $this->fileWithoutNamespaceNodeTraverser->traverse($newStmts);
-            return current($newStmts);
+            /** @var FileWithoutNamespace $currentStmt  */
+            $currentStmt = current($newStmts);
+
+            return $currentStmt;
         }
 
         return $currentStmt;

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -23,9 +23,6 @@ final class UseImportsResolver
     private function resolveNamespace(): Namespace_|FileWithoutNamespace|null
     {
         $file = $this->currentFileProvider->getFile();
-        if (! $file instanceof File) {
-            null;
-        }
 
         $newStmts = $file->getNewStmts();
         $namespaces = array_filter($newStmts, static fn(Stmt $stmt): bool => $stmt instanceof Namespace_);

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $uses = $this->useImportsResolver->resolveBareUsesForNode($node);
+        $uses = $this->useImportsResolver->resolveBareUses();
 
         // 1. bare tags without annotation class, e.g. "@inject"
         $genericAttributeGroups = $this->processGenericTags($phpDocInfo);

--- a/rules/Php80/Rector/Property/NestedAnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Property/NestedAnnotationToAttributeRector.php
@@ -114,7 +114,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $uses = $this->useImportsResolver->resolveBareUsesForNode($node);
+        $uses = $this->useImportsResolver->resolveBareUses();
 
         $attributeGroups = $this->transformDoctrineAnnotationClassesToAttributeGroups($phpDocInfo, $uses);
         if ($attributeGroups === []) {

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -355,7 +355,7 @@ final class ClassRenamer
 
     private function isValidUseImportChange(string $newName, UseUse $useUse): bool
     {
-        $uses = $this->useImportsResolver->resolveForNode($useUse);
+        $uses = $this->useImportsResolver->resolve();
         if ($uses === []) {
             return true;
         }

--- a/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
+++ b/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
@@ -57,7 +57,7 @@ final class ObjectTypeSpecifier
             }
         }
 
-        $uses = $this->useImportsResolver->resolveForNode($node);
+        $uses = $this->useImportsResolver->resolve();
         if ($uses === []) {
             if (! $this->reflectionProvider->hasClass($objectType->getClassName())) {
                 return new NonExistingObjectType($objectType->getClassName());


### PR DESCRIPTION
@TomasVotruba we don't support multiple namespaces in single file, so we can just use `File` object to get `Namespace_` or `FileWithoutNamespace` node to get `Use_` or `GroupUse_`