### PR TITLE
[NodeAnalyzer] Remove parent lookup on ExprAnalyzer::isNonTypedFromParam()

### DIFF
--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -9,26 +9,19 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\Encapsed;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\NodeManipulator\ArrayManipulator;
-use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
-use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class ExprAnalyzer
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly NodeNameResolver $nodeNameResolver,
         private readonly ArrayManipulator $arrayManipulator
     ) {
     }
@@ -39,31 +32,14 @@ final class ExprAnalyzer
             return false;
         }
 
-        $functionLike = $this->betterNodeFinder->findParentType($expr, FunctionLike::class);
-        if (! $functionLike instanceof FunctionLike) {
-            return false;
+        $scope = $expr->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            // uncertainty when scope not yet filled/overlapped on just refactored
+            return true;
         }
 
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
-
-        $params = $functionLike->getParams();
-        foreach ($params as $param) {
-            if (! $this->nodeComparator->areNodesEqual($param->var, $expr)) {
-                continue;
-            }
-
-            $paramName = $this->nodeNameResolver->getName($param->var);
-
-            if ($paramName === null) {
-                continue;
-            }
-
-            $paramTag = $phpDocInfo->getParamTagValueByName($paramName);
-
-            return $paramTag instanceof ParamTagValueNode && $param->type === null;
-        }
-
-        return false;
+        $nativeType = $scope->getNativeType($expr);
+        return $nativeType instanceof MixedType && ! $nativeType->isExplicitMixed();
     }
 
     public function isDynamicExpr(Expr $expr): bool


### PR DESCRIPTION
Let's try rely on `$scope->getNativeType($expr)` is a `MixedType` with `non explicit mixed` detection instead of climbing lookup parent.