### PR TITLE
Add test for merge ruleWithConfiguration() after sets on $isBound usage

### DIFF
--- a/tests/Issues/RuleWithConfigurationAfterSet/Fixture/skip_doctrine_class_string.php.inc
+++ b/tests/Issues/RuleWithConfigurationAfterSet/Fixture/skip_doctrine_class_string.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\RuleWithConfigurationAfterSet\Fixture;
+
+final class SkipDoctrineClassString
+{
+    public function run(): string
+    {
+        return 'Doctrine\Common\Collections\ArrayCollection';
+    }
+}

--- a/tests/Issues/RuleWithConfigurationAfterSet/RuleWithConfigurationAfterSet.php
+++ b/tests/Issues/RuleWithConfigurationAfterSet/RuleWithConfigurationAfterSet.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RuleWithConfigurationAfterSet;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RuleWithConfigurationAfterSet extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RuleWithConfigurationAfterSet/RuleWithConfigurationAfterSetTest.php
+++ b/tests/Issues/RuleWithConfigurationAfterSet/RuleWithConfigurationAfterSetTest.php
@@ -8,7 +8,7 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-final class RuleWithConfigurationAfterSet extends AbstractRectorTestCase
+final class RuleWithConfigurationAfterSetTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
     public function test(string $filePath): void

--- a/tests/Issues/RuleWithConfigurationAfterSet/config/configured_rule.php
+++ b/tests/Issues/RuleWithConfigurationAfterSet/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_81,
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(StringClassNameToClassConstantRector::class, [
+        'Doctrine\*'
+    ]);
+};


### PR DESCRIPTION
@TomasVotruba here test for PR:

- https://github.com/rectorphp/rector-src/pull/4880

for removal `$isBound` usage, on merge `sets` and direct `ruleWithConfiguration()`