### PR TITLE
[TypeDeclaration] Skip default not array type on StrictArrayParamDimFetchRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/skip_default_not_array_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/skip_default_not_array_type.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector\Fixture;
+
+final class SkipDefaultNotArrayType
+{
+    public function run($param = 'foo')
+    {
+	 if (isset($param['bar'])) {
+            echo $param['bar'];
+        }
+
+        echo $param;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/with_default_not_array_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/with_default_not_array_type.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector\Fixture;
+
+final class WithDefaultArrayType
+{
+    public function run($param = [])
+    {
+	 if (isset($param['bar'])) {
+            echo $param['bar'];
+        }
+
+        echo $param;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector\Fixture;
+
+final class WithDefaultArrayType
+{
+    public function run(array $param = [])
+    {
+	 if (isset($param['bar'])) {
+            echo $param['bar'];
+        }
+
+        echo $param;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\AssignOp\Coalesce as AssignOpCoalesce;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
@@ -84,6 +85,10 @@ CODE_SAMPLE
 
         foreach ($node->getParams() as $param) {
             if ($param->type instanceof Node) {
+                continue;
+            }
+
+            if ($param->default instanceof Expr && ! $this->getType($param->default)->isArray()->yes()) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8317