### PR TITLE
Exclude the full docs folder from archives

### DIFF
--- a/build/target-repository/.gitattributes
+++ b/build/target-repository/.gitattributes
@@ -17,7 +17,7 @@ CODE_OF_CONDUCT.md export-ignore
 # exclude only root dirs, otherwise nette/utils is removed - see https://github.com/TomasVotruba/tomasvotruba.com/pull/1197/checks?check_run_id=2577329283
 /stubs export-ignore
 
-docs/images export-ignore
+docs/ export-ignore
 .github export-ignore
 /e2e export-ignore
 


### PR DESCRIPTION
Refs https://github.com/rectorphp/rector/issues/7842

The issue also shows unnecessary files in the vendored evenement/evenement package. This will be solved once https://github.com/igorw/evenement/pull/82 is released and the vendored package gets updated.