### PR TITLE
[AutoImport] Allow auto import just renamed @var only docblock on RenameClassRector without removeUnusedImports() enabled

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/ClassRenamePhpDocNodeVisitor.php
@@ -15,8 +15,6 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
-use Rector\Core\Configuration\Option;
-use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -77,14 +75,6 @@ final class ClassRenamePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         $identifier = clone $node;
         $identifier->name = $this->resolveNamespacedName($identifier, $currentPhpNode, $node->name);
         $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($identifier, $currentPhpNode);
-
-        $shouldImport = SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_NAMES);
-        $isNoNamespacedName = ! str_starts_with($identifier->name, '\\') && substr_count($identifier->name, '\\') === 0;
-
-        // tweak overlapped import + rename
-        if ($shouldImport && $isNoNamespacedName) {
-            return null;
-        }
 
         // make sure to compare FQNs
         $objectType = $this->expandShortenedObjectType($staticType);

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Interop\Container\ContainerInterface;
+
+/** @var ContainerInterface */
+$container->get('Foo');
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Psr\Container\ContainerInterface;
+
+/** @var ContainerInterface */
+$container->get('Foo');
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock2.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock2.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Interop\Container\ContainerInterface;
+
+/** @var ContainerInterface */
+if ($container instanceof ContainerInterface) {
+    $container->get('Foo');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Psr\Container\ContainerInterface;
+
+/** @var ContainerInterface */
+if ($container instanceof ContainerInterface) {
+    $container->get('Foo');
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock3.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock3.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Interop\Container\ContainerInterface;
+
+if ($container instanceof ContainerInterface) {
+    /** @var ContainerInterface */
+    $container->get('Foo');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use Psr\Container\ContainerInterface;
+
+if ($container instanceof ContainerInterface) {
+    /** @var ContainerInterface */
+    $container->get('Foo');
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock4.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/rename_docblock4.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use DateTime;
+
+if ($var instanceof DateTime) {
+    /** @var DateTime */
+    $var->format('Y-m-d');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNamesWithoutRemoveUnusedImport;
+
+use DateTimeInterface;
+
+if ($var instanceof DateTimeInterface) {
+    /** @var DateTimeInterface */
+    $var->format('Y-m-d');
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
@@ -10,5 +10,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Interop\Container\ContainerInterface' => 'Psr\Container\ContainerInterface',
+        'DateTime' => 'DateTimeInterface',
     ]);
 };

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -53,6 +53,10 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
                 return false;
             }
 
+            if (! str_contains($fullyQualifiedName, '\\')) {
+                return $shortName !== $fullyQualifiedName;
+            }
+
             return $fullyQualifiedObjectType->getClassName() !== $fullyQualifiedName;
         }
 

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -36,6 +36,7 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
         $shortNamesToFullyQualifiedNames = $this->shortNameResolver->resolveFromFile($file);
         $removedUses = $this->renamedClassesDataCollector->getOldClasses();
         $fullyQualifiedObjectTypeShortName = $fullyQualifiedObjectType->getShortName();
+        $className = $fullyQualifiedObjectType->getClassName();
 
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
             if ($fullyQualifiedObjectTypeShortName !== $shortName) {
@@ -53,11 +54,9 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
                 return false;
             }
 
-            if (! str_contains($fullyQualifiedName, '\\')) {
-                return $shortName !== $fullyQualifiedName;
+            if (str_contains($fullyQualifiedName, '\\')) {
+                return $className !== $fullyQualifiedName;
             }
-
-            return $fullyQualifiedObjectType->getClassName() !== $fullyQualifiedName;
         }
 
         return false;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -54,9 +54,11 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
                 return false;
             }
 
-            if (str_contains($fullyQualifiedName, '\\')) {
-                return $className !== $fullyQualifiedName;
+            if (! str_contains($fullyQualifiedName, '\\')) {
+                return false;
             }
+
+            return $className !== $fullyQualifiedName;
         }
 
         return false;

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -39,7 +39,7 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
 
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
             if ($fullyQualifiedObjectTypeShortName !== $shortName) {
-                $shortName = str_contains($shortName, '\\')
+                $shortName = str_starts_with($shortName, '\\')
                     ? ltrim((string) Strings::after($shortName, '\\', -1))
                     : $shortName;
             }

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -40,7 +40,7 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
             if ($fullyQualifiedObjectTypeShortName !== $shortName) {
                 $shortName = str_contains($shortName, '\\')
-                    ? ltrim(Strings::after($shortName, '\\', -1))
+                    ? ltrim((string) Strings::after($shortName, '\\', -1))
                     : $shortName;
             }
 

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -50,15 +50,15 @@ final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImpor
             }
 
             $fullyQualifiedName = ltrim($fullyQualifiedName, '\\');
+            if ($className === $fullyQualifiedName) {
+                return false;
+            }
+
             if (in_array($fullyQualifiedName, $removedUses, true)) {
                 return false;
             }
 
-            if (! str_contains($fullyQualifiedName, '\\')) {
-                return false;
-            }
-
-            return $className !== $fullyQualifiedName;
+            return str_contains($fullyQualifiedName, '\\');
         }
 
         return false;


### PR DESCRIPTION
When `importNames()` enabled, but `removeUnusedImports()` not enabled, the only renamed `@var` should be allowed t be imported.