### PR TITLE
[BetterPhpDocParser] Use DocBlockUpdater directly on PhpDocTagRemover

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTagRemover.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocTagRemover.php
@@ -8,10 +8,15 @@ use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 
 final class PhpDocTagRemover
 {
+    public function __construct(private readonly DocBlockUpdater $docBlockUpdater)
+    {
+    }
+
     public function removeByName(PhpDocInfo $phpDocInfo, string $name): bool
     {
         $hasChanged = false;
@@ -33,6 +38,10 @@ final class PhpDocTagRemover
                 unset($phpDocNode->children[$key]);
                 $hasChanged = true;
             }
+        }
+
+        if ($hasChanged) {
+            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($phpDocInfo->getNode());
         }
 
         return $hasChanged;
@@ -60,6 +69,10 @@ final class PhpDocTagRemover
             $hasChanged = true;
             return PhpDocNodeTraverser::NODE_REMOVE;
         });
+
+        if ($hasChanged) {
+            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($phpDocInfo->getNode());
+        }
 
         return $hasChanged;
     }

--- a/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
+++ b/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
-use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -31,7 +30,6 @@ final class RemoveAnnotationRector extends AbstractRector implements Configurabl
 
     public function __construct(
         private readonly PhpDocTagRemover $phpDocTagRemover,
-        private readonly DocBlockUpdater $docBlockUpdater,
     ) {
     }
 
@@ -98,8 +96,6 @@ CODE_SAMPLE
         }
 
         if ($hasChanged) {
-            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
-
             return $node;
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
-use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\NodeCollector\UnusedParameterResolver;
 use Rector\DeadCode\NodeManipulator\VariadicFunctionLikeDetector;
@@ -28,7 +27,6 @@ final class RemoveUnusedPrivateMethodParameterRector extends AbstractRector
         private readonly VariadicFunctionLikeDetector $variadicFunctionLikeDetector,
         private readonly UnusedParameterResolver $unusedParameterResolver,
         private readonly PhpDocTagRemover $phpDocTagRemover,
-        private readonly DocBlockUpdater $docBlockUpdater,
     ) {
     }
 
@@ -203,7 +201,6 @@ CODE_SAMPLE
     private function clearPhpDocInfo(ClassMethod $classMethod, array $unusedParameters): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-        $hasChanged = false;
 
         foreach ($unusedParameters as $unusedParameter) {
             $parameterName = $this->getName($unusedParameter->var);
@@ -220,11 +217,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $hasChanged = $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $paramTagValueNode);
-        }
-
-        if ($hasChanged) {
-            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($classMethod);
+            $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $paramTagValueNode);
         }
     }
 }


### PR DESCRIPTION
Use manual call in the rule:

```php
$this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo
```

may cause overlap when `$hasChanged` is on the loop, for example:

https://github.com/rectorphp/rector-src/blob/09baf7dd0ce61eba0944f98977834f18665f3e9f/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php#L223-L226

which `$hasChanged` always replaced, and checked after loop.

This PR ensure it not overlap by run it in the `PhpDocTagRemover` itself.