### PR TITLE
[Performance][NodeManipulator] Avoid loop on search first variable named on next sliced next stmts on StmtsManipulator

### DIFF
--- a/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
@@ -207,7 +207,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (!isset($stmtsAware->stmts[$key + 1])) {
+        if (! isset($stmtsAware->stmts[$key + 1])) {
             return null;
         }
 

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -149,7 +149,7 @@ CODE_SAMPLE
     private function refactorEqualsMethodCall(MethodCall $methodCall): ?Identical
     {
         $expr = $this->getValidEnumExpr($methodCall->var);
-        if ($expr === null) {
+        if (!$expr instanceof Expr) {
             return null;
         }
 

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php81\Rector\MethodCall;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
@@ -147,22 +148,22 @@ CODE_SAMPLE
 
     private function refactorEqualsMethodCall(MethodCall $methodCall): ?Identical
     {
-        $left = $this->getValidEnumExpr($methodCall->var);
-        if ($left === null) {
+        $expr = $this->getValidEnumExpr($methodCall->var);
+        if ($expr === null) {
             return null;
         }
 
         $arg = $methodCall->getArgs()[0] ?? null;
-        if ($arg === null) {
+        if (!$arg instanceof Arg) {
             return null;
         }
 
         $right = $this->getValidEnumExpr($arg->value);
-        if ($right === null) {
+        if (!$right instanceof Expr) {
             return null;
         }
 
-        return new Identical($left, $right);
+        return new Identical($expr, $right);
     }
 
     private function getValidEnumExpr(Node $node): null|ClassConstFetch|Expr

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Php81\Rector\MethodCall;
 
-use PhpParser\Node\Arg;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\ClassConstFetch;
@@ -149,17 +149,17 @@ CODE_SAMPLE
     private function refactorEqualsMethodCall(MethodCall $methodCall): ?Identical
     {
         $expr = $this->getValidEnumExpr($methodCall->var);
-        if (!$expr instanceof Expr) {
+        if (! $expr instanceof Expr) {
             return null;
         }
 
         $arg = $methodCall->getArgs()[0] ?? null;
-        if (!$arg instanceof Arg) {
+        if (! $arg instanceof Arg) {
             return null;
         }
 
         $right = $this->getValidEnumExpr($arg->value);
-        if (!$right instanceof Expr) {
+        if (! $right instanceof Expr) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -125,6 +125,7 @@ CODE_SAMPLE
         if ($returnType instanceof UnionType) {
             return true;
         }
+
         return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope);
     }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -5,28 +5,19 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Ternary;
-use PhpParser\Node\Scalar;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\ConstantType;
-use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
-use Rector\TypeDeclaration\ValueObject\TernaryIfElseTypes;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -101,6 +92,7 @@ CODE_SAMPLE
         if (! $return->expr instanceof Ternary) {
             return null;
         }
+
         $ternary = $return->expr;
 
         $nativeTernaryType = $scope->getNativeType($ternary);
@@ -133,14 +125,7 @@ CODE_SAMPLE
         if ($returnType instanceof UnionType) {
             return true;
         }
-
-        if ($node instanceof ClassMethod) {
-            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope);
     }
 
 }

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -115,7 +115,8 @@ CODE_SAMPLE
         return PhpVersionFeature::SCALAR_TYPES;
     }
 
-    private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool {
+    private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool
+    {
         if ($node->returnType !== null) {
             return true;
         }
@@ -126,7 +127,9 @@ CODE_SAMPLE
             return true;
         }
 
-        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope);
+        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scope
+        );
     }
-
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\TypeAnalyzer;
 
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -71,9 +71,6 @@ final class StmtsManipulator
         }
 
         $stmts = array_slice($stmtsAware->stmts, $jumpToKey, null, true);
-        return (bool) $this->betterNodeFinder->findVariableOfName(
-            $stmts,
-            $variableName
-        );
+        return (bool) $this->betterNodeFinder->findVariableOfName($stmts, $variableName);
     }
 }

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -70,22 +70,10 @@ final class StmtsManipulator
             return false;
         }
 
-        $totalKeys = array_key_last($stmtsAware->stmts);
-        for ($key = $jumpToKey; $key <= $totalKeys; ++$key) {
-            if (! isset($stmtsAware->stmts[$key])) {
-                continue;
-            }
-
-            $isVariableUsed = (bool) $this->betterNodeFinder->findVariableOfName(
-                $stmtsAware->stmts[$key],
-                $variableName
-            );
-
-            if ($isVariableUsed) {
-                return true;
-            }
-        }
-
-        return false;
+        $stmts = array_slice($stmtsAware->stmts, $jumpToKey, null, true);
+        return (bool) $this->betterNodeFinder->findVariableOfName(
+            $stmts,
+            $variableName
+        );
     }
 }


### PR DESCRIPTION
Use `array_slice()` once and `$this->betterNodeFinder->findVariableOfName()` once instead of loop to avoid too many traverse call.

Ref https://3v4l.org/ZlJst