### PR TITLE
[DeadCode] Handle file_get_contents() only remove variable on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_file_get_contents.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_file_get_contents.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class OnFileGetContents {
+    public function run(array $params)
+    {
+        $return = file_get_contents("http://example.com");
+
+        var_dump($http_response_header);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class OnFileGetContents {
+    public function run(array $params)
+    {
+        file_get_contents("http://example.com");
+
+        var_dump($http_response_header);
+    }
+}
+
+?>

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -33,6 +33,8 @@ final class PureFunctionDetector
         // http
         'header', 'header_remove', 'http_response_code', 'setcookie',
 
+        'file_get_contents',
+
         // output buffer
         'ob_start', 'ob_end_clean', 'ob_get_clean', 'readfile', 'printf', 'var_dump', 'phpinfo',
         'ob_implicit_flush', 'vprintf',


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8263