### PR TITLE
[Reflection] Remove usage of PrivatesAccessor on ClassReflectionAnalyzer

### DIFF
--- a/src/Reflection/ClassReflectionAnalyzer.php
+++ b/src/Reflection/ClassReflectionAnalyzer.php
@@ -4,18 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\Core\Reflection;
 
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\Reflection\ClassReflection;
-use Rector\Core\Util\Reflection\PrivatesAccessor;
 use ReflectionEnum;
 
 final class ClassReflectionAnalyzer
 {
-    public function __construct(
-        private readonly PrivatesAccessor $privatesAccessor
-    ) {
-    }
-
     public function resolveParentClassName(ClassReflection $classReflection): ?string
     {
         $nativeReflection = $classReflection->getNativeReflection();
@@ -23,11 +16,6 @@ final class ClassReflectionAnalyzer
             return null;
         }
 
-        $betterReflectionClass = $this->privatesAccessor->getPrivateProperty(
-            $nativeReflection,
-            'betterReflectionClass'
-        );
-        /** @var ReflectionClass $betterReflectionClass */
-        return $betterReflectionClass->getParentClassName();
+        return $nativeReflection->getParentClassName();
     }
 }


### PR DESCRIPTION
@staabm using `ReflectionClass` seems can now resolve parent classname:

https://github.com/ondrejmirtes/BetterReflection/blob/d797409a7f702b14f8ea756af7bfd6c5ef4d3e5f/src/Reflection/Adapter/ReflectionClass.php#L525-L528