### PR TITLE
[TypeDeclaration] Skip param setter method intersection docblock not autoload on ReturnNeverTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_setters.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_setters.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @param Type&Parts[] $value
+     */
+    public function setter($value): void
+    {
+        $this->prop = $value;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_setters_param_intersection_docblock_not_autoload.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_setters_param_intersection_docblock_not_autoload.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
 
-final class DemoFile
+final class SkipSettersParamIntersectionDocblockNotAutoload
 {
     /**
      * @param Type&Parts[] $value
@@ -12,5 +12,3 @@ final class DemoFile
         $this->prop = $value;
     }
 }
-
-?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -141,7 +141,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $stmtType = $this->getType($stmt);
+            $stmtType = $this->nodeTypeResolver->getNativeType($stmt);
             if ($stmtType instanceof NeverType) {
                 $hasNeverType = true;
             }


### PR DESCRIPTION
Closes #4717 
Fixes https://github.com/rectorphp/rector/issues/8121