### PR TITLE
[Performance] Immediate remove UnreachableStatementNodeVisitor object after traverse to avoid re-use in next file

### DIFF
--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -48,12 +48,12 @@ final class NodeScopeAndMetadataDecorator
         $stmts = $this->phpStanNodeScopeResolver->processNodes($stmts, $file->getFilePath());
 
         if ($this->phpStanNodeScopeResolver->hasUnreachableStatementNode()) {
-            $unreachableStamtentNodeVisitor = new UnreachableStatementNodeVisitor(
+            $unreachableStatementNodeVisitor = new UnreachableStatementNodeVisitor(
                 $this->phpStanNodeScopeResolver,
                 $file->getFilePath(),
                 $this->scopeFactory
             );
-            $this->nodeTraverser->addVisitor($unreachableStamtentNodeVisitor);
+            $this->nodeTraverser->addVisitor($unreachableStatementNodeVisitor);
 
             $stmts = $this->nodeTraverser->traverse($stmts);
 
@@ -61,7 +61,7 @@ final class NodeScopeAndMetadataDecorator
              * immediate remove UnreachableStatementNodeVisitor after traverse to avoid
              * re-used in nodeTraverser property in next file
              */
-            $this->nodeTraverser->removeVisitor($unreachableStamtentNodeVisitor);
+            $this->nodeTraverser->removeVisitor($unreachableStatementNodeVisitor);
 
             return $stmts;
         }

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -57,8 +57,10 @@ final class NodeScopeAndMetadataDecorator
 
             $stmts = $this->nodeTraverser->traverse($stmts);
 
-            // immediate remove UnreachableStatementNodeVisitor after traverse to avoid
-            // re-used in nodeTraverser property in next file
+            /**
+             * immediate remove UnreachableStatementNodeVisitor after traverse to avoid
+             * re-used in nodeTraverser property in next file
+             *
             $this->nodeTraverser->removeVisitor($unreachableStamtentNodeVisitor);
 
             return $stmts;

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -60,7 +60,7 @@ final class NodeScopeAndMetadataDecorator
             /**
              * immediate remove UnreachableStatementNodeVisitor after traverse to avoid
              * re-used in nodeTraverser property in next file
-             *
+             */
             $this->nodeTraverser->removeVisitor($unreachableStamtentNodeVisitor);
 
             return $stmts;

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -58,7 +58,7 @@ final class NodeScopeAndMetadataDecorator
             $stmts = $this->nodeTraverser->traverse($stmts);
 
             // immediate remove UnreachableStatementNodeVisitor after traverse to avoid
-            // re-used as nodeTraverser in next file
+            // re-used in nodeTraverser property in next file
             $this->nodeTraverser->removeVisitor($unreachableStamtentNodeVisitor);
 
             return $stmts;

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -48,13 +48,20 @@ final class NodeScopeAndMetadataDecorator
         $stmts = $this->phpStanNodeScopeResolver->processNodes($stmts, $file->getFilePath());
 
         if ($this->phpStanNodeScopeResolver->hasUnreachableStatementNode()) {
-            $this->nodeTraverser->addVisitor(
-                new UnreachableStatementNodeVisitor(
-                    $this->phpStanNodeScopeResolver,
-                    $file->getFilePath(),
-                    $this->scopeFactory
-                )
+            $unreachableStamtentNodeVisitor = new UnreachableStatementNodeVisitor(
+                $this->phpStanNodeScopeResolver,
+                $file->getFilePath(),
+                $this->scopeFactory
             );
+            $this->nodeTraverser->addVisitor($unreachableStamtentNodeVisitor);
+
+            $stmts = $this->nodeTraverser->traverse($stmts);
+
+            // immediate remove UnreachableStatementNodeVisitor after traverse to avoid
+            // re-used as nodeTraverser in next file
+            $this->nodeTraverser->removeVisitor($unreachableStamtentNodeVisitor);
+
+            return $stmts;
         }
 
         return $this->nodeTraverser->traverse($stmts);


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/4416

immediate remove` UnreachableStatementNodeVisitor` after traverse to avoid re-used in nodeTraverser property in next file