### PR TITLE
[DeadCode] Skip nullable array on RemoveUnusedNonEmptyArrayBeforeForeachRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_nullable_array.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_nullable_array.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
+
+function run(?array $values) {
+    if (empty($values)) {
+        return;
+    }
+
+    foreach ($values as $value) {
+        echo $value;
+    }
+}
+
+?>
+

--- a/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_nullable_array.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector/Fixture/skip_nullable_array.php.inc
@@ -2,13 +2,16 @@
 
 namespace Rector\Tests\DeadCode\Rector\If_\RemoveUnusedNonEmptyArrayBeforeForeachRector\Fixture;
 
-function run(?array $values) {
-    if (empty($values)) {
-        return;
-    }
+class SkipNullableArray
+{
+    public function run(?array $values) {
+        if (empty($values)) {
+            return;
+        }
 
-    foreach ($values as $value) {
-        echo $value;
+        foreach ($values as $value) {
+            echo $value;
+        }
     }
 }
 

--- a/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Foreach_;
@@ -174,6 +175,18 @@ CODE_SAMPLE
                 $previousStmt,
                 $stmt->expr
             )) {
+                continue;
+            }
+
+            /** @var Empty_ $empty */
+            $empty = $previousStmt->cond;
+            $scope = $empty->getAttribute(AttributeKey::SCOPE);
+            if ($scope === null) {
+                continue;
+            }
+
+            $ifType = $scope->getNativeType($empty->expr);
+            if (! $ifType->isArray()->yes()) {
                 continue;
             }
 

--- a/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
@@ -180,8 +180,9 @@ CODE_SAMPLE
 
             /** @var Empty_ $empty */
             $empty = $previousStmt->cond;
+            // scope need to be pulled from Empty_ node to ensure it get correct type
             $scope = $empty->getAttribute(AttributeKey::SCOPE);
-            if ($scope === null) {
+            if (! $scope instanceof Scope) {
                 continue;
             }
 


### PR DESCRIPTION
The following code should be skipped:

```php
function run(?array $values) {
    if (empty($values)) {
        return;
    }

    foreach ($values as $value) {
        echo $value;
    }
}
```