### PR TITLE
BC: Separated regex matching in NodeNameResolver->isName()

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -196,8 +196,12 @@ final class NodeNameResolver
         return strtolower($resolvedName) === strtolower($desiredName);
     }
 
-    public function matchesStringName(string $resolvedName, string $desiredNamePattern): bool
+    public function matchesStringName(string|Identifier $resolvedName, string $desiredNamePattern): bool
     {
+        if ($resolvedName instanceof Identifier) {
+            $resolvedName = $resolvedName->toString();
+        }
+
         // is probably regex pattern
         if ($this->regexPatternDetector->isRegexPattern($desiredNamePattern)) {
             return StringUtils::isMatch($resolvedName, $desiredNamePattern);

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -198,27 +198,18 @@ final class NodeNameResolver
             return $desiredName === $resolvedName;
         }
 
-        $containsWildcard = false;
-        foreach (self::REGEX_WILDCARD_CHARS as $char) {
-            if (str_contains($desiredName, $char)) {
-                $containsWildcard = true;
-                break;
-            }
-        }
-
-        if ($containsWildcard) {
-            // is probably regex pattern
-            if ($this->regexPatternDetector->isRegexPattern($desiredName)) {
-                return StringUtils::isMatch($resolvedName, $desiredName);
-            }
-
-            // is probably fnmatch
-            if (\str_contains($desiredName, '*')) {
-                return fnmatch($desiredName, $resolvedName, FNM_NOESCAPE);
-            }
-        }
-
         return strtolower($resolvedName) === strtolower($desiredName);
+    }
+
+    public function matchesStringName(string $resolvedName, string $desiredNamePattern): bool
+    {
+        // is probably regex pattern
+        if ($this->regexPatternDetector->isRegexPattern($desiredNamePattern)) {
+            return StringUtils::isMatch($resolvedName, $desiredNamePattern);
+        }
+
+        // is probably fnmatch
+        return fnmatch($desiredNamePattern, $resolvedName, FNM_NOESCAPE);
     }
 
     private function isCallOrIdentifier(Expr|Identifier $node): bool

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -23,11 +23,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 final class NodeNameResolver
 {
     /**
-     * Used to check if a string might contain a regex or fnmatch pattern
-     */
-    private const REGEX_WILDCARD_CHARS = ['*', '#', '~', '/'];
-
-    /**
      * @var array<string, NodeNameResolverInterface|null>
      */
     private array $nodeNameResolversByClass = [];

--- a/rules/DeadCode/NodeManipulator/ControllerClassMethodManipulator.php
+++ b/rules/DeadCode/NodeManipulator/ControllerClassMethodManipulator.php
@@ -44,6 +44,6 @@ final class ControllerClassMethodManipulator
             return false;
         }
 
-        return $this->nodeNameResolver->isName($class->extends, '#(Controller|Presenter)$#');
+        return $this->nodeNameResolver->matchesStringName($class->extends->toString(), '#(Controller|Presenter)$#');
     }
 }

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -176,7 +176,7 @@ CODE_SAMPLE
         }
 
         foreach ($this->classesToSkip as $classToSkip) {
-            if ($this->nodeNameResolver->isStringName($classLikeName, $classToSkip)) {
+            if ($this->nodeNameResolver->matchesStringName($classLikeName, $classToSkip)) {
                 return true;
             }
         }

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -176,6 +176,10 @@ CODE_SAMPLE
         }
 
         foreach ($this->classesToSkip as $classToSkip) {
+            if ($this->nodeNameResolver->isStringName($classLikeName, $classToSkip)) {
+                return true;
+            }
+
             if ($this->nodeNameResolver->matchesStringName($classLikeName, $classToSkip)) {
                 return true;
             }

--- a/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
+++ b/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
@@ -116,7 +116,7 @@ CODE_SAMPLE
 
     private function shouldSkipClassMethod(ClassMethod $classMethod): bool
     {
-        if ($this->isName($classMethod, 'createComponent*')) {
+        if ($this->nodeNameResolver->matchesStringName($classMethod->name->toString(), 'createComponent*')) {
             return true;
         }
 

--- a/rules/Transform/Rector/Class_/AddAllowDynamicPropertiesAttributeRector.php
+++ b/rules/Transform/Rector/Class_/AddAllowDynamicPropertiesAttributeRector.php
@@ -142,6 +142,10 @@ CODE_SAMPLE
         if ($this->transformOnNamespaces !== []) {
             $className = (string) $this->nodeNameResolver->getName($class);
             foreach ($this->transformOnNamespaces as $transformOnNamespace) {
+                if ($this->nodeNameResolver->isStringName($className, $transformOnNamespace)) {
+                    continue;
+                }
+                
                 if (! $this->nodeNameResolver->matchesStringName($className, $transformOnNamespace)) {
                     return true;
                 }

--- a/rules/Transform/Rector/Class_/AddAllowDynamicPropertiesAttributeRector.php
+++ b/rules/Transform/Rector/Class_/AddAllowDynamicPropertiesAttributeRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
         if ($this->transformOnNamespaces !== []) {
             $className = (string) $this->nodeNameResolver->getName($class);
             foreach ($this->transformOnNamespaces as $transformOnNamespace) {
-                if (! $this->nodeNameResolver->isStringName($className, $transformOnNamespace)) {
+                if (! $this->nodeNameResolver->matchesStringName($className, $transformOnNamespace)) {
                     return true;
                 }
             }


### PR DESCRIPTION
as discussed in https://github.com/rectorphp/rector-src/pull/4950#discussion_r1320547797

----

Afte todays patches rectorphp is running 100 seconds faster over the [Mautic](https://twitter.com/Mautic) codebase.

latest stable release takes ~ 625.33s
rector@dev takes ~ 523s on my machine

.. and requires way less RAM