### PR TITLE
[DeadCode] Merge SideEffectNodeDetector::detectCallExpr() into detect()

### DIFF
--- a/rules/CodeQuality/Rector/Expression/TernaryFalseExpressionToIfRector.php
+++ b/rules/CodeQuality/Rector/Expression/TernaryFalseExpressionToIfRector.php
@@ -77,7 +77,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->sideEffectNodeDetector->detect($ternary->else, $scope) || $this->sideEffectNodeDetector->detectCallExpr($ternary->else, $scope)) {
+        if ($this->sideEffectNodeDetector->detect($ternary->else, $scope)) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
 
             // detect call expression has side effect
             // no calls on right, could hide e.g. array_pop()|array_shift()
-            if ($this->sideEffectNodeDetector->detectCallExpr($stmt->expr->expr, $scope)) {
+            if ($this->sideEffectNodeDetector->detect($stmt->expr->expr, $scope)) {
                 continue;
             }
 

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -140,7 +140,7 @@ CODE_SAMPLE
     {
         return (bool) $this->betterNodeFinder->findFirst(
             $expr,
-            fn (Node $subNode): bool => $this->sideEffectNodeDetector->detectCallExpr($subNode, $scope)
+            fn (Node $subNode): bool => $this->sideEffectNodeDetector->detect($subNode, $scope)
         );
     }
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/5373

this merge `detectCallExpr()` into `detect()` so no need to call both.