### PR TITLE
[Performance] Use filtered filePaths from ApplicationFileProcessor::configurePHPStanNodeScopeResolver on WorkerRunner::run() 

### DIFF
--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -82,7 +82,7 @@ final class WorkerRunner
             $systemErrors = [];
 
             // 1. allow PHPStan to work with static reflection on provided files
-            $this->applicationFileProcessor->configurePHPStanNodeScopeResolver($filePaths, $configuration);
+            $filePaths = $this->applicationFileProcessor->configurePHPStanNodeScopeResolver($filePaths, $configuration);
 
             foreach ($filePaths as $filePath) {
                 $file = null;

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -113,7 +113,7 @@ final class WorkerRunner
                 ReactCommand::ACTION => Action::RESULT,
                 self::RESULT => [
                     Bridge::FILE_DIFFS => $errorAndFileDiffs[Bridge::FILE_DIFFS] ?? [],
-                    Bridge::FILES_COUNT => is_countable($filePaths) ? count($filePaths) : 0,
+                    Bridge::FILES_COUNT => count($filePaths),
                     Bridge::SYSTEM_ERRORS => $systemErrors,
                     Bridge::SYSTEM_ERRORS_COUNT => $systemErrorsCount,
                 ],

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -113,7 +113,7 @@ final class WorkerRunner
                 ReactCommand::ACTION => Action::RESULT,
                 self::RESULT => [
                     Bridge::FILE_DIFFS => $errorAndFileDiffs[Bridge::FILE_DIFFS] ?? [],
-                    Bridge::FILES_COUNT => count($filePaths),
+                    Bridge::FILES_COUNT => is_countable($filePaths) ? count($filePaths) : 0,
                     Bridge::SYSTEM_ERRORS => $systemErrors,
                     Bridge::SYSTEM_ERRORS_COUNT => $systemErrorsCount,
                 ],

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -148,7 +148,7 @@ final class ApplicationFileProcessor
     /**
      * @param string[] $filePaths
      */
-    public function configurePHPStanNodeScopeResolver(array $filePaths, Configuration $configuration): void
+    public function configurePHPStanNodeScopeResolver(array &$filePaths, Configuration $configuration): void
     {
         $fileExtensions = $configuration->getFileExtensions();
         $fileWithExtensionsFilter = static function (string $filePath) use ($fileExtensions): bool {

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -147,8 +147,9 @@ final class ApplicationFileProcessor
 
     /**
      * @param string[] $filePaths
+     * @return string[]
      */
-    public function configurePHPStanNodeScopeResolver(array &$filePaths, Configuration $configuration): void
+    public function configurePHPStanNodeScopeResolver(array $filePaths, Configuration $configuration): array
     {
         $fileExtensions = $configuration->getFileExtensions();
         $fileWithExtensionsFilter = static function (string $filePath) use ($fileExtensions): bool {
@@ -158,6 +159,8 @@ final class ApplicationFileProcessor
 
         $filePaths = array_filter($filePaths, $fileWithExtensionsFilter);
         $this->nodeScopeResolver->setAnalysedFiles($filePaths);
+
+        return $filePaths;
     }
 
     /**

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -75,11 +75,11 @@ final class ApplicationFileProcessor
         if ($configuration->isParallel()) {
             $systemErrorsAndFileDiffs = $this->runParallel($filePaths, $configuration, $input);
         } else {
-            // 1. collect all files from files+dirs provided paths
-            $files = $this->fileFactory->createFromPaths($filePaths);
-
             // 2. PHPStan has to know about all files too
-            $this->configurePHPStanNodeScopeResolver($filePaths, $configuration);
+            $filePaths = $this->configurePHPStanNodeScopeResolver($filePaths, $configuration);
+
+            // 2. collect all files from files+dirs provided filtered paths
+            $files = $this->fileFactory->createFromPaths($filePaths);
 
             $systemErrorsAndFileDiffs = $this->processFiles($files, $configuration);
 


### PR DESCRIPTION
@TomasVotruba @staabm this is to ensure no need to read unsupported file extensions:

**Before**

```
vendor/bin/rector process app/admin/ --clear-cache --debug --clear-cache | grep ".xml" 
  string(55) "/home/abdul/www/kunzmann/app/admin/config/adminmenu.xml"
  string(50) "/home/abdul/www/kunzmann/app/admin/config/i18n.xml"
```

**After**

```
vendor/bin/rector process app/admin/ --clear-cache --debug --clear-cache | grep ".xml" 
```

Fixes https://github.com/rectorphp/rector/issues/8056