### PR TITLE
Clean up docblock on $nodesToReturn property on AbstractRector

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE;
     private CurrentFileProvider $currentFileProvider;
 
     /**
-     * @var array<string, Node[]|Node>
+     * @var array<string, Node[]>
      */
     private array $nodesToReturn = [];
 


### PR DESCRIPTION
Since the data is now only collection of nodes per spl_object_hash() key

Continue of PR:

- https://github.com/rectorphp/rector-src/pull/4865