### PR TITLE
[DX] Fix hang on twice run after all files processed cached

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -61,6 +61,7 @@ final class ApplicationFileProcessor
     public function run(Configuration $configuration, InputInterface $input): array
     {
         $filePaths = $this->fileFactory->findFilesInPaths($configuration->getPaths(), $configuration);
+        $filePaths = $this->resolveFilePathsByConfigurationFileExtensions($filePaths, $configuration);
 
         // no files found
         if ($filePaths === []) {
@@ -71,8 +72,6 @@ final class ApplicationFileProcessor
         }
 
         $this->configureCustomErrorHandler();
-
-        $filePaths = $this->resolveFilePathsByConfigurationFileExtensions($filePaths, $configuration);
 
         if ($configuration->isParallel()) {
             $systemErrorsAndFileDiffs = $this->runParallel($filePaths, $configuration, $input);


### PR DESCRIPTION
@TomasVotruba @staabm PR:

- https://github.com/rectorphp/rector-src/pull/4519

cause hang on twice run after cached on count filtered files already zero:

```
➜  CodeIgniter4 git:(develop) ✗ time vendor/bin/rector 
 783/783 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

vendor/bin/rector  266.09s user 7.52s system 709% cpu 38.567 total
➜  CodeIgniter4 git:(develop) ✗ time vendor/bin/rector
    0 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░
```

This patch fixed it:

```
➜  CodeIgniter4 git:(develop) ✗ time vendor/bin/rector


                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

vendor/bin/rector  0.94s user 0.15s system 99% cpu 1.097 total
```