### PR TITLE
[Php80] Allow subnamespace from use statements support on AnnotationToAttributeRector

### DIFF
--- a/rules/CodingStyle/NodeAnalyzer/UseImportNameMatcher.php
+++ b/rules/CodingStyle/NodeAnalyzer/UseImportNameMatcher.php
@@ -70,6 +70,12 @@ final class UseImportNameMatcher
         }
 
         if (! $originalUseUseNode->alias instanceof Identifier) {
+            $lastName = $originalUseUseNode->name->getLast();
+            if (str_starts_with($tag, $lastName . '\\')) {
+                $tagName = Strings::after($tag, '\\');
+                return $prefix . $originalUseUseNode->name->toString() . '\\' . $tagName;
+            }
+
             return $prefix . $originalUseUseNode->name->toString();
         }
 

--- a/tests/Issues/FqcnAnnotationToAttribute/Fixture/sub_namespace_from_use.php.inc
+++ b/tests/Issues/FqcnAnnotationToAttribute/Fixture/sub_namespace_from_use.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+
+use Doctrine\ORM\Mapping;
+
+/**
+ * @Mapping\Entity()
+ */
+class SubNamespaceFromUse
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+
+use Doctrine\ORM\Mapping;
+
+#[Mapping\Entity]
+class SubNamespaceFromUse
+{
+}
+
+?>


### PR DESCRIPTION
@etshy this should handle https://github.com/rectorphp/rector-src/pull/5123
Closes https://github.com/rectorphp/rector/issues/8224