### PR TITLE
[Naming] Skip singularize "cms" on RenameForeachValueVariableToMatchExprVariableRector

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_cms_middle.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_cms_middle.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class SkipCmsMiddle
+{
+    public function run()
+    {
+        foreach ($cmsBlocks as $cmsBlock) {
+        }
+    }
+}
+
+?>

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -97,7 +97,7 @@ final class InflectorSingularResolver
         foreach ($camelCases as $camelCase) {
             $value = $this->inflector->singularize($camelCase[self::CAMELCASE]);
 
-            if (in_array($camelCase[self::CAMELCASE], ['is', 'has'], true)) {
+            if (in_array($camelCase[self::CAMELCASE], ['is', 'has', 'cms'], true)) {
                 $value = $camelCase[self::CAMELCASE];
             }
 

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -95,10 +95,10 @@ final class InflectorSingularResolver
 
         $resolvedName = '';
         foreach ($camelCases as $camelCase) {
-            $value = $this->inflector->singularize($camelCase[self::CAMELCASE]);
-
             if (in_array($camelCase[self::CAMELCASE], ['is', 'has', 'cms'], true)) {
                 $value = $camelCase[self::CAMELCASE];
+            } else {
+                $value = $this->inflector->singularize($camelCase[self::CAMELCASE]);
             }
 
             $resolvedName .= $value;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8327