### PR TITLE
[Php80] Keep single quoted key: 'value' on AnnotationToAttributeRector

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
@@ -196,12 +196,12 @@ final class ArrayParser
             $key = $rawKey;
         }
 
-        if ($key !== null) {
-            return new ArrayItemNode($value, $key);
-        }
-
         if (is_string($value) && $valueQuoteKind === String_::KIND_SINGLE_QUOTED) {
             $value = trim($value, "'");
+        }
+
+        if ($key !== null) {
+            return new ArrayItemNode($value, $key);
         }
 
         return new ArrayItemNode($value);

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/keep_single_quoted_key_value.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/keep_single_quoted_key_value.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
+
+/**
+ * @GenericAnnotation("sample", itemOperations='yes')
+ */
+final class KeepSingleQuotedKeyValue
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
+
+#[GenericAnnotation('sample', itemOperations: 'yes')]
+final class KeepSingleQuotedKeyValue
+{
+}
+
+?>


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/5214

this is for key: 'value' to be kept on AnnotationToAttributeRector, which currently cause invalid change:

```diff
-#[GenericAnnotation('sample', itemOperations: 'yes')]
+#[GenericAnnotation('sample', itemOperations: "'yes'")]
```