### PR TITLE
[NodeTypeResolver] Handle nullable extended class on ->isObjectType() on DowngradeReflectionGetAttributesRector

### DIFF
--- a/packages/NodeTypeResolver/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/NodeTypeResolver.php
@@ -438,7 +438,7 @@ final class NodeTypeResolver
             return $this->isMatchObjectWithoutClassType($type, $requiredObjectType);
         }
 
-        return $type->isSuperTypeOf($requiredObjectType)
+        return $requiredObjectType->isSuperTypeOf($type)
             ->yes();
     }
 

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -94,7 +94,10 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
             $this->bootFromConfigFiles([$configFile]);
 
             $rectorsGenerator = $rectorConfig->tagged(RectorInterface::class);
-            $rectors = $rectorsGenerator instanceof RewindableGenerator ? iterator_to_array($rectorsGenerator->getIterator()) : [];
+            $rectors = $rectorsGenerator instanceof RewindableGenerator
+                ? iterator_to_array($rectorsGenerator->getIterator())
+                // no rules at all, e.g. in case of only post rector run
+                : [];
 
             /** @var RectorNodeTraverser $rectorNodeTraverser */
             $rectorNodeTraverser = $rectorConfig->make(RectorNodeTraverser::class);

--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -94,12 +94,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
             $this->bootFromConfigFiles([$configFile]);
 
             $rectorsGenerator = $rectorConfig->tagged(RectorInterface::class);
-            if ($rectorsGenerator instanceof RewindableGenerator) {
-                $rectors = iterator_to_array($rectorsGenerator->getIterator());
-            } else {
-                // no rules at all, e.g. in case of only post rector run
-                $rectors = [];
-            }
+            $rectors = $rectorsGenerator instanceof RewindableGenerator ? iterator_to_array($rectorsGenerator->getIterator()) : [];
 
             /** @var RectorNodeTraverser $rectorNodeTraverser */
             $rectorNodeTraverser = $rectorConfig->make(RectorNodeTraverser::class);
@@ -231,7 +226,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         // the file is now changed (if any rule matches)
         $rectorTestResult = $this->processFilePath($originalFilePath);
 
-        $changedContent = $rectorTestResult->getChangedContents();
+        $changedContents = $rectorTestResult->getChangedContents();
 
         $fixtureFilename = basename($fixtureFilePath);
         $failureMessage = sprintf('Failed on fixture file "%s"', $fixtureFilename);
@@ -247,12 +242,12 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         }
 
         try {
-            $this->assertSame($expectedFileContents, $changedContent, $failureMessage);
+            $this->assertSame($expectedFileContents, $changedContents, $failureMessage);
         } catch (ExpectationFailedException) {
-            FixtureFileUpdater::updateFixtureContent($originalFileContent, $changedContent, $fixtureFilePath);
+            FixtureFileUpdater::updateFixtureContent($originalFileContent, $changedContents, $fixtureFilePath);
 
             // if not exact match, check the regex version (useful for generated hashes/uuids in the code)
-            $this->assertStringMatchesFormat($expectedFileContents, $changedContent, $failureMessage);
+            $this->assertStringMatchesFormat($expectedFileContents, $changedContents, $failureMessage);
         }
     }
 

--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -29,7 +29,7 @@ return static function (RectorConfig $rectorConfig): void {
         new MethodCallRename(DifferentInterface::class, 'renameMe', 'toNewVersion'),
 
         // reflection method name
-        new MethodCallRename(ReflectionMethod::class, 'getTentativeReturnType', 'getReturnType'),
+        new MethodCallRename(ReflectionFunctionAbstract::class, 'getTentativeReturnType', 'getReturnType'),
 
         // with array key
         new MethodCallRenameWithArrayKey('Nette\Utils\Html', 'addToArray', 'addToHtmlArray', 'hey'),

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -22,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/marking_overriden_methods
  * @see \Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\AddOverrideAttributeToOverriddenMethodsRectorTest
  */
-class AddOverrideAttributeToOverriddenMethodsRector extends AbstractRector implements MinPhpVersionInterface
+final class AddOverrideAttributeToOverriddenMethodsRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
@@ -97,22 +97,25 @@ CODE_SAMPLE
 
         $hasChanged = false;
 
-        foreach ($node->getMethods() as $method) {
-            if ($method->name->toString() === '__construct') {
+        foreach ($node->getMethods() as $classMethod) {
+            if ($classMethod->name->toString() === '__construct') {
                 continue;
             }
+
             // Private methods should be ignored
-            if ($parentClassReflection->hasNativeMethod($method->name->toString())) {
+            if ($parentClassReflection->hasNativeMethod($classMethod->name->toString())) {
                 // ignore if it is a private method on the parent
-                $parentMethod = $parentClassReflection->getNativeMethod($method->name->toString());
+                $parentMethod = $parentClassReflection->getNativeMethod($classMethod->name->toString());
                 if ($parentMethod->isPrivate()) {
                     continue;
                 }
+
                 // ignore if it already uses the attribute
-                if ($this->phpAttributeAnalyzer->hasPhpAttribute($method, 'Override')) {
+                if ($this->phpAttributeAnalyzer->hasPhpAttribute($classMethod, 'Override')) {
                     continue;
                 }
-                $method->attrGroups[] = new AttributeGroup([new Attribute(new FullyQualified('Override'))]);
+
+                $classMethod->attrGroups[] = new AttributeGroup([new Attribute(new FullyQualified('Override'))]);
                 $hasChanged = true;
             }
         }
@@ -134,6 +137,7 @@ CODE_SAMPLE
         if ($this->classAnalyzer->isAnonymousClass($class)) {
             return true;
         }
+
         if (! $class->extends instanceof FullyQualified) {
             return true;
         }

--- a/tests/Issues/DowngradeNullableReflectionProperty/DowngradeNullableReflectionPropertyTest.php
+++ b/tests/Issues/DowngradeNullableReflectionProperty/DowngradeNullableReflectionPropertyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\DowngradeNullableReflectionProperty;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeNullableReflectionPropertyTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DowngradeNullableReflectionProperty/Fixture/use_nullable_reflection_property.php.inc
+++ b/tests/Issues/DowngradeNullableReflectionProperty/Fixture/use_nullable_reflection_property.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\DowngradeNullableReflectionProperty\Fixture;
+
+class UseNullableReflectionProperty
+{
+    public function run(?\ReflectionProperty $reflectionProperty)
+    {
+        if ($reflectionProperty->getAttributes('SomeAttribute')[0] ?? null) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\DowngradeNullableReflectionProperty\Fixture;
+
+class UseNullableReflectionProperty
+{
+    public function run(?\ReflectionProperty $reflectionProperty)
+    {
+        if ((method_exists($reflectionProperty, 'getAttributes') ? $reflectionProperty->getAttributes('SomeAttribute') : [])[0] ?? null) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+?>

--- a/tests/Issues/DowngradeNullableReflectionProperty/config/configured_rule.php
+++ b/tests/Issues/DowngradeNullableReflectionProperty/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp80\Rector\MethodCall\DowngradeReflectionGetAttributesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeReflectionGetAttributesRector::class);
+};


### PR DESCRIPTION
@malteschlueter @TomasVotruba let see if nullable extended class can be checked via `isObjectType()`, ref 

https://github.com/rectorphp/rector-downgrade-php/pull/203#pullrequestreview-1713160725
Closes https://github.com/rectorphp/rector-downgrade-php/pull/203

