### PR TITLE
[TypeDeclaration] Skip return has Expr even void result on AddVoidReturnTypeWhereNoReturnRector

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
@@ -1,6 +1,8 @@
 <?php
 
 declare(strict_types=1);
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTime;
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTimeInterface;
 
 use Acme\Bar\DoNotUpdateExistingTargetNamespace;
 use Rector\Config\RectorConfig;
@@ -24,8 +26,8 @@ return static function (RectorConfig $rectorConfig): void {
             'FqnizeNamespaced' => 'Abc\FqnizeNamespaced',
             OldClass::class => NewClass::class,
             // interface to class
-            \Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTime::class =>
-            \Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTimeInterface::class,
+            SomeBasicDateTime::class =>
+            SomeBasicDateTimeInterface::class,
 
             // test casing
             OldClassWithTypo::class => NewClassWithoutTypo::class,

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_return_has_expr_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_return_has_expr_void.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector\Fixture;
+
+/**
+ * Return with Expr even void result, converted to null, ref https://3v4l.org/jMmuT
+ */
+final class SkipReturnHasExprVoid
+{
+    public function getValues()
+    {
+        return $this->someVoid();
+    }
+
+    private function someVoid()
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_return_has_expr_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_return_has_expr_void.php.inc
@@ -3,7 +3,7 @@
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector\Fixture;
 
 /**
- * Return with Expr even void result, converted to null, ref https://3v4l.org/jMmuT
+ * Return with Expr even void result, converted to null, ref https://3v4l.org/vPV0Y
  */
 final class SkipReturnHasExprVoid
 {
@@ -12,7 +12,7 @@ final class SkipReturnHasExprVoid
         return $this->someVoid();
     }
 
-    private function someVoid()
+    private function someVoid(): void
     {
     }
 }


### PR DESCRIPTION
Given the following code should be skipped.

```php
final class SkipReturnHasExprVoid
{
    public function getValues()
    {
        return $this->someVoid();
    }

    private function someVoid(): void
    {
    }
}
```

as return with Expr means it return null, see https://3v4l.org/vPV0Y
when it add with void type, it will cause error https://3v4l.org/i2Uq2 

```
Fatal error: A void function must not return a value in /in/i2Uq2 on line 7
```