### PR TITLE
[Performance][Testing] Remove regex to split test input/output on FixtureSplitter

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
+++ b/packages-tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
@@ -6,7 +6,6 @@ namespace Rector\Tests\BetterPhpDocParser\PhpDocParser\TagValueNodeReprint;
 
 use Iterator;
 use Nette\Utils\FileSystem;
-use Nette\Utils\Strings;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -17,17 +16,12 @@ use Rector\Core\FileSystem\FilePathHelper;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\FileSystemRector\Parser\FileInfoParser;
 use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\Fixture\FixtureSplitter;
 use Rector\Testing\Fixture\FixtureTempFileDumper;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 
 final class TagValueNodeReprintTest extends AbstractLazyTestCase
 {
-    /**
-     * @var string
-     * @see https://regex101.com/r/0UHYBt/1
-     */
-    private const SPLIT_LINE_REGEX = "#-----\n#";
-
     private FileInfoParser $fileInfoParser;
 
     private BetterNodeFinder $betterNodeFinder;
@@ -53,9 +47,8 @@ final class TagValueNodeReprintTest extends AbstractLazyTestCase
     {
         $fixtureFileContents = FileSystem::read($filePath);
 
-        [$fileContents, $nodeClass, $tagValueNodeClasses] = Strings::split(
-            $fixtureFileContents,
-            self::SPLIT_LINE_REGEX
+        [$fileContents, $nodeClass, $tagValueNodeClasses] =  FixtureSplitter::splitFixtureFileContents(
+            $fixtureFileContents
         );
 
         $nodeClass = trim((string) $nodeClass);

--- a/packages/Testing/Fixture/FixtureSplitter.php
+++ b/packages/Testing/Fixture/FixtureSplitter.php
@@ -12,7 +12,7 @@ final class FixtureSplitter
 {
     public static function containsSplit(string $fixtureFileContent): bool
     {
-        return str_contains($fixtureFileContent, "-----\n");
+        return str_contains($fixtureFileContent, "-----" . PHP_EOL);
     }
 
     /**
@@ -30,6 +30,6 @@ final class FixtureSplitter
      */
     public static function splitFixtureFileContents(string $fixtureFileContents): array
     {
-        return explode("-----\n", $fixtureFileContents);
+        return explode("-----" . PHP_EOL, $fixtureFileContents);
     }
 }

--- a/packages/Testing/Fixture/FixtureSplitter.php
+++ b/packages/Testing/Fixture/FixtureSplitter.php
@@ -4,23 +4,15 @@ declare(strict_types=1);
 namespace Rector\Testing\Fixture;
 
 use Nette\Utils\FileSystem;
-use Nette\Utils\Strings;
 
 /**
  * @api
  */
 final class FixtureSplitter
 {
-    /**
-     * @api
-     * @var string
-     * @see https://regex101.com/r/zZDoyy/1
-     */
-    public const SPLIT_LINE_REGEX = '#\-\-\-\-\-\r?\n#';
-
     public static function containsSplit(string $fixtureFileContent): bool
     {
-        return Strings::match($fixtureFileContent, self::SPLIT_LINE_REGEX) !== null;
+        return str_contains($fixtureFileContent, "-----\n");
     }
 
     /**
@@ -30,7 +22,7 @@ final class FixtureSplitter
     {
         $fixtureFileContents = FileSystem::read($filePath);
 
-        return Strings::split($fixtureFileContents, self::SPLIT_LINE_REGEX);
+        return self::splitFixtureFileContents($fixtureFileContents);
     }
 
     /**
@@ -38,6 +30,6 @@ final class FixtureSplitter
      */
     public static function splitFixtureFileContents(string $fixtureFileContents): array
     {
-        return Strings::split($fixtureFileContents, self::SPLIT_LINE_REGEX);
+        return explode("-----\n", $fixtureFileContents);
     }
 }


### PR DESCRIPTION
Use `str_contains()` and `explode()` is enough.