### PR TITLE
[Config] Remove $isBound usage as cause empty configuration on RectorConfig

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -174,13 +174,6 @@ final class RectorConfig extends Container
             $configuration
         );
 
-        $isBound = $this->bound($rectorClass);
-
-        // avoid double registration
-        if ($isBound) {
-            return;
-        }
-
         $this->singleton($rectorClass);
         $this->tagRectorService($rectorClass);
 


### PR DESCRIPTION
@TomasVotruba as I guess last week at PR:

- https://github.com/rectorphp/rector-src/pull/4831#issuecomment-1689807318

that you replaced at PR:

- https://github.com/rectorphp/rector-src/pull/4838

the `$isBound` usage will make invalid, reproduced in rector-doctrine repo:

**With isBound**

```
array {}
```

**Without isBound**

```
array(5) {
  [0]=>
  string(10) "Doctrine\*"
  [1]=>
  string(7) "Gedmo\*"
  [2]=>
  string(5) "Knp\*"
  [3]=>
  string(8) "DateTime"
  [4]=>
  string(17) "DateTimeInterface"
}
```

see https://github.com/rectorphp/rector-doctrine/pull/221#discussion_r1309081757

The `singleTon()` is actually verify service registered once :)