### PR TITLE
[Performance] [NodeNameResolver] Move loop REGEX_WILDCARD_CHARS on last resort after $resolvedName, $desiredName compare to avoid unnecesary loop when possible

### DIFF
--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -186,13 +186,17 @@ final class NodeNameResolver
             return $desiredName === $resolvedName;
         }
 
+        if (strcasecmp($resolvedName, $desiredName) === 0) {
+            return true;
+        }
+
         foreach(self::REGEX_WILDCARD_CHARS as $char) {
             if (str_contains($desiredName, $char)) {
                 throw new ShouldNotHappenException('Matching of regular expressions is no longer supported. Use $this->getName() and compare with e.g. str_ends_with() or str_starts_with() instead.');
             }
         }
 
-        return strcasecmp($resolvedName, $desiredName) === 0;
+        return false;
     }
 
     private function isCallOrIdentifier(Expr|Identifier $node): bool


### PR DESCRIPTION
@TomasVotruba @staabm here to avoid unnecessary loop when possible

Ref https://github.com/rectorphp/rector-src/pull/4980#pullrequestreview-1620273041