### PR TITLE
[PHPStanStaticTypeMapper] Remove narrow string and int on UnionTypeMapper

### DIFF
--- a/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -318,23 +318,12 @@ final class UnionTypeMapper implements TypeMapperInterface
             return $compatibleObjectTypeNode;
         }
 
-        $integerIdentifier = $this->narrowIntegerType($unionType);
-        if ($integerIdentifier instanceof Identifier) {
-            return $integerIdentifier;
+        $type = $this->typeFactory->createMixedPassedOrUnionType($unionType->getTypes());
+        if (! $type instanceof UnionType) {
+            return $this->phpStanStaticTypeMapper->mapToPhpParserNode($type, $typeKind);
         }
 
-        return $this->narrowStringTypes($unionType);
-    }
-
-    private function narrowStringTypes(UnionType $unionType): ?Identifier
-    {
-        foreach ($unionType->getTypes() as $unionedType) {
-            if (! $unionedType->isString()->yes()) {
-                return null;
-            }
-        }
-
-        return new Identifier('string');
+        return null;
     }
 
     private function processResolveCompatibleObjectCandidates(UnionType $unionType): ?Node
@@ -473,17 +462,6 @@ final class UnionTypeMapper implements TypeMapperInterface
         }
 
         return $typeWithClassName;
-    }
-
-    private function narrowIntegerType(UnionType $unionType): ?Identifier
-    {
-        foreach ($unionType->getTypes() as $unionedType) {
-            if (! $unionedType->isInteger()->yes()) {
-                return null;
-            }
-        }
-
-        return new Identifier('int');
     }
 
     /**


### PR DESCRIPTION
Using `$this->typeFactory->createMixedPassedOrUnionType($unionType->getTypes());` can cover uniquate types