### PR TITLE
[Stub] Add Symfony Request stub to fix downgrade symfony/console on downgrading symfony/console:6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "rector/rector-phpunit": "dev-main",
         "rector/rector-symfony": "dev-main",
         "sebastian/diff": "^5.0",
-        "symfony/console": "~6.3.9",
+        "symfony/console": "^6.3",
         "symfony/filesystem": "^6.3",
         "symfony/finder": "^6.3",
         "symfony/process": "^6.3",

--- a/stubs/Symfony/Component/HttpFoundation/Request.php
+++ b/stubs/Symfony/Component/HttpFoundation/Request.php
@@ -1,0 +1,18 @@
+<?php
+
+/** @changelog https://github.com/symfony/http-foundation/blob/7.0/Request.php */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\HttpFoundation;
+
+if (class_exists('Symfony\Component\HttpFoundation\Request')) {
+    return;
+}
+
+class Request
+{
+    public function __construct(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null)
+    {
+    }
+}

--- a/tests/Issues/ComplexNamedArg/ComplexNamedArgTest.php
+++ b/tests/Issues/ComplexNamedArg/ComplexNamedArgTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues\ComplexNamedArg;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ComplexNamedArgTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/ComplexNamedArg/Fixture/cli_request.php.inc
+++ b/tests/Issues/ComplexNamedArg/Fixture/cli_request.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Core\Tests\Issues\ComplexNamedArg\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class CliRequest extends Request
+{
+    public function __construct(
+        public readonly TraceableCommand $command,
+    ) {
+        parent::__construct(
+            attributes: ['_controller' => \get_class($command->command), '_virtual_type' => 'command'],
+            server: $_SERVER,
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Issues\ComplexNamedArg\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class CliRequest extends Request
+{
+    /**
+     * @readonly
+     * @var \Rector\Core\Tests\Issues\ComplexNamedArg\Fixture\TraceableCommand
+     */
+    public $command;
+    public function __construct(TraceableCommand $command)
+    {
+        $this->command = $command;
+        parent::__construct([], [], ['_controller' => \get_class($command->command), '_virtual_type' => 'command'], [], [], $_SERVER);
+    }
+}
+
+?>

--- a/tests/Issues/ComplexNamedArg/config/configured_rule.php
+++ b/tests/Issues/ComplexNamedArg/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\DowngradeLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([DowngradeLevelSetList::DOWN_TO_PHP_72]);
+};


### PR DESCRIPTION
@TomasVotruba here continue of PR:

- https://github.com/rectorphp/rector-src/pull/5302

I added a stub file `stubs/Symfony/Component/HttpFoundation/Request.php` to allow downgrade symfony console:6.4 and rollback change on symfony/console dependency on 6.4.

Also add test to prove it.

Fixes https://github.com/rectorphp/rector/issues/8333