### PR TITLE
[Scope] Pull Scope from Node instead of origNode on Abstract*Rector take 2

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
@@ -131,7 +131,8 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         }
 
         $uses = $this->useImportsResolver->resolve();
-        $scope = $phpParserNode->getAttribute(AttributeKey::SCOPE);
+        $originalNode = $phpParserNode->getAttribute(AttributeKey::ORIGINAL_NODE) ?? $phpParserNode;
+        $scope = $originalNode->getAttribute(AttributeKey::SCOPE);
 
         if (! $scope instanceof Scope) {
             if (! $phpParserNode->hasAttribute(AttributeKey::ORIGINAL_NODE)) {

--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -75,11 +75,8 @@ final class ClassRenamingPostRector extends AbstractPostRector implements PostRe
             return null;
         }
 
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-        $originalNode ??= $node;
-
         /** @var Scope|null $scope */
-        $scope = $originalNode->getAttribute(AttributeKey::SCOPE);
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
         $result = $this->classRenamer->renameNode($node, $oldToNewClasses, $scope);
 
         if (! SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_NAMES)) {

--- a/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
@@ -207,7 +207,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (!isset($stmtsAware->stmts[$key + 1])) {
+        if (! isset($stmtsAware->stmts[$key + 1])) {
             return null;
         }
 

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php81\Rector\MethodCall;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
@@ -147,22 +148,22 @@ CODE_SAMPLE
 
     private function refactorEqualsMethodCall(MethodCall $methodCall): ?Identical
     {
-        $left = $this->getValidEnumExpr($methodCall->var);
-        if ($left === null) {
+        $expr = $this->getValidEnumExpr($methodCall->var);
+        if (!$expr instanceof Expr) {
             return null;
         }
 
         $arg = $methodCall->getArgs()[0] ?? null;
-        if ($arg === null) {
+        if (!$arg instanceof Arg) {
             return null;
         }
 
         $right = $this->getValidEnumExpr($arg->value);
-        if ($right === null) {
+        if (!$right instanceof Expr) {
             return null;
         }
 
-        return new Identical($left, $right);
+        return new Identical($expr, $right);
     }
 
     private function getValidEnumExpr(Node $node): null|ClassConstFetch|Expr

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Php81\Rector\MethodCall;
 
-use PhpParser\Node\Arg;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\ClassConstFetch;
@@ -149,17 +149,17 @@ CODE_SAMPLE
     private function refactorEqualsMethodCall(MethodCall $methodCall): ?Identical
     {
         $expr = $this->getValidEnumExpr($methodCall->var);
-        if (!$expr instanceof Expr) {
+        if (! $expr instanceof Expr) {
             return null;
         }
 
         $arg = $methodCall->getArgs()[0] ?? null;
-        if (!$arg instanceof Arg) {
+        if (! $arg instanceof Arg) {
             return null;
         }
 
         $right = $this->getValidEnumExpr($arg->value);
-        if (!$right instanceof Expr) {
+        if (! $right instanceof Expr) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -125,6 +125,7 @@ CODE_SAMPLE
         if ($returnType instanceof UnionType) {
             return true;
         }
+
         return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope);
     }
 

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -5,28 +5,19 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Ternary;
-use PhpParser\Node\Scalar;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\ConstantType;
-use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
-use Rector\TypeDeclaration\ValueObject\TernaryIfElseTypes;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -101,6 +92,7 @@ CODE_SAMPLE
         if (! $return->expr instanceof Ternary) {
             return null;
         }
+
         $ternary = $return->expr;
 
         $nativeTernaryType = $scope->getNativeType($ternary);
@@ -133,14 +125,7 @@ CODE_SAMPLE
         if ($returnType instanceof UnionType) {
             return true;
         }
-
-        if ($node instanceof ClassMethod) {
-            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope);
     }
 
 }

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -115,7 +115,8 @@ CODE_SAMPLE
         return PhpVersionFeature::SCALAR_TYPES;
     }
 
-    private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool {
+    private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool
+    {
         if ($node->returnType !== null) {
             return true;
         }
@@ -126,7 +127,9 @@ CODE_SAMPLE
             return true;
         }
 
-        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope);
+        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scope
+        );
     }
-
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\TypeAnalyzer;
 
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -227,7 +227,7 @@ CODE_SAMPLE;
             throw new ShouldNotHappenException($errorMessage);
         }
 
-        return $this->postRefactorProcess($originalNode, $refactoredNode);
+        return $this->postRefactorProcess($originalNode, $node, $refactoredNode);
     }
 
     /**
@@ -319,7 +319,7 @@ CODE_SAMPLE;
     /**
      * @param Node|Node[] $refactoredNode
      */
-    private function postRefactorProcess(Node $originalNode, Node|array|int $refactoredNode): Node
+    private function postRefactorProcess(Node $originalNode, Node $node, Node|array|int $refactoredNode): Node
     {
         /** @var non-empty-array<Node>|Node $refactoredNode */
         $this->createdByRuleDecorator->decorate($refactoredNode, $originalNode, static::class);
@@ -328,7 +328,7 @@ CODE_SAMPLE;
         $this->file->addRectorClassWithLine($rectorWithLineChange);
 
         /** @var MutatingScope|null $currentScope */
-        $currentScope = $originalNode->getAttribute(AttributeKey::SCOPE);
+        $currentScope = $node->getAttribute(AttributeKey::SCOPE);
         $filePath = $this->file->getFilePath();
 
         // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown

--- a/src/Rector/AbstractScopeAwareRector.php
+++ b/src/Rector/AbstractScopeAwareRector.php
@@ -30,11 +30,8 @@ abstract class AbstractScopeAwareRector extends AbstractRector implements ScopeA
      */
     public function refactor(Node $node)
     {
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-        $originalNode ??= $node;
-
         /** @var MutatingScope|null $currentScope */
-        $currentScope = $originalNode->getAttribute(AttributeKey::SCOPE);
+        $currentScope = $node->getAttribute(AttributeKey::SCOPE);
 
         if (! $currentScope instanceof MutatingScope) {
             $currentScope = $this->scopeAnalyzer->resolveScope($node, $this->file->getFilePath());


### PR DESCRIPTION
@TomasVotruba @staabm here I pull Scope on `AbstractRector`,  `AbstractScopeAwareRector` `ClassRenamingPostRector` from Node instead of origNode.

The docblock renamer seems still require it, so move the scope from origNode only on there :)