### PR TITLE
Faster name resolving

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -204,7 +204,7 @@ final class NodeNameResolver
             return $desiredName === $resolvedName;
         }
 
-        return strtolower($resolvedName) === strtolower($desiredName);
+        return strcasecmp($resolvedName, $desiredName) === 0;
     }
 
     public function matchesStringName(string|Identifier $resolvedName, string $desiredNamePattern): bool

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -318,8 +318,13 @@ CODE_SAMPLE
 
     private function refactorCall(StaticCall|MethodCall $call): void
     {
+        $callName = $this->getName($call->name);
+        if ($callName === null) {
+            return;
+        }
+
         foreach ($this->addedArguments as $addedArgument) {
-            if (! $this->isName($call->name, $addedArgument->getMethod())) {
+            if (! $this->nodeNameResolver->isStringName($callName, $addedArgument->getMethod())) {
                 continue;
             }
 

--- a/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
@@ -83,8 +83,13 @@ CODE_SAMPLE
             return $this->refactorNew($node);
         }
 
+        $nodeName = $this->getName($node->name);
+        if ($nodeName === null) {
+            return null;
+        }
+
         foreach ($this->replaceArgumentDefaultValues as $replaceArgumentDefaultValue) {
-            if (! $this->isName($node->name, $replaceArgumentDefaultValue->getMethod())) {
+            if (! $this->nodeNameResolver->isStringName($nodeName, $replaceArgumentDefaultValue->getMethod())) {
                 continue;
             }
 

--- a/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
@@ -157,8 +157,13 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($classOrInterface->getMethods() as $classMethod) {
+            $methodName = $this->getName($classMethod->name);
+            if ($methodName === null) {
+                continue;
+            }
+
             foreach ($this->methodCallRenames as $methodCallRename) {
-                if (! $this->isName($classMethod->name, $methodCallRename->getOldMethod())) {
+                if (! $this->nodeNameResolver->isStringName($methodName, $methodCallRename->getOldMethod())) {
                     continue;
                 }
 
@@ -192,8 +197,13 @@ CODE_SAMPLE
     private function refactorMethodCallAndStaticCall(
         StaticCall|MethodCall $call
     ): ArrayDimFetch|null|MethodCall|StaticCall {
+        $callName = $this->getName($call->name);
+        if ($callName === null) {
+            return null;
+        }
+
         foreach ($this->methodCallRenames as $methodCallRename) {
-            if (! $this->isName($call->name, $methodCallRename->getOldMethod())) {
+            if (! $this->nodeNameResolver->isStringName($callName, $methodCallRename->getOldMethod())) {
                 continue;
             }
 

--- a/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
@@ -163,22 +163,7 @@ CODE_SAMPLE
             }
 
             foreach ($this->methodCallRenames as $methodCallRename) {
-                if (! $this->nodeNameResolver->isStringName($methodName, $methodCallRename->getOldMethod())) {
-                    continue;
-                }
-
-                if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
-                    $classMethod,
-                    $methodCallRename->getObjectType()
-                )) {
-                    continue;
-                }
-
-                if ($this->shouldKeepForParentInterface($methodCallRename, $classReflection)) {
-                    continue;
-                }
-
-                if ($this->hasClassNewClassMethod($classOrInterface, $methodCallRename)) {
+                if ($this->shouldSkipRename($methodName, $classMethod, $methodCallRename, $classReflection, $classOrInterface)) {
                     continue;
                 }
 
@@ -192,6 +177,36 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function shouldSkipRename(
+        string $methodName,
+        Node\Stmt\ClassMethod $classMethod,
+        MethodCallRenameInterface $methodCallRename,
+        ClassReflection $classReflection,
+        Class_|Interface_ $classOrInterface
+    ): bool
+    {
+        if (! $this->nodeNameResolver->isStringName($methodName, $methodCallRename->getOldMethod())) {
+            return true;
+        }
+
+        if (! $this->nodeTypeResolver->isMethodStaticCallOrClassMethodObjectType(
+            $classMethod,
+            $methodCallRename->getObjectType()
+        )) {
+            return true;
+        }
+
+        if ($this->shouldKeepForParentInterface($methodCallRename, $classReflection)) {
+            return true;
+        }
+
+        if ($this->hasClassNewClassMethod($classOrInterface, $methodCallRename)) {
+            return true;
+        }
+
+        return false;
     }
 
     private function refactorMethodCallAndStaticCall(

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -88,8 +88,13 @@ CODE_SAMPLE
                 continue;
             }
 
+            $methodName = $this->getName($classMethod);
+            if ($methodName === null) {
+                continue;
+            }
+
             foreach ($this->addParamTypeDeclarations as $addParamTypeDeclaration) {
-                if (! $this->isName($classMethod, $addParamTypeDeclaration->getMethodName())) {
+                if (!$this->nodeNameResolver->isStringName($methodName, $addParamTypeDeclaration->getMethodName())) {
                     continue;
                 }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -89,10 +89,6 @@ CODE_SAMPLE
             }
 
             $methodName = $this->getName($classMethod);
-            if ($methodName === null) {
-                continue;
-            }
-
             foreach ($this->addParamTypeDeclarations as $addParamTypeDeclaration) {
                 if (!$this->nodeNameResolver->isStringName($methodName, $addParamTypeDeclaration->getMethodName())) {
                     continue;


### PR DESCRIPTION
in the worker profiles of mautic I could see these rectors spending a lot of time in repeated name resolving.

I moved the name determination before the loop and used a lower level name-resolver method for comparison.
I did so only in the rectors which were reported in profiles

---

running on mautic..

*before this PR*
```
time php ../rector-src/bin/rector.php --dry-run --no-progress-bar --no-diffs --clear-cache
                                                                                                                        
 [OK] 7 files would have changed (dry-run) by Rector                                                                    
                                                                                                                        
php ../rector-src/bin/rector.php --dry-run --no-progress-bar --no-diffs   478.62s user 8.69s system 873% cpu 55.776 total
```

*with this PR*
```
time php ../rector-src/bin/rector.php --dry-run --no-progress-bar --no-diffs --clear-cache
                                                                                                                        
 [OK] 7 files would have changed (dry-run) by Rector                                                                    
                                                                                                                        
php ../rector-src/bin/rector.php --dry-run --no-progress-bar --no-diffs   396.58s user 9.82s system 817% cpu 49.711 total
```

-> 80 seconds faster