### PR TITLE
[Parallel] Handle Spaced root project main script on parallel process

### DIFF
--- a/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -30,7 +30,7 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
     /**
      * @var string
      */
-    private const SPACED_DUMMY_MAIN_SCRIPT = 'C:\Users\P\Desktop\Web Dev\CodeIgniter4\rector.php';
+    private const SPACED_DUMMY_MAIN_SCRIPT = 'C:\Users\P\Desktop\Web Dev\vendor\bin\rector';
 
     private WorkerCommandLineFactory $workerCommandLineFactory;
 

--- a/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -60,8 +60,6 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
             2000
         );
 
-        echo $workerCommandLine . PHP_EOL;
-
         $this->assertSame($expectedCommand, $workerCommandLine);
     }
 

--- a/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -27,6 +27,11 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
      */
     private const DUMMY_MAIN_SCRIPT = 'main_script';
 
+    /**
+     * @var string
+     */
+    private const SPACED_DUMMY_MAIN_SCRIPT = 'C:\Users\P\Desktop\Web Dev\CodeIgniter4\rector.php';
+
     private WorkerCommandLineFactory $workerCommandLineFactory;
 
     private ProcessCommand $processCommand;
@@ -35,6 +40,65 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
     {
         $this->workerCommandLineFactory = $this->make(WorkerCommandLineFactory::class);
         $this->processCommand = $this->make(ProcessCommand::class);
+    }
+
+        /**
+     * @param array<string, mixed> $inputParameters
+     */
+    #[DataProvider('provideDataSpacedMainScript')]
+    public function testSpacedMainScript(array $inputParameters, string $expectedCommand): void
+    {
+        $inputDefinition = $this->prepareProcessCommandDefinition();
+        $arrayInput = new ArrayInput($inputParameters, $inputDefinition);
+
+        $workerCommandLine = $this->workerCommandLineFactory->create(
+            self::SPACED_DUMMY_MAIN_SCRIPT,
+            ProcessCommand::class,
+            'worker',
+            $arrayInput,
+            'identifier',
+            2000
+        );
+
+        echo $workerCommandLine . PHP_EOL;
+
+        $this->assertSame($expectedCommand, $workerCommandLine);
+    }
+
+    /**
+     * @return Iterator<array<int, array<string, string|string[]|bool>>|string[]>
+     */
+    public static function provideDataSpacedMainScript(): Iterator
+    {
+        $cliInputOptions = array_slice($_SERVER['argv'], 1);
+        $cliInputOptionsAsString = implode("' '", $cliInputOptions);
+
+        yield [
+            [
+                self::COMMAND => 'process',
+                Option::SOURCE => ['src'],
+            ],
+            "'" . PHP_BINARY . "' '" . self::SPACED_DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
+        ];
+
+        yield [
+            [
+                self::COMMAND => 'process',
+                Option::SOURCE => ['src'],
+                '--' . Option::OUTPUT_FORMAT => ConsoleOutputFormatter::NAME,
+            ],
+            "'" . PHP_BINARY . "' '" . self::SPACED_DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
+        ];
+
+        yield [
+            [
+                self::COMMAND => 'process',
+                Option::SOURCE => ['src'],
+                '--' . Option::OUTPUT_FORMAT => ConsoleOutputFormatter::NAME,
+                '--' . Option::DEBUG => true,
+            ],
+            "'" . PHP_BINARY . "' '" . self::SPACED_DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --debug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
+        ];
     }
 
     /**

--- a/packages/Parallel/Command/WorkerCommandLineFactory.php
+++ b/packages/Parallel/Command/WorkerCommandLineFactory.php
@@ -6,6 +6,7 @@ namespace Rector\Parallel\Command;
 
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
 use Rector\Core\Configuration\Option;
+use Rector\Core\FileSystem\FilePathHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symplify\EasyParallel\Exception\ParallelShouldNotHappenException;
@@ -22,11 +23,11 @@ final class WorkerCommandLineFactory
      */
     private const OPTION_DASHES = '--';
 
-    private readonly CommandFromReflectionFactory $commandFromReflectionFactory;
-
-    public function __construct()
+    public function __construct(
+        private readonly CommandFromReflectionFactory $commandFromReflectionFactory,
+        private readonly FilePathHelper $filePathHelper
+    )
     {
-        $this->commandFromReflectionFactory = new CommandFromReflectionFactory();
     }
 
     /**
@@ -115,7 +116,8 @@ final class WorkerCommandLineFactory
              *
              * tested in macOS and Ubuntu (github action)
              */
-            $workerCommandArray[] = escapeshellarg((string) $input->getOption(Option::CONFIG));
+            $config = (string) $input->getOption(Option::CONFIG);
+            $workerCommandArray[] = escapeshellarg($this->filePathHelper->relativePath($config));
         }
 
         return implode(' ', $workerCommandArray);

--- a/packages/Parallel/Command/WorkerCommandLineFactory.php
+++ b/packages/Parallel/Command/WorkerCommandLineFactory.php
@@ -61,6 +61,11 @@ final class WorkerCommandLineFactory
                 break;
             }
 
+            if ($arg === $mainScript) {
+                $workerCommandArray[] = '"' . $arg . '"';
+                continue;
+            }
+
             $workerCommandArray[] = escapeshellarg((string) $arg);
         }
 

--- a/packages/Parallel/Command/WorkerCommandLineFactory.php
+++ b/packages/Parallel/Command/WorkerCommandLineFactory.php
@@ -62,11 +62,6 @@ final class WorkerCommandLineFactory
                 break;
             }
 
-            if ($arg === $mainScript) {
-                $workerCommandArray[] = '"' . $arg . '"';
-                continue;
-            }
-
             $workerCommandArray[] = escapeshellarg((string) $arg);
         }
 


### PR DESCRIPTION
@paulbalandan @sh1hab this is test for https://github.com/rectorphp/rector/issues/8005

I copied existing test so I probablly missing the expecation assertion as currently shows:

```
'/usr/bin/php8.1' 'C:\Users\P\Desktop\Web Dev\vendor\bin\rector' 'packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi
.'/usr/bin/php8.1' 'C:\Users\P\Desktop\Web Dev\vendor\bin\rector' 'packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi
.'/usr/bin/php8.1' 'C:\Users\P\Desktop\Web Dev\vendor\bin\rector' 'packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php' worker --debug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi
```

Fixes https://github.com/rectorphp/rector/issues/8005