### PR TITLE
StaticMapper: added fast path for IdentifierTypeNode

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -60,7 +60,7 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             return null;
         }
 
-        $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
+        $staticType = $this->staticTypeMapper->mapIdentifierTypeNodeToPHPStanType(
             $node,
             $this->currentPhpParserNode
         );

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -22,6 +22,7 @@ use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeVisitor\AbstractPhpDocNodeVisitor;
 use Rector\PostRector\Collector\UseNodesToAddCollector;
+use Rector\StaticTypeMapper\PhpDocParser\IdentifierTypeMapper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
@@ -30,11 +31,11 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
     private ?PhpParserNode $currentPhpParserNode = null;
 
     public function __construct(
-        private readonly StaticTypeMapper $staticTypeMapper,
         private readonly ClassNameImportSkipper $classNameImportSkipper,
         private readonly UseNodesToAddCollector $useNodesToAddCollector,
         private readonly CurrentFileProvider $currentFileProvider,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly IdentifierTypeMapper $identifierTypeMapper,
     ) {
     }
 
@@ -60,7 +61,7 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             return null;
         }
 
-        $staticType = $this->staticTypeMapper->mapIdentifierTypeNodeToPHPStanType(
+        $staticType = $this->identifierTypeMapper->mapIdentifierTypeNode(
             $node,
             $this->currentPhpParserNode
         );

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -186,7 +186,7 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         }
 
         $identifierTypeNode = $doctrineAnnotationTagValueNode->identifierTypeNode;
-        $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
+        $staticType = $this->identifierTypeMapper->mapIdentifierTypeNode(
             $identifierTypeNode,
             $currentPhpParserNode
         );
@@ -239,7 +239,7 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             throw new ShouldNotHappenException();
         }
 
-        $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
+        $staticType = $this->identifierTypeMapper->mapIdentifierTypeNode(
             new IdentifierTypeNode($attributeClass),
             $currentPhpParserNode
         );

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -52,7 +52,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
     /**
      * @param IdentifierTypeNode $typeNode
      */
-    public function mapToPHPStanType(TypeNode $typeNode, Node $node, NameScope $nameScope): Type
+    public function mapToPHPStanType(TypeNode $typeNode, Node $node, ?NameScope $nameScope): Type
     {
         $type = $this->scalarStringToTypeMapper->mapScalarStringToType($typeNode->name);
         if (! $type instanceof MixedType) {

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -54,13 +54,10 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
      */
     public function mapToPHPStanType(TypeNode $typeNode, Node $node, NameScope $nameScope): Type
     {
-        return $this->mapToPHPStanTypeNew($typeNode, $node);
+        return $this->mapIdentifierTypeNode($typeNode, $node);
     }
 
-    /**
-     * @param IdentifierTypeNode $typeNode
-     */
-    public function mapToPHPStanTypeNew(TypeNode $typeNode, Node $node): Type
+    public function mapIdentifierTypeNode(IdentifierTypeNode $typeNode, Node $node): Type
     {
         $type = $this->scalarStringToTypeMapper->mapScalarStringToType($typeNode->name);
         if (! $type instanceof MixedType) {

--- a/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -52,7 +52,15 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
     /**
      * @param IdentifierTypeNode $typeNode
      */
-    public function mapToPHPStanType(TypeNode $typeNode, Node $node, ?NameScope $nameScope): Type
+    public function mapToPHPStanType(TypeNode $typeNode, Node $node, NameScope $nameScope): Type
+    {
+        return $this->mapToPHPStanTypeNew($typeNode, $node);
+    }
+
+    /**
+     * @param IdentifierTypeNode $typeNode
+     */
+    public function mapToPHPStanTypeNew(TypeNode $typeNode, Node $node): Type
     {
         $type = $this->scalarStringToTypeMapper->mapScalarStringToType($typeNode->name);
         if (! $type instanceof MixedType) {

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -46,8 +46,7 @@ final class StaticTypeMapper
         private readonly PHPStanStaticTypeMapper $phpStanStaticTypeMapper,
         private readonly PhpDocTypeMapper $phpDocTypeMapper,
         private readonly PhpParserNodeMapper $phpParserNodeMapper,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly IdentifierTypeMapper $identifierTypeMapper,
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -114,10 +113,5 @@ final class StaticTypeMapper
     {
         $nameScope = $this->nameScopeFactory->createNameScopeFromNode($node);
         return $this->phpDocTypeMapper->mapToPHPStanType($typeNode, $node, $nameScope);
-    }
-
-    public function mapIdentifierTypeNodeToPHPStanType(IdentifierTypeNode $typeNode, Node $node): Type
-    {
-        return $this->identifierTypeMapper->mapToPHPStanTypeNew($typeNode, $node);
     }
 }

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -15,7 +15,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
@@ -26,7 +25,6 @@ use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;
 use Rector\StaticTypeMapper\PhpDoc\PhpDocTypeMapper;
-use Rector\StaticTypeMapper\PhpDocParser\IdentifierTypeMapper;
 
 /**
  * Maps PhpParser <=> PHPStan <=> PHPStan doc <=> string type nodes between all possible formats

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -15,6 +15,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
@@ -25,6 +26,7 @@ use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;
 use Rector\StaticTypeMapper\PhpDoc\PhpDocTypeMapper;
+use Rector\StaticTypeMapper\PhpDocParser\IdentifierTypeMapper;
 
 /**
  * Maps PhpParser <=> PHPStan <=> PHPStan doc <=> string type nodes between all possible formats
@@ -44,7 +46,8 @@ final class StaticTypeMapper
         private readonly PHPStanStaticTypeMapper $phpStanStaticTypeMapper,
         private readonly PhpDocTypeMapper $phpDocTypeMapper,
         private readonly PhpParserNodeMapper $phpParserNodeMapper,
-        private readonly NodeNameResolver $nodeNameResolver
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly IdentifierTypeMapper $identifierTypeMapper,
     ) {
     }
 
@@ -111,5 +114,10 @@ final class StaticTypeMapper
     {
         $nameScope = $this->nameScopeFactory->createNameScopeFromNode($node);
         return $this->phpDocTypeMapper->mapToPHPStanType($typeNode, $node, $nameScope);
+    }
+
+    public function mapIdentifierTypeNodeToPHPStanType(IdentifierTypeNode $typeNode, Node $node): Type
+    {
+        return $this->identifierTypeMapper->mapToPHPStanType($typeNode, $node, null);
     }
 }

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -118,6 +118,6 @@ final class StaticTypeMapper
 
     public function mapIdentifierTypeNodeToPHPStanType(IdentifierTypeNode $typeNode, Node $node): Type
     {
-        return $this->identifierTypeMapper->mapToPHPStanType($typeNode, $node, null);
+        return $this->identifierTypeMapper->mapToPHPStanTypeNew($typeNode, $node);
     }
 }


### PR DESCRIPTION
the idea behind this method is: 

- we see in https://github.com/rectorphp/rector/issues/8077#issuecomment-1645081188 that name scope creation is slow
- IdentifierTypeMapper does not need the name-scope for its inner workings -> lets try a separate fast path in case we know the `$typeNode=IdentifierTypeNode` so we can skip name scope creation

----

Result: 1 minute faster rector runs ; additionally we are saving 11% on memory usage
 
![grafik](https://github.com/rectorphp/rector-src/assets/120441/1cadfc45-b0ca-4df7-9004-9504b27f7a70)

closes https://github.com/rectorphp/rector/issues/8077