### PR TITLE
[TypeDeclaration] Add Fixture tests for ClassMethodReturnTypeOverrideGuard usage on NumericReturnTypeFromStrictScalarReturnsRector  and AddReturnTypeDeclarationFromYieldsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/skip_construct.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NumericReturnTypeFromStrictScalarReturnsRector/Fixture/skip_construct.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarReturnsRector\Fixture;
+
+final class SkipConstruct
+{
+    public function __construct(int $first)
+    {
+        return ++$first;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector/Fixture/skip_construct.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddReturnTypeDeclarationFromYieldsRector/Fixture/skip_construct.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector\Fixture;
+
+final class SkipConstruct
+{
+    public function __construct()
+    {
+        yield;
+    }
+}


### PR DESCRIPTION
@staabm here the tests Ref https://github.com/rectorphp/rector-src/pull/5156#issuecomment-1758104035