### PR TITLE
[Php73] Remove unused tweak long array on SensitiveConstantNameRector

### DIFF
--- a/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
+++ b/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
@@ -153,11 +153,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (
-            str_contains($uppercasedConstantName, '\\')
-            || str_contains($uppercasedConstantName, '(')
-            || str_contains($uppercasedConstantName, "'")
-        ) {
+        if (str_contains($uppercasedConstantName, '\\')) {
             return null;
         }
 


### PR DESCRIPTION
By PR of re-create empty array when possible on:

- https://github.com/rectorphp/rector-src/pull/4842

the tweak on `SensitiveConstantNameRector` that applied previously on PR:

- https://github.com/rectorphp/rector-src/pull/4837

no longer needed.