### PR TITLE
[Php73][Php80] Handle empty long array syntax default value on SensitiveConstantNameRector+AddParamBasedOnParentClassMethodRector

### DIFF
--- a/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
+++ b/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
@@ -153,7 +153,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (str_contains($uppercasedConstantName, '\\') || str_contains($uppercasedConstantName, '(') || str_contains($uppercasedConstantName, "'") || str_contains($uppercasedConstantName, '"')) {
+        if (
+            str_contains($uppercasedConstantName, '\\')
+            || str_contains($uppercasedConstantName, '(')
+            || str_contains($uppercasedConstantName, "'")
+        ) {
             return null;
         }
 

--- a/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
+++ b/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
@@ -84,7 +84,6 @@ final class SensitiveConstantNameRector extends AbstractScopeAwareRector impleme
         'TRUE',
         'FALSE',
         'NULL',
-        'ARRAY()'
     ];
 
     public function __construct(
@@ -155,6 +154,10 @@ CODE_SAMPLE
         }
 
         if (str_contains($uppercasedConstantName, '\\')) {
+            return null;
+        }
+
+        if (str_contains($uppercasedConstantName, '(')) {
             return null;
         }
 

--- a/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
+++ b/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
@@ -153,11 +153,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (str_contains($uppercasedConstantName, '\\')) {
-            return null;
-        }
-
-        if (str_contains($uppercasedConstantName, '(')) {
+        if (str_contains($uppercasedConstantName, '\\') || str_contains($uppercasedConstantName, '(') || str_contains($uppercasedConstantName, "'") || str_contains($uppercasedConstantName, '"')) {
             return null;
         }
 

--- a/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
+++ b/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
@@ -84,6 +84,7 @@ final class SensitiveConstantNameRector extends AbstractScopeAwareRector impleme
         'TRUE',
         'FALSE',
         'NULL',
+        'ARRAY()'
     ];
 
     public function __construct(

--- a/tests/Issues/EmptyLongArraySyntax/EmptyLongArraySyntaxTest.php
+++ b/tests/Issues/EmptyLongArraySyntax/EmptyLongArraySyntaxTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EmptyLongArraySyntaxTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/EmptyLongArraySyntax/Fixture/empty_long_array.php.inc
+++ b/tests/Issues/EmptyLongArraySyntax/Fixture/empty_long_array.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax\Fixture;
+
+use Rector\Core\Tests\Issues\EmptyLongArraySyntax\Source\ParentWithEmptyLongArray;
+
+final class EmptyLongArray extends ParentWithEmptyLongArray
+{
+    public function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax\Fixture;
+
+use Rector\Core\Tests\Issues\EmptyLongArraySyntax\Source\ParentWithEmptyLongArray;
+
+final class EmptyLongArray extends ParentWithEmptyLongArray
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/tests/Issues/EmptyLongArraySyntax/Fixture/empty_long_array.php.inc
+++ b/tests/Issues/EmptyLongArraySyntax/Fixture/empty_long_array.php.inc
@@ -25,7 +25,7 @@ use Rector\Core\Tests\Issues\EmptyLongArraySyntax\Source\ParentWithEmptyLongArra
 
 final class EmptyLongArray extends ParentWithEmptyLongArray
 {
-    public function run()
+    public function run($default = array())
     {
     }
 }

--- a/tests/Issues/EmptyLongArraySyntax/Source/ParentWithEmptyLongArray.php
+++ b/tests/Issues/EmptyLongArraySyntax/Source/ParentWithEmptyLongArray.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax\Source;
+
+class ParentWithEmptyLongArray
+{
+    public function run($default = array())
+    {
+    }
+}

--- a/tests/Issues/EmptyLongArraySyntax/config/configured_rule.php
+++ b/tests/Issues/EmptyLongArraySyntax/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php73\Rector\ConstFetch\SensitiveConstantNameRector;
+use Rector\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        SensitiveConstantNameRector::class,
+        AddParamBasedOnParentClassMethodRector::class,
+    ]);
+};


### PR DESCRIPTION
When `SensitiveConstantNameRector` and `AddParamBasedOnParentClassMethodRector` combined. Empty long array `array()` become `\ARRAY`, see

```diff
-    public function run()
+    public function run($default = \ARRAY())
```

which should be `array()` lower case without `\` prefix.

This PR try to fix it /cc @klimslim 