### PR TITLE
Fix Rector invalidation in case of changes sets or rules

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -48,6 +48,9 @@ final class RectorConfig extends Container
             Assert::fileExists($set);
             $this->import($set);
         }
+
+        // for cache invalidation in case of sets change
+        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_SETS, $sets);
     }
 
     public function disableParallel(): void
@@ -183,6 +186,9 @@ final class RectorConfig extends Container
             $ruleConfiguration = $this->ruleConfigurations[$rectorClass];
             $configurableRector->configure($ruleConfiguration);
         });
+
+        // for cache invalidation in case of sets change
+        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
     }
 
     /**
@@ -209,6 +215,9 @@ final class RectorConfig extends Container
                 }
             );
         }
+
+        // for cache invalidation in case of change
+        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
     }
 
     public function import(string $filePath): void

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -218,4 +218,16 @@ final class Option
      * @var string
      */
     public const CONTAINER_CACHE_DIRECTORY = 'container-cache-directory';
+
+    /**
+     * @internal For cache invalidation in case of change
+     * @var string
+     */
+    public const REGISTERED_RECTOR_RULES = 'registered_rector_rules';
+
+    /**
+     * @internal For cache invalidation in case of change
+     * @var string
+     */
+    public const REGISTERED_RECTOR_SETS = 'registered_rector_sets';
 }


### PR DESCRIPTION
Currently, when a new rule or sets is registered, the parameters hash is the same. The `FileHashComputer` uses `\Rector\Core\Configuration\Parameter\SimpleParameterProvider::hash()` and ignored new rules/sets.

This PR fixes it :+1: 

