### PR TITLE
[DX] Always Re-init $this->hasChanged on Rector rules under refactor() to ensure the flag is reset on same call on different file

### DIFF
--- a/rules/CodingStyle/Rector/String_/SymplifyQuoteEscapeRector.php
+++ b/rules/CodingStyle/Rector/String_/SymplifyQuoteEscapeRector.php
@@ -77,6 +77,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?String_
     {
+        $this->hasChanged = false;
+
         if (StringUtils::isMatch($node->value, self::HAS_NON_PRINTABLE_CHARS)) {
             return null;
         }

--- a/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
+++ b/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
@@ -86,6 +86,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        $this->hasChanged = false;
+
         $this->refactorClassProperties($node);
 
         $hasPromotedPropertyChanged = $this->propertyPromotionRenamer->renamePropertyPromotion($node);

--- a/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
+++ b/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
@@ -86,6 +86,8 @@ CODE_SAMPLE
             return null;
         }
 
+        $this->hasChanged = false;
+
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         $this->refactorParamTypes($node, $phpDocInfo);

--- a/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
+++ b/rules/Renaming/Rector/PropertyFetch/RenamePropertyRector.php
@@ -55,6 +55,8 @@ final class RenamePropertyRector extends AbstractRector implements ConfigurableR
     public function refactor(Node $node): ?Node
     {
         if ($node instanceof ClassLike) {
+            $this->hasChanged = false;
+
             foreach ($this->renamedProperties as $renamedProperty) {
                 $this->renameProperty($node, $renamedProperty);
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -81,6 +81,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        $this->hasChanged = false;
+
         foreach ($node->getMethods() as $classMethod) {
             if ($this->shouldSkip($node, $classMethod)) {
                 continue;


### PR DESCRIPTION
@TomasVotruba here what I found on other rules which `$this->hasChanged` overwritten, so it need init in `refactor()` method.

Ref https://github.com/rectorphp/rector-src/pull/4451#pullrequestreview-1520888691