### PR TITLE
[TypeDeclaration] Skip default numeric string on param int on ParamTypeByMethodCallTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_default_numeric_string_param_int.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_default_numeric_string_param_int.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types= 1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector\Fixture;
+
+final class SkipDefaultNumericStringParamInt
+{
+    public function go($value = '1')
+    {
+        return $this->execute($value);
+    }
+
+    private function execute(int $value)
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_default_numeric_string_param_int.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_default_numeric_string_param_int.php.inc
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types= 1);
-
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector\Fixture;
 
 final class SkipDefaultNumericStringParamInt

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_default_numeric_string_param_int.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_default_numeric_string_param_int.php.inc
@@ -6,7 +6,7 @@ final class SkipDefaultNumericStringParamInt
 {
     public function go($value = '1')
     {
-        return $this->execute($value);
+        $this->execute($value);
     }
 
     private function execute(int $value)

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/with_default_constant_integer_type_param_int.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/with_default_constant_integer_type_param_int.php.inc
@@ -2,11 +2,11 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector\Fixture;
 
-final class WithDefaultSameType
+final class WithDefaultConstantIntegerTypeParamInt
 {
     public function go($value = 1)
     {
-        return $this->execute($value);
+        $this->execute($value);
     }
 
     private function execute(int $value)
@@ -20,11 +20,11 @@ final class WithDefaultSameType
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector\Fixture;
 
-final class WithDefaultSameType
+final class WithDefaultConstantIntegerTypeParamInt
 {
     public function go(int $value = 1)
     {
-        return $this->execute($value);
+        $this->execute($value);
     }
 
     private function execute(int $value)

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/with_default_same_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/with_default_same_type.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector\Fixture;
+
+final class WithDefaultSameType
+{
+    public function go($value = 1)
+    {
+        return $this->execute($value);
+    }
+
+    private function execute(int $value)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector\Fixture;
+
+final class WithDefaultSameType
+{
+    public function go(int $value = 1)
+    {
+        return $this->execute($value);
+    }
+
+    private function execute(int $value)
+    {
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\NodeAnalyzer;
 
+use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ComplexType;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -20,12 +22,16 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
+use Rector\StaticTypeMapper\StaticTypeMapper;
 
 final class CallerParamMatcher
 {
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly AstResolver $astResolver
+        private readonly AstResolver $astResolver,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly TypeComparator $typeComparator
     ) {
     }
 
@@ -36,6 +42,21 @@ final class CallerParamMatcher
     ): null | Identifier | Name | NullableType | UnionType | ComplexType {
         $callParam = $this->matchCallParam($call, $param, $scope);
         if (! $callParam instanceof Param) {
+            return null;
+        }
+
+        if (! $param->default instanceof Expr) {
+            return $callParam->type;
+        }
+
+        if (! $callParam->type instanceof Node) {
+            return null;
+        }
+
+        $callParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($callParam->type);
+        $defaultType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->default);
+
+        if (! $this->typeComparator->areTypesEqual($callParamType, $defaultType)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
@@ -56,11 +56,15 @@ final class CallerParamMatcher
         $callParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($callParam->type);
         $defaultType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->default);
 
-        if (! $this->typeComparator->areTypesEqual($callParamType, $defaultType)) {
-            return null;
+        if ($this->typeComparator->areTypesEqual($callParamType, $defaultType)) {
+            return $callParam->type;
         }
 
-        return $callParam->type;
+        if ($this->typeComparator->isSubtype($defaultType, $callParamType)) {
+            return $callParam->type;
+        }
+
+        return null;
     }
 
     public function matchParentParam(StaticCall $parentStaticCall, Param $param, Scope $scope): ?Param


### PR DESCRIPTION
The following code should be skipped:

```php
final class SkipDefaultNumericStringParamInt
{
    public function go($value = '1')
    {
        return $this->execute($value);
    }

    private function execute(int $value)
    {
    }
}
```

as cause fatal error with add `int` param, 

ref https://3v4l.org/50JON
ref https://getrector.com/demo/5394a6db-9a13-41ba-8910-4b3d890e5ac7

