### PR TITLE
[Performance] Avoid unnecessary IO dumpFile() called when file has no change on FileProcessor

### DIFF
--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -159,7 +159,7 @@ final class FileProcessor
             }
         }
 
-        // change file content to mark $file->hasChanged() based on new content
+        // change file content early to make $file->hasChanged() based on new content
         $file->changeFileContent($newContent);
 
         if (! $configuration->isDryRun() && $file->hasChanged()) {

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -164,9 +164,11 @@ final class FileProcessor
         if ($configuration->isDryRun()) {
             return;
         }
-        if (!$file->hasChanged()) {
+
+        if (! $file->hasChanged()) {
             return;
         }
+
         $this->formatPerservingPrinter->dumpFile($file->getFilePath(), $newContent);
     }
 

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -159,11 +159,12 @@ final class FileProcessor
             }
         }
 
-        if (! $configuration->isDryRun()) {
+        // change file content to mark $file->hasChanged() based on new content
+        $file->changeFileContent($newContent);
+
+        if (! $configuration->isDryRun() && $file->hasChanged()) {
             $this->formatPerservingPrinter->dumpFile($file->getFilePath(), $newContent);
         }
-
-        $file->changeFileContent($newContent);
     }
 
     private function parseFileNodes(File $file): void

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -161,10 +161,13 @@ final class FileProcessor
 
         // change file content early to make $file->hasChanged() based on new content
         $file->changeFileContent($newContent);
-
-        if (! $configuration->isDryRun() && $file->hasChanged()) {
-            $this->formatPerservingPrinter->dumpFile($file->getFilePath(), $newContent);
+        if ($configuration->isDryRun()) {
+            return;
         }
+        if (!$file->hasChanged()) {
+            return;
+        }
+        $this->formatPerservingPrinter->dumpFile($file->getFilePath(), $newContent);
     }
 
     private function parseFileNodes(File $file): void


### PR DESCRIPTION
Change file content to early to mark `$file->hasChanged()` based on new content passed, so on `dumpFile()` can be validated, when file no change, no need to re-dump into file as file never changed.