### PR TITLE
[DI] introduce boot() method to avoid hacking beforeResolving() closures

### DIFF
--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/NewTypeResolver/NewTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/NewTypeResolver/NewTypeResolverTest.php
@@ -47,9 +47,7 @@ final class NewTypeResolverTest extends AbstractNodeTypeResolverTestCase
         yield [__DIR__ . '/Source/NewDynamicNew.php', 0, $objectWithoutClassType, false];
 
         $objectWithoutClassTypeWithParentTypes = new ObjectWithoutClassTypeWithParentTypes(
-            [
-                new FullyQualifiedObjectType('Symfony\Bundle\TwigBundle\Loader\FilesystemLoader')
-            ]
+            [new FullyQualifiedObjectType('Symfony\Bundle\TwigBundle\Loader\FilesystemLoader')]
         );
         yield [__DIR__ . '/Source/NewDynamicNewExtends.php', 0, $objectWithoutClassTypeWithParentTypes, true];
     }

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -10,11 +10,13 @@ use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Contract\Rector\RectorInterface;
+use Rector\Core\DependencyInjection\Laravel\ContainerMemento;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\FileSystem\FilesystemTweaker;
 use Rector\Core\NodeAnalyzer\ScopeAnalyzer;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
 use Webmozart\Assert\Assert;
 
 /**
@@ -342,6 +344,24 @@ final class RectorConfig extends Container
     public function resetRuleConfigurations(): void
     {
         $this->ruleConfigurations = [];
+    }
+
+    /**
+     * Compiler passes-like method
+     */
+    public function boot(): void
+    {
+        $skippedClassResolver = new SkippedClassResolver();
+        $skippedElements = $skippedClassResolver->resolve();
+
+        foreach ($skippedElements as $skippedClass => $path) {
+            if ($path !== null) {
+                continue;
+            }
+
+            // completely forget the Rector rule only when no path specified
+            ContainerMemento::forgetService($this, $skippedClass);
+        }
     }
 
     private function importFile(string $filePath): void

--- a/packages/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -42,6 +42,8 @@ abstract class AbstractLazyTestCase extends TestCase
             self::$rectorConfig = $lazyContainerFactory->create();
         }
 
+        self::$rectorConfig->boot();
+
         return self::$rectorConfig;
     }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -104,5 +104,4 @@ final class AlwaysStrictScalarExprAnalyzer
 
         return null;
     }
-
 }

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -60,7 +60,6 @@ use Rector\Core\Console\Style\RectorStyle;
 use Rector\Core\Console\Style\SymfonyStyleFactory;
 use Rector\Core\Contract\DependencyInjection\ResetableInterface;
 use Rector\Core\Contract\Rector\RectorInterface;
-use Rector\Core\DependencyInjection\Laravel\ContainerMemento;
 use Rector\Core\Logging\CurrentRectorProvider;
 use Rector\Core\Logging\RectorOutput;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
@@ -162,7 +161,6 @@ use Rector\PHPStanStaticTypeMapper\TypeMapper\VoidTypeMapper;
 use Rector\PostRector\Application\PostFileProcessor;
 use Rector\RectorGenerator\Command\GenerateCommand;
 use Rector\RectorGenerator\Command\InitRecipeCommand;
-use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
@@ -715,28 +713,6 @@ final class LazyContainerFactory
         $rectorConfig->when(PhpDocNodeMapper::class)
             ->needs('$phpDocNodeVisitors')
             ->giveTagged(BasePhpDocNodeVisitorInterface::class);
-
-        /** @param mixed $parameters */
-        $hasForgotten = false;
-        $rectorConfig->beforeResolving(static function (string $abstract, array $parameters, Container $container) use (
-            &$hasForgotten
-        ): void {
-            // run only once
-            if ($hasForgotten && ! defined('PHPUNIT_COMPOSER_INSTALL')) {
-                return;
-            }
-
-            $skippedClassResolver = new SkippedClassResolver();
-            $skippedElements = $skippedClassResolver->resolve();
-            foreach ($skippedElements as $skippedClass => $path) {
-                // completely forget the Rector rule only when no path specified
-                if ($path === null) {
-                    ContainerMemento::forgetService($container, $skippedClass);
-                }
-            }
-
-            $hasForgotten = true;
-        });
 
         return $rectorConfig;
     }

--- a/src/DependencyInjection/RectorContainerFactory.php
+++ b/src/DependencyInjection/RectorContainerFactory.php
@@ -42,6 +42,8 @@ final class RectorContainerFactory
             $container->import($configFile);
         }
 
+        $container->boot();
+
         return $container;
     }
 }


### PR DESCRIPTION
Based on reddit feedback - https://www.reddit.com/r/PHP/comments/16cpxq1/comment/jzmy3bt/?utm_source=reddit&utm_medium=web2x&context=3,

this method is more commonly known in Laravel to handle post-process: https://laravel.com/docs/10.x/providers#the-boot-method