### PR TITLE
Add deprecation warning for FileProcessorInterface

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -650,3 +650,7 @@ parameters:
         -
             message: '#Function "(class_exists|interface_exists)\(\)" cannot be used/left in the code\: use ReflectionProvider\->has\*\(\) instead#'
             path: packages/Skipper/SkipCriteriaResolver/SkippedClassResolver.php
+
+        # deprecated, remove later
+        - '#deprecated (interface|class) Rector\\Core\\Contract\\Processor\\FileProcessorInterface#'
+        - '#Call to deprecated method processWithFileProcessors\(\) of class Rector\\Core\\Application\\ApplicationFileProcessor#'

--- a/rules-tests/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector/Fixture/skip_fixture2.php
+++ b/rules-tests/CodeQuality/Rector/BooleanAnd/SimplifyEmptyArrayCheckRector/Fixture/skip_fixture2.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector\Fixture;
+
+function simplifyEmptyCheck()
+{
+    $invalid = is_array($var) && in_array('foo', $var);
+    $almostValid = is_array($var) && count($var) > 0;
+    $invalid2 = isset($this->events[$event]) && !empty($this->events[$event]);
+    $completelyInvalid = !$value instanceof \Foo && !$value instanceof \Bar;
+
+    if (empty($this->orders) && empty($this->unionOrders)) {
+        throw new \RuntimeException('You must specify an orderBy clause when using this function.');
+    }
+
+    echo is_array($objects) && is_array($objects);
+}

--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -10,7 +10,6 @@ use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\ValueObjectFactory\ErrorFactory;
 use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
 use Rector\Core\Application\FileProcessor;
-use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\FileSystem\FilePathHelper;
 use Rector\Core\PhpParser\Printer\FormatPerservingPrinter;
@@ -24,7 +23,7 @@ use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
 
-final class PhpFileProcessor implements FileProcessorInterface
+final class PhpFileProcessor
 {
     /**
      * @var string
@@ -114,19 +113,6 @@ final class PhpFileProcessor implements FileProcessorInterface
 
         $systemErrorsAndFileDiffs[Bridge::FILE_DIFFS] = [$fileDiff];
         return $systemErrorsAndFileDiffs;
-    }
-
-    public function supports(File $file, Configuration $configuration): bool
-    {
-        return true;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getSupportedFileExtensions(): array
-    {
-        return ['php'];
     }
 
     /**

--- a/src/Contract/Processor/FileProcessorInterface.php
+++ b/src/Contract/Processor/FileProcessorInterface.php
@@ -11,6 +11,8 @@ use Rector\Core\ValueObject\Reporting\FileDiff;
 
 /**
  * @internal
+ *
+ * @deprecated This interface should not be used, as Rector will handle PHP code only. Use custom file processor with own finder instead for any non-PHP changes.
  */
 interface FileProcessorInterface
 {

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -446,8 +446,6 @@ final class LazyContainerFactory
         $rectorConfig->alias(TypeParser::class, BetterTypeParser::class);
 
         $rectorConfig->singleton(PhpFileProcessor::class);
-        $rectorConfig->tag(PhpFileProcessor::class, FileProcessorInterface::class);
-
         $rectorConfig->singleton(PostFileProcessor::class);
 
         if (class_exists(InitRecipeCommand::class)) {


### PR DESCRIPTION
Follow up to `NonPhpRectorInterface` deprecation, as we aim for PHP file processor now:
https://github.com/rectorphp/rector-src/pull/4761