### PR TITLE
[NodeAnalyzer] Mark Variable as non-refreshable MutatingScope on ScopeAnalyzer

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -47,7 +47,7 @@ final class ChangedNodeScopeRefresher
     public function refresh(Node $node, ?MutatingScope $mutatingScope, ?string $filePath = null): void
     {
         // nothing to refresh
-        if (! $this->scopeAnalyzer->hasScope($node)) {
+        if (! $this->scopeAnalyzer->isRefreshable($node)) {
             return;
         }
 

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\Core\NodeAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
@@ -20,16 +21,16 @@ final class ScopeAnalyzer
     /**
      * @var array<class-string<Node>>
      */
-    private const NO_SCOPE_NODES = [Name::class, Identifier::class, Param::class, Arg::class];
+    private const REFRESHABLE_NODES = [Name::class, Identifier::class, Param::class, Arg::class, Variable::class];
 
     public function __construct(
         private readonly ScopeFactory $scopeFactory
     ) {
     }
 
-    public function hasScope(Node $node): bool
+    public function isRefreshable(Node $node): bool
     {
-        foreach (self::NO_SCOPE_NODES as $noScopeNode) {
+        foreach (self::REFRESHABLE_NODES as $noScopeNode) {
             if ($node instanceof $noScopeNode) {
                 return false;
             }


### PR DESCRIPTION
When defined in `getNodeTypes()` in Rector rule, the `Variable` scope should not be refreshed as it can came from `Param` and can cause error like this:

```
 [ERROR] Could not process "utils/Rector/UnderscoreToCamelCaseVariableNameRector.php" file, due to:                     
         "System error: "Node "PhpParser\Node\Expr\Variable" with parent of "PhpParser\Node\Param" is missing scope     
         required for scope refresh."                                                                                   
         Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new". On line: 83
```

Ref https://github.com/rectorphp/rector-src/pull/4432#issue-1793159645