### PR TITLE
[Php70] Remove appendArgs() usage on CallUserMethodRector

### DIFF
--- a/rules/Php70/Rector/FuncCall/CallUserMethodRector.php
+++ b/rules/Php70/Rector/FuncCall/CallUserMethodRector.php
@@ -80,7 +80,7 @@ final class CallUserMethodRector extends AbstractRector implements MinPhpVersion
         unset($oldArgs[0]);
         unset($oldArgs[1]);
 
-        $node->args = $this->appendArgs($newArgs, $oldArgs);
+        $node->args = array_merge($newArgs, $oldArgs);
 
         return $node;
     }


### PR DESCRIPTION
Use native `array_merge()` instead, after all removed, we can remove the `appendArgs()` method from `AbstractRector`.