### PR TITLE
[TypeDeclaration] Use return bool for ParentClassMethodTypeOverrideGuard::hasParentClassMethod(), return ?MethodReflection for ParentClassMethodTypeOverrideGuard::getParentClassMethod()

### DIFF
--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -34,7 +34,8 @@ final class ParentClassMethodTypeOverrideGuard
 
             return $parentClassMethod instanceof MethodReflection;
         } catch (UnresolvableClassException) {
-            // we don't know all involved parents, marking as parent exists
+            // we don't know all involved parents,
+            // marking as parent exists which usually means the method is guarded against overrides.
             return true;
         }
     }

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -27,15 +27,15 @@ final class ParentClassMethodTypeOverrideGuard
     ) {
     }
 
-    public function hasParentClassMethod(ClassMethod $classMethod): ?bool
+    public function hasParentClassMethod(ClassMethod $classMethod): bool
     {
         try {
             $parentClassMethod = $this->resolveParentClassMethod($classMethod);
 
             return $parentClassMethod instanceof MethodReflection;
         } catch (UnresolvableClassException) {
-            // we don't know all involved parents.
-            return null;
+            // we don't know all involved parents, marking as parent exists
+            return true;
         }
     }
 
@@ -44,10 +44,7 @@ final class ParentClassMethodTypeOverrideGuard
         try {
             return $this->resolveParentClassMethod($classMethod);
         } catch (UnresolvableClassException) {
-            // we don't know all involved parents.
-            throw new ShouldNotHappenException(
-                'Unable to resolve involved class. You are likely missing hasParentClassMethod() before calling getParentClassMethod().'
-            );
+            return null;
         }
     }
 

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;

--- a/rector.php
+++ b/rector.php
@@ -61,7 +61,7 @@ return static function (RectorConfig $rectorConfig): void {
         RenameParamToMatchTypeRector::class => [
             __DIR__ . '/src/Console/Command/ListRulesCommand.php',
             __DIR__ . '/src/Configuration/ConfigInitializer.php',
-            __DIR__ . '/src/PhpParser/NodeTraverser/RectorNodeTraverser.php'
+            __DIR__ . '/src/PhpParser/NodeTraverser/RectorNodeTraverser.php',
         ],
 
         RenameVariableToMatchMethodCallReturnTypeRector::class => [__DIR__ . '/packages/Config/RectorConfig.php'],

--- a/rector.php
+++ b/rector.php
@@ -62,6 +62,7 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/Console/Command/ListRulesCommand.php',
             __DIR__ . '/src/Configuration/ConfigInitializer.php',
             __DIR__ . '/src/PhpParser/NodeTraverser/RectorNodeTraverser.php',
+            __DIR__ . '/src/DependencyInjection/LazyContainerFactory.php',
         ],
 
         RenameVariableToMatchMethodCallReturnTypeRector::class => [__DIR__ . '/packages/Config/RectorConfig.php'],

--- a/rector.php
+++ b/rector.php
@@ -61,8 +61,7 @@ return static function (RectorConfig $rectorConfig): void {
         RenameParamToMatchTypeRector::class => [
             __DIR__ . '/src/Console/Command/ListRulesCommand.php',
             __DIR__ . '/src/Configuration/ConfigInitializer.php',
-            __DIR__ . '/src/PhpParser/NodeTraverser/RectorNodeTraverser.php',
-            __DIR__ . '/src/DependencyInjection/LazyContainerFactory.php',
+            __DIR__ . '/src/PhpParser/NodeTraverser/RectorNodeTraverser.php'
         ],
 
         RenameVariableToMatchMethodCallReturnTypeRector::class => [__DIR__ . '/packages/Config/RectorConfig.php'],

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
@@ -123,7 +123,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node) !== false) {
+            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
                 return null;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -146,7 +146,7 @@ CODE_SAMPLE
             return true;
         }
 
-        return $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($classMethod) !== false;
+        return $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($classMethod);
     }
 
     private function mirrorParamType(

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -202,7 +202,7 @@ CODE_SAMPLE
         }
 
         if ($node instanceof ClassMethod) {
-            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
+            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node) !== false) {
                 return true;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -25,6 +25,7 @@ use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -36,7 +37,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
         private readonly ReturnTypeInferer $returnTypeInferer
     ) {
     }
@@ -91,7 +92,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSkipNode($node)) {
+        if ($this->shouldSkipNode($node, $scope)) {
             return null;
         }
 
@@ -195,14 +196,14 @@ CODE_SAMPLE
         return $isParamModified;
     }
 
-    private function shouldSkipNode(ClassMethod|Function_|Closure $node): bool
+    private function shouldSkipNode(ClassMethod|Function_|Closure $node, Scope $scope): bool
     {
         if ($node->returnType !== null) {
             return true;
         }
 
         if ($node instanceof ClassMethod) {
-            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
+            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope)) {
                 return true;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -202,7 +202,7 @@ CODE_SAMPLE
         }
 
         if ($node instanceof ClassMethod) {
-            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node) !== false) {
+            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
                 return true;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -25,7 +25,6 @@ use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
-use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -37,7 +36,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
         private readonly ReturnTypeInferer $returnTypeInferer
     ) {
     }
@@ -92,7 +91,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSkipNode($node, $scope)) {
+        if ($this->shouldSkipNode($node)) {
             return null;
         }
 
@@ -196,14 +195,14 @@ CODE_SAMPLE
         return $isParamModified;
     }
 
-    private function shouldSkipNode(ClassMethod|Function_|Closure $node, Scope $scope): bool
+    private function shouldSkipNode(ClassMethod|Function_|Closure $node): bool
     {
         if ($node->returnType !== null) {
             return true;
         }
 
         if ($node instanceof ClassMethod) {
-            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope)) {
+            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node) !== false) {
                 return true;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -25,7 +25,6 @@ use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
-use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -37,7 +36,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
         private readonly ReturnTypeInferer $returnTypeInferer
     ) {
     }
@@ -92,7 +91,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSkipNode($node, $scope)) {
+        if ($this->shouldSkipNode($node)) {
             return null;
         }
 
@@ -196,14 +195,14 @@ CODE_SAMPLE
         return $isParamModified;
     }
 
-    private function shouldSkipNode(ClassMethod|Function_|Closure $node, Scope $scope): bool
+    private function shouldSkipNode(ClassMethod|Function_|Closure $node): bool
     {
         if ($node->returnType !== null) {
             return true;
         }
 
         if ($node instanceof ClassMethod) {
-            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope)) {
+            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
                 return true;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictParamRector.php
@@ -25,6 +25,7 @@ use PHPStan\Type\UnionType;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -36,7 +37,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
         private readonly ReturnTypeInferer $returnTypeInferer
     ) {
     }
@@ -91,7 +92,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSkipNode($node)) {
+        if ($this->shouldSkipNode($node, $scope)) {
             return null;
         }
 
@@ -195,14 +196,14 @@ CODE_SAMPLE
         return $isParamModified;
     }
 
-    private function shouldSkipNode(ClassMethod|Function_|Closure $node): bool
+    private function shouldSkipNode(ClassMethod|Function_|Closure $node, Scope $scope): bool
     {
         if ($node->returnType !== null) {
             return true;
         }
 
         if ($node instanceof ClassMethod) {
-            if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node) !== false) {
+            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope)) {
                 return true;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
@@ -76,9 +76,7 @@ CODE_SAMPLE
     {
         $hasChanged = false;
 
-        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod(
-            $node
-        ) !== false) {
+        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
@@ -75,9 +75,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod(
-            $node
-        ) !== false) {
+        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/Param/ParamTypeFromStrictTypedPropertyRector.php
+++ b/rules/TypeDeclaration/Rector/Param/ParamTypeFromStrictTypedPropertyRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($classMethod) !== false) {
+        if ($this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($classMethod)) {
             return null;
         }
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/4619#pullrequestreview-1565014006