### PR TITLE
InlineConstructorDefaultToPropertyRector Readonly Class

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/do_not_change_readonly_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/do_not_change_readonly_class.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+readonly class DoNotChangeReadonlyClass
+{
+    private string $name;
+
+    public function __construct()
+    {
+        $this->name = 'John';
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -162,7 +162,7 @@ CODE_SAMPLE
             }
 
             // readonly property cannot have default value
-            if ($classStmt->isReadonly()) {
+            if ($classStmt->isReadonly() || $class->isReadonly()) {
                 continue;
             }
 


### PR DESCRIPTION
PHP Parser does not mark properties as readonly when the class itself is readonly. Therefor we also need to check the class if it's readonly.

This feels like a bug in PHP-Parser though, so I've also opened an issue there. https://github.com/nikic/PHP-Parser/issues/949