### PR TITLE
Implement ReturnTypeFromStrictParamRector

### DIFF
--- a/config/set/type-declaration.php
+++ b/config/set/type-declaration.php
@@ -26,6 +26,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictBoolReturnExpr
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictConstantReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
@@ -62,6 +63,7 @@ return static function (RectorConfig $rectorConfig): void {
         ReturnTypeFromStrictNativeCallRector::class,
         ReturnTypeFromStrictNewArrayRector::class,
         ReturnTypeFromStrictScalarReturnExprRector::class,
+        ReturnTypeFromStrictParamRector::class,
         TypedPropertyFromStrictSetUpRector::class,
         ParamTypeByParentCallTypeRector::class,
         AddParamTypeSplFixedArrayRector::class,

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example.php.inc
@@ -1,6 +1,7 @@
 <?php
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
 class Example {
     public function doFoo(Example $param) {
         return $param;
@@ -12,6 +13,7 @@ class Example {
 <?php
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
 class Example {
     public function doFoo(Example $param): Example {
         return $param;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+class Example {
+    public function doFoo(Example $param) {
+        return $param;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+class Example {
+    public function doFoo(Example $param): Example {
+        return $param;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_nullable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_nullable.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+class ExampleNullable {
+    public function doFoo(?ExampleNullable $param) {
+        return $param;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+class ExampleNullable {
+    public function doFoo(?ExampleNullable $param): ?ExampleNullable {
+        return $param;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_nullable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_nullable.php.inc
@@ -1,6 +1,7 @@
 <?php
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
 class ExampleNullable {
     public function doFoo(?ExampleNullable $param) {
         return $param;
@@ -12,6 +13,7 @@ class ExampleNullable {
 <?php
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
 class ExampleNullable {
     public function doFoo(?ExampleNullable $param): ?ExampleNullable {
         return $param;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_scalar.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_scalar.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+class ExampleInt {
+    public function doFoo(int $param) {
+        return $param;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+class ExampleInt {
+    public function doFoo(int $param): int {
+        return $param;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_scalar.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_scalar.php.inc
@@ -1,6 +1,7 @@
 <?php
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
 class ExampleInt {
     public function doFoo(int $param) {
         return $param;
@@ -12,6 +13,7 @@ class ExampleInt {
 <?php
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
 class ExampleInt {
     public function doFoo(int $param): int {
         return $param;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_with_call.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/example_with_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class ExampleWithCall {
+    public function doFoo(ExampleWithCall $param) {
+        $this->doBar($param);
+
+        return $param;
+    }
+
+    public function doBar($ref) {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class ExampleWithCall {
+    public function doFoo(ExampleWithCall $param): ExampleWithCall {
+        $this->doBar($param);
+
+        return $param;
+    }
+
+    public function doBar($ref) {}
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skill_null_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skill_null_return.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipNullReturn {
+    public function doFoo(SkipNullReturn $param) {
+        if (rand(0,1)) {
+            return null;
+        }
+        return $param;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_already_return_typed.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_already_return_typed.inc
@@ -3,7 +3,7 @@
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
 
 class SkipAlreadyReturnTyped {
-    public function doFoo(SkipAssign $param): int {
+    public function doFoo(SkipAlreadyReturnTyped $param): int {
         return $param;
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_already_return_typed.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_already_return_typed.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipAlreadyReturnTyped {
+    public function doFoo(SkipAssign $param): int {
+        return $param;
+    }
+}
+

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_assign.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_assign.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipAssign {
+    public function doFoo(SkipAssign $param) {
+        $param = 4;
+
+        return $param;
+    }
+}
+

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_assign_by_ref.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_assign_by_ref.php.inc
@@ -2,8 +2,8 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
 
-class SkipAssign {
-    public function doFoo(SkipAssign $param) {
+class SkipAssignByRef {
+    public function doFoo(SkipAssignByRef $param) {
         $z = &$param;
 
         $z = 5;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_assign_by_ref.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_assign_by_ref.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipAssign {
+    public function doFoo(SkipAssign $param) {
+        $z = &$param;
+
+        $z = 5;
+
+        return $param;
+    }
+}
+

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_call_by_ref.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_call_by_ref.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipAssign {
+    public function doFoo(SkipAssign $param) {
+        $this->doBar($param);
+
+        return $param;
+    }
+
+    public function doBar(&$ref) {}
+}
+

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_call_by_ref.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_call_by_ref.php.inc
@@ -2,8 +2,8 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
 
-class SkipAssign {
-    public function doFoo(SkipAssign $param) {
+class SkipCallbByRef {
+    public function doFoo(SkipCallbByRef $param) {
         $this->doBar($param);
 
         return $param;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
 
-class SkipConditionalReturn {
+class SkipClosure {
     public function doFoo() {
         // we have other rules which add closure return types
         // leave it as is

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
@@ -1,11 +1,12 @@
 <?php
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
 class SkipClosure {
     public function doFoo() {
         // we have other rules which add closure return types
         // leave it as is
-        $c = function (ExampleClosure $param) {
+        $c = function (SkipClosure $param) {
             return $param;
         };
         return $c;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
 
-class SkipClosure {
+class SkipConditionalReturn {
     public function doFoo() {
         // we have other rules which add closure return types
         // leave it as is

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_closure.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+class SkipClosure {
+    public function doFoo() {
+        // we have other rules which add closure return types
+        // leave it as is
+        $c = function (ExampleClosure $param) {
+            return $param;
+        };
+        return $c;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_conditional_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_conditional_return.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipConditionalReturn {
+    public function doFoo(SkipAssign $param) {
+        if (rand(0,1)) {
+            return 4;
+        }
+
+        return $param;
+    }
+}
+

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_magic.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_magic.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipMagic
+{
+    public function __get(string $name)
+    {
+        return $name;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_multiple_returns.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_multiple_returns.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipMultipleReturns {
+    public function doFoo(SkipMultipleReturns $param, B $param2) {
+        if (rand(0,1)) {
+            return $param2;
+        }
+
+        return $param;
+    }
+}
+
+class B {}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_parent_overridden.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_parent_overridden.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipParentOverridden extends SkipParentOverriddenBase {
+    public function doFoo(SkipParentOverridden $param) {
+        return $param;
+    }
+}
+
+
+class SkipParentOverriddenBase {
+    public function doFoo(SkipParentOverridden $param) {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_phpdoc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_phpdoc.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipPhpdoc {
+    /**
+     * @param SkipPhpdoc  $param
+     */
+    public function doFoo($param) {
+        return $param;
+    }
+}
+

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_union.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipUnion
+{
+    public function run(A|B $p)
+    {
+        return $p;
+    }
+}
+
+class A {}
+class B {}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/Fixture/skip_void.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+
+class SkipPossibleVoid
+{
+    public function run(int $p)
+    {
+        if (rand(0, 1)) {
+            return $p;
+        }
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/ReturnTypeFromStrictParamRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/ReturnTypeFromStrictParamRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReturnTypeFromStrictParamRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReturnTypeFromStrictParamRector::class);
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+};

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
@@ -197,6 +198,10 @@ CODE_SAMPLE
         }
 
         $returnType = $this->returnTypeInferer->inferFunctionLike($node);
+        if ($returnType instanceof MixedType) {
+            return true;
+        }
+
         $returnType = TypeCombinator::removeNull($returnType);
         if ($returnType instanceof UnionType) {
             return true;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -134,24 +134,26 @@ CODE_SAMPLE
         $returnVarName = null;
 
         $this->traverseNodesWithCallable($node->stmts, function (Node $node) use (&$return, &$returnVarName): ?int {
-            // skip scope nesting
-            if ($node instanceof FunctionLike) {
-                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-            }
-
             if (! $node instanceof Return_) {
                 return null;
             }
 
-            if (! $node->expr instanceof Variable) {
-                return null;
+            // skip scope nesting
+            if ($node instanceof FunctionLike) {
+                $return = null;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
 
+            if (! $node->expr instanceof Variable) {
+                $return = null;
+                return NodeTraverser::STOP_TRAVERSAL;
+            }
+
+            // skip as soon as we find a return which returns a different variable
             $returnName = $this->getName($node->expr);
             if ($returnVarName !== null && $returnName !== $returnVarName) {
                 $return = null;
-
-                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                return NodeTraverser::STOP_TRAVERSAL;
             }
 
             $returnVarName = $returnName;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -125,6 +125,10 @@ CODE_SAMPLE
     {
         $return = null;
 
+        if ($node->stmts === null) {
+            return null;
+        }
+
         $this->traverseNodesWithCallable($node->stmts, function (Node $node) use (&$return): ?int {
             if (! $node instanceof Return_) {
                 return null;
@@ -187,10 +191,6 @@ CODE_SAMPLE
     private function shouldSkipNode(ClassMethod|Function_ $node): bool
     {
         if ($node->returnType !== null) {
-            return true;
-        }
-
-        if ($node->stmts === null) {
             return true;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -93,13 +93,19 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node instanceof ClassMethod) {
+            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
+                return null;
+            }
+
+            if ($node->isMagic()) {
+                return null;
+            }
+        }
+
         $returnType = $this->returnTypeInferer->inferFunctionLike($node);
         $returnType = TypeCombinator::removeNull($returnType);
         if ($returnType instanceof UnionType) {
-            return null;
-        }
-
-        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
     {
         $return = null;
 
-        $this->traverseNodesWithCallable($node->getStmts(), function (Node $node) use (&$return): ?int {
+        $this->traverseNodesWithCallable($node->stmts, function (Node $node) use (&$return): ?int {
             if (! $node instanceof Return_) {
                 return null;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeTraverser;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Rector\AbstractScopeAwareRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\ReturnTypeFromStrictParamRectorTest
+ */
+final class ReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add return type based on strict parameter type', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function resolve(ParamType $item)
+    {
+        return $item;
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function resolve(ParamType $item): ParamType
+    {
+        return $item;
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::NULLABLE_TYPE;
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
+    {
+        if ($node->returnType !== null) {
+            return null;
+        }
+
+        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
+            return null;
+        }
+
+        $return = $this->findCurrentScopeReturn($node);
+        if ($return === null) {
+            return null;
+        }
+
+        $returnName = $this->getName($return->expr);
+        foreach ($node->getParams() as $param) {
+            if ($this->shouldSkipParam($param, $node)) {
+                continue;
+            }
+
+            $paramName = $this->getName($param);
+            if ($returnName !== $paramName) {
+                continue;
+            }
+
+            $resolvedType = $scope->getType($param->var);
+
+            /** @var Name $returnType */
+            $returnType = $resolvedType instanceof ObjectType
+                ? new FullyQualified($resolvedType->getClassName())
+                : $param->type;
+
+            $node->returnType = $returnType;
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function findCurrentScopeReturn(ClassMethod|Function_ $node): ?Return_
+    {
+        $return = null;
+
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        $returnVarName = null;
+
+        $this->traverseNodesWithCallable($node->stmts, function (Node $node) use (&$return, &$returnVarName): ?int {
+            // skip scope nesting
+            if ($node instanceof FunctionLike) {
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            if (! $node instanceof Return_) {
+                return null;
+            }
+
+            if (! $node->expr instanceof Variable) {
+                return null;
+            }
+
+            $returnName = $this->getName($node->expr);
+            if ($returnVarName !== null && $returnName !== $returnVarName) {
+                $return = null;
+
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            $returnVarName = $returnName;
+            $return = $node;
+            return null;
+        });
+
+        return $return;
+    }
+
+    private function shouldSkipParam(Param $param, ClassMethod|Function_ $functionLike): bool
+    {
+        if (!$param->type instanceof Node) {
+            return true;
+        }
+
+        $paramName = $this->getName($param);
+
+        $isParamModified = false;
+
+        $this->traverseNodesWithCallable($functionLike, function (Node $node) use (
+            $paramName,
+            &$isParamModified
+        ): int|null {
+            if (! $node instanceof Expr\Assign && !$node instanceof Expr\AssignRef) {
+                return null;
+            }
+
+            if (! $node->var instanceof Variable) {
+                return null;
+            }
+
+            if (! $this->isName($node->var, $paramName)) {
+                return null;
+            }
+
+            $isParamModified = true;
+            return NodeTraverser::STOP_TRAVERSAL;
+        });
+
+        return $isParamModified;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -125,10 +125,6 @@ CODE_SAMPLE
     {
         $return = null;
 
-        if ($node->stmts === null) {
-            return null;
-        }
-
         $this->traverseNodesWithCallable($node->stmts, function (Node $node) use (&$return): ?int {
             if (! $node instanceof Return_) {
                 return null;
@@ -191,6 +187,10 @@ CODE_SAMPLE
     private function shouldSkipNode(ClassMethod|Function_ $node): bool
     {
         if ($node->returnType !== null) {
+            return true;
+        }
+
+        if ($node->stmts === null) {
             return true;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
     {
         $return = null;
 
-        $this->traverseNodesWithCallable($node->stmts, function (Node $node) use (&$return): ?int {
+        $this->traverseNodesWithCallable($node->getStmts(), function (Node $node) use (&$return): ?int {
             if (! $node instanceof Return_) {
                 return null;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -110,6 +110,10 @@ CODE_SAMPLE
 
         $returnName = $this->getName($return->expr);
         foreach ($node->getParams() as $param) {
+            if (!$param->type instanceof Node) {
+                continue;
+            }
+
             if ($this->shouldSkipParam($param, $node)) {
                 continue;
             }
@@ -119,14 +123,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $resolvedType = $scope->getType($param->var);
-
-            /** @var Name $returnType */
-            $returnType = $resolvedType instanceof ObjectType
-                ? new FullyQualified($resolvedType->getClassName())
-                : $param->type;
-
-            $node->returnType = $returnType;
+            $node->returnType = $param->type;
             return $node;
         }
 
@@ -166,10 +163,6 @@ CODE_SAMPLE
 
     private function shouldSkipParam(Param $param, ClassMethod|Function_ $functionLike): bool
     {
-        if (!$param->type instanceof Node) {
-            return true;
-        }
-
         $paramName = $this->getName($param);
 
         $isParamModified = false;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -162,7 +162,14 @@ CODE_SAMPLE
             $paramName,
             &$isParamModified
         ): int|null {
-            if (! $node instanceof Expr\Assign && !$node instanceof Expr\AssignRef) {
+            if ($node instanceof Expr\AssignRef) {
+                if ($this->isName($node->expr, $paramName)) {
+                    $isParamModified = true;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+            }
+
+            if (! $node instanceof Expr\Assign) {
                 return null;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -158,7 +158,7 @@ CODE_SAMPLE
 
         $isParamModified = false;
 
-        $this->traverseNodesWithCallable($functionLike, function (Node $node) use (
+        $this->traverseNodesWithCallable($functionLike->getStmts(), function (Node $node) use (
             $paramName,
             &$isParamModified
         ): int|null {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -158,7 +158,11 @@ CODE_SAMPLE
 
         $isParamModified = false;
 
-        $this->traverseNodesWithCallable($functionLike->getStmts(), function (Node $node) use (
+        if ($functionLike->stmts === null) {
+            return true;
+        }
+
+        $this->traverseNodesWithCallable($functionLike->stmts, function (Node $node) use (
             $paramName,
             &$isParamModified
         ): int|null {


### PR DESCRIPTION
```diff
<?php

namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;

class Example {
-    public function doFoo(Example $param) {
+    public function doFoo(Example $param): Example {
        return $param;
    }
}

?>
```