### PR TITLE
[Caching] Remove REGISTERED_RECTOR_SETS constant for caching sets

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -49,9 +49,6 @@ final class RectorConfig extends Container
             Assert::fileExists($set);
             $this->import($set);
         }
-
-        // for cache invalidation in case of sets change
-        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_SETS, $sets);
     }
 
     public function disableParallel(): void

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -224,10 +224,4 @@ final class Option
      * @var string
      */
     public const REGISTERED_RECTOR_RULES = 'registered_rector_rules';
-
-    /**
-     * @internal For cache invalidation in case of change
-     * @var string
-     */
-    public const REGISTERED_RECTOR_SETS = 'registered_rector_sets';
 }


### PR DESCRIPTION
@TomasVotruba @staabm per https://github.com/rectorphp/rector-src/pull/4942#issuecomment-1712452727

It think the `REGISTERED_RECTOR_SETS` constant is not needed, here the process:

- `$rectorConfig->sets()` is 
   -  a collection of `$rectorConfig->import()` which
       - a collection of `$rectorConfig->rule()` or `$rectorConfig->ruleWithConfiguration()` which already collect `REGISTERED_RECTOR_RULES` constant.

unsetting or add new row into sets will add more imports, so it should invalidate the cache itself.