### PR TITLE
Refactor BetterNodeFinder::findFirstInFunctionLikeScoped() to work with SilentVoidResolver

### DIFF
--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -41,14 +41,11 @@ final class SilentVoidResolver
             return false;
         }
 
-        $returns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($functionLike, Return_::class);
-        foreach ($returns as $return) {
-            if ($return->expr instanceof Expr) {
-                return false;
-            }
-        }
-
-        return true;
+        $return = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+            $functionLike,
+            static fn (Node $node): bool => $node instanceof Return_ && $node->expr instanceof Expr
+        );
+        return ! $return instanceof Return_;
     }
 
     public function hasSilentVoid(FunctionLike $functionLike): bool

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -246,7 +246,7 @@ final class BetterNodeFinder
         $scopedNode = null;
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $functionLike->stmts,
-            static function (Node $subNode) use (&$scopedNode, $foundNode): ?int {
+            function (Node $subNode) use (&$scopedNode, $foundNode, $filter): ?int {
                 if ($subNode instanceof Class_ || $subNode instanceof Function_ || $subNode instanceof Closure) {
                     if ($foundNode instanceof $subNode && $subNode === $foundNode) {
                         $scopedNode = $subNode;
@@ -256,9 +256,12 @@ final class BetterNodeFinder
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
-                if ($foundNode instanceof $subNode && $subNode === $foundNode) {
-                    $scopedNode = $subNode;
-                    return NodeTraverser::STOP_TRAVERSAL;
+                if ($foundNode instanceof $subNode) {
+                    $scopedFoundNode = $this->findFirst($subNode, $filter);
+                    if ($scopedFoundNode instanceof Node) {
+                        $scopedNode = $subNode;
+                        return NodeTraverser::STOP_TRAVERSAL;
+                    }
                 }
 
                 return null;

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -256,12 +256,16 @@ final class BetterNodeFinder
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
-                if ($foundNode instanceof $subNode) {
-                    $scopedFoundNode = $this->findFirst($subNode, $filter);
-                    if ($scopedFoundNode instanceof Node) {
-                        $scopedNode = $subNode;
-                        return NodeTraverser::STOP_TRAVERSAL;
-                    }
+                if (! $foundNode instanceof $subNode) {
+                    return null;
+                }
+
+                // handle after Closure
+                // @see https://github.com/rectorphp/rector-src/pull/4931
+                $scopedFoundNode = $this->findFirst($subNode, $filter);
+                if ($scopedFoundNode === $subNode) {
+                    $scopedNode = $subNode;
+                    return NodeTraverser::STOP_TRAVERSAL;
                 }
 
                 return null;


### PR DESCRIPTION
@staabm here ensure search after not found on scoped search,

Ref bug:

- https://github.com/rectorphp/rector-src/pull/4923#discussion_r1317198130

that reverted at:

- https://github.com/rectorphp/rector-src/pull/4930

