### PR TITLE
[Renaming] FQN-ize namespaced import no namespace -> namespaced name on RenameClassRector

### DIFF
--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -107,6 +107,19 @@ final class UseAddingPostRector extends AbstractPostRector
         // B. no namespace? add in the top
         $useImportTypes = $this->filterOutNonNamespacedNames($useImportTypes);
 
+        $namespaces = array_filter($nodes, fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
+        if ($namespaces !== []) {
+            // then add, to prevent adding + removing false positive of same short use
+            $this->useImportsAdder->addImportsToNamespace(
+                current($namespaces),
+                $useImportTypes,
+                $constantUseImportTypes,
+                $functionUseImportTypes
+            );
+
+            return $nodes;
+        }
+
         // then add, to prevent adding + removing false positive of same short use
         return $this->useImportsAdder->addImportsToStmts(
             $namespace,

--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -107,7 +107,7 @@ final class UseAddingPostRector extends AbstractPostRector
         // B. no namespace? add in the top
         $useImportTypes = $this->filterOutNonNamespacedNames($useImportTypes);
 
-        $namespaces = array_filter($nodes, fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
+        $namespaces = array_filter($nodes, static fn(Stmt $stmt): bool => $stmt instanceof Namespace_);
         if ($namespaces !== []) {
             // then add, to prevent adding + removing false positive of same short use
             $this->useImportsAdder->addImportsToNamespace(

--- a/packages/PostRector/Rector/UseAddingPostRector.php
+++ b/packages/PostRector/Rector/UseAddingPostRector.php
@@ -104,9 +104,7 @@ final class UseAddingPostRector extends AbstractPostRector
             return $nodes;
         }
 
-        // B. no namespace? add in the top
-        $useImportTypes = $this->filterOutNonNamespacedNames($useImportTypes);
-
+        // just renamed no-namepaced class to namespaced class
         $namespaces = array_filter($nodes, static fn(Stmt $stmt): bool => $stmt instanceof Namespace_);
         if ($namespaces !== []) {
             // then add, to prevent adding + removing false positive of same short use
@@ -119,6 +117,9 @@ final class UseAddingPostRector extends AbstractPostRector
 
             return $nodes;
         }
+
+        // B. no namespace? add in the top
+        $useImportTypes = $this->filterOutNonNamespacedNames($useImportTypes);
 
         // then add, to prevent adding + removing false positive of same short use
         return $this->useImportsAdder->addImportsToStmts(

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/fqnize_namespaced_import.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/fqnize_namespaced_import.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+class FqnizeNamespacedImport
+{
+    public function run(DateTime $d)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Abc;
+
+use DateTimeInterface;
+class FqnizeNamespacedImport
+{
+    public function run(DateTimeInterface $d)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/fqnize_namespaced_import2.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNamesWithoutRemoveUnusedImport/fqnize_namespaced_import2.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Abc2;
+
+class FqnizeNamespacedImport2
+{
+    public function run(\DateTime $d)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Abc;
+
+use DateTimeInterface;
+class FqnizeNamespacedImport2
+{
+    public function run(DateTimeInterface $d)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
@@ -11,6 +11,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Interop\Container\ContainerInterface' => 'Psr\Container\ContainerInterface',
         'DateTime' => 'DateTimeInterface',
+        'FqnizeNamespacedImport' => 'Abc\FqnizeNamespacedImport',
         /**
          * This test never renamed as it is annotation @IsGranted
          *

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/auto_import_names_without_remove_unused_use.php
@@ -12,6 +12,7 @@ return static function (RectorConfig $rectorConfig): void {
         'Interop\Container\ContainerInterface' => 'Psr\Container\ContainerInterface',
         'DateTime' => 'DateTimeInterface',
         'FqnizeNamespacedImport' => 'Abc\FqnizeNamespacedImport',
+        'Abc2\FqnizeNamespacedImport2' => 'Abc\FqnizeNamespacedImport2',
         /**
          * This test never renamed as it is annotation @IsGranted
          *


### PR DESCRIPTION
On changing no namespaced class to namespaced class, it cause no-imported name which should be imported to ensure it pointed to correct name.