### PR TITLE
[ProcessAnalyzer] Ensure instanceof Stmt on check infinite loop on not yet has "created_by_rule" attribute

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\ProcessAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -45,7 +46,7 @@ final class RectifiedAnalyzer
         $createdByRule = $createdByRuleNode->getAttribute(AttributeKey::CREATED_BY_RULE) ?? [];
 
         if ($createdByRule === []) {
-            return ! $originalNode instanceof Node && count($node->getAttributes()) <= 1;
+            return ! $originalNode instanceof Node && $node instanceof Stmt && count($node->getAttributes()) <= 1;
         }
 
         return end($createdByRule) === $rectorClass;

--- a/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
+++ b/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
@@ -54,7 +54,7 @@ class Fixture {
 
     public function check(): bool
     {
-        return !($this->getString() === null || $this->getString() === '' || (($this->getString2() === null || $this->getString2() === '') && !is_numeric($this->getString2())));
+        return $this->getString() !== null && $this->getString() !== '' && !(($this->getString2() === null || $this->getString2() === '') && !is_numeric($this->getString2()));
     }
 }
 


### PR DESCRIPTION
Revisit of PR to handle infinite loop on:

- https://github.com/rectorphp/rector-src/pull/5057

it seems check on `Stmt` will better to have specific data use case. The `Stmt` set attributes may late because of `AbstractRector` returns array of `Stmt`.