### PR TITLE
[AutoImport] [Renaming] Skip remove used use statement on annotation during rename + auto import when no replacement on auto import

### DIFF
--- a/packages/PostRector/Application/PostFileProcessor.php
+++ b/packages/PostRector/Application/PostFileProcessor.php
@@ -31,11 +31,11 @@ final class PostFileProcessor
     ) {
         $this->postRectors = [
             // priority: 650
-            $classRenamingPostRector,
-            // priority: 600
             $nameImportingPostRector,
-            // priority: 500
+            // priority: 600
             $useAddingPostRector,
+            // priority: 500
+            $classRenamingPostRector,
             // priority: 100
             $unusedImportRemovingPostRector,
         ];

--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -16,6 +16,8 @@ use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\Core\Provider\CurrentFileProvider;
+use Rector\Core\ValueObject\Application\File;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Renaming\NodeManipulator\ClassRenamer;
 
@@ -26,7 +28,8 @@ final class ClassRenamingPostRector extends AbstractPostRector
     public function __construct(
         private readonly ClassRenamer $classRenamer,
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
-        private readonly UseImportsRemover $useImportsRemover
+        private readonly UseImportsRemover $useImportsRemover,
+        private readonly CurrentFileProvider $currentFileProvider
     ) {
     }
 
@@ -73,8 +76,13 @@ final class ClassRenamingPostRector extends AbstractPostRector
             return $result;
         }
 
+        $file = $this->currentFileProvider->getFile();
+        if (! $file instanceof File) {
+            return null;
+        }
+
         $removedUses = $this->renamedClassesDataCollector->getOldClasses();
-        $this->rootNode->stmts = $this->useImportsRemover->removeImportsFromStmts($this->rootNode->stmts, $removedUses);
+        $this->rootNode->stmts = $this->useImportsRemover->removeImportsFromStmts($this->rootNode->stmts, $removedUses, $file->getFilePath());
 
         return $result;
     }

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/skip_remove_use_statement_part_of_rename.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/skip_remove_use_statement_part_of_rename.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+/**
+ * @IsGranted('TEST')
+ */
+class IsGrantedController extends AbstractController
+{
+}

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names.php
@@ -19,5 +19,15 @@ return static function (RectorConfig $rectorConfig): void {
         SomeServiceClassFirstNamespace::class => SomeServiceClass::class,
         'Storage' => 'Illuminate\Support\Facades\Storage',
         'Queue' => 'Illuminate\Support\Facades\Queue',
+
+        /**
+         *
+         * For testing skip remove use statement part of rename during auto import
+         * the rename annotation is allowed only on specific symfony assert, doctrine, and serializer
+         *
+         * @see https://github.com/rectorphp/rector-src/blob/d55a35bcdede830d3927de1c11e0f7f0d12ee9e4/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php#L36-L38s
+         * @see https://github.com/rectorphp/rector-symfony/issues/535#issuecomment-1762822651
+         */
+        'Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted' => 'Symfony\Component\Security\Http\Attribute\IsGranted',
     ]);
 };

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\CodingStyle\Application;
 
-use Nette\Utils\Strings;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Use_;
 use Rector\PostRector\Collector\UseNodesToAddCollector;
@@ -17,6 +16,7 @@ final class UseImportsRemover
     {
 
     }
+
     /**
      * @param Stmt[] $stmts
      * @param string[] $removedUses

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -4,24 +4,34 @@ declare(strict_types=1);
 
 namespace Rector\CodingStyle\Application;
 
+use Nette\Utils\Strings;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Use_;
+use Rector\PostRector\Collector\UseNodesToAddCollector;
+use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
 final class UseImportsRemover
 {
+    public function __construct(private readonly UseNodesToAddCollector $useNodesToAddCollector)
+    {
+
+    }
     /**
      * @param Stmt[] $stmts
      * @param string[] $removedUses
      * @return Stmt[]
      */
-    public function removeImportsFromStmts(array $stmts, array $removedUses): array
+    public function removeImportsFromStmts(array $stmts, array $removedUses, string $filePath): array
     {
+        $useImportTypes = $this->useNodesToAddCollector->getObjectImportsByFilePath($filePath);
+
         foreach ($stmts as $key => $stmt) {
             if (! $stmt instanceof Use_) {
                 continue;
             }
 
-            $stmt = $this->removeUseFromUse($removedUses, $stmt);
+            $stmt = $this->removeUseFromUse($removedUses, $stmt, $useImportTypes);
 
             // remove empty uses
             if ($stmt->uses === []) {
@@ -34,14 +44,33 @@ final class UseImportsRemover
 
     /**
      * @param string[] $removedUses
+     * @param AliasedObjectType[]|FullyQualifiedObjectType[] $useImportTypes
      */
-    private function removeUseFromUse(array $removedUses, Use_ $use): Use_
+    private function removeUseFromUse(array $removedUses, Use_ $use, array $useImportTypes): Use_
     {
+        // nothing to remove, as no replacement
+        if ($useImportTypes === []) {
+            return $use;
+        }
+
         foreach ($use->uses as $usesKey => $useUse) {
             $useName = $useUse->name->toString();
-            if (in_array($useName, $removedUses, true)) {
-                unset($use->uses[$usesKey]);
+            if (! in_array($useName, $removedUses, true)) {
+                continue;
             }
+
+            foreach ($useImportTypes as $useImportType) {
+                $className = $useImportType instanceof AliasedObjectType
+                    ? $useImportType->getFullyQualifiedName()
+                    : $useImportType->getClassName();
+
+                if ($className === $useName) {
+                    unset($use->uses[$usesKey]);
+                    continue 2;
+                }
+            }
+
+            unset($use->uses[$usesKey]);
         }
 
         return $use;


### PR DESCRIPTION
Added test or testing skip remove use statement part of rename during auto import.

The rename annotation is allowed only on specific:

- symfony assert
- doctrine
- and serializer
  
see 

https://github.com/rectorphp/rector-src/blob/d55a35bcdede830d3927de1c11e0f7f0d12ee9e4/packages/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php#L36-L38
         
see 

- https://github.com/rectorphp/rector-symfony/issues/535#issuecomment-1762822651

on auto import, the process is overlapped, which annotation not renamed, but use statement removed during auto import.