### PR TITLE
[NodeTypeResolver] Remove parent attribute usage on PHPStanNodeScopeResolver for cover after UnreachableStatementNode

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -275,7 +275,7 @@ final class PHPStanNodeScopeResolver
 
             // special case for unreachable nodes
             if ($node instanceof UnreachableStatementNode) {
-                $this->processUnreachableStatementNode($node, $filePath, $mutatingScope);
+                $this->processUnreachableStatementNode($node, $mutatingScope);
             } else {
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
@@ -301,7 +301,7 @@ final class PHPStanNodeScopeResolver
             }
 
             if ($isPassedUnreachableStmt) {
-                $this->processUnreachableStatementNode($stmt, $filePath, $mutatingScope);
+                $this->processUnreachableStatementNode($stmt, $mutatingScope);
             }
         }
     }
@@ -424,7 +424,6 @@ final class PHPStanNodeScopeResolver
 
     private function processUnreachableStatementNode(
         UnreachableStatementNode|Stmt $unreachableStatementNode,
-        string $filePath,
         MutatingScope $mutatingScope
     ): void {
         $originalStmt = $unreachableStatementNode instanceof RemoveUnreachableStatementRector

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -61,7 +61,6 @@ use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PHPStan\NodeVisitor\WrappedNodeRestoringNodeVisitor;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
-use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -426,7 +426,7 @@ final class PHPStanNodeScopeResolver
         UnreachableStatementNode|Stmt $unreachableStatementNode,
         MutatingScope $mutatingScope
     ): void {
-        $originalStmt = $unreachableStatementNode instanceof RemoveUnreachableStatementRector
+        $originalStmt = $unreachableStatementNode instanceof UnreachableStatementNode
             ? $unreachableStatementNode->getOriginalStatement()
             : $unreachableStatementNode;
 


### PR DESCRIPTION
Try to use `StmtsAwareInterface` for fill the scope after `UnreachableStatementNode` early instead.