### PR TITLE
Add test fixture for only RenameClassRector with only importNames() without removeUnusedImports() enabled

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/AutoImportNamesWithoutRemoveUnusedImportTest.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/AutoImportNamesWithoutRemoveUnusedImportTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @see \Rector\PostRector\Rector\NameImportingPostRector
+ */
+final class AutoImportNamesWithoutRemoveUnusedImportTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureAutoImportNamesWithoutRemoveUnusedImport');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/auto_import_names_without_remove_unused_use.php';
+    }
+}

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/factory_invoke_typehint.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/factory_invoke_typehint.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Interop\Container\ContainerInterface;
+
+class FactoryInvokeTypehint
+{
+    public function __invoke(ContainerInterface $container)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Psr\Container\ContainerInterface;
+
+class FactoryInvokeTypehint
+{
+    public function __invoke(ContainerInterface $container)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Interop\Container\ContainerInterface' => 'Psr\Container\ContainerInterface',
+    ]);
+};


### PR DESCRIPTION
Current fixture for auto imports enable both `importNames()` and `removeUnusedImports()`. 

This PR is only for add test to ensure it works even without `removeUnusedImports()` enabled.

Cherry-picked from PR:

- https://github.com/rectorphp/rector-src/pull/5192