### PR TITLE
[DX] Show warning on AbstractRector::__get() when pull deprecated property from AbstractRector

### DIFF
--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -90,10 +90,22 @@ CODE_SAMPLE;
     private array $deprecatedDependencies = [];
 
     /**
+     * @var array<class-string, array<string, bool>>
+     */
+    private array $cachedDeprecatedDependenciesWarning = [];
+
+    /**
      * Handle deprecated dependencies compatbility
      */
     public function __get(string $name): mixed
     {
+        if (! isset($this->cachedDeprecatedDependenciesWarning[static::class][$name])) {
+            echo sprintf('Get %s property from AbstractRector on %s is deprecated, inject via __construct() instead', $name, static::class);
+            echo PHP_EOL;
+
+            $this->cachedDeprecatedDependenciesWarning[static::class][$name] = true;
+        }
+
         return $this->deprecatedDependencies[$name] ?? null;
     }
 


### PR DESCRIPTION
Show warning, with cached to make only show once:

➜  rector-src git:(show-warning) vendor/bin/phpunit rules-tests/Renaming/Rector/ClassMethod/RenameAnnotationRector/RenameAnnotationRectorTest.php
PHPUnit 10.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.10
Configuration: /Users/samsonasik/www/rector-src/phpunit.xml

**Get phpDocInfoFactory property from AbstractRector on Rector\Renaming\Rector\ClassMethod\RenameAnnotationRector is deprecated, inject via __construct() instead**
...                                                                 3 / 3 (100%)

Time: 00:00.727, Memory: 62.00 MB

OK (3 tests, 6 assertions)


Ref https://github.com/rectorphp/rector-src/pull/5051#pullrequestreview-1636032508