### PR TITLE
[NodeTypeResolver] Remove type detection from parent FunctionLike docblock on ParamTypeResolver

### DIFF
--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/ParamTypeResolver/ParamTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/ParamTypeResolver/ParamTypeResolverTest.php
@@ -22,7 +22,7 @@ final class ParamTypeResolverTest extends AbstractNodeTypeResolverTestCase
         $variableNodes = $this->getNodesForFileOfType($file, Param::class);
 
         $resolvedType = $this->nodeTypeResolver->getType($variableNodes[$nodePosition]);
-        $this->assertSame($expectedType, $resolvedType::class);
+        $this->assertSame($resolvedType::class, $expectedType);
     }
 
     public static function provideData(): Iterator

--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/ParamTypeResolver/ParamTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/ParamTypeResolver/ParamTypeResolverTest.php
@@ -6,11 +6,10 @@ namespace Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\ParamTypeResolver;
 
 use Iterator;
 use PhpParser\Node\Param;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\MixedType;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\AbstractNodeTypeResolverTestCase;
-use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\ParamTypeResolver\Source\Html;
 
 /**
  * @see \Rector\NodeTypeResolver\NodeTypeResolver\ParamTypeResolver
@@ -18,23 +17,17 @@ use Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\ParamTypeResolver\Source\H
 final class ParamTypeResolverTest extends AbstractNodeTypeResolverTestCase
 {
     #[DataProvider('provideData')]
-    public function test(string $file, int $nodePosition, TypeWithClassName $expectedTypeWithClassName): void
+    public function test(string $file, int $nodePosition, string $expectedType): void
     {
         $variableNodes = $this->getNodesForFileOfType($file, Param::class);
 
         $resolvedType = $this->nodeTypeResolver->getType($variableNodes[$nodePosition]);
-
-        $this->assertInstanceOf(TypeWithClassName::class, $resolvedType);
-
-        /** @var TypeWithClassName $resolvedType */
-        $this->assertSame($expectedTypeWithClassName->getClassName(), $resolvedType->getClassName());
+        $this->assertSame($expectedType, $resolvedType::class);
     }
 
     public static function provideData(): Iterator
     {
-        $objectType = new ObjectType(Html::class);
-
-        yield [__DIR__ . '/Source/MethodParamTypeHint.php', 0, $objectType];
-        yield [__DIR__ . '/Source/MethodParamDocBlock.php', 0, $objectType];
+        yield [__DIR__ . '/Source/MethodParamTypeHint.php', 0, FullyQualifiedObjectType::class];
+        yield [__DIR__ . '/Source/MethodParamDocBlock.php', 0, MixedType::class];
     }
 }

--- a/packages/NodeTypeResolver/NodeTypeResolver/ParamTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver/ParamTypeResolver.php
@@ -5,16 +5,10 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\NodeTypeResolver;
 
 use PhpParser\Node;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -26,12 +20,6 @@ use Symfony\Contracts\Service\Attribute\Required;
 final class ParamTypeResolver implements NodeTypeResolverInterface
 {
     private NodeTypeResolver $nodeTypeResolver;
-
-    public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-    ) {
-    }
 
     #[Required]
     public function autowire(NodeTypeResolver $nodeTypeResolver): void
@@ -52,37 +40,10 @@ final class ParamTypeResolver implements NodeTypeResolverInterface
      */
     public function resolve(Node $node): Type
     {
-        $paramType = $this->resolveFromParamType($node);
-        if (! $paramType instanceof MixedType) {
-            return $paramType;
-        }
-
-        return $this->resolveFromFunctionDocBlock($node);
-    }
-
-    private function resolveFromParamType(Param $param): Type
-    {
-        if ($param->type === null) {
+        if ($node->type === null) {
             return new MixedType();
         }
 
-        return $this->nodeTypeResolver->getType($param->type);
-    }
-
-    private function resolveFromFunctionDocBlock(Param $param): Type
-    {
-        $phpDocInfo = $this->getFunctionLikePhpDocInfo($param);
-        $paramName = $this->nodeNameResolver->getName($param);
-        return $phpDocInfo->getParamType($paramName);
-    }
-
-    private function getFunctionLikePhpDocInfo(Param $param): PhpDocInfo
-    {
-        $parentNode = $param->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $parentNode instanceof FunctionLike) {
-            throw new ShouldNotHappenException();
-        }
-
-        return $this->phpDocInfoFactory->createFromNodeOrEmpty($parentNode);
+        return $this->nodeTypeResolver->getType($node->type);
     }
 }


### PR DESCRIPTION
we currently don't use parent `FunctionLike` docblock as param detection, if it going to detect it, it should from `FunctionLike` itself instead of from `ParamTypeResolver`

Ref https://github.com/rectorphp/rector/issues/7947