### PR TITLE
[CodingStyle][Namespace_] Support constant imports

### DIFF
--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -19,6 +19,11 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
     /**
      * @var array<string, FullyQualifiedObjectType[]>
      */
+    private array $constantUseImportTypesInFilePath = [];
+
+    /**
+     * @var array<string, FullyQualifiedObjectType[]>
+     */
     private array $functionUseImportTypesInFilePath = [];
 
     /**
@@ -43,6 +48,14 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
         $file = $this->currentFileProvider->getFile();
 
         $this->useImportTypesInFilePath[$file->getFilePath()][] = $fullyQualifiedObjectType;
+    }
+
+    public function addConstantUseImport(FullyQualifiedObjectType $fullyQualifiedObjectType): void
+    {
+        /** @var File $file */
+        $file = $this->currentFileProvider->getFile();
+
+        $this->constantUseImportTypesInFilePath[$file->getFilePath()][] = $fullyQualifiedObjectType;
     }
 
     public function addFunctionUseImport(FullyQualifiedObjectType $fullyQualifiedObjectType): void
@@ -100,6 +113,14 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
             return true;
         }
 
+        $fileConstantUseImportTypes = $this->constantUseImportTypesInFilePath[$filePath] ?? [];
+
+        foreach ($fileConstantUseImportTypes as $fileConstantUseImportType) {
+            if ($fileConstantUseImportType->getShortName() === $shortName) {
+                return true;
+            }
+        }
+
         $fileFunctionUseImportTypes = $this->functionUseImportTypesInFilePath[$filePath] ?? [];
 
         foreach ($fileFunctionUseImportTypes as $fileFunctionUseImportType) {
@@ -122,6 +143,13 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
             }
         }
 
+        $constantImports = $this->constantUseImportTypesInFilePath[$filePath] ?? [];
+        foreach ($constantImports as $constantImport) {
+            if ($fullyQualifiedObjectType->equals($constantImport)) {
+                return true;
+            }
+        }
+
         $functionImports = $this->functionUseImportTypesInFilePath[$filePath] ?? [];
         foreach ($functionImports as $functionImport) {
             if ($fullyQualifiedObjectType->equals($functionImport)) {
@@ -138,6 +166,14 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
     public function getObjectImportsByFilePath(string $filePath): array
     {
         return $this->useImportTypesInFilePath[$filePath] ?? [];
+    }
+
+    /**
+     * @return FullyQualifiedObjectType[]
+     */
+    public function getConstantImportsByFilePath(string $filePath): array
+    {
+        return $this->constantUseImportTypesInFilePath[$filePath] ?? [];
     }
 
     /**

--- a/packages/StaticTypeMapper/ValueObject/Type/AliasedObjectType.php
+++ b/packages/StaticTypeMapper/ValueObject/Type/AliasedObjectType.php
@@ -29,13 +29,19 @@ final class AliasedObjectType extends ObjectType
         return $this->fullyQualifiedClass;
     }
 
-    public function getUseNode(): Use_
+    public function getUseNode(?int $useType = null): Use_
     {
         $name = new Name($this->fullyQualifiedClass);
         $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
 
         $useUse = new UseUse($name, $this->getClassName());
-        return new Use_([$useUse]);
+
+        $use = new Use_([$useUse]);
+        if ($useType !== null) {
+            $use->type = $useType;
+        }
+
+        return $use;
     }
 
     public function getShortName(): string
@@ -46,32 +52,6 @@ final class AliasedObjectType extends ObjectType
     public function areShortNamesEqual(self | FullyQualifiedObjectType $comparedObjectType): bool
     {
         return $this->getShortName() === $comparedObjectType->getShortName();
-    }
-
-    public function getConstantUseNode(): Use_
-    {
-        $name = new Name($this->fullyQualifiedClass);
-        $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
-
-        $useUse = new UseUse($name, $this->getClassName());
-
-        $use = new Use_([$useUse]);
-        $use->type = Use_::TYPE_CONSTANT;
-
-        return $use;
-    }
-
-    public function getFunctionUseNode(): Use_
-    {
-        $name = new Name($this->fullyQualifiedClass);
-        $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
-
-        $useUse = new UseUse($name, $this->getClassName());
-
-        $use = new Use_([$useUse]);
-        $use->type = Use_::TYPE_FUNCTION;
-
-        return $use;
     }
 
     public function equals(Type $type): bool

--- a/packages/StaticTypeMapper/ValueObject/Type/AliasedObjectType.php
+++ b/packages/StaticTypeMapper/ValueObject/Type/AliasedObjectType.php
@@ -48,6 +48,19 @@ final class AliasedObjectType extends ObjectType
         return $this->getShortName() === $comparedObjectType->getShortName();
     }
 
+    public function getConstantUseNode(): Use_
+    {
+        $name = new Name($this->fullyQualifiedClass);
+        $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
+
+        $useUse = new UseUse($name, $this->getClassName());
+
+        $use = new Use_([$useUse]);
+        $use->type = Use_::TYPE_CONSTANT;
+
+        return $use;
+    }
+
     public function getFunctionUseNode(): Use_
     {
         $name = new Name($this->fullyQualifiedClass);

--- a/packages/StaticTypeMapper/ValueObject/Type/FullyQualifiedObjectType.php
+++ b/packages/StaticTypeMapper/ValueObject/Type/FullyQualifiedObjectType.php
@@ -58,6 +58,19 @@ final class FullyQualifiedObjectType extends ObjectType
         return new Use_([$useUse]);
     }
 
+    public function getConstantUseNode(): Use_
+    {
+        $name = new Name($this->getClassName());
+        $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
+
+        $useUse = new UseUse($name, null);
+
+        $use = new Use_([$useUse]);
+        $use->type = Use_::TYPE_CONSTANT;
+
+        return $use;
+    }
+
     public function getFunctionUseNode(): Use_
     {
         $name = new Name($this->getClassName());

--- a/packages/StaticTypeMapper/ValueObject/Type/FullyQualifiedObjectType.php
+++ b/packages/StaticTypeMapper/ValueObject/Type/FullyQualifiedObjectType.php
@@ -48,38 +48,17 @@ final class FullyQualifiedObjectType extends ObjectType
         return $name;
     }
 
-    public function getUseNode(): Use_
+    public function getUseNode(?int $useType = null): Use_
     {
         $name = new Name($this->getClassName());
         $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
 
         $useUse = new UseUse($name);
 
-        return new Use_([$useUse]);
-    }
-
-    public function getConstantUseNode(): Use_
-    {
-        $name = new Name($this->getClassName());
-        $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
-
-        $useUse = new UseUse($name, null);
-
         $use = new Use_([$useUse]);
-        $use->type = Use_::TYPE_CONSTANT;
-
-        return $use;
-    }
-
-    public function getFunctionUseNode(): Use_
-    {
-        $name = new Name($this->getClassName());
-        $name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
-
-        $useUse = new UseUse($name, null);
-
-        $use = new Use_([$useUse]);
-        $use->type = Use_::TYPE_FUNCTION;
+        if ($useType !== null) {
+            $use->type = $useType;
+        }
 
         return $use;
     }

--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/FixtureConstant/double_import_constant.php.inc
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/FixtureConstant/double_import_constant.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\FixtureConstant;
+
+class DoubleImportConstant
+{
+    public function create()
+    {
+        return \Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Constant_\MY_BEAUTIFUL_CONSTANT;
+    }
+
+    public function emulate()
+    {
+        return \Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Constant_\MY_BEAUTIFUL_CONSTANT;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\FixtureConstant;
+
+use const Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Constant_\MY_BEAUTIFUL_CONSTANT;
+class DoubleImportConstant
+{
+    public function create()
+    {
+        return MY_BEAUTIFUL_CONSTANT;
+    }
+
+    public function emulate()
+    {
+        return MY_BEAUTIFUL_CONSTANT;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/FixtureNonNamespaced/constant_import.php.inc
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/FixtureNonNamespaced/constant_import.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+class ImportConstantWithoutNamespace
+{
+    public function run()
+    {
+        return \Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Constant_\MY_BEAUTIFUL_CONSTANT;
+    }
+}
+
+?>
+-----
+<?php
+
+use const Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Constant_\MY_BEAUTIFUL_CONSTANT;
+class ImportConstantWithoutNamespace
+{
+    public function run()
+    {
+        return MY_BEAUTIFUL_CONSTANT;
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
@@ -14,6 +14,7 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 final class ImportFullyQualifiedNamesRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
+    #[DataProvider('provideDataConstant')]
     #[DataProvider('provideDataFunction')]
     #[DataProvider('provideDataGeneric')]
     public function test(string $filePath): void
@@ -24,6 +25,11 @@ final class ImportFullyQualifiedNamesRectorTest extends AbstractRectorTestCase
     public static function provideData(): Iterator
     {
         return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public static function provideDataConstant(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureConstant');
     }
 
     public static function provideDataFunction(): Iterator

--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Source/Constant_/constant.php
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Source/Constant_/constant.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Constant_;
+
+const MY_BEAUTIFUL_CONSTANT = 'my_beautiful_constant';

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -188,21 +188,20 @@ final class UseImportsAdder
         ?string $namespaceName
     ): array {
         $newUses = [];
-        // ["getter" => [object types]]
         $importsMapping = [
-            'getUseNode' => $useImportTypes,
-            'getConstantUseNode' => $constantUseImportTypes,
-            'getFunctionUseNode' => $functionUseImportTypes,
+            Use_::TYPE_NORMAL => $useImportTypes,
+            Use_::TYPE_CONSTANT => $constantUseImportTypes,
+            Use_::TYPE_FUNCTION => $functionUseImportTypes,
         ];
 
-        foreach ($importsMapping as $nodeGetter => $objectTypes) {
-            foreach ($objectTypes as $objectType) {
-                if ($namespaceName !== null && $this->isCurrentNamespace($namespaceName, $objectType)) {
+        foreach ($importsMapping as $type => $importTypes) {
+            foreach ($importTypes as $importType) {
+                if ($namespaceName !== null && $this->isCurrentNamespace($namespaceName, $importType)) {
                     continue;
                 }
 
                 // already imported in previous cycle
-                $newUses[] = $objectType->{$nodeGetter}();
+                $newUses[] = $importType->getUseNode($type);
             }
         }
 

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -188,31 +188,22 @@ final class UseImportsAdder
         ?string $namespaceName
     ): array {
         $newUses = [];
-        foreach ($useImportTypes as $useImportType) {
-            if ($namespaceName !== null && $this->isCurrentNamespace($namespaceName, $useImportType)) {
-                continue;
+        // ["getter" => [object types]]
+        $importsMapping = [
+            'getUseNode' => $useImportTypes,
+            'getConstantUseNode' => $constantUseImportTypes,
+            'getFunctionUseNode' => $functionUseImportTypes,
+        ];
+
+        foreach ($importsMapping as $nodeGetter => $objectTypes) {
+            foreach ($objectTypes as $objectType) {
+                if ($namespaceName !== null && $this->isCurrentNamespace($namespaceName, $objectType)) {
+                    continue;
+                }
+
+                // already imported in previous cycle
+                $newUses[] = $objectType->{$nodeGetter}();
             }
-
-            // already imported in previous cycle
-            $newUses[] = $useImportType->getUseNode();
-        }
-
-        foreach ($constantUseImportTypes as $constantUseImportType) {
-            if ($namespaceName !== null && $this->isCurrentNamespace($namespaceName, $constantUseImportType)) {
-                continue;
-            }
-
-            // already imported in previous cycle
-            $newUses[] = $constantUseImportType->getConstantUseNode();
-        }
-
-        foreach ($functionUseImportTypes as $functionUseImportType) {
-            if ($namespaceName !== null && $this->isCurrentNamespace($namespaceName, $functionUseImportType)) {
-                continue;
-            }
-
-            // already imported in previous cycle
-            $newUses[] = $functionUseImportType->getFunctionUseNode();
         }
 
         return $newUses;

--- a/rules/CodingStyle/ClassNameImport/UseImportsTraverser.php
+++ b/rules/CodingStyle/ClassNameImport/UseImportsTraverser.php
@@ -33,6 +33,15 @@ final class UseImportsTraverser
      * @param Stmt[] $stmts
      * @param callable(UseUse $useUse, string $name): void $callable
      */
+    public function traverserStmtsForConstants(array $stmts, callable $callable): void
+    {
+        $this->traverseForType($stmts, $callable, Use_::TYPE_CONSTANT);
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     * @param callable(UseUse $useUse, string $name): void $callable
+     */
     public function traverserStmtsForFunctions(array $stmts, callable $callable): void
     {
         $this->traverseForType($stmts, $callable, Use_::TYPE_FUNCTION);

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -60,7 +60,7 @@ final class UsedImportsResolver
      */
     public function resolveConstantImportsForStmts(array $stmts): array
     {
-        $usedFunctionImports = [];
+        $usedConstImports = [];
 
         $this->useImportsTraverser->traverserStmtsForConstants($stmts, static function (
             UseUse $useUse,

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -69,7 +69,7 @@ final class UsedImportsResolver
             $usedConstImports[] = new FullyQualifiedObjectType($name);
         });
 
-        return $usedFunctionImports;
+        return $usedConstImports;
     }
 
     /**

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -65,7 +65,7 @@ final class UsedImportsResolver
         $this->useImportsTraverser->traverserStmtsForConstants($stmts, static function (
             UseUse $useUse,
             string $name
-        ) use (&$usedFunctionImports): void {
+        ) use (&$usedConstImports): void {
             $usedFunctionImports[] = new FullyQualifiedObjectType($name);
         });
 

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -58,6 +58,24 @@ final class UsedImportsResolver
      * @param Stmt[] $stmts
      * @return FullyQualifiedObjectType[]
      */
+    public function resolveConstantImportsForStmts(array $stmts): array
+    {
+        $usedFunctionImports = [];
+
+        $this->useImportsTraverser->traverserStmtsForConstants($stmts, static function (
+            UseUse $useUse,
+            string $name
+        ) use (&$usedFunctionImports): void {
+            $usedFunctionImports[] = new FullyQualifiedObjectType($name);
+        });
+
+        return $usedFunctionImports;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     * @return FullyQualifiedObjectType[]
+     */
     public function resolveFunctionImportsForStmts(array $stmts): array
     {
         $usedFunctionImports = [];

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -66,7 +66,7 @@ final class UsedImportsResolver
             UseUse $useUse,
             string $name
         ) use (&$usedConstImports): void {
-            $usedFunctionImports[] = new FullyQualifiedObjectType($name);
+            $usedConstImports[] = new FullyQualifiedObjectType($name);
         });
 
         return $usedFunctionImports;

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -131,6 +131,8 @@ final class NameImporter
 
         if ($name->getAttribute(AttributeKey::IS_FUNCCALL_NAME) === true) {
             $this->useNodesToAddCollector->addFunctionUseImport($fullyQualifiedObjectType);
+        } elseif ($name->getAttribute(AttributeKey::IS_CONSTFETCH_NAME) === true) {
+            $this->useNodesToAddCollector->addConstantUseImport($fullyQualifiedObjectType);
         } else {
             $this->useNodesToAddCollector->addUseImport($fullyQualifiedObjectType);
         }

--- a/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/ReturnTypeFromStrictTernaryRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
         $ternary = $return->expr;
 
         $returnScope = $return->expr->getAttribute(AttributeKey::SCOPE);
-        if (!$returnScope instanceof Scope) {
+        if (! $returnScope instanceof Scope) {
             return null;
         }
 


### PR DESCRIPTION
Hi there 👋 

In one of our project, we are using constants defined outside of a class, those constants are defined by a PHP extension.
We've been facing issues with Rector trying to replace the usage of those constants by imports incorrectly.

This PR extends the names importing logic to import constants the right way, really similar to the logic for functions imports.

Here is a simplified example of the situation in our project:

```php
namespace App;

final class Pkcs11Encryptor
{
    private function findKey(string $keyName): object
    {
        $objects = $this->session->findObjects([
            \Pkcs11\CKA_LABEL => $keyName, // <-- Rector wants to replace this by an import
        ]);

        // Rest of the logic...
    }
}
```

The current names import logic will result in the following:

```php
namespace App;

use Pkcs11\CKA_LABEL; // <-- This is broken "Class CKA_LABEL is not defined..."

final class Pkcs11Encryptor
{
    private function findKey(string $keyName): object
    {
        $objects = $this->session->findObjects([
            CKA_LABEL => $keyName, // <-- Replaced by import
        ]);

        // Rest of the logic...
    }
}
```

The logic from this PR will result in the following:

```php
namespace App;

use const Pkcs11\CKA_LABEL; // <-- Special import for constant

final class Pkcs11Encryptor
{
    private function findKey(string $keyName): object
    {
        $objects = $this->session->findObjects([
            CKA_LABEL => $keyName, // <-- Replaced by import
        ]);

        // Rest of the logic...
    }
}
```