### PR TITLE
[DeadCode] Skip indirect variable definition on RemoveNonExistingVarAnnotationRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_indirect_variable_definition.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_indirect_variable_definition.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector\Fixture;
+
+final class SkipIndirectVariableDefinition
+{
+    public function get()
+    {
+        /** @var MyClass<T>*/
+        $x = new MyClass;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_next_inline_html.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_next_inline_html.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @var string $value
+ */
+
+ ?>
+
+ <div class="<?php echo $value; ?>"></div>

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Static_;
@@ -193,7 +194,7 @@ CODE_SAMPLE
             }
         }
 
-        return false;
+        return isset($stmtsAware->stmts[$key+1]) && $stmtsAware->stmts[$key+1] instanceof InlineHTML;
     }
 
     private function hasVariableName(Stmt $stmt, string $variableName): bool

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\Node;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
@@ -147,7 +148,7 @@ CODE_SAMPLE
 
             $variableName = ltrim($varTagValueNode->variableName, '$');
 
-            if ($variableName === '' && $this->isAnnotatableReturn($stmt)) {
+            if ($variableName === '' && $this->isAllowedEmptyVariableName($stmt)) {
                 continue;
             }
 
@@ -227,8 +228,12 @@ CODE_SAMPLE
         return str_contains($varTagValueNode->description, '}');
     }
 
-    private function isAnnotatableReturn(Stmt $stmt): bool
+    private function isAllowedEmptyVariableName(Stmt $stmt): bool
     {
-        return $stmt instanceof Return_ && $stmt->expr instanceof CallLike && ! $stmt->expr instanceof New_;
+        if ($stmt instanceof Return_ && $stmt->expr instanceof CallLike && ! $stmt->expr instanceof New_) {
+            return true;
+        }
+
+        return $stmt instanceof Expression && $stmt->expr instanceof Assign && $stmt->expr->var instanceof Variable;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8253