### PR TITLE
Remove Dumper::dump() in print_node function

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -66,6 +66,8 @@ parameters:
         # tests
         - tests/DependencyInjection/config
 
+        - src/functions
+
     ignoreErrors:
         - '#Cognitive complexity for "Rector\\Php80\\NodeResolver\\SwitchExprsResolver\:\:resolve\(\)" is (.*?), keep it under 11#'
 

--- a/src/functions/node_helper.php
+++ b/src/functions/node_helper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
-use Tracy\Dumper;
 
 // @deprecated, use dump() or dd() instead
 if (! function_exists('dump_node')) {
@@ -29,7 +28,7 @@ if (! function_exists('print_node')) {
 
         foreach ($nodes as $node) {
             $printedContent = $standard->prettyPrint([$node]);
-            Dumper::dump($printedContent);
+            var_dump($printedContent);
         }
     }
 }


### PR DESCRIPTION
Since tracy is require-dev, Dumper::dump() in print_node function won't work on scoped build.

This PR replace with var_dump