### PR TITLE
[BetterPhpDocParser] Use DocBlockUpdater directly on PhpDocClassRenamer

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
+++ b/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
@@ -13,11 +13,13 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocParser\ClassAnnotationMatcher;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 
 final class PhpDocClassRenamer
 {
     public function __construct(
-        private readonly ClassAnnotationMatcher $classAnnotationMatcher
+        private readonly ClassAnnotationMatcher $classAnnotationMatcher,
+        private readonly DocBlockUpdater $docBlockUpdater
     ) {
     }
 
@@ -32,6 +34,10 @@ final class PhpDocClassRenamer
         $this->processAssertChoiceTagValueNode($oldToNewClasses, $phpDocInfo, $hasChanged);
         $this->processDoctrineRelationTagValueNode($node, $oldToNewClasses, $phpDocInfo, $hasChanged);
         $this->processSerializerTypeTagValueNode($oldToNewClasses, $phpDocInfo, $hasChanged);
+
+        if ($hasChanged) {
+            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($phpDocInfo->getNode());
+        }
 
         return $hasChanged;
     }

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -107,9 +107,8 @@ final class ClassRenamer
         }
 
         $hasChanged = $this->docBlockClassRenamer->renamePhpDocType($phpDocInfo, $oldToNewTypes);
-        $hasChanged = $this->phpDocClassRenamer->changeTypeInAnnotationTypes($node, $phpDocInfo, $oldToNewClasses, $hasChanged);
 
-        return $hasChanged;
+        return $this->phpDocClassRenamer->changeTypeInAnnotationTypes($node, $phpDocInfo, $oldToNewClasses, $hasChanged);
     }
 
     private function shouldSkip(string $newName, Name $name): bool

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -21,7 +21,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocClassRenamer;
 use Rector\BetterPhpDocParser\ValueObject\NodeTypes;
 use Rector\CodingStyle\Naming\ClassNaming;
-use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Util\FileHasher;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -53,7 +52,6 @@ final class ClassRenamer
         private readonly DocBlockClassRenamer $docBlockClassRenamer,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly FileHasher $fileHasher,
-        private readonly DocBlockUpdater $docBlockUpdater,
     ) {
     }
 
@@ -111,12 +109,7 @@ final class ClassRenamer
         $hasChanged = $this->docBlockClassRenamer->renamePhpDocType($phpDocInfo, $oldToNewTypes);
         $hasChanged = $this->phpDocClassRenamer->changeTypeInAnnotationTypes($node, $phpDocInfo, $oldToNewClasses, $hasChanged);
 
-        if ($hasChanged) {
-            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
-            return true;
-        }
-
-        return false;
+        return $hasChanged;
     }
 
     private function shouldSkip(string $newName, Name $name): bool


### PR DESCRIPTION
The `PhpDocManipulator` namespace should be the place that the `DocBlockUpdater` is called.