### PR TITLE
[Php70] Remove $scope->isInClass on Php4ConstructorRector

### DIFF
--- a/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
+++ b/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
@@ -89,10 +89,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $scope->isInClass()) {
-            return null;
-        }
-
         $psr4ConstructorMethod = $node->getMethod(lcfirst($className)) ?? $node->getMethod($className);
         if (! $psr4ConstructorMethod instanceof ClassMethod) {
             return null;

--- a/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
+++ b/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
@@ -25,6 +25,7 @@ use Rector\Php70\NodeAnalyzer\Php4ConstructorClassMethodAnalyzer;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use PHPStan\Reflection\ClassReflection;
 
 /**
  * @changelog https://wiki.php.net/rfc/remove_php4_constructors
@@ -99,6 +100,9 @@ CODE_SAMPLE
         }
 
         $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
 
         // process parent call references first
         $this->processClassMethodStatementsForParentConstructorCalls($psr4ConstructorMethod, $scope);

--- a/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
+++ b/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
@@ -25,7 +25,6 @@ use Rector\Php70\NodeAnalyzer\Php4ConstructorClassMethodAnalyzer;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use PHPStan\Reflection\ClassReflection;
 
 /**
  * @changelog https://wiki.php.net/rfc/remove_php4_constructors


### PR DESCRIPTION
`getNodeTypes()` already changed to `Class_` at PR:

- https://github.com/rectorphp/rector-src/pull/4487

so check inside class is not needed.