### PR TITLE
[ProcessAnalyzer] Skip process when origNode class is not equal with target node class

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -42,11 +42,5 @@ final class DowngradeRectorConfig
         'vendor/symfony/contracts/Cache/*',
 
         'vendor/rector/rector-generator/templates',
-
-        'vendor/rector/rector-symfony/config',
-        'vendor/rector/rector-doctrine/config',
-        'vendor/rector/rector-phpunit/config',
-        'vendor/rector/rector-generator/config',
-        'vendor/rector/rector-downgrade-php/config',
     ];
 }

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -52,7 +51,7 @@ final class RectifiedAnalyzer
     private function isJustReprintedOverlappedTokenStart(Node $node, ?Node $originalNode): bool
     {
         if ($originalNode instanceof Node) {
-            return $originalNode instanceof Expr && $node instanceof Stmt;
+            return ! $originalNode instanceof Stmt && $node instanceof Stmt;
         }
 
         if ($node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -51,7 +51,7 @@ final class RectifiedAnalyzer
     private function isJustReprintedOverlappedTokenStart(Node $node, ?Node $originalNode): bool
     {
         if ($originalNode instanceof Node) {
-            return ! $originalNode instanceof Stmt && $node instanceof Stmt;
+            return false;
         }
 
         if ($node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -51,7 +51,7 @@ final class RectifiedAnalyzer
     private function isJustReprintedOverlappedTokenStart(Node $node, ?Node $originalNode): bool
     {
         if ($originalNode instanceof Node) {
-            return false;
+            return $originalNode::class === $node::class;
         }
 
         if ($node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -51,7 +52,7 @@ final class RectifiedAnalyzer
     private function isJustReprintedOverlappedTokenStart(Node $node, ?Node $originalNode): bool
     {
         if ($originalNode instanceof Node) {
-            return $originalNode::class === $node::class;
+            return $originalNode instanceof Expr && $node instanceof Stmt;
         }
 
         if ($node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -228,7 +228,17 @@ CODE_SAMPLE;
         }
 
         $objectHash = spl_object_hash($node);
-        return $this->nodesToReturn[$objectHash] ?? $node;
+        $result = $this->nodesToReturn[$objectHash] ?? $node;
+
+        if (is_array($result)) {
+            return $result;
+        }
+
+        if ($result::class === $node::class) {
+            return $result;
+        }
+
+        return $node;
     }
 
     protected function isName(Node $node, string $name): bool


### PR DESCRIPTION
@TomasVotruba I tried locally, and verify `origNode` is equal with target `$node` class early on reprint seems fix the downgrade issue.

Ref https://github.com/rectorphp/rector-src/pull/4841#pullrequestreview-1597077172

Let's give it a try and test enable downgrade `vendor/rector/rector-*/config` again.