### PR TITLE
[CodingStyle] Refactor UseImportsAdder to return [FileWithoutNamespace] code on no namespaced code

### DIFF
--- a/packages/PostRector/Rector/NameImportingPostRector.php
+++ b/packages/PostRector/Rector/NameImportingPostRector.php
@@ -94,14 +94,8 @@ final class NameImportingPostRector extends AbstractPostRector
 
         $namespaces = array_filter(
             $file->getNewStmts(),
-            static fn (Stmt $stmt): bool => $stmt instanceof Namespace_ || $stmt instanceof FileWithoutNamespace
+            static fn (Stmt $stmt): bool => $stmt instanceof Namespace_
         );
-
-        // handle overlapped resolve last new stmts
-        // @see https://github.com/rectorphp/rector-src/pull/5251
-        if ($namespaces === []) {
-            return null;
-        }
 
         if (count($namespaces) > 1) {
             return null;

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -58,7 +58,7 @@ final class UseImportsAdder
 
         $newUses = $this->createUses($useImportTypes, $constantUseImportTypes, $functionUseImportTypes, null);
         if ($newUses === []) {
-            return $stmts;
+            return [$fileWithoutNamespace];
         }
 
         // place after declare strict_types
@@ -78,7 +78,7 @@ final class UseImportsAdder
                 $fileWithoutNamespace->stmts = $stmts;
                 $fileWithoutNamespace->stmts = array_values($fileWithoutNamespace->stmts);
 
-                return $fileWithoutNamespace->stmts;
+                return [$fileWithoutNamespace];
             }
         }
 
@@ -88,7 +88,7 @@ final class UseImportsAdder
         $fileWithoutNamespace->stmts = array_merge($newUses, $stmts);
         $fileWithoutNamespace->stmts = array_values($fileWithoutNamespace->stmts);
 
-        return $fileWithoutNamespace->stmts;
+        return [$fileWithoutNamespace];
     }
 
     /**

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Rector\Core\Rector;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\InlineHTML;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -20,7 +18,6 @@ use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
-use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -333,27 +330,5 @@ CODE_SAMPLE;
         }
 
         return false;
-    }
-
-    /**
-     * @return Node[]|null
-     */
-    public function afterTraverse(array $nodes): ?array
-    {
-        foreach ($nodes as $node) {
-            if ($node instanceof Namespace_) {
-                return parent::afterTraverse($nodes);
-            }
-
-            if ($node instanceof FileWithoutNamespace) {
-                return parent::afterTraverse($nodes);
-            }
-        }
-
-        /** @var Stmt[] $nodes */
-        $newNodes = [new FileWithoutNamespace($nodes)];
-        $this->file->changeNewStmts($newNodes);
-
-        return parent::afterTraverse($newNodes);
     }
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\Core\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\InlineHTML;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -18,6 +20,7 @@ use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeDecorator\CreatedByRuleDecorator;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -330,5 +333,27 @@ CODE_SAMPLE;
         }
 
         return false;
+    }
+
+    /**
+     * @return Node[]|null
+     */
+    public function afterTraverse(array $nodes): ?array
+    {
+        foreach ($nodes as $node) {
+            if ($node instanceof Namespace_) {
+                return parent::afterTraverse($nodes);
+            }
+
+            if ($node instanceof FileWithoutNamespace) {
+                return parent::afterTraverse($nodes);
+            }
+        }
+
+        /** @var Stmt[] $nodes */
+        $newNodes = [new FileWithoutNamespace($nodes)];
+        $this->file->changeNewStmts($newNodes);
+
+        return parent::afterTraverse($newNodes);
     }
 }


### PR DESCRIPTION
@TomasVotruba @staabm this is refactored version of patch on:

- https://github.com/rectorphp/rector-src/pull/5251

which ensure `[FileWithoutNamespace]` always set on UseImportsAdder