### PR TITLE
[ApplicationFileProcessor] Refactor ApplicationFileProcessor to filter file paths early before run both parallel and non-parallel

### DIFF
--- a/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/packages/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -34,21 +34,13 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
 
     public function report(ProcessResult $processResult, Configuration $configuration): void
     {
-        $errors = $processResult->getErrors();
-
-        // only show 100% when no errors
-        if ($errors === [] && $configuration->shouldShowProgressBar()) {
-            $this->rectorOutputStyle->progressFinish();
-        }
-
-        // show diff after progress bar
         if ($configuration->shouldShowDiffs()) {
             $this->reportFileDiffs($processResult->getFileDiffs());
         }
 
-        $this->reportErrors($errors);
+        $this->reportErrors($processResult->getErrors());
 
-        if ($errors !== []) {
+        if ($processResult->getErrors() !== []) {
             return;
         }
 

--- a/packages/Parallel/WorkerRunner.php
+++ b/packages/Parallel/WorkerRunner.php
@@ -7,8 +7,8 @@ namespace Rector\Parallel;
 use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
 use Nette\Utils\FileSystem;
+use PHPStan\Analyser\NodeScopeResolver;
 use Rector\Caching\Detector\ChangedFilesDetector;
-use Rector\Core\Application\ApplicationFileProcessor;
 use Rector\Core\Console\Style\RectorConsoleOutputStyle;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\Provider\CurrentFileProvider;
@@ -39,7 +39,7 @@ final class WorkerRunner
         private readonly CurrentFileProvider $currentFileProvider,
         private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator,
         private readonly RectorConsoleOutputStyle $rectorConsoleOutputStyle,
-        private readonly ApplicationFileProcessor $applicationFileProcessor,
+        private readonly NodeScopeResolver $nodeScopeResolver,
         private readonly ChangedFilesDetector $changedFilesDetector,
         private readonly iterable $fileProcessors = [],
     ) {
@@ -82,7 +82,7 @@ final class WorkerRunner
             $systemErrors = [];
 
             // 1. allow PHPStan to work with static reflection on provided files
-            $filePaths = $this->applicationFileProcessor->configurePHPStanNodeScopeResolver($filePaths, $configuration);
+            $this->nodeScopeResolver->setAnalysedFiles($filePaths);
 
             foreach ($filePaths as $filePath) {
                 $file = null;

--- a/src/Console/Output/RectorOutputStyle.php
+++ b/src/Console/Output/RectorOutputStyle.php
@@ -28,11 +28,6 @@ final class RectorOutputStyle implements OutputStyleInterface
         $this->rectorConsoleOutputStyle->progressAdvance($step);
     }
 
-    public function progressFinish(): void
-    {
-        $this->rectorConsoleOutputStyle->progressFinish();
-    }
-
     public function error(string $message): void
     {
         $this->rectorConsoleOutputStyle->error($message);

--- a/src/Console/Style/RectorConsoleOutputStyle.php
+++ b/src/Console/Style/RectorConsoleOutputStyle.php
@@ -81,15 +81,4 @@ final class RectorConsoleOutputStyle extends SymfonyStyle
     {
         return $this->progressBar ?? throw new RuntimeException('The ProgressBar is not started.');
     }
-
-    public function progressFinish(): void
-    {
-        // hide progress bar in tests
-        if (defined('PHPUNIT_COMPOSER_INSTALL')) {
-            return;
-        }
-
-        $progressBar = $this->getProgressBar();
-        $progressBar->finish();
-    }
 }

--- a/src/Contract/Console/OutputStyleInterface.php
+++ b/src/Contract/Console/OutputStyleInterface.php
@@ -34,6 +34,4 @@ interface OutputStyleInterface
     public function progressStart(int $fileCount): void;
 
     public function progressAdvance(int $step = 1): void;
-
-    public function progressFinish(): void;
 }


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/4513#issuecomment-1636443359

@TomasVotruba @staabm this filter file paths by supported file extensions early before process parallel or non-parallel so file counts will correctly counted, this revert the progress bar tweak on PR:

- https://github.com/rectorphp/rector-src/pull/4516

as the file now counted correctly on parallel.

We may need to centralize the process between parallel and non-parallel file process to avoid copy paste code if there is needed change, but that's will need separate PR :)