### PR TITLE
[TypeDeclaration] Skip return after return closure on AddVoidReturnTypeWhereNoReturnRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_return.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector\Fixture;
+
+final class SkipReturnAfterClosureReturn
+{
+    private function run($someObject)
+    {
+        $someData = $someObject->run('foo', function (): array {
+            return [];
+        }, strtotime('+6 hours'));
+
+        return $someData[$this->get()];
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -41,11 +41,14 @@ final class SilentVoidResolver
             return false;
         }
 
-        $return = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
-            $functionLike,
-            static fn (Node $node): bool => $node instanceof Return_ && $node->expr instanceof Expr
-        );
-        return ! $return instanceof Return_;
+        $returns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($functionLike, Return_::class);
+        foreach ($returns as $return) {
+            if ($return->expr instanceof Expr) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function hasSilentVoid(FunctionLike $functionLike): bool


### PR DESCRIPTION
@staabm here the following code should be skipped as returns something:

```php
final class SkipReturnAfterClosureReturn
{
    private function run($someObject)
    {
        $someData = $someObject->run('foo', function (): array {
            return [];
        }, strtotime('+6 hours'));

        return $someData[$this->get()];
    }
}
```

Ref https://getrector.com/demo/1f06cf14-382e-4161-ba39-d2061164ebab