### PR TITLE
[Docs] Skip collector from rule doc generator command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "phpstan-config": "vendor/bin/phpstan analyse config --ansi --error-format symplify",
         "phpstan-fixtures": "vendor/bin/phpstan analyse -c phpstan-for-fixtures.neon --ansi --error-format symplify",
         "docs": [
-            "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3 --skip-type \"Rector\\Core\\Rector\\AbstractCollectorRector\"",
+            "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3 --skip-type 'Rector\\Core\\Rector\\AbstractCollectorRector'",
             "mv build/rector_rules_overview.md build/target-repository/docs/rector_rules_overview.md"
         ],
         "rector": "bin/rector process --ansi",

--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "phpstan-config": "vendor/bin/phpstan analyse config --ansi --error-format symplify",
         "phpstan-fixtures": "vendor/bin/phpstan analyse -c phpstan-for-fixtures.neon --ansi --error-format symplify",
         "docs": [
-            "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3",
+            "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3 --skip-type \"Rector\\Core\\Rector\\AbstractCollectorRector\"",
             "mv build/rector_rules_overview.md build/target-repository/docs/rector_rules_overview.md"
         ],
         "rector": "bin/rector process --ansi",


### PR DESCRIPTION
@TomasVotruba this will require PR fix and new release from symplify/rule-doc-generator

- https://github.com/symplify/rule-doc-generator/pull/7

to allow skip `Rector\Core\Rector\AbstractCollectorRector` from doc generation.

without it, it currently got error:

```
composer docs


In RuleDefinition.php line 33:
                                                                                      
  Provide at least one code sample, so people can practically see what the rule does  
```

as it currently has empty doc and I think the collector class is not needed to be generated for now.

https://github.com/rectorphp/rector-src/blob/061eea0c0aca9f6f15ad35c82d5a9cb5323f3919/rules/Privatization/Rector/Class_/FinalizeClassesWithoutChildrenCollectorRector.php#L81-L84