### PR TITLE
[DX] Remove double call $configuration->getFileExtensions() on FileFactory

### DIFF
--- a/src/ValueObjectFactory/Application/FileFactory.php
+++ b/src/ValueObjectFactory/Application/FileFactory.php
@@ -32,10 +32,9 @@ final class FileFactory
         $supportedFileExtensions = $configuration->getFileExtensions();
         $filePaths = $this->filesFinder->findInDirectoriesAndFiles($paths, $supportedFileExtensions);
 
-        $fileExtensions = $configuration->getFileExtensions();
-        $fileWithExtensionsFilter = static function (string $filePath) use ($fileExtensions): bool {
+        $fileWithExtensionsFilter = static function (string $filePath) use ($supportedFileExtensions): bool {
             $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
-            return in_array($filePathExtension, $fileExtensions, true);
+            return in_array($filePathExtension, $supportedFileExtensions, true);
         };
 
         return array_filter($filePaths, $fileWithExtensionsFilter);


### PR DESCRIPTION
Use existing assigned variable is enough, no need to double call it.