### PR TITLE
[Performance] Add $hasUnreachableStatementNode flag on PHPStanNodeScopeResolver to ensure execute UnreachableStatementNodeVisitor only when it has

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -177,6 +177,7 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/../src/functions',
             __DIR__ . '/../src/PhpParser/Node/CustomNode',
             __DIR__ . '/../src/PhpParser/ValueObject',
+            __DIR__ . '/../src/PHPStan/NodeVisitor',
             __DIR__ . '/../src/constants.php',
         ]);
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -86,6 +86,8 @@ final class PHPStanNodeScopeResolver
 
     private readonly NodeTraverser $nodeTraverser;
 
+    private bool $hasUnreachableStatementNode = false;
+
     /**
      * @param ScopeResolverNodeVisitorInterface[] $nodeVisitors
      */
@@ -117,6 +119,7 @@ final class PHPStanNodeScopeResolver
         ?MutatingScope $formerMutatingScope = null
     ): array {
         $isScopeRefreshing = $formerMutatingScope instanceof MutatingScope;
+        $this->hasUnreachableStatementNode = false;
 
         /**
          * The stmts must be array of Stmt, or it will be silently skipped by PHPStan
@@ -484,6 +487,13 @@ final class PHPStanNodeScopeResolver
         $originalStmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
 
         $this->processNodes([$originalStmt], $filePath, $mutatingScope);
+
+        $this->hasUnreachableStatementNode = true;
+    }
+
+    public function hasUnreachableStatementNode(): bool
+    {
+        return $this->hasUnreachableStatementNode;
     }
 
     private function processProperty(Property $property, MutatingScope $mutatingScope): void


### PR DESCRIPTION
@TomasVotruba @staabm this is continue of PR:

- https://github.com/rectorphp/rector-src/pull/4415

to ensure execute `UnreachableStatementNodeVisitor` when the file actually have unreachable statement node to improve the performance.

For note: this only happen on init file, if it is required on refresh later, we may need to save the `UnreachableStatementNodeVisitor` on `Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor` namespace to allow revisit:

https://github.com/rectorphp/rector-src/tree/93a4b2b15eec15c506ae55c25b23a40dd0390cff/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor