### PR TITLE
refactor: add support for Custom Skip Voters

### DIFF
--- a/packages/Skipper/Skipper/Skipper.php
+++ b/packages/Skipper/Skipper/Skipper.php
@@ -8,8 +8,7 @@ use PhpParser\Node;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\ProcessAnalyzer\RectifiedAnalyzer;
 use Rector\Skipper\Contract\SkipVoterInterface;
-use Rector\Skipper\SkipVoter\ClassSkipVoter;
-use Rector\Skipper\SkipVoter\PathSkipVoter;
+use Webmozart\Assert\Assert;
 
 /**
  * @api
@@ -23,16 +22,13 @@ final class Skipper
     private const FILE_ELEMENT = 'file_elements';
 
     /**
-     * @var SkipVoterInterface[]
+     * @param iterable<SkipVoterInterface> $skipVoters
      */
-    private array $skipVoters = [];
-
     public function __construct(
-        ClassSkipVoter $classSkipVoter,
-        PathSkipVoter $pathSkipVoter,
-        private readonly RectifiedAnalyzer $rectifiedAnalyzer
+        private readonly RectifiedAnalyzer $rectifiedAnalyzer,
+        private readonly iterable $skipVoters = [],
     ) {
-        $this->skipVoters = [$classSkipVoter, $pathSkipVoter];
+        Assert::allIsInstanceOf($this->skipVoters, SkipVoterInterface::class);
     }
 
     public function shouldSkipElement(string | object $element): bool

--- a/packages/Skipper/Skipper/Skipper.php
+++ b/packages/Skipper/Skipper/Skipper.php
@@ -26,7 +26,7 @@ final class Skipper
      */
     public function __construct(
         private readonly RectifiedAnalyzer $rectifiedAnalyzer,
-        private readonly iterable $skipVoters = [],
+        private readonly array $skipVoters,
     ) {
         Assert::allIsInstanceOf($this->skipVoters, SkipVoterInterface::class);
     }

--- a/packages/Skipper/Skipper/Skipper.php
+++ b/packages/Skipper/Skipper/Skipper.php
@@ -22,7 +22,7 @@ final class Skipper
     private const FILE_ELEMENT = 'file_elements';
 
     /**
-     * @param iterable<SkipVoterInterface> $skipVoters
+     * @param array<SkipVoterInterface> $skipVoters
      */
     public function __construct(
         private readonly RectifiedAnalyzer $rectifiedAnalyzer,

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -154,7 +154,10 @@ use Rector\PHPStanStaticTypeMapper\TypeMapper\ThisTypeMapper;
 use Rector\PHPStanStaticTypeMapper\TypeMapper\TypeWithClassNameTypeMapper;
 use Rector\PHPStanStaticTypeMapper\TypeMapper\VoidTypeMapper;
 use Rector\PostRector\Application\PostFileProcessor;
+use Rector\Skipper\Contract\SkipVoterInterface;
 use Rector\Skipper\Skipper\Skipper;
+use Rector\Skipper\SkipVoter\ClassSkipVoter;
+use Rector\Skipper\SkipVoter\PathSkipVoter;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
@@ -358,6 +361,8 @@ final class LazyContainerFactory
         UnionTypeNodeMapper::class,
     ];
 
+    private const SKIP_VOTER_CLASSES = [ClassSkipVoter::class, PathSkipVoter::class];
+
     /**
      * @api used as next rectorConfig factory
      */
@@ -492,6 +497,12 @@ final class LazyContainerFactory
         $rectorConfig->when(NodeNameResolver::class)
             ->needs('$nodeNameResolvers')
             ->giveTagged(NodeNameResolverInterface::class);
+
+        $rectorConfig->when(Skipper::class)
+            ->needs('$skipVoters')
+            ->giveTagged(SkipVoterInterface::class);
+
+        $this->registerTagged($rectorConfig, self::SKIP_VOTER_CLASSES, SkipVoterInterface::class);
 
         $rectorConfig->afterResolving(
             AbstractRector::class,

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -361,6 +361,9 @@ final class LazyContainerFactory
         UnionTypeNodeMapper::class,
     ];
 
+    /**
+     * @var array<class-string<SkipVoterInterface>>
+     */
     private const SKIP_VOTER_CLASSES = [ClassSkipVoter::class, PathSkipVoter::class];
 
     /**


### PR DESCRIPTION
**Description:**

This pull request refactors the constructor of the **Skipper** class to improve its compatibility with dependency injection and to support custom SkipVoter implementations.

**Changes Made:**

1. Changed the constructor to accept an iterable of SkipVoterInterface objects, allowing for more flexibility in injecting multiple skip voters without having to explicitly list them.

2. Added a type hint for the $skipVoters parameter to ensure that all elements within the iterable are instances of SkipVoterInterface.

3. Used the Assert::allIsInstanceOf method to validate that all elements in $skipVoters are indeed instances of SkipVoterInterface.

**Reasoning:**

In version 0.16.0, before the introduction of the new Lazy Container, I implemented a custom SkipVoter for the company I work for. This custom implementation worked seamlessly. However, with the introduction of the Lazy Container and the subsequent change in the constructor signature, the ability to use custom SkipVoter implementations was hindered.

By allowing an iterable of skip voters, we can easily extend or modify the list of skip voters without changing the constructor signature. This change also aligns better with dependency injection principles, making it easier to bind and inject dependencies.

Furthermore, I plan to submit another pull request proposing a new "collector" based skip voter. The idea behind this is to provide a configurable mechanism to skip classes based on specific criteria, such as implementing a certain interface or extending a specific class.

**Potential Concerns:**

1. Backward Compatibility: This change might affect parts of the codebase or external projects that rely on the old constructor signature.

2. Performance: Using an iterable and asserting all elements might introduce a slight performance overhead. The impact should be minimal.

**3. Original Design Intent: I'd love to understand the original intention behind the design change. The previous design might have been intentional to restrict the number or type of skip voters. It's essential to ensure that this change aligns with the project's goals.**