### PR TITLE
BinaryOpNullableToInstanceofRector: test phpdoc ignorance

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/BooleanAnd/BinaryOpNullableToInstanceofRector/Fixture/skip_phpdoc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/BooleanAnd/BinaryOpNullableToInstanceofRector/Fixture/skip_phpdoc.php.inc
@@ -7,7 +7,7 @@ use Rector\Tests\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofR
 /**
  * @param SomeInstance|null $someClass
  */
-function binaryOrPhpdoc($someClass)
+function skipBinaryOrPhpdoc($someClass)
 {
     if ($someClass || $someClass->someMethod()) {
         return 'yes';

--- a/rules-tests/TypeDeclaration/Rector/BooleanAnd/BinaryOpNullableToInstanceofRector/Fixture/skip_phpdoc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/BooleanAnd/BinaryOpNullableToInstanceofRector/Fixture/skip_phpdoc.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector\Source\SomeInstance;
+
+/**
+ * @param SomeInstance|null $someClass
+ */
+function binaryOrPhpdoc($someClass)
+{
+    if ($someClass || $someClass->someMethod()) {
+        return 'yes';
+    }
+
+    return 'no';
+}
+


### PR DESCRIPTION
just adding missing test coverage.

was fixed in https://github.com/rectorphp/rector-src/commit/e6d5d3620448b27bce7d080c9832558e2f6cdf38 - https://github.com/rectorphp/rector-src/pull/5027