### PR TITLE
[TypeDeclaration] Remove AstResolver usage on ReturnedNodesReturnTypeInfererTypeInferer

### DIFF
--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
@@ -6,20 +6,14 @@ namespace Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MethodReflection;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VoidType;
-use Rector\Core\PhpParser\AstResolver;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
@@ -38,8 +32,6 @@ final class ReturnedNodesReturnTypeInfererTypeInferer
         private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private readonly TypeFactory $typeFactory,
         private readonly SplArrayFixedTypeNarrower $splArrayFixedTypeNarrower,
-        private readonly AstResolver $reflectionAstResolver,
-        private readonly BetterStandardPrinter $betterStandardPrinter,
         private readonly ReflectionResolver $reflectionResolver,
     ) {
     }
@@ -66,7 +58,6 @@ final class ReturnedNodesReturnTypeInfererTypeInferer
             $returnedExprType = $localReturnNode->expr instanceof Expr
                 ? $this->nodeTypeResolver->getNativeType($localReturnNode->expr)
                 : new VoidType();
-            $returnedExprType = $this->correctWithNestedType($returnedExprType, $localReturnNode, $functionLike);
 
             $types[] = $this->splArrayFixedTypeNarrower->narrow($returnedExprType);
         }
@@ -128,89 +119,5 @@ final class ReturnedNodesReturnTypeInfererTypeInferer
         }
 
         return $classReflection->isAbstract();
-    }
-
-    private function inferFromReturnedMethodCall(Return_ $return, FunctionLike $originalFunctionLike): Type
-    {
-        if (! $return->expr instanceof MethodCall) {
-            return new MixedType();
-        }
-
-        $methodReflection = $this->reflectionResolver->resolveMethodReflectionFromMethodCall($return->expr);
-        if (! $methodReflection instanceof MethodReflection) {
-            return new MixedType();
-        }
-
-        $isReturnScoped = false;
-
-        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
-            (array) $originalFunctionLike->getStmts(),
-            static function (Node $subNode) use ($return, &$isReturnScoped): ?int {
-                if ($subNode instanceof FunctionLike && ! $subNode instanceof ArrowFunction) {
-                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-                }
-
-                if (! $subNode instanceof Return_) {
-                    return null;
-                }
-
-                if ($return === $subNode) {
-                    $isReturnScoped = true;
-                    return NodeTraverser::STOP_TRAVERSAL;
-                }
-
-                return null;
-            }
-        );
-
-        if ($isReturnScoped) {
-            return new MixedType();
-        }
-
-        return $this->resolveClassMethod($methodReflection, $originalFunctionLike);
-    }
-
-    private function isArrayTypeMixed(Type $type): bool
-    {
-        if (! $type instanceof ArrayType) {
-            return false;
-        }
-
-        if (! $type->getItemType() instanceof MixedType) {
-            return false;
-        }
-
-        return $type->getKeyType() instanceof MixedType;
-    }
-
-    private function correctWithNestedType(Type $resolvedType, Return_ $return, FunctionLike $functionLike): Type
-    {
-        if ($resolvedType instanceof MixedType || $this->isArrayTypeMixed($resolvedType)) {
-            $correctedType = $this->inferFromReturnedMethodCall($return, $functionLike);
-
-            // override only if has some extra value
-            if (! $correctedType instanceof MixedType && ! $correctedType->isVoid()->yes()) {
-                return $correctedType;
-            }
-        }
-
-        return $resolvedType;
-    }
-
-    private function resolveClassMethod(MethodReflection $methodReflection, FunctionLike $originalFunctionLike): Type
-    {
-        $classMethod = $this->reflectionAstResolver->resolveClassMethodFromMethodReflection($methodReflection);
-        if (! $classMethod instanceof ClassMethod) {
-            return new MixedType();
-        }
-
-        $classMethodCacheKey = $this->betterStandardPrinter->print($classMethod);
-        $functionLikeCacheKey = $this->betterStandardPrinter->print($originalFunctionLike);
-
-        if ($classMethodCacheKey === $functionLikeCacheKey) {
-            return new MixedType();
-        }
-
-        return $this->inferFunctionLike($classMethod);
     }
 }


### PR DESCRIPTION
Since we use native type detection, using `AstResolver` to get source method seems no longer needed on `ReturnedNodesReturnTypeInfererTypeInferer`