### PR TITLE
[StaticTypeMapper] Remove standalone false handling on StaticTypeMapper

### DIFF
--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -18,7 +18,6 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
-use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;
@@ -34,8 +33,7 @@ final class StaticTypeMapper
         private readonly NameScopeFactory $nameScopeFactory,
         private readonly PHPStanStaticTypeMapper $phpStanStaticTypeMapper,
         private readonly PhpDocTypeMapper $phpDocTypeMapper,
-        private readonly PhpParserNodeMapper $phpParserNodeMapper,
-        private readonly NodeNameResolver $nodeNameResolver
+        private readonly PhpParserNodeMapper $phpParserNodeMapper
     ) {
     }
 

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -18,6 +18,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;

--- a/packages/StaticTypeMapper/StaticTypeMapper.php
+++ b/packages/StaticTypeMapper/StaticTypeMapper.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
-use PhpParser\Node\UnionType;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
@@ -20,7 +19,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;
@@ -32,13 +30,6 @@ use Rector\StaticTypeMapper\PhpDoc\PhpDocTypeMapper;
  */
 final class StaticTypeMapper
 {
-    /**
-     * @var array<string, string>
-     */
-    private const STANDALONE_MAPS = [
-        'false' => 'bool',
-    ];
-
     public function __construct(
         private readonly NameScopeFactory $nameScopeFactory,
         private readonly PHPStanStaticTypeMapper $phpStanStaticTypeMapper,
@@ -59,28 +50,7 @@ final class StaticTypeMapper
      */
     public function mapPHPStanTypeToPhpParserNode(Type $phpStanType, string $typeKind): ?Node
     {
-        $node = $this->phpStanStaticTypeMapper->mapToPhpParserNode($phpStanType, $typeKind);
-        if (! $node instanceof Node) {
-            return null;
-        }
-
-        if ($node instanceof UnionType) {
-            return $node;
-        }
-
-        if (! $node instanceof Name) {
-            return $node;
-        }
-
-        $nodeName = $this->nodeNameResolver->getName($node);
-
-        foreach (self::STANDALONE_MAPS as $key => $type) {
-            if ($nodeName === $key) {
-                return new Name($type);
-            }
-        }
-
-        return $node;
+        return $this->phpStanStaticTypeMapper->mapToPhpParserNode($phpStanType, $typeKind);
     }
 
     public function mapPhpParserNodePHPStanType(Node $node): Type


### PR DESCRIPTION
standalone `false` handling on `StaticTypeMapper` was added on PR:

- https://github.com/rectorphp/rector-src/pull/2084

which `TypedPropertyRector` which `TypedPropertyRector` is no longer exists.

If we have this case in the future, the standalone false handling should be on mapper itself