### PR TITLE
[Php55][Renaming] Handle rename string on combination StringClassNameToClassConstantRector+RenameStringRector

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -134,6 +134,12 @@ final class AttributeKey
     public const CREATED_BY_RULE = 'created_by_rule';
 
     /**
+     * Helps with skipped below node
+     * @var string
+     */
+    public const SKIPPED_BY_RECTOR_RULE = 'skipped_rector_rule';
+
+    /**
      * @var string
      */
     public const WRAPPED_IN_PARENTHESES = 'wrapped_in_parentheses';

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -27,7 +27,11 @@ final class RectifiedAnalyzer
             return true;
         }
 
-        return $this->isJustReprintedOverlappedTokenStart($node, $originalNode);
+        if ($this->isJustReprintedOverlappedTokenStart($node, $originalNode)) {
+            return true;
+        }
+
+        return $node->getAttribute(AttributeKey::SKIPPED_BY_RECTOR_RULE) === $rectorClass;
     }
 
     /**

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -203,7 +203,7 @@ CODE_SAMPLE;
                 return $refactoredNode;
             }
 
-            $this->decorateCurrentAndChildren($node, $originalNode);
+            $this->decorateCurrentAndChildren($node);
             return null;
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -195,11 +195,16 @@ CODE_SAMPLE;
         if (is_int($refactoredNode)) {
             $this->createdByRuleDecorator->decorate($node, $originalNode, static::class);
 
-            // notify this rule changing code
-            $rectorWithLineChange = new RectorWithLineChange(static::class, $originalNode->getLine());
-            $this->file->addRectorClassWithLine($rectorWithLineChange);
+            if (! in_array($refactoredNode, [NodeTraverser::DONT_TRAVERSE_CHILDREN, NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN], true)) {
+                // notify this rule changing code
+                $rectorWithLineChange = new RectorWithLineChange(static::class, $originalNode->getLine());
+                $this->file->addRectorClassWithLine($rectorWithLineChange);
 
-            return $refactoredNode;
+                return $refactoredNode;
+            }
+
+            $this->decorateCurrentAndChildren($node, $originalNode);
+            return null;
         }
 
         // nothing to change → continue
@@ -213,6 +218,26 @@ CODE_SAMPLE;
         }
 
         return $this->postRefactorProcess($originalNode, $node, $refactoredNode, $filePath);
+    }
+
+    private function decorateCurrentAndChildren(Node $node): void
+    {
+        // filter only types that
+        //    1. registered in getNodesTypes() method
+        //    2. different with current node type, as already decorated above
+        //
+        $types = array_filter(
+            $this->getNodeTypes(),
+            static fn (string $nodeType): bool => $nodeType !== $node::class
+        );
+        $this->traverseNodesWithCallable($node, static function (Node $subNode) use ($types) {
+            if (in_array($subNode::class, $types, true)) {
+                $subNode->setAttribute(AttributeKey::SKIPPED_BY_RECTOR_RULE, static::class);
+                $subNode->setAttribute(AttributeKey::SKIPPED_BY_RECTOR_RULE, static::class);
+            }
+
+            return null;
+        });
     }
 
     /**

--- a/tests/Issues/RenameString/Fixture/rename_string.php.inc
+++ b/tests/Issues/RenameString/Fixture/rename_string.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+
+final class RenameString
+{
+    public function run($variable)
+    {
+        return is_a(
+            $variable,
+            'Rector\Core\Tests\Issues\DoubleRun\Fixture\RenameString',
+            true
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+
+final class RenameString
+{
+    public function run($variable)
+    {
+        return is_a(
+            $variable,
+            'new test',
+            true
+        );
+    }
+}
+
+?>

--- a/tests/Issues/RenameString/RenameStringTest.php
+++ b/tests/Issues/RenameString/RenameStringTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RenameString;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenameStringTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RenameString/config/configured_rule.php
+++ b/tests/Issues/RenameString/config/configured_rule.php
@@ -1,14 +1,16 @@
 <?php
 
 declare(strict_types=1);
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Renaming\Rector\String_\RenameStringRector;
 
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(\Rector\Php55\Rector\String_\StringClassNameToClassConstantRector::class);
+    $rectorConfig->rule(StringClassNameToClassConstantRector::class);
 
     $rectorConfig->ruleWithConfiguration(
-        \Rector\Renaming\Rector\String_\RenameStringRector::class,
+        RenameStringRector::class,
         [
     		'Rector\Core\Tests\Issues\DoubleRun\Fixture\RenameString' => 'new test',
         ]

--- a/tests/Issues/RenameString/config/configured_rule.php
+++ b/tests/Issues/RenameString/config/configured_rule.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(\Rector\Php55\Rector\String_\StringClassNameToClassConstantRector::class);
+    $rectorConfig->rule(StringClassNameToClassConstantRector::class);
 
     $rectorConfig->ruleWithConfiguration(
-        \Rector\Renaming\Rector\String_\RenameStringRector::class,
+        RenameStringRector::class,
         [
     		'Rector\Core\Tests\Issues\DoubleRun\Fixture\RenameString' => 'new test',
         ]

--- a/tests/Issues/RenameString/config/configured_rule.php
+++ b/tests/Issues/RenameString/config/configured_rule.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(StringClassNameToClassConstantRector::class);
+    $rectorConfig->rule(\Rector\Php55\Rector\String_\StringClassNameToClassConstantRector::class);
 
     $rectorConfig->ruleWithConfiguration(
-        RenameStringRector::class,
+        \Rector\Renaming\Rector\String_\RenameStringRector::class,
         [
     		'Rector\Core\Tests\Issues\DoubleRun\Fixture\RenameString' => 'new test',
         ]

--- a/tests/Issues/RenameString/config/configured_rule.php
+++ b/tests/Issues/RenameString/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(\Rector\Php55\Rector\String_\StringClassNameToClassConstantRector::class);
+
+    $rectorConfig->ruleWithConfiguration(
+        \Rector\Renaming\Rector\String_\RenameStringRector::class,
+        [
+    		'Rector\Core\Tests\Issues\DoubleRun\Fixture\RenameString' => 'new test',
+        ]
+    );
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8160

`StringClassNameToClassConstantRector` directly use `return NodeTraverser::DONT_TRAVERSE_CHILDREN` on a refactor that cause other rule stopped:

https://github.com/rectorphp/rector-src/blob/1c56aa9bdad38af386edd67f45405d641da37ed5/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php#L110-L116

this should only stop below on current rule only. 

This PR also a rework of PR:

- https://github.com/rectorphp/rector-src/pull/4191

