### PR TITLE
[TypeDeclaration] Handle Union with array type on ReturnUnionTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/union_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/union_array.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+final class UnionArray
+{
+    public function run($a, $b)
+    {
+        if ($a) {
+            return null;
+        }
+
+        if ($b) {
+            return new DateTime('now');
+        }
+
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+final class UnionArray
+{
+    public function run($a, $b): null|\DateTime|array
+    {
+        if ($a) {
+            return null;
+        }
+
+        if ($b) {
+            return new DateTime('now');
+        }
+
+        return [];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/union_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/union_array.php.inc
@@ -32,7 +32,7 @@ use stdClass;
 
 final class UnionArray
 {
-    public function run($a, $b): null|\DateTime|array
+    public function run($a, $b): \DateTime|array|null
     {
         if ($a) {
             return null;


### PR DESCRIPTION
Given the following code:

```php
final class UnionArray
{
    public function run($a, $b)
    {
        if ($a) {
            return null;
        }

        if ($b) {
            return new DateTime('now');
        }

        return [];
    }
}
```

It currently produce:

```diff
-    public function run($a, $b)
+    public function run($a, $b): ?\DateTime
```

which `array` should be included.