### PR TITLE
[TypeDeclaration] Ensure ArrayType on ReturnTypeFromStrictNewArrayRector::shouldAddReturnArrayDocType()

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
-use PHPStan\Type\Type;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
@@ -23,6 +22,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersion;
@@ -133,8 +133,15 @@ CODE_SAMPLE
         return $this->processAddArrayReturnType($node, $returnType);
     }
 
-    private function processAddArrayReturnType(ClassMethod|Function_|Closure $node, Type $returnType): ClassMethod|Function_|Closure|null
+    public function provideMinPhpVersion(): int
     {
+        return PhpVersion::PHP_70;
+    }
+
+    private function processAddArrayReturnType(
+        ClassMethod|Function_|Closure $node,
+        Type $returnType
+    ): ClassMethod|Function_|Closure|null {
         if (! $returnType->isArray()->yes()) {
             return null;
         }
@@ -143,17 +150,11 @@ CODE_SAMPLE
         $node->returnType = new Identifier('array');
 
         // add more precise array type if suitable
-        /** @var ArrayType $returnType */
-        if ($this->shouldAddReturnArrayDocType($returnType)) {
+        if ($returnType instanceof ArrayType && $this->shouldAddReturnArrayDocType($returnType)) {
             $this->changeReturnType($node, $returnType);
         }
 
         return $node;
-    }
-
-    public function provideMinPhpVersion(): int
-    {
-        return PhpVersion::PHP_70;
     }
 
     private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool


### PR DESCRIPTION
Avoid error on unioned array:

```
         "System error:                                                                                                 
         "Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector::shouldAddReturnArrayDocType():  
         Argument #1 ($arrayType) must be of type PHPStan\Type\ArrayType, PHPStan\Type\UnionType given,
```