### PR TITLE
[TypeDeclaration] Place ReturnTypeFromStrictFluentReturnRector before ReturnTypeFromReturnNewRector in type-declaration config set

### DIFF
--- a/config/set/type-declaration.php
+++ b/config/set/type-declaration.php
@@ -51,6 +51,7 @@ return static function (RectorConfig $rectorConfig): void {
         TypedPropertyFromStrictConstructorReadonlyClassRector::class,
         ParamTypeFromStrictTypedPropertyRector::class,
         AddVoidReturnTypeWhereNoReturnRector::class,
+        ReturnTypeFromStrictFluentReturnRector::class,
         ReturnTypeFromReturnNewRector::class,
         TypedPropertyFromStrictGetterMethodReturnTypeRector::class,
         AddMethodCallBasedStrictParamTypeRector::class,
@@ -76,7 +77,6 @@ return static function (RectorConfig $rectorConfig): void {
         NumericReturnTypeFromStrictScalarReturnsRector::class,
         StrictArrayParamDimFetchRector::class,
         ReturnUnionTypeRector::class,
-        ReturnTypeFromStrictFluentReturnRector::class,
         StrictStringParamConcatRector::class,
     ]);
 };


### PR DESCRIPTION
@TomasVotruba based on our discussion today.

`ReturnTypeFromStrictFluentReturnRector` is specific for `return $this`, `return new self`, `return new static` which more speficic on verify class is anonymous, final class, and supported static return handling, so it needs to be placed before `ReturnTypeFromReturnNewRector` which more general.