### PR TITLE
[TypeDeclaration] Add false and true in union support on ReturnUnionTypeRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -132,6 +132,7 @@ parameters:
                 - src/PhpDocParser/PhpDocParser/PhpDocNodeTraverser.php
                 - rules/Php70/EregToPcreTransformer.php
                 - src/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
+                - src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
 
         # known types
         - '#Parameter (.*?) expects PhpParser\\Node, PhpParser\\Node\|null given#'

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/true_in_union_become_bool.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/true_in_union_become_bool.php.inc
@@ -2,12 +2,15 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
 
-final class MultiScalar
+/**
+ * true|othertype cannot work on <=php 8.1, ref https://3v4l.org/UJqXT
+ */
+final class TrueInUnionBecomeBool
 {
     public function run($value)
     {
         if ($value) {
-            return false;
+            return true;
         }
 
         return substr('warning', 1);
@@ -20,12 +23,15 @@ final class MultiScalar
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
 
-final class MultiScalar
+/**
+ * true|othertype cannot work on <=php 8.1, ref https://3v4l.org/UJqXT
+ */
+final class TrueInUnionBecomeBool
 {
-    public function run($value): false|string
+    public function run($value): bool|string
     {
         if ($value) {
-            return false;
+            return true;
         }
 
         return substr('warning', 1);

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_false_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_false_in_union.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class TrueFalseInUnion
+{
+    public function run($value)
+    {
+        if ($value) {
+            return true;
+        }
+
+        if (rand(0, 1)) {
+            return false;
+        }
+
+        return substr('warning', 1);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class TrueFalseInUnion
+{
+    public function run($value): bool|string
+    {
+        if ($value) {
+            return true;
+        }
+
+        if (rand(0, 1)) {
+            return false;
+        }
+
+        return substr('warning', 1);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_false_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_false_in_union.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\FixtureTrueInUnion;
 
 final class TrueFalseInUnion
 {
@@ -22,7 +22,7 @@ final class TrueFalseInUnion
 -----
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\FixtureTrueInUnion;
 
 final class TrueFalseInUnion
 {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_in_union.php.inc
@@ -2,12 +2,15 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
 
-final class MultiScalar
+/**
+ * true|othertype work on >= php 8.2, ref https://3v4l.org/UJqXT
+ */
+final class TrueInUnion
 {
     public function run($value)
     {
         if ($value) {
-            return false;
+            return true;
         }
 
         return substr('warning', 1);
@@ -20,12 +23,15 @@ final class MultiScalar
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
 
-final class MultiScalar
+/**
+ * true|othertype work on >= php 8.2, ref https://3v4l.org/UJqXT
+ */
+final class TrueInUnion
 {
-    public function run($value): false|string
+    public function run($value): true|string
     {
         if ($value) {
-            return false;
+            return true;
         }
 
         return substr('warning', 1);

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_in_union.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\FixtureTrueInUnion;
 
 /**
  * true|othertype work on >= php 8.2, ref https://3v4l.org/UJqXT
@@ -21,7 +21,7 @@ final class TrueInUnion
 -----
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\FixtureTrueInUnion;
 
 /**
  * true|othertype work on >= php 8.2, ref https://3v4l.org/UJqXT

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/TrueInUnionTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/TrueInUnionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TrueInUnionTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureTrueInUnion');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_true_in_union.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule_true_in_union.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule_true_in_union.php
@@ -8,5 +8,5 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ReturnUnionTypeRector::class);
-    $rectorConfig->phpVersion(PhpVersionFeature::UNION_TYPES);
+    $rectorConfig->phpVersion(PhpVersionFeature::NULL_FALSE_TRUE_STANDALONE_TYPE);
 };

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule_true_in_union.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule_true_in_union.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\ValueObject\PhpVersionFeature;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
@@ -66,7 +66,7 @@ final readonly class ReturnedNodesReturnTypeInfererTypeInferer
             $types[] = new VoidType();
         }
 
-        return $this->typeFactory->createMixedPassedOrUnionType($types);
+        return $this->typeFactory->createMixedPassedOrUnionTypeAndKeepConstant($types);
     }
 
     /**

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -51,6 +51,25 @@ final readonly class TypeFactory
         return $this->createUnionOrSingleType($types);
     }
 
+    private function normalizeObjectType(int $totalTypes, Type $type): Type
+    {
+        if ($totalTypes > 1 && $type instanceof ObjectWithoutClassTypeWithParentTypes) {
+            $parents = $type->getParentTypes();
+            return new ObjectType($parents[0]->getClassName());
+        }
+
+        return $type;
+    }
+
+    private function normalizeBooleanType(bool $hasFalse, bool $hasTrue, Type $type): Type
+    {
+        if ($hasFalse && $hasTrue && $type instanceof ConstantBooleanType) {
+            return new BooleanType();
+        }
+
+        return $type;
+    }
+
     /**
      * @template TType as Type
      * @param array<TType> $types
@@ -65,11 +84,7 @@ final readonly class TypeFactory
         $hasFalse = false;
         $hasTrue = false;
         foreach ($types as $type) {
-            if ($totalTypes > 1 && $type instanceof ObjectWithoutClassTypeWithParentTypes) {
-                $parents = $type->getParentTypes();
-                $type = new ObjectType($parents[0]->getClassName());
-            }
-
+            $type = $this->normalizeObjectType($totalTypes, $type);
             if ($type instanceof ConstantBooleanType) {
                 if ($type->getValue()) {
                     $hasTrue = true;
@@ -80,10 +95,7 @@ final readonly class TypeFactory
                 }
             }
 
-            if ($hasFalse && $hasTrue && $type instanceof ConstantBooleanType) {
-                $type = new BooleanType();
-            }
-
+            $type = $this->normalizeBooleanType($hasFalse, $hasTrue, $type);
             $removedConstantType = $this->removeValueFromConstantType($type);
             $removedConstantTypeHash = $this->typeHasher->createTypeHash($removedConstantType);
 

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -62,10 +62,26 @@ final readonly class TypeFactory
         $uniqueTypes = [];
         $totalTypes = count($types);
 
+        $hasFalse = false;
+        $hasTrue = false;
         foreach ($types as $type) {
             if ($totalTypes > 1 && $type instanceof ObjectWithoutClassTypeWithParentTypes) {
                 $parents = $type->getParentTypes();
                 $type = new ObjectType($parents[0]->getClassName());
+            }
+
+            if ($type instanceof \PHPStan\Type\Constant\ConstantBooleanType) {
+                if ($type->getValue() === true) {
+                    $hasTrue = true;
+                }
+
+                if ($type->getValue() === false) {
+                    $hasFalse = true;
+                }
+            }
+
+            if ($hasFalse && $hasTrue && $type instanceof \PHPStan\Type\Constant\ConstantBooleanType) {
+                $type = new BooleanType();
             }
 
             $removedConstantType = $this->removeValueFromConstantType($type);

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -70,8 +70,8 @@ final readonly class TypeFactory
                 $type = new ObjectType($parents[0]->getClassName());
             }
 
-            if ($type instanceof \PHPStan\Type\Constant\ConstantBooleanType) {
-                if ($type->getValue() === true) {
+            if ($type instanceof ConstantBooleanType) {
+                if ($type->getValue()) {
                     $hasTrue = true;
                 }
 
@@ -80,7 +80,7 @@ final readonly class TypeFactory
                 }
             }
 
-            if ($hasFalse && $hasTrue && $type instanceof \PHPStan\Type\Constant\ConstantBooleanType) {
+            if ($hasFalse && $hasTrue && $type instanceof ConstantBooleanType) {
                 $type = new BooleanType();
             }
 

--- a/src/NodeTypeResolver/PHPStan/TypeHasher.php
+++ b/src/NodeTypeResolver/PHPStan/TypeHasher.php
@@ -46,7 +46,7 @@ final class TypeHasher
         }
 
         if ($type instanceof ConstantType) {
-            return $type::class . $type->getValue();
+            return $type::class;
         }
 
         if ($type instanceof UnionType) {

--- a/src/NodeTypeResolver/PHPStan/TypeHasher.php
+++ b/src/NodeTypeResolver/PHPStan/TypeHasher.php
@@ -46,7 +46,7 @@ final class TypeHasher
         }
 
         if ($type instanceof ConstantType) {
-            return $type::class;
+            return $type::class . $type->getValue();
         }
 
         if ($type instanceof UnionType) {


### PR DESCRIPTION
This PR make:

- on php 8.0 until php 8.1: `false|string` is allowed, combine `true` and `string` become `bool|string`
- on >= php 8.2: `false|string` and `true|string` is allowed

ref 

- false|string: https://3v4l.org/KSofT 
- true|string: https://3v4l.org/UJqXT