### PR TITLE
[Php55] Check str_contains * before fnmatch() early on StringClassNameToClassConstantRector

### DIFF
--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -176,11 +176,15 @@ CODE_SAMPLE
         }
 
         foreach ($this->classesToSkip as $classToSkip) {
-            if ($this->nodeNameResolver->isStringName($classLikeName, $classToSkip)) {
-                return true;
+            if (str_contains($classToSkip, '*')) {
+                if (fnmatch($classToSkip, $classLikeName, FNM_NOESCAPE)) {
+                    return true;
+                }
+
+                continue;
             }
 
-            if (fnmatch($classToSkip, $classLikeName, FNM_NOESCAPE)) {
+            if ($this->nodeNameResolver->isStringName($classLikeName, $classToSkip)) {
                 return true;
             }
         }


### PR DESCRIPTION
@TomasVotruba @staabm here based on https://github.com/rectorphp/rector-src/pull/4980#issuecomment-1713784117