### PR TITLE
[DX] Remove Attribute support on ChangedNodeScopeRefresher

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -575,3 +575,7 @@ parameters:
         # deprecated parent property
         - '#Access to deprecated property \$phpDocInfoFactory of class Rector\\Core\\Rector\\AbstractRector#'
         - '#Fetching class constant class of deprecated class Rector\\CodingStyle\\Rector\\Switch_\\BinarySwitchToIfElseRector#'
+
+        -
+            path: rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
+            message: "#Method \"processToClassConstFetch\\(\\)\" returns bool type, so the name should start with is/has/was#"

--- a/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
+++ b/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
@@ -5,8 +5,16 @@ declare(strict_types=1);
 namespace Rector\Transform\Rector\Attribute;
 
 use PhpParser\Node;
-use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
@@ -72,20 +80,64 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Attribute::class];
+        return [
+            Class_::class,
+            Property::class,
+            Param::class,
+            ClassMethod::class,
+            Function_::class,
+            Closure::class,
+            ArrowFunction::class,
+            Interface_::class,
+        ];
     }
 
     /**
-     * @param Attribute $node
+     * @param Class_|Property|Param|ClassMethod|Function_|Closure|ArrowFunction|Interface_ $node
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->attrGroups === []) {
+            return null;
+        }
+
+        $hasChanged = false;
         foreach ($this->attributeKeysToClassConstFetches as $attributeKeyToClassConstFetch) {
-            if (! $this->isName($node->name, $attributeKeyToClassConstFetch->getAttributeClass())) {
+            foreach ($node->attrGroups as $attrGroup) {
+                if ($this->processToClassConstFetch($attrGroup, $attributeKeyToClassConstFetch)) {
+                    $hasChanged = true;
+                }
+            }
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, AttributeKeyToClassConstFetch::class);
+
+        $this->attributeKeysToClassConstFetches = $configuration;
+    }
+
+    private function processToClassConstFetch(
+        AttributeGroup $attributeGroup,
+        AttributeKeyToClassConstFetch $attributeKeyToClassConstFetch
+    ): bool {
+        $hasChanged = false;
+        foreach ($attributeGroup->attrs as $attribute) {
+            if (! $this->isName($attribute->name, $attributeKeyToClassConstFetch->getAttributeClass())) {
                 continue;
             }
 
-            foreach ($node->args as $arg) {
+            foreach ($attribute->args as $arg) {
                 $argName = $arg->name;
                 if (! $argName instanceof Identifier) {
                     continue;
@@ -107,20 +159,11 @@ CODE_SAMPLE
                     $constName
                 );
 
-                return $node;
+                $hasChanged = true;
+                continue 2;
             }
         }
 
-        return null;
-    }
-
-    /**
-     * @param mixed[] $configuration
-     */
-    public function configure(array $configuration): void
-    {
-        Assert::allIsAOf($configuration, AttributeKeyToClassConstFetch::class);
-
-        $this->attributeKeysToClassConstFetches = $configuration;
+        return $hasChanged;
     }
 }

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Rector\Core\Application;
 
 use PhpParser\Node;
-use PhpParser\Node\Attribute;
-use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
@@ -21,7 +19,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
-use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use PHPStan\Analyser\MutatingScope;
@@ -55,15 +52,6 @@ final class ChangedNodeScopeRefresher
             $errorMessage = sprintf('Node "%s" with is missing scope required for scope refresh', $node::class);
 
             throw new ShouldNotHappenException($errorMessage);
-        }
-
-        // note from flight: when we traverse ClassMethod, the scope must be already in Class_, otherwise it crashes
-        // so we need to somehow get a parent scope that is already in the same place the $node is
-
-        if ($node instanceof Attribute) {
-            // we'll have to fake-traverse 2 layers up, as PHPStan skips Scope for AttributeGroups and consequently Attributes
-            $attributeGroup = new AttributeGroup([$node]);
-            $node = new Property(0, [], [], null, [$attributeGroup]);
         }
 
         $stmts = $this->resolveStmts($node);


### PR DESCRIPTION
@TomasVotruba @etshy previously, we faked `Attribute` into `Property` to refresh `Attribute` Scope:

https://github.com/rectorphp/rector-src/blob/8e67265bbebb84e6b4dc8f3249ea191710980988/src/Application/ChangedNodeScopeRefresher.php#L60-L67

To avoid issue Scope overlapped like in `AttributeGroup` on issue:

- https://github.com/rectorphp/rector/issues/8237

this PR remove `Attribute` support on `ChangedNodeScopeRefresher`, so if user do:

```php
return $node;
```

which `$node` is `Attribute`, it will immediatelly got error:

https://github.com/rectorphp/rector-src/blob/8e67265bbebb84e6b4dc8f3249ea191710980988/src/Application/ChangedNodeScopeRefresher.php#L115-L116