### PR TITLE
[BetterPhpDocParser] Use ORIG_NODE attribute on DoctrineAnnotationDecorator on handle @\ after generic

### DIFF
--- a/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/packages/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -276,7 +276,7 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
             $phpDocNode->children[$key] = $spacelessPhpDocTagNode;
 
             // require to reprint the generic
-            $phpDocNode->children[$key]->setAttribute(PhpDocAttributeKey::IS_AFTER_GENERIC, true);
+            $phpDocNode->children[$key]->value->setAttribute(PhpDocAttributeKey::ORIG_NODE, null);
 
             array_splice($phpDocNode->children, $key + 1, 0, $spacelessPhpDocTagNodes);
         }

--- a/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -16,7 +16,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocNodeVisitor\ChangedPhpDocNodeVisitor;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;

--- a/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -342,11 +342,7 @@ final class PhpDocInfoPrinter
     private function shouldReprint(PhpDocChildNode $phpDocChildNode): bool
     {
         $this->changedPhpDocNodeTraverser->traverse($phpDocChildNode);
-        if ($this->changedPhpDocNodeVisitor->hasChanged()) {
-            return true;
-        }
-
-        return $phpDocChildNode instanceof SpacelessPhpDocTagNode && $phpDocChildNode->getAttribute(PhpDocAttributeKey::IS_AFTER_GENERIC) === true;
+        return $this->changedPhpDocNodeVisitor->hasChanged();
     }
 
     private function standardPrintPhpDocChildNode(PhpDocChildNode $phpDocChildNode): string

--- a/packages/BetterPhpDocParser/ValueObject/PhpDocAttributeKey.php
+++ b/packages/BetterPhpDocParser/ValueObject/PhpDocAttributeKey.php
@@ -33,9 +33,4 @@ final class PhpDocAttributeKey
      * @var string
      */
     public const ORIG_NODE = NativePhpDocAttributeKey::ORIG_NODE;
-
-    /**
-     * @var string
-     */
-    public const IS_AFTER_GENERIC = 'is_after_generic';
 }

--- a/packages/PhpDocParser/PhpDocParser/PhpDocNodeVisitor/CloningPhpDocNodeVisitor.php
+++ b/packages/PhpDocParser/PhpDocParser/PhpDocNodeVisitor/CloningPhpDocNodeVisitor.php
@@ -18,7 +18,11 @@ final class CloningPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
     public function enterNode(Node $node): Node
     {
         $clonedNode = clone $node;
-        $clonedNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, $node);
+
+        if (! $clonedNode->hasAttribute(PhpDocAttributeKey::ORIG_NODE)) {
+            $clonedNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, $node);
+        }
+
         return $clonedNode;
     }
 }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/5277

This utilize `ORIG_NODE` attribute instead for reprint handling.