### PR TITLE
Cleanup test fixtures for NumericReturnTypeFromStrictScalarReturnsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/binary_shift.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/binary_shift.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShiftAgain
+final class BinaryShift
 {
     public function resolve(int $first, int $second)
     {
@@ -21,7 +21,7 @@ final class BinaryShiftAgain
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShiftAgain
+final class BinaryShift
 {
     public function resolve(int $first, int $second): int
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/binary_shift.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/binary_shift.php.inc
@@ -2,11 +2,16 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShift
+final class BinaryShiftAgain
 {
     public function resolve(int $first, int $second)
     {
-        return $first & $second;
+        return $first << $second;
+    }
+
+    public function resolveRight(int $first, int $second)
+    {
+        return $first >> $second;
     }
 }
 
@@ -16,11 +21,16 @@ final class BinaryShift
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShift
+final class BinaryShiftAgain
 {
     public function resolve(int $first, int $second): int
     {
-        return $first & $second;
+        return $first << $second;
+    }
+
+    public function resolveRight(int $first, int $second): int
+    {
+        return $first >> $second;
     }
 }
 

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/bitwise_and.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/bitwise_and.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShift
+final class BitwiseAnd
 {
     public function resolve(int $first, int $second)
     {
@@ -16,7 +16,7 @@ final class BinaryShift
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShift
+final class BitwiseAnd
 {
     public function resolve(int $first, int $second): int
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/bitwise_and.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/bitwise_and.php.inc
@@ -2,16 +2,11 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShiftAgain
+final class BinaryShift
 {
     public function resolve(int $first, int $second)
     {
-        return $first << $second;
-    }
-
-    public function resolveRight(int $first, int $second)
-    {
-        return $first >> $second;
+        return $first & $second;
     }
 }
 
@@ -21,16 +16,11 @@ final class BinaryShiftAgain
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
 
-final class BinaryShiftAgain
+final class BinaryShift
 {
     public function resolve(int $first, int $second): int
     {
-        return $first << $second;
-    }
-
-    public function resolveRight(int $first, int $second): int
-    {
-        return $first >> $second;
+        return $first & $second;
     }
 }
 


### PR DESCRIPTION
rename existing tests, to make them reflect what they are doing.

the PR only changes file/class-names, no implementation/functional changes
