### PR TITLE
[TypeDeclaration] Skip mixing native + docblock union assign on TypedPropertyFromAssignsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_mixed_native_with_docblock_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_mixed_native_with_docblock_union.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+final class SkipNativeWithDocblockUnion
+{
+    private $property;
+
+    public function run1()
+    {
+        $this->property = new stdClass;
+    }
+
+    /**
+     * @param stdClass|DateTime $property
+     */
+    public function run2($property)
+    {
+        $this->property = $property;
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -198,6 +198,9 @@ final class AssignToPropertyTypeInferer
             }
 
             if ($this->exprAnalyzer->isNonTypedFromParam($node->expr)) {
+                $assignedExprTypes = [];
+                return NodeTraverser::STOP_TRAVERSAL;
+
                 return null;
             }
 

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -200,8 +200,6 @@ final class AssignToPropertyTypeInferer
             if ($this->exprAnalyzer->isNonTypedFromParam($node->expr)) {
                 $assignedExprTypes = [];
                 return NodeTraverser::STOP_TRAVERSAL;
-
-                return null;
             }
 
             $assignedExprTypes[] = $this->resolveExprStaticTypeIncludingDimFetch($node);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8177