### PR TITLE
fix(82): readonly class rule

### DIFF
--- a/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
+++ b/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
@@ -154,7 +154,7 @@ CODE_SAMPLE
         }
 
         $parents = $this->resolveParentClassReflections($scope);
-        if (! $class->isFinal()) {
+        if (! $class->isFinal() && !empty($parents)) {
             return ! $this->isExtendsReadonlyClass($parents);
         }
 


### PR DESCRIPTION
Hi,

Readonly class rule seems to not work correctly if class does not have any parents, this should fix it.