### PR TITLE
[PhpParser] Clean up current($nodes) check on FileWithoutNamespaceNodeTraverser

### DIFF
--- a/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
@@ -26,10 +26,6 @@ final class FileWithoutNamespaceNodeTraverser extends NodeTraverser
      */
     public function traverse(array $nodes): array
     {
-        if (current($nodes) instanceof FileWithoutNamespace) {
-            return $nodes;
-        }
-
         $hasNamespace = (bool) $this->nodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
         if (! $hasNamespace && $nodes !== []) {
             $fileWithoutNamespace = new FileWithoutNamespace($nodes);


### PR DESCRIPTION
since `FileWithoutNamespaceNodeTraverser` is only run once on `File` object with its stmts by PR:

- https://github.com/rectorphp/rector-src/pull/4369

the `current()` check no longer needed.