### PR TITLE
[Testing] Ensure immediate remove file after dump() to sys_get_temp_dir()  after FixtureTempFileDumper::dump() usage

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
@@ -66,6 +66,8 @@ final class TagValueNodeReprintTest extends AbstractLazyTestCase
         foreach ($tagValueNodeClasses as $tagValueNodeClass) {
             $this->doTestPrintedPhpDocInfo($fixtureFilePath, $tagValueNodeClass, $nodeClass);
         }
+
+        FileSystem::delete($fixtureFilePath);
     }
 
     public static function provideData(): Iterator

--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\BetterPhpDocParser\PhpDocParser\TagValueNodeReprint;
 
+use Nette\Utils\FileSystem;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
@@ -71,6 +72,8 @@ final class TestModifyReprintTest extends AbstractLazyTestCase
     {
         $fixtureFilePath = FixtureTempFileDumper::dump($fileContents);
         $nodes = $this->fileInfoParser->parseFileInfoToNodesAndDecorate($fixtureFilePath);
+
+        FileSystem::delete($fixtureFilePath);
 
         $node = $this->betterNodeFinder->findFirstInstanceOf($nodes, $nodeType);
         if (! $node instanceof Node) {

--- a/packages-tests/Comments/CommentRemover/CommentRemoverTest.php
+++ b/packages-tests/Comments/CommentRemover/CommentRemoverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Tests\Comments\CommentRemover;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Comments\CommentRemover;
 use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
@@ -36,6 +37,9 @@ final class CommentRemoverTest extends AbstractLazyTestCase
         $inputFilePath = FixtureTempFileDumper::dump($inputContents);
 
         $nodes = $this->fileInfoParser->parseFileInfoToNodesAndDecorate($inputFilePath);
+
+        FileSystem::delete($inputFilePath);
+
         $nodesWithoutComments = $this->commentRemover->removeFromNode($nodes);
 
         $fileContent = $this->betterStandardPrinter->print($nodesWithoutComments);

--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyFetchTypeResolver/PropertyFetchTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyFetchTypeResolver/PropertyFetchTypeResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyFetchTypeResolver;
 
 use Iterator;
+use Nette\Utils\FileSystem;
 use PhpParser\Node\Expr\PropertyFetch;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -32,12 +33,16 @@ final class PropertyFetchTypeResolverTest extends AbstractNodeTypeResolverTestCa
         [$inputFileContents, $expectedType] = FixtureSplitter::split($filePath);
         $inputFilePath = FixtureTempFileDumper::dump($inputFileContents);
 
+        FileSystem::delete($inputFilePath);
+
         $propertyFetchNodes = $this->getNodesForFileOfType($inputFilePath, PropertyFetch::class);
         $resolvedType = $this->nodeTypeResolver->getType($propertyFetchNodes[0]);
 
         // this file actually containts PHP for type
         $typeFilePath = FixtureTempFileDumper::dump($expectedType);
         $expectedType = include $typeFilePath;
+
+        FileSystem::delete($typeFilePath);
 
         $expectedTypeAsString = $this->getStringFromType($expectedType);
         $resolvedTypeAsString = $this->getStringFromType($resolvedType);

--- a/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyFetchTypeResolver/PropertyFetchTypeResolverTest.php
+++ b/packages-tests/NodeTypeResolver/PerNodeTypeResolver/PropertyFetchTypeResolver/PropertyFetchTypeResolverTest.php
@@ -33,8 +33,6 @@ final class PropertyFetchTypeResolverTest extends AbstractNodeTypeResolverTestCa
         [$inputFileContents, $expectedType] = FixtureSplitter::split($filePath);
         $inputFilePath = FixtureTempFileDumper::dump($inputFileContents);
 
-        FileSystem::delete($inputFilePath);
-
         $propertyFetchNodes = $this->getNodesForFileOfType($inputFilePath, PropertyFetch::class);
         $resolvedType = $this->nodeTypeResolver->getType($propertyFetchNodes[0]);
 
@@ -42,12 +40,13 @@ final class PropertyFetchTypeResolverTest extends AbstractNodeTypeResolverTestCa
         $typeFilePath = FixtureTempFileDumper::dump($expectedType);
         $expectedType = include $typeFilePath;
 
-        FileSystem::delete($typeFilePath);
-
         $expectedTypeAsString = $this->getStringFromType($expectedType);
         $resolvedTypeAsString = $this->getStringFromType($resolvedType);
 
         $this->assertSame($expectedTypeAsString, $resolvedTypeAsString);
+
+        FileSystem::delete($inputFilePath);
+        FileSystem::delete($typeFilePath);
     }
 
     private function getStringFromType(Type $type): string


### PR DESCRIPTION
I got many left over files in `/tmp/rector/tests_fixture_` without clean up after dump, this PR ensure the file is removed after used.