### PR TITLE
Reduce ConstExprClassNameDecorator overhead

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
@@ -27,6 +27,11 @@ final class ConstExprClassNameDecorator implements PhpDocNodeDecoratorInterface
 
     public function decorate(PhpDocNode $phpDocNode, PhpNode $phpNode): void
     {
+        // iterating all phpdocs has big overhead. peek into the phpdoc to exit early
+        if (str_contains($phpDocNode->__toString(), '::') === false) {
+            return;
+        }
+        
         $this->phpDocNodeTraverser->traverseWithCallable($phpDocNode, '', function (Node $node) use (
             $phpNode
         ): Node|null {


### PR DESCRIPTION
closes https://github.com/rectorphp/rector/issues/8079

15% faster

before 

```
$ time php vendor/bin/rector --dry-run --clear-cache
 1476/1476 [============================] 100%

 [OK] Rector is done!                                                                                                   

real    3m18.464s
user    0m0.000s
sys     0m0.000s

```

after

```
$ time php vendor/bin/rector --dry-run --clear-cache
 1476/1476 [============================] 100%
                                                                                                                        
 [OK] Rector is done!                                                                                                   

real    2m50.044s
user    0m0.015s
sys     0m0.000s
```
