### PR TITLE
Better approach leaveNode() check Stmt to non Stmt handling on AbstractRector

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
@@ -235,16 +236,12 @@ CODE_SAMPLE;
             return $result;
         }
 
-        if ($result instanceof Stmt && ! $node instanceof Stmt) {
+        if ($result instanceof Stmt && $node instanceof Expr) {
             return $node;
         }
 
-        if ($result instanceof Stmt) {
-            return $result;
-        }
-
-        if (! $node instanceof Stmt) {
-            return $result;
+        if ($result instanceof Expr && $node instanceof Stmt) {
+            return $node;
         }
 
         return $node;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -240,11 +240,15 @@ CODE_SAMPLE;
             return $node;
         }
 
-        if ($result instanceof Expr && $node instanceof Stmt) {
-            return $node;
+        if (! $result instanceof Expr) {
+            return $result;
         }
 
-        return $result;
+        if (! $node instanceof Stmt) {
+            return $result;
+        }
+
+        return $node;
     }
 
     protected function isName(Node $node, string $name): bool

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -243,7 +243,7 @@ CODE_SAMPLE;
             return $result;
         }
 
-        if (!$node instanceof Stmt) {
+        if (! $node instanceof Stmt) {
             return $result;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -244,7 +244,7 @@ CODE_SAMPLE;
             return $node;
         }
 
-        return $node;
+        return $result;
     }
 
     protected function isName(Node $node, string $name): bool

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -238,12 +238,13 @@ CODE_SAMPLE;
         if ($result instanceof Stmt && ! $node instanceof Stmt) {
             return $node;
         }
-
-        if (! $result instanceof Stmt && $node instanceof Stmt) {
-            return $node;
+        if ($result instanceof Stmt) {
+            return $result;
         }
-
-        return $result;
+        if (!$node instanceof Stmt) {
+            return $result;
+        }
+        return $node;
     }
 
     protected function isName(Node $node, string $name): bool

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
@@ -234,11 +235,15 @@ CODE_SAMPLE;
             return $result;
         }
 
-        if ($result::class === $node::class) {
-            return $result;
+        if ($result instanceof Stmt && ! $node instanceof Stmt) {
+            return $node;
         }
 
-        return $node;
+        if (! $result instanceof Stmt && $node instanceof Stmt) {
+            return $node;
+        }
+
+        return $result;
     }
 
     protected function isName(Node $node, string $name): bool

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -238,12 +238,15 @@ CODE_SAMPLE;
         if ($result instanceof Stmt && ! $node instanceof Stmt) {
             return $node;
         }
+
         if ($result instanceof Stmt) {
             return $result;
         }
+
         if (!$node instanceof Stmt) {
             return $result;
         }
+
         return $node;
     }
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/4861
- https://github.com/rectorphp/rector-src/pull/4862

check instanceof Stmt to non Stmt or vice verca seems better approach to be checked on `leaveNode()` method.