### PR TITLE
Recreate to exact Expr node instead of printing when possible on AddParamBasedOnParentClassMethodRector take 2

### DIFF
--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/extends_parent_default_empty_array_string.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/extends_parent_default_empty_array_string.php.inc
@@ -36,7 +36,7 @@ class ExtendsParentDefaultEmptyArrayString extends ParentWithParamWithDefaultVal
     public function emptyString($default = '') {
     }
 
-    public function emptyString2($default = '') {
+    public function emptyString2($default = "") {
     }
 }
 

--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/extends_parent_default_non_empty_array_string.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/extends_parent_default_non_empty_array_string.php.inc
@@ -10,6 +10,9 @@ class ExtendsParentDefaultEmptyArrayString extends ParentWithParamWithDefaultVal
 
     public function nonEmptyString() {
     }
+
+    public function nonEmptyString2() {
+    }
 }
 
 ?>
@@ -25,6 +28,9 @@ class ExtendsParentDefaultEmptyArrayString extends ParentWithParamWithDefaultVal
     }
 
     public function nonEmptyString($default = 'some value') {
+    }
+
+    public function nonEmptyString2($default = "some value") {
     }
 }
 

--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Source/ParentWithParamWithDefaultValue.php
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Source/ParentWithParamWithDefaultValue.php
@@ -32,6 +32,10 @@ class ParentWithParamWithDefaultValue
         return $default;
     }
 
+    public function nonEmptyString2($default = "some value") {
+        return $default;
+    }
+
     public function intParam($default = 123) {
         return $default;
     }

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -217,7 +217,7 @@ CODE_SAMPLE
             $paramDefault = $parentClassMethodParam->default;
 
             if ($paramDefault instanceof Expr) {
-                $paramDefault = $this->resolveParamDefault($paramDefault);
+                $paramDefault = $this->resolveParamDefault($paramDefault, $parentClassMethodParam);
             }
 
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
@@ -242,11 +242,11 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function resolveParamDefault(Expr $expr): Expr
+    private function resolveParamDefault(Expr $expr, Param $param): Expr
     {
         // re-create to avoid TokenStream error
-        if ($expr instanceof String_ && $expr->value === '') {
-            return new String_($expr->value);
+        if ($expr instanceof String_) {
+            return new String_($expr->value, [AttributeKey::KIND => $expr->getAttribute(AttributeKey::KIND)]);
         }
 
         if ($expr instanceof LNumber) {
@@ -257,11 +257,11 @@ CODE_SAMPLE
             return new DNumber($expr->value);
         }
 
-        $printParamDefault = $this->betterStandardPrinter->print($expr);
-        if ($printParamDefault === '[]') {
-            return new Array_([]);
+        if ($expr instanceof Array_ && $expr->items === []) {
+            return new Array_($expr->items, [AttributeKey::KIND => $expr->getAttribute(AttributeKey::KIND)]);
         }
 
+        $printParamDefault = $this->betterStandardPrinter->print($expr);
         return new ConstFetch(new Name($printParamDefault));
     }
 

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -217,7 +217,7 @@ CODE_SAMPLE
             $paramDefault = $parentClassMethodParam->default;
 
             if ($paramDefault instanceof Expr) {
-                $paramDefault = $this->resolveParamDefault($paramDefault, $parentClassMethodParam);
+                $paramDefault = $this->resolveParamDefault($paramDefault);
             }
 
             $paramName = $this->nodeNameResolver->getName($parentClassMethodParam);
@@ -242,7 +242,7 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function resolveParamDefault(Expr $expr, Param $param): Expr
+    private function resolveParamDefault(Expr $expr): Expr
     {
         // re-create to avoid TokenStream error
         if ($expr instanceof String_) {


### PR DESCRIPTION
Utilize `Attributekey::KIND` attribute to get type of string: single or double quote, array: short or long type.