### PR TITLE
Remove symfony/strings dependency

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -70,7 +70,7 @@ jobs:
                         name: 'Detect unused dependencies'
                         # "default" format overrides default "github" in CI
                         run: |
-                            composer require icanhazstring/composer-unused --dev
+                            composer require symfony/strings icanhazstring/composer-unused --dev
                             vendor/bin/composer-unused --ansi --output-format=default
 
         name: ${{ matrix.actions.name }}

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -70,8 +70,8 @@ jobs:
                         name: 'Detect unused dependencies'
                         # "default" format overrides default "github" in CI
                         run: |
-                            composer require symfony/strings icanhazstring/composer-unused --dev
-                            vendor/bin/composer-unused --ansi --output-format=default
+                            composer create-project icanhazstring/composer-unused
+                            composer-unused/bin/composer-unused --ansi --output-format=default
 
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -135,6 +135,9 @@
     },
     "extra": {
         "patches": {
+            "symfony/console": [
+                "patches/symfony-console-helper-helper-php.patch"
+            ],
             "illuminate/container": [
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches//illuminate-container-container-php.patch"
             ],

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
     },
     "replace": {
         "rector/rector": "self.version",
+        "symfony/string": "*",
         "symfony/polyfill-ctype": "*",
         "symfony/polyfill-intl-grapheme": "*",
         "symfony/deprecation-contracts": "*"

--- a/patches/symfony-console-helper-helper-php.patch
+++ b/patches/symfony-console-helper-helper-php.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ ../Helper/Helper.php
+@@ -46,6 +46,7 @@
+     public static function width(?string $string): int
+     {
+         $string ??= '';
++        return \strlen($string);
+ 
+         if (preg_match('//u', $string)) {
+             return (new UnicodeString($string))->width(false);
+@@ -65,6 +66,7 @@
+     public static function length(?string $string): int
+     {
+         $string ??= '';
++        return \strlen($string);
+ 
+         if (preg_match('//u', $string)) {
+             return (new UnicodeString($string))->length();

--- a/scoper.php
+++ b/scoper.php
@@ -92,19 +92,6 @@ return [
             );
         },
 
-        // fixes https://github.com/rectorphp/rector/issues/7017
-        static function (string $filePath, string $prefix, string $content): string {
-            if (str_ends_with($filePath, 'vendor/symfony/string/ByteString.php')) {
-                return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
-            }
-
-            if (str_ends_with($filePath, 'vendor/symfony/string/AbstractUnicodeString.php')) {
-                return Strings::replace($content, '#' . $prefix . '\\\\\\\\1_\\\\\\\\2#', '\\\\1_\\\\2');
-            }
-
-            return $content;
-        },
-
         // un-prefix composer plugin
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'vendor/rector/extension-installer/src/Plugin.php')) {


### PR DESCRIPTION
Ref https://tomasvotruba.com/blog/how-to-remove-transitional-dependencies-you-dont-need


* Added 4 new lines in https://github.com/rectorphp/rector-symfony/pull/511/files :heavy_check_mark: 
* Removed 3960 lines :heavy_check_mark:  :tada: 


![Screenshot from 2023-08-20 12-41-44](https://github.com/rectorphp/rector-src/assets/924196/0f3a155a-ee79-43b7-9a5b-143484649be6)




https://github.com/rectorphp/rector/commit/c9318c9c37a1cb4ffeef438f10af5ef992c7af60