### PR TITLE
[NodeTypeResolver] Only use FileWithoutNamespaceNodeTraverser once on NodeScopeAndMetadataDecorator

### DIFF
--- a/packages/FileSystemRector/Parser/FileInfoParser.php
+++ b/packages/FileSystemRector/Parser/FileInfoParser.php
@@ -6,7 +6,6 @@ namespace Rector\FileSystemRector\Parser;
 
 use Nette\Utils\FileSystem;
 use PhpParser\Node\Stmt;
-use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
 use Rector\Core\PhpParser\Parser\RectorParser;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -19,7 +18,6 @@ final class FileInfoParser
 {
     public function __construct(
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
-        private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser,
         private readonly RectorParser $rectorParser,
         private readonly CurrentFileProvider $currentFileProvider
     ) {
@@ -32,7 +30,6 @@ final class FileInfoParser
     public function parseFileInfoToNodesAndDecorate(string $filePath): array
     {
         $stmts = $this->rectorParser->parseFile($filePath);
-        $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
 
         $file = new File($filePath, FileSystem::read($filePath));
         $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
+use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionLikeParamArgPositionNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
@@ -21,6 +22,7 @@ final class NodeScopeAndMetadataDecorator
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         ParentConnectingVisitor $parentConnectingVisitor,
         FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
+        private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser
     ) {
         $this->nodeTraverser = new NodeTraverser();
 
@@ -39,7 +41,9 @@ final class NodeScopeAndMetadataDecorator
      */
     public function decorateNodesFromFile(File $file, array $stmts): array
     {
+        $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
         $stmts = $this->phpStanNodeScopeResolver->processNodes($stmts, $file->getFilePath());
+
         return $this->nodeTraverser->traverse($stmts);
     }
 }

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -253,17 +253,22 @@ CODE_SAMPLE
 
         // Check if default value is the same
         $classMethod = $this->astResolver->resolveClassMethodFromCall($node);
-        if (($classMethod instanceof ClassMethod) &&
-            isset($classMethod->params[$position]) &&
-            ! $this->changedArgumentsDetector->isDefaultValueChanged(
-                $classMethod->params[$position],
-                $argumentAdder->getArgumentDefaultValue()
-            )) {
-            return true;
+        if (!$classMethod instanceof ClassMethod) {
+            // is correct scope?
+            return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
         }
-
-        // is correct scope?
-        return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
+        if (!isset($classMethod->params[$position])) {
+            // is correct scope?
+            return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
+        }
+        if ($this->changedArgumentsDetector->isDefaultValueChanged(
+            $classMethod->params[$position],
+            $argumentAdder->getArgumentDefaultValue()
+        )) {
+            // is correct scope?
+            return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
+        }
+        return true;
     }
 
     private function addClassMethodParam(

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -257,10 +257,12 @@ CODE_SAMPLE
             // is correct scope?
             return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
         }
+
         if (!isset($classMethod->params[$position])) {
             // is correct scope?
             return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
         }
+
         if ($this->changedArgumentsDetector->isDefaultValueChanged(
             $classMethod->params[$position],
             $argumentAdder->getArgumentDefaultValue()
@@ -268,6 +270,7 @@ CODE_SAMPLE
             // is correct scope?
             return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
         }
+
         return true;
     }
 

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -10,15 +10,13 @@ use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
-use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 
 final class UseImportsResolver
 {
     public function __construct(
-        private readonly CurrentFileProvider $currentFileProvider,
-        private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 
@@ -50,11 +48,7 @@ final class UseImportsResolver
 
         $currentStmt = current($newStmts);
         if (! $currentStmt instanceof FileWithoutNamespace) {
-            $newStmts = $this->fileWithoutNamespaceNodeTraverser->traverse($newStmts);
-            /** @var FileWithoutNamespace $currentStmt  */
-            $currentStmt = current($newStmts);
-
-            return $currentStmt;
+            return null;
         }
 
         return $currentStmt;

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\Application;
 
-use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
 use Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser;
 use Rector\Core\PhpParser\Parser\RectorParser;
 use Rector\Core\ValueObject\Application\File;
@@ -16,7 +15,6 @@ final class FileProcessor
         private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
         private readonly RectorParser $rectorParser,
         private readonly RectorNodeTraverser $rectorNodeTraverser,
-        private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser,
     ) {
     }
 

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -34,8 +34,7 @@ final class FileProcessor
 
     public function refactor(File $file): void
     {
-        $newStmts = $this->fileWithoutNamespaceNodeTraverser->traverse($file->getNewStmts());
-        $newStmts = $this->rectorNodeTraverser->traverse($newStmts);
+        $newStmts = $this->rectorNodeTraverser->traverse($file->getNewStmts());
 
         $file->changeNewStmts($newStmts);
     }


### PR DESCRIPTION
Remove usage `FileWithoutNamespaceNodeTraverser` in multiple locations, use only on `NodeScopeAndMetadataDecorator`