### PR TITLE
[Printer] Remove has InlineHTML node check after apply changes on PhpFileProcessor

### DIFF
--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -155,8 +155,14 @@ dump_node($node, 1);
 
 ## Known Drawbacks
 
+Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an *abstract syntax tree* (AST).
+
 ### How to Apply Coding Standards?
 
-Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an *abstract syntax tree* (AST). An AST doesn't know about spaces and when written to a file it produces poorly formatted code in both PHP and docblock annotations. **That's why your project needs to have a coding standard tool** and a set of formatting rules, so it can make Rector's output code nice and shiny again.
+An AST doesn't know about spaces and when written to a file it produces poorly formatted code in both PHP and docblock annotations. **That's why your project needs to have a coding standard tool** and a set of formatting rules, so it can make Rector's output code nice and shiny again.
 
 We're using [ECS](https://github.com/symplify/easy-coding-standard) with [this setup](https://github.com/rectorphp/rector-src/blob/main/ecs.php).
+
+### May cause unexpected output on File with mixed PHP+HTML content
+
+The [nikic/php-parser](https://github.com/nikic/PHP-Parser/) Printer may produce unexpected printing output when dealing with PHP+HTMl content, you may need to manually verify the changed file after apply the changes.

--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -155,11 +155,9 @@ dump_node($node, 1);
 
 ## Known Drawbacks
 
-Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an *abstract syntax tree* (AST).
-
 ### How to Apply Coding Standards?
 
-An AST doesn't know about spaces and when written to a file it produces poorly formatted code in both PHP and docblock annotations. **That's why your project needs to have a coding standard tool** and a set of formatting rules, so it can make Rector's output code nice and shiny again.
+Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an *abstract syntax tree* (AST). An AST doesn't know about spaces and when written to a file it produces poorly formatted code in both PHP and docblock annotations. **That's why your project needs to have a coding standard tool** and a set of formatting rules, so it can make Rector's output code nice and shiny again.
 
 We're using [ECS](https://github.com/symplify/easy-coding-standard) with [this setup](https://github.com/rectorphp/rector-src/blob/main/ecs.php).
 

--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -155,12 +155,14 @@ dump_node($node, 1);
 
 ## Known Drawbacks
 
+Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an *abstract syntax tree* (AST). An AST doesn't know about spaces and when written to a file it produces poorly formatted code in both PHP and docblock annotations.
+
 ### How to Apply Coding Standards?
 
-Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), built on technology called an *abstract syntax tree* (AST). An AST doesn't know about spaces and when written to a file it produces poorly formatted code in both PHP and docblock annotations. **That's why your project needs to have a coding standard tool** and a set of formatting rules, so it can make Rector's output code nice and shiny again.
+**Your project needs to have a coding standard tool** and a set of formatting rules, so it can make Rector's output code nice and shiny again.
 
 We're using [ECS](https://github.com/symplify/easy-coding-standard) with [this setup](https://github.com/rectorphp/rector-src/blob/main/ecs.php).
 
 ### May cause unexpected output on File with mixed PHP+HTML content
 
-The [nikic/php-parser](https://github.com/nikic/PHP-Parser/) Printer may produce unexpected printing output when dealing with PHP+HTMl content, you may need to manually verify the changed file after apply the changes.
+When you apply changes to File(s) thas has mixed PHP+HTML content, you may need to manually verify the changed file after apply the changes.

--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -92,14 +92,6 @@ final class PhpFileProcessor implements FileProcessorInterface
             }
         } while ($fileHasChangedInCurrentPass);
 
-        // show warning on has InlineHTML node if file has changed
-        if ($fileHasChanged && $file->hasInlineHTMLNode()) {
-            $this->symfonyStyle->warning(sprintf(
-                'File %s has InlineHTML node, this may cause unexpected output, you may need to manually verify the changed file',
-                $this->filePathHelper->relativePath($file->getFilePath())
-            ));
-        }
-
         // 5. add as cacheable if not changed at all
         if (! $fileHasChanged) {
             $this->changedFilesDetector->addCachableFile($file->getFilePath());

--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -22,7 +22,6 @@ use Rector\Core\ValueObject\Reporting\FileDiff;
 use Rector\Parallel\ValueObject\Bridge;
 use Rector\PostRector\Application\PostFileProcessor;
 use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
 
 final class PhpFileProcessor implements FileProcessorInterface
@@ -41,8 +40,7 @@ final class PhpFileProcessor implements FileProcessorInterface
         private readonly ChangedFilesDetector $changedFilesDetector,
         private readonly PostFileProcessor $postFileProcessor,
         private readonly ErrorFactory $errorFactory,
-        private readonly FilePathHelper $filePathHelper,
-        private readonly SymfonyStyle $symfonyStyle
+        private readonly FilePathHelper $filePathHelper
     ) {
     }
 

--- a/src/ValueObject/Application/File.php
+++ b/src/ValueObject/Application/File.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\ValueObject\Application;
 
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\InlineHTML;
-use PhpParser\NodeFinder;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\ValueObject\Reporting\FileDiff;
@@ -153,15 +151,5 @@ final class File
     public function getRectorWithLineChanges(): array
     {
         return $this->rectorWithLineChanges;
-    }
-
-    public function hasInlineHTMLNode(): bool
-    {
-        if ($this->newStmts === []) {
-            throw new ShouldNotHappenException();
-        }
-
-        $nodeFinder = new NodeFinder();
-        return (bool) $nodeFinder->findFirstInstanceOf($this->newStmts, InlineHTML::class);
     }
 }


### PR DESCRIPTION
@realtebo @staabm based on @TomasVotruba suggestion on https://github.com/rectorphp/rector/issues/8076#issuecomment-1649503460 , this PR do remove `InlineHTML` check and warning on `PhpFileProcessor`, instead, add warning to README.md file as Known Drawbacks

Fixes https://github.com/rectorphp/rector/issues/8076
Fixes https://github.com/rectorphp/rector/issues/8062