### PR TITLE
[Php80] Keep single quoted Argument Attribute on AnnotationToAttributeRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
@@ -200,6 +200,10 @@ final class ArrayParser
             return new ArrayItemNode($value, $key);
         }
 
+        if (is_string($value) && $valueQuoteKind === String_::KIND_SINGLE_QUOTED) {
+            $value = trim($value, "'");
+        }
+
         return new ArrayItemNode($value);
     }
 

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/keep_single_quoted.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/keep_single_quoted.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericSingleImplicitAnnotation;
+
+/**
+ * @GenericSingleImplicitAnnotation('/')
+ */
+final class KeepSingleQuoted
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericSingleImplicitAnnotation;
+
+#[GenericSingleImplicitAnnotation('/')]
+final class KeepSingleQuoted
+{
+}
+
+?>


### PR DESCRIPTION
Single quoted annotation currently convered to:

```diff
-#[GenericSingleImplicitAnnotation('/')]
+#[GenericSingleImplicitAnnotation("'/'")]
```

which should be kept.