### PR TITLE
Fix ReturnBinaryOrToEarlyReturnRector mixing up returned nodes of array, hook into StmtsAwareInterface instead to keep next Rector rules updated

### DIFF
--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
         /** @var BooleanAnd $booleanAnd */
         $booleanAnd = $node->expr;
 
-        $lastReturnExpr = $this->assignAndBinaryMap->getTruthyExpr($booleanAnd->right, $scope);
+        $lastReturnExpr = $this->assignAndBinaryMap->getTruthyExpr($booleanAnd->right);
         return array_merge($ifNegations, [new Return_($lastReturnExpr)]);
     }
 

--- a/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/ReturnBinaryAndToEarlyReturnRector.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\Scope;
 use Rector\Core\NodeAnalyzer\CallAnalyzer;
 use Rector\Core\NodeManipulator\IfManipulator;
 use Rector\Core\PhpParser\Node\AssignAndBinaryMap;
+use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\EarlyReturn\Rector\Return_\ReturnBinaryAndToEarlyReturnRector\ReturnBinaryAndToEarlyReturnRectorTest
  */
-final class ReturnBinaryAndToEarlyReturnRector extends AbstractScopeAwareRector
+final class ReturnBinaryAndToEarlyReturnRector extends AbstractRector
 {
     public function __construct(
         private readonly IfManipulator $ifManipulator,
@@ -73,7 +74,7 @@ CODE_SAMPLE
      * @param Return_ $node
      * @return null|Node[]
      */
-    public function refactorWithScope(Node $node, Scope $scope): ?array
+    public function refactor(Node $node): ?array
     {
         if (! $node->expr instanceof BooleanAnd) {
             return null;

--- a/src/PhpParser/Node/AssignAndBinaryMap.php
+++ b/src/PhpParser/Node/AssignAndBinaryMap.php
@@ -42,7 +42,7 @@ use PhpParser\Node\Expr\BinaryOp\Smaller;
 use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Cast\Bool_;
-use PHPStan\Analyser\Scope;
+use Rector\NodeTypeResolver\NodeTypeResolver;
 
 final class AssignAndBinaryMap
 {
@@ -83,8 +83,9 @@ final class AssignAndBinaryMap
      */
     private array $binaryOpToAssignClasses = [];
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly NodeTypeResolver $nodeTypeResolver
+    ) {
         $this->binaryOpToAssignClasses = array_flip(self::ASSIGN_OP_TO_BINARY_OP_CLASSES);
     }
 
@@ -115,7 +116,7 @@ final class AssignAndBinaryMap
         return self::BINARY_OP_TO_INVERSE_CLASSES[$nodeClass] ?? null;
     }
 
-    public function getTruthyExpr(Expr $expr, Scope $scope): Expr
+    public function getTruthyExpr(Expr $expr): Expr
     {
         if ($expr instanceof Bool_) {
             return $expr;
@@ -125,8 +126,9 @@ final class AssignAndBinaryMap
             return $expr;
         }
 
-        $type = $scope->getType($expr);
-        if ($type->isBoolean()->yes()) {
+        $exprType = $this->nodeTypeResolver->getType($expr);
+        // $type = $scope->getType($expr);
+        if ($exprType->isBoolean()->yes()) {
             return $expr;
         }
 

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -57,10 +56,10 @@ final class RectifiedAnalyzer
             return false;
         }
 
-        if (! $node instanceof Stmt) {
-            $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
-            return $createdByRule === [];
-        }
+        //        if (! $node instanceof Stmt) {
+        //            $createdByRule = $node->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
+        //            return $createdByRule === [];
+        //        }
 
         /**
          * Start token pos must be < 0 to continue, as the node and parent node just re-printed

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -243,8 +243,6 @@ CODE_SAMPLE;
         }
 
         $objectHash = spl_object_hash($node);
-
-        // update parents relations!!!
         return $this->nodesToReturn[$objectHash] ?? $node;
     }
 
@@ -342,9 +340,9 @@ CODE_SAMPLE;
 
             $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
+            // will be replaced in leaveNode() the original node must be passed
             $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
 
-            // will be replaced in leaveNode() the original node must be passed
             return $originalNode;
         }
 

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
@@ -2,12 +2,9 @@
 
 namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
 
-class ParentClass
-{
-    protected $d;
-}
+use Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Source\ParentClassWithLetter;
 
-class Fixture extends ParentClass
+final class Fixture extends ParentClassWithLetter
 {
     public function run($a, $b, $c)
     {
@@ -23,16 +20,13 @@ class Fixture extends ParentClass
 
 namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
 
-class ParentClass
-{
-    protected $d;
-}
+use Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Source\ParentClassWithLetter;
 
-class Fixture extends ParentClass
+final class Fixture extends ParentClassWithLetter
 {
     public function run($a, $b, $c)
     {
-        if (!($a === 'a' || $b === 'b')) {
+        if ($a !== 'a' && $b !== 'b') {
             return;
         }
         if (!$c) {

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/Source/ParentClassWithLetter.php
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/Source/ParentClassWithLetter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Source;
+
+abstract class ParentClassWithLetter
+{
+    protected $d;
+}

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/config/configured_rule.php
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/config/configured_rule.php
@@ -8,7 +8,9 @@ use Rector\Config\RectorConfig;
 use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(ChangeAndIfToEarlyReturnRector::class);
-    $rectorConfig->rule(CompleteDynamicPropertiesRector::class);
-    $rectorConfig->rule(SimplifyDeMorganBinaryRector::class);
+    $rectorConfig->rules([
+        ChangeAndIfToEarlyReturnRector::class,
+        CompleteDynamicPropertiesRector::class,
+        SimplifyDeMorganBinaryRector::class,
+    ]);
 };

--- a/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/config/configured_rule.php
+++ b/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/config/configured_rule.php
@@ -7,6 +7,5 @@ use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(RemoveAlwaysElseRector::class);
-    $rectorConfig->rule(ReturnEarlyIfVariableRector::class);
+    $rectorConfig->rules([RemoveAlwaysElseRector::class, ReturnEarlyIfVariableRector::class]);
 };

--- a/tests/Issues/ReplaceStmtToExpr/Fixture/some_fixture.php.inc
+++ b/tests/Issues/ReplaceStmtToExpr/Fixture/some_fixture.php.inc
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\ReplaceStmtToExpr\Fixture;
 
-class Fixture
+use Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser;
+
+final class SomeFixture
 {
-    public function getUser(?User $user = null): ?User
+    public function getUser(?SomeUser $user = null): ?SomeUser
     {
         return $user ?? (Auth::check() ? Auth::user() : null);
     }
 
     public function doFoo(
-        ?User $user = null
+        ?SomeUser $user = null
     ): bool {
         $user = $this->getUser($user);
 
@@ -33,19 +35,21 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\ReplaceStmtToExpr\Fixture;
 
-class Fixture
+use Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser;
+
+final class SomeFixture
 {
-    public function getUser(?User $user = null): ?User
+    public function getUser(?SomeUser $user = null): ?SomeUser
     {
         return $user ?? (Auth::check() ? Auth::user() : null);
     }
 
     public function doFoo(
-        ?User $user = null
+        ?SomeUser $user = null
     ): bool {
         $user = $this->getUser($user);
 
-        if ($user === null) {
+        if (!$user instanceof \Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser) {
             return false;
         }
         if ($user->isFoo()) {

--- a/tests/Issues/ReplaceStmtToExpr/Source/SomeUser.php
+++ b/tests/Issues/ReplaceStmtToExpr/Source/SomeUser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source;
+
+class SomeUser
+{
+
+}


### PR DESCRIPTION
* fixes https://github.com/rectorphp/rector-src/pull/4474 
* fixes https://github.com/rectorphp/rector/issues/8044

After 3 hours of debugging, I've found out the issue is in 1 node being replaced by many nodes. Espcially `return` with many `ifs`. Lot of rules hook into the `If_` node then and php-parser incorrectly resolved original position. Instead of working with new array, it still operates with original tree. Then the node tree gets messed up as some rules work with one node and another with array of many nodes.

**This is trail of making the rule work with parent node - `StmtsAwareInterface`, to always provide child node with final rules.**

In short: replace one node with array of nodes only on a stmts aware. Better do not change node structure from 1 to many :) 

Let's see how it works, we might want to update few more rules in the future.