### PR TITLE
[Performance][Testing] Avoid double call FileSystem::read() on AbstractRectorTestCase

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -231,7 +231,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         SimpleParameterProvider::setParameter(Option::SOURCE, [$originalFilePath]);
 
         $changedContent = $this->processFilePath($originalFilePath);
-        $originalContents = $this->currentFileProvider->getFile()->getOriginalFileContent();
+        $originalFileContent = $this->currentFileProvider->getFile()->getOriginalFileContent();
 
         $fixtureFilename = basename($fixtureFilePath);
         $failureMessage = sprintf('Failed on fixture file "%s"', $fixtureFilename);
@@ -239,7 +239,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         try {
             $this->assertSame($expectedFileContents, $changedContent, $failureMessage);
         } catch (ExpectationFailedException) {
-            FixtureFileUpdater::updateFixtureContent($originalContents, $changedContent, $fixtureFilePath);
+            FixtureFileUpdater::updateFixtureContent($originalFileContent, $changedContent, $fixtureFilePath);
 
             // if not exact match, check the regex version (useful for generated hashes/uuids in the code)
             $this->assertStringMatchesFormat($expectedFileContents, $changedContent, $failureMessage);


### PR DESCRIPTION
When calling:

```php
$this->applicationFileProcessor->processFiles([$filePath], $configuration);
```

The `CurrentFileProvider` service is set to `File` object with its originalContent and new content, so we no longer need to re-read file.

This PR make pull from `CurrentFileProvider` service.