### PR TITLE
Create skip_call_by_ref_method_scope.php.inc

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_call_by_ref_method_scope.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_call_by_ref_method_scope.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class Simulation
+{
+    public function __construct(
+        private OutputInterface $output,
+        private readonly Composer $composer,
+        private readonly string $targetDirectory,
+    ) {
+    }
+    
+    public function prepare(): void
+    {
+        $exitCode = $composer->install(
+            $this->targetDirectory.'/composer.json',
+            $this->output,
+        );
+    }
+}
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class Composer
+{
+    public function install(
+        string $composerJson,
+        OutputInterface &$output = null,
+    ): int {
+        $input = new ArrayInput([
+            'command' => 'install',
+            '--working-dir' => dirname($composerJson),
+        ]);
+        
+        if (null === $output) {
+            $output = new BufferedOutput();
+        }
+        
+        $application = new Application();
+        $application->setAutoExit(false);
+
+        return $application->run($input, $output);
+    }
+}
+?>

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_call_by_ref_method_scope.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_call_by_ref_method_scope.php.inc
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-
-namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
 
 final class Simulation
 {
@@ -25,8 +25,6 @@ final class Simulation
         );
     }
 }
-
-namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
 
 final class Composer
 {


### PR DESCRIPTION
This PR is a follow-up to #4593. It adds a failing test case to showcase the expected behavior when passing non-readonly properties by reference in a method other than the constructor.

See https://github.com/rectorphp/rector-src/pull/4593#issuecomment-1653027106 for more details.