### PR TITLE
[Performance] Use more performance spl_object_id()

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -57,10 +57,10 @@ final class PhpDocInfoFactory
 
     public function createFromNode(Node $node): ?PhpDocInfo
     {
-        $objectHash = spl_object_id($node);
+        $objectId = spl_object_id($node);
 
-        if (isset($this->phpDocInfosByObjectHash[$objectHash])) {
-            return $this->phpDocInfosByObjectHash[$objectHash];
+        if (isset($this->phpDocInfosByObjectHash[$objectId])) {
+            return $this->phpDocInfosByObjectHash[$objectId];
         }
 
         /** @see \Rector\BetterPhpDocParser\PhpDocParser\DoctrineAnnotationDecorator::decorate() */
@@ -84,7 +84,7 @@ final class PhpDocInfoFactory
         }
 
         $phpDocInfo = $this->createFromPhpDocNode($phpDocNode, $tokenIterator, $node);
-        $this->phpDocInfosByObjectHash[$objectHash] = $phpDocInfo;
+        $this->phpDocInfosByObjectHash[$objectId] = $phpDocInfo;
 
         return $phpDocInfo;
     }

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -25,7 +25,7 @@ final class PhpDocInfoFactory
     /**
      * @var array<int, PhpDocInfo>
      */
-    private array $phpDocInfosByObjectHash = [];
+    private array $phpDocInfosByObjectId = [];
 
     public function __construct(
         private readonly PhpDocNodeMapper $phpDocNodeMapper,
@@ -59,8 +59,8 @@ final class PhpDocInfoFactory
     {
         $objectId = spl_object_id($node);
 
-        if (isset($this->phpDocInfosByObjectHash[$objectId])) {
-            return $this->phpDocInfosByObjectHash[$objectId];
+        if (isset($this->phpDocInfosByObjectId[$objectId])) {
+            return $this->phpDocInfosByObjectId[$objectId];
         }
 
         /** @see \Rector\BetterPhpDocParser\PhpDocParser\DoctrineAnnotationDecorator::decorate() */
@@ -84,7 +84,7 @@ final class PhpDocInfoFactory
         }
 
         $phpDocInfo = $this->createFromPhpDocNode($phpDocNode, $tokenIterator, $node);
-        $this->phpDocInfosByObjectHash[$objectId] = $phpDocInfo;
+        $this->phpDocInfosByObjectId[$objectId] = $phpDocInfo;
 
         return $phpDocInfo;
     }

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -57,7 +57,7 @@ final class PhpDocInfoFactory
 
     public function createFromNode(Node $node): ?PhpDocInfo
     {
-        $objectHash = spl_object_hash($node);
+        $objectHash = spl_object_id($node);
 
         if (isset($this->phpDocInfosByObjectHash[$objectHash])) {
             return $this->phpDocInfosByObjectHash[$objectHash];

--- a/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/BetterPhpDocParser/PhpDocInfo/PhpDocInfoFactory.php
@@ -23,7 +23,7 @@ use Rector\StaticTypeMapper\StaticTypeMapper;
 final class PhpDocInfoFactory
 {
     /**
-     * @var array<string, PhpDocInfo>
+     * @var array<int, PhpDocInfo>
      */
     private array $phpDocInfosByObjectHash = [];
 

--- a/packages/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
@@ -33,7 +33,7 @@ final class ClassAnnotationMatcher
 
     public function resolveTagFullyQualifiedName(string $tag, Node $node): string
     {
-        $uniqueHash = $tag . spl_object_hash($node);
+        $uniqueHash = $tag . spl_object_id($node);
         if (isset($this->fullyQualifiedNameByHash[$uniqueHash])) {
             return $this->fullyQualifiedNameByHash[$uniqueHash];
         }

--- a/packages/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
@@ -33,9 +33,9 @@ final class ClassAnnotationMatcher
 
     public function resolveTagFullyQualifiedName(string $tag, Node $node): string
     {
-        $uniqueHash = $tag . spl_object_id($node);
-        if (isset($this->fullyQualifiedNameByHash[$uniqueHash])) {
-            return $this->fullyQualifiedNameByHash[$uniqueHash];
+        $uniqueId = $tag . spl_object_id($node);
+        if (isset($this->fullyQualifiedNameByHash[$uniqueId])) {
+            return $this->fullyQualifiedNameByHash[$uniqueId];
         }
 
         $tag = ltrim($tag, '@');
@@ -47,7 +47,7 @@ final class ClassAnnotationMatcher
             $fullyQualifiedClass = $tag;
         }
 
-        $this->fullyQualifiedNameByHash[$uniqueHash] = $fullyQualifiedClass;
+        $this->fullyQualifiedNameByHash[$uniqueId] = $fullyQualifiedClass;
 
         return $fullyQualifiedClass;
     }

--- a/packages/PhpDocParser/NodeVisitor/CallableNodeVisitor.php
+++ b/packages/PhpDocParser/NodeVisitor/CallableNodeVisitor.php
@@ -18,7 +18,7 @@ final class CallableNodeVisitor extends NodeVisitorAbstract
      */
     private $callable;
 
-    private ?int $nodeHashToRemove = null;
+    private ?int $nodeIdToRemove = null;
 
     /**
      * @param callable(Node $node): (int|Node|null) $callable
@@ -38,7 +38,7 @@ final class CallableNodeVisitor extends NodeVisitorAbstract
         $newNode = $callable($node);
 
         if ($newNode === NodeTraverser::REMOVE_NODE) {
-            $this->nodeHashToRemove = spl_object_id($originalNode);
+            $this->nodeIdToRemove = spl_object_id($originalNode);
             return $originalNode;
         }
 
@@ -51,8 +51,8 @@ final class CallableNodeVisitor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node): int|Node
     {
-        if ($this->nodeHashToRemove === spl_object_id($node)) {
-            $this->nodeHashToRemove = null;
+        if ($this->nodeIdToRemove === spl_object_id($node)) {
+            $this->nodeIdToRemove = null;
             return NodeTraverser::REMOVE_NODE;
         }
 

--- a/packages/PhpDocParser/NodeVisitor/CallableNodeVisitor.php
+++ b/packages/PhpDocParser/NodeVisitor/CallableNodeVisitor.php
@@ -18,7 +18,7 @@ final class CallableNodeVisitor extends NodeVisitorAbstract
      */
     private $callable;
 
-    private ?string $nodeHashToRemove = null;
+    private ?int $nodeHashToRemove = null;
 
     /**
      * @param callable(Node $node): (int|Node|null) $callable
@@ -38,7 +38,7 @@ final class CallableNodeVisitor extends NodeVisitorAbstract
         $newNode = $callable($node);
 
         if ($newNode === NodeTraverser::REMOVE_NODE) {
-            $this->nodeHashToRemove = spl_object_hash($originalNode);
+            $this->nodeHashToRemove = spl_object_id($originalNode);
             return $originalNode;
         }
 
@@ -51,7 +51,7 @@ final class CallableNodeVisitor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node): int|Node
     {
-        if ($this->nodeHashToRemove === spl_object_hash($node)) {
+        if ($this->nodeHashToRemove === spl_object_id($node)) {
             $this->nodeHashToRemove = null;
             return NodeTraverser::REMOVE_NODE;
         }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_anonymous_class.php.inc
@@ -51,7 +51,7 @@ class SkipAnonymousClass
 
             private function processClassNode(Class_ $classNode): Class_
             {
-                $variableInfos = $this->propertiesByClass[spl_object_hash($classNode)] ?? [];
+                $variableInfos = $this->propertiesByClass[spl_object_id($classNode)] ?? [];
                 foreach ($variableInfos as $propertyInfo) {
                     $this->classManipulator->addConstructorDependency($classNode, $propertyInfo);
                 }

--- a/rules/Naming/Naming/ConflictingNameResolver.php
+++ b/rules/Naming/Naming/ConflictingNameResolver.php
@@ -64,10 +64,10 @@ final class ConflictingNameResolver
         ClassMethod | Function_ | Closure | ArrowFunction $functionLike
     ): array {
         // cache it!
-        $classMethodHash = spl_object_id($functionLike);
+        $classMethodId = spl_object_id($functionLike);
 
-        if (isset($this->conflictingVariableNamesByClassMethod[$classMethodHash])) {
-            return $this->conflictingVariableNamesByClassMethod[$classMethodHash];
+        if (isset($this->conflictingVariableNamesByClassMethod[$classMethodId])) {
+            return $this->conflictingVariableNamesByClassMethod[$classMethodId];
         }
 
         $paramNames = $this->functionLikeManipulator->resolveParamNames($functionLike);
@@ -77,7 +77,7 @@ final class ConflictingNameResolver
         $protectedNames = array_merge($paramNames, $newAssignNames, $nonNewAssignNames);
 
         $protectedNames = $this->arrayFilter->filterWithAtLeastTwoOccurences($protectedNames);
-        $this->conflictingVariableNamesByClassMethod[$classMethodHash] = $protectedNames;
+        $this->conflictingVariableNamesByClassMethod[$classMethodId] = $protectedNames;
 
         return $protectedNames;
     }

--- a/rules/Naming/Naming/ConflictingNameResolver.php
+++ b/rules/Naming/Naming/ConflictingNameResolver.php
@@ -64,7 +64,7 @@ final class ConflictingNameResolver
         ClassMethod | Function_ | Closure | ArrowFunction $functionLike
     ): array {
         // cache it!
-        $classMethodHash = spl_object_hash($functionLike);
+        $classMethodHash = spl_object_id($functionLike);
 
         if (isset($this->conflictingVariableNamesByClassMethod[$classMethodHash])) {
             return $this->conflictingVariableNamesByClassMethod[$classMethodHash];

--- a/rules/Naming/Naming/ConflictingNameResolver.php
+++ b/rules/Naming/Naming/ConflictingNameResolver.php
@@ -17,7 +17,7 @@ use Rector\Naming\PhpArray\ArrayFilter;
 final class ConflictingNameResolver
 {
     /**
-     * @var array<string, string[]>
+     * @var array<int, string[]>
      */
     private array $conflictingVariableNamesByClassMethod = [];
 

--- a/rules/Naming/Naming/OverridenExistingNamesResolver.php
+++ b/rules/Naming/Naming/OverridenExistingNamesResolver.php
@@ -65,7 +65,7 @@ final class OverridenExistingNamesResolver
      */
     private function resolveOveriddenNamesForNew(ClassMethod | Function_ | Closure $functionLike): array
     {
-        $classMethodHash = spl_object_hash($functionLike);
+        $classMethodHash = spl_object_id($functionLike);
 
         if (isset($this->overridenExistingVariableNamesByClassMethod[$classMethodHash])) {
             return $this->overridenExistingVariableNamesByClassMethod[$classMethodHash];

--- a/rules/Naming/Naming/OverridenExistingNamesResolver.php
+++ b/rules/Naming/Naming/OverridenExistingNamesResolver.php
@@ -65,10 +65,10 @@ final class OverridenExistingNamesResolver
      */
     private function resolveOveriddenNamesForNew(ClassMethod | Function_ | Closure $functionLike): array
     {
-        $classMethodHash = spl_object_id($functionLike);
+        $classMethodId = spl_object_id($functionLike);
 
-        if (isset($this->overridenExistingVariableNamesByClassMethod[$classMethodHash])) {
-            return $this->overridenExistingVariableNamesByClassMethod[$classMethodHash];
+        if (isset($this->overridenExistingVariableNamesByClassMethod[$classMethodId])) {
+            return $this->overridenExistingVariableNamesByClassMethod[$classMethodId];
         }
 
         $currentlyUsedNames = [];
@@ -90,7 +90,7 @@ final class OverridenExistingNamesResolver
         $currentlyUsedNames = array_values($currentlyUsedNames);
         $currentlyUsedNames = $this->arrayFilter->filterWithAtLeastTwoOccurences($currentlyUsedNames);
 
-        $this->overridenExistingVariableNamesByClassMethod[$classMethodHash] = $currentlyUsedNames;
+        $this->overridenExistingVariableNamesByClassMethod[$classMethodId] = $currentlyUsedNames;
 
         return $currentlyUsedNames;
     }

--- a/rules/Naming/Naming/OverridenExistingNamesResolver.php
+++ b/rules/Naming/Naming/OverridenExistingNamesResolver.php
@@ -17,7 +17,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 final class OverridenExistingNamesResolver
 {
     /**
-     * @var array<string, array<int, string>>
+     * @var array<int, array<int, string>>
      */
     private array $overridenExistingVariableNamesByClassMethod = [];
 

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -49,6 +49,11 @@ final class ClassMethodAssignManipulator
             }
         }
 
-        return false;
+        $classMethodHash = spl_object_id($classMethod);
+        if (! isset($this->alreadyAddedClassMethodNames[$classMethodHash])) {
+            return false;
+        }
+
+        return in_array($name, $this->alreadyAddedClassMethodNames[$classMethodHash], true);
     }
 }

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -48,12 +48,6 @@ final class ClassMethodAssignManipulator
                 return true;
             }
         }
-
-        $classMethodHash = spl_object_id($classMethod);
-        if (! isset($this->alreadyAddedClassMethodNames[$classMethodHash])) {
-            return false;
-        }
-
-        return in_array($name, $this->alreadyAddedClassMethodNames[$classMethodHash], true);
+        return false;
     }
 }

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -48,6 +48,7 @@ final class ClassMethodAssignManipulator
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -14,7 +14,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 final class ClassMethodAssignManipulator
 {
     /**
-     * @var array<string, string[]>
+     * @var array<int, string[]>
      */
     private array $alreadyAddedClassMethodNames = [];
 

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -37,7 +37,7 @@ final class ClassMethodAssignManipulator
         $classMethod->params[] = $this->nodeFactory->createParamFromNameAndType($name, $type);
         $classMethod->stmts[] = new Expression($assign);
 
-        $classMethodHash = spl_object_hash($classMethod);
+        $classMethodHash = spl_object_id($classMethod);
         $this->alreadyAddedClassMethodNames[$classMethodHash][] = $name;
     }
 
@@ -49,7 +49,7 @@ final class ClassMethodAssignManipulator
             }
         }
 
-        $classMethodHash = spl_object_hash($classMethod);
+        $classMethodHash = spl_object_id($classMethod);
         if (! isset($this->alreadyAddedClassMethodNames[$classMethodHash])) {
             return false;
         }

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -37,8 +37,8 @@ final class ClassMethodAssignManipulator
         $classMethod->params[] = $this->nodeFactory->createParamFromNameAndType($name, $type);
         $classMethod->stmts[] = new Expression($assign);
 
-        $classMethodHash = spl_object_id($classMethod);
-        $this->alreadyAddedClassMethodNames[$classMethodHash][] = $name;
+        $classMethodId = spl_object_id($classMethod);
+        $this->alreadyAddedClassMethodNames[$classMethodId][] = $name;
     }
 
     private function hasMethodParameter(ClassMethod $classMethod, string $name): bool
@@ -49,11 +49,11 @@ final class ClassMethodAssignManipulator
             }
         }
 
-        $classMethodHash = spl_object_id($classMethod);
-        if (! isset($this->alreadyAddedClassMethodNames[$classMethodHash])) {
+        $classMethodId = spl_object_id($classMethod);
+        if (! isset($this->alreadyAddedClassMethodNames[$classMethodId])) {
             return false;
         }
 
-        return in_array($name, $this->alreadyAddedClassMethodNames[$classMethodHash], true);
+        return in_array($name, $this->alreadyAddedClassMethodNames[$classMethodId], true);
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE;
 
     private RectorOutput $rectorOutput;
 
-    private ?string $toBeRemovedNodeHash = null;
+    private ?int $toBeRemovedNodeHash = null;
 
     public function autowire(
         NodeNameResolver $nodeNameResolver,
@@ -183,7 +183,7 @@ CODE_SAMPLE;
 
         // @see NodeTraverser::* codes, e.g. removal of node of stopping the traversing
         if ($refactoredNode === NodeTraverser::REMOVE_NODE) {
-            $this->toBeRemovedNodeHash = spl_object_hash($originalNode);
+            $this->toBeRemovedNodeHash = spl_object_id($originalNode);
 
             // notify this rule changing code
             $rectorWithLineChange = new RectorWithLineChange(static::class, $originalNode->getLine());
@@ -234,7 +234,7 @@ CODE_SAMPLE;
             return null;
         }
 
-        $objectHash = spl_object_hash($node);
+        $objectHash = spl_object_id($node);
         if ($this->toBeRemovedNodeHash === $objectHash) {
             $this->toBeRemovedNodeHash = null;
 
@@ -349,7 +349,7 @@ CODE_SAMPLE;
             $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
             // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
-            $originalNodeHash = spl_object_hash($originalNode);
+            $originalNodeHash = spl_object_id($originalNode);
 
             // will be replaced in leaveNode() the original node must be passed
             $this->nodesToReturn[$originalNodeHash] = $refactoredNode;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -349,10 +349,10 @@ CODE_SAMPLE;
             $this->refreshScopeNodes($refactoredNode, $filePath, $currentScope);
 
             // search "infinite recursion" in https://github.com/nikic/PHP-Parser/blob/master/doc/component/Walking_the_AST.markdown
-            $originalNodeHash = spl_object_id($originalNode);
+            $originalNodeId = spl_object_id($originalNode);
 
             // will be replaced in leaveNode() the original node must be passed
-            $this->nodesToReturn[$originalNodeHash] = $refactoredNode;
+            $this->nodesToReturn[$originalNodeId] = $refactoredNode;
 
             return $originalNode;
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE;
     private CurrentFileProvider $currentFileProvider;
 
     /**
-     * @var array<string, Node[]>
+     * @var array<int, Node[]>
      */
     private array $nodesToReturn = [];
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE;
 
     private RectorOutput $rectorOutput;
 
-    private ?int $toBeRemovedNodeHash = null;
+    private ?int $toBeRemovedNodeId = null;
 
     public function autowire(
         NodeNameResolver $nodeNameResolver,
@@ -183,7 +183,7 @@ CODE_SAMPLE;
 
         // @see NodeTraverser::* codes, e.g. removal of node of stopping the traversing
         if ($refactoredNode === NodeTraverser::REMOVE_NODE) {
-            $this->toBeRemovedNodeHash = spl_object_id($originalNode);
+            $this->toBeRemovedNodeId = spl_object_id($originalNode);
 
             // notify this rule changing code
             $rectorWithLineChange = new RectorWithLineChange(static::class, $originalNode->getLine());
@@ -234,14 +234,14 @@ CODE_SAMPLE;
             return null;
         }
 
-        $objectHash = spl_object_id($node);
-        if ($this->toBeRemovedNodeHash === $objectHash) {
-            $this->toBeRemovedNodeHash = null;
+        $objectId = spl_object_id($node);
+        if ($this->toBeRemovedNodeId === $objectId) {
+            $this->toBeRemovedNodeId = null;
 
             return NodeTraverser::REMOVE_NODE;
         }
 
-        return $this->nodesToReturn[$objectHash] ?? $node;
+        return $this->nodesToReturn[$objectId] ?? $node;
     }
 
     protected function isName(Node $node, string $name): bool


### PR DESCRIPTION
`spl_object_id()` is exists since php 7.2, I think we can use `spl_object_id()`.

Refs:

- https://github.com/php/php-src/pull/2611
- https://developer.wordpress.com/2023/08/24/speedier-php-execution-in-wordpress-6-3/

**Benchmark**

**Before** **_call in loop took: 13.639ms_**

https://3v4l.org/4rUL4

**After**  **_call in loop took: 4.835ms_**

https://3v4l.org/jKtO6
