### PR TITLE
Support literals in ReturnTypeFromStrictTypedCallRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/same_typed_array_returns.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/same_typed_array_returns.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SameTypedArrayReturns
+{
+    public function getData()
+    {
+        if (rand(0,1)) {
+            return [];
+        }
+
+        return $this->getArray();
+    }
+
+    public function getArray(): array
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SameTypedArrayReturns
+{
+    public function getData(): array
+    {
+        if (rand(0,1)) {
+            return [];
+        }
+
+        return $this->getArray();
+    }
+
+    public function getArray(): array
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/same_typed_int_returns.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/same_typed_int_returns.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SameTypedIntReturns
+{
+    public function getData()
+    {
+        if (rand(0,1)) {
+            return 0;
+        }
+
+        return $this->getInt();
+    }
+
+    public function getInt(): int
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SameTypedIntReturns
+{
+    public function getData(): int
+    {
+        if (rand(0,1)) {
+            return 0;
+        }
+
+        return $this->getInt();
+    }
+
+    public function getInt(): int
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/same_typed_string_returns.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/same_typed_string_returns.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SameTypedStringReturns
+{
+    public function getData()
+    {
+        if (rand(0,1)) {
+            return 'hallo';
+        }
+
+        return $this->getString();
+    }
+
+    public function getString(): string
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SameTypedStringReturns
+{
+    public function getData(): string
+    {
+        if (rand(0,1)) {
+            return 'hallo';
+        }
+
+        return $this->getString();
+    }
+
+    public function getString(): string
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_mix_typed_returns.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_mix_typed_returns.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SkipMixedTypeReturns
+{
+    public function getData()
+    {
+        if (rand(0,1)) {
+            return 0;
+        }
+
+        return $this->differentType();
+    }
+
+    public function differentType(): float
+    {
+
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
 
         $currentScopeReturns = $this->findCurrentScopeReturns($node);
 
-        $returnedStrictTypes = $this->returnStrictTypeAnalyzer->collectStrictReturnTypes($currentScopeReturns);
+        $returnedStrictTypes = $this->returnStrictTypeAnalyzer->collectStrictReturnTypes($currentScopeReturns, $scope);
         if ($returnedStrictTypes === []) {
             return null;
         }

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -12,7 +12,9 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
+use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Type\MixedType;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -33,8 +35,9 @@ final class ReturnStrictTypeAnalyzer
      * @param Return_[] $returns
      * @return array<Identifier|Name|NullableType>
      */
-    public function collectStrictReturnTypes(array $returns): array
+    public function collectStrictReturnTypes(array $returns, Scope $scope): array
     {
+        $containsStrictCall = false;
         $returnedStrictTypeNodes = [];
 
         foreach ($returns as $return) {
@@ -45,7 +48,15 @@ final class ReturnStrictTypeAnalyzer
             $returnedExpr = $return->expr;
 
             if ($returnedExpr instanceof MethodCall || $returnedExpr instanceof StaticCall || $returnedExpr instanceof FuncCall) {
+                $containsStrictCall = true;
                 $returnNode = $this->resolveMethodCallReturnNode($returnedExpr);
+            } elseif (
+                $returnedExpr instanceof Expr\Array_
+                || $returnedExpr instanceof Node\Scalar\String_
+                || $returnedExpr instanceof Node\Scalar\LNumber
+                || $returnedExpr instanceof Node\Scalar\DNumber
+            ) {
+                $returnNode = $this->resolveLiteralReturnNode($returnedExpr, $scope);
             } else {
                 return [];
             }
@@ -55,6 +66,10 @@ final class ReturnStrictTypeAnalyzer
             }
 
             $returnedStrictTypeNodes[] = $returnNode;
+        }
+
+        if (! $containsStrictCall) {
+            return [];
         }
 
         return $this->typeNodeUnwrapper->uniquateNodes($returnedStrictTypeNodes);
@@ -80,5 +95,11 @@ final class ReturnStrictTypeAnalyzer
         }
 
         return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
+    }
+
+    private function resolveLiteralReturnNode(Expr\Array_|Scalar $returnedExpr, Scope $scope)
+    {
+        $returnType = $scope->getType($returnedExpr);
+        return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);;
     }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -100,6 +100,6 @@ final class ReturnStrictTypeAnalyzer
     private function resolveLiteralReturnNode(Expr\Array_|Scalar $returnedExpr, Scope $scope): ?Node
     {
         $returnType = $scope->getType($returnedExpr);
-        return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);;
+        return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
     }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -97,7 +97,7 @@ final class ReturnStrictTypeAnalyzer
         return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
     }
 
-    private function resolveLiteralReturnNode(Expr\Array_|Scalar $returnedExpr, Scope $scope)
+    private function resolveLiteralReturnNode(Expr\Array_|Scalar $returnedExpr, Scope $scope): ?Node
     {
         $returnType = $scope->getType($returnedExpr);
         return $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);;


### PR DESCRIPTION
before this PR `ReturnTypeFromStrictTypedCallRector` gave up adding return types, as soon as a single return was contained which cannot be resolved to the same type as others.

after this PR we also take returns into account which contain literal values, e.g. `return 1;`.

this allows in the following example to infer the type, which we couldn't without the patch:

```diff
final class SameTypedArrayReturns
{
-    public function getData()
+    public function getData(): array
    {
        if (rand(0,1)) {
            return []; // this path made the previous implementation give up adding a type
        }

        return $this->getArray();
    }

    public function getArray(): array
    {

    }
}
```