### PR TITLE
[EarlyReturn] Handle multiple statements in else in ChangeIfElseValueAssignToEarlyReturnRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\BetterPhpDocParser\PhpDocParser;
 
 use PhpParser\Node as PhpNode;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;

--- a/rules-tests/EarlyReturn/Rector/If_/ChangeIfElseValueAssignToEarlyReturnRector/Fixture/else_with_multiple_statements.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/ChangeIfElseValueAssignToEarlyReturnRector/Fixture/else_with_multiple_statements.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector\Fixture;
+
+class ElseWithMultipleStatementsFixture
+{
+    public function generateNumber(int $bonus, int $multiplier): int
+    {
+        if (mt_rand(0, 1) === 1) {
+            $number = 10;
+        } else {
+            $bonus *= $multiplier;
+            $number = 20 + $bonus;
+        }
+
+        return $number;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector\Fixture;
+
+class ElseWithMultipleStatementsFixture
+{
+    public function generateNumber(int $bonus, int $multiplier): int
+    {
+        if (mt_rand(0, 1) === 1) {
+            return 10;
+        }
+        $bonus *= $multiplier;
+
+        return 20 + $bonus;
+    }
+}
+
+?>

--- a/rules/EarlyReturn/Rector/If_/ChangeIfElseValueAssignToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/If_/ChangeIfElseValueAssignToEarlyReturnRector.php
@@ -127,6 +127,10 @@ CODE_SAMPLE
             $if->else = null;
             $stmt->expr = $assign->expr;
 
+            $lastStmt = array_pop($node->stmts);
+            $elseStmtsExceptLast = array_slice($elseStmts, 0, -1);
+            $node->stmts = [...$node->stmts, ...$elseStmtsExceptLast, $lastStmt];
+
             return $node;
         }
 


### PR DESCRIPTION
Added test case + updated ChangeIfElseValueAssignToEarlyReturnRector to handle situations like this:
```php
public function generateNumber(int $bonus, int $multiplier): int
{
    if (mt_rand(0, 1) === 1) {
        $number = 10;
    } else {
        $bonus *= $multiplier;
        $number = 20 + $bonus;
    }

    return $number;
}
```
Without this fix, it gets dropped:
```php
public function generateNumber(int $bonus, int $multiplier): int
{
    if (mt_rand(0, 1) === 1) {
        return 10;
    }

    return 20 + $bonus;
}
```

With this fix, it is preserved:
```php
public function generateNumber(int $bonus, int $multiplier): int
{
    if (mt_rand(0, 1) === 1) {
        return 10;
    }
    $bonus *= $multiplier;

    return 20 + $bonus;
}
```
