### PR TITLE
[NodeNameResolver] Check regex start delimiter and contains * on NodeNameResolver to use fnmatch()

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -181,7 +181,15 @@ final class NodeNameResolver
             return $desiredName === $resolvedName;
         }
 
-        return strcasecmp($resolvedName, $desiredName) === 0;
+        if (strcasecmp($resolvedName, $desiredName) === 0) {
+            return true;
+        }
+
+        if (str_starts_with($desiredName, '*') || str_ends_with($desiredName, '*')) {
+            return fnmatch($desiredName, $resolvedName, FNM_NOESCAPE);
+        }
+
+        return false;
     }
 
     private function isCallOrIdentifier(Expr|Identifier $node): bool

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -185,7 +185,7 @@ final class NodeNameResolver
             return true;
         }
 
-        if (str_starts_with($desiredName, '*') || str_ends_with($desiredName, '*')) {
+        if (str_contains($desiredName, '*')) {
             return fnmatch($desiredName, $resolvedName, FNM_NOESCAPE);
         }
 

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -15,7 +15,9 @@ use PHPStan\Analyser\Scope;
 use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\CallAnalyzer;
+use Rector\Core\Util\StringUtils;
 use Rector\NodeNameResolver\Contract\NodeNameResolverInterface;
+use Rector\NodeNameResolver\Regex\RegexPatternDetector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class NodeNameResolver
@@ -31,6 +33,7 @@ final class NodeNameResolver
     public function __construct(
         private readonly ClassNaming $classNaming,
         private readonly CallAnalyzer $callAnalyzer,
+        private readonly RegexPatternDetector $regexPatternDetector,
         private readonly iterable $nodeNameResolvers = []
     ) {
     }
@@ -183,6 +186,10 @@ final class NodeNameResolver
 
         if (strcasecmp($resolvedName, $desiredName) === 0) {
             return true;
+        }
+
+        if ($this->regexPatternDetector->isRegexPattern($desiredName)) {
+            return StringUtils::isMatch($resolvedName, $desiredName);
         }
 
         if (str_contains($desiredName, '*')) {

--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/skip_nette_class.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/skip_nette_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
+
+final class SkipNetteClass
+{
+    public function run()
+    {
+        return 'Nette\Utils\FileSystem';
+    }
+}

--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/skip_phpstan_class.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/skip_phpstan_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
+
+final class SkipPHPStanClass
+{
+    public function run()
+    {
+        return 'Nette\Utils\FileSystem';
+    }
+}

--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/config/configured_rule.php
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/config/configured_rule.php
@@ -7,5 +7,10 @@ use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
-        ->ruleWithConfiguration(StringClassNameToClassConstantRector::class, ['Nette\*', 'Error', 'Exception']);
+        ->ruleWithConfiguration(StringClassNameToClassConstantRector::class, [
+            'Nette\*',
+            '#^PHPStan\\\\Type#',
+            'Error',
+            'Exception'
+        ]);
 };

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -179,10 +179,6 @@ CODE_SAMPLE
             if ($this->nodeNameResolver->isStringName($classLikeName, $classToSkip)) {
                 return true;
             }
-
-            if (fnmatch($classToSkip, $classLikeName, FNM_NOESCAPE)) {
-                return true;
-            }
         }
 
         return false;


### PR DESCRIPTION
@TomasVotruba @staabm this is to avoid bc break with check string contains first :)