### PR TITLE
[Php81] Fix regression skip call by ref on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_call_by_ref.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_call_by_ref.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipCallByRef
+{
+    public function __construct(
+        private array $someArray,
+    ) {
+        $this->doSomething($this->someArray);
+    }
+
+    public function doSomething(array &$someArray = null): void
+    {
+    }
+}

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -109,7 +109,7 @@ CODE_SAMPLE
 
         foreach ($node->getMethods() as $classMethod) {
             foreach ($classMethod->params as $param) {
-                $justChanged = $this->refactorParam($node, $classMethod, $param);
+                $justChanged = $this->refactorParam($node, $classMethod, $param, $scope);
                 // different variable to ensure $hasRemoved not replaced
                 if ($justChanged instanceof Param) {
                     $hasChanged = true;
@@ -118,7 +118,7 @@ CODE_SAMPLE
         }
 
         foreach ($node->getProperties() as $property) {
-            $changedProperty = $this->refactorProperty($node, $property);
+            $changedProperty = $this->refactorProperty($node, $property, $scope);
             if ($changedProperty instanceof Property) {
                 $hasChanged = true;
             }
@@ -136,7 +136,7 @@ CODE_SAMPLE
         return PhpVersionFeature::READONLY_PROPERTY;
     }
 
-    private function refactorProperty(Class_ $class, Property $property): ?Property
+    private function refactorProperty(Class_ $class, Property $property, Scope $scope): ?Property
     {
         // 1. is property read-only?
         if ($property->isReadonly()) {
@@ -159,7 +159,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->propertyManipulator->isPropertyChangeableExceptConstructor($class, $property)) {
+        if ($this->propertyManipulator->isPropertyChangeableExceptConstructor($class, $property, $scope)) {
             return null;
         }
 
@@ -177,7 +177,7 @@ CODE_SAMPLE
         return $property;
     }
 
-    private function refactorParam(Class_ $class, ClassMethod $classMethod, Param $param): Param | null
+    private function refactorParam(Class_ $class, ClassMethod $classMethod, Param $param, Scope $scope): Param | null
     {
         if (! $this->visibilityManipulator->hasVisibility($param, Visibility::PRIVATE)) {
             return null;
@@ -188,7 +188,7 @@ CODE_SAMPLE
         }
 
         // promoted property?
-        if ($this->propertyManipulator->isPropertyChangeableExceptConstructor($class, $param)) {
+        if ($this->propertyManipulator->isPropertyChangeableExceptConstructor($class, $param, $scope)) {
             return null;
         }
 

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -173,7 +173,7 @@ final class PropertyManipulator
         PropertyFetch|StaticPropertyFetch $propertyFetch,
         ?ClassMethod $classMethod
     ): MethodCall | StaticCall | null {
-        if (! $classMethod instanceof ClassMethod || $classMethod->stmts === null) {
+        if (! $classMethod instanceof ClassMethod) {
             return null;
         }
 

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -208,7 +208,6 @@ final class PropertyManipulator
             return true;
         }
 
-        // args most likely do not change properties
         if ($propertyFetch->getAttribute(AttributeKey::IS_ARG_VALUE)) {
             $caller = $this->resolveCaller($propertyFetch, $classMethod);
             return $this->isFoundByRefParam($caller, $scope);

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -177,29 +177,24 @@ final class PropertyManipulator
         }
 
         // args most likely do not change properties
-        if ($propertyFetch->getAttribute(AttributeKey::IS_ARG_VALUE)) {
-            if ($classMethod instanceof ClassMethod && $classMethod->stmts !== null) {
-                $parentArg = null;
-
-                $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
-                    $classMethod->stmts,
-                    function (Node $subNode) use ($propertyFetch, &$parentArg) {
-                        if ($subNode instanceof CallLike && ! $subNode->isFirstClassCallable()) {
-                            foreach ($subNode->getArgs() as $arg) {
-                                if ($arg->value === $propertyFetch) {
-                                    $parentArg = $subNode;
-                                    return NodeTraverser::STOP_TRAVERSAL;
-                                }
+        if ($propertyFetch->getAttribute(AttributeKey::IS_ARG_VALUE) && ($classMethod instanceof ClassMethod && $classMethod->stmts !== null)) {
+            $parentArg = null;
+            $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+                $classMethod->stmts,
+                static function (Node $subNode) use ($propertyFetch, &$parentArg) {
+                    if ($subNode instanceof CallLike && ! $subNode->isFirstClassCallable()) {
+                        foreach ($subNode->getArgs() as $arg) {
+                            if ($arg->value === $propertyFetch) {
+                                $parentArg = $subNode;
+                                return NodeTraverser::STOP_TRAVERSAL;
                             }
                         }
-                    });
-
-                if (! $parentArg instanceof CallLike) {
-                    return false;
-                }
-
-                return $this->isFoundByRefParam($parentArg, $scope);
+                    }
+                });
+            if (! $parentArg instanceof CallLike) {
+                return false;
             }
+            return $this->isFoundByRefParam($parentArg, $scope);
         }
 
         return $propertyFetch->getAttribute(AttributeKey::INSIDE_ARRAY_DIM_FETCH, false);

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -177,8 +177,8 @@ final class PropertyManipulator
             return null;
         }
 
-        return $this->betterNodeFinder->findFirst(
-            $classMethod->stmts,
+        return $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+            $classMethod,
             static function (Node $subNode) use ($propertyFetch): bool {
                 if (! $subNode instanceof MethodCall && ! $subNode instanceof StaticCall) {
                     return false;

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -194,6 +194,7 @@ final class PropertyManipulator
             if (! $parentArg instanceof CallLike) {
                 return false;
             }
+
             return $this->isFoundByRefParam($parentArg, $scope);
         }
 


### PR DESCRIPTION
The lower readonly complexity in PR:

- https://github.com/rectorphp/rector-src/pull/4429

cause regression issue : 

- https://github.com/rectorphp/rector/issues/8082

this PR try to fix it.

Fixes https://github.com/rectorphp/rector/issues/8082