### PR TITLE
[TypeDeclaration] Allow change multiple methods on AddParamTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector/Fixture/fixture.php.inc
@@ -6,7 +6,15 @@ use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRecto
 
 class DetectedByParentInterface implements ParentInterfaceWithChangeTypeInterface
 {
+    public function notChanged($name)
+    {
+    }
+
     public function process($name)
+    {
+    }
+
+    public function run($name)
     {
     }
 }
@@ -21,7 +29,15 @@ use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRecto
 
 class DetectedByParentInterface implements ParentInterfaceWithChangeTypeInterface
 {
+    public function notChanged($name)
+    {
+    }
+
     public function process(string $name)
+    {
+    }
+
+    public function run(string $name)
     {
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector/config/configured_rule.php
@@ -23,6 +23,12 @@ return static function (RectorConfig $rectorConfig): void {
                 0,
                 new StringType()
             ),
+            new AddParamTypeDeclaration(
+                ParentInterfaceWithChangeTypeInterface::class,
+                'run',
+                0,
+                new StringType()
+            ),
             new AddParamTypeDeclaration(ParserInterface::class, 'parse', 0, new StringType()),
             new AddParamTypeDeclaration(
                 ClassMetadataFactory::class,

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -99,10 +99,10 @@ CODE_SAMPLE
 
                 $this->refactorClassMethodWithTypehintByParameterPosition($classMethod, $addParamTypeDeclaration);
             }
+        }
 
-            if (! $this->hasChanged) {
-                return null;
-            }
+        if (! $this->hasChanged) {
+            return null;
         }
 
         return $node;


### PR DESCRIPTION
Previosly, the `if (! $this->hasChanged) {` inside loop cause stop when passed method is not changed early, this change apply check `if (! $this->hasChanged) {` after the loop instead to allow by passed not changed method, then continue apply change on changed target methods.