### PR TITLE
[TypeDeclaration] Do not add default value when assigned in __construct() on TypedPropertyFromStrictGetterMethodReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/Fixture/assigned_in_construct.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector/Fixture/assigned_in_construct.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector\Fixture;
+
+final class AssignedInConstruct
+{
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector\Fixture;
+
+final class AssignedInConstruct
+{
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
@@ -104,7 +104,7 @@ CODE_SAMPLE
 
             $isAssignedInConstructor = $this->constructorAssignDetector->isPropertyAssigned(
                 $node,
-                (string) $this->getName($property)
+                $this->getName($property)
             );
 
             // if property is public, it should be nullable


### PR DESCRIPTION
@TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/4885

when initialized in `__construct()`, default value should not be added.