### PR TITLE
[DX] Add optional testdox/pest like output to get exact test metrics per unit test fixture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "phpunit/phpunit": "^10.1",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-generator": "dev-main",
+        "robiningelbrecht/phpunit-pretty-print": "^1.2",
         "spatie/enum": "^3.13",
         "symplify/easy-ci": "^11.1.18",
         "symplify/easy-coding-standard": "^12.0.5",

--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,11 @@
     "extra": {
         "patches": {
             "symfony/console": [
+<<<<<<< HEAD
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/symfony-console-helper-helper-php.patch"
+=======
+                "patches/symfony-console-helper-helper-php.patch"
+>>>>>>> 060ca9d667 (patch width/height in console helper)
             ],
             "illuminate/container": [
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches//illuminate-container-container-php.patch"

--- a/composer.json
+++ b/composer.json
@@ -136,11 +136,7 @@
     "extra": {
         "patches": {
             "symfony/console": [
-<<<<<<< HEAD
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/symfony-console-helper-helper-php.patch"
-=======
-                "patches/symfony-console-helper-helper-php.patch"
->>>>>>> 060ca9d667 (patch width/height in console helper)
             ],
             "illuminate/container": [
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches//illuminate-container-container-php.patch"

--- a/phpstan-for-rector.neon
+++ b/phpstan-for-rector.neon
@@ -11,4 +11,3 @@ parameters:
     # see https://github.com/rectorphp/rector/issues/3490#issue-634342324
     featureToggles:
         disableRuntimeReflectionProvider: true
-

--- a/phpunit-debug.xml
+++ b/phpunit-debug.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    executionOrder="defects"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+>
+    <testsuites>
+        <testsuite name="main">
+            <directory>tests</directory>
+            <directory>rules-tests</directory>
+            <directory>packages-tests</directory>
+            <directory>utils-tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <extensions>
+        <bootstrap class="RobinIngelbrecht\PHPUnitPrettyPrint\PhpUnitExtension">
+        </bootstrap>
+    </extensions>
+</phpunit>


### PR DESCRIPTION
Make use of https://github.com/robiningelbrecht/phpunit-pretty-print to return *testdox-like* output.

This allows us:

* see test runtime in ms per case
* see slow tests
* see progress of current test case


Use like:

```bash
vendor/bin/phpunit -c phpunit-debug.xml
```