### PR TITLE
Create failing test for ReturnTypeFromStrictTypedCallRector rule

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/use_correct_return_type_on_named_constructor.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/use_correct_return_type_on_named_constructor.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class BaseClass
+{
+    public function run()
+    {
+        return SomeNamedConstructorClass::from();
+    }
+}
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+class SomeNamedConstructorClass {
+	public static function from(): static
+    {
+     	return new static();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class BaseClass
+{
+    public function run(): SomeNamedConstructorClass
+    {
+        return SomeNamedConstructorClass::from();
+    }
+}
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+class SomeNamedConstructorClass {
+	public static function from(): static
+    {
+     	return new static();
+    }
+}
+
+?>


### PR DESCRIPTION
When trying to use named constructors with the ReturnTypeFromStrictTypedCallRector rule the `static` return type just gets used instead of the static class name.