### PR TITLE
Skip PHPDoc return type in AddReturnTypeDeclarationBasedOnParentClassMethodRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_extended_phpdoc_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_extended_phpdoc_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithPHPDocReturnType;
+
+class MyClass extends SomeClassWithPHPDocReturnType
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithPHPDocReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithPHPDocReturnType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
+
+class SomeClassWithPHPDocReturnType
+{
+    /**
+     * @return int
+     */
+    public function run()
+    {
+      return 5;
+    }
+}


### PR DESCRIPTION
the rule did not yet contain a test which covers how it behaves with PHPDocs