### PR TITLE
[Parallel] Fix missing --xdebug in WorkerCommand line on WorkerCommandLineFactory when --xdebug provided

### DIFF
--- a/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/packages-tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -100,6 +100,17 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
             ],
             "'" . PHP_BINARY . "' '" . self::SPACED_DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --debug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
         ];
+
+        yield [
+            [
+                self::COMMAND => 'process',
+                Option::SOURCE => ['src'],
+                '--' . Option::OUTPUT_FORMAT => ConsoleOutputFormatter::NAME,
+                '--' . Option::DEBUG => true,
+                '--' . Option::XDEBUG => true,
+            ],
+            "'" . PHP_BINARY . "' '" . self::SPACED_DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --debug --xdebug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
+        ];
     }
 
     /**
@@ -159,6 +170,17 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
                 '--' . Option::DEBUG => true,
             ],
             "'" . PHP_BINARY . "' '" . self::DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --debug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
+        ];
+
+        yield [
+            [
+                self::COMMAND => 'process',
+                Option::SOURCE => ['src'],
+                '--' . Option::OUTPUT_FORMAT => ConsoleOutputFormatter::NAME,
+                '--' . Option::DEBUG => true,
+                '--' . Option::XDEBUG => true,
+            ],
+            "'" . PHP_BINARY . "' '" . self::DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --debug --xdebug --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
         ];
     }
 

--- a/packages/Parallel/Command/WorkerCommandLineFactory.php
+++ b/packages/Parallel/Command/WorkerCommandLineFactory.php
@@ -114,10 +114,6 @@ final class WorkerCommandLineFactory
             $workerCommandArray[] = escapeshellarg($this->filePathHelper->relativePath($config));
         }
 
-        if (! in_array('--xdebug', $workerCommandArray, true) && in_array('--xdebug', $args, true)) {
-            $workerCommandArray[] = '--xdebug';
-        }
-
         return implode(' ', $workerCommandArray);
     }
 

--- a/packages/Parallel/Command/WorkerCommandLineFactory.php
+++ b/packages/Parallel/Command/WorkerCommandLineFactory.php
@@ -114,6 +114,10 @@ final class WorkerCommandLineFactory
             $workerCommandArray[] = escapeshellarg($this->filePathHelper->relativePath($config));
         }
 
+        if (! in_array('--xdebug', $workerCommandArray, true) && in_array('--xdebug', $args, true)) {
+            $workerCommandArray[] = '--xdebug';
+        }
+
         return implode(' ', $workerCommandArray);
     }
 

--- a/src/Console/ConsoleApplication.php
+++ b/src/Console/ConsoleApplication.php
@@ -43,7 +43,7 @@ final class ConsoleApplication extends Application
     {
         // @fixes https://github.com/rectorphp/rector/issues/2205
         $isXdebugAllowed = $input->hasParameterOption('--xdebug');
-        if (! $isXdebugAllowed) {
+        if ($isXdebugAllowed) {
             $xdebugHandler = new XdebugHandler('rector');
             $xdebugHandler->check();
             unset($xdebugHandler);

--- a/src/Console/ProcessConfigureDecorator.php
+++ b/src/Console/ProcessConfigureDecorator.php
@@ -64,5 +64,7 @@ final class ProcessConfigureDecorator
 
         $command->addOption(Option::PARALLEL_PORT, null, InputOption::VALUE_REQUIRED);
         $command->addOption(Option::PARALLEL_IDENTIFIER, null, InputOption::VALUE_REQUIRED);
+
+        $command->addOption(Option::XDEBUG, null, InputOption::VALUE_NONE, 'Display xdebug output.');
     }
 }


### PR DESCRIPTION
@zangai @deviantintegral @MartinsRucevskis @staabm  could you verify manually this patch on  `WorkerCommandLineFactory` can fix https://github.com/rectorphp/rector/issues/8060

Thank you.

