### PR TITLE
[TypeDeclaration] Add return static object support on ReturnTypeFromStrictFluentReturnRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector/Fixture/return_static.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector/Fixture/return_static.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictFluentReturnRector\Fixture;
+
+class ReturnStatic
+{
+    private $foo = 'bar';
+
+    public function test()
+    {
+        $obj = new static();
+        $obj->foo = 'foo';
+
+        return $obj;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictFluentReturnRector\Fixture;
+
+class ReturnStatic
+{
+    private $foo = 'bar';
+
+    public function test(): static
+    {
+        $obj = new static();
+        $obj->foo = 'foo';
+
+        return $obj;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector/FixturePhp74/return_static_on_php74.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector/FixturePhp74/return_static_on_php74.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictFluentReturnRector\FixturePhp74;
+
+class ReturnStatic
+{
+    private $foo = 'bar';
+
+    public function test()
+    {
+        $obj = new static();
+        $obj->foo = 'foo';
+
+        return $obj;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictFluentReturnRector\FixturePhp74;
+
+class ReturnStatic
+{
+    private $foo = 'bar';
+
+    public function test(): self
+    {
+        $obj = new static();
+        $obj->foo = 'foo';
+
+        return $obj;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector.php
@@ -112,19 +112,19 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSelf($classReflection)) {
-            $node->returnType = new Name('self');
-        } else {
-            $node->returnType = new Name('static');
-        }
+        $node->returnType = $this->shouldSelf($classReflection) ? new Name('self') : new Name('static');
 
         return $node;
     }
 
     private function shouldSelf(ClassReflection $classReflection): bool
     {
-        return $classReflection->isAnonymous()
-            || $classReflection->isFinalByKeyword()
-            || ! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::STATIC_RETURN_TYPE);
+        if ($classReflection->isAnonymous()) {
+            return true;
+        }
+        if ($classReflection->isFinalByKeyword()) {
+            return true;
+        }
+        return ! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::STATIC_RETURN_TYPE);
     }
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector.php
@@ -122,9 +122,11 @@ CODE_SAMPLE
         if ($classReflection->isAnonymous()) {
             return true;
         }
+
         if ($classReflection->isFinalByKeyword()) {
             return true;
         }
+
         return ! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::STATIC_RETURN_TYPE);
     }
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictFluentReturnRector.php
@@ -96,11 +96,7 @@ CODE_SAMPLE
         $returnType = $this->returnTypeInferer->inferFunctionLike($node);
 
         if ($returnType instanceof StaticType && $returnType->getStaticObjectType()->getClassName() === $classReflection->getName()) {
-            $node->returnType = $this->shouldSelf($classReflection)
-                ? new Name('self')
-                : new Name('static');
-
-            return $node;
+            return $this->processAddReturnSelfOrStatic($node, $classReflection);
         }
 
         if ($returnType instanceof ObjectType && $returnType->getClassName() === $classReflection->getName()) {
@@ -112,9 +108,18 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->returnType = $this->shouldSelf($classReflection) ? new Name('self') : new Name('static');
+        return $this->processAddReturnSelfOrStatic($node, $classReflection);
+    }
 
-        return $node;
+    private function processAddReturnSelfOrStatic(
+        ClassMethod $classMethod,
+        ClassReflection $classReflection
+    ): ClassMethod {
+        $classMethod->returnType = $this->shouldSelf($classReflection)
+            ? new Name('self')
+            : new Name('static');
+
+        return $classMethod;
     }
 
     private function shouldSelf(ClassReflection $classReflection): bool


### PR DESCRIPTION
@staabm continue of :

- https://github.com/rectorphp/rector-src/pull/4915

This will return static on php 8.x, and return self on php 7.x when it returns new static.

The `self` return is happen on:

- anonymous class
- final class
- not yet supported (php 7.x)

otherwise, it will return `static`.