### PR TITLE
[TypeDeclaration] Handle fallback from param same type object on ReturnTypeFromReturnNewRector

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -106,11 +106,8 @@ final class AutoloadIncluder
             return;
         }
 
+        /** @var string $realPath always string after file_exists() check */
         $realPath = realpath($filePath);
-        if (! is_string($realPath)) {
-            return;
-        }
-
         $this->alreadyLoadedAutoloadFiles[] = $realPath;
 
         require_once $filePath;

--- a/packages/Caching/Detector/ChangedFilesDetector.php
+++ b/packages/Caching/Detector/ChangedFilesDetector.php
@@ -85,6 +85,7 @@ final class ChangedFilesDetector
 
     private function resolvePath(string $filePath): string
     {
+        /** @var string|false $realPath */
         $realPath = realpath($filePath);
 
         if ($realPath === false) {

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -373,12 +373,12 @@ final class RectorConfig extends Container
             is_string($skipRule)
             // not regex path
             && ! str_contains($skipRule, '*')
+            // a Rector end
+            && str_ends_with($skipRule, 'Rector')
             // not directory
             && ! is_dir($skipRule)
             // not file
             && ! is_file($skipRule)
-            // a Rector end
-            && str_ends_with($skipRule, 'Rector')
             // class not exists
             && ! class_exists($skipRule);
     }

--- a/packages/Config/RectorConfig.php
+++ b/packages/Config/RectorConfig.php
@@ -373,8 +373,10 @@ final class RectorConfig extends Container
             is_string($skipRule)
             // not regex path
             && ! str_contains($skipRule, '*')
-            // not realpath
-            && realpath($skipRule) === false
+            // not directory
+            && ! is_dir($skipRule)
+            // not file
+            && ! is_file($skipRule)
             // a Rector end
             && str_ends_with($skipRule, 'Rector')
             // class not exists

--- a/packages/Skipper/FileSystem/FnMatchPathNormalizer.php
+++ b/packages/Skipper/FileSystem/FnMatchPathNormalizer.php
@@ -16,6 +16,7 @@ final class FnMatchPathNormalizer
         }
 
         if (\str_contains($path, '..')) {
+            /** @var string|false $path */
             $path = realpath($path);
             if ($path === false) {
                 return '';

--- a/packages/Skipper/RealpathMatcher.php
+++ b/packages/Skipper/RealpathMatcher.php
@@ -8,11 +8,13 @@ final class RealpathMatcher
 {
     public function match(string $matchingPath, string $filePath): bool
     {
+        /** @var string|false $realPathMatchingPath */
         $realPathMatchingPath = realpath($matchingPath);
         if (! is_string($realPathMatchingPath)) {
             return false;
         }
 
+        /** @var string|false $realpathFilePath */
         $realpathFilePath = realpath($filePath);
         if (! is_string($realpathFilePath)) {
             return false;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Source\SomeResponse;
+
+final class FallbackFromParam
+{
+    public function action(SomeResponse $someResponse)
+    {
+        if (rand(0, 1)) {
+            return new SomeResponse();
+        }
+
+        return $someResponse;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Source\SomeResponse;
+
+final class FallbackFromParam
+{
+    public function action(SomeResponse $someResponse): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Source\SomeResponse
+    {
+        if (rand(0, 1)) {
+            return new SomeResponse();
+        }
+
+        return $someResponse;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param2.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+final class FallbackFromParam2
+{
+    public function action(self $obj)
+    {
+        if (rand(0, 1)) {
+            return new FallbackFromParam2();
+        }
+
+        return $obj;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+final class FallbackFromParam2
+{
+    public function action(self $obj): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture\FallbackFromParam2
+    {
+        if (rand(0, 1)) {
+            return new FallbackFromParam2();
+        }
+
+        return $obj;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param_self.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param_self.php.inc
@@ -9,7 +9,7 @@ final class FallbackFromParamSelf
     public function action(self $obj)
     {
         if (rand(0, 1)) {
-            return new FallbackFromParam2();
+            return new FallbackFromParamSelf();
         }
 
         return $obj;
@@ -26,10 +26,10 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNe
 
 final class FallbackFromParamSelf
 {
-    public function action(self $obj): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture\FallbackFromParam2
+    public function action(self $obj): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture\FallbackFromParamSelf
     {
         if (rand(0, 1)) {
-            return new FallbackFromParam2();
+            return new FallbackFromParamSelf();
         }
 
         return $obj;

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param_self.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/fallback_from_param_self.php.inc
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
 
-final class FallbackFromParam2
+final class FallbackFromParamSelf
 {
     public function action(self $obj)
     {
@@ -24,7 +24,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
 
-final class FallbackFromParam2
+final class FallbackFromParamSelf
 {
     public function action(self $obj): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture\FallbackFromParam2
     {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -201,6 +201,12 @@ CODE_SAMPLE
         $newTypes = [];
         foreach ($returns as $return) {
             if (! $return->expr instanceof New_) {
+                $returnType = $this->nodeTypeResolver->getNativeType($return->expr);
+                if ($returnType instanceof \PHPStan\Type\ObjectType) {
+                    $newTypes[] = $returnType;
+                    continue;
+                }
+
                 return null;
             }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
@@ -201,6 +202,10 @@ CODE_SAMPLE
         $newTypes = [];
         foreach ($returns as $return) {
             if (! $return->expr instanceof New_) {
+                if (! $return->expr instanceof Expr) {
+                    return null;
+                }
+
                 $returnType = $this->nodeTypeResolver->getNativeType($return->expr);
                 if ($returnType instanceof ObjectType) {
                     $newTypes[] = $returnType;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -201,11 +201,11 @@ CODE_SAMPLE
     {
         $newTypes = [];
         foreach ($returns as $return) {
-            if (! $return->expr instanceof New_) {
-                if (! $return->expr instanceof Expr) {
-                    return null;
-                }
+            if (! $return->expr instanceof Expr) {
+                return null;
+            }
 
+            if (! $return->expr instanceof New_) {
                 $returnType = $this->nodeTypeResolver->getNativeType($return->expr);
                 if ($returnType instanceof ObjectType) {
                     $newTypes[] = $returnType;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -202,7 +202,7 @@ CODE_SAMPLE
         foreach ($returns as $return) {
             if (! $return->expr instanceof New_) {
                 $returnType = $this->nodeTypeResolver->getNativeType($return->expr);
-                if ($returnType instanceof \PHPStan\Type\ObjectType) {
+                if ($returnType instanceof ObjectType) {
                     $newTypes[] = $returnType;
                     continue;
                 }

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -41,6 +41,7 @@ final class BootstrapFilesIncluder
 
     private function requireRectorStubs(): void
     {
+        /** @var false|string $stubsRectorDirectory */
         $stubsRectorDirectory = realpath(__DIR__ . '/../../stubs-rector');
         if ($stubsRectorDirectory === false) {
             return;

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -141,7 +141,9 @@ final class MissingInSetCommand extends Command
             $hasError = true;
             $this->symfonyStyle->title('We could not find there rules in configs');
 
-            $setRealpath = (string) realpath($setFile);
+            /** @var string|false $setRealpath */
+            $setRealpath = realpath($setFile);
+            $setRealpath = (string) $setRealpath;
             $relativeFilePath = Strings::after($setRealpath, getcwd() . '/');
 
             $this->symfonyStyle->writeln(' * ' . $relativeFilePath);


### PR DESCRIPTION
@staabm this is to handle fallback from param on return new object:

```php
final class FallbackFromParam
{
    public function action(SomeResponse $someResponse)
    {
        if (rand(0, 1)) {
            return new SomeResponse();
        }

        return $someResponse;
    }
}
```