### PR TITLE
[Testing] Remove gc_collect_cycles() on AbstractRectorTestCase to avoid random error in tests due to SimpleParameterProvider static property usage lost

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -68,13 +68,12 @@ abstract class AbstractRectorTestCase extends AbstractTestCase implements Rector
             FileSystem::delete($this->inputFilePath);
         }
 
-        // free memory and trigger gc to reduce memory peak consumption on windows
+        // free memory to reduce memory peak consumption on windows
         unset(
             $this->applicationFileProcessor,
             $this->parameterProvider,
             $this->dynamicSourceLocatorProvider,
         );
-        gc_collect_cycles();
     }
 
     /**

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
@@ -1,14 +1,28 @@
 <?php
 
-function() {
-    /** @psalm-suppress UndefinedFunction */
-    return ff();
-};
+class KeepDocblockOnReturn
+{
+    public function run()
+    {
+        function() {
+            /** @psalm-suppress UndefinedFunction */
+            return ff();
+        };
+    }
+}
+
 ?>
 -----
 <?php
 
-fn() =>
-    /** @psalm-suppress UndefinedFunction */
-    ff();
+class KeepDocblockOnReturn
+{
+    public function run()
+    {
+        fn() =>
+            /** @psalm-suppress UndefinedFunction */
+            ff();
+    }
+}
+
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return2.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return2.php.inc
@@ -1,14 +1,28 @@
 <?php
 
-function() {
-    // @psalm-suppress UndefinedFunction
-    return ff();
-};
+class KeepDocblockOnReturn2
+{
+    public function run()
+    {
+        function() {
+            // @psalm-suppress UndefinedFunction
+            return ff();
+        };
+    }
+}
+
 ?>
 -----
 <?php
 
-fn() =>
-    // @psalm-suppress UndefinedFunction
-    ff();
+class KeepDocblockOnReturn2
+{
+    public function run()
+    {
+        fn() =>
+            // @psalm-suppress UndefinedFunction
+            ff();
+    }
+}
+
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return3.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return3.php.inc
@@ -1,22 +1,36 @@
 <?php
 
-function() {
-    /**
-     * comment
-     */
-    // something
-    // @psalm-suppress UndefinedFunction
-    return ff();
-};
+class KeepDocblockOnReturn3
+{
+    public function run()
+    {
+        function() {
+            /**
+             * comment
+             */
+            // something
+            // @psalm-suppress UndefinedFunction
+            return ff();
+        };
+    }
+}
+
 ?>
 -----
 <?php
 
-fn() =>
-    /**
-     * comment
-     */
-    // something
-    // @psalm-suppress UndefinedFunction
-    ff();
+class KeepDocblockOnReturn3
+{
+    public function run()
+    {
+        fn() =>
+            /**
+             * comment
+             */
+            // something
+            // @psalm-suppress UndefinedFunction
+            ff();
+    }
+}
+
 ?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return4.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return4.php.inc
@@ -1,26 +1,40 @@
 <?php
 
-function deep() {
-    function() {
-        /**
-         * comment
-         */
-        // something
-        // @psalm-suppress UndefinedFunction
-        return ff();
-    };
+class KeepDocblockOnReturn4
+{
+    public function run()
+    {
+        function deep() {
+            function() {
+                /**
+                 * comment
+                 */
+                // something
+                // @psalm-suppress UndefinedFunction
+                return ff();
+            };
+        }
+    }
 }
+
 ?>
 -----
 <?php
 
-function deep() {
-    fn() =>
-        /**
-         * comment
-         */
-        // something
-        // @psalm-suppress UndefinedFunction
-        ff();
+class KeepDocblockOnReturn4
+{
+    public function run()
+    {
+        function deep() {
+            fn() =>
+                /**
+                 * comment
+                 */
+                // something
+                // @psalm-suppress UndefinedFunction
+                ff();
+        }
+    }
 }
+
 ?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/AutoImportNamesTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/AutoImportNamesTest.php
@@ -6,13 +6,11 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 /**
  * @see \Rector\PostRector\Rector\NameImportingPostRector
  */
-#[RunTestsInSeparateProcesses]
 final class AutoImportNamesTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/RenameClassRectorTest.php
@@ -6,10 +6,8 @@ namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-#[RunTestsInSeparateProcesses]
 final class RenameClassRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]


### PR DESCRIPTION
@TomasVotruba  `SimpleParameterProvider` static property usage dynamically lost on `AbstractRectorTestCase` and make random error. 

Remove `gc_collect_cycles()` actually resolve it, no need `RunTestsInSeparateProcesses` anymore.

Ref https://github.com/rectorphp/rector-src/pull/4471#issuecomment-1628776738