### PR TITLE
[CodingStyle] Handle crash on empty cases on BinarySwitchToIfElseRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Switch_/BinarySwitchToIfElseRector/Fixture/skip_empty_cases.php.inc
+++ b/rules-tests/CodingStyle/Rector/Switch_/BinarySwitchToIfElseRector/Fixture/skip_empty_cases.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Switch_\BinarySwitchToIfElseRector\Fixture;
+
+final class SkipEmptyCases
+{
+    public function run()
+    {
+        switch(true) {
+        }
+    }
+}

--- a/rules/CodingStyle/Rector/Switch_/BinarySwitchToIfElseRector.php
+++ b/rules/CodingStyle/Rector/Switch_/BinarySwitchToIfElseRector.php
@@ -69,7 +69,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (count($node->cases) > 2) {
+        if ($node->cases === [] || count($node->cases) > 2) {
             return null;
         }
 

--- a/src/PhpParser/NodeFinder/PropertyFetchFinder.php
+++ b/src/PhpParser/NodeFinder/PropertyFetchFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\PhpParser\NodeFinder;
 
+use PHPStan\Type\StaticType;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
@@ -141,7 +142,7 @@ final class PropertyFetchFinder
         }
 
         $type = $this->nodeTypeResolver->getType($expr->var);
-        if ($type instanceof \PHPStan\Type\StaticType || $type instanceof FullyQualifiedObjectType) {
+        if ($type instanceof StaticType || $type instanceof FullyQualifiedObjectType) {
             return $this->nodeNameResolver->isName($class, $type->getClassName());
         }
 


### PR DESCRIPTION
Given the following code:

```php
        switch(true) {
        }
```

it cause crash:

```
1 test triggered 1 PHP warning:

1) Rector\Tests\CodingStyle\Rector\Switch_\BinarySwitchToIfElseRector\BinarySwitchToIfElseRectorTest::test with data set #5
Attempt to read property "cond" on null
/Users/samsonasik/www/rector-src/rules/CodingStyle/Rector/Switch_/BinarySwitchToIfElseRector.php:81
```

see warning at:

https://github.com/rectorphp/rector-src/actions/runs/5699733738/job/15448931304#step:5:34

Ref https://getrector.com/demo/075d1acc-887a-4c89-852c-761bb3d57417
This PR try to fix it.