### PR TITLE
[PHPStanStaticTypeMapper] Remove TypeKind::ANY

### DIFF
--- a/packages/PHPStanStaticTypeMapper/Enum/TypeKind.php
+++ b/packages/PHPStanStaticTypeMapper/Enum/TypeKind.php
@@ -20,9 +20,4 @@ final class TypeKind
      * @var string
      */
     public const PARAM = 'param';
-
-    /**
-     * @var string
-     */
-    public const ANY = 'any';
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
@@ -156,7 +156,7 @@ CODE_SAMPLE
             $nodeExprType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($exprType, TypeKind::PARAM);
 
             $varType = $this->nodeTypeResolver->getNativeType($node->var);
-            $nodeVarType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, TypeKind::ANY);
+            $nodeVarType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, TypeKind::PARAM);
 
             if ($nodeExprType instanceof Node && ! $this->nodeComparator->areNodesEqual($nodeExprType, $nodeVarType)) {
                 return null;

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector.php
@@ -156,7 +156,7 @@ CODE_SAMPLE
             $nodeExprType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($exprType, TypeKind::PARAM);
 
             $varType = $this->nodeTypeResolver->getNativeType($node->var);
-            $nodeVarType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, TypeKind::PARAM);
+            $nodeVarType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, TypeKind::PROPERTY);
 
             if ($nodeExprType instanceof Node && ! $this->nodeComparator->areNodesEqual($nodeExprType, $nodeVarType)) {
                 return null;


### PR DESCRIPTION
It only used once at `AddParamTypeFromPropertyTypeRector` and it seems can use `TypeKind::PROPERTY` instead.