### PR TITLE
[CodeQuality] Skip Superglobals variable on SimplifyEmptyCheckOnEmptyArrayRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_global_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRectorTest/Fixture/skip_global_variable.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRectorTest\Fixture;
+
+final class SkipGlobalVariable
+{
+    public function run()
+    {
+        return empty($_SESSION);
+    }
+}

--- a/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
+++ b/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
@@ -93,6 +93,15 @@ CODE_SAMPLE
         return new Identical($node->expr, new Array_());
     }
 
+    private function isAllowedVariable(Variable $variable): bool
+    {
+        if (is_string($variable->name) && $this->reservedKeywordAnalyzer->isNativeVariable($variable->name)) {
+            return false;
+        }
+
+        return ! $this->exprAnalyzer->isNonTypedFromParam($variable);
+    }
+
     private function isAllowedExpr(Expr $expr, Scope $scope): bool
     {
         if (! $scope->getType($expr) instanceof ArrayType) {
@@ -100,11 +109,7 @@ CODE_SAMPLE
         }
 
         if ($expr instanceof Variable) {
-            if (is_string($expr->name) && $this->reservedKeywordAnalyzer->isNativeVariable($expr->name)) {
-                return false;
-            }
-
-            return ! $this->exprAnalyzer->isNonTypedFromParam($expr);
+            return $this->isAllowedVariable($expr);
         }
 
         if (! $expr instanceof PropertyFetch && ! $expr instanceof StaticPropertyFetch) {

--- a/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
+++ b/rules/CodeQuality/Rector/Empty_/SimplifyEmptyCheckOnEmptyArrayRector.php
@@ -21,6 +21,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
 use Rector\Core\NodeAnalyzer\ExprAnalyzer;
+use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\Reflection\ReflectionResolver;
@@ -37,7 +38,8 @@ final class SimplifyEmptyCheckOnEmptyArrayRector extends AbstractScopeAwareRecto
         private readonly ExprAnalyzer $exprAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly AstResolver $astResolver,
-        private readonly AllAssignNodePropertyTypeInferer $allAssignNodePropertyTypeInferer
+        private readonly AllAssignNodePropertyTypeInferer $allAssignNodePropertyTypeInferer,
+        private readonly ReservedKeywordAnalyzer $reservedKeywordAnalyzer
     ) {
     }
 
@@ -98,6 +100,10 @@ CODE_SAMPLE
         }
 
         if ($expr instanceof Variable) {
+            if (is_string($expr->name) && $this->reservedKeywordAnalyzer->isNativeVariable($expr->name)) {
+                return false;
+            }
+
             return ! $this->exprAnalyzer->isNonTypedFromParam($expr);
         }
 


### PR DESCRIPTION
`$_SESSION` may got null value on cli:

```php
➜  rector-src git:(main) ✗ php -a
Interactive shell

php > var_dump($_SESSION);
PHP Warning:  Undefined global variable $_SESSION in php shell code on line 1

Warning: Undefined global variable $_SESSION in php shell code on line 1
NULL
```