### PR TITLE
[Php70] Fix Php4 contructor not replaced with __construct() on php 7.4 environment

### DIFF
--- a/rules-tests/Php70/Rector/ClassMethod/Php4ConstructorRector/Fixture/skip_only_other_method.php.inc
+++ b/rules-tests/Php70/Rector/ClassMethod/Php4ConstructorRector/Fixture/skip_only_other_method.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+class SkipOnlyOtherMethod
+{
+    public function run()
+    {
+    }
+}

--- a/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
+++ b/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
@@ -107,7 +107,7 @@ CODE_SAMPLE
         $this->processClassMethodStatementsForParentConstructorCalls($psr4ConstructorMethod, $scope);
 
         // does it already have a __construct method?
-        if (! $classReflection->hasConstructor()) {
+        if (! $classReflection->hasNativeMethod(MethodName::CONSTRUCT)) {
             $psr4ConstructorMethod->name = new Identifier(MethodName::CONSTRUCT);
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8100