### PR TITLE
PreparedValueToEarlyReturnRector creates invalid code

### DIFF
--- a/rules-tests/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector/Fixture/demo_file.php.inc
+++ b/rules-tests/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector/Fixture/demo_file.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector\Fixture;
+
+final class DemoFile
+{
+    public function run( $arg )
+    {
+		$arg = preg_replace_callback(
+			'/([a-z])?([a-z])([a-z]*)/',
+			static function ( $match ) {
+				$replace = '';
+				if ( !empty( $match[1] ) ) {
+					$replace = 'abc';
+				}
+				$replace .= $match[2];
+				if ( !empty( $match[3] ) ) {
+					$replace .= 'abc';
+				}
+				return $replace;
+			},
+			$arg
+		);
+
+		return $arg;
+    }
+}
+
+?>


### PR DESCRIPTION
There are some options to change this to early return, however I'm not sure if this is wanted here (since it would mean you'd have to concat in the return), so I suggested to not change the code at all (instead of creating invalid code as it does now)