### PR TITLE
[BetterPhpDocParser] Run PhpDocNodeTraverser->traverse() once take 2

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocNodeMapper.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeMapper.php
@@ -34,12 +34,10 @@ final class PhpDocNodeMapper
     {
         $this->currentTokenIteratorProvider->setBetterTokenIterator($betterTokenIterator);
 
-        $connectingAndCloningPhpDocNodeTraverser = new PhpDocNodeTraverser();
-        $connectingAndCloningPhpDocNodeTraverser->addPhpDocNodeVisitor($this->parentConnectingPhpDocNodeVisitor);
-        $connectingAndCloningPhpDocNodeTraverser->addPhpDocNodeVisitor($this->cloningPhpDocNodeVisitor);
-        $connectingAndCloningPhpDocNodeTraverser->traverse($phpDocNode);
-
         $phpDocNodeTraverser = new PhpDocNodeTraverser();
+        $phpDocNodeTraverser->addPhpDocNodeVisitor($this->parentConnectingPhpDocNodeVisitor);
+        $phpDocNodeTraverser->addPhpDocNodeVisitor($this->cloningPhpDocNodeVisitor);
+
         foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
             $phpDocNodeTraverser->addPhpDocNodeVisitor($phpDocNodeVisitor);
         }

--- a/packages/BetterPhpDocParser/PhpDocNodeMapper.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeMapper.php
@@ -25,23 +25,22 @@ final class PhpDocNodeMapper
         private readonly CurrentTokenIteratorProvider $currentTokenIteratorProvider,
         private readonly ParentConnectingPhpDocNodeVisitor $parentConnectingPhpDocNodeVisitor,
         private readonly CloningPhpDocNodeVisitor $cloningPhpDocNodeVisitor,
+        private readonly PhpDocNodeTraverser $phpDocNodeTraverser,
         private readonly array $phpDocNodeVisitors
     ) {
         Assert::notEmpty($phpDocNodeVisitors);
+
+        $this->phpDocNodeTraverser->addPhpDocNodeVisitor($this->parentConnectingPhpDocNodeVisitor);
+        $this->phpDocNodeTraverser->addPhpDocNodeVisitor($this->cloningPhpDocNodeVisitor);
+
+        foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+            $this->phpDocNodeTraverser->addPhpDocNodeVisitor($phpDocNodeVisitor);
+        }
     }
 
     public function transform(PhpDocNode $phpDocNode, BetterTokenIterator $betterTokenIterator): void
     {
         $this->currentTokenIteratorProvider->setBetterTokenIterator($betterTokenIterator);
-
-        $phpDocNodeTraverser = new PhpDocNodeTraverser();
-        $phpDocNodeTraverser->addPhpDocNodeVisitor($this->parentConnectingPhpDocNodeVisitor);
-        $phpDocNodeTraverser->addPhpDocNodeVisitor($this->cloningPhpDocNodeVisitor);
-
-        foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
-            $phpDocNodeTraverser->addPhpDocNodeVisitor($phpDocNodeVisitor);
-        }
-
-        $phpDocNodeTraverser->traverse($phpDocNode);
+        $this->phpDocNodeTraverser->traverse($phpDocNode);
     }
 }

--- a/packages/BetterPhpDocParser/PhpDocNodeMapper.php
+++ b/packages/BetterPhpDocParser/PhpDocNodeMapper.php
@@ -25,22 +25,23 @@ final class PhpDocNodeMapper
         private readonly CurrentTokenIteratorProvider $currentTokenIteratorProvider,
         private readonly ParentConnectingPhpDocNodeVisitor $parentConnectingPhpDocNodeVisitor,
         private readonly CloningPhpDocNodeVisitor $cloningPhpDocNodeVisitor,
-        private readonly PhpDocNodeTraverser $phpDocNodeTraverser,
         private readonly array $phpDocNodeVisitors
     ) {
         Assert::notEmpty($phpDocNodeVisitors);
-
-        $this->phpDocNodeTraverser->addPhpDocNodeVisitor($this->parentConnectingPhpDocNodeVisitor);
-        $this->phpDocNodeTraverser->addPhpDocNodeVisitor($this->cloningPhpDocNodeVisitor);
-
-        foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
-            $this->phpDocNodeTraverser->addPhpDocNodeVisitor($phpDocNodeVisitor);
-        }
     }
 
     public function transform(PhpDocNode $phpDocNode, BetterTokenIterator $betterTokenIterator): void
     {
         $this->currentTokenIteratorProvider->setBetterTokenIterator($betterTokenIterator);
-        $this->phpDocNodeTraverser->traverse($phpDocNode);
+
+        $phpDocNodeTraverser = new PhpDocNodeTraverser();
+        $phpDocNodeTraverser->addPhpDocNodeVisitor($this->parentConnectingPhpDocNodeVisitor);
+        $phpDocNodeTraverser->addPhpDocNodeVisitor($this->cloningPhpDocNodeVisitor);
+
+        foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+            $phpDocNodeTraverser->addPhpDocNodeVisitor($phpDocNodeVisitor);
+        }
+
+        $phpDocNodeTraverser->traverse($phpDocNode);
     }
 }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/4822

use only single `PhpDocNodeTraverser` to traverse all registered visitors.