### PR TITLE
[Renaming] Use RunTestsInSeparateProcesses on RenameClassRector tests

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/AutoImportNamesTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/AutoImportNamesTest.php
@@ -6,11 +6,13 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 /**
  * @see \Rector\PostRector\Rector\NameImportingPostRector
  */
+#[RunTestsInSeparateProcesses]
 final class AutoImportNamesTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
@@ -6,8 +6,10 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+#[RunTestsInSeparateProcesses]
 final class RenameClassRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]


### PR DESCRIPTION
It randomly show errors locally, tested in macOS and Ubuntu.

Fixing local by rename fixtures make CI error, I think `RunTestsInSeparateProcesses` to keep both working in CI and local.