### PR TITLE
Bump to PHPStan 1.10.26

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "phpstan/phpstan": "^1.10.20"
+        "phpstan/phpstan": "^1.10.26"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "nikic/php-parser": "^4.16.0",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.21.3",
-        "phpstan/phpstan": "^1.10.20",
+        "phpstan/phpstan": "^1.10.26",
         "react/event-loop": "^1.3",
         "react/socket": "^1.12",
         "react/promise": "^2.10",

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -458,13 +458,17 @@ final class PHPStanNodeScopeResolver
             $classReflection = $this->reflectionProvider->getClass($className);
         }
 
-        // on refresh, remove entered class avoid entering the class again
-        if ($isScopeRefreshing && $mutatingScope->isInClass() && ! $isAnonymous) {
+        try {
+            $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
+            $this->privatesAccessor->setPrivateProperty($context, 'classReflection', $classReflection);
+
+            return $mutatingScope->enterClass($classReflection);
+        } catch (\PHPStan\ShouldNotHappenException) {
             $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
             $this->privatesAccessor->setPrivateProperty($context, 'classReflection', null);
-        }
 
-        return $mutatingScope->enterClass($classReflection);
+            return $mutatingScope->enterClass($classReflection);
+        }
     }
 
     private function resolveClassName(Class_ | Interface_ | Trait_| Enum_ $classLike): string

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -457,13 +457,12 @@ final class PHPStanNodeScopeResolver
             $classReflection = $this->reflectionProvider->getClass($className);
         }
 
-        try {
-            $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
-            $this->privatesAccessor->setPrivateProperty($context, 'classReflection', $classReflection);
+        $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
 
+        try {
+            $this->privatesAccessor->setPrivateProperty($context, 'classReflection', $classReflection);
             return $mutatingScope->enterClass($classReflection);
         } catch (\PHPStan\ShouldNotHappenException) {
-            $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
             $this->privatesAccessor->setPrivateProperty($context, 'classReflection', null);
         }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -465,9 +465,9 @@ final class PHPStanNodeScopeResolver
         } catch (\PHPStan\ShouldNotHappenException) {
             $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
             $this->privatesAccessor->setPrivateProperty($context, 'classReflection', null);
-
-            return $mutatingScope->enterClass($classReflection);
         }
+
+        return $mutatingScope->enterClass($classReflection);
     }
 
     private function resolveClassName(Class_ | Interface_ | Trait_| Enum_ $classLike): string

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -110,8 +110,6 @@ final class PHPStanNodeScopeResolver
         string $filePath,
         ?MutatingScope $formerMutatingScope = null
     ): array {
-        $isScopeRefreshing = $formerMutatingScope instanceof MutatingScope;
-
         /**
          * The stmts must be array of Stmt, or it will be silently skipped by PHPStan
          * @see vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:282
@@ -126,7 +124,6 @@ final class PHPStanNodeScopeResolver
         // skip chain method calls, performance issue: https://github.com/phpstan/phpstan/issues/254
         $nodeCallback = function (Node $node, MutatingScope $mutatingScope) use (
             &$nodeCallback,
-            $isScopeRefreshing,
             $filePath
         ): void {
             if ($node instanceof FileWithoutNamespace) {

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -261,7 +261,7 @@ final class PHPStanNodeScopeResolver
             // so we need to get it from the first after this one
             if ($node instanceof Class_ || $node instanceof Interface_ || $node instanceof Enum_) {
                 /** @var MutatingScope $mutatingScope */
-                $mutatingScope = $this->resolveClassOrInterfaceScope($node, $mutatingScope, $isScopeRefreshing);
+                $mutatingScope = $this->resolveClassOrInterfaceScope($node, $mutatingScope);
             }
 
             // special case for unreachable nodes
@@ -443,8 +443,7 @@ final class PHPStanNodeScopeResolver
 
     private function resolveClassOrInterfaceScope(
         Class_ | Interface_ | Enum_ $classLike,
-        MutatingScope $mutatingScope,
-        bool $isScopeRefreshing
+        MutatingScope $mutatingScope
     ): MutatingScope {
         $className = $this->resolveClassName($classLike);
         $isAnonymous = $this->classAnalyzer->isAnonymousClass($classLike);

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -458,6 +458,12 @@ final class PHPStanNodeScopeResolver
             $classReflection = $this->reflectionProvider->getClass($className);
         }
 
+        // on refresh, remove entered class avoid entering the class again
+        if ($isScopeRefreshing && $mutatingScope->isInClass() && ! $isAnonymous) {
+            $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
+            $this->privatesAccessor->setPrivateProperty($context, 'classReflection', null);
+        }
+
         return $mutatingScope->enterClass($classReflection);
     }
 

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -458,12 +458,6 @@ final class PHPStanNodeScopeResolver
             $classReflection = $this->reflectionProvider->getClass($className);
         }
 
-        // on refresh, remove entered class avoid entering the class again
-        if ($isScopeRefreshing && $mutatingScope->isInClass() && ! $isAnonymous) {
-            $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
-            $this->privatesAccessor->setPrivateProperty($context, 'classReflection', null);
-        }
-
         return $mutatingScope->enterClass($classReflection);
     }
 


### PR DESCRIPTION
@TomasVotruba new PHPStan release 1.10.26 https://github.com/phpstan/phpstan/releases/tag/1.10.26 cause error in unit test:

```
➜  rector-phpunit git:(main) vendor/bin/phpunit tests/Rector/ClassMethod/CreateMockToAnonymousClassRector 
PHPUnit 10.2.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.5
Configuration: /Users/samsonasik/www/rector-phpunit/phpunit.xml

E.E                                                                 3 / 3 (100%)

Time: 00:01.379, Memory: 90.50 MB

There were 2 errors:

1) Rector\PHPUnit\Tests\Rector\ClassMethod\CreateMockToAnonymousClassRector\CreateMockToAnonymousClassRectorTest::test with data set #0
TypeError: PHPStan\Node\MethodReturnStatementsNode::__construct(): Argument #6 ($classReflection) must be of type PHPStan\Reflection\ClassReflection, null given, called in phar:///Users/samsonasik/www/rector-phpunit/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php on line 563
```

Ref https://github.com/rectorphp/rector-src/actions/runs/5600187475/jobs/10242212477