### PR TITLE
[Performance] Only save nodesToReturn[$objectHash] on return array of nodes on AbstractRector

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -221,21 +221,15 @@ CODE_SAMPLE;
      */
     public function leaveNode(Node $node): array|int|Node|null
     {
-        if ($this->toBeRemovedNodeHash !== null && $this->toBeRemovedNodeHash === spl_object_hash($node)) {
+        $objectHash = spl_object_hash($node);
+        if ($this->toBeRemovedNodeHash !== null && $this->toBeRemovedNodeHash === $objectHash) {
             $this->toBeRemovedNodeHash = null;
 
             return NodeTraverser::REMOVE_NODE;
         }
 
-        $objectHash = spl_object_hash($node);
-        $result = $this->nodesToReturn[$objectHash] ?? $node;
-
-        if (is_array($result)) {
-            return $result;
-        }
-
-        if ($result::class === $node::class) {
-            return $result;
+        if (isset($this->nodesToReturn[$objectHash])) {
+            return $this->nodesToReturn[$objectHash];
         }
 
         return $node;
@@ -315,14 +309,14 @@ CODE_SAMPLE;
         /** @var MutatingScope|null $currentScope */
         $currentScope = $node->getAttribute(AttributeKey::SCOPE);
 
-        // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
-        $originalNodeHash = spl_object_hash($originalNode);
-
         if (is_array($refactoredNode)) {
             $firstNode = current($refactoredNode);
             $this->mirrorComments($firstNode, $originalNode);
 
             $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
+
+            // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
+            $originalNodeHash = spl_object_hash($originalNode);
 
             // will be replaced in leaveNode() the original node must be passed
             $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
@@ -331,8 +325,6 @@ CODE_SAMPLE;
         }
 
         $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
-
-        $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
         return $refactoredNode;
     }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -228,11 +228,7 @@ CODE_SAMPLE;
             return NodeTraverser::REMOVE_NODE;
         }
 
-        if (isset($this->nodesToReturn[$objectHash])) {
-            return $this->nodesToReturn[$objectHash];
-        }
-
-        return $node;
+        return $this->nodesToReturn[$objectHash] ?? $node;
     }
 
     protected function isName(Node $node, string $name): bool


### PR DESCRIPTION
Save indexed `nodesToReturn[$objectHash]` seems only needed when return array of nodes.