### PR TITLE
Add currentStmt property on AbstractRector to allow pull Scope from it on deep Expr

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -44,7 +44,7 @@ final class ChangedNodeScopeRefresher
     ) {
     }
 
-    public function refresh(Node $node, ?MutatingScope $mutatingScope, ?string $filePath = null): void
+    public function refresh(Node $node, ?MutatingScope $mutatingScope, ?string $filePath = null, ?Stmt $currentStmt = null): void
     {
         // nothing to refresh
         if (! $this->scopeAnalyzer->isRefreshable($node)) {
@@ -57,7 +57,9 @@ final class ChangedNodeScopeRefresher
             $filePath = $file->getFilePath();
         }
 
-        $mutatingScope = $this->scopeAnalyzer->resolveScope($node, $filePath, $mutatingScope);
+        $mutatingScope = $mutatingScope instanceof MutatingScope
+            ? $mutatingScope
+            : $this->scopeAnalyzer->resolveScope($node, $filePath, $currentStmt);
 
         if (! $mutatingScope instanceof MutatingScope) {
             /**

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
-use PHPStan\Analyser\Scope;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -12,8 +11,8 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
-use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
+use PHPStan\Analyser\Scope;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 
@@ -40,11 +39,8 @@ final class ScopeAnalyzer
         return true;
     }
 
-    public function resolveScope(
-        Node $node,
-        string $filePath,
-        ?Stmt $currentStmt = null
-    ): ?Scope {
+    public function resolveScope(Node $node, string $filePath, ?Stmt $currentStmt = null): ?Scope
+    {
         // on File level
         if ($node instanceof Stmt && $node->getAttribute(AttributeKey::STATEMENT_DEPTH) === 0) {
             return $this->scopeFactory->createFromFile($filePath);

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
+use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
@@ -50,10 +51,12 @@ final class ScopeAnalyzer
         }
 
         // too deep Expr, eg: $$param = $$bar = self::decodeValue($result->getItem()->getTextContent());
-        if ($node instanceof Expr
-            && $node->getAttribute(AttributeKey::EXPRESSION_DEPTH) >= 2
-            && $currentStmt instanceof Stmt) {
-            return $currentStmt->getAttribute(AttributeKey::SCOPE);
+        if ($node instanceof Expr && $node->getAttribute(AttributeKey::EXPRESSION_DEPTH) >= 2) {
+            $scope = $currentStmt instanceof Stmt
+                ? $currentStmt->getAttribute(AttributeKey::SCOPE)
+                : $this->scopeFactory->createFromFile($filePath);
+
+            return $scope instanceof Scope ? $scope : $this->scopeFactory->createFromFile($filePath);
         }
 
         /**

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\NodeAnalyzer;
 
+use PHPStan\Analyser\Scope;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -42,7 +43,7 @@ final class ScopeAnalyzer
         Node $node,
         string $filePath,
         ?Stmt $currentStmt = null
-    ): ?\PHPStan\Analyser\Scope {
+    ): ?Scope {
         // on File level
         if ($node instanceof Stmt && $node->getAttribute(AttributeKey::STATEMENT_DEPTH) === 0) {
             return $this->scopeFactory->createFromFile($filePath);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -78,6 +78,8 @@ CODE_SAMPLE;
 
     protected File $file;
 
+    protected ?Stmt $currentStmt = null;
+
     private ChangedNodeScopeRefresher $changedNodeScopeRefresher;
 
     private SimpleCallableNodeTraverser $simpleCallableNodeTraverser;
@@ -170,8 +172,7 @@ CODE_SAMPLE;
 
     final public function enterNode(Node $node)
     {
-        $nodeClass = $node::class;
-        if (! $this->isMatchingNodeType($nodeClass)) {
+        if (! $this->isMatchingNodeType($node)) {
             return null;
         }
 
@@ -380,19 +381,23 @@ CODE_SAMPLE;
         $nodes = $node instanceof Node ? [$node] : $node;
 
         foreach ($nodes as $node) {
-            $this->changedNodeScopeRefresher->refresh($node, $mutatingScope, $filePath);
+            $this->changedNodeScopeRefresher->refresh($node, $mutatingScope, $filePath, $this->currentStmt);
         }
     }
 
-    /**
-     * @param class-string<Node> $nodeClass
-     */
-    private function isMatchingNodeType(string $nodeClass): bool
+    private function isMatchingNodeType(Node $node): bool
     {
+        $nodeClass = $node::class;
         foreach ($this->getNodeTypes() as $nodeType) {
-            if (is_a($nodeClass, $nodeType, true)) {
-                return true;
+            if (! is_a($nodeClass, $nodeType, true)) {
+                if ($node instanceof Stmt) {
+                    $this->currentStmt = $node;
+                }
+
+                continue;
             }
+
+            return true;
         }
 
         return false;

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -37,7 +37,7 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
         $currentScope = $originalNode->getAttribute(AttributeKey::SCOPE);
 
         if (! $currentScope instanceof MutatingScope) {
-            $currentScope = $this->scopeAnalyzer->resolveScope($node, $this->file->getFilePath());
+            $currentScope = $this->scopeAnalyzer->resolveScope($node, $this->file->getFilePath(), $this->currentStmt);
         }
 
         if (! $currentScope instanceof Scope) {


### PR DESCRIPTION
Currently, on out of control deep Expr, like this:

```php
$$param = $$bar = $zzz = self::decodeValue($result->getItem()->getTextContent());
```

we currrently direct pull Scope from File:

```php
        // too deep Expr, eg: $$param = $$bar = self::decodeValue($result->getItem()->getTextContent());
        if ($node instanceof Expr && $node->getAttribute(AttributeKey::EXPRESSION_DEPTH) >= 2) {
            return $this->scopeFactory->createFromFile($filePath);
        }
``` 

Instead, I think we can pull Scope from nearest current `Stmt`, which can be pulled on `AbstractRector` when verify current valid Node, check nearest Stmt before match:

```diff
    private function isMatchingNodeType(Node $node): bool
    {
        $nodeClass = $node::class;
        foreach ($this->getNodeTypes() as $nodeType) {
            if (! is_a($nodeClass, $nodeType, true)) {
+                if ($node instanceof Stmt) {
+                    $this->currentStmt = $node;
+                }

                continue;
            }

            return true;
        }

        return false;
    }
```

so we can pull Scope from there.