### PR TITLE
[NodeTypeResolver][Performance] Use isset of nodeTypeResolvers instead of double loop on resolve node type resolver by node

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -326,12 +326,10 @@ final class NodeTypeResolver
 
     private function resolveByNodeTypeResolvers(Node $node): ?Type
     {
-        foreach ($this->nodeTypeResolvers as $nodeClass => $nodeTypeResolver) {
-            if (! $node instanceof $nodeClass) {
-                continue;
-            }
+        $nodeClass = $node::class;
 
-            return $nodeTypeResolver->resolve($node);
+        if (isset($this->nodeTypeResolvers[$nodeClass])) {
+            return $this->nodeTypeResolvers[$nodeClass]->resolve($node);
         }
 
         return null;


### PR DESCRIPTION
`nodeTypeResolvers` array data already filled on `__construct()` so no need to double loop.

https://github.com/rectorphp/rector-src/blob/22e423dc79a8e4677198c8b260fb24243db0ea45/packages/NodeTypeResolver/NodeTypeResolver.php#L64-L68