### PR TITLE
Add test for string numeric key on ArrayItemNode

### DIFF
--- a/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
+++ b/packages/BetterPhpDocParser/PhpDoc/ArrayItemNode.php
@@ -22,7 +22,7 @@ final class ArrayItemNode implements PhpDocTagValueNode, Stringable
     {
         $value = '';
 
-        if ($this->key !== null && ! is_numeric($this->key)) {
+        if ($this->key !== null && ! is_int($this->key)) {
             $value .= $this->key . '=';
         }
 

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic_with_string_key_numeric.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic_with_string_key_numeric.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+class TwoRoutesAfterGenericWithStringKeyNumeric
+{
+    /**
+     * @OA\Property(
+     *     type="array",
+     *     '1'=@OA\Items(ref=@Model(type=TestItem::class))
+     * )
+     * @\Symfony\Component\Routing\Annotation\Route("/first", methods={"GET"})
+     * @\Symfony\Component\Routing\Annotation\Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use Symfony\Component\Routing\Annotation\Route;
+class TwoRoutesAfterGenericWithStringKeyNumeric
+{
+    /**
+     * @OA\Property(type="array", '1'=@OA\Items(ref=@Model(type=TestItem::class)))
+     * @Route("/first", methods={"GET"})
+     * @Route("/second", methods={"GET"})
+     */
+    public function some(): Response
+    {
+        return new Response();
+    }
+}
+
+?>


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/5277

this make compatible with other usage, with `is_int()` instead with added test.