### PR TITLE
[CodeQuality] Skip VB style if endif on CompleteMissingIfElseBracketRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/skip_vb_style.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/skip_vb_style.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\CompleteMissingIfElseBracketRector\Fixture;
+
+class SkipVbStyle
+{
+    public function run($value)
+    {
+        if ($value):
+            return 1;
+        endif;
+    }
+}

--- a/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
+++ b/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
                 $nextToken = $oldTokens[$i + 2];
             }
 
-            if ($nextToken === '{') {
+            if (in_array($nextToken, ['{', ':'], true)) {
                 // all good
                 return true;
             }


### PR DESCRIPTION
@TomasVotruba the following code should be skipped as it mostly used on view files.

```php
        if ($value):
            return 1;
        endif;
```