### PR TITLE
[Performance][DI] Remove double loop on ContainerMemento

### DIFF
--- a/src/DependencyInjection/Laravel/ContainerMemento.php
+++ b/src/DependencyInjection/Laravel/ContainerMemento.php
@@ -5,28 +5,28 @@ declare(strict_types=1);
 namespace Rector\Core\DependencyInjection\Laravel;
 
 use Illuminate\Container\Container;
+use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
 
 /**
- * Helper service to modify Laravel container
+ * Helper service to modify Laravel container to remove skipped Rector rule
  */
 final class ContainerMemento
 {
-    public static function forgetService(Container $container, string $typeToForget): void
+    public static function forgetService(Container $container, string $rectorClass): void
     {
         // 1. remove the service
-        $container->offsetUnset($typeToForget);
+        $container->offsetUnset($rectorClass);
 
-        // 2. remove all tagged rules
+        // 2. remove tagged rule
         $privatesAccessor = new PrivatesAccessor();
         $privatesAccessor->propertyClosure($container, 'tags', static function (array $tags) use (
-            $typeToForget
+            $rectorClass
         ): array {
-            foreach ($tags as $tagName => $taggedClasses) {
-                foreach ($taggedClasses as $key => $taggedClass) {
-                    if (is_a($taggedClass, $typeToForget, true)) {
-                        unset($tags[$tagName][$key]);
-                    }
+            foreach ($tags[RectorInterface::class] ?? [] as $key => $taggedClass) {
+                if ($taggedClass === $rectorClass) {
+                    unset($tags[RectorInterface::class][$key]);
+                    break;
                 }
             }
 


### PR DESCRIPTION
`ContainerMemento` class only used to remove tag on skipped rule, so I think direct index `RectorInterface` and `break;` ealry after untag can be used.