### PR TITLE
Fix infinite loop test InfiniteLoopTest

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
@@ -7,7 +7,6 @@ namespace Rector\Tests\BetterPhpDocParser\PhpDocParser\TagValueNodeReprint;
 use Nette\Utils\FileSystem;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\StringNode;
@@ -40,7 +39,6 @@ final class TestModifyReprintTest extends AbstractLazyTestCase
         $this->phpDocInfoFactory = $this->make(PhpDocInfoFactory::class);
     }
 
-    #[RunInSeparateProcess]
     public function test(): void
     {
         [$inputContent, $expectedContent] = FixtureSplitter::split(

--- a/packages-tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
+++ b/packages-tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Caching\Config\FileHashComputer;
 
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Caching\Config\FileHashComputer;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
@@ -19,7 +18,6 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         $this->fileHashComputer = $this->make(FileHashComputer::class);
     }
 
-    #[RunInSeparateProcess]
     public function testRectorPhpChanged(): void
     {
         $this->bootFromConfigFiles([__DIR__ . '/Fixture/rector.php']);
@@ -39,7 +37,6 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         $this->assertNotSame($newHashedFile, $hashedFile);
     }
 
-    #[RunInSeparateProcess]
     public function testRectorPhpNotChanged(): void
     {
         $this->bootFromConfigFiles([__DIR__ . '/Fixture/rector.php']);

--- a/packages-tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
+++ b/packages-tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Caching\Config\FileHashComputer;
 
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Rector\Caching\Config\FileHashComputer;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
@@ -18,6 +19,7 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         $this->fileHashComputer = $this->make(FileHashComputer::class);
     }
 
+    #[RunInSeparateProcess]
     public function testRectorPhpChanged(): void
     {
         $this->bootFromConfigFiles([__DIR__ . '/Fixture/rector.php']);
@@ -37,6 +39,7 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         $this->assertNotSame($newHashedFile, $hashedFile);
     }
 
+    #[RunInSeparateProcess]
     public function testRectorPhpNotChanged(): void
     {
         $this->bootFromConfigFiles([__DIR__ . '/Fixture/rector.php']);

--- a/tests/Issues/InfiniteLoop/InfiniteLoopTest.php
+++ b/tests/Issues/InfiniteLoop/InfiniteLoopTest.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Rector\Core\Tests\Issues\InfiniteLoop;
 
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class InfiniteLoopTest extends AbstractRectorTestCase
 {
-    public function testException(): void
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
     {
-        $this->doTestFile(__DIR__ . '/Fixture/some_method_call_infinity.php.inc');
+        $this->doTestFile($filePath);
     }
 
-    public function testPass(): void
+    public static function provideData(): Iterator
     {
-        $this->doTestFile(__DIR__ . '/Fixture/de_morgan.php.inc');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Issues/InfiniteLoop/Rector/MethodCall/InfinityLoopRector.php
+++ b/tests/Issues/InfiniteLoop/Rector/MethodCall/InfinityLoopRector.php
@@ -7,6 +7,7 @@ namespace Rector\Core\Tests\Issues\InfiniteLoop\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\NodeTraverser;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,15 +21,18 @@ final class InfinityLoopRector extends AbstractRector
      */
     public function getNodeTypes(): array
     {
-        return [MethodCall::class];
+        return [Assign::class, MethodCall::class];
     }
 
     /**
-     * @param MethodCall $node
-     * @return Assign|null
+     * @param Assign|MethodCall $node
      */
-    public function refactor(Node $node): ?Node
+    public function refactor(Node $node): Assign|null|int
     {
+        if ($node instanceof Assign) {
+            return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+        }
+
         if (! $this->isName($node->name, 'modify')) {
             return null;
         }


### PR DESCRIPTION
@TomasVotruba current infinite loop test seems use manual:

```php
$this->doTestFile(__DIR__ . '/Fixture/de_morgan.php.inc');
```

which miss the skipped part of fixture, this PR try to resolve it.