### PR TITLE
[Naming] Skip `$this` in RenameForeachValueVariableToMatchExprVariableRector

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_this.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_this.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class SkipThis
+{
+    public function run()
+    {
+        foreach ($this as $item) {
+        }
+    }
+}
+
+?>

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -95,7 +95,7 @@ final class InflectorSingularResolver
 
         $resolvedName = '';
         foreach ($camelCases as $camelCase) {
-            if (in_array($camelCase[self::CAMELCASE], ['is', 'has', 'cms'], true)) {
+            if (in_array($camelCase[self::CAMELCASE], ['is', 'has', 'cms', 'this'], true)) {
                 $value = $camelCase[self::CAMELCASE];
             } else {
                 $value = $this->inflector->singularize($camelCase[self::CAMELCASE]);


### PR DESCRIPTION
- closes https://github.com/rectorphp/rector/issues/8359