### PR TITLE
Reduce excessive regex use

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -24,9 +24,6 @@ final class NodeNameResolver
 {
     /**
      * Used to check if a string might contain a regex or fnmatch pattern
-     *
-     * @var string
-     * @see https://regex101.com/r/ImTV1W/1
      */
     private const REGEX_WILDCARD_CHARS = ['*', '#', '~', '/'];
 

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -28,7 +28,7 @@ final class NodeNameResolver
      * @var string
      * @see https://regex101.com/r/ImTV1W/1
      */
-    private const CONTAINS_WILDCARD_CHARS_REGEX = '/[\*\#\~\/]/';
+    private const REGEX_WILDCARD_CHARS = ['*', '#', '~', '/'];
 
     /**
      * @var array<string, NodeNameResolverInterface|null>
@@ -201,7 +201,15 @@ final class NodeNameResolver
             return $desiredName === $resolvedName;
         }
 
-        if (StringUtils::isMatch($desiredName, self::CONTAINS_WILDCARD_CHARS_REGEX)) {
+        $containsWildcard = false;
+        foreach(self::REGEX_WILDCARD_CHARS as $char) {
+            if (str_contains($desiredName, $char)) {
+                $containsWildcard = true;
+                break;
+            }
+        }
+
+        if ($containsWildcard) {
             // is probably regex pattern
             if ($this->regexPatternDetector->isRegexPattern($desiredName)) {
                 return StringUtils::isMatch($resolvedName, $desiredName);


### PR DESCRIPTION
see https://github.com/rectorphp/rector/issues/8175#issuecomment-1712489680

---

blackfire suggest a reduction in memory usage by 67% per worker when running rector on the mautic codebase

<img width="1068" alt="grafik" src="https://github.com/rectorphp/rector-src/assets/120441/16bd02f0-053c-4c22-b632-f709f5659363">
