### PR TITLE
[TypeDeclaration] Skip public method on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_public_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_public_method.php.inc
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
 
-abstract class SkipPublicMethodWithDefaultValue
+abstract class SkipPublicMethod
 {
     public function toJson()
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_public_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_public_method.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+abstract class SkipPublicMethodWithDefaultValue
+{
+    public function toJson()
+    {
+        return $this->toArray(true);
+    }
+
+    public function __toString()
+    {
+        return implode(', ', $this->toArray());
+    }
+
+    final public function toArray($cols = false)
+    {
+        if ((! is_bool($cols)) && (! is_array($cols))) {
+            throw new Exception('Invalid value cols');
+        }
+    }
+
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
@@ -100,8 +100,10 @@ CODE_SAMPLE
                     && $node->implements === []
                 )
                 || $method->isPrivate();
-
-            if (! $isPrivate || $method->isPublic()) {
+            if (! $isPrivate) {
+                continue;
+            }
+            if ($method->isPublic()) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
@@ -103,6 +103,7 @@ CODE_SAMPLE
             if (! $isPrivate) {
                 continue;
             }
+
             if ($method->isPublic()) {
                 continue;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
                 )
                 || $method->isPrivate();
 
-            if (! $isPrivate) {
+            if (! $isPrivate || $method->isPublic()) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8116

@staabm as protected with final class checked at PR:

- https://github.com/rectorphp/rector-src/pull/4611

let's exclude next public method.