### PR TITLE
[Traverser] Set explicitely nodeConnectingVisitorCompatibility: false config in config/phpstan/static-reflection.neon

### DIFF
--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -2,6 +2,7 @@ parameters:
     # see https://github.com/rectorphp/rector/issues/3490#issue-634342324
     featureToggles:
         disableRuntimeReflectionProvider: false
+        nodeConnectingVisitorCompatibility: false
 
 services:
     - Rector\NodeTypeResolver\Reflection\BetterReflection\RectorBetterReflectionSourceLocatorFactory

--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -64,6 +64,7 @@ final class AttributeKey
      *
      * The parent node can be still enabled by using custom PHPStan configuration,
      * @see https://github.com/rectorphp/rector-src/pull/4458#discussion_r1257478146
+     * @see https://github.com/rectorphp/rector-src/pull/4841
      */
     public const PARENT_NODE = 'parent';
 


### PR DESCRIPTION
@TomasVotruba the `parent`, `prev`, and `next` attribute seems shown after bleeding edge disabled, because of this disabled by `bleedingEdge.neon` config:

https://github.com/phpstan/phpstan-src/blob/9a014a17000af1e1c99783f48aa3d61699406c3f/conf/bleedingEdge.neon#L10

**Before set nodeConnectingVisitorCompatibility: false** 

```php
.PhpParser\Node\Stmt\ClassMethod #42281
   attributes: array (13)
   |  'parent' => PhpParser\Node\Stmt\Enum_ #42282 ...
   |  'previous' => PhpParser\Node\Stmt\ClassMethod #42274 ...
```

**After set nodeConnectingVisitorCompatibility: false** 

```php
null
```

This config set is to disable `NodeConnectingVisitor` by default that caused by PR:

- https://github.com/rectorphp/rector-src/pull/4840

make enabled again.

Fixes https://github.com/rectorphp/rector/issues/8155