### PR TITLE
Bump to reactphp/event-loop ^1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.23",
         "phpstan/phpstan": "^1.10.35",
-        "react/event-loop": "^1.3",
+        "react/event-loop": "^1.5",
         "react/promise": "^2.10",
         "react/socket": "^1.12",
         "rector/extension-installer": "^0.11.2",


### PR DESCRIPTION
It include performance improvement by using `spl_object_id()` instead of `spl_object_hash()`

https://github.com/reactphp/event-loop/releases/tag/v1.5.0


From PR:

- https://github.com/reactphp/event-loop/pull/267