### PR TITLE
[TypeDeclaration] Skip has parent class method on AddParamTypeFromPropertyTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Fixture/skip_override_from_parent.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Fixture/skip_override_from_parent.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector\Source\ParentWithNumber;
+
+final class SkipOverrideFromParent extends ParentWithNumber
+{
+    protected function getNumber($number)
+    {
+        $this->number = $number;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Source/ParentWithNumber.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Source/ParentWithNumber.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector\Source;
+
+class ParentWithNumber
+{
+    protected string $number;
+
+    abstract protected function getNumber($number);
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
@@ -18,6 +18,7 @@ use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -36,6 +37,7 @@ final class AddParamTypeFromPropertyTypeRector extends AbstractRector implements
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private readonly TypeFactory $typeFactory,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
     ) {
     }
 
@@ -119,6 +121,10 @@ CODE_SAMPLE
             $paramType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($possibleParamType, TypeKind::PARAM);
             if (! $paramType instanceof Node) {
                 continue;
+            }
+
+            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
+                return null;
             }
 
             $param->type = $paramType;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8098