### PR TITLE
AddParamTypeBasedOnPHPUnitDataProviderRector: Enhance existing rule to handle PHPUnit 10+ DataProvider Attribute

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -6230,7 +6230,7 @@ Adds param type declaration based on PHPUnit provider return type declaration
 - class: [`Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector`](../rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php)
 
 ```diff
- use PHPUnit\Framework\TestCase
+ use PHPUnit\Framework\TestCase;
 
  final class SomeTest extends TestCase
  {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/check_all_providers_using_attribute.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/check_all_providers_using_attribute.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MultipleProviders extends TestCase
+{
+    public function dataProvider1(): iterable {
+        yield [1];
+        yield [null];
+    }
+
+    public function dataProvider2(): iterable {
+        yield ['foo'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider1')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider2')]
+    public function testGetFromId($data): void {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/check_all_providers_using_attribute_and_phpdoc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/check_all_providers_using_attribute_and_phpdoc.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MultipleProviders extends TestCase
+{
+    public function dataProvider1(): iterable {
+        yield [1];
+        yield [null];
+    }
+
+    public function dataProvider2(): iterable {
+        yield ['foo'];
+    }
+
+    /**
+     * @dataProvider dataProvider1
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider2')]
+    public function testGetFromId($data): void {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/fixture_using_attribute.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/fixture_using_attribute.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestWithDataProvider extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test_with_attribute($name)
+    {
+    }
+
+    public function provideData(): Iterator
+    {
+        yield ['some'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTestWithDataProvider extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test_with_attribute(string $name)
+    {
+    }
+
+    public function provideData(): Iterator
+    {
+        yield ['some'];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/many_scalars_using_attribute.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/many_scalars_using_attribute.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case including a dataProvider using an array that lead to an incorrect types being added.
+ * `array` was added for $one, but should be `string`, or the parameter should be left alone entirely.
+ * The $two and $three parameters did not get hints added at all.
+ * See: https://phpunit.readthedocs.io/en/9.3/writing-tests-for-phpunit.html#data-providers
+ */
+final class ManyScalars extends TestCase
+{
+    public function provideThings(): array {
+        return [
+            [ 123, true, 'I am a string', null, 'a' ],
+            [ 123, true, 'I am a string', 999, [] ],
+            [ 123, true, 'I am a string', 999, 123 ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideThings')]
+    public function testGetFromId($one, $two, $three, $four, $five): void {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case including a dataProvider using an array that lead to an incorrect types being added.
+ * `array` was added for $one, but should be `string`, or the parameter should be left alone entirely.
+ * The $two and $three parameters did not get hints added at all.
+ * See: https://phpunit.readthedocs.io/en/9.3/writing-tests-for-phpunit.html#data-providers
+ */
+final class ManyScalars extends TestCase
+{
+    public function provideThings(): array {
+        return [
+            [ 123, true, 'I am a string', null, 'a' ],
+            [ 123, true, 'I am a string', 999, [] ],
+            [ 123, true, 'I am a string', 999, 123 ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideThings')]
+    public function testGetFromId(int $one, bool $two, string $three, ?int $four, $five): void {}
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/return_array_using_attribute.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/return_array_using_attribute.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+
+final class ReturnArray extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test_with_attribute($name, $number)
+    {
+    }
+
+    public function provideData()
+    {
+        return [['some', 100]];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+
+final class ReturnArray extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test_with_attribute(string $name, int $number)
+    {
+    }
+
+    public function provideData()
+    {
+        return [['some', 100]];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/skip_existing_using_attribute.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/skip_existing_using_attribute.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipExisting extends TestCase
+{
+    public function provideThings(): array
+    {
+        return [
+            [ 123 ],
+            [ 'I am a string' ],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideThings')]
+    public function testGetFromId(int $one)
+    {
+
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/skip_no_type_using_attribute.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/Fixture/skip_no_type_using_attribute.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeBasedOnPHPUnitDataProviderRector\Fixture;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+
+final class SkipNoType extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testGetFromId($one)
+    {
+    }
+
+    public static function provideData(): array
+    {
+        return [
+            [ self::SOMETHING ],
+        ];
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
@@ -130,7 +130,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $dataProviderNodes = $this->resolveDataProviderPhpDocTagNode($classMethod);
+            $dataProviderNodes = $this->resolveDataProviderNodes($classMethod);
             if ($dataProviderNodes === []) {
                 return null;
             }
@@ -285,7 +285,7 @@ CODE_SAMPLE
     /**
      * @return array<PhpDocTagNode>
      */
-    private function resolveDataProviderPhpDocTagNode(ClassMethod $classMethod): array
+    private function resolveDataProviderNodes(ClassMethod $classMethod): array
     {
         $classMethodPhpDocInfo = $this->phpDocInfoFactory->createFromNode($classMethod);
         if (! $classMethodPhpDocInfo instanceof PhpDocInfo) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
@@ -66,7 +66,7 @@ final class AddParamTypeBasedOnPHPUnitDataProviderRector extends AbstractRector
         return new RuleDefinition(self::ERROR_MESSAGE, [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-use PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
 
 final class SomeTest extends TestCase
 {
@@ -85,7 +85,7 @@ final class SomeTest extends TestCase
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
-use PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
 
 final class SomeTest extends TestCase
 {

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
@@ -130,12 +130,12 @@ CODE_SAMPLE
                 continue;
             }
 
-            $dataProviderPhpDocTagNodes = $this->resolveDataProviderPhpDocTagNode($classMethod);
-            if ($dataProviderPhpDocTagNodes === []) {
+            $dataProviderNodes = $this->resolveDataProviderPhpDocTagNode($classMethod);
+            if ($dataProviderNodes === []) {
                 return null;
             }
 
-            $hasClassMethodChanged = $this->refactorClassMethod($classMethod, $node, $dataProviderPhpDocTagNodes);
+            $hasClassMethodChanged = $this->refactorClassMethod($classMethod, $node, $dataProviderNodes);
             if ($hasClassMethodChanged) {
                 $hasChanged = true;
             }
@@ -148,9 +148,9 @@ CODE_SAMPLE
         return null;
     }
 
-    private function inferParam(Class_ $class, Param $param, PhpDocTagNode $dataProviderPhpDocTagNode): Type
+    private function inferParam(Class_ $class, Param $param, PhpDocTagNode $dataProviderNode): Type
     {
-        $dataProviderClassMethod = $this->resolveDataProviderClassMethod($class, $dataProviderPhpDocTagNode);
+        $dataProviderClassMethod = $this->resolveDataProviderClassMethod($class, $dataProviderNode);
         if (! $dataProviderClassMethod instanceof ClassMethod) {
             return new MixedType();
         }
@@ -173,13 +173,13 @@ CODE_SAMPLE
 
     private function resolveDataProviderClassMethod(
         Class_ $class,
-        PhpDocTagNode $dataProviderPhpDocTagNode
+        PhpDocTagNode $dataProviderNode
     ): ?ClassMethod {
-        if (! $dataProviderPhpDocTagNode->value instanceof GenericTagValueNode) {
+        if (! $dataProviderNode->value instanceof GenericTagValueNode) {
             return null;
         }
 
-        $content = $dataProviderPhpDocTagNode->value->value;
+        $content = $dataProviderNode->value->value;
         $match = Strings::match($content, self::METHOD_NAME_REGEX);
         if ($match === null) {
             return null;
@@ -296,12 +296,12 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<PhpDocTagNode> $dataProviderPhpDocTagNodes
+     * @param array<PhpDocTagNode> $dataProviderNodes
      */
     private function refactorClassMethod(
         ClassMethod $classMethod,
         Class_ $class,
-        array $dataProviderPhpDocTagNodes
+        array $dataProviderNodes
     ): bool {
         $hasChanged = false;
 
@@ -311,8 +311,8 @@ CODE_SAMPLE
             }
 
             $paramTypes = [];
-            foreach ($dataProviderPhpDocTagNodes as $dataProviderPhpDocTagNode) {
-                $paramTypes[] = $this->inferParam($class, $param, $dataProviderPhpDocTagNode);
+            foreach ($dataProviderNodes as $dataProviderNode) {
+                $paramTypes[] = $this->inferParam($class, $param, $dataProviderNode);
             }
 
             $paramTypeDeclaration = TypeCombinator::union(...$paramTypes);

--- a/rules/TypeDeclaration/ValueObject/DataProviderNodes.php
+++ b/rules/TypeDeclaration/ValueObject/DataProviderNodes.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\ValueObject;
+
+use PhpParser\Node\Attribute;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+
+final class DataProviderNodes
+{
+    /**
+     * @param array<array-key, Attribute|PhpDocTagNode> $nodes
+     */
+    public function __construct(
+        public readonly array $nodes,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->nodes === [];
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to hopefully address https://github.com/rectorphp/rector/issues/8179.

I have tried to add atomic commits which should hopefully explain the changes made if you have time to review them commit by commit. I first started by adding failing tests as part of the first commit, which when running when checked out on that commit, fail.

I then refactored the existing code slightly to reuse the existing logic but with a renamed variable name, and then made the changes which I hope are along the right lines and within the expectations of the contributing guide.

The new method `getPhpDataProviderAttribute`, I added, is very similar to the existing code of https://github.com/rectorphp/rector-src/blob/77258018af10a7c23477831e0eab49dd7c0b2bfe/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php#L31-L44 but I thought instead of doing a `hasAttribute` check, I would rather just loop through the attributes and collect what was needed (If the Attribute is the one we want here).

I am also not sure if we have to add a check that the version of PHP should be at least 8.0 for this feature, I tried to do so but the existing configured rule logic caused my tests to fail when having the following check in the rule:

```
    private function getPhpDataProviderAttribute($node): ?Attribute
    {
+        if (!$this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ATTRIBUTES)) {
+            return null;
+        }
```

because of the existing code:

https://github.com/rectorphp/rector-src/blob/48febdb978201ffdd2d62ccb970ede09c3160134/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector/config/configured_rule.php#L12

I have left out the above `isAtLeastPhpVersion` check for now.

## Other notes

- Please see the commit and test I added for allowing only single data providers per test method. We may want to add this for the PHPDoc style of declaring data providers too, but I thought it may be out of scope for this PR, to do so. I hope you can see why this may be undesirable, because the types across different providers may be different - unless we did some sort of merging of all providers to determine the type.
- I also added a rather minor housekeeping update for the docs to do with a missing `;`, I can remove this if you would like it to be separate from this PR / want it gone.
- I am not sure if I was supposed to include the built docs as part of the PR, which I have done.

## Technical notes

- As mentioned in the PHPUnit 10 upgrade: https://github.com/sebastianbergmann/phpunit/issues/4502

> PHPUnit 10 will first look for metadata in attributes before it looks at comments

which we probably want to do here.

- An edge case that I may not have covered is for test methods that do the following (although it would be very unlikely but I guess could happen like anything :smile: ):

```
    /** @dataProvider provideData */
    #[\PHPUnit\Framework\Attributes\DataProvider('provideMoreData')]
    public function testAttributes($one, $two): void
    {
    }

    public static function provideData(): Iterator
    {
        yield ['string', 456];
    }

    public static function provideMoreData(): Iterator
    {
        yield [456, 'string'];
    }
```

Should we account for this?

Please let me know if you would like to make any changes, or please feel free to make any modifications to suit your needs/code style, if preferred.

I am fairly new to writing code in Rector but it is a rather enjoyable thing to work with.