### PR TITLE
[AutoImport] Handle AnnotationToAttributeRector + RenameClassRector then enable auto import

### DIFF
--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -91,6 +91,10 @@ final class NameImportingPostRector extends AbstractPostRector
 
     private function resolveNameFromAttribute(Name $name): Name
     {
+        if ($name instanceof FullyQualified) {
+            return $name;
+        }
+
         if ($name->hasAttribute(AttributeKey::PHP_ATTRIBUTE_NAME)) {
             $oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
             $phpAttributeName = $name->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);

--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -21,6 +21,7 @@ use Rector\CodingStyle\Node\NameImporter;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -40,6 +41,7 @@ final class NameImportingPostRector extends AbstractPostRector
         private readonly UseImportsResolver $useImportsResolver,
         private readonly AliasNameResolver $aliasNameResolver,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
     ) {
     }
 
@@ -60,6 +62,7 @@ final class NameImportingPostRector extends AbstractPostRector
         }
 
         if ($node instanceof Name) {
+            $node = $this->resolveNameFromAttribute($node);
             return $this->processNodeName($node, $file);
         }
 
@@ -84,6 +87,22 @@ final class NameImportingPostRector extends AbstractPostRector
 
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
         return $node;
+    }
+
+    private function resolveNameFromAttribute(Name $name): Name
+    {
+        if ($name->hasAttribute(AttributeKey::PHP_ATTRIBUTE_NAME)) {
+            $oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
+            $phpAttributeName = $name->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
+
+            foreach ($oldToNewClasses as $oldName => $newName) {
+                if ($oldName === $phpAttributeName) {
+                    return new FullyQualified($newName);
+                }
+            }
+        }
+
+        return $name;
     }
 
     private function processNodeName(Name $name, File $file): ?Node

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/AnnotationToAttributeRenameAutoImportTest.php
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/AnnotationToAttributeRenameAutoImportTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AnnotationToAttributeRenameAutoImportTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/fixture.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/fixture.php.inc
@@ -6,7 +6,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 /**
- * @IsGranted('TEST')
+ * @IsGranted("TEST")
  */
 class IsGrantedController extends AbstractController
 {
@@ -21,7 +21,7 @@ namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-#[IsGranted("'TEST'")]
+#[IsGranted('TEST')]
 class IsGrantedController extends AbstractController
 {
 }

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/fixture.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+/**
+ * @IsGranted('TEST')
+ */
+class IsGrantedController extends AbstractController
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+#[IsGranted("'TEST'")]
+class IsGrantedController extends AbstractController
+{
+}
+
+?>

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+/**
+ * @\Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted("TEST")
+ */
+class NotImportedYet extends AbstractController
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+#[IsGranted('TEST')]
+class NotImportedYet extends AbstractController
+{
+}
+
+?>

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet2.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet2.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+/**
+ * @\Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted("TEST")
+ */
+class NotImportedYet2 extends AbstractController
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+#[IsGranted('TEST')]
+class NotImportedYet2 extends AbstractController
+{
+}
+
+?>

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/config/configured_rule.php
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/config/configured_rule.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Rector\Renaming\Rector\Name\RenameClassRector;
 
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
@@ -14,7 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->ruleWithConfiguration(
-        \Rector\Renaming\Rector\Name\RenameClassRector::class,
+        RenameClassRector::class,
         [
             'Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted' => 'Symfony\Component\Security\Http\Attribute\IsGranted',
         ],

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/config/configured_rule.php
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/config/configured_rule.php
@@ -1,8 +1,8 @@
 <?php
 
 declare(strict_types=1);
-use Rector\Renaming\Rector\Name\RenameClassRector;
 
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/config/configured_rule.php
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/config/configured_rule.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+
+    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+        new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        \Rector\Renaming\Rector\Name\RenameClassRector::class,
+        [
+            'Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted' => 'Symfony\Component\Security\Http\Attribute\IsGranted',
+        ],
+    );
+};


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/issues/535#issuecomment-1783983383

On auto import, when change to attribute then rename attribute name, the import removed with `$rectorConfig->importNames()` applied, see

https://getrector.com/demo/4c8f80f5-9050-4b6b-b58e-93034ea3d45b