### PR TITLE
[Renaming] Skip nullable object object|null on RenameMethodRector

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -434,6 +434,10 @@ final class NodeTypeResolver
         // for falsy nullables
         $type = TypeCombinator::remove($type, new ConstantBooleanType(false));
 
+        if ($type instanceof ObjectWithoutClassType) {
+            return $this->isMatchObjectWithoutClassType($type, $requiredObjectType);
+        }
+
         return $type->isSuperTypeOf($requiredObjectType)
             ->yes();
     }

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/skip_class_method_uniontype_object_null.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/skip_class_method_uniontype_object_null.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture;
 
-class Baz
+class SkipClassMethodUnionTypeObjectNull
 {
     public function doSomething() {
         /** @var object|null $bar */

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/skip_class_method_uniontype_object_null.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/skip_class_method_uniontype_object_null.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture;
+
+class Baz
+{
+    public function doSomething() {
+        /** @var object|null $bar */
+        $bar = $fooo->getBar();
+        $bat = $bar->some_old();
+    }
+}


### PR DESCRIPTION
Fix https://github.com/rectorphp/rector/issues/8251
Closes https://github.com/rectorphp/rector-src/pull/5180