### PR TITLE
[CodingStyle] Use str_starts_with() on isName($node, 'test*') on DataProviderArrayItemsNewlinedRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/DataProviderArrayItemsNewlinedRector/Fixture/skip_test_method.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/DataProviderArrayItemsNewlinedRector/Fixture/skip_test_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\DataProviderArrayItemsNewlinedRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipTestMethod extends TestCase
+{
+    public function test(): array
+    {
+        return [['content', 8], ['content123', 11]];
+    }
+}

--- a/rules/CodingStyle/Rector/ClassMethod/DataProviderArrayItemsNewlinedRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/DataProviderArrayItemsNewlinedRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
         }
 
         // skip test methods
-        if ($this->isName($node, 'test*')) {
+        if (str_starts_with($node->name->toString(), 'test')) {
             return null;
         }
 


### PR DESCRIPTION
@TomasVotruba @staabm here based on https://github.com/rectorphp/rector-src/pull/4980#issuecomment-1713784117