### PR TITLE
Remove `ArraySpreadInsteadOfArrayMergeRector` from `LevelSetList::UP_TO_PHP_74`

### DIFF
--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -39,7 +39,6 @@ return static function (RectorConfig $rectorConfig): void {
         RealToFloatTypeCastRector::class,
         NullCoalescingOperatorRector::class,
         ClosureToArrowFunctionRector::class,
-        ArraySpreadInsteadOfArrayMergeRector::class,
         AddLiteralSeparatorToNumberRector::class,
         RestoreDefaultNullToNullableTypePropertyRector::class,
         CurlyToSquareBracketArrayStringRector::class,


### PR DESCRIPTION


closes https://github.com/rectorphp/rector/issues/8292