### PR TITLE
[NodeTypeResolver] Remove parent attribute on PHPStanNodeScopeResolver for after UnreachableStatementNode detector

### DIFF
--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -3,15 +3,10 @@ parameters:
     featureToggles:
         disableRuntimeReflectionProvider: false
 
-conditionalTags:
-    PhpParser\NodeVisitor\ParentConnectingVisitor:
-        phpstan.parser.richParserNodeVisitor: true
-
 services:
     - Rector\NodeTypeResolver\Reflection\BetterReflection\RectorBetterReflectionSourceLocatorFactory
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocator\IntermediateSourceLocator
     - Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider
-    - PhpParser\NodeVisitor\ParentConnectingVisitor
 
     # basically decorates native PHPStan source locator with a dynamic source locator that is also available in Rector DI
     betterReflectionSourceLocator:

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -9,6 +9,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
+use Rector\Core\PHPStan\NodeVisitor\UnreachableStatementNodeVisitor;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionLikeParamArgPositionNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
@@ -22,6 +23,7 @@ final class NodeScopeAndMetadataDecorator
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         ParentConnectingVisitor $parentConnectingVisitor,
         FunctionLikeParamArgPositionNodeVisitor $functionLikeParamArgPositionNodeVisitor,
+        UnreachableStatementNodeVisitor $unreachableStatementNodeVisitor,
         private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser
     ) {
         $this->nodeTraverser = new NodeTraverser();
@@ -33,6 +35,8 @@ final class NodeScopeAndMetadataDecorator
         $this->nodeTraverser->addVisitor($parentConnectingVisitor);
 
         $this->nodeTraverser->addVisitor($functionLikeParamArgPositionNodeVisitor);
+
+        $this->nodeTraverser->addVisitor($unreachableStatementNodeVisitor);
     }
 
     /**

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -334,10 +334,6 @@ final class PHPStanNodeScopeResolver
                 }
             }
 
-            if ($node instanceof Stmt) {
-                $this->setChildOfUnreachableStatementNodeAttribute($node, $mutatingScope);
-            }
-
             // special case for unreachable nodes
             if ($node instanceof UnreachableStatementNode) {
                 $this->processUnreachableStatementNode($node, $filePath, $mutatingScope);
@@ -511,23 +507,6 @@ final class PHPStanNodeScopeResolver
         $originalStmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
 
         $this->processNodes([$originalStmt], $filePath, $mutatingScope);
-
-        $parentNode = $unreachableStatementNode->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parentNode instanceof StmtsAwareInterface && ! $parentNode instanceof ClassLike && ! $parentNode instanceof Declare_) {
-            return;
-        }
-
-        $stmtKey = $unreachableStatementNode->getAttribute(AttributeKey::STMT_KEY);
-        $totalKeys = $parentNode->stmts === null ? 0 : count($parentNode->stmts);
-
-        for ($key = $stmtKey + 1; $key < $totalKeys; ++$key) {
-            if (! isset($parentNode->stmts[$key])) {
-                continue;
-            }
-
-            $parentNode->stmts[$key]->setAttribute(AttributeKey::IS_UNREACHABLE, true);
-            $this->processNodes([$parentNode->stmts[$key]], $filePath, $mutatingScope);
-        }
     }
 
     private function processProperty(Property $property, MutatingScope $mutatingScope): void

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -34,8 +34,6 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\EnumCase;
 use PhpParser\Node\Stmt\Expression;
@@ -65,7 +63,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Caching\FileSystem\DependencyResolver;
-use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -411,26 +408,6 @@ final class PHPStanNodeScopeResolver
             $expr->expr->setAttribute(AttributeKey::SCOPE, $mutatingScope);
 
             $expr = $expr->expr;
-        }
-    }
-
-    private function setChildOfUnreachableStatementNodeAttribute(Stmt $stmt, MutatingScope $mutatingScope): void
-    {
-        if (! $stmt instanceof StmtsAwareInterface && ! $stmt instanceof ClassLike && ! $stmt instanceof Declare_) {
-            return;
-        }
-
-        if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) !== true) {
-            return;
-        }
-
-        if ($stmt->stmts === null) {
-            return;
-        }
-
-        foreach ($stmt->stmts as $childStmt) {
-            $childStmt->setAttribute(AttributeKey::IS_UNREACHABLE, true);
-            $childStmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
         }
     }
 

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -61,21 +61,17 @@ final class UndefinedVariableResolver
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
-            if ($node instanceof Foreach_) {
+            if ($node instanceof Foreach_ || $node instanceof Case_) {
                 // handled above
                 return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
-            if ($node instanceof Case_) {
-                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-            }
-
             if ($node instanceof Stmt) {
-                if ($node->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
+                $currentStmt = $node;
+
+                if ($currentStmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
                     return NodeTraverser::STOP_TRAVERSAL;
                 }
-
-                $currentStmt = $node;
             }
 
             if (! $node instanceof Variable) {
@@ -88,16 +84,8 @@ final class UndefinedVariableResolver
                 return NodeTraverser::STOP_TRAVERSAL;
             }
 
-            if ($node->getAttribute(AttributeKey::IS_BEING_ASSIGNED) === true) {
-                return null;
-            }
-
             $variableName = (string) $this->nodeNameResolver->getName($node);
-            if ($this->shouldSkipVariable($node, $variableName, $checkedVariables)) {
-                return null;
-            }
-
-            if ($this->hasVariableTypeOrCurrentStmtUnreachable($node, $variableName, $currentStmt)) {
+            if ($this->shouldSkipVariable($node, $variableName, $checkedVariables, $currentStmt)) {
                 return null;
             }
 
@@ -209,8 +197,12 @@ final class UndefinedVariableResolver
     /**
      * @param string[] $checkedVariables
      */
-    private function shouldSkipVariable(Variable $variable, string $variableName, array &$checkedVariables): bool
-    {
+    private function shouldSkipVariable(
+        Variable $variable,
+        string $variableName,
+        array &$checkedVariables,
+        ?Stmt $currentStmt
+    ): bool {
         $variableName = $this->nodeNameResolver->getName($variable);
 
         // skip $this, as probably in outer scope
@@ -230,7 +222,15 @@ final class UndefinedVariableResolver
             return true;
         }
 
-        return in_array($variableName, $checkedVariables, true);
+        if (in_array($variableName, $checkedVariables, true)) {
+            return true;
+        }
+
+        if ($variable->getAttribute(AttributeKey::IS_BEING_ASSIGNED) === true) {
+            return true;
+        }
+
+        return $this->hasVariableTypeOrCurrentStmtUnreachable($variable, $variableName, $currentStmt);
     }
 
     private function isDifferentWithOriginalNodeOrNoScope(Variable $variable): bool

--- a/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
+++ b/rules/Php56/NodeAnalyzer/UndefinedVariableResolver.php
@@ -71,6 +71,10 @@ final class UndefinedVariableResolver
             }
 
             if ($node instanceof Stmt) {
+                if ($node->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+
                 $currentStmt = $node;
             }
 

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\PHPStan\NodeVisitor;
 
+use PHPStan\Analyser\MutatingScope;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Declare_;
@@ -39,7 +40,7 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 
         $filePath = $file->getFilePath();
         $isPassedUnreachableStmt = false;
-        /** @var \PHPStan\Analyser\MutatingScope $mutatingScope **/
+        /** @var MutatingScope $mutatingScope **/
         $mutatingScope = $node->getAttribute(AttributeKey::SCOPE);
 
         foreach ($node->stmts as $stmt) {

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -39,7 +39,8 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 
         $filePath = $file->getFilePath();
         $isPassedUnreachableStmt = false;
-        $mutatingScope ??= $node->getAttribute(AttributeKey::SCOPE);
+        /** @var \PHPStan\Analyser\MutatingScope $mutatingScope **/
+        $mutatingScope = $node->getAttribute(AttributeKey::SCOPE);
 
         foreach ($node->stmts as $stmt) {
             if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -20,7 +20,7 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
     public function __construct(
         private readonly ScopeFactory $scopeFactory,
         private readonly CurrentFileProvider $currentFileProvider,
-        private readonly PHPStanNodeScopeResolver $pHPStanNodeScopeResolver
+        private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver
     )
     {
     }
@@ -47,7 +47,7 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
         foreach ($node->stmts as $stmt) {
             if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
                 $mutatingScope ??= $this->scopeFactory->createFromFile($file->getFilePath());
-                $this->pHPStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
+                $this->phpStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
 
                 $isPassedUnreachableStmt = true;
                 continue;
@@ -55,7 +55,7 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 
             if ($isPassedUnreachableStmt) {
                 $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-                $this->pHPStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
+                $this->phpStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
             }
         }
 

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\PHPStan\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Declare_;
+use PhpParser\NodeVisitorAbstract;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Core\Provider\CurrentFileProvider;
+use Rector\Core\ValueObject\Application\File;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
+use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
+
+final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
+{
+    public function __construct(
+        private readonly ScopeFactory $scopeFactory,
+        private readonly CurrentFileProvider $currentFileProvider,
+        private readonly PHPStanNodeScopeResolver $pHPStanNodeScopeResolver
+    )
+    {
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof StmtsAwareInterface && ! $node instanceof ClassLike && ! $node instanceof Declare_) {
+            return null;
+        }
+
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        $file = $this->currentFileProvider->getFile();
+        if (! $file instanceof File) {
+            return null;
+        }
+
+        $filePath = $file->getFilePath();
+        $isPassedUnreachableStmt = false;
+        $mutatingScope = null;
+
+        foreach ($node->stmts as $stmt) {
+            if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
+                $mutatingScope ??= $this->scopeFactory->createFromFile($file->getFilePath());
+                $this->pHPStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
+
+                $isPassedUnreachableStmt = true;
+                continue;
+            }
+
+            if ($isPassedUnreachableStmt) {
+                $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+                $this->pHPStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -45,13 +45,12 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 
         foreach ($node->stmts as $stmt) {
             if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
-                $this->phpStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
-
                 $isPassedUnreachableStmt = true;
                 continue;
             }
 
             if ($isPassedUnreachableStmt) {
+                $stmt->setAttribute(AttributeKey::IS_UNREACHABLE, true);
                 $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
                 $this->phpStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
             }

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\PHPStan\NodeVisitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\NodeVisitorAbstract;

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -42,11 +42,10 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 
         $filePath = $file->getFilePath();
         $isPassedUnreachableStmt = false;
-        $mutatingScope = null;
+        $mutatingScope ??= $node->getAttribute(AttributeKey::SCOPE);
 
         foreach ($node->stmts as $stmt) {
             if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
-                $mutatingScope ??= $this->scopeFactory->createFromFile($file->getFilePath());
                 $this->phpStanNodeScopeResolver->processNodes([$stmt], $filePath, $mutatingScope);
 
                 $isPassedUnreachableStmt = true;

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -13,16 +13,13 @@ use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
-use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 
 final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 {
     public function __construct(
-        private readonly ScopeFactory $scopeFactory,
         private readonly CurrentFileProvider $currentFileProvider,
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver
-    )
-    {
+    ) {
     }
 
     public function enterNode(Node $node): ?Node

--- a/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
@@ -26,10 +26,6 @@ final class FileWithoutNamespaceNodeTraverser extends NodeTraverser
         }
 
         $fileWithoutNamespace = new FileWithoutNamespace($nodes);
-        foreach ($nodes as $node) {
-            $node->setAttribute(AttributeKey::PARENT_NODE, $fileWithoutNamespace);
-        }
-
         return [$fileWithoutNamespace];
     }
 }

--- a/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\NodeTraverser;
 
-use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class FileWithoutNamespaceNodeTraverser extends NodeTraverser
 {

--- a/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/FileWithoutNamespaceNodeTraverser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\NodeTraverser;
 
+use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;


### PR DESCRIPTION
Create new visitor: `UnreachableStatementNodeVisitor` for set child and next of unreachable statement node Scope filing.