### PR TITLE
[AutoImport] Handle multiple @\ before GenericTagValueNode

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -185,10 +185,12 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
         PhpDocNode $phpDocNode,
         Node $currentPhpNode
     ): void {
+        $lastKey = 0;
         foreach ($phpDocNode->children as $key => $phpDocChildNode) {
             // the @\FQN use case
             if ($phpDocChildNode instanceof PhpDocTextNode) {
                 $key = $this->processTextSpacelessInTextNode($phpDocNode, $phpDocChildNode, $currentPhpNode, $key);
+                $lastKey = $key;
                 continue;
             }
 
@@ -203,6 +205,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                     $currentPhpNode,
                     $key
                 );
+                $lastKey = $key;
                 continue;
             }
 
@@ -229,6 +232,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             );
 
             $this->attributeMirrorer->mirror($phpDocChildNode, $spacelessPhpDocTagNode);
+            $key = $lastKey === 0 ? $key : $lastKey + 1;
             $phpDocNode->children[$key] = $spacelessPhpDocTagNode;
         }
     }

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -185,12 +185,10 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
         PhpDocNode $phpDocNode,
         Node $currentPhpNode
     ): void {
-        $lastKey = 0;
         foreach ($phpDocNode->children as $key => $phpDocChildNode) {
             // the @\FQN use case
             if ($phpDocChildNode instanceof PhpDocTextNode) {
                 $key = $this->processTextSpacelessInTextNode($phpDocNode, $phpDocChildNode, $currentPhpNode, $key);
-                $lastKey = $key;
                 continue;
             }
 
@@ -205,7 +203,6 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                     $currentPhpNode,
                     $key
                 );
-                $lastKey = $key;
                 continue;
             }
 
@@ -232,7 +229,11 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             );
 
             $this->attributeMirrorer->mirror($phpDocChildNode, $spacelessPhpDocTagNode);
-            $key = $lastKey === 0 ? $key : $lastKey + 1;
+
+            while (isset($phpDocNode->children[$key]) && $phpDocNode->children[$key] !== $phpDocChildNode) {
+                ++$key;
+            }
+
             $phpDocNode->children[$key] = $spacelessPhpDocTagNode;
         }
     }

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_before_generic.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_before_generic.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+class TwoRoutesBeforeGeneric
+{
+    /**
+     * @\Symfony\Component\Routing\Annotation\Route("/first", methods={"GET"})
+     * @\Symfony\Component\Routing\Annotation\Route("/second", methods={"GET"})
+     * @OA\Property(
+     *     type="array",
+     *     @OA\Items(ref=@Model(type=TestItem::class))
+     * )
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use Symfony\Component\Routing\Annotation\Route;
+class TwoRoutesBeforeGeneric
+{
+    /**
+     * @Route("/first", methods={"GET"})
+     * @Route("/second", methods={"GET"})
+     * @OA\Property(
+     *     type="array",
+     *     @OA\Items(ref=@Model(type=TestItem::class))
+     * )
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/5275

this handle multiple `@\` before `GenericTagValueNode`