### PR TITLE
Allow namespace import to be resolved

### DIFF
--- a/rules-tests/CodingStyle/NodeAnalyzer/UseImportNameMatcher/Fixture/FixtureAnnotation/CustomAnnotation.php
+++ b/rules-tests/CodingStyle/NodeAnalyzer/UseImportNameMatcher/Fixture/FixtureAnnotation/CustomAnnotation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\NodeAnalyzer\UseImportNameMatcher\Fixture\FixtureAnnotation;
+
+/**
+ * @Annotation
+ */
+class CustomAnnotation
+{
+
+}

--- a/rules-tests/CodingStyle/NodeAnalyzer/UseImportNameMatcher/Fixture/UseClass.php
+++ b/rules-tests/CodingStyle/NodeAnalyzer/UseImportNameMatcher/Fixture/UseClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\NodeAnalyzer\UseImportNameMatcher\Fixture;
+
+
+use Rector\Tests\CodingStyle\NodeAnalyzer\UseImportNameMatcher\Fixture\FixtureAnnotation;
+use Rector\Tests\CodingStyle\NodeAnalyzer\UseImportNameMatcher\Fixture\FixtureAnnotation as Test;
+
+class UseClass
+{
+    /**
+     * @var float
+     *
+     * @FixtureAnnotation\CustomAnnotation()
+     * @Test\CustomAnnotation()
+     */
+    private $property;
+}

--- a/rules-tests/CodingStyle/NodeAnalyzer/UseImportNameMatcher/UseImportNameMatcherTest.php
+++ b/rules-tests/CodingStyle/NodeAnalyzer/UseImportNameMatcher/UseImportNameMatcherTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\NodeAnalyzer\UseImportNameMatcher;
+
+use Iterator;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\CodingStyle\NodeAnalyzer\UseImportNameMatcher;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Naming\Naming\UseImportsResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Testing\TestingParser\TestingParser;
+use Rector\Tests\CodingStyle\NodeAnalyzer\UseImportNameMatcher\Fixture\FixtureAnnotation\CustomAnnotation;
+
+class UseImportNameMatcherTest extends AbstractLazyTestCase
+{
+    private TestingParser $testingParser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testingParser = $this->make(TestingParser::class);
+    }
+
+    #[DataProvider('provideData')]
+    public function testMatchNameWithUses(string $tag, string $expectedResolvedClass): void
+    {
+        $file = $this->testingParser->parseFilePathToFile(__DIR__ . '/Fixture/UseClass.php');
+
+        $betterNodeFinder = $this->make(BetterNodeFinder::class);
+        $useImportsResolver = $this->make(UseImportsResolver::class);
+        $useImportNameMatcher = new UseImportNameMatcher($betterNodeFinder, $useImportsResolver);
+
+        $parserFactory = new ParserFactory();
+        $phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+
+        $stmts = $phpParser->parse($file->getFileContent());
+        if ($stmts === null) {
+            $this->fail('No statements parsed');
+        }
+
+        $uses = $betterNodeFinder->findInstanceOf($stmts, Use_::class);
+        foreach ($uses as $useKey => $use) {
+            foreach ($use->uses as $useUseKey => $useUse) {
+                $useUse->setAttribute(AttributeKey::ORIGINAL_NODE, $useUse);
+                unset($use->uses[$useUseKey]);
+                $use->uses[$useUseKey] = $useUse;
+            }
+            unset($uses[$useKey]);
+            $uses[$useKey] = $use;
+        }
+        $resolvedName = $useImportNameMatcher->matchNameWithUses($tag, $uses);
+
+        $this->assertEquals($expectedResolvedClass, $resolvedName);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield ['FixtureAnnotation\CustomAnnotation', CustomAnnotation::class];
+        yield ['Test\CustomAnnotation', CustomAnnotation::class];
+    }
+}

--- a/rules/CodingStyle/NodeAnalyzer/UseImportNameMatcher.php
+++ b/rules/CodingStyle/NodeAnalyzer/UseImportNameMatcher.php
@@ -70,6 +70,15 @@ final class UseImportNameMatcher
         }
 
         if (! $originalUseUseNode->alias instanceof Identifier) {
+            $parts = $originalUseUseNode->name->getParts();
+            $tagExploded = explode('\\', $tag);
+            if (count($tagExploded) > 1 && reset($tagExploded) === end($parts)) {
+                //no alias and not a direct use import of a class, search the class
+                array_pop($parts);
+                $FQNClassArray = [$prefix, ...$parts, ...$tagExploded];
+                $FQNClassArray = array_filter($FQNClassArray);
+                return implode('\\', $FQNClassArray);
+            }
             return $prefix . $originalUseUseNode->name->toString();
         }
 


### PR DESCRIPTION
fix rectorphp/rector#8224

I didn't run tests for `rector/symfony` `rector\doctrine`, etc. hope it won't break anything there.

Like discussed in the issue, I removed the `class_exists` check