### PR TITLE
[AutoImport] Handle multiple @\ after GenericTagValueNode

### DIFF
--- a/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
+++ b/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
@@ -22,7 +22,7 @@ final class ArrayItemNode implements PhpDocTagValueNode, Stringable
     {
         $value = '';
 
-        if ($this->key !== null) {
+        if ($this->key !== null && ! is_numeric($this->key)) {
             $value .= $this->key . '=';
         }
 

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -270,8 +270,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             );
 
             $this->attributeMirrorer->mirror($phpDocNode->children[$key], $spacelessPhpDocTagNode);
-
-         //   $phpDocNode->children[$key] = $spacelessPhpDocTagNode;
+            $phpDocNode->children[$key] = $spacelessPhpDocTagNode;
 
             array_splice($phpDocNode->children, $key + 1, 0, $spacelessPhpDocTagNodes);
         }

--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -22,6 +22,7 @@ use Rector\BetterPhpDocParser\ValueObject\DoctrineAnnotation\SilentKeyMap;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 use Rector\BetterPhpDocParser\ValueObject\StartAndEnd;
 use Rector\Core\Util\StringUtils;
+use Webmozart\Assert\Assert;
 
 final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
 {
@@ -258,6 +259,8 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
                 continue;
             }
 
+            Assert::isAOf($phpDocNode->children[$key], PhpDocTagNode::class);
+
             $texts = explode("\n@\\", $phpDocChildNode->value->value);
             $phpDocNode->children[$key]->value = new GenericTagValueNode($texts[0]);
             $phpDocNode->children[$key]->value->setAttribute(PhpDocAttributeKey::START_AND_END, $startAndEnd);
@@ -271,6 +274,9 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
 
             $this->attributeMirrorer->mirror($phpDocNode->children[$key], $spacelessPhpDocTagNode);
             $phpDocNode->children[$key] = $spacelessPhpDocTagNode;
+
+            // require to reprint the generic
+            $phpDocNode->children[$key]->setAttribute(PhpDocAttributeKey::IS_AFTER_GENERIC, true);
 
             array_splice($phpDocNode->children, $key + 1, 0, $spacelessPhpDocTagNodes);
         }

--- a/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -16,8 +16,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
-use Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocNodeVisitor\ChangedPhpDocNodeVisitor;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
@@ -342,10 +340,6 @@ final class PhpDocInfoPrinter
 
     private function shouldReprint(PhpDocChildNode $phpDocChildNode): bool
     {
-        if ($phpDocChildNode instanceof SpacelessPhpDocTagNode && $phpDocChildNode->value instanceof DoctrineAnnotationTagValueNode && $phpDocChildNode->value->hasChanged) {
-            return true;
-        }
-
         $this->changedPhpDocNodeTraverser->traverse($phpDocChildNode);
         return $this->changedPhpDocNodeVisitor->hasChanged();
     }

--- a/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -16,6 +16,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
+use Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocNodeVisitor\ChangedPhpDocNodeVisitor;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
@@ -341,7 +342,15 @@ final class PhpDocInfoPrinter
     private function shouldReprint(PhpDocChildNode $phpDocChildNode): bool
     {
         $this->changedPhpDocNodeTraverser->traverse($phpDocChildNode);
-        return $this->changedPhpDocNodeVisitor->hasChanged();
+        if ($this->changedPhpDocNodeVisitor->hasChanged()) {
+            return true;
+        }
+
+        if ($phpDocChildNode instanceof SpacelessPhpDocTagNode && $phpDocChildNode->getAttribute(PhpDocAttributeKey::IS_AFTER_GENERIC) === true) {
+            return true;
+        }
+
+        return false;
     }
 
     private function standardPrintPhpDocChildNode(PhpDocChildNode $phpDocChildNode): string

--- a/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -345,12 +345,7 @@ final class PhpDocInfoPrinter
         if ($this->changedPhpDocNodeVisitor->hasChanged()) {
             return true;
         }
-
-        if ($phpDocChildNode instanceof SpacelessPhpDocTagNode && $phpDocChildNode->getAttribute(PhpDocAttributeKey::IS_AFTER_GENERIC) === true) {
-            return true;
-        }
-
-        return false;
+        return $phpDocChildNode instanceof SpacelessPhpDocTagNode && $phpDocChildNode->getAttribute(PhpDocAttributeKey::IS_AFTER_GENERIC) === true;
     }
 
     private function standardPrintPhpDocChildNode(PhpDocChildNode $phpDocChildNode): string

--- a/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -345,6 +345,7 @@ final class PhpDocInfoPrinter
         if ($this->changedPhpDocNodeVisitor->hasChanged()) {
             return true;
         }
+
         return $phpDocChildNode instanceof SpacelessPhpDocTagNode && $phpDocChildNode->getAttribute(PhpDocAttributeKey::IS_AFTER_GENERIC) === true;
     }
 

--- a/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -16,6 +16,8 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocNodeVisitor\ChangedPhpDocNodeVisitor;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
@@ -340,6 +342,10 @@ final class PhpDocInfoPrinter
 
     private function shouldReprint(PhpDocChildNode $phpDocChildNode): bool
     {
+        if ($phpDocChildNode instanceof SpacelessPhpDocTagNode && $phpDocChildNode->value instanceof DoctrineAnnotationTagValueNode && $phpDocChildNode->value->hasChanged) {
+            return true;
+        }
+
         $this->changedPhpDocNodeTraverser->traverse($phpDocChildNode);
         return $this->changedPhpDocNodeVisitor->hasChanged();
     }

--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
@@ -14,7 +14,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
 {
     use NodeAttributes;
 
-    protected bool $hasChanged = false;
+    public bool $hasChanged = false;
 
     /**
      * @param ArrayItemNode[] $values Must be public so node traverser can go through them

--- a/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDoc/DoctrineAnnotation/AbstractValuesAwareNode.php
@@ -14,7 +14,7 @@ abstract class AbstractValuesAwareNode implements PhpDocTagValueNode
 {
     use NodeAttributes;
 
-    public bool $hasChanged = false;
+    protected bool $hasChanged = false;
 
     /**
      * @param ArrayItemNode[] $values Must be public so node traverser can go through them

--- a/packages/BetterPhpDocParser/ValueObject/PhpDocAttributeKey.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDocAttributeKey.php
@@ -33,4 +33,9 @@ final class PhpDocAttributeKey
      * @var string
      */
     public const ORIG_NODE = NativePhpDocAttributeKey::ORIG_NODE;
+
+    /**
+     * @var string
+     */
+    public const IS_AFTER_GENERIC = 'is_after_generic';
 }

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic.php.inc
@@ -28,10 +28,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesAfterGeneric
 {
     /**
-     * @OA\Property(
-     *     type="array",
-     *     @OA\Items(ref=@Model(type=TestItem::class))
-     * )
+     * @OA\Property(type="array", @OA\Items(ref=@Model(type=TestItem::class)))
      * @Route("/first", methods={"GET"})
      * @Route("/second", methods={"GET"})
      */

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+class TwoRoutesAfterGeneric
+{
+    /**
+     * @OA\Property(
+     *     type="array",
+     *     @OA\Items(ref=@Model(type=TestItem::class))
+     * )
+     * @\Symfony\Component\Routing\Annotation\Route("/first", methods={"GET"})
+     * @\Symfony\Component\Routing\Annotation\Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use Symfony\Component\Routing\Annotation\Route;
+class TwoRoutesAfterGeneric
+{
+    /**
+     * @OA\Property(
+     *     type="array",
+     *     @OA\Items(ref=@Model(type=TestItem::class))
+     * )
+     * @Route("/first", methods={"GET"})
+     * @Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/5276 

this handle multiple `@\` after `GenericTagValueNode`