### PR TITLE
[DX] Kick of SimpleParameterProvider

### DIFF
--- a/packages/Caching/CacheFactory.php
+++ b/packages/Caching/CacheFactory.php
@@ -8,6 +8,7 @@ use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\ParameterProvider;
+use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Symfony\Component\Filesystem\Filesystem;
 
 final class CacheFactory
@@ -26,7 +27,8 @@ final class CacheFactory
         $cacheDirectory = $this->parameterProvider->provideStringParameter(Option::CACHE_DIR);
 
         $cacheClass = FileCacheStorage::class;
-        if ($this->parameterProvider->hasParameter(Option::CACHE_CLASS)) {
+
+        if (SimpleParameterProvider::hasParameter(Option::CACHE_CLASS)) {
             $cacheClass = $this->parameterProvider->provideStringParameter(Option::CACHE_CLASS);
         }
 

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -6,6 +6,7 @@ namespace Rector\Config;
 
 use Rector\Caching\Contract\ValueObject\Storage\CacheStorageInterface;
 use Rector\Core\Configuration\Option;
+use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\Configuration\ValueObjectInliner;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Contract\Rector\NonPhpRectorInterface;
@@ -35,6 +36,8 @@ final class RectorConfig extends ContainerConfigurator
 
         $parameters = $this->parameters();
         $parameters->set(Option::PATHS, $paths);
+
+        SimpleParameterProvider::addParameter(Option::PATHS, $paths);
     }
 
     /**
@@ -53,29 +56,42 @@ final class RectorConfig extends ContainerConfigurator
     public function disableParallel(): void
     {
         $parameters = $this->parameters();
+
         $parameters->set(Option::PARALLEL, false);
+        SimpleParameterProvider::setParameter(Option::PARALLEL, false);
     }
 
     public function parallel(int $seconds = 120, int $maxNumberOfProcess = 16, int $jobSize = 20): void
     {
         $parameters = $this->parameters();
+
         $parameters->set(Option::PARALLEL, true);
+        SimpleParameterProvider::setParameter(Option::PARALLEL, true);
 
         $parameters->set(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $seconds);
+        SimpleParameterProvider::setParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $seconds);
+
         $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $maxNumberOfProcess);
+        SimpleParameterProvider::setParameter(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, $maxNumberOfProcess);
+
         $parameters->set(Option::PARALLEL_JOB_SIZE, $jobSize);
+        SimpleParameterProvider::setParameter(Option::PARALLEL_JOB_SIZE, $jobSize);
     }
 
     public function noDiffs(): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::NO_DIFFS, true);
+
+        SimpleParameterProvider::setParameter(Option::NO_DIFFS, true);
     }
 
     public function memoryLimit(string $memoryLimit): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::MEMORY_LIMIT, $memoryLimit);
+
+        SimpleParameterProvider::setParameter(Option::MEMORY_LIMIT, $memoryLimit);
     }
 
     /**
@@ -85,25 +101,35 @@ final class RectorConfig extends ContainerConfigurator
     {
         $parameters = $this->parameters();
         $parameters->set(Option::SKIP, $criteria);
+
+        SimpleParameterProvider::addParameter(Option::SKIP, $criteria);
     }
 
     public function removeUnusedImports(bool $removeUnusedImports = true): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::REMOVE_UNUSED_IMPORTS, $removeUnusedImports);
+
+        SimpleParameterProvider::setParameter(Option::REMOVE_UNUSED_IMPORTS, $removeUnusedImports);
     }
 
     public function importNames(bool $importNames = true, bool $importDocBlockNames = true): void
     {
         $parameters = $this->parameters();
+
         $parameters->set(Option::AUTO_IMPORT_NAMES, $importNames);
+        SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_NAMES, $importNames);
+
         $parameters->set(Option::AUTO_IMPORT_DOC_BLOCK_NAMES, $importDocBlockNames);
+        SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_DOC_BLOCK_NAMES, $importDocBlockNames);
     }
 
     public function importShortClasses(bool $importShortClasses = true): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::IMPORT_SHORT_CLASSES, $importShortClasses);
+
+        SimpleParameterProvider::setParameter(Option::IMPORT_SHORT_CLASSES, $importShortClasses);
     }
 
     /**
@@ -116,6 +142,8 @@ final class RectorConfig extends ContainerConfigurator
 
         $parameters = $this->parameters();
         $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, $filePath);
+
+        SimpleParameterProvider::setParameter(Option::PHPSTAN_FOR_RECTOR_PATH, $filePath);
     }
 
     /**
@@ -183,6 +211,8 @@ final class RectorConfig extends ContainerConfigurator
     {
         $parameters = $this->parameters();
         $parameters->set(Option::PHP_VERSION_FEATURES, $phpVersion);
+
+        SimpleParameterProvider::setParameter(Option::PHP_VERSION_FEATURES, $phpVersion);
     }
 
     /**
@@ -194,6 +224,8 @@ final class RectorConfig extends ContainerConfigurator
 
         $parameters = $this->parameters();
         $parameters->set(Option::AUTOLOAD_PATHS, $autoloadPaths);
+
+        SimpleParameterProvider::addParameter(Option::AUTOLOAD_PATHS, $autoloadPaths);
     }
 
     /**
@@ -205,18 +237,24 @@ final class RectorConfig extends ContainerConfigurator
 
         $parameters = $this->parameters();
         $parameters->set(Option::BOOTSTRAP_FILES, $bootstrapFiles);
+
+        SimpleParameterProvider::addParameter(Option::BOOTSTRAP_FILES, $bootstrapFiles);
     }
 
     public function symfonyContainerXml(string $filePath): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::SYMFONY_CONTAINER_XML_PATH_PARAMETER, $filePath);
+
+        SimpleParameterProvider::setParameter(Option::SYMFONY_CONTAINER_XML_PATH_PARAMETER, $filePath);
     }
 
     public function symfonyContainerPhp(string $filePath): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::SYMFONY_CONTAINER_PHP_PATH_PARAMETER, $filePath);
+
+        SimpleParameterProvider::setParameter(Option::SYMFONY_CONTAINER_PHP_PATH_PARAMETER, $filePath);
     }
 
     /**
@@ -228,12 +266,16 @@ final class RectorConfig extends ContainerConfigurator
 
         $parameters = $this->parameters();
         $parameters->set(Option::FILE_EXTENSIONS, $extensions);
+
+        SimpleParameterProvider::setParameter(Option::FILE_EXTENSIONS, $extensions);
     }
 
     public function nestedChainMethodCallLimit(int $limit): void
     {
         $parameters = $this->parameters();
         $parameters->set(Option::NESTED_CHAIN_METHOD_CALL_LIMIT, $limit);
+
+        SimpleParameterProvider::setParameter(Option::NESTED_CHAIN_METHOD_CALL_LIMIT, $limit);
     }
 
     public function cacheDirectory(string $directoryPath): void
@@ -242,6 +284,8 @@ final class RectorConfig extends ContainerConfigurator
         // when not exists, so no need to validate $directoryPath is a directory
         $parameters = $this->parameters();
         $parameters->set(Option::CACHE_DIR, $directoryPath);
+
+        SimpleParameterProvider::setParameter(Option::CACHE_DIR, $directoryPath);
     }
 
     public function containerCacheDirectory(string $directoryPath): void
@@ -251,6 +295,8 @@ final class RectorConfig extends ContainerConfigurator
 
         $parameters = $this->parameters();
         $parameters->set(Option::CONTAINER_CACHE_DIRECTORY, $directoryPath);
+
+        SimpleParameterProvider::setParameter(Option::CONTAINER_CACHE_DIRECTORY, $directoryPath);
     }
 
     /**
@@ -262,6 +308,8 @@ final class RectorConfig extends ContainerConfigurator
 
         $parameters = $this->parameters();
         $parameters->set(Option::CACHE_CLASS, $cacheClass);
+
+        SimpleParameterProvider::setParameter(Option::CACHE_CLASS, $cacheClass);
     }
 
     /**

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -37,7 +37,7 @@ final class RectorConfig extends ContainerConfigurator
         $parameters = $this->parameters();
         $parameters->set(Option::PATHS, $paths);
 
-        SimpleParameterProvider::addParameter(Option::PATHS, $paths);
+        SimpleParameterProvider::setParameter(Option::PATHS, $paths);
     }
 
     /**
@@ -225,7 +225,7 @@ final class RectorConfig extends ContainerConfigurator
         $parameters = $this->parameters();
         $parameters->set(Option::AUTOLOAD_PATHS, $autoloadPaths);
 
-        SimpleParameterProvider::addParameter(Option::AUTOLOAD_PATHS, $autoloadPaths);
+        SimpleParameterProvider::setParameter(Option::AUTOLOAD_PATHS, $autoloadPaths);
     }
 
     /**
@@ -238,7 +238,7 @@ final class RectorConfig extends ContainerConfigurator
         $parameters = $this->parameters();
         $parameters->set(Option::BOOTSTRAP_FILES, $bootstrapFiles);
 
-        SimpleParameterProvider::addParameter(Option::BOOTSTRAP_FILES, $bootstrapFiles);
+        SimpleParameterProvider::setParameter(Option::BOOTSTRAP_FILES, $bootstrapFiles);
     }
 
     public function symfonyContainerXml(string $filePath): void

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -16,6 +16,7 @@ use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\ParameterProvider;
+use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -145,10 +146,8 @@ final class PHPStanServicesFactory
     {
         $additionalConfigFiles = [];
 
-        if ($this->parameterProvider->hasParameter(Option::PHPSTAN_FOR_RECTOR_PATH)) {
-            $additionalConfigFiles[] = $this->parameterProvider->provideStringParameter(
-                Option::PHPSTAN_FOR_RECTOR_PATH
-            );
+        if (SimpleParameterProvider::hasParameter(Option::PHPSTAN_FOR_RECTOR_PATH)) {
+            $additionalConfigFiles[] = SimpleParameterProvider::provideStringParameter(Option::PHPSTAN_FOR_RECTOR_PATH);
         }
 
         $additionalConfigFiles[] = __DIR__ . '/../../../config/phpstan/static-reflection.neon';

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -30,7 +30,7 @@ final class PHPStanServicesFactory
     private readonly Container $container;
 
     public function __construct(
-        private readonly ParameterProvider $parameterProvider,
+        ParameterProvider $parameterProvider,
         private readonly PHPStanExtensionsConfigResolver $phpStanExtensionsConfigResolver,
         BleedingEdgeIncludePurifier $bleedingEdgeIncludePurifier,
     ) {

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -16,6 +16,7 @@ use Rector\Core\Autoloading\BootstrapFilesIncluder;
 use Rector\Core\Configuration\ConfigurationFactory;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\ParameterProvider;
+use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
@@ -147,6 +148,7 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
         string $fixtureFilePath
     ): void {
         $this->parameterProvider->changeParameter(Option::SOURCE, [$originalFilePath]);
+        SimpleParameterProvider::setParameter(Option::SOURCE, [$originalFilePath]);
 
         $changedContent = $this->processFilePath($originalFilePath, $inputFileContents);
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -691,3 +691,13 @@ parameters:
             path: src/PhpParser/Node/BetterNodeFinder.php
 
         - '#The "Rector\\Core\\ValueObject\\Application\\File" class always calls "hydrateStmtsAndTokens\(\)" setters, better move it to constructor#'
+
+        # refactor in next PR
+        - '#(.*?) has typehint with deprecated class Rector\\Core\\Configuration\\Parameter\\ParameterProvider#'
+
+        -
+            message: '#Do not use static property#'
+            path: src/Configuration/Parameter/SimpleParameterProvider.php
+
+
+        - '#Fetching class constant class of deprecated class Rector\\Core\\Configuration\\Parameter\\ParameterProvider\:#'

--- a/rules/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector.php
@@ -38,9 +38,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class NumericReturnTypeFromStrictScalarReturnsRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private ExprAnalyzer $exprAnalyzer,
-    )
-    {
+        private readonly ExprAnalyzer $exprAnalyzer,
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -189,16 +188,12 @@ CODE_SAMPLE
         return null;
     }
 
-    private function isBinaryOpContainingNonTypedParam(
-        BinaryOp $binaryOp
-    ):bool {
+    private function isBinaryOpContainingNonTypedParam(BinaryOp $binaryOp): bool
+    {
         if ($this->exprAnalyzer->isNonTypedFromParam($binaryOp->left)) {
             return true;
         }
-        if ($this->exprAnalyzer->isNonTypedFromParam($binaryOp->right)) {
-            return true;
-        }
 
-        return false;
+        return $this->exprAnalyzer->isNonTypedFromParam($binaryOp->right);
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -6,6 +6,7 @@ namespace Rector\Core\Configuration;
 
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\Core\Configuration\Parameter\ParameterProvider;
+use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\Contract\Console\OutputStyleInterface;
 use Rector\Core\ValueObject\Configuration;
 use Symfony\Component\Console\Input\InputInterface;
@@ -131,10 +132,10 @@ final class ConfigurationFactory
             return (string) $memoryLimit;
         }
 
-        if (! $this->parameterProvider->hasParameter(Option::MEMORY_LIMIT)) {
+        if (! SimpleParameterProvider::hasParameter(Option::MEMORY_LIMIT)) {
             return null;
         }
 
-        return $this->parameterProvider->provideStringParameter(Option::MEMORY_LIMIT);
+        return SimpleParameterProvider::provideStringParameter(Option::MEMORY_LIMIT);
     }
 }

--- a/src/Configuration/Parameter/ParameterProvider.php
+++ b/src/Configuration/Parameter/ParameterProvider.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Rector\Core\Configuration\Parameter;
 
+use Rector\Core\Configuration\Option;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
  * @deprecated Use SimpleParameterProvider to avoid coupling with Symfony container.
- * This class will be removed in next major release.
+ * This class will be removed in next major release
+ *
  * @api
  */
 final class ParameterProvider
@@ -27,12 +29,16 @@ final class ParameterProvider
         $this->parameters = $parameterBag->all();
     }
 
+    /**
+     * @param Option::* $name
+     */
     public function hasParameter(string $name): bool
     {
         return isset($this->parameters[$name]);
     }
 
     /**
+     * @param Option::* $name
      * @api
      */
     public function provideParameter(string $name): mixed
@@ -41,6 +47,7 @@ final class ParameterProvider
     }
 
     /**
+     * @param Option::* $name
      * @api
      */
     public function provideStringParameter(string $name, ?string $default = null): string
@@ -53,7 +60,7 @@ final class ParameterProvider
     }
 
     /**
-     * @api
+     * @param Option::* $name
      * @return mixed[]
      */
     public function provideArrayParameter(string $name): array
@@ -64,25 +71,21 @@ final class ParameterProvider
     }
 
     /**
+     * @param Option::* $name
      * @api
      */
-    public function provideBoolParameter(string $parameterName): bool
+    public function provideBoolParameter(string $name): bool
     {
-        return $this->parameters[$parameterName] ?? false;
-    }
-
-    public function changeParameter(string $name, mixed $value): void
-    {
-        $this->parameters[$name] = $value;
+        return $this->parameters[$name] ?? false;
     }
 
     /**
-     * @api
-     * @return mixed[]
+     * @param Option::* $name
      */
-    public function provide(): array
+    public function changeParameter(string $name, mixed $value): void
     {
-        return $this->parameters;
+        $this->parameters[$name] = $value;
+        SimpleParameterProvider::setParameter($name, $value);
     }
 
     /**

--- a/src/Configuration/Parameter/ParameterProvider.php
+++ b/src/Configuration/Parameter/ParameterProvider.php
@@ -9,6 +9,8 @@ use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
+ * @deprecated Use SimpleParameterProvider to avoid coupling with Symfony container.
+ * This class will be removed in next major release.
  * @api
  */
 final class ParameterProvider

--- a/src/Configuration/Parameter/SimpleParameterProvider.php
+++ b/src/Configuration/Parameter/SimpleParameterProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Configuration\Parameter;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @api
+ */
+final class SimpleParameterProvider
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private static array $parameters = [];
+
+    public static function addParameter(string $key, mixed $value): void
+    {
+        if (is_array($value)) {
+            $mergedParameters = array_merge(self::$parameters[$key] ?? [], $value);
+            self::$parameters[$key] = $mergedParameters;
+        } else {
+            self::$parameters[$key][] = $value;
+        }
+    }
+
+    public static function setParameter(string $key, mixed $value): void
+    {
+        self::$parameters[$key] = $value;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public static function provideArrayParameter(string $key): array
+    {
+        $parameter = self::$parameters[$key] ?? [];
+        Assert::isArray($parameter);
+
+        if (array_is_list($parameter)) {
+            // remove duplicates
+            return array_values(array_unique($parameter));
+        }
+
+        return $parameter;
+    }
+
+    public static function hasParameter(string $name): bool
+    {
+        return array_key_exists($name, self::$parameters);
+    }
+
+    public static function provideStringParameter(string $key): string
+    {
+        return self::$parameters[$key];
+    }
+
+    public static function provideIntParameter(string $key): int
+    {
+        return self::$parameters[$key];
+    }
+
+    public static function provideBoolParameter(string $key): bool
+    {
+        return self::$parameters[$key];
+    }
+}

--- a/src/Configuration/Parameter/SimpleParameterProvider.php
+++ b/src/Configuration/Parameter/SimpleParameterProvider.php
@@ -41,7 +41,8 @@ final class SimpleParameterProvider
 
         if (array_is_list($parameter)) {
             // remove duplicates
-            return array_values(array_unique($parameter));
+            $uniqueParameters = array_unique($parameter);
+            return array_values($uniqueParameters);
         }
 
         return $parameter;

--- a/src/NodeManipulator/ArrayManipulator.php
+++ b/src/NodeManipulator/ArrayManipulator.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class ArrayManipulator
 {
-    private readonly ExprAnalyzer $exprAnalyzer;
+    private ExprAnalyzer $exprAnalyzer;
 
     public function __construct(
         private readonly RectorChangeCollector $rectorChangeCollector

--- a/src/NodeManipulator/ArrayManipulator.php
+++ b/src/NodeManipulator/ArrayManipulator.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class ArrayManipulator
 {
-    private ExprAnalyzer $exprAnalyzer;
+    private readonly ExprAnalyzer $exprAnalyzer;
 
     public function __construct(
         private readonly RectorChangeCollector $rectorChangeCollector


### PR DESCRIPTION
Mirror PR to https://github.com/easy-coding-standard/easy-coding-standard/pull/96

The goal is to lower unneded Symfony DI scalar parameter juggling, to lower the coupling and allow future decouping from Symfony.