### PR TITLE
[Performance][PhpParser] Improve performance of AstResolver to use existing File Object stmts when current file is equal to target file name to check

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -318,7 +318,7 @@ final class AstResolver
 
         /**
          * When current File object file path is equal to target file name to check
-         * no need to re-decorate it, just pull from its getNewStmts() instead
+         * no need to scan and re-decorate it, just pull from its getNewStmts() instead
          */
         $file = $this->currentFileProvider->getFile();
 

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -37,7 +37,6 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpDocParser\PhpParser\SmartPhpParser;
 use Throwable;
-use Webmozart\Assert\Assert;
 
 /**
  * The nodes provided by this resolver is for read-only analysis only!
@@ -310,9 +309,7 @@ final class AstResolver
          */
         $file = $this->currentFileProvider->getFile();
 
-        Assert::isInstanceOf($file, File::class);
-
-        if ($file->getFilePath() === $fileName) {
+        if ($file instanceof File && $file->getFilePath() === $fileName) {
             return $this->parsedFileNodes[$fileName] = $file->getNewStmts();
         }
 

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -37,6 +37,7 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpDocParser\PhpParser\SmartPhpParser;
 use Throwable;
+use Webmozart\Assert\Assert;
 
 /**
  * The nodes provided by this resolver is for read-only analysis only!
@@ -320,7 +321,10 @@ final class AstResolver
          * no need to re-decorate it, just pull from its getNewStmts() instead
          */
         $file = $this->currentFileProvider->getFile();
-        if ($file instanceof File && $file->getFilePath() === $fileName) {
+
+        Assert::isInstanceOf($file, File::class);
+
+        if ($file->getFilePath() === $fileName) {
             return $this->parsedFileNodes[$fileName] = $file->getNewStmts();
         }
 

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -81,11 +81,6 @@ final class AstResolver
         $classReflection = $methodReflection->getDeclaringClass();
         $fileName = $classReflection->getFileName();
 
-        // probably native PHP method → un-parseable
-        if ($fileName === null) {
-            return null;
-        }
-
         $nodes = $this->parseFileNameToDecoratedNodes($fileName);
         if ($nodes === []) {
             return null;
@@ -134,10 +129,6 @@ final class AstResolver
     public function resolveFunctionFromFunctionReflection(FunctionReflection $functionReflection): ?Function_
     {
         $fileName = $functionReflection->getFileName();
-        if ($fileName === null) {
-            return null;
-        }
-
         $nodes = $this->parseFileNameToDecoratedNodes($fileName);
         if ($nodes === []) {
             return null;
@@ -219,10 +210,6 @@ final class AstResolver
         $traits = [];
         foreach ($classLikes as $classLike) {
             $fileName = $classLike->getFileName();
-            if ($fileName === null) {
-                continue;
-            }
-
             $nodes = $this->parseFileNameToDecoratedNodes($fileName);
             if ($nodes === []) {
                 continue;
@@ -263,10 +250,6 @@ final class AstResolver
         $classReflection = $phpPropertyReflection->getDeclaringClass();
 
         $fileName = $classReflection->getFileName();
-        if ($fileName === null) {
-            return null;
-        }
-
         $nodes = $this->parseFileNameToDecoratedNodes($fileName);
         if ($nodes === []) {
             return null;
@@ -310,8 +293,13 @@ final class AstResolver
     /**
      * @return Stmt[]
      */
-    public function parseFileNameToDecoratedNodes(string $fileName): array
+    public function parseFileNameToDecoratedNodes(?string $fileName): array
     {
+        // probably native PHP → un-parseable
+        if ($fileName === null) {
+            return [];
+        }
+
         if (isset($this->parsedFileNodes[$fileName])) {
             return $this->parsedFileNodes[$fileName];
         }

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -318,7 +318,7 @@ final class AstResolver
         try {
             $file = $this->currentFileProvider->getFile();
             $stmts = $file instanceof File && $file->getFilePath() === $fileName
-                ? $this->smartPhpParser->parseString($file->getFileContent())
+                ? $file->getNewStmts()
                 : $this->smartPhpParser->parseFile($fileName);
         } catch (Throwable $throwable) {
             /**

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -315,11 +315,17 @@ final class AstResolver
             return $this->parsedFileNodes[$fileName];
         }
 
+        /**
+         * When current File object is equal to target file name to check
+         * no need to re-decorate it, just pull from its getNewStmts() instead
+         */
+        $file = $this->currentFileProvider->getFile();
+        if ($file instanceof File && $file->getFilePath() === $fileName) {
+            return $this->parsedFileNodes[$fileName] = $file->getNewStmts();
+        }
+
         try {
-            $file = $this->currentFileProvider->getFile();
-            $stmts = $file instanceof File && $file->getFilePath() === $fileName
-                ? $file->getNewStmts()
-                : $this->smartPhpParser->parseFile($fileName);
+            $stmts = $this->smartPhpParser->parseFile($fileName);
         } catch (Throwable $throwable) {
             /**
              * phpstan.phar contains jetbrains/phpstorm-stubs which the code is not downgraded

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -316,7 +316,7 @@ final class AstResolver
         }
 
         /**
-         * When current File object is equal to target file name to check
+         * When current File object file path is equal to target file name to check
          * no need to re-decorate it, just pull from its getNewStmts() instead
          */
         $file = $this->currentFileProvider->getFile();


### PR DESCRIPTION
No need to re-read file to reduce IO when possible.