### PR TITLE
[Caching] Move cache invalidation from RectorConfig::sets() to RectorConfig::import()

### DIFF
--- a/packages-tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
+++ b/packages-tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
@@ -30,6 +30,7 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         copy(__DIR__ . '/Fixture/updated_rector_rule.php', __DIR__ . '/Fixture/rector.php');
 
         SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, null);
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_IMPORTFILES, null);
 
         $this->bootFromConfigFiles([__DIR__ . '/Fixture/rector.php']);
 
@@ -50,6 +51,7 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         copy(__DIR__ . '/Fixture/rector_rule_equals.php', __DIR__ . '/Fixture/rector.php');
 
         SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, null);
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_IMPORTFILES, null);
 
         $this->bootFromConfigFiles([__DIR__ . '/Fixture/rector.php']);
 

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -49,9 +49,6 @@ final class RectorConfig extends Container
             Assert::fileExists($set);
             $this->import($set);
         }
-
-        // for cache invalidation in case of sets change
-        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_SETS, $sets);
     }
 
     public function disableParallel(): void
@@ -233,6 +230,9 @@ final class RectorConfig extends Container
         foreach ($paths as $path) {
             $this->importFile($path);
         }
+
+        // for cache invalidation in case of change
+        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_IMPORTFILES, $paths);
     }
 
     /**

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -229,5 +229,5 @@ final class Option
      * @internal For cache invalidation in case of change
      * @var string
      */
-    public const REGISTERED_RECTOR_SETS = 'registered_rector_sets';
+    public const REGISTERED_RECTOR_IMPORTFILES = 'registered_rector_importfiles';
 }


### PR DESCRIPTION
@TomasVotruba @staabm here the cache should collect "parameters" from `import()` instead of `sets()`, because user can define theirself:

```php
// wildcard on purpose
$rectorConfig->import(__DIR__ . '/wildcard/*/config/*');

// specific path
$rectorConfig->import(__DIR__ . '/path/to/config.php');
```

and with current `parameter` collection, it doesn't invalidate change for add new import() call. 

On other case, directly use `RectorConfig::sets()` invalidate change, which `RectorConfig::sets()` is collection of import, so placing in import is the best way imo.