### PR TITLE
[TypeDeclaration] Handle skipped by file path on DeclareStrictTypesRector due to use beforeTraverse()

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/Fixture/skipped_by_path.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/Fixture/skipped_by_path.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector\Fixture;
+
+function skipped_by_path()
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
@@ -9,8 +9,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(DeclareStrictTypesRector::class);
     $rectorConfig->skip([
         DeclareStrictTypesRector::class => [
-            // .php.inc changed .php during running test
-            __DIR__ . '/../Fixture/skipped_by_path.php',
+            realpath(__DIR__ . '/../Fixture/skipped_by_path.php.inc'),
         ],
     ]);
 };

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
@@ -10,7 +10,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->skip([
         DeclareStrictTypesRector::class => [
             // .php.inc changed .php during running test
-            realpath(__DIR__ . '/../Fixture') . 'skipped_by_path.php',
+            realpath(__DIR__ . '/../Fixture') . '/skipped_by_path.php',
         ],
     ]);
 };

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
@@ -7,4 +7,10 @@ use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(DeclareStrictTypesRector::class);
+    $rectorConfig->skip([
+        DeclareStrictTypesRector::class => [
+            // .php.inc changed .php during running test
+            __DIR__ . '/../Fixture/skipped_by_path.php',
+        ],
+    ]);
 };

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector/config/configured_rule.php
@@ -9,7 +9,8 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(DeclareStrictTypesRector::class);
     $rectorConfig->skip([
         DeclareStrictTypesRector::class => [
-            realpath(__DIR__ . '/../Fixture/skipped_by_path.php.inc'),
+            // .php.inc changed .php during running test
+            realpath(__DIR__ . '/../Fixture') . 'skipped_by_path.php',
         ],
     ]);
 };

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
@@ -53,6 +53,11 @@ CODE_SAMPLE
     {
         parent::beforeTraverse($nodes);
 
+        $filePath = $this->file->getFilePath();
+        if ($this->skipper->shouldSkipElementAndFilePath(self::class, $filePath)) {
+            return null;
+        }
+
         $newStmts = $this->file->getNewStmts();
 
         if ($newStmts === []) {

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -71,7 +71,7 @@ CODE_SAMPLE;
 
     private SimpleCallableNodeTraverser $simpleCallableNodeTraverser;
 
-    private Skipper $skipper;
+    protected Skipper $skipper;
 
     private CurrentFileProvider $currentFileProvider;
 


### PR DESCRIPTION
@kenjis this is for bug you found on CodeIgniter PR:

- https://github.com/codeigniter4/CodeIgniter4/pull/8072#issuecomment-1774055246

which `DeclareStrictTypesRector` due to use `beforeTraverse()` instead of `enterNode()`, while on `AbstractRector`, checking skip is by `enterNode()` so it overlapped.