### PR TITLE
[DX] Merge RectorConfig cacheDirectory() and containerCacheDirectory() to one to ease changing paths in case of non-writeable cache

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -25,7 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->fileExtensions(['php']);
 
     $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/rector_cached_files');
-    $rectorConfig->containerCacheDirectory(sys_get_temp_dir());
 
     // use faster in-memory cache in CI.
     // CI always starts from scratch, therefore IO intensive caching is not worth it

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -280,7 +280,7 @@ final class RectorConfig extends Container
     }
 
     /**
-     * @info Rector no longer user compiled container, but Laravel lazy one.
+     * @info Rector no longer uses compiled container, but Laravel lazy one.
      * This option is for PHPStan container in case the sys_get_temp_dir() is not available for the current user.
      */
     public function containerCacheDirectory(string $directoryPath): void

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -279,6 +279,10 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::CACHE_DIR, $directoryPath);
     }
 
+    /**
+     * @info Rector no longer user compiled container, but Laravel lazy one.
+     * This option is for PHPStan container in case the sys_get_temp_dir() is not available for the current user.
+     */
     public function containerCacheDirectory(string $directoryPath): void
     {
         // container cache directory path must be a directory on the first place

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -47,12 +47,13 @@ final class PHPStanServicesFactory
             $purifiedConfigFiles[] = $purifiedConfigFile;
         }
 
+        $cacheDirectory = SimpleParameterProvider::provideStringParameter(Option::CACHE_DIR);
+
+        // make sure directory exists as PHPStan Nette container will not create it and crash
+        \Nette\Utils\FileSystem::createDir($cacheDirectory);
+
         $containerFactory = new ContainerFactory(getcwd());
-        $this->container = $containerFactory->create(
-            sys_get_temp_dir() . '/phpstan-container-for-rector',
-            $additionalConfigFiles,
-            []
-        );
+        $this->container = $containerFactory->create($cacheDirectory, $additionalConfigFiles, []);
 
         // clear temporary files, after container is created
         $filesystem = new Filesystem();

--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -49,7 +49,7 @@ final class PHPStanServicesFactory
 
         $containerFactory = new ContainerFactory(getcwd());
         $this->container = $containerFactory->create(
-            SimpleParameterProvider::provideStringParameter(Option::CONTAINER_CACHE_DIRECTORY),
+            sys_get_temp_dir() . '/phpstan-container-for-rector',
             $additionalConfigFiles,
             []
         );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -213,7 +213,6 @@ parameters:
         - '#Parameter \#1 \$node (.*?) of method Rector\\(.*?)Rector\:\:refactor\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\PhpRectorInterface\:\:refactor\(\)#'
 
         # generics
-        - '#Method Rector\\Core\\PhpParser\\NodeTraverser\\RectorNodeTraverser\:\:traverse\(\) should return array<TNode of PhpParser\\Node\> but returns array<PhpParser\\Node\>#'
         - '#Parameter \#1 \$stmts of class Rector\\Core\\PhpParser\\Node\\CustomNode\\FileWithoutNamespace constructor expects array<PhpParser\\Node\\Stmt\>, array<TNode of PhpParser\\Node\> given#'
 
         # strict - resolve later
@@ -424,9 +423,6 @@ parameters:
             message: '#Instead of "instanceof/is_a\(\)" use ReflectionProvider service or "\(new ObjectType\(<desired_type>\)\)\->isSuperTypeOf\(<element_type>\)" for static reflection to work#'
             path: packages/Skipper/Skipper/SkipSkipper.php
 
-        # the local instanceof for known types
-        - '#Instead of "instanceof/is_a\(\)" use ReflectionProvider service or "\(new ObjectType\(<desired_type>\)\)\->isSuperTypeOf\(<element_type>\)" for static reflection to work#'
-
         # required for reflection
         -
             message: '#Function "(.*?)\(\)" cannot be used/left in the code#'
@@ -518,9 +514,6 @@ parameters:
         # useless
         - '#Parameter \#1 \$suffix of method PHPUnit\\Framework\\Assert\:\:assertStringEndsWith\(\) expects non\-empty\-string, string given#'
 
-        # reported in configs
-        - '#Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\service not found#'
-
         -
             message: '#Function "function_exists\(\)" cannot be used/left in the code#'
             path: src/functions/node_helper.php
@@ -536,9 +529,6 @@ parameters:
         # phpstan 1.10.0
         - '#Call to deprecated method getDirectClassNames\(\) of class PHPStan\\Type\\TypeUtils.*#'
         - '#Parameter 3 should use "PHPStan\\Reflection\\ParameterReflectionWithPhpDocs" type as the only type passed to this method#'
-
-        # various usage
-        - '#Parameters should use "PHPStan\\DependencyInjection\\Container" types as the only types passed to this method#'
 
         # actually used in global scope
         -
@@ -598,9 +588,6 @@ parameters:
             message: '#Parameters should use "array" types as the only types passed to this method#'
             path: packages/VersionBonding/PhpVersionedFilter.php
 
-        # for symfony configs check
-        - '#Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\tagged_iterator not found#'
-
         -
             message: '#Do not use static property#'
             path: src/Configuration/Parameter/SimpleParameterProvider.php
@@ -633,25 +620,10 @@ parameters:
             message: '#Parameters should use "Symfony\\Component\\Console\\Application\|string\|callable" types as the only types passed to this method#'
             path: src/Util/Reflection/PrivatesAccessor.php
 
-        # false positives
-        - '#Property Rector\\PhpAttribute\\AnnotationToAttributeMapper\:\:\$annotationToAttributeMappers \(array<Rector\\PhpAttribute\\Contract\\AnnotationToAttributeMapperInterface>\) does not accept iterable<Rector\\PhpAttribute\\Contract\\AnnotationToAttributeMapperInterface>#'
-
         # avoid circular dependency
         -
             message: '#\$this as argument is not allowed\. Refactor method to service composition#'
             path: packages/NodeTypeResolver/NodeTypeResolver.php
-
-        - '#Call to an undefined method Rector\\Config\\RectorConfig\:\:(.*?)\(\)#'
-        - '#Call to an undefined method Illuminate\\Container\\Container\:\:(.*?)\(\)#'
-        - '#Parameter 1 should use "Illuminate\\Container\\Container" type as the only type passed to this method#'
-        - '#Parameter \#1 \$container of method Rector\\Core\\DependencyInjection\\LazyContainerFactory\:\:createPHPStanServices\(\) expects Rector\\Config\\RectorConfig, Illuminate\\Container\\Container given#'
-
-        - '#Property Rector\\Core\\Configuration\\ConfigInitializer\:\:\$rectors \(array<Rector\\Core\\Contract\\Rector\\RectorInterface>\) does not accept iterable<Rector\\Core\\Contract\\Rector\\RectorInterface>#'
-
-        # false positive
-        - '#Parameter \#1 \$commands of method Symfony\\Component\\Console\\Application\:\:addCommands\(\) expects array<Symfony\\Component\\Console\\Command\\Command>, iterable<Symfony\\Component\\Console\\Command\\Command> given#'
-
-        - '#Property Rector\\Core\\Console\\Command\\ListRulesCommand\:\:\$rectors \(array<Rector\\Core\\Contract\\Rector\\RectorInterface>\) does not accept array\|iterable<Rector\\Core\\Contract\\Rector\\RectorInterface>#'
 
         # reflection property change
         -
@@ -664,9 +636,6 @@ parameters:
         - '#Use separate function calls with readable variable names#'
 
         - '#Class "Rector\\Renaming\\Rector\\FileWithoutNamespace\\PseudoNamespaceToNamespaceRector" is missing @see annotation with test case class reference#'
-
-        # iterable mix
-        - '#Property Rector\\Core\\Configuration\\ConfigInitializer\:\:\$rectors \(array<Rector\\Core\\Contract\\Rector\\RectorInterface>\) does not accept array\|iterable<Rector\\Core\\Contract\\Rector\\RectorInterface>#'
 
         # chicken/egg
         -
@@ -691,4 +660,4 @@ parameters:
             message: '#Make callable type explicit\. Here is how\: https\://phpstan\.org/writing\-php\-code/phpdoc\-types\#callables#'
             path: packages/Config/RectorConfig.php
 
-        - '#Method Rector\\Core\\PhpParser\\NodeTraverser\\RectorNodeTraverser\:\:__construct\(\) has parameter \$phpRectors with no value type specified in iterable type iterable#'
+        -  '#Method Rector\\Core\\PhpParser\\NodeTraverser\\RectorNodeTraverser\:\:traverse\(\) should return array<TNode of PhpParser\\Node> but returns array<PhpParser\\Node>#'

--- a/scoper.php
+++ b/scoper.php
@@ -72,10 +72,9 @@ return [
             $content
         ),
 
-        static function (string $filePath, string $prefix, string $content): string {
+        static fn(string $filePath, string $prefix, string $content): string =>
             // comment out
-            return str_replace('\\' . $prefix . '\trigger_deprecation(', '// \trigger_deprecation(', $content);
-        },
+            str_replace('\\' . $prefix . '\trigger_deprecation(', '// \trigger_deprecation(', $content),
 
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'src/Application/VersionResolver.php')) {

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -398,6 +398,8 @@ final class LazyContainerFactory
         $rectorConfig->fileExtensions(['php']);
 
         $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/rector_cached_files');
+
+        // cache directory for PHPStan container
         $rectorConfig->containerCacheDirectory(sys_get_temp_dir());
 
         // make use of https://github.com/symplify/easy-parallel

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -399,9 +399,6 @@ final class LazyContainerFactory
 
         $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/rector_cached_files');
 
-        // cache directory for PHPStan container
-        $rectorConfig->containerCacheDirectory(sys_get_temp_dir());
-
         // make use of https://github.com/symplify/easy-parallel
         $rectorConfig->singleton(Application::class, static function (): Application {
             $application = new Application();


### PR DESCRIPTION
~~The Symfony container was compiled, but Laravel one is lazy, so doesn't use any kind of dumped cache file. PHPStan handles this in its own way, so we can drop it completely.~~


EDIT: This option is needed for PHPStan container. Yet should be united with other cache directory option to avoid duplicated work and WTFs in https://github.com/rectorphp/rector/issues/8112 



Closes: https://github.com/rectorphp/rector/issues/8112
