### PR TITLE
[Php80] Handle crash Property ReflectionEnum::$betterReflectionClass does not exist on AddParamBasedOnParentClassMethodRector on Enum usage

### DIFF
--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -101,7 +101,6 @@ final class ParentClassMethodTypeOverrideGuard
 
     private function hasClassParent(ClassReflection $classReflection): bool
     {
-        // XXX rework this hack, after https://github.com/phpstan/phpstan-src/pull/2563 landed
         return $this->classReflectionAnalyzer->resolveParentClassName($classReflection) !== null;
     }
 }

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Rector\VendorLocker;
 
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
 use Rector\Core\Reflection\ClassReflectionAnalyzer;
 use Rector\Core\Reflection\ReflectionResolver;
-use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -24,7 +22,6 @@ final class ParentClassMethodTypeOverrideGuard
         private readonly ReflectionResolver $reflectionResolver,
         private readonly TypeComparator $typeComparator,
         private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly PrivatesAccessor $privatesAccessor,
         private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }

--- a/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/packages/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -9,6 +9,7 @@ use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
+use Rector\Core\Reflection\ClassReflectionAnalyzer;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -24,6 +25,7 @@ final class ParentClassMethodTypeOverrideGuard
         private readonly TypeComparator $typeComparator,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly PrivatesAccessor $privatesAccessor,
+        private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }
 
@@ -103,13 +105,6 @@ final class ParentClassMethodTypeOverrideGuard
     private function hasClassParent(ClassReflection $classReflection): bool
     {
         // XXX rework this hack, after https://github.com/phpstan/phpstan-src/pull/2563 landed
-        $nativeReflection = $classReflection->getNativeReflection();
-        $betterReflectionClass = $this->privatesAccessor->getPrivateProperty(
-            $nativeReflection,
-            'betterReflectionClass'
-        );
-        /** @var ReflectionClass $betterReflectionClass */
-        $parentClassName = $betterReflectionClass->getParentClassName();
-        return $parentClassName !== null;
+        return $this->classReflectionAnalyzer->resolveParentClassName($classReflection) !== null;
     }
 }

--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/skip_enum.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/skip_enum.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Fixture;
+
+enum SkipEnum: string
+{
+	case EN = 'en';
+
+	public static function ui(): array
+	{
+		return [
+			self::EN,
+		];
+	}
+
+	public static function dynamicContent(): array
+	{
+		return self::cases();
+	}
+}

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Enum\ObjectReference;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
@@ -19,7 +18,6 @@ use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Reflection\ClassReflectionAnalyzer;
-use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 
 final class ParentPropertyLookupGuard
@@ -30,7 +28,6 @@ final class ParentPropertyLookupGuard
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly AstResolver $astResolver,
         private readonly PropertyManipulator $propertyManipulator,
-        private readonly PrivatesAccessor $privatesAccessor,
         private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -18,6 +18,7 @@ use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\NodeManipulator\PropertyManipulator;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\Reflection\ClassReflectionAnalyzer;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 
@@ -29,7 +30,8 @@ final class ParentPropertyLookupGuard
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly AstResolver $astResolver,
         private readonly PropertyManipulator $propertyManipulator,
-        private readonly PrivatesAccessor $privatesAccessor
+        private readonly PrivatesAccessor $privatesAccessor,
+        private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }
 
@@ -48,15 +50,7 @@ final class ParentPropertyLookupGuard
             return false;
         }
 
-        // XXX rework this hack, after https://github.com/phpstan/phpstan-src/pull/2563 landed
-        $nativeReflection = $classReflection->getNativeReflection();
-        $betterReflectionClass = $this->privatesAccessor->getPrivateProperty(
-            $nativeReflection,
-            'betterReflectionClass'
-        );
-        /** @var ReflectionClass $betterReflectionClass */
-        $parentClassName = $betterReflectionClass->getParentClassName();
-
+        $parentClassName = $this->classReflectionAnalyzer->resolveParentClassName($classReflection);
         if ($parentClassName === null) {
             return true;
         }

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -24,6 +24,7 @@ use Rector\Core\Enum\ObjectReference;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ConstFetchAnalyzer;
 use Rector\Core\Provider\CurrentFileProvider;
+use Rector\Core\Reflection\ClassReflectionAnalyzer;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -46,7 +47,8 @@ final class ValueResolver
         private readonly ReflectionProvider $reflectionProvider,
         private readonly CurrentFileProvider $currentFileProvider,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly PrivatesAccessor $privatesAccessor
+        private readonly PrivatesAccessor $privatesAccessor,
+        private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }
 
@@ -334,16 +336,8 @@ final class ValueResolver
             );
         }
 
-        // XXX rework this hack, after https://github.com/phpstan/phpstan-src/pull/2563 landed
         // ensure parent class name still resolved even not autoloaded
-        $nativeReflection = $classReflection->getNativeReflection();
-        $betterReflectionClass = $this->privatesAccessor->getPrivateProperty(
-            $nativeReflection,
-            'betterReflectionClass'
-        );
-        /** @var ReflectionClass $betterReflectionClass */
-        $parentClassName = $betterReflectionClass->getParentClassName();
-
+        $parentClassName = $this->classReflectionAnalyzer->resolveParentClassName($classReflection);
         if ($parentClassName === null) {
             throw new ShouldNotHappenException();
         }

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\MagicConst\File;
 use PHPStan\Analyser\Scope;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -26,7 +25,6 @@ use Rector\Core\NodeAnalyzer\ConstFetchAnalyzer;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\Reflection\ClassReflectionAnalyzer;
 use Rector\Core\Reflection\ReflectionResolver;
-use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -47,7 +45,6 @@ final class ValueResolver
         private readonly ReflectionProvider $reflectionProvider,
         private readonly CurrentFileProvider $currentFileProvider,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly PrivatesAccessor $privatesAccessor,
         private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }

--- a/src/Reflection/ClassReflectionAnalyzer.php
+++ b/src/Reflection/ClassReflectionAnalyzer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Reflection;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\Php\PhpPropertyReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\TypeUtils;
+use PHPStan\Type\TypeWithClassName;
+use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\NodeAnalyzer\ClassAnalyzer;
+use Rector\Core\PhpParser\AstResolver;
+use Rector\Core\PHPStan\Reflection\TypeToCallReflectionResolver\TypeToCallReflectionResolverRegistry;
+use Rector\Core\Util\Reflection\PrivatesAccessor;
+use Rector\Core\ValueObject\MethodName;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
+use PHPStan\BetterReflection\Reflection\ReflectionClass;
+
+final class ClassReflectionAnalyzer
+{
+    public function __construct(private readonly PrivatesAccessor $privatesAccessor)
+    {
+    }
+
+    public function resolveParentClassName(ClassReflection $classReflection): ?string
+    {
+        $nativeReflection = $classReflection->getNativeReflection();
+        if ($nativeReflection instanceof \ReflectionEnum) {
+            return null;
+        }
+
+        $betterReflectionClass = $this->privatesAccessor->getPrivateProperty(
+            $nativeReflection,
+            'betterReflectionClass'
+        );
+        /** @var ReflectionClass $betterReflectionClass */
+        return $betterReflectionClass->getParentClassName();
+    }
+}

--- a/src/Reflection/ClassReflectionAnalyzer.php
+++ b/src/Reflection/ClassReflectionAnalyzer.php
@@ -4,35 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Core\Reflection;
 
-use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Name;
-use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\Analyser\Scope;
+use ReflectionEnum;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\Php\PhpPropertyReflection;
-use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\TypeUtils;
-use PHPStan\Type\TypeWithClassName;
-use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\NodeAnalyzer\ClassAnalyzer;
-use Rector\Core\PhpParser\AstResolver;
-use Rector\Core\PHPStan\Reflection\TypeToCallReflectionResolver\TypeToCallReflectionResolverRegistry;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
-use Rector\Core\ValueObject\MethodName;
-use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\NodeTypeResolver;
-use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use PHPStan\BetterReflection\Reflection\ReflectionClass;
 
 final class ClassReflectionAnalyzer
@@ -44,7 +18,7 @@ final class ClassReflectionAnalyzer
     public function resolveParentClassName(ClassReflection $classReflection): ?string
     {
         $nativeReflection = $classReflection->getNativeReflection();
-        if ($nativeReflection instanceof \ReflectionEnum) {
+        if ($nativeReflection instanceof ReflectionEnum) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8126
Ref https://getrector.com/demo/a1fd1e68-ba6b-4114-be3e-b2bd6932b018