### PR TITLE
[TypeDeclaration] Skip non void or never already return typed on ReturnNeverTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_already_typed_non_void_or_never.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector/Fixture/skip_already_typed_non_void_or_never.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector\Fixture;
+
+final class SkipAlreadyTypedNonVoidOrNever
+{
+    public function run(): bool
+    {
+        return true;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -93,6 +93,10 @@ CODE_SAMPLE
 
     private function shouldSkip(ClassMethod | Function_ | Closure $node, Scope $scope): bool
     {
+        if ($node->returnType instanceof Node && ! $this->isNames($node->returnType, ['void', 'return'])) {
+            return true;
+        }
+
         $hasReturn = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, Return_::class);
         if ($hasReturn) {
             return true;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
 
     private function shouldSkip(ClassMethod | Function_ | Closure $node, Scope $scope): bool
     {
-        if ($node->returnType instanceof Node && ! $this->isNames($node->returnType, ['void', 'return'])) {
+        if ($node->returnType instanceof Node && ! $this->isName($node->returnType, 'void')) {
             return true;
         }
 


### PR DESCRIPTION
`ReturnNeverTypeRector` allow to change `void` to `never`:

https://getrector.com/demo/a1dc789f-5f71-49ab-a896-477e0365e055

so it detect the return data inside `FunctionLike`, for other than `void` or `never` and already typed, eg: `bool`, I think no need to check inside `FunctionLike`, just skipped early.