### PR TITLE
[Php80] Handle multiple ->ruleWithConfiguration() call in same rule on AnnotationToAttributeRector

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -165,9 +165,18 @@ final class RectorConfig extends Container
 
         $this->singleton($rectorClass);
         $this->afterResolving($rectorClass, static function (ConfigurableRectorInterface $configurableRector) use (
-            $configuration
+            $configuration,
+            $rectorClass
         ): void {
+            $configuration = array_merge(
+                SimpleParameterProvider::provideArrayParameter(Option::RECTOR_CONFIGURATION)[$rectorClass] ?? [],
+                $configuration
+            );
             $configurableRector->configure($configuration);
+
+            SimpleParameterProvider::addParameter(Option::RECTOR_CONFIGURATION, [
+                $rectorClass => $configuration,
+            ]);
         });
 
         $this->tagRectorService($rectorClass);

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -53,6 +53,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
 
         SimpleParameterProvider::setParameter(Option::INDENT_CHAR, ' ');
         SimpleParameterProvider::setParameter(Option::INDENT_SIZE, 4);
+        SimpleParameterProvider::setParameter(Option::RECTOR_CONFIGURATION, []);
     }
 
     protected function setUp(): void

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixtureMultipleCall/fixture.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/FixtureMultipleCall/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureMultipleCall;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\ManyToMany;
+
+/**
+ * @Entity
+ */
+class User
+{
+    /**
+     * @ManyToMany(targetEntity="Phonenumber")
+     */
+    public $phonenumbers;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\FixtureMultipleCall;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\ManyToMany;
+
+#[Entity]
+class User
+{
+    #[ManyToMany(targetEntity: 'Phonenumber')]
+    public $phonenumbers;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/MultipleCallAnnotationToAttributeRectorTest.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/MultipleCallAnnotationToAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MultipleCallAnnotationToAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureMultipleCall');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/multiple_call_configured_rule.php';
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/multiple_call_configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/multiple_call_configured_rule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->phpVersion(PhpVersionFeature::ATTRIBUTES);
+
+    $rectorConfig
+        ->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity'),
+        ]);
+
+    // should merge with existing config
+    $rectorConfig
+        ->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+            new AnnotationToAttribute('Doctrine\ORM\Mapping\ManyToMany'),
+        ]);
+};

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -153,6 +153,12 @@ final class Option
     public const PHPSTAN_FOR_RECTOR_PATHS = 'phpstan_for_rector_paths';
 
     /**
+     * @internal Use @see \Rector\Config\RectorConfig::ruleWithConfiguration() instead
+     * @var string
+     */
+    public const RECTOR_CONFIGURATION = 'rector_configuration';
+
+    /**
      * @var string
      */
     public const NO_DIFFS = 'no-diffs';


### PR DESCRIPTION
@TomasVotruba @lucasmirloup this is failing fixture for multiple calls `->ruleWithConfiguration()` on same rector rule which should merge instead of replace:

```php
    $rectorConfig
        ->ruleWithConfiguration(AnnotationToAttributeRector::class, [
            new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity'),
        ]);

    // should merge with existing config
    $rectorConfig
        ->ruleWithConfiguration(AnnotationToAttributeRector::class, [
            new AnnotationToAttribute('Doctrine\ORM\Mapping\ManyToMany'),
        ]);
```

Fixes https://github.com/rectorphp/rector/issues/8150
Ref https://getrector.com/demo/d196b918-b061-4c2d-a439-7058e88e6e57