### PR TITLE
[DeadCode] Handle duplicated annotation on space before close parentheses on RemoveUselessParamTagRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -115,7 +115,10 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                     continue;
                 }
 
-                $isNewLinedGenericTagValueNode = str_starts_with($genericTagValueNode->value, '(') && ! str_ends_with($genericTagValueNode->value, ')');
+                $isNewLinedGenericTagValueNode = str_starts_with($genericTagValueNode->value, '(') && ! str_ends_with(
+                    $genericTagValueNode->value,
+                    ')'
+                );
                 if ($this->isClosedContent($genericTagValueNode->value, $isNewLinedGenericTagValueNode)) {
                     break;
                 }
@@ -234,7 +237,10 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             }
 
             if ($composedTokenIterator->isCurrentTokenType(Lexer::TOKEN_PHPDOC_EOL)
-                && $composedTokenIterator->getContentBetween($composedTokenIterator->currentPosition() -1, $composedTokenIterator->currentPosition()) === '('
+                && $composedTokenIterator->getContentBetween(
+                    $composedTokenIterator->currentPosition() - 1,
+                    $composedTokenIterator->currentPosition()
+                ) === '('
                 && $isNewLined
                 && $openBracketCount > $closeBracketCount
             ) {

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -115,7 +115,8 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                     continue;
                 }
 
-                if ($this->isClosedContent($genericTagValueNode->value)) {
+                $isNewLinedGenericTagValueNode = str_starts_with($genericTagValueNode->value, '(') && ! str_ends_with($genericTagValueNode->value, ')');
+                if ($this->isClosedContent($genericTagValueNode->value, $isNewLinedGenericTagValueNode)) {
                     break;
                 }
 
@@ -204,7 +205,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
      * This is closed block, e.g. {( ... )},
      * false on: {( ... )
      */
-    private function isClosedContent(string $composedContent): bool
+    private function isClosedContent(string $composedContent, bool $isNewLined): bool
     {
         $composedTokenIterator = $this->tokenIteratorFactory->create($composedContent);
         $tokenCount = $composedTokenIterator->count();
@@ -223,9 +224,9 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                 ++$openBracketCount;
             }
 
-            if (str_contains($composedTokenIterator->currentTokenValue(), "\n")
-                && trim($composedTokenIterator->currentTokenValue()) === ''
+            if ($composedTokenIterator->isCurrentTokenType(Lexer::TOKEN_PHPDOC_EOL)
                 && $composedTokenIterator->getContentBetween($composedTokenIterator->currentPosition() -1, $composedTokenIterator->currentPosition()) === '('
+                && $isNewLined
             ) {
                 --$openBracketCount;
             }

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -115,10 +115,8 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                     continue;
                 }
 
-                $isNewLinedGenericTagValueNode = str_starts_with($genericTagValueNode->value, '(') && ! str_ends_with(
-                    $genericTagValueNode->value,
-                    ')'
-                );
+                $isNewLinedGenericTagValueNode = str_starts_with($genericTagValueNode->value, '(')
+                    && ! str_ends_with($genericTagValueNode->value, ')');
                 if ($this->isClosedContent($genericTagValueNode->value, $isNewLinedGenericTagValueNode)) {
                     break;
                 }

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -223,6 +223,10 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                 ++$openBracketCount;
             }
 
+            if (str_contains($composedTokenIterator->currentTokenValue(), "\n")) {
+                --$openBracketCount;
+            }
+
             if (
                 $composedTokenIterator->isCurrentTokenType(
                     Lexer::TOKEN_CLOSE_CURLY_BRACKET,

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -217,6 +217,15 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
         }
 
         do {
+            if (
+                $composedTokenIterator->isCurrentTokenType(
+                    Lexer::TOKEN_CLOSE_CURLY_BRACKET,
+                    Lexer::TOKEN_CLOSE_PARENTHESES
+                    // sometimes it gets mixed int    ")
+                ) || \str_contains($composedTokenIterator->currentTokenValue(), ')')) {
+                ++$closeBracketCount;
+            }
+
             if ($composedTokenIterator->isCurrentTokenType(
                 Lexer::TOKEN_OPEN_CURLY_BRACKET,
                 Lexer::TOKEN_OPEN_PARENTHESES
@@ -227,17 +236,9 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             if ($composedTokenIterator->isCurrentTokenType(Lexer::TOKEN_PHPDOC_EOL)
                 && $composedTokenIterator->getContentBetween($composedTokenIterator->currentPosition() -1, $composedTokenIterator->currentPosition()) === '('
                 && $isNewLined
+                && $openBracketCount > $closeBracketCount
             ) {
                 --$openBracketCount;
-            }
-
-            if (
-                $composedTokenIterator->isCurrentTokenType(
-                    Lexer::TOKEN_CLOSE_CURLY_BRACKET,
-                    Lexer::TOKEN_CLOSE_PARENTHESES
-                    // sometimes it gets mixed int    ")
-                ) || \str_contains($composedTokenIterator->currentTokenValue(), ')')) {
-                ++$closeBracketCount;
             }
 
             $composedTokenIterator->next();

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -223,7 +223,10 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                 ++$openBracketCount;
             }
 
-            if (str_contains($composedTokenIterator->currentTokenValue(), "\n")) {
+            if (str_contains($composedTokenIterator->currentTokenValue(), "\n")
+                && trim($composedTokenIterator->currentTokenValue()) === ''
+                && $composedTokenIterator->getContentBetween($composedTokenIterator->currentPosition() -1, $composedTokenIterator->currentPosition()) === '('
+            ) {
                 --$openBracketCount;
             }
 

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/do_not_duplicate_annotations.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/do_not_duplicate_annotations.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+final class DoNotDuplicateAnnotations
+{
+    /**
+     * @ApiDoc(
+     *   description = "Some Description"
+     *
+     * )
+     *
+     * @Route("/some/route")
+     *
+     * @param string $thing
+     */
+    public function foo(string $thing)
+    {
+        echo $thing;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+final class DoNotDuplicateAnnotations
+{
+    /**
+     * @ApiDoc(
+     *   description = "Some Description"
+     *
+     * )
+     *
+     * @Route("/some/route")
+     */
+    public function foo(string $thing)
+    {
+        echo $thing;
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #4641 
Closes https://github.com/rectorphp/rector/issues/8101