### PR TITLE
[Php83] Fix const from applying incorrect types

### DIFF
--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_only_to_private_const_when_public_available.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_only_to_private_const_when_public_available.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+class ApplyOnlyToPrivateConstWhenPublicAvailable
+{
+    private const A = 1000;
+    public const B = 'foo';
+    public const C = 'bar';
+}
+?>
+-----
+<?php
+
+class ApplyOnlyToPrivateConstWhenPublicAvailable
+{
+    private const int A = 1000;
+    public const B = 'foo';
+    public const C = 'bar';
+}
+?>

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_only_to_private_const_when_public_available.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_only_to_private_const_when_public_available.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
 class ApplyOnlyToPrivateConstWhenPublicAvailable
 {
     private const A = 1000;
@@ -9,6 +11,8 @@ class ApplyOnlyToPrivateConstWhenPublicAvailable
 ?>
 -----
 <?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
 
 class ApplyOnlyToPrivateConstWhenPublicAvailable
 {

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -90,6 +90,8 @@ CODE_SAMPLE
         $changes = false;
 
         foreach ($consts as $const) {
+            $valueType = null;
+
             // If a type is set, skip
             if ($const->type !== null) {
                 continue;


### PR DESCRIPTION
A fix for the PHP 8.3 rule [AddTypeToConstRector](https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#addtypetoconstrector).

[Rule was reported to be applying an incorrect type to public consts due to a loop not resetting it's values.](https://github.com/rectorphp/rector-src/pull/5290#issuecomment-1839344029)

Added a test to cover the scenario.