### PR TITLE
Add regression fixture for RemoveUnusedPrivateMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/used_as_closure.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/used_as_closure.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+final class DemoFile
+{
+    public function foo(): \Closure
+    {
+        return \Closure::fromCallable(self::bar(...));
+    }
+    
+    private static function bar(): void
+    {
+        echo 'Hello world';
+    }
+}
+
+?>


### PR DESCRIPTION
This is a regression test for a bug that I found in my code applying Rector 0.17.2 dead code set list. Private method is extracted as closure, but removed as unused.