### PR TITLE
[Caching] Add VersionResolver::PACKAGE_VERSION to FileHashComputer::compute() so cache cleared on composer update got new version

### DIFF
--- a/packages/Caching/Config/FileHashComputer.php
+++ b/packages/Caching/Config/FileHashComputer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Caching\Config;
 
+use Rector\Core\Application\VersionResolver;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\Exception\ShouldNotHappenException;
 
@@ -17,7 +18,7 @@ final class FileHashComputer
         $this->ensureIsPhp($filePath);
 
         $parametersHash = SimpleParameterProvider::hash();
-        return sha1($filePath . $parametersHash);
+        return sha1($filePath . $parametersHash . VersionResolver::PACKAGE_VERSION);
     }
 
     private function ensureIsPhp(string $filePath): void


### PR DESCRIPTION
@TomasVotruba @staabm here to include `VersionResolver::PACKAGE_VERSION` value to be part of hash to ensure when run:

```
composer update

# got new version

# re-run rector got automatically cleared cache
vendor/bin/rector
``` 