### PR TITLE
[ProcessAnalyzer] Remove unnecessary hasAttribute(origNode) on RectifiedAnalyzer

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
@@ -131,11 +131,13 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         }
 
         $uses = $this->useImportsResolver->resolve();
-        $originalNode = $phpParserNode->getAttribute(AttributeKey::ORIGINAL_NODE) ?? $phpParserNode;
-        $scope = $originalNode->getAttribute(AttributeKey::SCOPE);
+        $originalNode = $phpParserNode->getAttribute(AttributeKey::ORIGINAL_NODE);
+        $scope = $originalNode instanceof PhpParserNode
+            ? $originalNode->getAttribute(AttributeKey::SCOPE)
+            : $phpParserNode->getAttribute(AttributeKey::SCOPE);
 
         if (! $scope instanceof Scope) {
-            if (! $phpParserNode->hasAttribute(AttributeKey::ORIGINAL_NODE)) {
+            if (! $originalNode instanceof PhpParserNode) {
                 return $this->resolveNamefromUse($uses, $name);
             }
 

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -57,10 +57,6 @@ final class RectifiedAnalyzer
             return false;
         }
 
-        if ($node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {
-            return false;
-        }
-
         /**
          * Start token pos must be < 0 to continue, as the node and parent node just re-printed
          *


### PR DESCRIPTION
`$node->hasAttribute(AttributeKey::ORIGINAL_NODE)` seems no longer needed on `RectifiedAnalyzer`