### PR TITLE
[DX] Make PhpDocInfoFactory explicitly required in Rector rule constructor, if needed

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -566,3 +566,6 @@ parameters:
             path: rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorReadonlyClassRector.php
 
         - '#Fetching class constant class of deprecated class Rector\\TypeDeclaration\\Rector\\Property\\TypedPropertyFromStrictConstructorReadonlyClassRector#'
+
+        # dev rule
+        - '#Class "Rector\\Utils\\Rector\\MoveAbstractRectorToChildrenRector" is missing @see annotation with test case class reference#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -569,3 +569,6 @@ parameters:
 
         # dev rule
         - '#Class "Rector\\Utils\\Rector\\MoveAbstractRectorToChildrenRector" is missing @see annotation with test case class reference#'
+
+        # deprecated parent property
+        - '#Access to deprecated property \$phpDocInfoFactory of class Rector\\Core\\Rector\\AbstractRector#'

--- a/rector.php
+++ b/rector.php
@@ -11,11 +11,13 @@ use Rector\Naming\Rector\Class_\RenamePropertyToMatchTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenCollectorRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Collector\ParentClassCollector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+use Rector\Utils\Rector\MoveAbstractRectorToChildrenRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
@@ -33,14 +35,11 @@ return static function (RectorConfig $rectorConfig): void {
         PHPUnitSetList::PHPUNIT_100,
     ]);
 
-    // @todo collectors - just for testing purpose
+    // testing collectors
     $rectorConfig->collector(ParentClassCollector::class);
-    $rectorConfig->rule(\Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenCollectorRector::class);
+    $rectorConfig->rule(FinalizeClassesWithoutChildrenCollectorRector::class);
 
-    $rectorConfig->rules([
-        DeclareStrictTypesRector::class,
-        \Rector\Utils\Rector\MoveAbstractRectorToChildrenRector::class,
-    ]);
+    $rectorConfig->rules([DeclareStrictTypesRector::class, MoveAbstractRectorToChildrenRector::class]);
 
     $rectorConfig->paths([
         __DIR__ . '/bin',

--- a/rector.php
+++ b/rector.php
@@ -37,7 +37,10 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->collector(ParentClassCollector::class);
     $rectorConfig->rule(\Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenCollectorRector::class);
 
-    $rectorConfig->rules([DeclareStrictTypesRector::class]);
+    $rectorConfig->rules([
+        DeclareStrictTypesRector::class,
+        \Rector\Utils\Rector\MoveAbstractRectorToChildrenRector::class,
+    ]);
 
     $rectorConfig->paths([
         __DIR__ . '/bin',

--- a/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector.php
+++ b/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Type\MixedType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\NodeAnalyzer\CallAnalyzer;
 use Rector\Core\NodeAnalyzer\VariableAnalyzer;
@@ -30,7 +31,8 @@ final class SimplifyUselessVariableRector extends AbstractRector
     public function __construct(
         private readonly AssignAndBinaryMap $assignAndBinaryMap,
         private readonly VariableAnalyzer $variableAnalyzer,
-        private readonly CallAnalyzer $callAnalyzer
+        private readonly CallAnalyzer $callAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/CodeQuality/Rector/If_/CombineIfRector.php
+++ b/rules/CodeQuality/Rector/If_/CombineIfRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\If_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use Rector\BetterPhpDocParser\Comment\CommentsMerger;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -21,7 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class CombineIfRector extends AbstractRector
 {
     public function __construct(
-        private readonly CommentsMerger $commentsMerger
+        private readonly CommentsMerger $commentsMerger,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/CodingStyle/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
+++ b/rules/CodingStyle/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\CodingStyle\TypeAnalyzer\IterableTypeAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -34,7 +35,8 @@ final class AddArrayDefaultToArrayPropertyRector extends AbstractRector
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly IterableTypeAnalyzer $iterableTypeAnalyzer,
         private readonly VisibilityManipulator $visibilityManipulator,
-        private readonly ConstructorAssignDetector $constructorAssignDetector
+        private readonly ConstructorAssignDetector $constructorAssignDetector,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
+++ b/rules/DeadCode/Rector/ClassLike/RemoveAnnotationRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
@@ -32,6 +33,7 @@ final class RemoveAnnotationRector extends AbstractRector implements Configurabl
     public function __construct(
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -29,6 +30,7 @@ final class RemoveUnusedPrivateMethodParameterRector extends AbstractRector
         private readonly UnusedParameterResolver $unusedParameterResolver,
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector.php
@@ -7,6 +7,7 @@ namespace Rector\DeadCode\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\PhpDoc\TagRemover\ParamTagRemover;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -18,7 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveUselessParamTagRector extends AbstractRector
 {
     public function __construct(
-        private readonly ParamTagRemover $paramTagRemover
+        private readonly ParamTagRemover $paramTagRemover,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\PhpDoc\TagRemover\ReturnTagRemover;
@@ -20,6 +21,7 @@ final class RemoveUselessReturnTagRector extends AbstractRector
     public function __construct(
         private readonly ReturnTagRemover $returnTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/DeadCode/Rector/Expression/RemoveDeadStmtRector.php
+++ b/rules/DeadCode/Rector/Expression/RemoveDeadStmtRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -27,7 +28,8 @@ final class RemoveDeadStmtRector extends AbstractRector
     public function __construct(
         private readonly LivingCodeManipulator $livingCodeManipulator,
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\While_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\NodeManipulator\StmtsManipulator;
@@ -55,6 +56,7 @@ final class RemoveNonExistingVarAnnotationRector extends AbstractRector
     public function __construct(
         private readonly StmtsManipulator $stmtsManipulator,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
@@ -14,6 +14,7 @@ use PhpParser\NodeTraverser;
 use PHPStan\Analyser\Scope;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\DeadCode\NodeAnalyzer\PropertyWriteonlyAnalyzer;
@@ -28,6 +29,7 @@ final class RemoveUnusedPrivatePropertyRector extends AbstractScopeAwareRector
     public function __construct(
         private readonly PropertyFetchFinder $propertyFetchFinder,
         private readonly PropertyWriteonlyAnalyzer $propertyWriteonlyAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/DeadCode/Rector/Property/RemoveUselessVarTagRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUselessVarTagRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -18,6 +19,7 @@ final class RemoveUselessVarTagRector extends AbstractRector
 {
     public function __construct(
         private readonly VarTagRemover $varTagRemover,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
+++ b/rules/EarlyReturn/Rector/StmtsAwareInterface/ReturnEarlyIfVariableRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\NodeAnalyzer\VariableAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -26,7 +27,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnEarlyIfVariableRector extends AbstractRector
 {
     public function __construct(
-        private readonly VariableAnalyzer $variableAnalyzer
+        private readonly VariableAnalyzer $variableAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
+++ b/rules/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\Guard\BreakingVariableRenameGuard;
@@ -42,7 +43,8 @@ final class RenameVariableToMatchMethodCallReturnTypeRector extends AbstractRect
         private readonly VarTagValueNodeRenamer $varTagValueNodeRenamer,
         private readonly VariableAndCallAssignMatcher $variableAndCallAssignMatcher,
         private readonly VariableRenamer $variableRenamer,
-        private readonly DocBlockUpdater $docBlockUpdater
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -20,6 +20,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
@@ -61,6 +62,7 @@ final class AnnotationToAttributeRector extends AbstractRector implements Config
         private readonly UseImportsResolver $useImportsResolver,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -18,6 +18,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\NodeAnalyzer\ParamAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -67,7 +68,8 @@ final class ClassPropertyAssignToConstructorPromotionRector extends AbstractRect
         private readonly MakePropertyPromotionGuard $makePropertyPromotionGuard,
         private readonly TypeComparator $typeComparator,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly PropertyPromotionRenamer $propertyPromotionRenamer
+        private readonly PropertyPromotionRenamer $propertyPromotionRenamer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
+++ b/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
@@ -14,6 +14,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -34,7 +35,8 @@ final class MixedTypeRector extends AbstractRector implements MinPhpVersionInter
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ClassChildAnalyzer $classChildAnalyzer,
-        private readonly ParamTagRemover $paramTagRemover
+        private readonly ParamTagRemover $paramTagRemover,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/Php80/Rector/Property/NestedAnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Property/NestedAnnotationToAttributeRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -49,6 +50,7 @@ final class NestedAnnotationToAttributeRector extends AbstractRector implements 
         private readonly NestedAttrGroupsFactory $nestedAttrGroupsFactory,
         private readonly UseNodesToAddCollector $useNodesToAddCollector,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
+++ b/rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
@@ -33,6 +34,7 @@ final class RenameAnnotationRector extends AbstractRector implements Configurabl
     public function __construct(
         private readonly DocBlockTagReplacer $docBlockTagReplacer,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeBasedOnPHPUnitDataProviderRector.php
@@ -19,6 +19,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -46,7 +47,8 @@ final class AddParamTypeBasedOnPHPUnitDataProviderRector extends AbstractRector
 
     public function __construct(
         private readonly TypeFactory $typeFactory,
-        private readonly TestsNodeAnalyzer $testsNodeAnalyzer
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -23,6 +23,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersion;
@@ -40,7 +41,8 @@ final class ReturnTypeFromStrictNewArrayRector extends AbstractScopeAwareRector 
     public function __construct(
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
-        private readonly ReturnTypeInferer $returnTypeInferer
+        private readonly ReturnTypeInferer $returnTypeInferer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictStringParamConcatRector.php
@@ -21,6 +21,7 @@ use PhpParser\NodeTraverser;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Rector\AbstractRector;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -33,6 +34,7 @@ final class StrictStringParamConcatRector extends AbstractRector
 {
     public function __construct(
         private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddParamTypeSplFixedArrayRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddParamTypeSplFixedArrayRector.php
@@ -12,6 +12,7 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -32,6 +33,7 @@ final class AddParamTypeSplFixedArrayRector extends AbstractRector
 
     public function __construct(
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -13,6 +13,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -52,7 +53,8 @@ final class TypedPropertyFromAssignsRector extends AbstractRector implements Min
         private readonly PropertyTypeDecorator $propertyTypeDecorator,
         private readonly VarTagRemover $varTagRemover,
         private readonly MakePropertyTypedGuard $makePropertyTypedGuard,
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorReadonlyClassRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorReadonlyClassRector.php
@@ -6,7 +6,6 @@ namespace Rector\TypeDeclaration\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\PhpVersionFeature;

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -39,7 +40,8 @@ final class TypedPropertyFromStrictConstructorRector extends AbstractRector impl
         private readonly PropertyTypeOverrideGuard $propertyTypeOverrideGuard,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
-        private readonly PropertyTypeDefaultValueAnalyzer $propertyTypeDefaultValueAnalyzer
+        private readonly PropertyTypeDefaultValueAnalyzer $propertyTypeDefaultValueAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictGetterMethodReturnTypeRector.php
@@ -14,6 +14,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -36,7 +37,8 @@ final class TypedPropertyFromStrictGetterMethodReturnTypeRector extends Abstract
         private readonly VarTagRemover $varTagRemover,
         private readonly ParentPropertyLookupGuard $parentPropertyLookupGuard,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly ConstructorAssignDetector $constructorAssignDetector
+        private readonly ConstructorAssignDetector $constructorAssignDetector,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -531,6 +531,7 @@ final class LazyContainerFactory
                     $container->get(NodeTypeResolver::class),
                     $container->get(SimpleCallableNodeTraverser::class),
                     $container->get(NodeFactory::class),
+                    // @deprecated, use injected PhpDocInfoFactory service in your Rector rules
                     $container->get(PhpDocInfoFactory::class),
                     $container->get(StaticTypeMapper::class),
                     $container->get(Skipper::class),

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -31,6 +31,10 @@ use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
+/**
+ * @property-read PhpDocInfoFactory $phpDocInfoFactory; @deprecated The parent AbstractRector dependency is deprecated and will be removed.
+ *  Use dependency injection in your own rule instead.
+ */
 abstract class AbstractRector extends NodeVisitorAbstract implements RectorInterface
 {
     /**
@@ -53,8 +57,6 @@ CODE_SAMPLE;
     protected NodeTypeResolver $nodeTypeResolver;
 
     protected StaticTypeMapper $staticTypeMapper;
-
-    protected PhpDocInfoFactory $phpDocInfoFactory;
 
     protected NodeFactory $nodeFactory;
 
@@ -83,6 +85,19 @@ CODE_SAMPLE;
 
     private ?int $toBeRemovedNodeId = null;
 
+    /**
+     * @var array<string, object>
+     */
+    private array $deprecatedDependencies = [];
+
+    /**
+     * Handle deprecated dependencies compatbility
+     */
+    public function __get(string $name): mixed
+    {
+        return $this->deprecatedDependencies[$name] ?? null;
+    }
+
     public function autowire(
         NodeNameResolver $nodeNameResolver,
         NodeTypeResolver $nodeTypeResolver,
@@ -102,7 +117,6 @@ CODE_SAMPLE;
         $this->nodeTypeResolver = $nodeTypeResolver;
         $this->simpleCallableNodeTraverser = $simpleCallableNodeTraverser;
         $this->nodeFactory = $nodeFactory;
-        $this->phpDocInfoFactory = $phpDocInfoFactory;
         $this->staticTypeMapper = $staticTypeMapper;
         $this->skipper = $skipper;
         $this->valueResolver = $valueResolver;
@@ -111,6 +125,8 @@ CODE_SAMPLE;
         $this->currentFileProvider = $currentFileProvider;
         $this->createdByRuleDecorator = $createdByRuleDecorator;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
+
+        $this->deprecatedDependencies['phpDocInfoFactory'] = $phpDocInfoFactory;
     }
 
     /**

--- a/utils/Rector/MoveAbstractRectorToChildrenRector.php
+++ b/utils/Rector/MoveAbstractRectorToChildrenRector.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Utils\Rector;
+
+// e.g. to move PhpDocInfo to the particular rule itself
+use PhpParser\Node;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Core\NodeManipulator\ClassDependencyManipulator;
+use Rector\Core\Rector\AbstractRector;
+use Rector\PostRector\ValueObject\PropertyMetadata;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class MoveAbstractRectorToChildrenRector extends AbstractRector
+{
+    /**
+     * @var array<string, string>
+     */
+    private const PROPERTIES_TO_TYPES = [
+        'phpDocInfoFactory' => PhpDocInfoFactory::class,
+    ];
+
+    public function __construct(
+        private readonly ClassDependencyManipulator $classDependencyManipulator,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Move parent class autowired dependency to constructor of children', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    /**
+     * @param Node\Stmt\Class_ $node
+     */
+    public function refactor(Node $node)
+    {
+        if ($node->isAbstract()) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node, new ObjectType('Rector\Core\Rector\AbstractRector'))) {
+            return null;
+        }
+
+        $typesToAdd = [];
+
+        // has dependency on X type?
+        $this->traverseNodesWithCallable($node->stmts, function (\PhpParser\Node $node) use (&$typesToAdd) {
+            if (! $node instanceof Node\Expr\PropertyFetch) {
+                return null;
+            }
+
+            if (! $this->isName($node->var, 'this')) {
+                return null;
+            }
+
+            foreach (self::PROPERTIES_TO_TYPES as $propertyName => $propertyType) {
+                if (! $this->isName($node->name, $propertyName)) {
+                    continue;
+                }
+
+                $typesToAdd[$propertyName] = $propertyType;
+            }
+        });
+
+        if ($typesToAdd === []) {
+            return null;
+        }
+
+        foreach ($typesToAdd as $propertyNameToAdd => $propertyTypeToAdd) {
+            $this->classDependencyManipulator->addConstructorDependency(
+                $node,
+                new PropertyMetadata($propertyNameToAdd, new ObjectType($propertyTypeToAdd))
+            );
+        }
+
+        return $node;
+    }
+}


### PR DESCRIPTION
AbstractRector is quite heavy class with "handy" dependencies. At least that was the original idea :)

Now it contains ~15 services just in case they're used in child service:
https://github.com/rectorphp/rector-src/blob/5ee831f533cf97bc985b381cfd067122e2a479d2/src/Rector/AbstractRector.php#L86-L114

This design doesn't seem smart anymore and only forces each rule to decide if they use global dependency or local one. It's like having Doctrine serivce in every Controller.

Instead, there should be zero global dependencies (unless used in the AbstractRector itself) and each rule should ask only what they need. Goal is to make design from ambiguous to single dependency injection, and lighten all the rules.