### PR TITLE
[TypeDeclaration] optionally only add types for hard coded return values in `ReturnTypeFromStrictScalarReturnExprRector`

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 354 Rules Overview
+# 355 Rules Overview
 
 <br>
 
@@ -44,7 +44,7 @@
 
 - [Php82](#php82) (4)
 
-- [Php83](#php83) (2)
+- [Php83](#php83) (3)
 
 - [Privatization](#privatization) (4)
 
@@ -5312,6 +5312,19 @@ Add const to type
 
 <br>
 
+### CombineHostPortLdapUriRector
+
+Combine separated host and port on `ldap_connect()` args
+
+- class: [`Rector\Php83\Rector\FuncCall\CombineHostPortLdapUriRector`](../rules/Php83/Rector/FuncCall/CombineHostPortLdapUriRector.php)
+
+```diff
+-ldap_connect('ldap://ldap.example.com', 389);
++ldap_connect('ldap://ldap.example.com:389');
+```
+
+<br>
+
 ## Privatization
 
 ### FinalizeClassesWithoutChildrenRector
@@ -6850,19 +6863,27 @@ Add return type based on strict parameter type
 
 Change return type based on strict scalar returns - string, int, float or bool
 
+:wrench: **configure it!**
+
 - class: [`Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector`](../rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php)
 
 ```diff
  final class SomeClass
  {
--    public function run($value)
-+    public function run($value): string
+-    public function foo($value)
++    public function foo($value): string
      {
          if ($value) {
              return 'yes';
          }
 
          return 'no';
+     }
+
+-    public function bar(string $value)
++    public function bar(string $value): int
+     {
+         return strlen($value);
      }
  }
 ```

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/bool.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/bool.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class Bool
+{
+    public function test($value)
+    {
+        if ($value) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class Bool
+{
+    public function test($value): bool
+    {
+        if ($value) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/final_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/final_method.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class UntypedBaseClass
+{
+    public function test()
+    {
+        return 0;
+    }
+}
+
+class SomeChild2 extends UntypedBaseClass
+{
+    final public function test()
+    {
+        return 'abc';
+    }
+
+}
+
+class SomeChild2Child extends SomeChild2 {}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class UntypedBaseClass
+{
+    public function test()
+    {
+        return 0;
+    }
+}
+
+class SomeChild2 extends UntypedBaseClass
+{
+    final public function test(): string
+    {
+        return 'abc';
+    }
+
+}
+
+class SomeChild2Child extends SomeChild2 {}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/float.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/float.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class Float
+{
+    public function test()
+    {
+        return 10.4;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class Float
+{
+    public function test(): float
+    {
+        return 10.4;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/float_negative.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/float_negative.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class FloatNegative
+{
+    public function test()
+    {
+        return -23.1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class FloatNegative
+{
+    public function test(): float
+    {
+        return -23.1;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/float_positive.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/float_positive.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class FloatPositive
+{
+    public function test()
+    {
+        return +33.9;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class FloatPositive
+{
+    public function test(): float
+    {
+        return +33.9;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/int.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/int.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class Int
+{
+    public function test()
+    {
+        return 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class Int
+{
+    public function test(): int
+    {
+        return 1;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/int_negative.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/int_negative.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class IntNegative
+{
+    public function test()
+    {
+        return -3;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class IntNegative
+{
+    public function test(): int
+    {
+        return -3;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/int_positive.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/int_positive.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class IntPositive
+{
+    public function test()
+    {
+        return +1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class IntPositive
+{
+    public function test(): int
+    {
+        return +1;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_calc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_calc.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class SkipCalc
+{
+    public function test()
+    {
+        return 1 + 2;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_call.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_call.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class SkipCall
+{
+    public function test($value)
+    {
+        return strlen($value);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_concat.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_concat.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class SkipConcat
+{
+    public function test()
+    {
+        return 'hello' . 'world';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_ternary.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_ternary.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class SkipTernary
+{
+    public function test($value)
+    {
+        return $value ? 10 : 0;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_variable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/skip_variable.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class SkipVariable
+{
+    public function test()
+    {
+        $value = 'test';
+        return $value;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/string.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/FixtureHardCodedOnly/string.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class String
+{
+    public function test()
+    {
+        return 'test';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector\FixtureHardCodedOnly;
+
+class String
+{
+    public function test(): string
+    {
+        return 'test';
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/HardCodedOnlyTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/HardCodedOnlyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class HardCodedOnlyTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureHardCodedOnly');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_hard_coded_only.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/config/configured_rule_hard_coded_only.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector/config/configured_rule_hard_coded_only.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ReturnTypeFromStrictScalarReturnExprRector::class, [
+        ReturnTypeFromStrictScalarReturnExprRector::HARD_CODED_ONLY => true,
+    ]);
+};


### PR DESCRIPTION
Supersedes #5361, relates to https://github.com/rectorphp/rector/discussions/8362