### PR TITLE
[Utils] Cleap up MissingInSetCommand skipped rules constant

### DIFF
--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -8,7 +8,6 @@ use Nette\Utils\Strings;
 use Rector\CodingStyle\Rector\Switch_\BinarySwitchToIfElseRector;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\RemoveSetMethodsMethodCallRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenCollectorRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorReadonlyClassRector;
@@ -39,9 +38,6 @@ final class MissingInSetCommand extends Command
         TypedPropertyFromStrictConstructorReadonlyClassRector::class,
         BinarySwitchToIfElseRector::class,
         CountOnNullRector::class,
-
-        // namespace to be moved from CodeQuality to PHPUnit100
-        RemoveSetMethodsMethodCallRector::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
Ref rector-phpunit:

- https://github.com/rectorphp/rector-phpunit/pull/294