### PR TITLE
Remove duplicate ReturnNeverTypeRector rule

### DIFF
--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -30,6 +30,5 @@ return static function (RectorConfig $rectorConfig): void {
         IntersectionTypesRector::class,
         NullToStrictStringFuncCallArgRector::class,
         FirstClassCallableRector::class,
-        ReturnNeverTypeRector::class,
     ]);
 };


### PR DESCRIPTION
The PHP 8.1 set defines the `ReturnNeverTypeRector` two times.

This removes the last entry as it was at the first position as well before refactoring in https://github.com/rectorphp/rector-src/commit/7f49261e293df93ac9a81dd49e59ad4abed9ed41