### PR TITLE
RemoveUselessReturnTagRector doesn't recognize tag comments on a new line given a PHP core type hint

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/multiline_comment_for_core_php_return.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/multiline_comment_for_core_php_return.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+class DemoFile
+{
+    /**
+     * @return UserlandClass
+     *   A userland class is fine.
+     */
+    public function userland(): callable
+    {
+    }
+
+    /**
+     * @return callable
+     *   A PHP core class is not.
+     */
+    public function phpCore(): callable
+    {
+    }
+
+    /**
+     * @return string
+     *   Neither is a primitive.
+     */
+    public function primitive(): string
+    {
+    }
+}
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+class UserlandClass
+{
+}
+
+?>


### PR DESCRIPTION
# Bug Report

| Subject        | Details              |
| :------------- | :--------------------|
| Rector version | last dev-main      |
| Installed as   | composer dependency  |

`RemoveUselessReturnTagRector` doesn't seem to recognize `@return` tag comments if they're on a new line and the `@return` has PHP core type hint--it incorrectly considers the `@param` useless.

## Minimal PHP Code Causing Issue

See https://getrector.com/demo/2f905b5e-abf3-4268-b95f-096f49fd8b3f

### Responsible rules

* `RemoveUselessReturnTagRector`

## Expected Behavior

Rector should skip it.
