### PR TITLE
[PHP 7.0] Skip mt_rand() replacement as not valuable

### DIFF
--- a/rules-tests/Php70/Rector/FuncCall/RandomFunctionRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php70/Rector/FuncCall/RandomFunctionRector/Fixture/fixture.php.inc
@@ -55,7 +55,7 @@ function randomFunction()
 
     random_int($a, \Other\Scope\mt_rand($a));
 
-    $a = random_int(1, 2) + random_int(3, 4);
+    $a = random_int(1, 2) + mt_rand(3, 4);
 }
 
 ?>

--- a/rules/Php70/Rector/FuncCall/RandomFunctionRector.php
+++ b/rules/Php70/Rector/FuncCall/RandomFunctionRector.php
@@ -26,14 +26,13 @@ final class RandomFunctionRector extends AbstractRector implements MinPhpVersion
     private const OLD_TO_NEW_FUNCTION_NAMES = [
         'getrandmax' => 'mt_getrandmax',
         'srand' => 'mt_srand',
-        'mt_rand' => 'random_int',
         'rand' => 'random_int',
     ];
 
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Changes rand, srand, mt_rand and getrandmax to newer alternatives.',
+            'Changes rand, srand, and getrandmax to newer alternatives',
             [new CodeSample('rand();', 'random_int();')]
         );
     }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8166