### PR TITLE
[TypeDeclaration] Skip void type on caller on ReturnTypeFromStrictTypedCallRector

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
@@ -1,6 +1,8 @@
 <?php
 
 declare(strict_types=1);
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTime;
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTimeInterface;
 
 use Acme\Bar\DoNotUpdateExistingTargetNamespace;
 use Rector\Config\RectorConfig;
@@ -24,8 +26,8 @@ return static function (RectorConfig $rectorConfig): void {
             'FqnizeNamespaced' => 'Abc\FqnizeNamespaced',
             OldClass::class => NewClass::class,
             // interface to class
-            \Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTime::class =>
-            \Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTimeInterface::class,
+            SomeBasicDateTime::class =>
+            SomeBasicDateTimeInterface::class,
 
             // test casing
             OldClassWithTypo::class => NewClassWithoutTypo::class,

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
@@ -1,16 +1,17 @@
 <?php
 
 declare(strict_types=1);
-use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTime;
-use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTimeInterface;
 
 use Acme\Bar\DoNotUpdateExistingTargetNamespace;
 use Rector\Config\RectorConfig;
+
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture\DuplicatedClass;
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\Contract\FirstInterface;
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\Contract\SecondInterface;
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\Contract\ThirdInterface;
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTime;
+use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\InterfaceAndClass\SomeBasicDateTimeInterface;
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\NewClass;
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\NewClassWithoutTypo;
 use Rector\Tests\Renaming\Rector\Name\RenameClassRector\Source\OldClass;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_void_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_void_type.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class SkipVoidType
+{
+    public function run()
+    {
+        return $this->execute();
+    }
+
+    private function execute(): void
+    {
+    }
+}

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -72,6 +72,10 @@ final class ReturnStrictTypeAnalyzer
                 return [];
             }
 
+            if ($returnNode instanceof Identifier && $returnNode->toString() === 'void') {
+                return [];
+            }
+
             $returnedStrictTypeNodes[] = $returnNode;
         }
 


### PR DESCRIPTION
Given the following code should be skipped:

```php
final class SkipVoidType
{
    public function run()
    {
        return $this->execute();
    }

    private function execute(): void
    {
    }
}
```

should be skipped or it will cause error:

```
Fatal error: A void function must not return a value
```

Ref https://3v4l.org/SAZMn