### PR TITLE
[AutoImport] Skip case insensitive conflict defined class name on $rectorConfig->importNames()

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -19,6 +19,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\CodingStyle\NodeAnalyzer\UseImportNameMatcher;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Util\StringUtils;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -79,7 +80,7 @@ final class ShortNameResolver
         $newStmts = $file->getNewStmts();
 
         /** @var Namespace_[] $namespaces */
-        $namespaces = array_filter($newStmts, static fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
+        $namespaces = array_filter($newStmts, static fn (Stmt $stmt): bool => $stmt instanceof Namespace_ || $stmt instanceof FileWithoutNamespace);
         if (count($namespaces) !== 1) {
             // only handle single namespace nodes
             return [];

--- a/tests/Issues/AutoImport/Fixture/skip_conflict_case_insensitive_class_name.php.inc
+++ b/tests/Issues/AutoImport/Fixture/skip_conflict_case_insensitive_class_name.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+class Bar
+{
+	public static function execute()
+    {
+    	echo strtolower(\Foo\BaR::execute());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8227
Ref https://3v4l.org/nC7Mq