### PR TITLE
Skip description on same line, remove on next line as based on phpdoc-parser in RemoveUselessParamTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class DemoFile
+{
+    /**
+     * @param string $primitiveValue
+     *   A primitive is fine.
+     * @param callable $callableValue
+     *   A PHP core class is fine.
+     * @param UserlandClass $userlandClass
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, UserlandClass $userlandClass)
+    {
+    }
+}
+
+class UserlandClass
+{
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
@@ -2,14 +2,32 @@
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
 
-class DemoFile
+final class MultilineCommentForUserlandClassTypeHint
 {
     /**
      * @param string $primitiveValue
      *   A primitive is fine.
-     * @param callable $callableValue
-     *   A PHP core class is fine.
      * @param UserlandClass $userlandClass
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, UserlandClass $userlandClass)
+    {
+    }
+}
+
+class UserlandClass
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+final class MultilineCommentForUserlandClassTypeHint
+{
+    /**  A primitive is fine.
      *   A user land class is not.
      */
     public function test(string $primitiveValue, callable $callableValue, UserlandClass $userlandClass)

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_multiline_comment_for_userland_class_type_hint.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/skip_multiline_comment_for_userland_class_type_hint.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+final class MultilineCommentForUserlandClassTypeHint
+{
+    /**
+     * @param string $primitiveValue start on first line
+     *   A primitive is fine.
+     * @param callable $callableValue start on first line
+     *   A PHP core class is fine.
+     * @param AnotherUserlandClass $userlandClass start on first line
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, AnotherUserlandClass $userlandClass)
+    {
+    }
+}
+
+class AnotherUserlandClass
+{
+}

--- a/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector.php
@@ -100,7 +100,10 @@ CODE_SAMPLE
             return null;
         }
 
-        $classMethodReflection = $this->reflectionResolver->resolveMethodReflectionFromClassMethod($classMethod, $scope);
+        $classMethodReflection = $this->reflectionResolver->resolveMethodReflectionFromClassMethod(
+            $classMethod,
+            $scope
+        );
         if (! $classMethodReflection instanceof MethodReflection) {
             return null;
         }

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -4,19 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc;
 
-use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\DeadCode\TypeNodeAnalyzer\GenericTypeNodeAnalyzer;
 use Rector\DeadCode\TypeNodeAnalyzer\MixedArrayTypeNodeAnalyzer;
@@ -64,7 +57,7 @@ final class DeadParamTagValueNodeAnalyzer
         }
 
         if (! $paramTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
-            return $this->isEmptyDescription($paramTagValueNode, $param->type);
+            return $paramTagValueNode->description === '';
         }
 
         if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($paramTagValueNode->type)) {
@@ -72,73 +65,9 @@ final class DeadParamTagValueNodeAnalyzer
         }
 
         if (! $this->genericTypeNodeAnalyzer->hasGenericType($paramTagValueNode->type)) {
-            return $this->isEmptyDescription($paramTagValueNode, $param->type);
+            return $paramTagValueNode->description === '';
         }
 
         return false;
-    }
-
-    private function isEmptyDescription(ParamTagValueNode $paramTagValueNode, Node $node): bool
-    {
-        if ($paramTagValueNode->description !== '') {
-            return false;
-        }
-
-        $parentNode = $paramTagValueNode->getAttribute(PhpDocAttributeKey::PARENT);
-        if (! $parentNode instanceof PhpDocTagNode) {
-            return true;
-        }
-
-        $parentNode = $parentNode->getAttribute(PhpDocAttributeKey::PARENT);
-        if (! $parentNode instanceof PhpDocNode) {
-            return true;
-        }
-
-        $children = $parentNode->children;
-
-        foreach ($children as $key => $child) {
-            if ($child instanceof PhpDocTagNode && $node instanceof FullyQualified) {
-                return $this->isUnionIdentifier($child);
-            }
-
-            if (! $this->isTextNextline($key, $child)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private function isTextNextline(int $key, PhpDocChildNode $phpDocChildNode): bool
-    {
-        if ($key < 1) {
-            return true;
-        }
-
-        if (! $phpDocChildNode instanceof PhpDocTextNode) {
-            return true;
-        }
-
-        return (string) $phpDocChildNode === '';
-    }
-
-    private function isUnionIdentifier(PhpDocTagNode $phpDocTagNode): bool
-    {
-        if (! $phpDocTagNode->value instanceof ParamTagValueNode) {
-            return true;
-        }
-
-        if (! $phpDocTagNode->value->type instanceof BracketsAwareUnionTypeNode) {
-            return true;
-        }
-
-        $types = $phpDocTagNode->value->type->types;
-        foreach ($types as $type) {
-            if ($type instanceof IdentifierTypeNode) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
@@ -8,6 +8,7 @@ use PhpParser\Node\FunctionLike;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\DeadCode\PhpDoc\DeadParamTagValueNodeAnalyzer;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
@@ -39,6 +40,11 @@ final class ParamTagRemover
 
             // handle only basic types, keep phpstan/psalm helper ones
             if ($docNode->name !== '@param') {
+                return null;
+            }
+
+            // skip union types
+            if ($docNode->value->type instanceof UnionTypeNode) {
                 return null;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-src/pull/4480


Skip description on same line, remove on next line as based on phpdoc-parser, so there is not much we can do with it, unless handled there first.


This removal is based on phpdoc-parser implementation that only makes multi-line docblock those line, that start on the same line as param, see: https://github.com/phpstan/phpdoc-parser/blob/2108d702baa4883362a8824def66b96733b8cf82/tests/PHPStan/Parser/PhpDocParserTest.php#L1978-L1998

There are 2 possible fixes - move first letter to first line:

```php
class DemoFile
{
    /**
     * @param string $primitiveValue A
     *   primitive is fine.
     */
    public function test(string $primitiveValue)
    {
    }
}
```

Or move the wholeparam to first line:

```php
class DemoFile
{
    /**
     * @param string $primitiveValue A primitive is fine.
     */
    public function test(string $primitiveValue)
    {
    }
}
```