### PR TITLE
[TypeDeclaration] Add new return type rule which handles literal scalars

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 353 Rules Overview
+# 354 Rules Overview
 
 <br>
 
@@ -56,7 +56,7 @@
 
 - [Transform](#transform) (22)
 
-- [TypeDeclaration](#typedeclaration) (40)
+- [TypeDeclaration](#typedeclaration) (41)
 
 - [Visibility](#visibility) (3)
 
@@ -6671,6 +6671,29 @@ Add "never" return-type for methods that never return anything
 +    public function run(): never
      {
          throw new InvalidException();
+     }
+ }
+```
+
+<br>
+
+### ReturnTypeFromLiteralScalarReturnRector
+
+Change return type based on literal scalar returns - string, int, float or bool
+
+- class: [`Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector`](../rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector.php)
+
+```diff
+ final class SomeClass
+ {
+-    public function run($value)
++    public function run($value): string
+     {
+         if ($value) {
+             return 'yes';
+         }
+
+         return 'no';
      }
  }
 ```

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/bool_multiple.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/bool_multiple.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class BoolMultiple
+{
+    public function run()
+    {
+        if (false) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class BoolMultiple
+{
+    public function run(): bool
+    {
+        if (false) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/bool_single.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/bool_single.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class BoolSingle
+{
+    public function run()
+    {
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class BoolSingle
+{
+    public function run(): bool
+    {
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/float_multiple.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/float_multiple.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class FloatMultiple
+{
+    public function run()
+    {
+        if (false) {
+            return 10.0;
+        }
+
+        return 0.0;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class FloatMultiple
+{
+    public function run(): float
+    {
+        if (false) {
+            return 10.0;
+        }
+
+        return 0.0;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/float_single.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/float_single.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class FloatSingle
+{
+    public function run()
+    {
+        return -10.1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class FloatSingle
+{
+    public function run(): float
+    {
+        return -10.1;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/int_multiple.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/int_multiple.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class IntMultiple
+{
+    public function run()
+    {
+        if (false) {
+            return 10;
+        }
+
+        return 0;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class IntMultiple
+{
+    public function run(): int
+    {
+        if (false) {
+            return 10;
+        }
+
+        return 0;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/int_single.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/int_single.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class IntSingle
+{
+    public function run()
+    {
+        return -10;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class IntSingle
+{
+    public function run(): int
+    {
+        return -10;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_differing_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_differing_types.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class SkipDiffering
+{
+    public function run()
+    {
+        if (false) {
+            return 1;
+        }
+
+        return 'test';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_empty_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_empty_return.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class SkipEmptyReturn
+{
+    public function run()
+    {
+        if (false) {
+            return;
+        }
+
+        return 'test';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_float_calc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_float_calc.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class SkipFloatCalc
+{
+    public function run()
+    {
+        return 3.4 + 9.2;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_int_calc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_int_calc.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class SkipIntCalc
+{
+    public function run()
+    {
+        return 3 + 9;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_string_concat.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_string_concat.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class SkipStringConcat
+{
+    public function run()
+    {
+        return 'hello' . 'world';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_string_mixed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/skip_string_mixed.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class SkipStringMixed
+{
+    public function run()
+    {
+        if (false) {
+            return 'hello' . 'world';
+        }
+
+        return 'test';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/string_herenowdoc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/string_herenowdoc.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class StringHerenowdoc
+{
+    public function run()
+    {
+        return <<<TEST
+test
+TEST;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class StringHerenowdoc
+{
+    public function run(): string
+    {
+        return <<<TEST
+test
+TEST;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/string_multiple.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/string_multiple.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class StringMultiple
+{
+    public function run()
+    {
+        if (false) {
+            return 'hello';
+        }
+
+        return 'world';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class StringMultiple
+{
+    public function run(): string
+    {
+        if (false) {
+            return 'hello';
+        }
+
+        return 'world';
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/string_single.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/Fixture/string_single.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class StringSingle
+{
+    public function run()
+    {
+        return 'test';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\Fixture;
+
+final class StringSingle
+{
+    public function run(): string
+    {
+        return 'test';
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/ReturnTypeFromLiteralScalarReturnRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/ReturnTypeFromLiteralScalarReturnRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReturnTypeFromLiteralScalarReturnRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReturnTypeFromLiteralScalarReturnRector::class);
+};

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/LiteralScalarReturnTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/LiteralScalarReturnTypeAnalyzer.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Type\Type;
+use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
+use Rector\TypeDeclaration\TypeAnalyzer\AlwaysStrictScalarExprAnalyzer;
+
+final class LiteralScalarReturnTypeAnalyzer
+{
+    public function __construct(
+        private readonly AlwaysStrictReturnAnalyzer $alwaysStrictReturnAnalyzer,
+        private readonly AlwaysStrictScalarExprAnalyzer $alwaysStrictScalarExprAnalyzer,
+        private readonly TypeFactory $typeFactory,
+    ) {
+    }
+
+    public function matchAlwaysLiteralScalarReturnType(ClassMethod|Closure|Function_ $functionLike): ?Type
+    {
+        $returns = $this->alwaysStrictReturnAnalyzer->matchAlwaysStrictReturns($functionLike);
+        if ($returns === null) {
+            return null;
+        }
+
+        $scalarTypes = [];
+
+        foreach ($returns as $return) {
+            if (! $this->isScalarExpression($return->expr)) {
+                return null;
+            }
+
+            $scalarType = $this->alwaysStrictScalarExprAnalyzer->matchStrictScalarExpr($return->expr);
+            if (! $scalarType instanceof Type) {
+                return null;
+            }
+
+            $scalarTypes[] = $scalarType;
+        }
+
+        return $this->typeFactory->createMixedPassedOrUnionType($scalarTypes);
+    }
+
+    /**
+     * @phpstan-assert-if-true Scalar|ConstFetch|UnaryMinus $expr
+     */
+    private function isScalarExpression(?Expr $expr): bool
+    {
+        // Normal scalar values like strings, integers and floats
+        if ($expr instanceof Scalar) {
+            return true;
+        }
+
+        // true / false / null are constants
+        if ($expr instanceof ConstFetch &&
+            in_array($expr->name->toLowerString(), ['true', 'false', 'null'], true)) {
+            return true;
+        }
+
+        // Negative numbers are wrapped in UnaryMinus, so check expression inside it
+        if ($expr instanceof UnaryMinus && $expr->expr instanceof Scalar) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromLiteralScalarReturnRector.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\UnionType;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\Type;
+use Rector\Core\Rector\AbstractScopeAwareRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer\LiteralScalarReturnTypeAnalyzer;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector\ReturnTypeFromLiteralScalarReturnRectorTest
+ */
+final class ReturnTypeFromLiteralScalarReturnRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly LiteralScalarReturnTypeAnalyzer $literalScalarReturnTypeAnalyzer,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+        private readonly StaticTypeMapper $staticTypeMapper
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change return type based on literal scalar returns - string, int, float or bool', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function run($value)
+    {
+        if ($value) {
+            return 'yes';
+        }
+
+        return 'no';
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function run($value): string
+    {
+        if ($value) {
+            return 'yes';
+        }
+
+        return 'no';
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class, Closure::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_|Closure $node
+     */
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
+    {
+        if ($node->returnType instanceof Node) {
+            return null;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scope
+        )) {
+            return null;
+        }
+
+        $scalarReturnType = $this->literalScalarReturnTypeAnalyzer->matchAlwaysLiteralScalarReturnType($node);
+        if (! $scalarReturnType instanceof Type) {
+            return null;
+        }
+
+        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($scalarReturnType, TypeKind::RETURN);
+        if (! $returnTypeNode instanceof Node) {
+            return null;
+        }
+
+        if ($returnTypeNode instanceof UnionType) {
+            return null;
+        }
+
+        $node->returnType = $returnTypeNode;
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::HAS_RETURN_TYPE;
+    }
+}

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -10,6 +10,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenCollectorRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromLiteralScalarReturnRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
 use Rector\Utils\Enum\RectorDirectoryToSetFileMap;
@@ -37,6 +38,8 @@ final class MissingInSetCommand extends Command
         JsonThrowOnErrorRector::class,
         // in confront with sub type safe belt detection on RemoveUseless*TagRector
         RemoveNullTagValueNodeRector::class,
+        // is a 100% subset of `ReturnTypeFromStrictScalarReturnExprRector`
+        ReturnTypeFromLiteralScalarReturnRector::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
Add a new return type rule which only adds return types for literal scalar returns. All return points must match this type, as no unions will be created. Operations on two literals, like string concat, or calculations with integers / floats are also ignored. The only special cases that are handling are true/false/null. This as these aren't actual scalar values but constants.

This follows on discussion: https://github.com/rectorphp/rector/discussions/8362. Not sure if you do want it, as it's functionality will be a 100% subset of `ReturnTypeFromStrictScalarReturnExprRector`, so enabling the latter will do the same, and more, compared to this rule. That's also why I opted not to add it to the `TYPE_DECLARATION` set, as `ReturnTypeFromStrictScalarReturnExprRector` already is in there and it would just "waste" resources on running both.