### PR TITLE
[Performance][NodeTypeResolver] Remove $mutatingScope->enterCatchType() usage on PHPStanNodeScopeResolver

### DIFF
--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -55,7 +55,6 @@ use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PHPStan\NodeVisitor\ExprScopeFromStmtNodeVisitor;
 use Rector\Core\PHPStan\NodeVisitor\WrappedNodeRestoringNodeVisitor;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
-use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
 use Webmozart\Assert\Assert;
@@ -84,7 +83,6 @@ final class PHPStanNodeScopeResolver
         iterable $nodeVisitors,
         private readonly ScopeFactory $scopeFactory,
         private readonly PrivatesAccessor $privatesAccessor,
-        private readonly NodeNameResolver $nodeNameResolver,
         private readonly ClassAnalyzer $classAnalyzer
     ) {
         $this->nodeTraverser = new NodeTraverser();

--- a/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -49,8 +49,6 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Node\UnreachableStatementNode;
 use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\TypeCombinator;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ClassAnalyzer;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -152,7 +150,7 @@ final class PHPStanNodeScopeResolver
             } elseif ($node instanceof Switch_) {
                 $this->processSwitch($node, $mutatingScope);
             } elseif ($node instanceof TryCatch) {
-                $this->processTryCatch($node, $filePath, $mutatingScope);
+                $this->processTryCatch($node, $mutatingScope);
             } elseif ($node instanceof ArrayItem) {
                 $this->processArrayItem($node, $mutatingScope);
             } elseif ($node instanceof NullableType) {
@@ -271,19 +269,13 @@ final class PHPStanNodeScopeResolver
         }
     }
 
-    private function processTryCatch(TryCatch $tryCatch, string $filePath, MutatingScope $mutatingScope): void
+    private function processTryCatch(TryCatch $tryCatch, MutatingScope $mutatingScope): void
     {
         foreach ($tryCatch->catches as $catch) {
-            $varName = $catch->var instanceof Variable
-                ? $this->nodeNameResolver->getName($catch->var)
-                : null;
-
-            $type = TypeCombinator::union(
-                ...array_map(static fn (Name $name): ObjectType => new ObjectType((string) $name), $catch->types)
-            );
-
-            $catchMutatingScope = $mutatingScope->enterCatchType($type, $varName);
-            $this->processNodes($catch->stmts, $filePath, $catchMutatingScope);
+            $catch->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+            if ($catch->var instanceof Variable) {
+                $catch->var->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+            }
         }
 
         if ($tryCatch->finally instanceof Finally_) {


### PR DESCRIPTION
@staabm if I remember correctly, `$mutatingScope->enterCatchType()` on try catch was used on detecting undefined variable which the rule is removed at PR:

- https://github.com/rectorphp/rector-src/pull/4729

I think it save to be removed to reduce memory usage. I will check if this compatible with different projects after this merged.