### PR TITLE
[PhpParser] Remove NodeFinder usage on FileWithoutNamespaceNodeTraverser

### DIFF
--- a/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
@@ -6,16 +6,14 @@ namespace Rector\Core\PhpParser\NodeTraverser;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_;
-use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class FileWithoutNamespaceNodeTraverser extends NodeTraverser
 {
-    public function __construct(
-        private readonly NodeFinder $nodeFinder,
-    ) {
+    public function __construct()
+    {
         parent::__construct();
     }
 
@@ -26,16 +24,17 @@ final class FileWithoutNamespaceNodeTraverser extends NodeTraverser
      */
     public function traverse(array $nodes): array
     {
-        $hasNamespace = (bool) $this->nodeFinder->findFirstInstanceOf($nodes, Namespace_::class);
-        if (! $hasNamespace && $nodes !== []) {
-            $fileWithoutNamespace = new FileWithoutNamespace($nodes);
-            foreach ($nodes as $node) {
-                $node->setAttribute(AttributeKey::PARENT_NODE, $fileWithoutNamespace);
+        foreach ($nodes as $node) {
+            if ($node instanceof Namespace_) {
+                return $nodes;
             }
-
-            return [$fileWithoutNamespace];
         }
 
-        return $nodes;
+        $fileWithoutNamespace = new FileWithoutNamespace($nodes);
+        foreach ($nodes as $node) {
+            $node->setAttribute(AttributeKey::PARENT_NODE, $fileWithoutNamespace);
+        }
+
+        return [$fileWithoutNamespace];
     }
 }

--- a/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
@@ -12,11 +12,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class FileWithoutNamespaceNodeTraverser extends NodeTraverser
 {
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     /**
      * @template TNode as Node
      * @param TNode[] $nodes


### PR DESCRIPTION
`Namespace_` only exists in first statement depth node, no need to lookup deep via `NodeFinder`, just loop and return early when exists.