### PR TITLE
Skip readonly with new static call

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_readonly_new_static.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_readonly_new_static.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+class SkipReadonlyNewStatic
+{
+    private string $method;
+    
+    public static function create(): static
+    {
+        $self = new static();
+        $self->method = 'hi';
+        $self->method = 'hello';
+        return $self;
+    }
+}
+
+?>


### PR DESCRIPTION
Add new fixture for readonly including a `new static()`

Reference for this fixture is: https://github.com/rectorphp/rector/issues/8095