### PR TITLE
Refactor MyCLabs\Enum\Enum::equals calls to comparisons

### DIFF
--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_equals.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_equals.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class UsageOfEquals
+{
+    private SomeEnum $prop;
+
+    public function run($value)
+    {
+        $this->prop = $var = SomeEnum::USED_TO_BE_CONST();
+
+        $compare = SomeEnum::USED_TO_BE_CONST()->equals(SomeEnum::USED_TO_BE_CONST());
+        $compare = SomeEnum::USED_TO_BE_CONST()->equals($var);
+        $compare = SomeEnum::USED_TO_BE_CONST()->equals($this->prop);
+
+        $compare = $var->equals(SomeEnum::USED_TO_BE_CONST());
+        $compare = $var->equals($var);
+        $compare = $var->equals($this->prop);
+
+        $compare = $this->prop->equals(SomeEnum::USED_TO_BE_CONST());
+        $compare = $this->prop->equals($var);
+        $compare = $this->prop->equals($this->prop);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class UsageOfEquals
+{
+    private SomeEnum $prop;
+
+    public function run($value)
+    {
+        $this->prop = $var = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST === \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST === $var;
+        $compare = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST === $this->prop;
+
+        $compare = $var === \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+        $compare = $var === $var;
+        $compare = $var === $this->prop;
+
+        $compare = $this->prop === \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+        $compare = $this->prop === $var;
+        $compare = $this->prop === $this->prop;
+    }
+}
+
+?>

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -6,10 +6,12 @@ namespace Rector\Php81\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -143,8 +145,67 @@ CODE_SAMPLE
         return new PropertyFetch($enumConstFetch, 'value');
     }
 
-    private function refactorMethodCall(MethodCall $methodCall, string $methodName): null|ClassConstFetch|PropertyFetch
+    private function refactorEqualsMethodCall(MethodCall $methodCall): ?Identical
     {
+        $left = $this->getValidEnumExpr($methodCall->var);
+        if ($left === null) {
+            return null;
+        }
+
+        $arg = $methodCall->getArgs()[0] ?? null;
+        if ($arg === null) {
+            return null;
+        }
+
+        $right = $this->getValidEnumExpr($arg->value);
+        if ($right === null) {
+            return null;
+        }
+
+        return new Identical($left, $right);
+    }
+
+    private function getValidEnumExpr(Node $node): null|ClassConstFetch|Expr
+    {
+        return match ($node::class) {
+            Variable::class, PropertyFetch::class => $this->getPropertyFetchOrVariable($node),
+            StaticCall::class => $this->getEnumConstFetch($node),
+            default => null,
+        };
+    }
+
+    private function getPropertyFetchOrVariable(PropertyFetch|Variable $expr): null|PropertyFetch|Variable
+    {
+        if (! $this->isObjectType($expr, new ObjectType('MyCLabs\Enum\Enum'))) {
+            return null;
+        }
+
+        return $expr;
+    }
+
+    private function getEnumConstFetch(StaticCall $staticCall): null|ClassConstFetch
+    {
+        $className = $this->getName($staticCall->class);
+        if ($className === null) {
+            return null;
+        }
+
+        $enumCaseName = $this->getName($staticCall->name);
+        if ($enumCaseName === null) {
+            return null;
+        }
+
+        if ($this->shouldOmitEnumCase($enumCaseName)) {
+            return null;
+        }
+
+        return $this->nodeFactory->createClassConstFetch($className, $enumCaseName);
+    }
+
+    private function refactorMethodCall(
+        MethodCall $methodCall,
+        string $methodName
+    ): null|ClassConstFetch|PropertyFetch|Identical {
         if (! $this->isObjectType($methodCall->var, new ObjectType('MyCLabs\Enum\Enum'))) {
             return null;
         }
@@ -155,6 +216,10 @@ CODE_SAMPLE
 
         if ($methodName === 'getValue') {
             return $this->refactorGetValueMethodCall($methodCall);
+        }
+
+        if ($methodName === 'equals') {
+            return $this->refactorEqualsMethodCall($methodCall);
         }
 
         return null;


### PR DESCRIPTION
When upgrading a codebase that uses the `myclabs/php-enum` package I noticed that the `equals` calls were not converted to comparisons. These changes add that functionality.