### PR TITLE
[CodeQuality] Skip magic property fetch on IssetOnPropertyObjectToPropertyExistsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_magic_property_fetch.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_magic_property_fetch.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
+
+class SkipMagicPropertyFetch
+{
+    public $x;
+}
+
+$f = new SkipMagicPropertyFetch();
+$p = 'x';
+isset($f->{$p});

--- a/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
@@ -154,6 +155,10 @@ CODE_SAMPLE
 
     private function shouldSkipForPropertyTypeDeclaration(PropertyFetch $propertyFetch): bool
     {
+        if (! $propertyFetch->name instanceof Identifier) {
+            return true;
+        }
+
         $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($propertyFetch);
         if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
             return false;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8260