### PR TITLE
[Comments] Remove unused copy Node object on CommentRemover

### DIFF
--- a/packages/Comments/CommentRemover.php
+++ b/packages/Comments/CommentRemover.php
@@ -27,9 +27,7 @@ final class CommentRemover
             return null;
         }
 
-        $copiedNodes = $node;
-
-        $nodes = is_array($copiedNodes) ? $copiedNodes : [$copiedNodes];
+        $nodes = is_array($node) ? $node : [$node];
         return $this->commentRemovingNodeTraverser->traverse($nodes);
     }
 }


### PR DESCRIPTION
There is already clone process on `CommentRemovingNodeVisitor`

https://github.com/rectorphp/rector-src/blob/418821236de4fe723114d95846a22741d14fc7f8/packages/Comments/NodeVisitor/CommentRemovingNodeVisitor.php#L15-L16