### PR TITLE
[NodeAnalyzer] Add instanceof check statementDepth on Stmt, and expressionDepth on Expr on ScopeAnalyzer

### DIFF
--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -6,9 +6,11 @@ namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
 use PHPStan\Analyser\MutatingScope;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
@@ -45,11 +47,13 @@ final class ScopeAnalyzer
             return $mutatingScope;
         }
 
-        if ($node->getAttribute(AttributeKey::STATEMENT_DEPTH) === 0) {
+        // on File level
+        if ($node instanceof Stmt && $node->getAttribute(AttributeKey::STATEMENT_DEPTH) === 0) {
             return $this->scopeFactory->createFromFile($filePath);
         }
 
-        if ($node->getAttribute(AttributeKey::EXPRESSION_DEPTH) >= 2) {
+        // too deep Expr, eg: $$param = $$bar = self::decodeValue($result->getItem()->getTextContent());
+        if ($node instanceof Expr && $node->getAttribute(AttributeKey::EXPRESSION_DEPTH) >= 2) {
             return $this->scopeFactory->createFromFile($filePath);
         }
 


### PR DESCRIPTION
- `statementDepth` attribute is on `Stmt`, and check `0` on `File` level 
- `expressionDepth` attribute is on `Expr`, and check `>=2` to ensure not too deep `Scope` filling, eg:

```php
$$param = $$bar = self::decodeValue($result->getItem()->getTextContent());
```