### PR TITLE
[Php73] Handle crash Type Error on JsonThrowOnErrorRector

### DIFF
--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_with_constant.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_with_constant.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+class SkipWithConstant
+{
+    private const MIN_DELAY = 1000;
+
+    private const MAX_DELAY = self::MIN_DELAY * 60 * 10;
+
+    public function getWaitingTime(): int
+    {
+        return min(self::MAX_DELAY, 0);
+    }
+}

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -28,6 +28,7 @@ use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use TypeError;
 
 /**
  * @see \Rector\Core\Tests\PhpParser\Node\Value\ValueResolverTest
@@ -156,7 +157,7 @@ final class ValueResolver
         try {
             $constExprEvaluator = $this->getConstExprEvaluator();
             return $constExprEvaluator->evaluateDirectly($expr);
-        } catch (ConstExprEvaluationException) {
+        } catch (ConstExprEvaluationException|TypeError) {
         }
 
         return null;


### PR DESCRIPTION
Given the following code:

```php
class SkipWithConstant
{
    private const MIN_DELAY = 1000;

    private const MAX_DELAY = self::MIN_DELAY * 60 * 10;

    public function getWaitingTime(): int
    {
        return min(self::MAX_DELAY, 0);
    }
}
```

It currently produce error:

```bash
There was 1 error:

1) Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\JsonThrowOnErrorRectorTest::test with data set #7
TypeError: Unsupported operand types: string * int

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ConstExprEvaluator.php:131
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ConstExprEvaluator.php:204
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ConstExprEvaluator.php:131
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/ConstExprEvaluator.php:101
```

This PR try to fix it.
Fixes https://github.com/rectorphp/rector/issues/8102