### PR TITLE
Support final methods in ClassMethodReturnTypeOverrideGuard

### DIFF
--- a/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/packages/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -75,6 +75,10 @@ final class ClassMethodReturnTypeOverrideGuard
             return true;
         }
 
+        if ($classMethod->isFinal()) {
+            return false;
+        }
+
         $childrenClassReflections = $this->familyRelationsAnalyzer->getChildrenOfClassReflection($classReflection);
         if ($childrenClassReflections === []) {
             return false;

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/final_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/final_method.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\Fixture;
+
+class UntypedBaseClass
+{
+    public function test()
+    {
+        return 0;
+    }
+}
+
+class SomeChild2 extends UntypedBaseClass
+{
+    final public function test()
+    {
+        return 'abc';
+    }
+
+}
+
+class SomeChild2Child extends SomeChild2 {}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\Fixture;
+
+class UntypedBaseClass
+{
+    public function test()
+    {
+        return 0;
+    }
+}
+
+class SomeChild2 extends UntypedBaseClass
+{
+    final public function test(): string
+    {
+        return 'abc';
+    }
+
+}
+
+class SomeChild2Child extends SomeChild2 {}
+
+?>


### PR DESCRIPTION
when methods are final we don't need to skip them when inferring types, as they cannot be overridden by a potential subclass and therefore cannot get in conflict with method declarations down the type hierarchy.

this PR effectively enables the feature for all rules which use `ClassMethodReturnTypeOverrideGuard`