### PR TITLE
[CodingStyle][Php80][Privatization] Handle SeparateMultiUseImportsRector+ClassPropertyAssignToConstructorPromotionRector+FinalizeClassesWithoutChildrenRector cause invalid removal

### DIFF
--- a/rules/CodingStyle/Rector/Use_/SeparateMultiUseImportsRector.php
+++ b/rules/CodingStyle/Rector/Use_/SeparateMultiUseImportsRector.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Rector\CodingStyle\Rector\Use_;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\TraitUse;
 use PhpParser\Node\Stmt\Use_;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -51,20 +54,45 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Use_::class, TraitUse::class];
+        return [FileWithoutNamespace::class, Namespace_::class, Class_::class];
     }
 
     /**
-     * @param Use_|TraitUse $node
+     * @param FileWithoutNamespace|Namespace_|Class_ $node
      * @return Use_[]|TraitUse[]|null
      */
-    public function refactor(Node $node): ?array
+    public function refactor(Node $node): FileWithoutNamespace|Namespace_|Class_|null
     {
-        if ($node instanceof Use_) {
-            return $this->refactorUseImport($node);
+        $hasChanged = false;
+        foreach ($node->stmts as $key => $stmt) {
+            if ($stmt instanceof Use_) {
+                $refactorUseImport = $this->refactorUseImport($stmt);
+                if ($refactorUseImport !== null) {
+                    unset($node->stmts[$key]);
+                    array_splice($node->stmts, $key, 0, $refactorUseImport);
+
+                    $hasChanged = true;
+                }
+
+                continue;
+            }
+
+            if ($stmt instanceof TraitUse) {
+                $refactorTraitUse = $this->refactorTraitUse($stmt);
+                if ($refactorTraitUse !== null) {
+                    unset($node->stmts[$key]);
+                    array_splice($node->stmts, $key, 0, $refactorTraitUse);
+
+                    $hasChanged = true;
+                }
+            }
         }
 
-        return $this->refactorTraitUse($node);
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
     }
 
     /**

--- a/rules/CodingStyle/Rector/Use_/SeparateMultiUseImportsRector.php
+++ b/rules/CodingStyle/Rector/Use_/SeparateMultiUseImportsRector.php
@@ -59,7 +59,6 @@ CODE_SAMPLE
 
     /**
      * @param FileWithoutNamespace|Namespace_|Class_ $node
-     * @return Use_[]|TraitUse[]|null
      */
     public function refactor(Node $node): FileWithoutNamespace|Namespace_|Class_|null
     {

--- a/tests/Issues/IssueTraitUseKey/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueTraitUseKey/Fixture/fixture.php.inc
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueTraitUseKey\Fixture;
+
+use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitA;
+use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitB;
+
+class Fixture
+{
+    use TraitA, TraitB;
+
+    public const PUBLIC_CONST = 2;
+
+    private const PRIVATE_CONST = 1;
+
+    protected $foo;
+
+    public $bar;
+
+    public function __construct(int $foo, int $bar)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    public function getConst(): int
+    {
+        return self::PRIVATE_CONST ?? self::PUBLIC_CONST;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueTraitUseKey\Fixture;
+
+use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitA;
+use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitB;
+
+final class Fixture
+{
+    use TraitA;
+    use TraitB;
+
+    public const PUBLIC_CONST = 2;
+
+    private const PRIVATE_CONST = 1;
+
+    public function __construct(protected int $foo, public int $bar)
+    {
+    }
+
+    public function getConst(): int
+    {
+        return self::PRIVATE_CONST ?? self::PUBLIC_CONST;
+    }
+}
+
+?>

--- a/tests/Issues/IssueTraitUseKey/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueTraitUseKey/Fixture/fixture.php.inc
@@ -46,7 +46,6 @@ final class Fixture
 {
     use TraitA;
     use TraitB;
-
     public const PUBLIC_CONST = 2;
 
     private const PRIVATE_CONST = 1;

--- a/tests/Issues/IssueTraitUseKey/IssueTraitUseKeyTest.php
+++ b/tests/Issues/IssueTraitUseKey/IssueTraitUseKeyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueTraitUseKey;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class IssueTraitUseKeyTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssueTraitUseKey/Source/TraitA.php
+++ b/tests/Issues/IssueTraitUseKey/Source/TraitA.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueTraitUseKey;
+
+trait TraitA
+{
+}

--- a/tests/Issues/IssueTraitUseKey/Source/TraitB.php
+++ b/tests/Issues/IssueTraitUseKey/Source/TraitB.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\IssueTraitUseKey;
+
+trait TraitB
+{
+}

--- a/tests/Issues/IssueTraitUseKey/config/configured_rule.php
+++ b/tests/Issues/IssueTraitUseKey/config/configured_rule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
 use Rector\CodingStyle\Rector\Use_\SeparateMultiUseImportsRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;

--- a/tests/Issues/IssueTraitUseKey/config/configured_rule.php
+++ b/tests/Issues/IssueTraitUseKey/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\CodingStyle\Rector\Use_\SeparateMultiUseImportsRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(SeparateMultiUseImportsRector::class);
+    $rectorConfig->rule(ClassPropertyAssignToConstructorPromotionRector::class);
+    $rectorConfig->rule(FinalizeClassesWithoutChildrenRector::class);
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8114