### PR TITLE
Faster AddParamBasedOnParentClassMethodRector

### DIFF
--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -104,12 +104,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $parentClassMethod = $this->astResolver->resolveClassMethodFromMethodReflection($parentMethodReflection);
-        if (! $parentClassMethod instanceof ClassMethod) {
+        if ($parentMethodReflection->isPrivate()) {
             return null;
         }
 
-        if ($parentClassMethod->isPrivate()) {
+        $parentClassMethod = $this->astResolver->resolveClassMethodFromMethodReflection($parentMethodReflection);
+        if (! $parentClassMethod instanceof ClassMethod) {
             return null;
         }
 


### PR DESCRIPTION
`astResolver->resolveClassMethodFromMethodReflection` is slow as can be seen in https://github.com/rectorphp/rector-src/pull/4804

we can do the `isPrivate` check earlier based on `MethodReflection` and therefore reduce the number of times we need to invoke `astResolver->resolveClassMethodFromMethodReflection`