### PR TITLE
[NodeTypeResolver] Reduce duplicated Scope fill on FuncCall

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -188,10 +188,6 @@ final class PHPStanNodeScopeResolver
                 $this->processArrayItem($node, $mutatingScope);
             }
 
-            if ($node instanceof FuncCall && $node->name instanceof Expr) {
-                $node->name->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-            }
-
             if ($node instanceof NullableType) {
                 $node->type->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }


### PR DESCRIPTION
Already covered in `processCallike()` method:


https://github.com/rectorphp/rector-src/blob/a4ef13b30cfd2ee5a02f547256673064d648c558/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php#L292-L306