### PR TITLE
fix(rules): Skip readonly classes from restoring default null value.

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_class.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
 
-final readonly class A
+final readonly class SkipReadonlyClass
 {
     public string|null $display;
 }

--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_class.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+final readonly class A
+{
+    public string|null $display;
+}

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -62,6 +62,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->isReadonly()) {
+            return null;
+        }
+
         $hasChanged = false;
 
         foreach ($node->getProperties() as $property) {


### PR DESCRIPTION
Hello! 
My first contribution to that great tool! 

Fix for: https://github.com/rectorphp/rector/issues/7998