### PR TITLE
[DeadCode] Skip possible null Iterator with Array Dim Fetch on RemoveDeadInstanceOfRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_possible_null_array_dim_fetch.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadInstanceOfRector/Fixture/skip_possible_null_array_dim_fetch.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\Fixture;
+
+use Iterator;
+use stdClass;
+
+class SkipPossibleNullArrayDimFetch
+{
+    public function go(Iterator $articles)
+    {
+        $result = [
+            'artikel' => $articles,
+            'farben' => null,
+            'artikel_ids' => [],
+        ];
+
+        // collect article ids
+        foreach ($result['artikel'] as $article) {
+            $result['artikel_ids'][] = 1;
+        }
+
+        if ($result['artikel_ids'] !== []) {
+            $result['farben'] = new stdClass();
+        }
+
+        // $result['farben'] might be also null
+        if ($result['farben'] instanceof stdClass) {
+            echo '123';
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8147