### PR TITLE
[NodeTypeResolver] Reduce parent lookup on ParamTypeResolver by remove resolveFromFirstVariableUse()

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver/ParamTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/ParamTypeResolver.php
@@ -13,11 +13,9 @@ use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -31,10 +29,8 @@ final class ParamTypeResolver implements NodeTypeResolverInterface
     private StaticTypeMapper $staticTypeMapper;
 
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 


### PR DESCRIPTION
It climbing parent, and search in stmts to get type, let see if it removable.