### PR TITLE
[AutoImport] Handle multile @\ with comment before

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -166,7 +166,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
         }
 
         $otherText = Strings::replace($phpDocTextNode->text, self::LONG_ANNOTATION_REGEX, '');
-        if ($otherText !== "\n") {
+        if (! in_array($otherText, ["\n", ""], true)) {
             $phpDocNode->children[$key] = new PhpDocTextNode($otherText);
             array_splice($phpDocNode->children, $key + 1, 0, $spacelessPhpDocTagNodes);
 

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -150,6 +150,37 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
         }
     }
 
+    private function processTextSpacelessInTextNode(
+        PhpDocNode $phpDocNode,
+        PhpDocTextNode $phpDocTextNode,
+        Node $currentPhpNode,
+        int $key
+    ): int {
+        $spacelessPhpDocTagNodes = $this->resolveFqnAnnotationSpacelessPhpDocTagNode(
+            $phpDocTextNode,
+            $currentPhpNode
+        );
+
+        if ($spacelessPhpDocTagNodes === []) {
+            return $key;
+        }
+
+        $otherText = Strings::replace($phpDocTextNode->text, self::LONG_ANNOTATION_REGEX, '');
+        if ($otherText !== "\n") {
+            $phpDocNode->children[$key] = new PhpDocTextNode($otherText);
+            array_splice($phpDocNode->children, $key + 1, 0, $spacelessPhpDocTagNodes);
+
+            $key += count($spacelessPhpDocTagNodes);
+        } else {
+            unset($phpDocNode->children[$key]);
+            array_splice($phpDocNode->children, $key, 0, $spacelessPhpDocTagNodes);
+
+            $key += count($spacelessPhpDocTagNodes) - 1;
+        }
+
+        return $key;
+    }
+
     private function transformGenericTagValueNodesToDoctrineAnnotationTagValueNodes(
         PhpDocNode $phpDocNode,
         Node $currentPhpNode
@@ -157,20 +188,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
         foreach ($phpDocNode->children as $key => $phpDocChildNode) {
             // the @\FQN use case
             if ($phpDocChildNode instanceof PhpDocTextNode) {
-                $spacelessPhpDocTagNodes = $this->resolveFqnAnnotationSpacelessPhpDocTagNode(
-                    $phpDocChildNode,
-                    $currentPhpNode
-                );
-
-                if ($spacelessPhpDocTagNodes === []) {
-                    continue;
-                }
-
-                unset($phpDocNode->children[$key]);
-                array_splice($phpDocNode->children, $key, 0, $spacelessPhpDocTagNodes);
-
-                $key += count($spacelessPhpDocTagNodes);
-
+                $key = $this->processTextSpacelessInTextNode($phpDocNode, $phpDocChildNode, $currentPhpNode, $key);
                 continue;
             }
 

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_comment_before.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_comment_before.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
 class TwoRoutesWithCommentBefore
 {
     /**
-     * Test
+     * Testsssssssssss
      *
      * @\Symfony\Component\Routing\Annotation\Route("/first", methods={"GET"})
      * @\Symfony\Component\Routing\Annotation\Route("/second", methods={"GET"})
@@ -26,8 +26,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesWithCommentBefore
 {
     /**
-     * Test
-     *
+     * Testsssssssssss
      * @Route("/first", methods={"GET"})
      * @Route("/second", methods={"GET"})
      */

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_comment_before.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_comment_before.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+class TwoRoutesWithCommentBefore
+{
+    /**
+     * Test
+     *
+     * @\Symfony\Component\Routing\Annotation\Route("/first", methods={"GET"})
+     * @\Symfony\Component\Routing\Annotation\Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use Symfony\Component\Routing\Annotation\Route;
+class TwoRoutesWithCommentBefore
+{
+    /**
+     * Test
+     *
+     * @Route("/first", methods={"GET"})
+     * @Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/5274

this handle multiple `@\` with comment before.