### PR TITLE
[ProcessAnalyzer] Handle only 2 rules, flip flop run should just stop

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -48,7 +48,12 @@ final class RectifiedAnalyzer
             return false;
         }
 
-        return end($createdByRule) === $rectorClass;
+        if (end($createdByRule) === $rectorClass) {
+            return true;
+        }
+
+        // only 2 rules, flip-flop
+        return count($createdByRule) === 2 && $createdByRule[0] === $rectorClass;
     }
 
     private function isJustReprintedOverlappedTokenStart(Node $node, ?Node $originalNode): bool

--- a/tests/Issues/RemoveClosureUseByIndex/Fixture/remove_closure_use_by_index.php.inc
+++ b/tests/Issues/RemoveClosureUseByIndex/Fixture/remove_closure_use_by_index.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+
+final class RemoveClosureUseByIndex
+{
+    public function run()
+    {
+        function () use ($a, $b, $c) {
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+
+final class RemoveClosureUseByIndex
+{
+    public function run()
+    {
+        function () use ($a, $d) {
+        };
+    }
+}
+
+?>

--- a/tests/Issues/RemoveClosureUseByIndex/RemoveClosureUseByIndexTest.php
+++ b/tests/Issues/RemoveClosureUseByIndex/RemoveClosureUseByIndexTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveClosureUseByIndex;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveClosureUseByIndexTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/RemoveClosureUseByIndex/Source/ChangeClosureUseByIndexRector.php
+++ b/tests/Issues/RemoveClosureUseByIndex/Source/ChangeClosureUseByIndexRector.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveClosureUseByIndex\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ChangeClosureUseByIndexRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('change closure use with index 1 to d', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Closure::class,
+        ];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactor(Node $node)
+    {
+        $node->uses[1]->var->name = 'd';
+        return $node;
+    }
+}

--- a/tests/Issues/RemoveClosureUseByIndex/Source/RemoveClosureUseByIndexRector.php
+++ b/tests/Issues/RemoveClosureUseByIndex/Source/RemoveClosureUseByIndexRector.php
@@ -11,11 +11,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 class RemoveClosureUseByIndexRector extends AbstractRector
 {
-    private bool $hasChanged = false;
-
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('remove closure use with index "b"', []);
+        return new RuleDefinition('remove closure use with index 1', []);
     }
 
     public function getNodeTypes(): array

--- a/tests/Issues/RemoveClosureUseByIndex/Source/RemoveClosureUseByIndexRector.php
+++ b/tests/Issues/RemoveClosureUseByIndex/Source/RemoveClosureUseByIndexRector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\RemoveClosureUseByIndex\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class RemoveClosureUseByIndexRector extends AbstractRector
+{
+    private bool $hasChanged = false;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('remove closure use with index "b"', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Closure::class,
+        ];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactor(Node $node)
+    {
+        unset($node->uses[1]);
+        return $node;
+    }
+}

--- a/tests/Issues/RemoveClosureUseByIndex/config/configured_rule.php
+++ b/tests/Issues/RemoveClosureUseByIndex/config/configured_rule.php
@@ -8,9 +8,9 @@ use Rector\Core\Tests\Issues\RemoveClosureUseByIndex\Source\RemoveClosureUseByIn
 
 return static function (RectorConfig $rectorConfig): void {
     /**
-     * index a, b, c
-     * - start with remove index 1 with key "b"
-     * - change index 1 to "d"
+     * index 0, 1, 2 with values a, b, c
+     * - start with remove index 1 with value "b"
+     * - change index 1 value "d"
      * - result: a, d
      */
     $rectorConfig->rules([

--- a/tests/Issues/RemoveClosureUseByIndex/config/configured_rule.php
+++ b/tests/Issues/RemoveClosureUseByIndex/config/configured_rule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\Tests\Issues\RemoveClosureUseByIndex\Source\ChangeClosureUseByIndexRector;
+use Rector\Core\Tests\Issues\RemoveClosureUseByIndex\Source\RemoveClosureUseByIndexRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    /**
+     * index a, b, c
+     * - start with remove index 1 with key "b"
+     * - change index 1 to "d"
+     * - result: a, d
+     */
+    $rectorConfig->rules([
+        RemoveClosureUseByIndexRector::class,
+        ChangeClosureUseByIndexRector::class,
+    ]);
+};


### PR DESCRIPTION
When there are 2 rules run with the following process:

1. There is closuse use variable value a, b, c ( index 0 => a, 1 => b, 2 => c)
2. Rule A remove index 1 with variable name "b"
3. Rule B change index 1 to variable name "d"
4. The result should be a, b, c, and stop

Continue the process make error:

```
There was 1 error:

1) Rector\Core\Tests\Issues\RemoveClosureUseByIndex\RemoveClosureUseByIndexTest::test with data set #0
Error: Attempt to modify property "var" on null
```

This also detect possible infinite loop flip flop 2 rules.