### PR TITLE
[Performance] [PostRector] Reduce repetitive resolve uses statements on NameImportingPostRector

### DIFF
--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -149,7 +149,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $aliasName = $this->aliasNameResolver->resolveByName($name);
+        $aliasName = $this->aliasNameResolver->resolveByName($name, $currentUses);
         if (is_string($aliasName)) {
             return new Name($aliasName);
         }

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -22,6 +22,7 @@ use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\Naming\AliasNameResolver;
 use Rector\Naming\Naming\PropertyNaming;
+use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -39,7 +40,8 @@ final class CatchExceptionNameMatchingTypeRector extends AbstractRector
 
     public function __construct(
         private readonly PropertyNaming $propertyNaming,
-        private readonly AliasNameResolver $aliasNameResolver
+        private readonly AliasNameResolver $aliasNameResolver,
+        private readonly UseImportsResolver $useImportsResolver
     ) {
     }
 
@@ -105,6 +107,8 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
+        $uses = $this->useImportsResolver->resolve();
+
         foreach ($node->stmts as $key => $stmt) {
             if ($this->shouldSkip($stmt)) {
                 continue;
@@ -127,8 +131,8 @@ CODE_SAMPLE
 
             $type = $catch->types[0];
             $typeShortName = $this->nodeNameResolver->getShortName($type);
+            $aliasName = $this->aliasNameResolver->resolveByName($type, $uses);
 
-            $aliasName = $this->aliasNameResolver->resolveByName($type);
             if (is_string($aliasName)) {
                 $typeShortName = $aliasName;
             }

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -107,7 +107,7 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
-        $uses = $this->useImportsResolver->resolve();
+        $uses = null;
 
         foreach ($node->stmts as $key => $stmt) {
             if ($this->shouldSkip($stmt)) {
@@ -128,6 +128,10 @@ CODE_SAMPLE
 
             /** @var string $oldVariableName */
             $oldVariableName = (string) $this->getName($catchVar);
+
+            if ($uses === null) {
+                $uses = $this->useImportsResolver->resolve();
+            }
 
             $type = $catch->types[0];
             $typeShortName = $this->nodeNameResolver->getShortName($type);

--- a/rules/Naming/Naming/AliasNameResolver.php
+++ b/rules/Naming/Naming/AliasNameResolver.php
@@ -6,6 +6,8 @@ namespace Rector\Naming\Naming;
 
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Use_;
 
 final class AliasNameResolver
 {
@@ -14,9 +16,11 @@ final class AliasNameResolver
     ) {
     }
 
-    public function resolveByName(Name $name): ?string
+    /**
+     * @param Use_[]|GroupUse[] $uses
+     */
+    public function resolveByName(Name $name, array $uses): ?string
     {
-        $uses = $this->useImportsResolver->resolve();
         $nameString = $name->toString();
 
         foreach ($uses as $use) {


### PR DESCRIPTION
@TomasVotruba @staabm this reduce repetitive internal call resolve use statements on `NameImportingPostRector` to improve performance.