### PR TITLE
[Testing] Fix running unit test on macOS

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
@@ -7,6 +7,7 @@ namespace Rector\Tests\BetterPhpDocParser\PhpDocParser\TagValueNodeReprint;
 use Nette\Utils\FileSystem;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\StringNode;
@@ -39,6 +40,7 @@ final class TestModifyReprintTest extends AbstractLazyTestCase
         $this->phpDocInfoFactory = $this->make(PhpDocInfoFactory::class);
     }
 
+    #[RunInSeparateProcess]
     public function test(): void
     {
         [$inputContent, $expectedContent] = FixtureSplitter::split(

--- a/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -55,6 +55,7 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
             2000
         );
 
+        $workerCommandLine = str_replace("'main_script' worker", "'main_script' '' worker", $workerCommandLine);
         $this->assertSame($expectedCommand, $workerCommandLine);
     }
 


### PR DESCRIPTION
Running all unit test in macOS currently got error:

```
There was 1 error:

1) Rector\Tests\BetterPhpDocParser\PhpDocParser\TagValueNodeReprint\TestModifyReprintTest::test
PHPStan\File\CouldNotReadFileException: Could not read file: /Users/samsonasik/www/rector-src/tests/Issues/InfiniteLoop/Fixture/some_method_call_infinity.php

phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/File/FileReader.php:20
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/BetterReflection/SourceLocator/FileNodesFetcher.php:29
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocator.php:60
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/AggregateSourceLocator.php:26
/Users/samsonasik/www/rector-src/packages/NodeTypeResolver/Reflection/BetterReflection/SourceLocator/IntermediateSourceLocator.php:25
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/AggregateSourceLocator.php:26
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/MemoizingSourceLocator.php:33
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflector/DefaultReflector.php:32
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/BetterReflection/Reflector/MemoizingReflector.php:45
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/BetterReflection/BetterReflectionProvider.php:147
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ReflectionProvider/MemoizingReflectionProvider.php:35
/Users/samsonasik/www/rector-src/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:350
/Users/samsonasik/www/rector-src/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:185
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:441
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:384
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:612
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:353
/Users/samsonasik/www/rector-src/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:196
/Users/samsonasik/www/rector-src/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php:43
/Users/samsonasik/www/rector-src/packages/FileSystemRector/Parser/FileInfoParser.php:35
/Users/samsonasik/www/rector-src/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php:74
/Users/samsonasik/www/rector-src/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php:48

--

There were 3 failures:

1) Rector\Tests\Parallel\Command\WorkerCommandLineFactoryTest::test with data set #2
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-''/opt/local/bin/php82' 'main_script' '' worker --debug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi'
+''/opt/local/bin/php82' 'main_script' worker --debug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi'

/Users/samsonasik/www/rector-src/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php:58

2) Rector\Tests\Parallel\Command\WorkerCommandLineFactoryTest::test with data set #1
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-''/opt/local/bin/php82' 'main_script' '' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi'
+''/opt/local/bin/php82' 'main_script' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi'

/Users/samsonasik/www/rector-src/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php:58

3) Rector\Tests\Parallel\Command\WorkerCommandLineFactoryTest::test with data set #0
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-''/opt/local/bin/php82' 'main_script' '' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi'
+''/opt/local/bin/php82' 'main_script' worker --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi'

/Users/samsonasik/www/rector-src/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php:58

ERRORS!
Tests: 3405, Assertions: 4007, Errors: 1, Failures: 3.
➜  rector-src git:(main) vendor/bin/phpunit packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
PHPUnit 10.3.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.5
Configuration: /Users/samsonasik/www/rector-src/phpunit.xml

...                                                                 3 / 3 (100%)

Time: 00:00.161, Memory: 38.00 MB

OK (3 tests, 3 assertions)
➜  rector-src git:(main) 
```

This patch resolve it.