### PR TITLE
[Config] Move content of private method importFile() to import() method

### DIFF
--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -225,7 +225,7 @@ final class RectorConfig extends Container
     {
         if (str_contains($filePath, '*')) {
             throw new ShouldNotHappenException(
-                'Matching file paths by using glob($filePath) is no longer supported. Use specific file path instead.'
+                'Matching file paths by using glob-patterns is no longer supported. Use specific file path instead.'
             );
         }
 

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -223,7 +223,14 @@ final class RectorConfig extends Container
 
     public function import(string $filePath): void
     {
-        $this->importFile($filePath);
+        Assert::fileExists($filePath);
+
+        $self = $this;
+        $callable = (require $filePath);
+
+        Assert::isCallable($callable);
+        /** @var callable(Container $container): void $callable */
+        $callable($self);
     }
 
     /**
@@ -353,18 +360,6 @@ final class RectorConfig extends Container
             // completely forget the Rector rule only when no path specified
             ContainerMemento::forgetService($this, $skippedClass);
         }
-    }
-
-    private function importFile(string $filePath): void
-    {
-        Assert::fileExists($filePath);
-
-        $self = $this;
-        $callable = (require $filePath);
-
-        Assert::isCallable($callable);
-        /** @var callable(Container $container): void $callable */
-        $callable($self);
     }
 
     private function isRuleNoLongerExists(mixed $skipRule): bool

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -223,6 +223,12 @@ final class RectorConfig extends Container
 
     public function import(string $filePath): void
     {
+        if (str_contains($filePath, '*')) {
+            throw new ShouldNotHappenException(
+                'Matching file paths by using glob($filePath) is no longer supported. Use specific file path instead.'
+            );
+        }
+
         Assert::fileExists($filePath);
 
         $self = $this;


### PR DESCRIPTION
Since asterisk support removed at PR:

- https://github.com/rectorphp/rector-src/pull/5010

call private method is no longer needed, this PR apply directly use the import code in the import method.