### PR TITLE
[Dep] Remove abandoned phpstan/phpstan-php-parser PHPStan extension on require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "nategood/httpful": "^0.3.2",
         "phpstan/extension-installer": "^1.3.1",
         "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-php-parser": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3.11",
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpstan/phpstan-webmozart-assert": "^1.2.2",


### PR DESCRIPTION
The `phpstan/phpstan-php-parser` extension is now abandoned, this PR remove it from require-dev.


https://github.com/phpstan/phpstan-php-parser

