### PR TITLE
[PostRector] strtolower() early on UseNodesToAddCollector

### DIFF
--- a/packages/PostRector/Collector/UseNodesToAddCollector.php
+++ b/packages/PostRector/Collector/UseNodesToAddCollector.php
@@ -109,10 +109,6 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
         $shortName = $fullyQualifiedObjectType->getShortName();
         $filePath = $file->getFilePath();
 
-        if ($this->isShortClassImported($filePath, $shortName)) {
-            return true;
-        }
-
         $fileConstantUseImportTypes = $this->constantUseImportTypesInFilePath[$filePath] ?? [];
 
         foreach ($fileConstantUseImportTypes as $fileConstantUseImportType) {
@@ -122,10 +118,14 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
             }
         }
 
-        $fileFunctionUseImportTypes = $this->functionUseImportTypesInFilePath[$filePath] ?? [];
+        $shortName = strtolower($shortName);
+        if ($this->isShortClassImported($filePath, $shortName)) {
+            return true;
+        }
 
+        $fileFunctionUseImportTypes = $this->functionUseImportTypesInFilePath[$filePath] ?? [];
         foreach ($fileFunctionUseImportTypes as $fileFunctionUseImportType) {
-            if (strtolower($fileFunctionUseImportType->getShortName()) === strtolower($shortName)) {
+            if (strtolower($fileFunctionUseImportType->getShortName()) === $shortName) {
                 return true;
             }
         }
@@ -190,7 +190,7 @@ final class UseNodesToAddCollector implements NodeCollectorInterface
         $fileUseImports = $this->useImportTypesInFilePath[$filePath] ?? [];
 
         foreach ($fileUseImports as $fileUseImport) {
-            if (strtolower($fileUseImport->getShortName()) === strtolower($shortName)) {
+            if (strtolower($fileUseImport->getShortName()) === $shortName) {
                 return true;
             }
         }


### PR DESCRIPTION
continue of PR:

- https://github.com/rectorphp/rector-src/pull/4829

call `strtolower()` early on usage on 

- `use function` 
- `use ClassName` 

on `UseNodesToAddCollector`. 

For use const, it not lowered on purpose as allowed https://3v4l.org/lteVa