### PR TITLE
[BetterPhpDocParser] Use DocBlockUpdater directly on DocBlockTagReplacer

### DIFF
--- a/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockTagReplacer.php
+++ b/packages/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockTagReplacer.php
@@ -8,11 +8,13 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\Annotation\AnnotationNaming;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 
 final class DocBlockTagReplacer
 {
     public function __construct(
-        private readonly AnnotationNaming $annotationNaming
+        private readonly AnnotationNaming $annotationNaming,
+        private readonly DocBlockUpdater $docBlockUpdater
     ) {
     }
 
@@ -36,6 +38,10 @@ final class DocBlockTagReplacer
             unset($phpDocNode->children[$key]);
             $phpDocNode->children[] = new PhpDocTagNode($newTag, new GenericTagValueNode(''));
             $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($phpDocInfo->getNode());
         }
 
         return $hasChanged;

--- a/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
+++ b/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockTagReplacer;
@@ -31,8 +30,7 @@ final class RenameAnnotationRector extends AbstractRector implements Configurabl
     private array $renameAnnotations = [];
 
     public function __construct(
-        private readonly DocBlockTagReplacer $docBlockTagReplacer,
-        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly DocBlockTagReplacer $docBlockTagReplacer
     ) {
     }
 
@@ -119,7 +117,6 @@ CODE_SAMPLE
                 );
 
                 if ($hasDocBlockChanged) {
-                    $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($stmt);
                     $hasChanged = true;
                 }
             }
@@ -160,7 +157,6 @@ CODE_SAMPLE
         }
 
         if ($hasChanged) {
-            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($expression);
             return $expression;
         }
 


### PR DESCRIPTION
`DocBlockTagReplacer` should be place to call `DocBlockUpdater` instead of target rule to avoid unnecessary re-call multiple times in the rule.