### PR TITLE
[Performance][AstResolver] Avoid parse file on NativeFunctionReflection on AstResolver::resolveFunctionFromFunctionReflection()

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -24,6 +24,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\Php\PhpFunctionReflection;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\TypeWithClassName;
@@ -124,6 +125,10 @@ final class AstResolver
 
     public function resolveFunctionFromFunctionReflection(FunctionReflection $functionReflection): ?Function_
     {
+        if (! $functionReflection instanceof PhpFunctionReflection) {
+            return null;
+        }
+
         $fileName = $functionReflection->getFileName();
         $nodes = $this->parseFileNameToDecoratedNodes($fileName);
 


### PR DESCRIPTION
Only scan file on `PHPStan\Reflection\Php\PhpFunctionReflection`, avoid unnecessary scan on `PHPStan\Reflection\Native\NativeFunctionReflection`