### PR TITLE
[Performance] Remove regex check on open tag spaced check on FileProcessor

### DIFF
--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\Application;
 
-use Nette\Utils\Strings;
 use PHPStan\AnalysedCodeException;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\ValueObjectFactory\ErrorFactory;
@@ -29,12 +28,6 @@ use Throwable;
 
 final class FileProcessor
 {
-    /**
-     * @var string
-     * @see https://regex101.com/r/xP2MGa/1
-     */
-    private const OPEN_TAG_SPACED_REGEX = '#^(?<open_tag_spaced>[^\S\r\n]+\<\?php)#m';
-
     public function __construct(
         private readonly FormatPerservingPrinter $formatPerservingPrinter,
         private readonly RectorNodeTraverser $rectorNodeTraverser,
@@ -151,9 +144,8 @@ final class FileProcessor
          * On printing, the space may be wiped, these below check compare with original file content used to verify
          * that no change actually needed
          */
-        if (! $file->getFileDiff() instanceof FileDiff && current(
-            $file->getNewStmts()
-        ) instanceof FileWithoutNamespace) {
+        if (! $file->getFileDiff() instanceof FileDiff
+            && current($file->getNewStmts()) instanceof FileWithoutNamespace) {
             /**
              * Handle new line or space before <?php or InlineHTML node wiped on print format preserving
              * On very first content level
@@ -162,17 +154,6 @@ final class FileProcessor
             $ltrimOriginalFileContent = ltrim($originalFileContent);
 
             if ($ltrimOriginalFileContent === $newContent) {
-                return;
-            }
-
-            $cleanOriginalContent = Strings::replace($ltrimOriginalFileContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
-            $cleanNewContent = Strings::replace($newContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
-
-            /**
-             * Handle space before <?php wiped on print format preserving
-             * On inside content level
-             */
-            if ($cleanOriginalContent === $cleanNewContent) {
                 return;
             }
         }

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -144,8 +144,9 @@ final class FileProcessor
          * On printing, the space may be wiped, these below check compare with original file content used to verify
          * that no change actually needed
          */
-        if (! $file->getFileDiff() instanceof FileDiff
-            && current($file->getNewStmts()) instanceof FileWithoutNamespace) {
+        if (! $file->getFileDiff() instanceof FileDiff && current(
+            $file->getNewStmts()
+        ) instanceof FileWithoutNamespace) {
             /**
              * Handle new line or space before <?php or InlineHTML node wiped on print format preserving
              * On very first content level

--- a/tests/Issues/NoNamespaced/Fixture/open_tag_spaced.php.inc
+++ b/tests/Issues/NoNamespaced/Fixture/open_tag_spaced.php.inc
@@ -1,0 +1,10 @@
+<?php
+function test_callback2() {
+  // var_dump($output);
+  ?>
+  <div class="wrap">
+    <img src="<?= escape('hi there'); ?>">
+  </div>
+  <?php
+            echo " <?php";
+}

--- a/tests/Issues/NoNamespaced/Fixture/space_before_open_tag.php.inc
+++ b/tests/Issues/NoNamespaced/Fixture/space_before_open_tag.php.inc
@@ -1,0 +1,5 @@
+
+
+<?php
+
+echo 'no change, has space before open tag';


### PR DESCRIPTION
Regex check for space before open tag in deep content on `FileWithoutNamespace` seems no longer needed.