### PR TITLE
[DeadCode] Skip count() on mixed on RemoveUnusedNonEmptyArrayBeforeForeachRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_count_different_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_count_different_variable.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+class SkipCountDifferentVariable
+{
+    public function run(array $vars, array $vars2)
+    {
+        if (count($vars) > 0) {
+            foreach ($vars2 as $key => $val) {
+                echo "hello";
+            }
+        }
+
+        return [];
+    }
+}

--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_count_mixed.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_count_mixed.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+class SkipCountMixed
+{
+    public function run($vars)
+    {
+        if (count($vars) > 0) {
+            foreach ($vars as $key => $val) {
+                echo "hello";
+            }
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8265