### PR TITLE
RemoveUselessParamTagRector doesn't recognize tag comments on a new line given userland type hints

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class DemoFile
+{
+    /**
+     * @param string $primitiveValue
+     *   A primitive is fine.
+     * @param callable $callableValue
+     *   A PHP core class is fine.
+     * @param UserlandClass $userlandClass
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, UserlandClass $userlandClass)
+    {
+    }
+}
+
+class UserlandClass
+{
+}
+
+?>


### PR DESCRIPTION
# Bug Report

<!-- First, thank you for reporting a bug. That takes time and we appreciate that! -->

| Subject        | Details              |
| :------------- | :--------------------|
| Rector version | last dev-main      |
| Installed as   | composer dependency  |

`RemoveUselessParamTagRector` doesn't seem to recognize `@param` tag comments if they're on a new line and the `@param` has userland type hints--it incorrectly considers the `@param` useless.

## Minimal PHP Code Causing Issue

[See https://getrector.com/demo/f4bf96c8-3a1d-4f41-bec0-37695ca0c2e9](https://getrector.com/demo/2c664f40-b430-445c-8058-d20c7134ee26)

### Responsible rules

* `RemoveUselessParamTagRector`

## Expected Behavior

Rector should skip it.

## p.s.

This is my first attempt to contribute to Rector, but I could see myself doing more in the future. So if there's anything I can do better here, please let me know. I don't mind nits. 🙂