### PR TITLE
[DeadCode] Skip append += assignment on RemoveUnusedPrivatePropertyRector

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
@@ -7,7 +7,6 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
-use PhpParser\Node\Expr\AssignOp\Coalesce;
 use PhpParser\NodeVisitorAbstract;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
@@ -19,12 +18,13 @@ final class AssignedToNodeVisitor extends NodeVisitorAbstract implements ScopeRe
 {
     public function enterNode(Node $node): ?Node
     {
-        if (! $node instanceof Assign && ! $node instanceof AssignOp) {
+        if ($node instanceof AssignOp) {
+            $node->var->setAttribute(AttributeKey::IS_ASSIGNED_TO, true);
             return null;
         }
 
-        if ($node instanceof Coalesce) {
-            $node->var->setAttribute(AttributeKey::IS_ASSIGNED_TO, true);
+        if (! $node instanceof Assign) {
+            return null;
         }
 
         $node->var->setAttribute(AttributeKey::IS_BEING_ASSIGNED, true);

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_append_assignment.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_append_assignment.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+class SkipAppendAssignment {
+    private int $bar = 2;
+
+    public function bar(): int {
+        return $this->bar += 3;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_appender_assignment.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_appender_assignment.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+class SkipAppenderAssignment {
+    private int $bar = 2;
+
+    public function bar(): int {
+        $a = 1;
+        $a += $this->bar;
+
+        return $a;
+    }
+}

--- a/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/appender.php.inc
+++ b/rules-tests/Php56/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/appender.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class Appender
+{
+    public function run($a = 1)
+    {
+        return $a += $b;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+class Appender
+{
+    public function run($a = 1)
+    {
+        $b = null;
+        return $a += $b;
+    }
+}
+
+?>

--- a/tests/Issues/DoNotReplaceUnknownClasses/config/configured_rule.php
+++ b/tests/Issues/DoNotReplaceUnknownClasses/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Doctrine\Rector\Property\DoctrineTargetEntityStringToClassConstantRector;
+use Rector\Doctrine\CodeQuality\Rector\Property\DoctrineTargetEntityStringToClassConstantRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
 return static function (RectorConfig $rectorConfig): void {


### PR DESCRIPTION
Based on https://github.com/rectorphp/rector-src/pull/4491#pullrequestreview-1527308161