### PR TITLE
[Performance] Avoid ReflectionProvider check function exists on NameImportingPostRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
+++ b/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
@@ -31,7 +31,7 @@ final class ArrayItemNode implements PhpDocTagValueNode, Stringable
                 $value .= $singleValue;
             }
         } elseif ($this->value instanceof DoctrineAnnotationTagValueNode) {
-            $value .= (string) $this->value->identifierTypeNode . $this->value;
+            $value .= $this->value->identifierTypeNode . $this->value;
         } else {
             $value .= $this->value;
         }

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
@@ -37,7 +36,6 @@ final class NameImportingPostRector extends AbstractPostRector
         private readonly DocBlockNameImporter $docBlockNameImporter,
         private readonly ClassNameImportSkipper $classNameImportSkipper,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly ReflectionProvider $reflectionProvider,
         private readonly CurrentFileProvider $currentFileProvider,
         private readonly UseImportsResolver $useImportsResolver,
         private readonly AliasNameResolver $aliasNameResolver,
@@ -208,10 +206,6 @@ final class NameImportingPostRector extends AbstractPostRector
             return true;
         }
 
-        if ($this->classNameImportSkipper->isAlreadyImported($name, $currentUses)) {
-            return true;
-        }
-
-        return $this->reflectionProvider->hasFunction(new Name($name->getLast()), null);
+        return $this->classNameImportSkipper->isAlreadyImported($name, $currentUses);
     }
 }


### PR DESCRIPTION
While I was trying to fix conflict defined function to fqcn function at PR:

- https://github.com/rectorphp/rector-src/pull/5082

the `ReflectionProvider` check function is not needed, it seems for native function, checked at 

https://github.com/rectorphp/rector-src/blob/50e589ca482e73daea8d2d4949c9ec9869fa59a3/rules/CodingStyle/Node/NameImporter.php#L119-L121
