### PR TITLE
[PhpParser] Fix crash read jetbrains/phpstorm-stubs included in phpstan.phar on PHP 8.0 and PHP 7.4

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -314,10 +314,12 @@ final class AstResolver
 
         try {
             $stmts = $this->smartPhpParser->parseFile($fileName);
-        } catch (Throwable) {
+        } catch (Throwable $throwable) {
             if (str_contains($fileName, 'phpstan.phar')) {
                 return [];
             }
+
+            throw $throwable;
         }
 
         if ($stmts === []) {

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -315,6 +315,12 @@ final class AstResolver
         try {
             $stmts = $this->smartPhpParser->parseFile($fileName);
         } catch (Throwable $throwable) {
+            /**
+             * phpstan.phar contains jetbrains/phpstorm-stubs which the code is not downgraded
+             * that if read from lower php < 8.1 may cause crash
+             *
+             * @see https://github.com/rectorphp/rector/issues/8193
+             */
             if (str_contains($fileName, 'phpstan.phar')) {
                 return [];
             }

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -329,10 +329,6 @@ final class AstResolver
             throw $throwable;
         }
 
-        if ($stmts === []) {
-            return $this->parsedFileNodes[$fileName] = [];
-        }
-
         return $this->parsedFileNodes[$fileName] = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile(
             $fileName,
             $stmts

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -319,7 +319,8 @@ final class AstResolver
              * phpstan.phar contains jetbrains/phpstorm-stubs which the code is not downgraded
              * that if read from lower php < 8.1 may cause crash
              *
-             * @see https://github.com/rectorphp/rector/issues/8193
+             * @see https://github.com/rectorphp/rector/issues/8193 on php 8.0
+             * @see https://github.com/rectorphp/rector/issues/8145 on php 7.4
              */
             if (str_contains($fileName, 'phpstan.phar')) {
                 return [];

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -34,6 +34,7 @@ use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpDocParser\PhpParser\SmartPhpParser;
+use Throwable;
 
 /**
  * The nodes provided by this resolver is for read-only analysis only!
@@ -311,7 +312,14 @@ final class AstResolver
             return $this->parsedFileNodes[$fileName];
         }
 
-        $stmts = $this->smartPhpParser->parseFile($fileName);
+        try {
+            $stmts = $this->smartPhpParser->parseFile($fileName);
+        } catch (Throwable) {
+            if (str_contains($fileName, 'phpstan.phar')) {
+                return [];
+            }
+        }
+
         if ($stmts === []) {
             return $this->parsedFileNodes[$fileName] = [];
         }


### PR DESCRIPTION
@vjik this should fix https://github.com/rectorphp/rector/issues/8193

also fix https://github.com/rectorphp/rector/issues/8145

**Before**

```
php80 vendor/bin/rector process src/StringableObject.php --dry-run --clear-cache
 0/1 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%string(226) "phar:///Users/samsonasik/www/rector-custom/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/SourceLocator/SourceStubber/../../../../../jetbrains/phpstorm-stubs/Core/Core_c.stub"
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [ERROR] Could not process "src/StringableObject.php" file, due to:                                                     
         "System error: "Syntax error, unexpected T_STRING, expecting T_VARIABLE906, Syntax error, unexpected T_STRING, 
         expecting T_VARIABLE920, Syntax error, unexpected T_STRING, expecting T_VARIABLE945, Syntax error, unexpected  
         T_STRING, expecting T_VARIABLE970, Syntax error, unexpected T_STRING, expecting T_VARIABLE1119"                
         Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new". On line: 56
```

**After**

```
php80 vendor/bin/rector process src/StringableObject.php --dry-run --clear-cache
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        
```