### PR TITLE
try Pin react/socket to 1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpstan/phpstan": "^1.10.31",
         "react/event-loop": "^1.3",
         "react/promise": "^2.10",
-        "react/socket": "^1.12",
+        "react/socket": "1.13.0",
         "rector/extension-installer": "^0.11.2",
         "rector/rector-doctrine": "dev-main",
         "rector/rector-downgrade-php": "dev-main",


### PR DESCRIPTION
@TomasVotruba react socket 1.14.0 released yesterday

https://github.com/reactphp/socket/releases/tag/v1.14.0

it probably cause some memory leak on downgrade build, let see if this pin to 1.13 resolve it.