### PR TITLE
[Strict] Allow check '0' empty zero on BooleanInTernaryOperatorRuleFixerRector on string type

### DIFF
--- a/config/set/php83.php
+++ b/config/set/php83.php
@@ -1,12 +1,14 @@
 <?php
 
 declare(strict_types=1);
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
-        \Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class,
-        \Rector\Php83\Rector\ClassConst\AddTypeToConstRector::class,
+        AddOverrideAttributeToOverriddenMethodsRector::class,
+        AddTypeToConstRector::class,
     ]);
 };

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/config/configured_rule.php
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/config/configured_rule.php
@@ -1,12 +1,13 @@
 <?php
 
 declare(strict_types=1);
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(\Rector\Php83\Rector\ClassConst\AddTypeToConstRector::class);
+    $rectorConfig->rule(AddTypeToConstRector::class);
 
     $rectorConfig->phpVersion(PhpVersion::PHP_83);
 };

--- a/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/negated_string.php.inc
+++ b/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/negated_string.php.inc
@@ -32,7 +32,7 @@ final class NegatedString
 
     public function run()
     {
-        if ($this->name === '') {
+        if ($this->name === '' || $this->name = '0') {
             return 'name';
         }
 

--- a/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/negated_string.php.inc
+++ b/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/negated_string.php.inc
@@ -32,7 +32,7 @@ final class NegatedString
 
     public function run()
     {
-        if ($this->name === '' || $this->name = '0') {
+        if ($this->name === '' || $this->name === '0') {
             return 'name';
         }
 

--- a/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/string_null_and_false.php.inc
+++ b/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/string_null_and_false.php.inc
@@ -28,7 +28,7 @@ class StringNullAndFalse
 {
     public function run(string|null|false $name)
     {
-        if ($name === '' || $name === null || $name === false) {
+        if ($name === '' || $name === '0' || $name === null || $name === false) {
             return 'no name';
         }
 

--- a/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/string_union_integer.php.inc
+++ b/rules-tests/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector/Fixture/string_union_integer.php.inc
@@ -28,7 +28,7 @@ final class StringUnionInteger
 {
     public function run(string|int $maye)
     {
-        if ($maye === '' || $maye === 0) {
+        if ($maye === '' || $maye === '0' || $maye === 0) {
             return true;
         }
 

--- a/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/from_return_method.php.inc
+++ b/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/from_return_method.php.inc
@@ -30,12 +30,12 @@ final class FromReturnCall
 {
     public function run()
     {
-        return $this->getProperty() === '';
+        return $this->getProperty() === '' || $this->getProperty() === '0';
     }
 
     public function run2()
     {
-        return $this->getProperty() !== '';
+        return $this->getProperty() !== '' && $this->getProperty() !== '0';
     }
 
     public function getProperty(): string

--- a/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/elseif_negated_string.php.inc
+++ b/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/elseif_negated_string.php.inc
@@ -36,7 +36,7 @@ final class ElseIfNegatedString
     {
         if ($boolValue) {
             return 'bool';
-        } elseif ($this->name !== '') {
+        } elseif ($this->name !== '' && $this->name !== '0') {
             return 'name';
         }
 

--- a/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/integer_union_string.php.inc
+++ b/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/integer_union_string.php.inc
@@ -28,7 +28,7 @@ final class IntegerUnionString
 {
     public function run(int|string $value)
     {
-        if ($value !== 0 && $value !== '') {
+        if ($value !== 0 && ($value !== '' && $value !== '0')) {
             return 'name';
         }
 

--- a/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/negated_string.php.inc
+++ b/rules-tests/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector/Fixture/negated_string.php.inc
@@ -32,7 +32,7 @@ final class NegatedString
 
     public function run()
     {
-        if ($this->name !== '') {
+        if ($this->name !== '' && $this->name !== '0') {
             return 'name';
         }
 

--- a/rules-tests/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector/Fixture/string_silent_compare.php.inc
+++ b/rules-tests/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector/Fixture/string_silent_compare.php.inc
@@ -24,7 +24,7 @@ final class StringSilentCompare
 {
     public function run(string $string)
     {
-        return $string !== '' ? 1 : 2;
+        return $string !== '' && $string !== '0' ? 1 : 2;
     }
 }
 

--- a/rules-tests/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector/Fixture/short_ternary_string.php.inc
+++ b/rules-tests/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector/Fixture/short_ternary_string.php.inc
@@ -24,7 +24,7 @@ final class ShortTernaryString
 {
     public function run(string $string)
     {
-        return $string !== '' ? $string : 2;
+        return $string !== '' && $string !== '0' ? $string : 2;
     }
 }
 

--- a/rules/Strict/NodeFactory/ExactCompareFactory.php
+++ b/rules/Strict/NodeFactory/ExactCompareFactory.php
@@ -6,7 +6,6 @@ namespace Rector\Strict\NodeFactory;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
@@ -37,10 +36,6 @@ final class ExactCompareFactory
         bool $isOnlyString = true
     ): Identical|BooleanOr|NotIdentical|BooleanNot|Instanceof_|BooleanAnd|null {
         if ($exprType->isString()->yes()) {
-            if ($expr instanceof ArrayDimFetch) {
-                return new Identical($expr, new String_(''));
-            }
-
             if ($treatAsNonEmpty || ! $isOnlyString) {
                 return new Identical($expr, new String_(''));
             }
@@ -81,10 +76,6 @@ final class ExactCompareFactory
         bool $isOnlyString = true
     ): Identical|Instanceof_|BooleanOr|NotIdentical|BooleanAnd|BooleanNot|null {
         if ($exprType->isString()->yes()) {
-            if ($expr instanceof ArrayDimFetch) {
-                return new NotIdentical($expr, new String_(''));
-            }
-
             if ($treatAsNotEmpty || ! $isOnlyString) {
                 return new NotIdentical($expr, new String_(''));
             }

--- a/src/Exception/FullyQualifiedNameNotAutoloadedException.php
+++ b/src/Exception/FullyQualifiedNameNotAutoloadedException.php
@@ -7,7 +7,7 @@ namespace Rector\Core\Exception;
 use PhpParser\Node\Name;
 use RuntimeException;
 
-class FullyQualifiedNameNotAutoloadedException extends RuntimeException
+final class FullyQualifiedNameNotAutoloadedException extends RuntimeException
 {
     public function __construct(
         protected Name $name

--- a/tests/Issues/EmptyBooleanCompare/Fixture/always_exists_array_dim_fetch_item.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/always_exists_array_dim_fetch_item.php.inc
@@ -44,7 +44,7 @@ final class AlwaysExistsArrayDimFetchItem
             ];
         }
 
-        if (isset($parts['host']) && $parts['host'] !== '') {
+        if (isset($parts['host']) && ($parts['host'] !== '' && $parts['host'] !== '0')) {
             return $parts['host'];
         }
 

--- a/tests/Issues/EmptyBooleanCompare/Fixture/fixture.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/fixture.php.inc
@@ -28,7 +28,7 @@ final class SomeFixture
     {
         $parts = parse_url($url);
 
-        if (isset($parts['host']) && $parts['host'] !== '') {
+        if (isset($parts['host']) && ($parts['host'] !== '' && $parts['host'] !== '0')) {
             return $parts['host'];
         }
 

--- a/tests/Issues/EmptyBooleanCompare/Fixture/on_array_object.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/on_array_object.php.inc
@@ -28,7 +28,7 @@ final class OnArrayObject
     {
         $parts = new \ArrayObject(['host' => 'test'], \ArrayObject::ARRAY_AS_PROPS);
 
-        if (isset($parts['host']) && $parts['host'] !== '') {
+        if (isset($parts['host']) && ($parts['host'] !== '' && $parts['host'] !== '0')) {
             return $parts['host'];
         }
 


### PR DESCRIPTION
@staabm  @TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/5296

this apply on only string type.

Fixes https://github.com/rectorphp/rector/issues/8137