### PR TITLE
[TypeDeclaration] Skip @param int on StrictStringParamConcatRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector/Fixture/skip_param_doc_int.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector/Fixture/skip_param_doc_int.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictStringParamConca
 class SkipParamDocInt
 {
     /**
-     * @param int
+     * @param int $total
      */
     public function resolve($total)
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector/Fixture/skip_param_doc_int.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector/Fixture/skip_param_doc_int.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector\Fixture;
+
+class SkipParamDocInt
+{
+    /**
+     * @param int
+     */
+    public function resolve($total)
+    {
+        return 'we have ' . $total . 'item';
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
             }
 
             $paramDocType = $phpDocInfo->getParamType($this->getName($param));
-            if ($paramDocType->isInteger()->yes()) {
+            if (! $paramDocType instanceof MixedType && ! $paramDocType->isString()->yes()) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
@@ -81,6 +81,7 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         foreach ($node->getParams() as $param) {
             if ($param->type instanceof Node) {
@@ -89,6 +90,11 @@ CODE_SAMPLE
 
             $variableConcattedFromParam = $this->resolveVariableConcattedFromParam($param, $node);
             if (! $variableConcattedFromParam instanceof Variable) {
+                continue;
+            }
+
+            $paramDocType = $phpDocInfo->getParamType($this->getName($param));
+            if ($paramDocType->isInteger()->yes()) {
                 continue;
             }
 


### PR DESCRIPTION
@TomasVotruba @staabm integer can be concatted like this:

```php
class SkipParamDocInt
{
    /**
     * @param int $total
     */
    public function resolve($total)
    {
        return 'we have ' . $total . 'item';
    }
}
```

Above, changing to `string $total` seems invalid. 

Ref https://3v4l.org/AdvoT