### PR TITLE
Add test for change Stmt to different Stmt

### DIFF
--- a/tests/Issues/ChangeToDifferentExpr/ChangeToDifferentExprTest.php
+++ b/tests/Issues/ChangeToDifferentExpr/ChangeToDifferentExprTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeToDifferentExprTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/ChangeToDifferentExpr/Fixture/change_string_to_assign.php.inc
+++ b/tests/Issues/ChangeToDifferentExpr/Fixture/change_string_to_assign.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr\Fixture;
+
+final class ChangeStringToAssign
+{
+    public function run()
+    {
+        echo "test";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr\Fixture;
+
+final class ChangeStringToAssign
+{
+    public function run()
+    {
+        echo $test = $foo;
+    }
+}
+
+?>

--- a/tests/Issues/ChangeToDifferentExpr/Source/TestRector.php
+++ b/tests/Issues/ChangeToDifferentExpr/Source/TestRector.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class TestRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('change to different Expr', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            String_::class,
+        ];
+    }
+
+    public function refactor(Node $node)
+    {
+        return new Assign(new Variable('test'), new Variable('foo'));
+    }
+}

--- a/tests/Issues/ChangeToDifferentExpr/config/configured_rule.php
+++ b/tests/Issues/ChangeToDifferentExpr/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\Tests\Issues\ChangeToDifferentExpr\Source\TestRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TestRector::class);
+};

--- a/tests/Issues/ChangeToDifferentStmt/ChangeToDifferentStmtTest.php
+++ b/tests/Issues/ChangeToDifferentStmt/ChangeToDifferentStmtTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeToDifferentStmtTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/ChangeToDifferentStmt/Fixture/change_if_to_echo.php.inc
+++ b/tests/Issues/ChangeToDifferentStmt/Fixture/change_if_to_echo.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt\Fixture;
+
+final class ChangeIfToEcho
+{
+    public function run()
+    {
+        if (rand(0,1)) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt\Fixture;
+
+final class ChangeIfToEcho
+{
+    public function run()
+    {
+        echo 'test';
+    }
+}
+
+?>

--- a/tests/Issues/ChangeToDifferentStmt/Source/TestRector.php
+++ b/tests/Issues/ChangeToDifferentStmt/Source/TestRector.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Echo_;
+use PhpParser\Node\Stmt\If_;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class TestRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('change to different Stmt', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            If_::class,
+        ];
+    }
+
+    public function refactor(Node $node)
+    {
+        return new Echo_([new String_('test')]);
+    }
+}

--- a/tests/Issues/ChangeToDifferentStmt/config/configured_rule.php
+++ b/tests/Issues/ChangeToDifferentStmt/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\Tests\Issues\ChangeToDifferentStmt\Source\TestRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TestRector::class);
+};


### PR DESCRIPTION
@TomasVotruba this is test for PR:

- https://github.com/rectorphp/rector-src/pull/4861

the different node class check is against origNode, so change `If_` to `Echo_` is still working ok as the check is against its origNode from `spl_object_hash()` 

https://github.com/rectorphp/rector-src/blob/3199e0a00c19bbdbd4ac59f10b4368657b70cfd1/src/Rector/AbstractRector.php#L318-L319

https://github.com/rectorphp/rector-src/blob/3199e0a00c19bbdbd4ac59f10b4368657b70cfd1/src/Rector/AbstractRector.php#L230