### PR TITLE
[Performance] Avoid double read file on parsing + create File object on creating StmtsAndTokens object

### DIFF
--- a/packages-tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php.inc
+++ b/packages-tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php.inc
@@ -40,7 +40,7 @@ class ArrayItemNodeTest extends AbstractLazyTestCase
         $filePath = __DIR__ . '/FixtureNested/DoctrineNestedClassAnnotation.php.inc';
         $file = new File($filePath, UtilsFileSystem::read($filePath));
 
-        $stmtsAndTokens = $this->rectorParser->parseFileToStmtsAndTokens($file->getFilePath());
+        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getOriginalFileContent());
         $oldStmts = $stmtsAndTokens->getStmts();
         $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $oldStmts);
 

--- a/packages-tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php.inc
+++ b/packages-tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php.inc
@@ -38,9 +38,10 @@ class ArrayItemNodeTest extends AbstractLazyTestCase
     public function testUpdateNestedClassAnnotation(): void
     {
         $filePath = __DIR__ . '/FixtureNested/DoctrineNestedClassAnnotation.php.inc';
-        $file = new File($filePath, UtilsFileSystem::read($filePath));
+        $fileContent = UtilsFileSystem::read($filePath);
+        $file = new File($filePath, $fileContent);
 
-        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getOriginalFileContent());
+        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($fileContent);
         $oldStmts = $stmtsAndTokens->getStmts();
         $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $oldStmts);
 

--- a/packages-tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php.inc
+++ b/packages-tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php.inc
@@ -43,7 +43,7 @@ class ArrayItemNodeTest extends AbstractLazyTestCase
 
         $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($fileContent);
         $oldStmts = $stmtsAndTokens->getStmts();
-        $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $oldStmts);
+        $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath, $oldStmts);
 
         $classStmt = null;
         $classDocComment = null;

--- a/packages/FileSystemRector/Parser/FileInfoParser.php
+++ b/packages/FileSystemRector/Parser/FileInfoParser.php
@@ -29,9 +29,10 @@ final class FileInfoParser
      */
     public function parseFileInfoToNodesAndDecorate(string $filePath): array
     {
-        $stmts = $this->rectorParser->parseFile($filePath);
+        $fileContent = FileSystem::read($filePath);
+        $stmts = $this->rectorParser->parseString($fileContent);
 
-        $file = new File($filePath, FileSystem::read($filePath));
+        $file = new File($filePath, $fileContent);
         $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
 
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);

--- a/packages/FileSystemRector/Parser/FileInfoParser.php
+++ b/packages/FileSystemRector/Parser/FileInfoParser.php
@@ -33,7 +33,7 @@ final class FileInfoParser
         $stmts = $this->rectorParser->parseString($fileContent);
 
         $file = new File($filePath, $fileContent);
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file->getFilePath(), $stmts);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath, $stmts);
 
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
         $this->currentFileProvider->setFile($file);

--- a/packages/FileSystemRector/Parser/FileInfoParser.php
+++ b/packages/FileSystemRector/Parser/FileInfoParser.php
@@ -33,7 +33,7 @@ final class FileInfoParser
         $stmts = $this->rectorParser->parseString($fileContent);
 
         $file = new File($filePath, $fileContent);
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file->getFilePath(), $stmts);
 
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
         $this->currentFileProvider->setFile($file);

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -9,7 +9,6 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use Rector\Core\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
 use Rector\Core\PHPStan\NodeVisitor\UnreachableStatementNodeVisitor;
-use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionLikeParamArgPositionNodeVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
 use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;

--- a/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/packages/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -36,9 +36,8 @@ final class NodeScopeAndMetadataDecorator
      * @param Stmt[] $stmts
      * @return Stmt[]
      */
-    public function decorateNodesFromFile(File|string $file, array $stmts): array
+    public function decorateNodesFromFile(string $filePath, array $stmts): array
     {
-        $filePath = $file instanceof File ? $file->getFilePath() : $file;
         $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
         $stmts = $this->phpStanNodeScopeResolver->processNodes($stmts, $filePath);
 

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -58,7 +58,7 @@ final class TestingParser
         $stmts = $this->rectorParser->parseString($fileContent);
         $file = new File($filePath, $fileContent);
 
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath), $stmts);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath, $stmts);
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
 
         $this->currentFileProvider->setFile($file);

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -36,7 +36,7 @@ final class TestingParser
         $file = new File($filePath, $fileContent);
         $stmts = $this->rectorParser->parseString($fileContent);
 
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file->getFilePath(), $stmts);
 
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
         $this->currentFileProvider->setFile($file);
@@ -58,7 +58,7 @@ final class TestingParser
         $stmts = $this->rectorParser->parseString($fileContent);
         $file = new File($filePath, $fileContent);
 
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file->getFilePath(), $stmts);
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
 
         $this->currentFileProvider->setFile($file);

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -36,7 +36,7 @@ final class TestingParser
         $file = new File($filePath, $fileContent);
         $stmts = $this->rectorParser->parseString($fileContent);
 
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file->getFilePath(), $stmts);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath, $stmts);
 
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
         $this->currentFileProvider->setFile($file);
@@ -58,7 +58,7 @@ final class TestingParser
         $stmts = $this->rectorParser->parseString($fileContent);
         $file = new File($filePath, $fileContent);
 
-        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file->getFilePath(), $stmts);
+        $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath), $stmts);
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);
 
         $this->currentFileProvider->setFile($file);

--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -32,8 +32,9 @@ final class TestingParser
         // needed for PHPStan reflection, as it caches the last processed file
         $this->dynamicSourceLocatorProvider->setFilePath($filePath);
 
-        $file = new File($filePath, FileSystem::read($filePath));
-        $stmts = $this->rectorParser->parseFile($filePath);
+        $fileContent = FileSystem::read($filePath);
+        $file = new File($filePath, $fileContent);
+        $stmts = $this->rectorParser->parseString($fileContent);
 
         $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
 
@@ -53,8 +54,9 @@ final class TestingParser
 
         SimpleParameterProvider::setParameter(Option::SOURCE, [$filePath]);
 
-        $stmts = $this->rectorParser->parseFile($filePath);
-        $file = new File($filePath, FileSystem::read($filePath));
+        $fileContent = FileSystem::read($filePath);
+        $stmts = $this->rectorParser->parseString($fileContent);
+        $file = new File($filePath, $fileContent);
 
         $stmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $stmts);
         $file->hydrateStmtsAndTokens($stmts, $stmts, []);

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -175,7 +175,8 @@ final class FileProcessor
 
     private function parseFileNodes(File $file): void
     {
-        $fileContent = FileSystem::read($file->getFilePath());
+        $filePath = $file->getFilePath();
+        $fileContent = FileSystem::read($filePath);
 
         // store tokens by absolute path, so we don't have to print them right now
         $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($fileContent);
@@ -183,7 +184,7 @@ final class FileProcessor
         $oldStmts = $stmtsAndTokens->getStmts();
         $oldTokens = $stmtsAndTokens->getTokens();
 
-        $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file, $oldStmts);
+        $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath, $oldStmts);
         $file->hydrateStmtsAndTokens($newStmts, $oldStmts, $oldTokens);
     }
 }

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Application;
 
+use Nette\Utils\FileSystem;
 use PHPStan\AnalysedCodeException;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\ValueObjectFactory\ErrorFactory;
@@ -174,8 +175,10 @@ final class FileProcessor
 
     private function parseFileNodes(File $file): void
     {
+        $fileContent = FileSystem::read($file->getFilePath());
+
         // store tokens by absolute path, so we don't have to print them right now
-        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getOriginalFileContent());
+        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($fileContent);
 
         $oldStmts = $stmtsAndTokens->getStmts();
         $oldTokens = $stmtsAndTokens->getTokens();

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -174,7 +174,7 @@ final class FileProcessor
 
     private function parseFileNodes(File $file): void
     {
-        // store tokens by absolute path, so we don't have to print them right now
+        // store tokens by original file content, so we don't have to print them right now
         $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getOriginalFileContent());
 
         $oldStmts = $stmtsAndTokens->getStmts();

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -175,7 +175,7 @@ final class FileProcessor
     private function parseFileNodes(File $file): void
     {
         // store tokens by absolute path, so we don't have to print them right now
-        $stmtsAndTokens = $this->rectorParser->parseFileToStmtsAndTokens($file->getFilePath());
+        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getOriginalFileContent());
 
         $oldStmts = $stmtsAndTokens->getStmts();
         $oldTokens = $stmtsAndTokens->getTokens();

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -175,7 +175,7 @@ final class FileProcessor
     private function parseFileNodes(File $file): void
     {
         // store tokens by absolute path, so we don't have to print them right now
-        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getFileContent());
+        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getOriginalFileContent());
 
         $oldStmts = $stmtsAndTokens->getStmts();
         $oldTokens = $stmtsAndTokens->getTokens();

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -175,16 +175,13 @@ final class FileProcessor
 
     private function parseFileNodes(File $file): void
     {
-        $filePath = $file->getFilePath();
-        $fileContent = FileSystem::read($filePath);
-
         // store tokens by absolute path, so we don't have to print them right now
-        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($fileContent);
+        $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($file->getFileContent());
 
         $oldStmts = $stmtsAndTokens->getStmts();
         $oldTokens = $stmtsAndTokens->getTokens();
 
-        $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($filePath, $oldStmts);
+        $newStmts = $this->nodeScopeAndMetadataDecorator->decorateNodesFromFile($file->getFilePath(), $oldStmts);
         $file->hydrateStmtsAndTokens($newStmts, $oldStmts, $oldTokens);
     }
 }

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\Application;
 
-use Nette\Utils\FileSystem;
 use PHPStan\AnalysedCodeException;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\ValueObjectFactory\ErrorFactory;

--- a/src/PhpParser/Parser/RectorParser.php
+++ b/src/PhpParser/Parser/RectorParser.php
@@ -18,6 +18,8 @@ final class RectorParser
     }
 
     /**
+     * @api used by rector-symfony
+     *
      * @return Stmt[]
      */
     public function parseFile(string $filePath): array

--- a/src/PhpParser/Parser/RectorParser.php
+++ b/src/PhpParser/Parser/RectorParser.php
@@ -25,9 +25,17 @@ final class RectorParser
         return $this->parser->parseFile($filePath);
     }
 
-    public function parseFileToStmtsAndTokens(string $filePath): StmtsAndTokens
+    /**
+     * @return Stmt[]
+     */
+    public function parseString(string $filePath): array
     {
-        $stmts = $this->parseFile($filePath);
+        return $this->parser->parseString($filePath);
+    }
+
+    public function parseFileContentToStmtsAndTokens(string $fileContent): StmtsAndTokens
+    {
+        $stmts = $this->parser->parseString($fileContent);
         $tokens = $this->lexer->getTokens();
 
         return new StmtsAndTokens($stmts, $tokens);


### PR DESCRIPTION
@staabm @TomasVotruba this should improve performance with avoid double read file.

This PR read file once, use on both parsing and filling File object by using `parseString()` method.