### PR TITLE
[CodeQuality] Skip direct InlineHTML on CompleteMissingIfElseBracketRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/echo_after_if.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/echo_after_if.php.inc
@@ -1,0 +1,5 @@
+<div class="test <?php if (rand(0,1)) echo 'hidden'; ?>"></div>
+-----
+<div class="test <?php if (rand(0,1)) {
+    echo 'hidden';
+} ?>"></div>

--- a/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/skip_direct_html.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/skip_direct_html.php.inc
@@ -10,4 +10,26 @@ class SkipDirectHTML
             <div>Hello</div>
         <?php
     }
+
+    public function run2($value)
+    {
+        if ($value) {
+
+        } elseif (rand(0, 1)) ?>
+
+            <div>Hello</div>
+
+        <?php
+    }
+
+    public function run3($value)
+    {
+        if ($value) {
+
+        } else ?>
+
+            <div>Hello</div>
+
+        <?php
+    }
 }

--- a/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/skip_direct_html.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector/Fixture/skip_direct_html.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\CompleteMissingIfElseBracketRector\Fixture;
+
+class SkipDirectHTML
+{
+    public function run($value)
+    {
+        if ($value) ?>
+            <div>Hello</div>
+        <?php
+    }
+}

--- a/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
+++ b/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
         }
 
         $oldTokens = $this->file->getOldTokens();
-        if ($this->isIfConditionFollowedByOpeningCurlyBracket($node, $oldTokens)) {
+        if ($this->shouldSkip($node, $oldTokens)) {
             return null;
         }
 
@@ -80,7 +80,7 @@ CODE_SAMPLE
     /**
      * @param mixed[] $oldTokens
      */
-    private function isIfConditionFollowedByOpeningCurlyBracket(If_|ElseIf_|Else_ $if, array $oldTokens): bool
+    private function shouldSkip(If_|ElseIf_|Else_ $if, array $oldTokens): bool
     {
         for ($i = $if->getStartTokenPos(); $i < $if->getEndTokenPos(); ++$i) {
             if ($oldTokens[$i] === ';') {

--- a/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
+++ b/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
                 $nextToken = $oldTokens[$i + 2];
             }
 
-            if (is_array($nextToken) && str_ends_with(trim($nextToken[1]), '?>')) {
+            if (is_array($nextToken) && str_ends_with(trim((string) $nextToken[1]), '?>')) {
                 // all good
                 return true;
             }

--- a/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
+++ b/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
@@ -101,6 +101,11 @@ CODE_SAMPLE
                 $nextToken = $oldTokens[$i + 2];
             }
 
+            if (is_array($nextToken) && str_ends_with(trim($nextToken[1]), '?>')) {
+                // all good
+                return true;
+            }
+
             if (in_array($nextToken, ['{', ':'], true)) {
                 // all good
                 return true;

--- a/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
+++ b/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
@@ -87,29 +87,13 @@ CODE_SAMPLE
                 // all good
                 return true;
             }
+        }
 
-            if ($oldTokens[$i] !== ')') {
-                continue;
-            }
+        $startStmt = current($if->stmts);
+        $lastStmt = end($if->stmts);
 
-            // first closing bracket must be followed by curly opening brackets
-            // what is next token?
-            $nextToken = $oldTokens[$i + 1];
-
-            if (is_array($nextToken) && trim((string) $nextToken[1]) === '') {
-                // next token is whitespace
-                $nextToken = $oldTokens[$i + 2];
-            }
-
-            if (is_array($nextToken) && str_ends_with(trim((string) $nextToken[1]), '?>')) {
-                // all good
-                return true;
-            }
-
-            if (in_array($nextToken, ['{', ':'], true)) {
-                // all good
-                return true;
-            }
+        if ($startStmt === false || $lastStmt === false) {
+            return true;
         }
 
         return false;

--- a/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
+++ b/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
@@ -83,12 +83,12 @@ CODE_SAMPLE
     private function isIfConditionFollowedByOpeningCurlyBracket(If_|ElseIf_|Else_ $if, array $oldTokens): bool
     {
         for ($i = $if->getStartTokenPos(); $i < $if->getEndTokenPos(); ++$i) {
-            if ($oldTokens[$i] !== ')') {
-                if ($oldTokens[$i] === ';') {
-                    // all good
-                    return true;
-                }
+            if ($oldTokens[$i] === ';') {
+                // all good
+                return true;
+            }
 
+            if ($oldTokens[$i] !== ')') {
                 continue;
             }
 

--- a/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
+++ b/rules/CodeQuality/Rector/If_/CompleteMissingIfElseBracketRector.php
@@ -91,12 +91,7 @@ CODE_SAMPLE
 
         $startStmt = current($if->stmts);
         $lastStmt = end($if->stmts);
-
-        if ($startStmt === false || $lastStmt === false) {
-            return true;
-        }
-
-        return false;
+        return $startStmt === false || $lastStmt === false;
     }
 
     private function isBareNewNode(If_|ElseIf_|Else_ $if): bool


### PR DESCRIPTION
Direct HTML usage cause fatal error:

```diff
     public function run($value)
     {
-        if ($value) ?>
-            <div>Hello</div>
+        if ($value) {
+        }            <div>Hello</div>
         <?php
```

and need to be skipped.