### PR TITLE
[DeadCode] Remove UnionType check on RecastingRemovalRector

### DIFF
--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Expr\Cast\Object_;
 use PhpParser\Node\Expr\Cast\String_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\StaticPropertyFetch;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -137,14 +137,7 @@ CODE_SAMPLE
 
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
-            $propertyType = $expr instanceof StaticPropertyFetch
-                ? $this->nodeTypeResolver->getType($expr->class)
-                : $this->nodeTypeResolver->getType($expr->var);
-
-            // need to UnionType check due rectify with RecastingRemovalRector + CountOnNullRector
-            // cause add (array) cast on $node->args
-            // on union $node types FuncCall|MethodCall|StaticCall
-            return ! $propertyType instanceof UnionType;
+            return true;
         }
 
         $nativeType = $phpPropertyReflection->getNativeType();


### PR DESCRIPTION
Since `CountOnNullRector` is now deprecated on combine 2 rules on `RecastingRemovalRector`+`CountOnNullRector`, the `UnionType` check seems no longer needed.