### PR TITLE
[DeadCode] Remove @return void on return self on RemoveUselessReturnTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/return_void_on_fluent.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/return_void_on_fluent.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class ReturnVoidOnFluent
+{
+    /**
+     * @return void
+     */
+    public static function resolve(): self
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class ReturnVoidOnFluent
+{
+    public static function resolve(): self
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/return_void_on_fluent.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/return_void_on_fluent.php.inc
@@ -7,7 +7,7 @@ final class ReturnVoidOnFluent
     /**
      * @return void
      */
-    public static function resolve(): self
+    public function resolve(): self
     {
         return $this;
     }
@@ -21,7 +21,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\
 
 final class ReturnVoidOnFluent
 {
-    public static function resolve(): self
+    public function resolve(): self
     {
         return $this;
     }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/return_void_on_void.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/return_void_on_void.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class ReturnVoidOnVoid
+{
+    /**
+     * @return void
+     */
+    public function resolve(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class ReturnVoidOnVoid
+{
+    public function resolve(): void
+    {
+    }
+}
+
+?>

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -40,6 +40,10 @@ final class DeadParamTagValueNodeAnalyzer
             return false;
         }
 
+        if ($paramTagValueNode->description !== '') {
+            return false;
+        }
+
         if ($param->type instanceof Name && $this->nodeNameResolver->isName($param->type, 'object')) {
             return $paramTagValueNode->type instanceof IdentifierTypeNode && (string) $paramTagValueNode->type === 'object';
         }
@@ -57,17 +61,13 @@ final class DeadParamTagValueNodeAnalyzer
         }
 
         if (! $paramTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
-            return $paramTagValueNode->description === '';
+            return true;
         }
 
         if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($paramTagValueNode->type)) {
             return false;
         }
 
-        if (! $this->genericTypeNodeAnalyzer->hasGenericType($paramTagValueNode->type)) {
-            return $paramTagValueNode->description === '';
-        }
-
-        return false;
+        return ! $this->genericTypeNodeAnalyzer->hasGenericType($paramTagValueNode->type);
     }
 }

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -36,6 +36,10 @@ final class DeadReturnTagValueNodeAnalyzer
             return false;
         }
 
+        if ($returnTagValueNode->description !== '') {
+            return false;
+        }
+
         $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
         if ($scope instanceof Scope && $scope->isInTrait() && $returnTagValueNode->type instanceof ThisTypeNode) {
             return false;
@@ -65,11 +69,7 @@ final class DeadReturnTagValueNodeAnalyzer
             return false;
         }
 
-        if ($this->hasTruePseudoType($returnTagValueNode->type)) {
-            return false;
-        }
-
-        return $returnTagValueNode->description === '';
+        return ! $this->hasTruePseudoType($returnTagValueNode->type);
     }
 
     private function isIdentiferRemovalAllowed(ReturnTagValueNode $returnTagValueNode, Node $node): bool

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc;
 
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -50,11 +50,7 @@ final class DeadReturnTagValueNodeAnalyzer
             $returnTagValueNode->type,
             $classMethod,
         )) {
-            if ($returnType instanceof Name) {
-                return $returnTagValueNode->type instanceof IdentifierTypeNode && (string) $returnTagValueNode->type !== 'static';
-            }
-
-            return false;
+            return $returnTagValueNode->type instanceof IdentifierTypeNode && (string) $returnTagValueNode->type === 'void';
         }
 
         if ($this->phpDocTypeChanger->isAllowed($returnTagValueNode->type)) {

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc;
 
-use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
@@ -58,7 +57,7 @@ final class DeadReturnTagValueNodeAnalyzer
         }
 
         if (! $returnTagValueNode->type instanceof BracketsAwareUnionTypeNode) {
-            return $this->isIdentiferRemovalAllowed($returnTagValueNode, $returnType);
+            return $this->standaloneTypeRemovalGuard->isLegal($returnTagValueNode->type, $returnType);
         }
 
         if ($this->genericTypeNodeAnalyzer->hasGenericType($returnTagValueNode->type)) {
@@ -70,15 +69,6 @@ final class DeadReturnTagValueNodeAnalyzer
         }
 
         return ! $this->hasTruePseudoType($returnTagValueNode->type);
-    }
-
-    private function isIdentiferRemovalAllowed(ReturnTagValueNode $returnTagValueNode, Node $node): bool
-    {
-        if ($returnTagValueNode->description === '') {
-            return $this->standaloneTypeRemovalGuard->isLegal($returnTagValueNode->type, $node);
-        }
-
-        return false;
     }
 
     private function hasTruePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc;
 
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
@@ -49,6 +50,10 @@ final class DeadReturnTagValueNodeAnalyzer
             $returnTagValueNode->type,
             $classMethod,
         )) {
+            if ($returnType instanceof Name) {
+                return $returnTagValueNode->type instanceof IdentifierTypeNode && (string) $returnTagValueNode->type !== 'static';
+            }
+
             return false;
         }
 

--- a/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
@@ -25,6 +25,10 @@ final class DeadVarTagValueNodeAnalyzer
             return false;
         }
 
+        if ($varTagValueNode->description !== '') {
+            return false;
+        }
+
         // is strict type superior to doc type? keep strict type only
         $propertyType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($property->type);
         $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($varTagValueNode->type, $property);
@@ -33,14 +37,10 @@ final class DeadVarTagValueNodeAnalyzer
             return ! $docType instanceof IntersectionType;
         }
 
-        if (! $this->typeComparator->arePhpParserAndPhpStanPhpDocTypesEqual(
+        return $this->typeComparator->arePhpParserAndPhpStanPhpDocTypesEqual(
             $property->type,
             $varTagValueNode->type,
             $property
-        )) {
-            return false;
-        }
-
-        return $varTagValueNode->description === '';
+        );
     }
 }


### PR DESCRIPTION
Given the following code:

```php
    /**
     * @return void
     */
    public function resolve(): self
    {
        return $this;
    }
```

`@return void` should be removed. /cc @staabm 