### PR TITLE
[Testing] Remove unnecessary set Parameter Source on TestingParser

### DIFF
--- a/packages/Testing/TestingParser/TestingParser.php
+++ b/packages/Testing/TestingParser/TestingParser.php
@@ -6,8 +6,6 @@ namespace Rector\Testing\TestingParser;
 
 use Nette\Utils\FileSystem;
 use PhpParser\Node;
-use Rector\Core\Configuration\Option;
-use Rector\Core\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Core\PhpParser\Parser\RectorParser;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\ValueObject\Application\File;
@@ -51,8 +49,6 @@ final class TestingParser
     {
         // needed for PHPStan reflection, as it caches the last processed file
         $this->dynamicSourceLocatorProvider->setFilePath($filePath);
-
-        SimpleParameterProvider::setParameter(Option::SOURCE, [$filePath]);
 
         $fileContent = FileSystem::read($filePath);
         $stmts = $this->rectorParser->parseString($fileContent);


### PR DESCRIPTION
Set:

```php
SimpleParameterProvider::setParameter(Option::SOURCE, [$filePath]);
```

seems no longer needed in `TestingParser`