### PR TITLE
[Application] Move filter files by config extensions to FileFactory

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -61,7 +61,6 @@ final class ApplicationFileProcessor
     public function run(Configuration $configuration, InputInterface $input): array
     {
         $filePaths = $this->fileFactory->findFilesInPaths($configuration->getPaths(), $configuration);
-        $filePaths = $this->resolveFilePathsByConfigurationFileExtensions($filePaths, $configuration);
 
         // no files found
         if ($filePaths === []) {
@@ -144,21 +143,6 @@ final class ApplicationFileProcessor
         }
 
         return $systemErrorsAndFileDiffs;
-    }
-
-    /**
-     * @param string[] $filePaths
-     * @return string[]
-     */
-    public function resolveFilePathsByConfigurationFileExtensions(array $filePaths, Configuration $configuration): array
-    {
-        $fileExtensions = $configuration->getFileExtensions();
-        $fileWithExtensionsFilter = static function (string $filePath) use ($fileExtensions): bool {
-            $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
-            return in_array($filePathExtension, $fileExtensions, true);
-        };
-
-        return array_filter($filePaths, $fileWithExtensionsFilter);
     }
 
     /**

--- a/src/ValueObjectFactory/Application/FileFactory.php
+++ b/src/ValueObjectFactory/Application/FileFactory.php
@@ -22,7 +22,7 @@ final class FileFactory
     public function __construct(
         private readonly FilesFinder $filesFinder,
         private readonly ChangedFilesDetector $changedFilesDetector,
-        private readonly iterable $fileProcessors,
+        private readonly iterable $fileProcessors
     ) {
     }
 
@@ -37,8 +37,15 @@ final class FileFactory
         }
 
         $supportedFileExtensions = $this->resolveSupportedFileExtensions($configuration);
+        $filePaths = $this->filesFinder->findInDirectoriesAndFiles($paths, $supportedFileExtensions);
 
-        return $this->filesFinder->findInDirectoriesAndFiles($paths, $supportedFileExtensions);
+        $fileExtensions = $configuration->getFileExtensions();
+        $fileWithExtensionsFilter = static function (string $filePath) use ($fileExtensions): bool {
+            $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
+            return in_array($filePathExtension, $fileExtensions, true);
+        };
+
+        return array_filter($filePaths, $fileWithExtensionsFilter);
     }
 
     /**


### PR DESCRIPTION
@TomasVotruba @staabm this continue of PR:

- https://github.com/rectorphp/rector-src/pull/4521

to move filter file paths by extensions to `FileFactory::findFilesInPaths()` itself to avoid missplaced re-filter paths again in the future 👍 