### PR TITLE
fix(ArrayKeyFirstLastRector): Skip exection when pointer is changed

### DIFF
--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_next_call_after.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_next_call_after.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+function a(array $arr) {
+    reset($arr);
+    while ($key !== null) {
+        $key = key($arr);
+        $value = current($arr);
+        if ($key === null) {
+            break;
+        }
+        echo $key . ": " . $value . PHP_EOL;
+        next($arr);
+    }
+}
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_next_call_after.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_next_call_after.php.inc
@@ -1,5 +1,5 @@
 <?php
-<?php
+
 
 namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeyFirstLastRector\Fixture;
 

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_next_call_after.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeyFirstLastRector/Fixture/skip_next_call_after.php.inc
@@ -1,6 +1,9 @@
 <?php
+<?php
 
-function a(array $arr) {
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeyFirstLastRector\Fixture;
+
+function skipExecutionHasNextNext(array $arr) {
     reset($arr);
     while ($key !== null) {
         $key = key($arr);

--- a/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
+++ b/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
@@ -200,7 +200,6 @@ CODE_SAMPLE
                     if (! $subNode instanceof FuncCall) {
                         return false;
                     }
-                    echo $subNode->name;
 
                     if (! $this->isNames($subNode, ['prev', 'next'])) {
                         return false;

--- a/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
+++ b/rules/Php73/Rector/FuncCall/ArrayKeyFirstLastRector.php
@@ -137,7 +137,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($this->hasPrevCallNext($stmtsAware, $key + 2, $totalKeys, $keyFuncCall)) {
+            if ($this->hasInternalPointerChangeNext($stmtsAware, $key + 1, $totalKeys, $keyFuncCall)) {
                 continue;
             }
 
@@ -183,7 +183,7 @@ CODE_SAMPLE
         });
     }
 
-    private function hasPrevCallNext(
+    private function hasInternalPointerChangeNext(
         StmtsAwareInterface $stmtsAware,
         int $nextKey,
         int $totalKeys,
@@ -200,8 +200,9 @@ CODE_SAMPLE
                     if (! $subNode instanceof FuncCall) {
                         return false;
                     }
+                    echo $subNode->name;
 
-                    if (! $this->isName($subNode, 'prev')) {
+                    if (! $this->isNames($subNode, ['prev', 'next'])) {
                         return false;
                     }
 


### PR DESCRIPTION
Hello! 

Fix https://github.com/rectorphp/rector/issues/8203
It looks like skipping next node was also causing the issue - next call was not checked inside the loop. 
