### PR TITLE
[Performance][FileProcessor] Only check space before <?php on FileWithoutNamespace

### DIFF
--- a/src/Application/FileProcessor/PhpFileProcessor.php
+++ b/src/Application/FileProcessor/PhpFileProcessor.php
@@ -12,6 +12,7 @@ use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
 use Rector\Core\Application\FileProcessor;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\FileSystem\FilePathHelper;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PhpParser\Printer\FormatPerservingPrinter;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
@@ -128,7 +129,7 @@ final class PhpFileProcessor
          * On printing, the space may be wiped, these below check compare with original file content used to verify
          * that no change actually needed
          */
-        if (! $file->getFileDiff() instanceof FileDiff) {
+        if (! $file->getFileDiff() instanceof FileDiff && current($file->getNewStmts()) instanceof FileWithoutNamespace) {
             /**
              * Handle new line or space before <?php or InlineHTML node wiped on print format preserving
              * On very first content level


### PR DESCRIPTION
Only `FileWithoutNamespace` that no error with space before `<?php` https://getrector.com/demo/1bb1de08-192e-45d6-83bf-24b9f9b71e77

no need regex compare on namespaced file :)
