### PR TITLE
[AutoImport] Handle complex usage of multiple @\ combined with other doc

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -169,7 +169,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                 unset($phpDocNode->children[$key]);
                 array_splice($phpDocNode->children, $key, 0, $spacelessPhpDocTagNodes);
 
-                $key = $key + count($spacelessPhpDocTagNodes);
+                $key += count($spacelessPhpDocTagNodes);
 
                 continue;
             }
@@ -179,47 +179,40 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             }
 
             if (! $phpDocChildNode->value instanceof GenericTagValueNode) {
-                if (! isset($phpDocChildNode->value->description)) {
+                if (!property_exists($phpDocChildNode->value, 'description')) {
                     continue;
                 }
-
+                if ($phpDocChildNode->value->description === null) {
+                    continue;
+                }
                 $description = $phpDocChildNode->value->description;
-                if (! str_contains($description, "\n")) {
+                if (! str_contains((string) $description, "\n")) {
                     continue;
                 }
-
                 $textNode = new PhpDocTextNode($description);
                 $startAndEnd = $phpDocChildNode->value->getAttribute(PhpDocAttributeKey::START_AND_END);
                 if (! $startAndEnd instanceof StartAndEnd) {
                     continue;
                 }
-
                 $textNode->setAttribute(PhpDocAttributeKey::START_AND_END, $startAndEnd);
                 $spacelessPhpDocTagNodes = $this->resolveFqnAnnotationSpacelessPhpDocTagNode(
                     $textNode,
                     $currentPhpNode
                 );
-
                 if ($spacelessPhpDocTagNodes === []) {
                     continue;
                 }
-
                 $unsetKey = $phpDocNode->children[$key] instanceof SpacelessPhpDocTagNode
                     ? $key + count($spacelessPhpDocTagNodes)
                     : $key;
-
                 unset($phpDocNode->children[$unsetKey]);
-
                 $classNode = new PhpDocTagNode($phpDocChildNode->name, $phpDocChildNode->value);
                 $description = Strings::replace($description, self::LONG_ANNOTATION_REGEX, '');
-                $description = trim(str_replace("\n *", '', $description));
+                $description = trim(str_replace("\n *", '', (string) $description));
                 $classNode->value->description = $description;
                 $phpDocNode->children[$unsetKey] = $classNode;
-
                 array_splice($phpDocNode->children, $unsetKey + 1, 0, $spacelessPhpDocTagNodes);
-
-                $key = $key + count($spacelessPhpDocTagNodes);
-
+                $key += count($spacelessPhpDocTagNodes);
                 continue;
             }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -179,40 +179,50 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             }
 
             if (! $phpDocChildNode->value instanceof GenericTagValueNode) {
-                if (!property_exists($phpDocChildNode->value, 'description')) {
+                if (! property_exists($phpDocChildNode->value, 'description')) {
                     continue;
                 }
+
                 if ($phpDocChildNode->value->description === null) {
                     continue;
                 }
+
                 $description = $phpDocChildNode->value->description;
                 if (! str_contains((string) $description, "\n")) {
                     continue;
                 }
+
                 $textNode = new PhpDocTextNode($description);
                 $startAndEnd = $phpDocChildNode->value->getAttribute(PhpDocAttributeKey::START_AND_END);
                 if (! $startAndEnd instanceof StartAndEnd) {
                     continue;
                 }
+
                 $textNode->setAttribute(PhpDocAttributeKey::START_AND_END, $startAndEnd);
                 $spacelessPhpDocTagNodes = $this->resolveFqnAnnotationSpacelessPhpDocTagNode(
                     $textNode,
                     $currentPhpNode
                 );
+
                 if ($spacelessPhpDocTagNodes === []) {
                     continue;
                 }
+
                 $unsetKey = $phpDocNode->children[$key] instanceof SpacelessPhpDocTagNode
                     ? $key + count($spacelessPhpDocTagNodes)
                     : $key;
+
                 unset($phpDocNode->children[$unsetKey]);
+
                 $classNode = new PhpDocTagNode($phpDocChildNode->name, $phpDocChildNode->value);
                 $description = Strings::replace($description, self::LONG_ANNOTATION_REGEX, '');
                 $description = trim(str_replace("\n *", '', (string) $description));
-                $classNode->value->description = $description;
+                $phpDocChildNode->value->description = $description;
                 $phpDocNode->children[$unsetKey] = $classNode;
+
                 array_splice($phpDocNode->children, $unsetKey + 1, 0, $spacelessPhpDocTagNodes);
                 $key += count($spacelessPhpDocTagNodes);
+
                 continue;
             }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -179,50 +179,12 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             }
 
             if (! $phpDocChildNode->value instanceof GenericTagValueNode) {
-                if (! property_exists($phpDocChildNode->value, 'description')) {
-                    continue;
-                }
-
-                if ($phpDocChildNode->value->description === null) {
-                    continue;
-                }
-
-                $description = $phpDocChildNode->value->description;
-                if (! str_contains((string) $description, "\n")) {
-                    continue;
-                }
-
-                $textNode = new PhpDocTextNode($description);
-                $startAndEnd = $phpDocChildNode->value->getAttribute(PhpDocAttributeKey::START_AND_END);
-                if (! $startAndEnd instanceof StartAndEnd) {
-                    continue;
-                }
-
-                $textNode->setAttribute(PhpDocAttributeKey::START_AND_END, $startAndEnd);
-                $spacelessPhpDocTagNodes = $this->resolveFqnAnnotationSpacelessPhpDocTagNode(
-                    $textNode,
-                    $currentPhpNode
+                $key = $this->processDescriptionAsSpacelessPhpDoctagNode(
+                    $phpDocNode,
+                    $phpDocChildNode,
+                    $currentPhpNode,
+                    $key
                 );
-
-                if ($spacelessPhpDocTagNodes === []) {
-                    continue;
-                }
-
-                $unsetKey = $phpDocNode->children[$key] instanceof SpacelessPhpDocTagNode
-                    ? $key + count($spacelessPhpDocTagNodes)
-                    : $key;
-
-                unset($phpDocNode->children[$unsetKey]);
-
-                $classNode = new PhpDocTagNode($phpDocChildNode->name, $phpDocChildNode->value);
-                $description = Strings::replace($description, self::LONG_ANNOTATION_REGEX, '');
-                $description = trim(str_replace("\n *", '', (string) $description));
-                $phpDocChildNode->value->description = $description;
-                $phpDocNode->children[$unsetKey] = $classNode;
-
-                array_splice($phpDocNode->children, $unsetKey + 1, 0, $spacelessPhpDocTagNodes);
-                $key += count($spacelessPhpDocTagNodes);
-
                 continue;
             }
 
@@ -251,6 +213,54 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             $this->attributeMirrorer->mirror($phpDocChildNode, $spacelessPhpDocTagNode);
             $phpDocNode->children[$key] = $spacelessPhpDocTagNode;
         }
+    }
+
+    private function processDescriptionAsSpacelessPhpDoctagNode(
+        PhpDocNode $phpDocNode,
+        PhpDocTagNode $phpDocTagNode,
+        Node $currentPhpNode,
+        int $key
+    ): int {
+        if (! property_exists($phpDocTagNode->value, 'description')) {
+            return $key;
+        }
+
+        $description = (string) $phpDocTagNode->value->description;
+        if (! str_contains($description, "\n")) {
+            return $key;
+        }
+
+        $phpDocTextNode = new PhpDocTextNode($description);
+        $startAndEnd = $phpDocTagNode->value->getAttribute(PhpDocAttributeKey::START_AND_END);
+        if (! $startAndEnd instanceof StartAndEnd) {
+            return $key;
+        }
+
+        $phpDocTextNode->setAttribute(PhpDocAttributeKey::START_AND_END, $startAndEnd);
+        $spacelessPhpDocTagNodes = $this->resolveFqnAnnotationSpacelessPhpDocTagNode(
+            $phpDocTextNode,
+            $currentPhpNode
+        );
+
+        if ($spacelessPhpDocTagNodes === []) {
+            return $key;
+        }
+
+        $unsetKey = $phpDocNode->children[$key] instanceof SpacelessPhpDocTagNode
+            ? $key + count($spacelessPhpDocTagNodes)
+            : $key;
+
+        unset($phpDocNode->children[$unsetKey]);
+
+        $classNode = new PhpDocTagNode($phpDocTagNode->name, $phpDocTagNode->value);
+        $description = Strings::replace($description, self::LONG_ANNOTATION_REGEX, '');
+        $description = trim(str_replace("\n *", '', $description));
+        $phpDocTagNode->value->description = $description;
+        $phpDocNode->children[$unsetKey] = $classNode;
+
+        array_splice($phpDocNode->children, $unsetKey + 1, 0, $spacelessPhpDocTagNodes);
+
+        return $key + count($spacelessPhpDocTagNodes);
     }
 
     /**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -106,6 +106,7 @@ parameters:
                 - packages/NodeNameResolver/NodeNameResolver.php
                 - utils/ChangelogGenerator/Command/
                 - packages/BetterPhpDocParser/PhpDocParser/BetterPhpDocParser.php
+                - packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
 
         # known types
         - '#Call to an undefined method PHPStan\\Type\\ConstantType\:\:getValue\(\)#'

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_next_doc_other_routes.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_next_doc_other_routes.php.inc
@@ -29,7 +29,7 @@ class TwoRoutesWithNextDoc2
      * @Route("/first", methods={"GET"})
      * @Route("/second", methods={"GET"})
      * @return Response
-     * @\Symfony\Component\Routing\Annotation\Route("/third", methods={"GET"})
+     * @Route("/third", methods={"GET"})
      */
     public function some(): Response
     {

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc.php.inc
@@ -14,3 +14,25 @@ class TwoRoutesWithPrevDoc
         return new Response();
     }
 }
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use Symfony\Component\Routing\Annotation\Route;
+class TwoRoutesWithPrevDoc
+{
+    /**
+     * @return Response
+     * @Route("/first", methods={"GET"})
+     * @Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba this is continue of PR:

- https://github.com/rectorphp/rector-src/pull/5271

to handle complex usage of `@\` combined with other docblocks.