### PR TITLE
[CodeQuality][TypeDeclaration] Add string append support on ReturnTypeFromStrictScalarReturnExprRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/string_append_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/Fixture/string_append_variable.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\Fixture;
+
+class StringAppendVariable
+{
+    public function resolve(array $data)
+    {
+        $content = '';
+
+        foreach ($data as $value) {
+            $content .= $value;
+        }
+
+        return $content;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\Fixture;
+
+class StringAppendVariable
+{
+    public function resolve(array $data): string
+    {
+        $content = '';
+
+        foreach ($data as $value) {
+            $content .= $value;
+        }
+
+        return $content;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -69,12 +69,17 @@ final class AlwaysStrictScalarExprAnalyzer
             return $this->resolveFuncCallType($expr, $scope);
         }
 
+        $exprType = $this->nodeTypeResolver->getNativeType($expr);
+        if ($this->isScalarType($exprType)) {
+            return $exprType;
+        }
+
         return null;
     }
 
     private function resolveCastType(Cast $cast): ?Type
     {
-        $type = $this->nodeTypeResolver->getType($cast);
+        $type = $this->nodeTypeResolver->getNativeType($cast);
         if ($this->isScalarType($type)) {
             return $type;
         }


### PR DESCRIPTION
Given the following code:

```php
class StringAppendVariable
{
    public function resolve(array $data)
    {
        $content = '';

        foreach ($data as $value) {
            $content .= $value;
        }

        return $content;
    }
}
```

should result:

```diff
-    public function resolve(array $data)
+    public function resolve(array $data): string
```

as it returns appended from initialized string content variable.