### PR TITLE
[PHP 5.5] Remove extra preslash in class reference, as in practice removal manually

### DIFF
--- a/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/no_pre_slash.php.inc
+++ b/rules-tests/Php55/Rector/String_/StringClassNameToClassConstantRector/Fixture/no_pre_slash.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
 
-final class PreSlash
+final class NoPreSlash
 {
     public function preSlash()
     {
@@ -16,11 +16,11 @@ final class PreSlash
 
 namespace Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Fixture;
 
-final class PreSlash
+final class NoPreSlash
 {
     public function preSlash()
     {
-        return '\\' . \Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass::class;
+        return \Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\Source\AnotherClass::class;
     }
 }
 

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -88,8 +88,11 @@ final class DeadReturnTagValueNodeAnalyzer
         return $node instanceof Identifier && $node->toString() === 'never';
     }
 
-    private function isDeadNotEqual(ReturnTagValueNode $returnTagValueNode, Node $node, ClassMethod|Function_ $functionLike): bool
-    {
+    private function isDeadNotEqual(
+        ReturnTagValueNode $returnTagValueNode,
+        Node $node,
+        ClassMethod|Function_ $functionLike
+    ): bool {
         if ($returnTagValueNode->type instanceof IdentifierTypeNode && (string) $returnTagValueNode->type === 'void') {
             return true;
         }

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Php55\Rector\String_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
@@ -91,7 +90,7 @@ CODE_SAMPLE
     /**
      * @param String_|FuncCall|ClassConst $node
      */
-    public function refactor(Node $node): Concat|ClassConstFetch|null|int
+    public function refactor(Node $node): ClassConstFetch|null|int
     {
         // allow class strings to be part of class const arrays, as probably on purpose
         if ($node instanceof ClassConst) {
@@ -132,15 +131,6 @@ CODE_SAMPLE
         }
 
         $fullyQualified = new FullyQualified($classLikeName);
-
-        if ($classLikeName !== $node->value) {
-            $preSlashCount = strlen($node->value) - strlen($classLikeName);
-            $preSlash = str_repeat('\\', $preSlashCount);
-            $string = new String_($preSlash);
-
-            return new Concat($string, new ClassConstFetch($fullyQualified, 'class'));
-        }
-
         return new ClassConstFetch($fullyQualified, 'class');
     }
 

--- a/rules/TypeDeclaration/Rector/Class_/MergeDateTimePropertyTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/MergeDateTimePropertyTypeDeclarationRector.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\Rector\Class_;
 
-use PHPStan\Type\TypeWithClassName;
 use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\Type\TypeWithClassName;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -26,15 +26,16 @@ final class MergeDateTimePropertyTypeDeclarationRector extends AbstractRector im
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockUpdater $docBlockUpdater
-    )
-    {
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Set DateTime to DateTimeInterface for DateTime property with DateTimeInterface docblock', [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Set DateTime to DateTimeInterface for DateTime property with DateTimeInterface docblock',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 final class SomeClass
 {
     /**
@@ -44,15 +45,17 @@ final class SomeClass
 }
 CODE_SAMPLE
 
-                ,
-                <<<'CODE_SAMPLE'
+                    ,
+                    <<<'CODE_SAMPLE'
 final class SomeClass
 {
     private DateTimeInterface $dateTime;
 }
 CODE_SAMPLE
-            ),
-        ]);
+                ),
+
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
I've learned in Mautic upgrade sprint, this rule is adding extra slash that has to be removed.
Let's make it easy to use :+1: 