### PR TITLE
AddReturnTypeDeclarationBasedOnParentClassMethodRector: don't trust phpdoc types

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_extended_phpdoc_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_extended_phpdoc_type.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
 
-use Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithPHPDocReturnType;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithPHPDocReturnType;
 
 class MyClass extends SomeClassWithPHPDocReturnType
 {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithPHPDocReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithPHPDocReturnType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source;
 
 class SomeClassWithPHPDocReturnType
 {

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
@@ -134,9 +135,15 @@ CODE_SAMPLE
                 return null;
             }
 
-            $parentReturnType = ParametersAcceptorSelector::selectSingle(
+            $parameterAcceptor = ParametersAcceptorSelector::selectSingle(
                 $parentMethodReflection->getVariants()
-            )->getNativeReturnType();
+            );
+
+            if (!$parameterAcceptor instanceof ParametersAcceptorWithPhpDocs) {
+                return null;
+            }
+
+            $parentReturnType = $parameterAcceptor->getNativeReturnType();
             if (! $parentReturnType instanceof MixedType) {
                 return $parentReturnType;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -135,7 +136,7 @@ CODE_SAMPLE
 
             $parentReturnType = ParametersAcceptorSelector::selectSingle(
                 $parentMethodReflection->getVariants()
-            )->getReturnType();
+            )->getNativeReturnType();
             if (! $parentReturnType instanceof MixedType) {
                 return $parentReturnType;
             }


### PR DESCRIPTION
fixes the typo in https://github.com/rectorphp/rector-src/pull/4809 so the test fails as I expected ;-)