### PR TITLE
[TypeDeclaration] Set minimum php version for AddReturnTypeDeclarationBasedOnParentClassMethodRector to php 7.0

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
@@ -37,7 +37,7 @@ final class AddReturnTypeDeclarationBasedOnParentClassMethodRector extends Abstr
 
     public function provideMinPhpVersion(): int
     {
-        return PhpVersionFeature::FATAL_ERROR_ON_INCOMPATIBLE_METHOD_SIGNATURE;
+        return PhpVersionFeature::SCALAR_TYPES;
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/8104#issuecomment-1665498815

Ref https://getrector.com/demo/ed7376e7-fd2a-41c2-a6a8-dbf76aa66eda

@TomasVotruba @staabm here the existing rule for match child with parent return type `AddReturnTypeDeclarationBasedOnParentClassMethodRector`, the existing functionality require php 8.0.

This PR make it available when for code configured php 7.0 as it already fatal error on php 7.0 https://3v4l.org/XC1kR#v7.0.33