### PR TITLE
[ECS] Skip SelfAccessorFixer on *Rector.php to skip example code for using using self::

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff;
+use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
+use PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
@@ -29,7 +31,7 @@ return static function (ECSConfig $ecsConfig): void {
         __DIR__ . '/build/build-preload.php',
     ]);
 
-    $ecsConfig->rules([\PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer::class]);
+    $ecsConfig->rules([FunctionTypehintSpaceFixer::class]);
 
     $ecsConfig->ruleWithConfiguration(NoSuperfluousPhpdocTagsFixer::class, [
         'allow_mixed' => true,
@@ -56,5 +58,7 @@ return static function (ECSConfig $ecsConfig): void {
         PhpdocNoEmptyReturnFixer::class => [
             __DIR__ . '/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php',
         ],
+
+        SelfAccessorFixer::class => ['*/*Rector.php'],
     ]);
 };

--- a/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
+++ b/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
@@ -87,7 +87,7 @@ class SomeClass
 CODE_SAMPLE
                     ,
                     [
-                        self::LIMIT_VALUE => 1_000_000,
+                        AddLiteralSeparatorToNumberRector::LIMIT_VALUE => 1_000_000,
                     ]
                 ),
             ]

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -105,7 +105,7 @@ class SomeClass
 CODE_SAMPLE
                     ,
                     [
-                        self::INLINE_PUBLIC => false,
+                        ClassPropertyAssignToConstructorPromotionRector::INLINE_PUBLIC => false,
                     ]
                 ),
             ]

--- a/rules/Php82/Rector/Param/AddSensitiveParameterAttributeRector.php
+++ b/rules/Php82/Rector/Param/AddSensitiveParameterAttributeRector.php
@@ -92,7 +92,7 @@ class SomeClass
 CODE_SAMPLE
                     ,
                     [
-                        self::SENSITIVE_PARAMETERS => ['password'],
+                        AddSensitiveParameterAttributeRector::SENSITIVE_PARAMETERS => ['password'],
                     ]
                 ),
 

--- a/rules/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector.php
+++ b/rules/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector.php
@@ -63,7 +63,7 @@ class SomeClass
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => true,
+                    BooleanInBooleanNotRuleFixerRector::TREAT_AS_NON_EMPTY => true,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
+++ b/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
@@ -59,7 +59,7 @@ final class SomeEmptyArray
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    DisallowedEmptyRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector.php
+++ b/rules/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector.php
@@ -64,7 +64,7 @@ final class NegatedString
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    BooleanInIfConditionRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector.php
+++ b/rules/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector.php
@@ -55,7 +55,7 @@ final class ArrayCompare
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    BooleanInTernaryOperatorRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector.php
+++ b/rules/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector.php
@@ -58,7 +58,7 @@ final class ShortTernaryArray
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    DisallowedShortTernaryRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
+++ b/rules/Transform/Rector/Attribute/AttributeKeyToClassConstFetchRector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Transform\Rector\Attribute;
 
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\ArrowFunction;
@@ -157,7 +159,7 @@ CODE_SAMPLE
         return $hasChanged;
     }
 
-    private function processArg(Node\Arg $arg, AttributeKeyToClassConstFetch $attributeKeyToClassConstFetch): bool
+    private function processArg(Arg $arg, AttributeKeyToClassConstFetch $attributeKeyToClassConstFetch): bool
     {
         $value = $this->valueResolver->getValue($arg->value);
 
@@ -172,7 +174,7 @@ CODE_SAMPLE
         );
 
         if (
-            $arg->value instanceof Node\Expr\ClassConstFetch
+            $arg->value instanceof ClassConstFetch
             && $this->getName($arg->value) === $this->getName($newValue)
         ) {
             return false;

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -97,7 +97,7 @@ final class SomeClass
 CODE_SAMPLE
                 ,
                 [
-                    self::INLINE_PUBLIC => false,
+                    TypedPropertyFromAssignsRector::INLINE_PUBLIC => false,
                 ]
             ),
         ]);


### PR DESCRIPTION
@TomasVotruba this is to ensure code example on file `*Rector.php` not changed with `self::` as pointed to class name when configuring it, ref https://github.com/rectorphp/rector-src/pull/5362#pullrequestreview-1785173829