### PR TITLE
[DeadCode] Skip used by trait inside Closure on RemoveUnusedPrivateMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_used_by_closure_trait.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_used_by_closure_trait.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Source\TraitConsumer;
+
+class SkipUsedByTraitClosureTrait
+{
+    use TraitConsumer;
+
+    private function world()
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Source/TraitConsumer.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Source/TraitConsumer.php
@@ -15,4 +15,11 @@ trait TraitConsumer
     {
         self::hello();
     }
+
+    public function some()
+    {
+        function () {
+            $this->world();
+        };
+    }
 }

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -192,18 +192,7 @@ final class IsClassMethodUsedAnalyzer
                         return NodeTraverser::STOP_TRAVERSAL;
                     }
 
-                    if (! $subNode instanceof StaticCall) {
-                        return null;
-                    }
-
-                    if (! $subNode->class instanceof Name) {
-                        return null;
-                    }
-
-                    if (($subNode->class->isSpecialClassName() || $subNode->class->toString() === $className) && $this->nodeNameResolver->isName(
-                        $subNode->name,
-                        $classMethodName
-                    )) {
+                    if ($this->isStaticCallMatch($subNode, $className, $classMethodName)) {
                         $callMethod = $subNode;
                         return NodeTraverser::STOP_TRAVERSAL;
                     }
@@ -218,5 +207,19 @@ final class IsClassMethodUsedAnalyzer
         }
 
         return false;
+    }
+
+    private function isStaticCallMatch(Node $subNode, string $className, string $classMethodName): bool
+    {
+        if (! $subNode instanceof StaticCall) {
+            return false;
+        }
+
+        if (! $subNode->class instanceof Name) {
+            return false;
+        }
+
+        return ($subNode->class->isSpecialClassName() || $subNode->class->toString() === $className)
+            && $this->nodeNameResolver->isName($subNode->name, $classMethodName);
     }
 }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/4770

Method Call inside Closure can call Method from `$this` so should be skipped as well.