### PR TITLE
[Transform] Do not create a new node if the existing node is already the correct one on AttributeKeyToClassConstFetchRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -524,7 +524,7 @@ parameters:
 
         -
             path: rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
-            message: "#Method \"processToClassConstFetch\\(\\)\" returns bool type, so the name should start with is/has/was#"
+            message: "#Method \"process(ToClassConstFetch|Arg)\\(\\)\" returns bool type, so the name should start with is/has/was#"
 
         # optional as changes behavior, should be used explicitly outside PHP upgrade
         - '#Register "Rector\\Php73\\Rector\\FuncCall\\JsonThrowOnErrorRector" service to "php73\.php" config set#'

--- a/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Fixture/not_replacing_existing_constant.php.inc
+++ b/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Fixture/not_replacing_existing_constant.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Fixture;
+
+use Doctrine\ORM\Mapping\Column;
+use Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Source\Constant;
+use Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Source\TestAttribute;
+
+class SomeClass
+{
+    #[TestAttribute(type: Constant::VALUE)]
+    public string $name;
+}
+
+?>

--- a/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Fixture/skip_already.php.inc
+++ b/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Fixture/skip_already.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Fixture;
+
+use Doctrine\ORM\Mapping\Column;
+
+use Doctrine\DBAL\Types\Types;
+
+class SkipAlready
+{
+    #[Column(type: Types::STRING)]
+    public $name;
+}
+
+?>

--- a/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Source/Constant.php
+++ b/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Source/Constant.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Source;
+
+class Constant
+{
+    public const VALUE = 'value';
+}

--- a/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Source/TestAttribute.php
+++ b/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/Source/TestAttribute.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Source;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class TestAttribute
+{
+    public function __construct(
+        public readonly string $type,
+    ) {
+    }
+}

--- a/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector/config/configured_rule.php
@@ -12,5 +12,8 @@ return static function (RectorConfig $rectorConfig): void {
             new AttributeKeyToClassConstFetch('Doctrine\ORM\Mapping\Column', 'type', 'Doctrine\DBAL\Types\Types', [
                 'string' => 'STRING',
             ]),
+            new AttributeKeyToClassConstFetch('Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Source\TestAttribute', 'type', 'Rector\Tests\Transform\Rector\Attribute\AttributeKeyToClassConstFetchRector\Source\Constant', [
+                'value' => 'VALUE',
+            ]),
         ]);
 };

--- a/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
+++ b/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
@@ -132,6 +132,7 @@ CODE_SAMPLE
         AttributeKeyToClassConstFetch $attributeKeyToClassConstFetch
     ): bool {
         $hasChanged = false;
+
         foreach ($attributeGroup->attrs as $attribute) {
             if (! $this->isName($attribute->name, $attributeKeyToClassConstFetch->getAttributeClass())) {
                 continue;
@@ -147,23 +148,38 @@ CODE_SAMPLE
                     continue;
                 }
 
-                $value = $this->valueResolver->getValue($arg->value);
-
-                $constName = $attributeKeyToClassConstFetch->getValuesToConstantsMap()[$value] ?? null;
-                if ($constName === null) {
-                    continue;
+                if ($this->processArg($arg, $attributeKeyToClassConstFetch)) {
+                    $hasChanged = true;
                 }
-
-                $arg->value = $this->nodeFactory->createClassConstFetch(
-                    $attributeKeyToClassConstFetch->getConstantClass(),
-                    $constName
-                );
-
-                $hasChanged = true;
-                continue 2;
             }
         }
 
         return $hasChanged;
+    }
+
+    private function processArg(Node\Arg $arg, AttributeKeyToClassConstFetch $attributeKeyToClassConstFetch): bool
+    {
+        $value = $this->valueResolver->getValue($arg->value);
+
+        $constName = $attributeKeyToClassConstFetch->getValuesToConstantsMap()[$value] ?? null;
+        if ($constName === null) {
+            return false;
+        }
+
+        $newValue = $this->nodeFactory->createClassConstFetch(
+            $attributeKeyToClassConstFetch->getConstantClass(),
+            $constName
+        );
+
+        if (
+            $arg->value instanceof Node\Expr\ClassConstFetch
+            && $this->getName($arg->value) === $this->getName($newValue)
+        ) {
+            return false;
+        }
+
+        $arg->value = $newValue;
+
+        return true;
     }
 }


### PR DESCRIPTION
As stated in rectorphp/rector#8341 replacing the node, even if it leads to the same reference, forces a change, that is not required.
I added a check to skip recreating the node if the class reference stays the same.

During testing I found out, that resolving the value works differently based on if the referenced class actually exists or not.
So the added testfile currently passes the test, but only because the resolved value is not present as a key in the map.

Is there already a real class with constants that could be used, to make it a real test?