### PR TITLE
[Performance] Avoid spl_object_hash() when has origNode attribute on AbstractRector::leaveNode()

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -230,6 +230,10 @@ CODE_SAMPLE;
      */
     public function leaveNode(Node $node): array|int|Node|null
     {
+        if ($node->hasAttribute(AttributeKey::ORIGINAL_NODE)) {
+            return null;
+        }
+
         $objectHash = spl_object_hash($node);
         if ($this->toBeRemovedNodeHash === $objectHash) {
             $this->toBeRemovedNodeHash = null;


### PR DESCRIPTION
`spl_object_hash()` is against origNode:

https://github.com/rectorphp/rector-src/blob/9e8ed6c33f39aa9d7d859fb39b6f2d0344cdea0d/src/Rector/AbstractRector.php#L348

so the check should only on node that doesn't have origNode => the origNode itself.