### PR TITLE
Move betterNodeFinder,valueResolver,phpDocInfoFactory dependencies from AbstractRector into rules

### DIFF
--- a/tests/Issues/PartialValueDocblockUpdate/Source/PartialUpdateTestRector.php
+++ b/tests/Issues/PartialValueDocblockUpdate/Source/PartialUpdateTestRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
@@ -17,6 +18,7 @@ final class PartialUpdateTestRector extends AbstractRector
 {
     public function __construct(
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/utils/Rector/MoveAbstractRectorToChildrenRector.php
+++ b/utils/Rector/MoveAbstractRectorToChildrenRector.php
@@ -10,8 +10,10 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\NodeManipulator\ClassDependencyManipulator;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PostRector\ValueObject\PropertyMetadata;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,8 +24,8 @@ final class MoveAbstractRectorToChildrenRector extends AbstractRector
      * @var array<string, string>
      */
     private const PROPERTIES_TO_TYPES = [
-        //        'phpDocInfoFactory' => PhpDocInfoFactory::class,
-        //        'valueResolver' => ValueResolver::class,
+        'phpDocInfoFactory' => PhpDocInfoFactory::class,
+        'valueResolver' => ValueResolver::class,
         'betterNodeFinder' => BetterNodeFinder::class,
     ];
 


### PR DESCRIPTION
Ref
 
- https://github.com/rectorphp/rector-src/pull/5051
- https://github.com/rectorphp/rector-src/pull/5052
- https://github.com/rectorphp/rector-src/pull/5053