### PR TITLE
[Performance][PostRector] Remove alias exists check on NameImporter called from NameImportingPostRector

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -121,7 +121,8 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         $newNode = new IdentifierTypeNode($fullyQualifiedObjectType->getShortName());
 
         // should skip because its already used
-        if ($this->useNodesToAddCollector->isShortImported($file, $fullyQualifiedObjectType) && ! $this->useNodesToAddCollector->isImportShortable($file, $fullyQualifiedObjectType)) {
+        if ($this->useNodesToAddCollector->isShortImported($file, $fullyQualifiedObjectType)
+            && ! $this->useNodesToAddCollector->isImportShortable($file, $fullyQualifiedObjectType)) {
             return null;
         }
 

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -121,10 +121,8 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         $newNode = new IdentifierTypeNode($fullyQualifiedObjectType->getShortName());
 
         // should skip because its already used
-        if ($this->useNodesToAddCollector->isShortImported($file, $fullyQualifiedObjectType)) {
-            if (! $this->useNodesToAddCollector->isImportShortable($file, $fullyQualifiedObjectType)) {
-                return null;
-            }
+        if ($this->useNodesToAddCollector->isShortImported($file, $fullyQualifiedObjectType) && ! $this->useNodesToAddCollector->isImportShortable($file, $fullyQualifiedObjectType)) {
+            return null;
         }
 
         if ($this->shouldImport($newNode, $identifierTypeNode, $fullyQualifiedObjectType)) {

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
                 return $nameInUse;
             }
 
-            return $this->nameImporter->importName($name, $file, $currentUses);
+            return $this->nameImporter->importName($name, $file);
         }
 
         return null;

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -41,8 +41,7 @@ final class NameImporter
             return null;
         }
 
-        $className = $staticType->getClassName();
-        return $this->importNameAndCollectNewUseStatement($file, $name, $staticType, $className);
+        return $this->importNameAndCollectNewUseStatement($file, $name, $staticType);
     }
 
     private function shouldSkipName(Name $name): bool
@@ -81,8 +80,7 @@ final class NameImporter
     private function importNameAndCollectNewUseStatement(
         File $file,
         Name $name,
-        FullyQualifiedObjectType $fullyQualifiedObjectType,
-        string $className
+        FullyQualifiedObjectType $fullyQualifiedObjectType
     ): ?Name {
         // the same end is already imported → skip
         if ($this->classNameImportSkipper->shouldSkipNameForFullyQualifiedObjectType(

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -7,7 +7,6 @@ namespace Rector\CodingStyle\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Use_;
-use Rector\CodingStyle\ClassNameImport\AliasUsesResolver;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
@@ -20,7 +19,6 @@ use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 final class NameImporter
 {
     public function __construct(
-        private readonly AliasUsesResolver $aliasUsesResolver,
         private readonly ClassNameImportSkipper $classNameImportSkipper,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly UseNodesToAddCollector $useNodesToAddCollector

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -19,11 +19,6 @@ use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
 final class NameImporter
 {
-    /**
-     * @var string[]
-     */
-    private array $aliasedUses = [];
-
     public function __construct(
         private readonly AliasUsesResolver $aliasUsesResolver,
         private readonly ClassNameImportSkipper $classNameImportSkipper,
@@ -35,7 +30,7 @@ final class NameImporter
     /**
      * @param Use_[]|GroupUse[] $uses
      */
-    public function importName(Name $name, File $file, array $uses): ?Name
+    public function importName(Name $name, File $file): ?Name
     {
         if ($this->shouldSkipName($name)) {
             return null;
@@ -47,11 +42,6 @@ final class NameImporter
         }
 
         $className = $staticType->getClassName();
-        // class has \, no need to search in aliases, mark aliasedUses as empty
-        $this->aliasedUses = str_contains($className, '\\')
-            ? []
-            : $this->aliasUsesResolver->resolveFromStmts($uses);
-
         return $this->importNameAndCollectNewUseStatement($file, $name, $staticType, $className);
     }
 
@@ -112,18 +102,6 @@ final class NameImporter
         }
 
         $this->addUseImport($file, $name, $fullyQualifiedObjectType);
-
-        if ($this->aliasedUses === []) {
-            return $fullyQualifiedObjectType->getShortNameNode();
-        }
-
-        // possibly aliased
-        foreach ($this->aliasedUses as $aliasedUse) {
-            if ($className === $aliasedUse) {
-                return null;
-            }
-        }
-
         return $fullyQualifiedObjectType->getShortNameNode();
     }
 

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Rector\CodingStyle\Node;
 
 use PhpParser\Node\Name;
-use PhpParser\Node\Stmt\GroupUse;
-use PhpParser\Node\Stmt\Use_;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
@@ -25,9 +23,6 @@ final class NameImporter
     ) {
     }
 
-    /**
-     * @param Use_[]|GroupUse[] $uses
-     */
     public function importName(Name $name, File $file): ?Name
     {
         if ($this->shouldSkipName($name)) {


### PR DESCRIPTION
@TomasVotruba @staabm the alias exists check already in `NameImportingPostRector` before `NameImporter->importName()` called

https://github.com/rectorphp/rector-src/blob/2faa19f25fc05b98515b280d38241d688909511b/packages/PostRector/Rector/NameImportingPostRector.php#L152-L155

, so I think it no longer needed.

Ref https://github.com/rectorphp/rector/issues/8077