### PR TITLE
Update github actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -31,7 +31,7 @@ jobs:
                 run: sleep 20
 
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
 
             # 6. clone remote repository, so we can push it
             -
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
                 with:
                     repository: rectorphp/rector
                     path: remote-repository

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -77,7 +77,7 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             # see https://github.com/shivammathur/setup-php
             -

--- a/.github/workflows/code_analysis_no_dev.yaml
+++ b/.github/workflows/code_analysis_no_dev.yaml
@@ -13,7 +13,7 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/e2e_consecutive_changes.yaml
+++ b/.github/workflows/e2e_consecutive_changes.yaml
@@ -29,7 +29,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }} [disableParallel=${{ matrix.rector_disable_parallel }}]
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/e2e_with_cache.yaml
+++ b/.github/workflows/e2e_with_cache.yaml
@@ -30,7 +30,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -37,7 +37,7 @@ jobs:
         steps:
             # see https://github.com/actions/checkout#usage
             -
-                uses: "actions/checkout@v3"
+                uses: "actions/checkout@v4"
                 with:
                     repository: ${{ matrix.repository_name }}
                     ref: "main"

--- a/.github/workflows/php_linter.yaml
+++ b/.github/workflows/php_linter.yaml
@@ -13,7 +13,7 @@ jobs:
         timeout-minutes: 3
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -19,7 +19,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == 'rectorphp/rector-src'
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
 
         name: PHP 8.1 tests
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -33,7 +33,7 @@ jobs:
 
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/build/target-repository/.github/workflows/along_other_packages.yaml
+++ b/build/target-repository/.github/workflows/along_other_packages.yaml
@@ -31,7 +31,7 @@ jobs:
         name: "PHP ${{ matrix.php_version }}"
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/build/target-repository/.github/workflows/bare_run.yaml
+++ b/build/target-repository/.github/workflows/bare_run.yaml
@@ -16,7 +16,7 @@ jobs:
                 php_version: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -
                 uses: shivammathur/setup-php@v2

--- a/build/target-repository/.github/workflows/e2e.yaml
+++ b/build/target-repository/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/build/target-repository/.github/workflows/e2e_diff.yaml
+++ b/build/target-repository/.github/workflows/e2e_diff.yaml
@@ -22,7 +22,7 @@ jobs:
         name: End to end test with diff - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/build/target-repository/.github/workflows/e2e_global.yaml
+++ b/build/target-repository/.github/workflows/e2e_global.yaml
@@ -19,7 +19,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/build/target-repository/.github/workflows/e2e_php72.yaml
+++ b/build/target-repository/.github/workflows/e2e_php72.yaml
@@ -13,7 +13,7 @@ jobs:
         name: End to end test - PHP 7.2 with load ReflectionUnionType stub
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/build/target-repository/.github/workflows/e2e_php74.yaml
+++ b/build/target-repository/.github/workflows/e2e_php74.yaml
@@ -16,7 +16,7 @@ jobs:
         name: End to end test - PHP 7.4 and Match class name
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/build/target-repository/.github/workflows/standalone_rule_test.yaml
+++ b/build/target-repository/.github/workflows/standalone_rule_test.yaml
@@ -19,7 +19,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -166,7 +166,7 @@ CODE_SAMPLE
     private function refactorEqualsMethodCall(MethodCall $methodCall): ?Identical
     {
         $expr = $this->getNonEnumReturnTypeExpr($methodCall->var);
-        if ($expr === null) {
+        if (!$expr instanceof Expr) {
             $expr = $this->getValidEnumExpr($methodCall->var);
             if (! $expr instanceof Expr) {
                 return null;
@@ -179,7 +179,7 @@ CODE_SAMPLE
         }
 
         $right = $this->getNonEnumReturnTypeExpr($arg->value);
-        if ($right === null) {
+        if (!$right instanceof Expr) {
             $right = $this->getValidEnumExpr($arg->value);
             if (! $right instanceof Expr) {
                 return null;

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\AssignOp\Coalesce as AssignOpCoalesce;
@@ -159,7 +161,7 @@ CODE_SAMPLE
             $nodeToCheck = $firstArg->value;
         }
 
-        if ($node instanceof Node\Stmt\Expression) {
+        if ($node instanceof Expression) {
             $nodeToCheck = $node->expr;
         }
 
@@ -171,7 +173,7 @@ CODE_SAMPLE
             $nodeToCheck = $node->var;
         }
 
-        if ($nodeToCheck instanceof Node\Expr\MethodCall) {
+        if ($nodeToCheck instanceof MethodCall) {
             return $nodeToCheck->var instanceof Variable && $this->isName($nodeToCheck->var, $paramName);
         }
 

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -11,7 +11,7 @@ jobs:
         steps:
             -
                 if: github.event.pull_request.head.repo.full_name == github.repository
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Current github actions/checkout v3 got error:

```

Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff2bd294095638e18286ca9a3d1956744)
Error: Can't use 'tar -xzf' extract archive file: /home/runner/work/_actions/_temp_4ecd32f5-c361-435e-b74b-7171ccb18414/3c125ce6-395a-4023-acd8-39fc47eba947.tar.gz. return code: 2.
```

Ref https://github.com/rectorphp/rector-src/actions/runs/6074243601/job/16477779233#step:1:35

It reported at:

- https://github.com/actions/checkout/issues/1448

This PR try to update to github actions/checkout v4.