### PR TITLE
[NodeTypeResolver] Use Scope->getType() on ArrayDimFetch on NodeTypeResolver::getNativeType()

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -325,7 +325,7 @@ final class NodeTypeResolver
         return $classReflection->isSubclassOf($objectType->getClassName());
     }
 
-    private function resolveNativeUnionType(UnionType $unionType): UnionType
+    private function resolveNativeUnionType(UnionType $unionType): Type
     {
         $hasChanged = false;
         $types = $unionType->getTypes();

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -250,20 +250,7 @@ final class NodeTypeResolver
             return $this->accessoryNonEmptyStringTypeCorrector->correct($type);
         }
 
-        $hasChanged = false;
-        $types = $type->getTypes();
-        foreach ($types as $key => $childType) {
-            if ($this->isAnonymousObjectType($childType)) {
-                $types[$key] = new ObjectWithoutClassType();
-                $hasChanged = true;
-            }
-        }
-
-        if ($hasChanged) {
-            return $this->accessoryNonEmptyStringTypeCorrector->correct(new UnionType($types));
-        }
-
-        return $this->accessoryNonEmptyStringTypeCorrector->correct($type);
+        return $this->resolveNativeUnionType($type);
     }
 
     public function isNumberType(Expr $expr): bool
@@ -336,6 +323,24 @@ final class NodeTypeResolver
         }
 
         return $classReflection->isSubclassOf($objectType->getClassName());
+    }
+
+    private function resolveNativeUnionType(UnionType $unionType): UnionType
+    {
+        $hasChanged = false;
+        $types = $unionType->getTypes();
+        foreach ($types as $key => $childType) {
+            if ($this->isAnonymousObjectType($childType)) {
+                $types[$key] = new ObjectWithoutClassType();
+                $hasChanged = true;
+            }
+        }
+
+        if ($hasChanged) {
+            return $this->accessoryNonEmptyStringTypeCorrector->correct(new UnionType($types));
+        }
+
+        return $this->accessoryNonEmptyStringTypeCorrector->correct($unionType);
     }
 
     private function isMatchObjectWithoutClassType(

--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeTypeResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
@@ -234,7 +235,13 @@ final class NodeTypeResolver
             }
         }
 
-        $type = $scope->getNativeType($expr);
+        /**
+         * ArrayDimFetch got type by its Scope->getType(), otherwise, it got MixedType
+         */
+        $type = $expr instanceof ArrayDimFetch
+            ? $scope->getType($expr)
+            : $scope->getNativeType($expr);
+
         if (! $type instanceof UnionType) {
             if ($this->isAnonymousObjectType($type)) {
                 return new ObjectWithoutClassType();

--- a/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
+++ b/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
 
         $empty = $booleanNot->expr;
         if ($empty->expr instanceof ArrayDimFetch) {
-            return $this->createDimFetchBooleanAnd($empty);
+            return $this->createDimFetchBooleanAnd($empty->expr);
         }
 
         if ($this->exprAnalyzer->isNonTypedFromParam($empty->expr)) {
@@ -123,12 +123,12 @@ CODE_SAMPLE
         return $this->exactCompareFactory->createIdenticalFalsyCompare($exprType, $empty->expr, $treatAsNonEmpty);
     }
 
-    private function createDimFetchBooleanAnd(Empty_ $empty): ?BooleanAnd
+    private function createDimFetchBooleanAnd(ArrayDimFetch $arrayDimFetch): ?BooleanAnd
     {
-        $exprType = $this->nodeTypeResolver->getNativeType($empty->expr);
+        $exprType = $this->nodeTypeResolver->getNativeType($arrayDimFetch);
 
-        $isset = new Isset_([$empty->expr]);
-        $compareExpr = $this->exactCompareFactory->createNotIdenticalFalsyCompare($exprType, $empty->expr, false);
+        $isset = new Isset_([$arrayDimFetch]);
+        $compareExpr = $this->exactCompareFactory->createNotIdenticalFalsyCompare($exprType, $arrayDimFetch, false);
 
         if (! $compareExpr instanceof Expr) {
             return null;

--- a/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
+++ b/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
 
     private function createDimFetchBooleanAnd(Empty_ $empty): ?BooleanAnd
     {
-        $exprType = $this->getType($empty->expr);
+        $exprType = $this->nodeTypeResolver->getNativeType($empty->expr);
 
         $isset = new Isset_([$empty->expr]);
         $compareExpr = $this->exactCompareFactory->createNotIdenticalFalsyCompare($exprType, $empty->expr, false);

--- a/tests/Issues/EmptyBooleanCompare/Fixture/array_dim_fetch_from_docblock.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/array_dim_fetch_from_docblock.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+
+final class ArrayDimFetchFromDocblock
+{
+    /**
+     * @param array{host: string} $parts
+     */
+    public function checkUrl(array $parts)
+    {
+        if (!empty($parts['host'])) {
+            return $parts['host'];
+        }
+
+        return null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+
+final class ArrayDimFetchFromDocblock
+{
+    /**
+     * @param array{host: string} $parts
+     */
+    public function checkUrl(array $parts)
+    {
+        if (isset($parts['host']) && $parts['host'] !== '') {
+            return $parts['host'];
+        }
+
+        return null;
+    }
+}
+
+?>


### PR DESCRIPTION
@staabm this is what I mean for using `Scope->getType()` on `ArrayDimFetch`, as using `getNativeType()` will got mixed on this code:

```php
        $parts = parse_url($url);

        if (!empty($parts['host'])) {
            return $parts['host'];
        }

        return null;
```

checking with `getNativeType()` always got `MixedType` on `$parts['host']` which always string by `getType()`, see fixture:

https://github.com/rectorphp/rector-src/blob/8ba3d90ba430782c8e9bba135411260df802df3e/tests/Issues/EmptyBooleanCompare/Fixture/fixture.php.inc#L3-L37
