### PR TITLE
[PHPStanStaticTypeMapper] Fix IntersectionTypeMapper to make ObjectType have FQCN

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -56,14 +56,6 @@ final class IntersectionTypeMapper implements TypeMapperInterface
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
     {
-        $type = TypeTraverser::map($type, function (Type $type, callable $traverse): Type {
-            if ($type instanceof ObjectType) {
-                return $this->objectTypeMapper->mapToPHPStanPhpDocTypeNode($type);
-            }
-
-            return $traverse($type);
-        });
-
         $typeNode = $type->toPhpDocNode();
 
         $phpDocNodeTraverser = new PhpDocNodeTraverser();

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -7,6 +7,8 @@ namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PHPStan\PhpDocParser\Ast\Node as AstNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\IntersectionType;
@@ -16,6 +18,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -61,7 +64,23 @@ final class IntersectionTypeMapper implements TypeMapperInterface
             return $traverse($type);
         });
 
-        return $type->toPhpDocNode();
+        $typeNode = $type->toPhpDocNode();
+
+        $phpDocNodeTraverser = new PhpDocNodeTraverser();
+        $phpDocNodeTraverser->traverseWithCallable(
+            $typeNode,
+            '',
+            static function (AstNode $astNode) {
+                if ($astNode instanceof IdentifierTypeNode) {
+                    $astNode->name = '\\' . $astNode->name;
+                    return $astNode;
+                }
+
+                return null;
+            }
+        );
+
+        return $typeNode;
     }
 
     /**

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -15,7 +15,6 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeTraverser;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
@@ -32,8 +31,7 @@ final class IntersectionTypeMapper implements TypeMapperInterface
 
     public function __construct(
         private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly ObjectTypeMapper $objectTypeMapper
+        private readonly ReflectionProvider $reflectionProvider
     ) {
     }
 
@@ -62,7 +60,7 @@ final class IntersectionTypeMapper implements TypeMapperInterface
         $phpDocNodeTraverser->traverseWithCallable(
             $typeNode,
             '',
-            static function (AstNode $astNode) {
+            static function (AstNode $astNode): ?IdentifierTypeNode {
                 if ($astNode instanceof IdentifierTypeNode) {
                     $astNode->name = '\\' . $astNode->name;
                     return $astNode;

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -53,7 +53,7 @@ final class IntersectionTypeMapper implements TypeMapperInterface
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
     {
-        $type = TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+        $type = TypeTraverser::map($type, function (Type $type, callable $traverse): Type {
             if ($type instanceof ObjectType) {
                 return $this->objectTypeMapper->mapToPHPStanPhpDocTypeNode($type);
             }

--- a/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -35,7 +35,7 @@ final class IntersectionTypeMapper implements TypeMapperInterface
     }
 
     #[Required]
-    public function __constr(PHPStanStaticTypeMapper $phpStanStaticTypeMapper): void
+    public function autowire(PHPStanStaticTypeMapper $phpStanStaticTypeMapper): void
     {
         $this->phpStanStaticTypeMapper = $phpStanStaticTypeMapper;
     }


### PR DESCRIPTION
@TomasVotruba let's try to fix `IntersectionTypeMapper` by using `PhpDocNodeTraverser::traverse()` to fix https://github.com/rectorphp/rector/issues/8086

The rector-downgrade-php fixtures needs update by this if this succeed

https://github.com/rectorphp/rector-downgrade-php/commit/e72d49309c6e2b488d563126e2fc34b193d2f9a2#diff-f38988a031bf24e97c3d87001cf2d59dbbfd287cac75f445c967fe450ef7f379