### PR TITLE
[Arguments] Allow no default value on ArgumentAdderRector

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/without_default_value.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/without_default_value.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeContainerBuilder;
+
+class WithoutDefaultValue
+{
+    public function someMethod()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeContainerBuilder;
+
+class WithoutDefaultValue
+{
+    public function someMethod(array $foo)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
@@ -9,7 +9,9 @@ use PHPStan\Type\ObjectType;
 use Rector\Arguments\NodeAnalyzer\ArgumentAddingScope;
 use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
 use Rector\Config\RectorConfig;
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture\WithoutDefaultValue;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeClass;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeContainerBuilder;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
@@ -53,5 +55,6 @@ return static function (RectorConfig $rectorConfig): void {
             new ArgumentAdder(SomeClass::class, 'withoutTypeOrDefaultValue', 0, 'arguments', [], $arrayType),
             new ArgumentAdder(SomeMultiArg::class, 'run', 2, 'c', 4),
             new ArgumentAdder(SomeClass::class, 'someMethod', 0, 'default', 1),
+            new ArgumentAdderWithoutDefaultValue(WithoutDefaultValue::class, 'someMethod', 0, 'foo', $arrayType),
         ]);
 };

--- a/rules/Arguments/NodeAnalyzer/ArgumentAddingScope.php
+++ b/rules/Arguments/NodeAnalyzer/ArgumentAddingScope.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use Rector\Arguments\ValueObject\ArgumentAdder;
+use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
 use Rector\Core\Enum\ObjectReference;
 use Rector\NodeNameResolver\NodeNameResolver;
 
@@ -36,7 +37,7 @@ final class ArgumentAddingScope
     ) {
     }
 
-    public function isInCorrectScope(MethodCall | StaticCall $expr, ArgumentAdder $argumentAdder): bool
+    public function isInCorrectScope(MethodCall | StaticCall $expr, ArgumentAdder|ArgumentAdderWithoutDefaultValue $argumentAdder): bool
     {
         if ($argumentAdder->getScope() === null) {
             return true;

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -170,8 +170,11 @@ CODE_SAMPLE
         $this->processMethodCall($node, $argumentAdder, $position);
     }
 
-    private function processMethodCall(MethodCall $methodCall, ArgumentAdder|ArgumentAdderWithoutDefaultValue $argumentAdder, int $position): void
-    {
+    private function processMethodCall(
+        MethodCall $methodCall,
+        ArgumentAdder|ArgumentAdderWithoutDefaultValue $argumentAdder,
+        int $position
+    ): void {
         if ($argumentAdder instanceof ArgumentAdderWithoutDefaultValue) {
             return;
         }
@@ -238,10 +241,7 @@ CODE_SAMPLE
             }
 
             // argument added and default has been changed
-            if ($argumentAdder instanceof ArgumentAdder && $this->changedArgumentsDetector->isDefaultValueChanged(
-                $param,
-                $argumentAdder->getArgumentDefaultValue()
-            )) {
+            if ($this->isDefaultValueChanged($argumentAdder, $node, $position)) {
                 return true;
             }
 
@@ -265,15 +265,23 @@ CODE_SAMPLE
             return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
         }
 
-        if ($argumentAdder instanceof ArgumentAdder && $this->changedArgumentsDetector->isDefaultValueChanged(
-            $classMethod->params[$position],
-            $argumentAdder->getArgumentDefaultValue()
-        )) {
+        if ($this->isDefaultValueChanged($argumentAdder, $classMethod, $position)) {
             // is correct scope?
             return ! $this->argumentAddingScope->isInCorrectScope($node, $argumentAdder);
         }
 
         return true;
+    }
+
+    private function isDefaultValueChanged(
+        ArgumentAdder|ArgumentAdderWithoutDefaultValue $argumentAdder,
+        ClassMethod $classMethod,
+        int $position
+    ): bool {
+        return $argumentAdder instanceof ArgumentAdder && $this->changedArgumentsDetector->isDefaultValueChanged(
+            $classMethod->params[$position],
+            $argumentAdder->getArgumentDefaultValue()
+        );
     }
 
     private function addClassMethodParam(
@@ -288,7 +296,9 @@ CODE_SAMPLE
         }
 
         if ($argumentAdder instanceof ArgumentAdder) {
-            $param = new Param(new Variable($argumentName), BuilderHelpers::normalizeValue($argumentAdder->getArgumentDefaultValue()));
+            $param = new Param(new Variable($argumentName), BuilderHelpers::normalizeValue(
+                $argumentAdder->getArgumentDefaultValue()
+            ));
         } else {
             $param = new Param(new Variable($argumentName));
         }
@@ -301,8 +311,11 @@ CODE_SAMPLE
         $this->hasChanged = true;
     }
 
-    private function processStaticCall(StaticCall $staticCall, int $position, ArgumentAdder|ArgumentAdderWithoutDefaultValue $argumentAdder): void
-    {
+    private function processStaticCall(
+        StaticCall $staticCall,
+        int $position,
+        ArgumentAdder|ArgumentAdderWithoutDefaultValue $argumentAdder
+    ): void {
         if ($argumentAdder instanceof ArgumentAdderWithoutDefaultValue) {
             return;
         }

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -238,7 +238,7 @@ CODE_SAMPLE
             }
 
             // argument added and default has been changed
-            if ($this->changedArgumentsDetector->isDefaultValueChanged(
+            if ($argumentAdder instanceof ArgumentAdder && $this->changedArgumentsDetector->isDefaultValueChanged(
                 $param,
                 $argumentAdder->getArgumentDefaultValue()
             )) {

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -38,7 +38,7 @@ use Webmozart\Assert\Assert;
 final class ArgumentAdderRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var ArgumentAdder[]
+     * @var ArgumentAdder[]|ArgumentAdderWithoutDefaultValue[]
      */
     private array $addedArguments = [];
 

--- a/rules/Arguments/ValueObject/ArgumentAdderWithoutDefaultValue.php
+++ b/rules/Arguments/ValueObject/ArgumentAdderWithoutDefaultValue.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Arguments\ValueObject;
+
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Rector\Core\Validation\RectorAssert;
+
+final class ArgumentAdderWithoutDefaultValue
+{
+    public function __construct(
+        private readonly string $class,
+        private readonly string $method,
+        private readonly int $position,
+        private readonly ?string $argumentName = null,
+        private readonly Type | null $argumentType = null,
+        private readonly ?string $scope = null
+    ) {
+        RectorAssert::className($class);
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->class);
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function getArgumentName(): ?string
+    {
+        return $this->argumentName;
+    }
+
+    public function getArgumentType(): ?Type
+    {
+        return $this->argumentType;
+    }
+
+    public function getScope(): ?string
+    {
+        return $this->scope;
+    }
+}


### PR DESCRIPTION
@joachim-n this should handle https://github.com/rectorphp/rector/issues/8350
Closes https://github.com/rectorphp/rector/issues/8350

with add `ArgumentAdderWithoutDefaultValue` value object for it.