### PR TITLE
[PostRector] Allow remove end with name check backslash on UnusedImportRemovingPostRector

### DIFF
--- a/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/packages/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -172,7 +172,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
 
         // match partial import
         foreach ($names as $name) {
-            if (str_ends_with($comparedName, $name)) {
+            if (str_ends_with($comparedName, '\\' . $name)) {
                 return true;
             }
 

--- a/tests/Issues/NamespacedUse/Fixture/end_with_name_backslash.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/end_with_name_backslash.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Bar;
+
+use SomeResponse;
+
+final class EndWithNameBackslash
+{
+    public function run(Response $baz)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace App\Bar;
+
+final class EndWithNameBackslash
+{
+    public function run(Response $baz)
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
`SomeResponse` is ends with `Response`, but they are different, so the `use SomeResponse` can be removed on this case:

```php
use SomeResponse;

final class EndWithNameBackslash
{
    public function run(Response $baz)
    {
    }
}
```