### PR TITLE
[ProcessAnalyzer] Remove phpstan_cache_printer tweak check on RectifiedAnalyzer

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\PhpDocParser\ValueObject\AttributeKey as ValueObjectAttributeKey;
 
 /**
  * This service verify if the Node:
@@ -60,16 +58,11 @@ final class RectifiedAnalyzer
 
         /**
          * Start token pos must be < 0 to continue, as the node and parent node just re-printed
-         * except the Node is not Stmt and doesn't have 'phpstan_cache_printer' attribute yet
          *
          * - Node's original node is null
          * - Parent Node's original node is null
          */
         $startTokenPos = $node->getStartTokenPos();
-        if ($startTokenPos >= 0) {
-            return true;
-        }
-
-        return ! $node instanceof Stmt && ! $node->hasAttribute(ValueObjectAttributeKey::PHPSTAN_CACHE_PRINTER);
+        return $startTokenPos >= 0;
     }
 }

--- a/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
+++ b/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
@@ -54,7 +54,7 @@ class Fixture {
 
     public function check(): bool
     {
-        return !($this->getString() === null || $this->getString() === '' || (($this->getString2() === null || $this->getString2() === '') && !is_numeric($this->getString2())));
+        return $this->getString() !== null && $this->getString() !== '' && !(($this->getString2() === null || $this->getString2() === '') && !is_numeric($this->getString2()));
     }
 }
 


### PR DESCRIPTION
Since `AbstractRector::nodesToReturn` now only save when return array of nodes (Stmt obviously) on PR:

- https://github.com/rectorphp/rector-src/pull/4865

The phpstan cache printer check on `RectifiedAnalyzer` seems no longer needed.