### PR TITLE
NameImportingPhpDocNodeVisitor: Cheap checks first

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -97,17 +97,17 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         FullyQualifiedObjectType $fullyQualifiedObjectType,
         File $file
     ): ?IdentifierTypeNode {
+        $parentNode = $identifierTypeNode->getAttribute(PhpDocAttributeKey::PARENT);
+        if ($parentNode instanceof TemplateTagValueNode) {
+            // might break
+            return null;
+        }
+
         if (str_starts_with($fullyQualifiedObjectType->getClassName(), '@')) {
             $fullyQualifiedObjectType = new FullyQualifiedObjectType(ltrim(
                 $fullyQualifiedObjectType->getClassName(),
                 '@'
             ));
-        }
-
-        $parentNode = $identifierTypeNode->getAttribute(PhpDocAttributeKey::PARENT);
-        if ($parentNode instanceof TemplateTagValueNode) {
-            // might break
-            return null;
         }
 
         if ($this->classNameImportSkipper->shouldSkipNameForFullyQualifiedObjectType(

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -104,17 +104,17 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             ));
         }
 
+        $parentNode = $identifierTypeNode->getAttribute(PhpDocAttributeKey::PARENT);
+        if ($parentNode instanceof TemplateTagValueNode) {
+            // might break
+            return null;
+        }
+
         if ($this->classNameImportSkipper->shouldSkipNameForFullyQualifiedObjectType(
             $file,
             $phpParserNode,
             $fullyQualifiedObjectType
         )) {
-            return null;
-        }
-
-        $parentNode = $identifierTypeNode->getAttribute(PhpDocAttributeKey::PARENT);
-        if ($parentNode instanceof TemplateTagValueNode) {
-            // might break
             return null;
         }
 

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -125,13 +125,6 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             if (! $this->useNodesToAddCollector->isImportShortable($file, $fullyQualifiedObjectType)) {
                 return null;
             }
-
-            if ($this->shouldImport($newNode, $identifierTypeNode, $fullyQualifiedObjectType)) {
-                $this->useNodesToAddCollector->addUseImport($fullyQualifiedObjectType);
-                return $newNode;
-            }
-
-            return null;
         }
 
         if ($this->shouldImport($newNode, $identifierTypeNode, $fullyQualifiedObjectType)) {


### PR DESCRIPTION
shouldSkipNameForFullyQualifiedObjectType shows up in profiles, which means it is slow. lets move it after some very fast checks