### PR TITLE
 [Php80] Skip PDO::query() on AddParamBasedOnParentClassMethodRector 

### DIFF
--- a/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/skip_extends_pdo_query.php.inc
+++ b/rules-tests/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector/Fixture/skip_extends_pdo_query.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector\Fixture;
+
+class SkipExtendsPDOQuery extends \PDO {
+    public function query() {
+        $args = func_get_args();
+        return parent::query($args[0]);
+    }
+}

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -13,11 +13,13 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -37,6 +39,7 @@ final class AddParamBasedOnParentClassMethodRector extends AbstractRector implem
         private readonly AstResolver $astResolver,
         private readonly BetterStandardPrinter $betterStandardPrinter,
         private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -106,6 +109,13 @@ CODE_SAMPLE
         }
 
         if ($parentMethodReflection->isPrivate()) {
+            return null;
+        }
+
+        $currentClassReflection = $this->reflectionResolver->resolveClassReflection($node);
+        $isPDO = $currentClassReflection instanceof  ClassReflection && $currentClassReflection->isSubclassOf('PDO');
+
+        if ($isPDO && $parentMethodReflection->getName() === 'query') {
             return null;
         }
 

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -115,8 +115,8 @@ CODE_SAMPLE
         $currentClassReflection = $this->reflectionResolver->resolveClassReflection($node);
         $isPDO = $currentClassReflection instanceof  ClassReflection && $currentClassReflection->isSubclassOf('PDO');
 
-        // @see it relies on phpstorm stubs that define 2 kind of query method for both php 7.4 and php 8.0
-        // https://github.com/JetBrains/phpstorm-stubs/blob/e2e898a29929d2f520fe95bdb2109d8fa895ba4a/PDO/PDO.php#L1096-L1126
+        // It relies on phpstorm stubs that define 2 kind of query method for both php 7.4 and php 8.0
+        // @see https://github.com/JetBrains/phpstorm-stubs/blob/e2e898a29929d2f520fe95bdb2109d8fa895ba4a/PDO/PDO.php#L1096-L1126
         if ($isPDO && $parentMethodReflection->getName() === 'query') {
             return null;
         }

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -115,6 +115,8 @@ CODE_SAMPLE
         $currentClassReflection = $this->reflectionResolver->resolveClassReflection($node);
         $isPDO = $currentClassReflection instanceof  ClassReflection && $currentClassReflection->isSubclassOf('PDO');
 
+        // @see it relies on phpstorm stubs that define 2 kind of query method for both php 7.4 and php 8.0
+        // https://github.com/JetBrains/phpstorm-stubs/blob/e2e898a29929d2f520fe95bdb2109d8fa895ba4a/PDO/PDO.php#L1096-L1126
         if ($isPDO && $parentMethodReflection->getName() === 'query') {
             return null;
         }


### PR DESCRIPTION
@TomasVotruba here to skip `PDO::query()`