### PR TITLE
[AutoImport] Handle multi @\ usage on multiline description

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -254,7 +254,8 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
 
         $classNode = new PhpDocTagNode($phpDocTagNode->name, $phpDocTagNode->value);
         $description = Strings::replace($description, self::LONG_ANNOTATION_REGEX, '');
-        $description = trim(str_replace("\n *", '', $description));
+        $description = substr($description, 0, -7);
+
         $phpDocTagNode->value->description = $description;
         $phpDocNode->children[$unsetKey] = $classNode;
 

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc_with_description_multiline.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc_with_description_multiline.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+class TwoRoutesWithPrevDocWithDescriptionMultiline
+{
+    /**
+     * @return Response line 1
+     *     line 2
+     *      line 3
+     * @\Symfony\Component\Routing\Annotation\Route("/first", methods={"GET"})
+     * @\Symfony\Component\Routing\Annotation\Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use Symfony\Component\Routing\Annotation\Route;
+class TwoRoutesWithPrevDocWithDescriptionMultiline
+{
+    /**
+     * @return Response line 1
+     *     line 2
+     *      line 3
+     * @Route("/first", methods={"GET"})
+     * @Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba this is continue of PR:

- https://github.com/rectorphp/rector-src/pull/5273

to handle complex usage of `@\` combined with other docblocks with multiline description.