### PR TITLE
[DeadCode] Skip property not exists on RemoveTypedPropertyDeadInstanceOfRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Fixture/skip_use_property_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Fixture/skip_use_property_docblock.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveTypedPropertyDeadInstanceOfRector\Fixture;
+
+/**
+ * @property Document|Course|Book $target
+ */
+class SearchResultClickedResource
+{
+    /**
+     * @return 'document'|'course'|'book'|'unknown'
+     */
+    private function getType(): string
+    {
+        if ($this->target instanceof Document) {
+            return 'document';
+        }
+
+        if ($this->target instanceof Course) {
+            return 'course';
+        }
+
+        if ($this->target instanceof Book) {
+            return 'book';
+        }
+
+        return 'unknown';
+    }
+}

--- a/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Source/Book.php
+++ b/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Source/Book.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveTypedPropertyDeadInstanceOfRector\Source;
+
+class Book
+{
+}

--- a/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Source/Course.php
+++ b/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Source/Course.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveTypedPropertyDeadInstanceOfRector\Source;
+
+class Course
+{
+}

--- a/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Source/Document.php
+++ b/rules-tests/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector/Source/Document.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveTypedPropertyDeadInstanceOfRector\Source;
+
+class Document
+{
+}

--- a/rules/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector.php
@@ -197,7 +197,7 @@ CODE_SAMPLE
 
         $property = $class->getProperty($propertyName);
         if (! $property instanceof Property) {
-            return false;
+            return true;
         }
 
         return $property->type === null;


### PR DESCRIPTION
@canvural this should fixes https://github.com/rectorphp/rector/issues/8049 , I check on server directly and seems working ok by change the property exists check.