### PR TITLE
[BetterPhpDocParser] Handle nested doctrine annotation with single quote content

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -401,7 +401,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             $formerStartEnd = $phpDocTextNode->getAttribute(PhpDocAttributeKey::START_AND_END);
 
             if (isset($nestedAnnotationOpen[1])) {
-                $annotationContent = '("' . trim($nestedAnnotationOpen[1], '"') . '")';
+                $annotationContent = '("' . trim($nestedAnnotationOpen[1], '"\'') . '")';
             }
 
             $spacelessPhpDocTagNodes[] = $this->createDoctrineSpacelessPhpDocTagNode(

--- a/tests/Issues/FqcnAnnotationToAttribute/Fixture/single_quote.php.inc
+++ b/tests/Issues/FqcnAnnotationToAttribute/Fixture/single_quote.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+
+/**
+ * @\Doctrine\ORM\Mapping\Entity()
+ * @\Doctrine\ORM\Mapping\Table('user', indexes={
+ *  @\Doctrine\ORM\Mapping\Index(name="name_index", columns={"name"}),
+ *  @\Doctrine\ORM\Mapping\Index(name="surname_index", columns={"surname"}),
+ * })
+ * @\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity("azureB2cUuid")
+ * @\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity("uuid")
+ * @\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity("email")
+ */
+class SingleQuote
+{
+    /**
+     * @\Symfony\Component\Validator\Constraints\NotBlank()
+     * @\Symfony\Component\Validator\Constraints\Email(mode="strict")
+     * @\Doctrine\ORM\Mapping\Column(type="string", unique=true)
+     * @\Symfony\Component\Serializer\Annotation\Groups({"import", "export-user", "export-claim"})
+     */
+    protected string $email = "";
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+
+#[\Doctrine\ORM\Mapping\Entity]
+#[\Doctrine\ORM\Mapping\Index(name: 'name_index', columns: ['name'])]
+#[\Doctrine\ORM\Mapping\Index(name: 'surname_index', columns: ['surname'])]
+#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity('azureB2cUuid')]
+#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity('uuid')]
+#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity('email')]
+#[\Doctrine\ORM\Mapping\Table('user')]
+class SingleQuote
+{
+    #[\Symfony\Component\Validator\Constraints\NotBlank]
+    #[\Symfony\Component\Validator\Constraints\Email(mode: 'strict')]
+    #[\Doctrine\ORM\Mapping\Column(type: 'string', unique: true)]
+    #[\Symfony\Component\Serializer\Annotation\Groups(['import', 'export-user', 'export-claim'])]
+    protected string $email = "";
+}
+
+?>


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/5240

this is for single quote:

```
 * @\Doctrine\ORM\Mapping\Table('user', {
```

on nested annotation.