### PR TITLE
Remove json throw on error rule from PHP 7.3 set, as changed behavior and must be applied on purpose

### DIFF
--- a/config/set/php73.php
+++ b/config/set/php73.php
@@ -7,7 +7,6 @@ use Rector\Php52\Rector\Switch_\ContinueToBreakInSwitchRector;
 use Rector\Php73\Rector\BooleanOr\IsCountableRector;
 use Rector\Php73\Rector\ConstFetch\SensitiveConstantNameRector;
 use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\RegexDashEscapeRector;
 use Rector\Php73\Rector\FuncCall\SensitiveDefineRector;
 use Rector\Php73\Rector\FuncCall\SetCookieRector;
@@ -16,12 +15,6 @@ use Rector\Php73\Rector\String_\SensitiveHereNowDocRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(IsCountableRector::class);
-    $rectorConfig->rule(ArrayKeyFirstLastRector::class);
-    $rectorConfig->rule(SensitiveDefineRector::class);
-    $rectorConfig->rule(SensitiveConstantNameRector::class);
-    $rectorConfig->rule(SensitiveHereNowDocRector::class);
-
     $rectorConfig
         ->ruleWithConfiguration(RenameFunctionRector::class, [
             # https://wiki.php.net/rfc/deprecations_php_7_3
@@ -41,9 +34,20 @@ return static function (RectorConfig $rectorConfig): void {
             'mbereg_search_getpos' => 'mb_ereg_search_getpos',
         ]);
 
-    $rectorConfig->rule(StringifyStrNeedlesRector::class);
-    $rectorConfig->rule(JsonThrowOnErrorRector::class);
-    $rectorConfig->rule(RegexDashEscapeRector::class);
-    $rectorConfig->rule(ContinueToBreakInSwitchRector::class);
-    $rectorConfig->rule(SetCookieRector::class);
+    $rectorConfig->rules([
+        StringifyStrNeedlesRector::class,
+        RegexDashEscapeRector::class,
+        ContinueToBreakInSwitchRector::class,
+        SetCookieRector::class,
+        IsCountableRector::class,
+
+        ArrayKeyFirstLastRector::class,
+
+        SensitiveDefineRector::class,
+
+        SensitiveConstantNameRector::class,
+
+        SensitiveHereNowDocRector::class,
+
+    ]);
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -525,3 +525,6 @@ parameters:
         -
             path: rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
             message: "#Method \"processToClassConstFetch\\(\\)\" returns bool type, so the name should start with is/has/was#"
+
+        # optional as changes behavior, should be used explicitly outside PHP upgrade
+        - '#Register "Rector\\Php73\\Rector\\FuncCall\\JsonThrowOnErrorRector" service to "php73\.php" config set#'

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -6,6 +6,7 @@ namespace Rector\Utils\Command;
 
 use Nette\Utils\Strings;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenCollectorRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
@@ -31,6 +32,8 @@ final class MissingInSetCommand extends Command
         WhileNullableToInstanceofRector::class,
         // collectors
         FinalizeClassesWithoutChildrenCollectorRector::class,
+        // changes behavior, should be applied on purpose regardless PHP 7.3 level
+        JsonThrowOnErrorRector::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
This rule should be applied only on purpose in case of behavior changed is needed.
In practise this stop the seamless PHP 7.3 upgrade and rule has to be manually excluded.

Better alrenatives as nette/utils json class are also available, so this upgrade is optional.