### PR TITLE
Remove __get() from AbstractRector

### DIFF
--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -64,9 +64,7 @@ use Rector\Core\Contract\Rector\CollectorRectorInterface;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
-use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\Rector\AbstractRector;
@@ -531,14 +529,8 @@ final class LazyContainerFactory
                     $container->get(NodeTypeResolver::class),
                     $container->get(SimpleCallableNodeTraverser::class),
                     $container->get(NodeFactory::class),
-                    // @deprecated, use injected service in your Rector rules
-                    $container->get(PhpDocInfoFactory::class),
                     $container->get(StaticTypeMapper::class),
                     $container->get(Skipper::class),
-                    // @deprecated, use injected service in your Rector rules
-                    $container->get(ValueResolver::class),
-                    // @deprecated, use injected service in your Rector rules
-                    $container->get(BetterNodeFinder::class),
                     $container->get(NodeComparator::class),
                     $container->get(CurrentFileProvider::class),
                     $container->get(CreatedByRuleDecorator::class),

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -12,16 +12,13 @@ use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
 use Rector\Core\Application\ChangedNodeScopeRefresher;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
-use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -31,13 +28,6 @@ use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-/**
- * @property-read PhpDocInfoFactory $phpDocInfoFactory; @deprecated The parent AbstractRector dependency is deprecated and will be removed. Use dependency injection in your own rule instead.
- *
- * @property-read ValueResolver $valueResolver; @deprecated The parent AbstractRector dependency is deprecated and will be removed. Use dependency injection in your own rule instead.
- *
- * @property-read BetterNodeFinder $betterNodeFinder; @deprecated The parent AbstractRector dependency is deprecated and will be removed. Use dependency injection in your own rule instead.
- */
 abstract class AbstractRector extends NodeVisitorAbstract implements RectorInterface
 {
     /**
@@ -84,45 +74,13 @@ CODE_SAMPLE;
 
     private ?int $toBeRemovedNodeId = null;
 
-    /**
-     * @var array<string, object>
-     */
-    private array $deprecatedDependencies = [];
-
-    /**
-     * @var array<class-string, array<string, bool>>
-     */
-    private array $cachedDeprecatedDependenciesWarning = [];
-
-    /**
-     * Handle deprecated dependencies compatbility
-     */
-    public function __get(string $name): mixed
-    {
-        if (! isset($this->cachedDeprecatedDependenciesWarning[static::class][$name])) {
-            echo sprintf(
-                'Get %s property from AbstractRector on %s is deprecated, inject via __construct() instead',
-                $name,
-                static::class
-            );
-            echo PHP_EOL;
-
-            $this->cachedDeprecatedDependenciesWarning[static::class][$name] = true;
-        }
-
-        return $this->deprecatedDependencies[$name] ?? null;
-    }
-
     public function autowire(
         NodeNameResolver $nodeNameResolver,
         NodeTypeResolver $nodeTypeResolver,
         SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         NodeFactory $nodeFactory,
-        PhpDocInfoFactory $phpDocInfoFactory,
         StaticTypeMapper $staticTypeMapper,
         Skipper $skipper,
-        ValueResolver $valueResolver,
-        BetterNodeFinder $betterNodeFinder,
         NodeComparator $nodeComparator,
         CurrentFileProvider $currentFileProvider,
         CreatedByRuleDecorator $createdByRuleDecorator,
@@ -138,10 +96,6 @@ CODE_SAMPLE;
         $this->currentFileProvider = $currentFileProvider;
         $this->createdByRuleDecorator = $createdByRuleDecorator;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
-
-        $this->deprecatedDependencies['phpDocInfoFactory'] = $phpDocInfoFactory;
-        $this->deprecatedDependencies['valueResolver'] = $valueResolver;
-        $this->deprecatedDependencies['betterNodeFinder'] = $betterNodeFinder;
     }
 
     /**


### PR DESCRIPTION
Since Rector 0.18.4 released, the `__get()` can be removed as user already will be notified on current release for pull the properties from `AbstractRector`.