### PR TITLE
[Performance][Renaming] Use FullyQualified on RenameClassRector

### DIFF
--- a/packages/NodeTypeResolver/Node/AttributeKey.php
+++ b/packages/NodeTypeResolver/Node/AttributeKey.php
@@ -255,11 +255,6 @@ final class AttributeKey
     /**
      * @var string
      */
-    public const IS_NAMESPACE_NAME = 'is_namespace_name';
-
-    /**
-     * @var string
-     */
     public const IS_USEUSE_NAME = 'is_useuse_name';
 
     /**

--- a/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/NameNodeVisitor.php
+++ b/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/NameNodeVisitor.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
 use PhpParser\NodeVisitorAbstract;
@@ -21,11 +20,6 @@ final class NameNodeVisitor extends NodeVisitorAbstract implements ScopeResolver
 {
     public function enterNode(Node $node): ?Node
     {
-        if ($node instanceof Namespace_ && $node->name instanceof Name) {
-            $node->name->setAttribute(AttributeKey::IS_NAMESPACE_NAME, true);
-            return null;
-        }
-
         if ($node instanceof UseUse && ($node->type === Use_::TYPE_NORMAL || $node->type === Use_::TYPE_UNKNOWN)) {
             $node->name->setAttribute(AttributeKey::IS_USEUSE_NAME, true);
             return null;

--- a/packages/PostRector/Rector/ClassRenamingPostRector.php
+++ b/packages/PostRector/Rector/ClassRenamingPostRector.php
@@ -64,9 +64,11 @@ final class ClassRenamingPostRector extends AbstractPostRector
 
         /** @var Scope|null $scope */
         $scope = $node->getAttribute(AttributeKey::SCOPE);
-        $result = $this->classRenamer->renameNode($node, $oldToNewClasses, $scope);
+        $result = null;
 
-        if (! $result instanceof Name && ! $node instanceof FullyQualified) {
+        if ($node instanceof FullyQualified) {
+            $result = $this->classRenamer->renameNode($node, $oldToNewClasses, $scope);
+        } else {
             $phpAttributeName = $node->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
             if (is_string($phpAttributeName)) {
                 $result = $this->classRenamer->renameNode(

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -6,7 +6,7 @@ namespace Rector\Renaming\Rector\Name;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Expression;
@@ -90,7 +90,7 @@ CODE_SAMPLE
     public function getNodeTypes(): array
     {
         return [
-            Name::class,
+            FullyQualified::class,
             Property::class,
             FunctionLike::class,
             Expression::class,
@@ -101,7 +101,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param FunctionLike|Name|ClassLike|Expression|Namespace_|Property|If_ $node
+     * @param FunctionLike|FullyQualified|ClassLike|Expression|Namespace_|Property|If_ $node
      */
     public function refactor(Node $node): ?Node
     {


### PR DESCRIPTION
By this, we can remove unused attribute  `IS_NAMESPACE_NAME` as it always a `Name` instead of `FullyQualified. 

For renaming by namespace, it renamed from `Namespace_` node on `getNodeTypes()` already.