### PR TITLE
[Performance][BetterPhpDocParser] Remove unused ConstExprNode check on ConstExprClassNameDecorator

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
@@ -45,9 +45,9 @@ final class ConstExprClassNameDecorator implements PhpDocNodeDecoratorInterface
         });
     }
 
-    private function resolveFullyQualifiedClass(ConstFetchNode $constExprNode, PhpNode $phpNode): ?string
+    private function resolveFullyQualifiedClass(ConstFetchNode $constFetchNode, PhpNode $phpNode): ?string
     {
         $nameScope = $this->nameScopeFactory->createNameScopeFromNodeWithoutTemplateTypes($phpNode);
-        return $nameScope->resolveStringName($constExprNode->className);
+        return $nameScope->resolveStringName($constFetchNode->className);
     }
 }

--- a/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
@@ -36,16 +36,13 @@ final class ConstExprClassNameDecorator implements PhpDocNodeDecoratorInterface
             }
 
             $className = $this->resolveFullyQualifiedClass($node, $phpNode);
-            if ($className === null) {
-                return null;
-            }
-
             $node->setAttribute(PhpDocAttributeKey::RESOLVED_CLASS, $className);
+
             return $node;
         });
     }
 
-    private function resolveFullyQualifiedClass(ConstFetchNode $constFetchNode, PhpNode $phpNode): ?string
+    private function resolveFullyQualifiedClass(ConstFetchNode $constFetchNode, PhpNode $phpNode): string
     {
         $nameScope = $this->nameScopeFactory->createNameScopeFromNodeWithoutTemplateTypes($phpNode);
         return $nameScope->resolveStringName($constFetchNode->className);

--- a/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
@@ -31,7 +31,7 @@ final class ConstExprClassNameDecorator implements PhpDocNodeDecoratorInterface
         $this->phpDocNodeTraverser->traverseWithCallable($phpDocNode, '', function (Node $node) use (
             $phpNode
         ): Node|null {
-            if (! $node instanceof ConstExprNode) {
+            if (! $node instanceof ConstFetchNode) {
                 return null;
             }
 
@@ -45,12 +45,8 @@ final class ConstExprClassNameDecorator implements PhpDocNodeDecoratorInterface
         });
     }
 
-    private function resolveFullyQualifiedClass(ConstExprNode $constExprNode, PhpNode $phpNode): ?string
+    private function resolveFullyQualifiedClass(ConstFetchNode $constExprNode, PhpNode $phpNode): ?string
     {
-        if (! $constExprNode instanceof ConstFetchNode) {
-            return null;
-        }
-
         $nameScope = $this->nameScopeFactory->createNameScopeFromNodeWithoutTemplateTypes($phpNode);
         return $nameScope->resolveStringName($constExprNode->className);
     }


### PR DESCRIPTION
Directly use `ConstFetchNode` should be working.

@TomasVotruba @staabm this is to reduce double instanceof check on ConstExprClassNameDecorator

Ref https://github.com/rectorphp/rector/issues/8079