### PR TITLE
[BUGFIX] Ensure proper reprint with attributes for finalized classes

### DIFF
--- a/rules-tests/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenRector/Fixture/class_with_attribute.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenRector/Fixture/class_with_attribute.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+#[SomeAttribute]
+class ClassWithAttribute
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+#[SomeAttribute]
+final class ClassWithAttribute
+{
+}
+
+?>

--- a/rules/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenRector.php
@@ -12,6 +12,7 @@ use Rector\Core\NodeAnalyzer\DoctrineEntityAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -98,6 +99,11 @@ CODE_SAMPLE
         $childrenClassReflections = $this->familyRelationsAnalyzer->getChildrenOfClassReflection($classReflection);
         if ($childrenClassReflections !== []) {
             return null;
+        }
+
+        if ($node->attrGroups !== []) {
+            // improve reprint with correct newline
+            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }
 
         $this->visibilityManipulator->makeFinal($node);


### PR DESCRIPTION
Previously, a finalized class would be printed on the same line as the attribute above, like this:

```php
#[SomeAttribute]final class ClassWithAttribute
{
}
```

for the new provided test case.

---
Fixes [#8080](https://github.com/rectorphp/rector/issues/8080)