### PR TITLE
[DeadCode] Remove AstResolver usage on RecastingRemovalRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/method_call_return_string_type_external.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/method_call_return_string_type_external.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Source\ExternalStrictReturnType;
+
+class MethodCallReturnStrictTypeExternal
+{
+    public function run(): string
+    {
+        $obj = new ExternalStrictReturnType();
+        return (string) $obj->getResult();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Source\ExternalStrictReturnType;
+
+class MethodCallReturnStrictTypeExternal
+{
+    public function run(): string
+    {
+        $obj = new ExternalStrictReturnType();
+        return $obj->getResult();
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Source/ExternalStrictReturnType.php
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Source/ExternalStrictReturnType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Source;
+
+final class ExternalStrictReturnType
+{
+    public function getResult(): string
+    {
+        return 'test';
+    }
+}

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Expr\Cast\String_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
-use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
@@ -29,7 +28,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
-use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -55,8 +53,7 @@ final class RecastingRemovalRector extends AbstractRector
     public function __construct(
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly ExprAnalyzer $exprAnalyzer,
-        private readonly AstResolver $astResolver
+        private readonly ExprAnalyzer $exprAnalyzer
     ) {
     }
 
@@ -128,12 +125,8 @@ CODE_SAMPLE
             return false;
         }
 
-        $classMethod = $this->astResolver->resolveClassMethodFromCall($expr);
-        if (! $classMethod instanceof ClassMethod) {
-            return false;
-        }
-
-        return ! $classMethod->returnType instanceof Node;
+        $type = $this->nodeTypeResolver->getNativeType($expr);
+        return $type instanceof MixedType && ! $type->isExplicitMixed();
     }
 
     private function shouldSkip(Expr $expr): bool


### PR DESCRIPTION
Detect target method has native return via `NodeTypeResolver->getNativeType()`