### PR TITLE
Improve UnaryPlus and UnaryMinus support in isDynamicExpr

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPrope
 
 define("FLOAT_CONSTANT_1", 10.1);
 
-final class SomeClass
+final class NegativePositiveConstant
 {
     const INT_CONSTANT_2 = 10;
 
@@ -40,7 +40,7 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPrope
 
 define("FLOAT_CONSTANT_1", 10.1);
 
-final class SomeClass
+final class NegativePositiveConstant
 {
     const INT_CONSTANT_2 = 10;
 

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
@@ -1,0 +1,66 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+define("FLOAT_CONSTANT_1", 10.1);
+
+final class SomeClass
+{
+    const INT_CONSTANT_2 = 10;
+
+    private $number1;
+    private $number2;
+    private $number3;
+    private $number4;
+    private $number5;
+    private $number6;
+    private $number7;
+    private $number8;
+    private $number9;
+
+    public function __construct()
+    {
+        $this->number1 = +FLOAT_CONSTANT_1;
+        $this->number2 = FLOAT_CONSTANT_1;
+        $this->number3 = -FLOAT_CONSTANT_1;
+        $this->number4 = +self::INT_CONSTANT_2;
+        $this->number5 = self::INT_CONSTANT_2;
+        $this->number6 = -self::INT_CONSTANT_2;
+        $this->number7 = +static::INT_CONSTANT_2;
+        $this->number8 = static::INT_CONSTANT_2;
+        $this->number9 = -static::INT_CONSTANT_2;
+    }
+}
+
+?>
+-----
+<?php
+
+numberspace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+define("FLOAT_CONSTANT_1", 10.1);
+
+final class SomeClass
+{
+    const INT_CONSTANT_2 = 10;
+
+    private $number1 = +FLOAT_CONSTANT_1;
+    private $number2 = FLOAT_CONSTANT_1;
+    private $number3 = -FLOAT_CONSTANT_1;
+    private $number4 = +self::INT_CONSTANT_2;
+    private $number5 = self::INT_CONSTANT_2;
+    private $number6 = -self::INT_CONSTANT_2;
+    private $number7;
+    private $number8;
+    private $number9;
+
+    public function __construct()
+    {
+        $this->number7 = +static::INT_CONSTANT_2;
+        $this->number8 = static::INT_CONSTANT_2;
+        $this->number9 = -static::INT_CONSTANT_2;
+    }
+}
+
+?>
+

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
@@ -63,4 +63,3 @@ final class SomeClass
 }
 
 ?>
-

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_constant.php.inc
@@ -36,7 +36,7 @@ final class SomeClass
 -----
 <?php
 
-numberspace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
 
 define("FLOAT_CONSTANT_1", 10.1);
 

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_numeric_string.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_numeric_string.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
 
-final class NegativePositiveInt
+final class NegativePositiveNumericString
 {
     private $propertyA;
     private $propertyB;
@@ -22,7 +22,7 @@ final class NegativePositiveInt
 
 namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
 
-final class NegativePositiveInt
+final class NegativePositiveNumericString
 {
     private $propertyA = -"100";
     private $propertyB = "100";

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_numeric_string.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/negative_positive_numeric_string.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class NegativePositiveInt
+{
+    private $propertyA;
+    private $propertyB;
+    private $propertyC;
+
+    public function __construct()
+    {
+        $this->propertyA = -"100";
+        $this->propertyB = "100";
+        $this->propertyC = +"100";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class NegativePositiveInt
+{
+    private $propertyA = -"100";
+    private $propertyB = "100";
+    private $propertyC = +"100";
+
+    public function __construct()
+    {
+    }
+}
+
+?>

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -56,7 +56,7 @@ final class ExprAnalyzer
     {
         // Unwrap UnaryPlus and UnaryMinus
         if ($expr instanceof UnaryPlus || $expr instanceof UnaryMinus) {
-            return $this->isDynamicExpr($expr->expr);
+            $expr = $expr->expr;
         }
 
         if ($expr instanceof Array_) {

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -54,13 +54,13 @@ final class ExprAnalyzer
 
     public function isDynamicExpr(Expr $expr): bool
     {
-        if ($expr instanceof Array_) {
-            return $this->isDynamicArray($expr);
-        }
-
         // Unwrap UnaryPlus and UnaryMinus
         if ($expr instanceof UnaryPlus || $expr instanceof UnaryMinus) {
-            $expr = $expr->expr;
+            return $this->isDynamicExpr($expr->expr);
+        }
+
+        if ($expr instanceof Array_) {
+            return $this->isDynamicArray($expr);
         }
 
         if ($expr instanceof Scalar) {

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
-use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
@@ -59,13 +58,14 @@ final class ExprAnalyzer
             return $this->isDynamicArray($expr);
         }
 
+        // Unwrap UnaryPlus and UnaryMinus
+        if ($expr instanceof UnaryPlus || $expr instanceof UnaryMinus) {
+            $expr = $expr->expr;
+        }
+
         if ($expr instanceof Scalar) {
             // string interpolation is true, otherwise false
             return $expr instanceof Encapsed;
-        }
-
-        if ($expr instanceof UnaryPlus || $expr instanceof UnaryMinus) {
-            return ! $expr->expr instanceof LNumber && ! $expr->expr instanceof DNumber;
         }
 
         return ! $this->isAllowedConstFetchOrClassConstFetch($expr);

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -55,20 +55,20 @@ final class ExprAnalyzer
 
     public function isDynamicExpr(Expr $expr): bool
     {
-        if (! $expr instanceof Array_) {
-            if ($expr instanceof Scalar) {
-                // string interpolation is true, otherwise false
-                return $expr instanceof Encapsed;
-            }
-
-            if ($expr instanceof UnaryPlus || $expr instanceof UnaryMinus) {
-                return ! $expr->expr instanceof LNumber && ! $expr->expr instanceof DNumber;
-            }
-
-            return ! $this->isAllowedConstFetchOrClassConstFetch($expr);
+        if ($expr instanceof Array_) {
+            return $this->isDynamicArray($expr);
         }
 
-        return $this->isDynamicArray($expr);
+        if ($expr instanceof Scalar) {
+            // string interpolation is true, otherwise false
+            return $expr instanceof Encapsed;
+        }
+
+        if ($expr instanceof UnaryPlus || $expr instanceof UnaryMinus) {
+            return ! $expr->expr instanceof LNumber && ! $expr->expr instanceof DNumber;
+        }
+
+        return ! $this->isAllowedConstFetchOrClassConstFetch($expr);
     }
 
     public function isDynamicArray(Array_ $array): bool


### PR DESCRIPTION
This expands support in `ExprAnalyzer::isDynamicExpr()` for `UnaryPlus` and `UnaryMinus` to unwrap the expression for the purposes of determining if it's dynamic instead of only allowing numbers.

This also contains a tiny bit of refactoring to reduce the indentation in the `isDynamicExpr()` method as it was getting a bit deep.

This expands on the original (and correct) fix for rectorphp/rector#8261 to generalise the fix for just about every possible scenario.

From my investigation, adding a `-` or a `+` to the front of just about any expression is valid _syntax_, but determining what is and isn't going to produce a `TypeError` on execution was deemed to be too costly for what is ultimately a pretty "trivial" check, and policing "good" code by my standards is pretty pointless, all things considered.

This obviously allows a lot of really bad and stupid code past. E.g. all of these are valid _syntax_ but obviously will crash with `TypeError`s when executed:

```php
define("STRING_CONSTANT", "crash");
$a = (-"crash");
$b = (-[]);
$c = (-(new DateTime()));
$d = (-STRING_CONSTANT);
```

And there's also a huge amount of bad, wrong and incorrect code that does work, e.g.:

```php
define("STRING_NUMBER", "123");
$a = (-"123");
$b = (-STRING_NUMBER);
```

And this only covers scenarios that make sense within a couple of lines of code.

I've added some tests to the suite for `InlineConstructorDefaultToPropertyRector` as that was the Rector that triggered this whole story, however there should probably be a stack of direct tests on `ExprAnalyzer` as testing it via Rectors feels clunky.

This has been verified as a working fix by modifying `InlineConstructorDefaultToPropertyRector` to execute functionally equivalent code.