### PR TITLE
[DX] Validate rules no longer exists on $rectorConfig->skip()

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -74,10 +74,10 @@ final class RectorConfig extends ContainerConfigurator
         SimpleParameterProvider::setParameter(Option::MEMORY_LIMIT, $memoryLimit);
     }
 
-    private function isRuleNoLongerExists(int|null|string $skipRule): bool
+    private function isRuleNoLongerExists(mixed $skipRule): bool
     {
         return
-            // direct string in list
+            // only validate string
             is_string($skipRule)
             // not regex path
             && ! str_contains($skipRule, '*')

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -312,6 +312,7 @@ parameters:
                 # for config class reflection
                 - src/Bootstrap/ExtensionConfigResolver.php
                 - config/config.php
+                - packages/Config/RectorConfig.php
 
         # use of internal phpstan classes
         -


### PR DESCRIPTION
Currently, `$rectorConfig->skip()` doesn't validate if rule no longer exists, this PR add it so user can be clean up when rule is removed or changed to different namespace.