### PR TITLE
[DeadCode] Skip return false pseudo type in union on RemoveUselessReturnTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_return_false_in_union_bool.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_return_false_in_union_bool.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class SkipReturnFalseOnUnionBool
+{
+    /**
+     * @return false|\stdClass
+     */
+    function run(): bool|\stdClass
+    {
+        if (rand(0, 1)) {
+            return false;
+        }
+
+        return new \stdClass();
+    }
+}

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -68,10 +68,10 @@ final class DeadReturnTagValueNodeAnalyzer
             return false;
         }
 
-        return ! $this->hasTruePseudoType($returnTagValueNode->type);
+        return ! $this->hasTrueFalsePseudoType($returnTagValueNode->type);
     }
 
-    private function hasTruePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
+    private function hasTrueFalsePseudoType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
     {
         $unionTypes = $bracketsAwareUnionTypeNode->types;
 
@@ -81,7 +81,7 @@ final class DeadReturnTagValueNodeAnalyzer
             }
 
             $name = strtolower((string) $unionType);
-            if ($name === 'true') {
+            if (in_array($name, ['true', 'false'], true)) {
                 return true;
             }
         }

--- a/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\Rector\If_;
 
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
@@ -203,7 +204,7 @@ CODE_SAMPLE
 
     private function shouldSkipForeachExpr(Expr $foreachExpr, Scope $scope): bool
     {
-        if ($foreachExpr instanceof Expr\ArrayDimFetch && $foreachExpr->dim !== null) {
+        if ($foreachExpr instanceof ArrayDimFetch && $foreachExpr->dim !== null) {
             $exprType = $this->nodeTypeResolver->getNativeType($foreachExpr->var);
             $dimType = $this->nodeTypeResolver->getNativeType($foreachExpr->dim);
             if (! $exprType->hasOffsetValueType($dimType)->yes()) {


### PR DESCRIPTION
The following code is valid:

```php
final class SkipReturnFalseOnUnionBool
{
    /**
     * @return false|\stdClass
     */
    function run(): bool|\stdClass
    {
        if (rand(0, 1)) {
            return false;
        }

        return new \stdClass();
    }
}
```

see https://phpstan.org/r/00534257-55dd-42d2-9104-c25aa5ca9872