### PR TITLE
RestoreDefaultNullToNullableTypePropertyRector: skip `@readonly` phpdoc

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_phpdoc.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_phpdoc.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+final class SkipReadonly
+{
+    public const LEVEL_NONE = 'none';
+
+    private const LEVEL_SHORT_TERM = 'short-term';
+
+    public const LEVELS = [
+        self::LEVEL_NONE => self::LEVEL_NONE,
+        self::LEVEL_SHORT_TERM => self::LEVEL_SHORT_TERM,
+    ];
+
+    /**
+     * @var self::LEVEL_*|null
+     *
+     * @readonly
+     */
+    private ?string $level;
+
+    private function __construct(string $level)
+    {
+        if (isset(self::LEVELS[$level])) {
+            $this->level = self::LEVELS[$level];
+        } else {
+            $this->level = null;
+        }
+    }
+
+}

--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_phpdoc.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_readonly_phpdoc.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
 
-final class SkipReadonly
+final class SkipReadonlyPhpdoc
 {
     public const LEVEL_NONE = 'none';
 

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -106,7 +106,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($property->isReadonly()) {
+        if ($this->isReadonly($property)) {
             return true;
         }
 
@@ -117,5 +117,17 @@ CODE_SAMPLE
         // is variable assigned in constructor
         $propertyName = $this->getName($property);
         return $this->constructorAssignDetector->isPropertyAssigned($class, $propertyName);
+    }
+
+    private function isReadonly(Property $property): bool {
+        // native readonly
+        if ($property->isReadonly()) {
+            return true;
+        }
+
+        // @readonly annotation
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+        $tags = $phpDocInfo->getTagsByName('@readonly');
+        return $tags !== [];
     }
 }


### PR DESCRIPTION
before this fix rector changed the code in a way which makes phpstan error

>  @readonly property cannot have a default value.

https://getrector.com/demo/3501e2b7-8e44-44fa-8d2f-b954e3320d60
https://phpstan.org/r/19c64f77-e460-43c8-b504-70f73f3446e6