### PR TITLE
Skip classes without final and exception as possibly invoke child implement in AddVoidReturnTypeWhereNoReturnRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -528,3 +528,8 @@ parameters:
 
         # optional as changes behavior, should be used explicitly outside PHP upgrade
         - '#Register "Rector\\Php73\\Rector\\FuncCall\\JsonThrowOnErrorRector" service to "php73\.php" config set#'
+
+        # soon to be extended
+        -
+            path: src/Reflection/ClassModifierChecker.php
+            message: '#Parameters should use "PhpParser\\Node\\Stmt\\ClassMethod" types as the only types passed to this method#'

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_non_final_with_exception.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector/Fixture/skip_non_final_with_exception.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector\Fixture;
+
+use Rector\Core\Exception\ShouldNotHappenException;
+
+class SkipNonFinalWithException
+{
+    public function getValues()
+    {
+        throw new ShouldNotHappenException('Implement in child');
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -127,17 +127,17 @@ CODE_SAMPLE
         return $this->classModifierChecker->isInsideAbstractClass($functionLike) && $functionLike->getStmts() === [];
     }
 
-    private function isNotFinalAndHasExceptionOnly(ClassMethod $functionLike): bool
+    private function isNotFinalAndHasExceptionOnly(ClassMethod $classMethod): bool
     {
-        if ($this->classModifierChecker->isInsideFinalClass($functionLike)) {
+        if ($this->classModifierChecker->isInsideFinalClass($classMethod)) {
             return false;
         }
 
-        if (count((array) $functionLike->stmts) !== 1) {
+        if (count((array) $classMethod->stmts) !== 1) {
             return false;
         }
 
-        $onlyStmt = $functionLike->stmts[0] ?? null;
+        $onlyStmt = $classMethod->stmts[0] ?? null;
         return $onlyStmt instanceof Throw_;
     }
 }

--- a/src/Reflection/ClassModifierChecker.php
+++ b/src/Reflection/ClassModifierChecker.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Reflection;
+
+use PhpParser\Node;
+use PHPStan\Reflection\ClassReflection;
+
+final class ClassModifierChecker
+{
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver
+    ) {
+    }
+
+    public function isInsideFinalClass(Node $node): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->isFinalByKeyword();
+    }
+
+    public function isInsideAbstractClass(Node $node): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->isAbstract();
+    }
+}


### PR DESCRIPTION
This is based on mautic and private project ugprades. The methods like these are often used as form of enforcement to require child method to be implemented. Most often with return value.

That's why `void` causes a false positive as child classes return different value.