### PR TITLE
[TypeDeclaration] Handle anonymous class in union on AddArrowFunctionReturnTypeRector

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -249,11 +249,6 @@ final class NodeTypeResolver
         return $this->accessoryNonEmptyStringTypeCorrector->correct($type);
     }
 
-    private function isAnonymousObjectType(Type $type): bool
-    {
-        return $type instanceof ObjectType && $this->classAnalyzer->isAnonymousClassName($type->getClassName());
-    }
-
     public function isNumberType(Expr $expr): bool
     {
         $nodeType = $this->getType($expr);
@@ -324,6 +319,11 @@ final class NodeTypeResolver
         }
 
         return $classReflection->isSubclassOf($objectType->getClassName());
+    }
+
+    private function isAnonymousObjectType(Type $type): bool
+    {
+        return $type instanceof ObjectType && $this->classAnalyzer->isAnonymousClassName($type->getClassName());
     }
 
     private function isUnionTypeable(Type $first, Type $second): bool

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -216,8 +216,8 @@ final class NodeTypeResolver
             return new MixedType();
         }
 
-        // cover anonymous class
-        if ($expr instanceof New_ && $this->classAnalyzer->isAnonymousClass($expr->class)) {
+        // cover direct New_ class
+        if ($this->classAnalyzer->isAnonymousClass($expr)) {
             $type = $this->nodeTypeResolvers[New_::class]->resolve($expr);
             if ($type instanceof ObjectWithoutClassType) {
                 return $type;
@@ -225,12 +225,33 @@ final class NodeTypeResolver
         }
 
         $type = $scope->getNativeType($expr);
-        // ObjectType anonymous may be assigned first, fallback to ObjectWithoutClassType
-        if ($type instanceof ObjectType && $this->classAnalyzer->isAnonymousClassName($type->getClassName())) {
-            return new ObjectWithoutClassType();
+        if (! $type instanceof UnionType) {
+            if ($this->isAnonymousObjectType($type)) {
+                return new ObjectWithoutClassType();
+            }
+
+            return $this->accessoryNonEmptyStringTypeCorrector->correct($type);
+        }
+
+        $hasChanged = false;
+        $types = $type->getTypes();
+        foreach ($types as $key => $childType) {
+            if ($this->isAnonymousObjectType($childType)) {
+                $types[$key] = new ObjectWithoutClassType();
+                $hasChanged = true;
+            }
+        }
+
+        if ($hasChanged) {
+            return $this->accessoryNonEmptyStringTypeCorrector->correct(new UnionType($types));
         }
 
         return $this->accessoryNonEmptyStringTypeCorrector->correct($type);
+    }
+
+    private function isAnonymousObjectType(Type $type): bool
+    {
+        return $type instanceof ObjectType && $this->classAnalyzer->isAnonymousClassName($type->getClassName());
     }
 
     public function isNumberType(Expr $expr): bool

--- a/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/union_type_with_anonymous_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/union_type_with_anonymous_class.php.inc
@@ -20,7 +20,7 @@ class UnionTypeWithAnonymousClass
 {
     public function run()
     {
-        fn () => rand(0, 1) ? new class {} : true;
+        fn (): object|bool => rand(0, 1) ? new class {} : true;
     }
 }
 

--- a/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/union_type_with_anonymous_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/union_type_with_anonymous_class.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class UnionTypeWithAnonymousClass
+{
+    public function run()
+    {
+        fn () => rand(0, 1) ? new class {} : true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class UnionTypeWithAnonymousClass
+{
+    public function run()
+    {
+        fn () => rand(0, 1) ? new class {} : true;
+    }
+}
+
+?>

--- a/src/NodeAnalyzer/ClassAnalyzer.php
+++ b/src/NodeAnalyzer/ClassAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
@@ -27,7 +28,7 @@ final class ClassAnalyzer
     public function isAnonymousClass(Node $node): bool
     {
         if (! $node instanceof Class_) {
-            return false;
+            return $node instanceof New_ && $this->isAnonymousClass($node->class);
         }
 
         if ($node->isAnonymous()) {


### PR DESCRIPTION
Given the following code:

```php
class UnionTypeWithAnonymousClass
{
    public function run()
    {
        fn () => rand(0, 1) ? new class {} : true;
    }
}
```

It currently produce:

```diff
+        fn (): \AnonymousClass8f0e16dd866a4cd6ee65b7ec688a5ed6|bool => rand(0, 1) ? new class {} : true;
```

which should be:

```diff
+        fn (): object|bool => rand(0, 1) ? new class {} : true;
```

This PR try to fix it.