### PR TITLE
[DeadCode] Skip has parent class with __call() magic method on RemoveParentCallWithoutParentRector

### DIFF
--- a/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_parent_has_call_magic.php.inc
+++ b/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_parent_has_call_magic.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Source\SomeParentMethodMagicCall;
+
+class SkipParentHasCallMagic extends SomeParentMethodMagicCall
+{
+    public function getDerp() {
+        $derp = parent::getDerp();
+    }
+}
+

--- a/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Source/SomeParentMethodMagicCall.php
+++ b/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Source/SomeParentMethodMagicCall.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Source;
+
+class SomeParentMethodMagicCall
+{
+    public function __call($name, $arguments)
+    {
+    }
+}

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -52,10 +52,18 @@ final class ClassMethodManipulator
             if ($parentClassReflection->hasMethod($methodName)) {
                 return true;
             }
+
+            if ($parentClassReflection->hasMethod(MethodName::CALL)) {
+                return true;
+            }
         }
 
         foreach ($classReflection->getInterfaces() as $interfaceReflection) {
             if ($interfaceReflection->hasMethod($methodName)) {
+                return true;
+            }
+
+            if ($parentClassReflection->hasMethod(MethodName::CALL)) {
                 return true;
             }
         }

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -62,10 +62,6 @@ final class ClassMethodManipulator
             if ($interfaceReflection->hasMethod($methodName)) {
                 return true;
             }
-
-            if ($interfaceReflection->hasMethod(MethodName::CALL)) {
-                return true;
-            }
         }
 
         return false;

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -63,7 +63,7 @@ final class ClassMethodManipulator
                 return true;
             }
 
-            if ($parentClassReflection->hasMethod(MethodName::CALL)) {
+            if ($interfaceReflection->hasMethod(MethodName::CALL)) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8345