### PR TITLE
[psr-4] Move tests to main namespace, as part of /src and /packages merge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,10 +91,10 @@
         "psr-4": {
             "Rector\\Tests\\": [
                 "packages-tests",
-                "rules-tests"
+                "rules-tests",
+                "tests"
             ],
             "Rector\\Utils\\Tests\\": "utils-tests",
-            "Rector\\Core\\Tests\\": "tests",
             "Rector\\RuleDocGenerator\\": "utils/RuleDocGenerator/src",
             "E2e\\Parallel\\Reflection\\Resolver\\": [
                 "e2e/parallel-reflection-resolver/src/",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -207,16 +207,8 @@ parameters:
         - '#Method "(change|remove)(.*?)" returns bool type, so the name should start with is/has/was#'
 
         -
-            message: '#Casting to float something that.{1}s already float#'
-            path: packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php #38
-
-        -
-            message: '#Casting to string something that.{1}s already string#'
-            path: packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php #42
-
-        -
-            message: '#Casting to int something that.{1}s already int#'
-            path: packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php #46
+            message: '#Casting to (float|string|int) something that.{1}s already (.*?)#'
+            path: packages/NodeTypeResolver/NodeTypeResolver/ScalarTypeResolver.php
 
         -
             message: '#Use value object over return of values#'
@@ -359,7 +351,7 @@ parameters:
             path: src/Util/ArrayParametersMerger.php
 
         # fixture class
-        - '#Class "Rector\\Core\\Tests\\Issues\\ScopeNotAvailable\\Variable\\ArrayItemForeachValueRector" is missing @see annotation with test case class reference#'
+        - '#Class "Rector\\Tests\\Issues\\ScopeNotAvailable\\Variable\\ArrayItemForeachValueRector" is missing @see annotation with test case class reference#'
 
         # returns bool for notifications
         - '#Method "renamePropertyPromotion\(\)" returns bool type, so the name should start with is/has/was#'

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -9,7 +9,7 @@ use Nette\Utils\Strings;
 use Rector\Core\Util\StringUtils;
 
 /**
- * @see \Rector\Core\Tests\Naming\ExpectedNameResolver\InflectorSingularResolverTest
+ * @see \Rector\Tests\Naming\ExpectedNameResolver\InflectorSingularResolverTest
  */
 final class InflectorSingularResolver
 {

--- a/tests/Application/VersionResolverTest.php
+++ b/tests/Application/VersionResolverTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Application;
+namespace Rector\Tests\Application;
 
 use PHPUnit\Framework\TestCase;
 use Rector\Core\Application\VersionResolver;

--- a/tests/Autoloading/BootstrapFilesIncluderTest.php
+++ b/tests/Autoloading/BootstrapFilesIncluderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Autoloading;
+namespace Rector\Tests\Autoloading;
 
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use Rector\Core\Autoloading\BootstrapFilesIncluder;

--- a/tests/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Configuration/ConfigurationFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Configuration;
+namespace Rector\Tests\Configuration;
 
 use Rector\Core\Configuration\ConfigurationFactory;
 use Rector\Core\FileSystem\FilesFinder;

--- a/tests/Console/Formatter/ColorConsoleDiffFormatterTest.php
+++ b/tests/Console/Formatter/ColorConsoleDiffFormatterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Console\Formatter;
+namespace Rector\Tests\Console\Formatter;
 
 use Iterator;
 use Nette\Utils\FileSystem;

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\DependencyInjection;
+namespace Rector\Tests\DependencyInjection;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/FileSystem/FileAndDirectoryFilter/FileAndDirectoryFilterTest.php
+++ b/tests/FileSystem/FileAndDirectoryFilter/FileAndDirectoryFilterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\FileSystem\FileAndDirectoryFilter;
+namespace Rector\Tests\FileSystem\FileAndDirectoryFilter;
 
 use PHPUnit\Framework\TestCase;
 use Rector\Core\FileSystem\FileAndDirectoryFilter;

--- a/tests/FileSystem/FilePathHelperTest.php
+++ b/tests/FileSystem/FilePathHelperTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\FileSystem;
+namespace Rector\Tests\FileSystem;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/FileSystem/FilesFinder/ExcludePaths/ExcludePathsTest.php
+++ b/tests/FileSystem/FilesFinder/ExcludePaths/ExcludePathsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\FileSystem\FilesFinder\ExcludePaths;
+namespace Rector\Tests\FileSystem\FilesFinder\ExcludePaths;
 
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;

--- a/tests/FileSystem/FilesFinder/ExcludePaths/Source/ShouldBeExcluded/FileWithMissingClass.php
+++ b/tests/FileSystem/FilesFinder/ExcludePaths/Source/ShouldBeExcluded/FileWithMissingClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\FileSystem\FilesFinder\ExcludePaths\Source\ShouldBeExcluded;
+namespace Rector\Tests\FileSystem\FilesFinder\ExcludePaths\Source\ShouldBeExcluded;
 
 final class FileWithMissingClass extends ThisClassIsNotHere
 {

--- a/tests/FileSystem/FilesFinder/ExcludePaths/Source/ThisShouldBeHere.php
+++ b/tests/FileSystem/FilesFinder/ExcludePaths/Source/ThisShouldBeHere.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\FileSystem\FilesFinder\ExcludePaths\Source;
+namespace Rector\Tests\FileSystem\FilesFinder\ExcludePaths\Source;
 
 final class ThisShouldBeHere
 {

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\FileSystem\FilesFinder;
+namespace Rector\Tests\FileSystem\FilesFinder;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/FileSystem/InitFilePathsResolver/InitFilePathsResolverTest.php
+++ b/tests/FileSystem/InitFilePathsResolver/InitFilePathsResolverTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\FileSystem\InitFilePathsResolver;
+namespace Rector\Tests\FileSystem\InitFilePathsResolver;
 
 use PHPUnit\Framework\TestCase;
 use Rector\Core\FileSystem\InitFilePathsResolver;

--- a/tests/Issues/AlwaysTrueIfInDeadConstructor/AlwaysTrueIfInDeadConstructorTest.php
+++ b/tests/Issues/AlwaysTrueIfInDeadConstructor/AlwaysTrueIfInDeadConstructorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AlwaysTrueIfInDeadConstructor;
+namespace Rector\Tests\Issues\AlwaysTrueIfInDeadConstructor;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/AlwaysTrueIfInDeadConstructor/Fixture/fixture.php.inc
+++ b/tests/Issues/AlwaysTrueIfInDeadConstructor/Fixture/fixture.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AlwaysTrueIfInDeadConstructor\Fixture;
+namespace Rector\Tests\Issues\AlwaysTrueIfInDeadConstructor\Fixture;
 
 final class Fixture
 {
@@ -19,7 +19,7 @@ final class Fixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AlwaysTrueIfInDeadConstructor\Fixture;
+namespace Rector\Tests\Issues\AlwaysTrueIfInDeadConstructor\Fixture;
 
 final class Fixture
 {

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/AnnotationToAttributeRenameAutoImportTest.php
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/AnnotationToAttributeRenameAutoImportTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport;
+namespace Rector\Tests\Issues\AnnotationToAttributeRenameAutoImport;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/fixture.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+namespace Rector\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -16,7 +16,7 @@ class IsGrantedController extends AbstractController
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+namespace Rector\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
 
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+namespace Rector\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
@@ -15,7 +15,7 @@ class NotImportedYet extends AbstractController
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+namespace Rector\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
 
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet2.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/not_imported_yet2.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+namespace Rector\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -16,7 +16,7 @@ class NotImportedYet2 extends AbstractController
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
+namespace Rector\Tests\Issues\AnnotationToAttributeRenameAutoImport\Fixture;
 
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/with_existing_attribute.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/with_existing_attribute.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\RenameAnnotationToAttributeAutoImport\Fixture;
+namespace Rector\Tests\Issues\RenameAnnotationToAttributeAutoImport\Fixture;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -18,7 +18,7 @@ class WithExistingAttribute extends AbstractController
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\RenameAnnotationToAttributeAutoImport\Fixture;
+namespace Rector\Tests\Issues\RenameAnnotationToAttributeAutoImport\Fixture;
 
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/tests/Issues/AutoImport/AutoImportTest.php
+++ b/tests/Issues/AutoImport/AutoImportTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImport;
+namespace Rector\Tests\Issues\AutoImport;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/AutoImport/Fixture/DocBlock/annotation_to_attribute.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/annotation_to_attribute.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 /**
  * @\Doctrine\ORM\Mapping\Entity()
@@ -13,7 +13,7 @@ class SomeEntity
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Doctrine\ORM\Mapping\Entity;
 #[Entity]

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutes
 {
@@ -18,7 +18,7 @@ class TwoRoutes
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutes

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesAfterGeneric
 {
@@ -22,7 +22,7 @@ class TwoRoutesAfterGeneric
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesAfterGeneric

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic_with_string_key_numeric.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_after_generic_with_string_key_numeric.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesAfterGenericWithStringKeyNumeric
 {
@@ -22,7 +22,7 @@ class TwoRoutesAfterGenericWithStringKeyNumeric
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesAfterGenericWithStringKeyNumeric

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_before_generic.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_before_generic.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesBeforeGeneric
 {
@@ -22,7 +22,7 @@ class TwoRoutesBeforeGeneric
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesBeforeGeneric

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_comment_before.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_comment_before.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesWithCommentBefore
 {
@@ -20,7 +20,7 @@ class TwoRoutesWithCommentBefore
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesWithCommentBefore

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_next_doc.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_next_doc.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesWithNextDoc
 {
@@ -19,7 +19,7 @@ class TwoRoutesWithNextDoc
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesWithNextDoc

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_next_doc_other_routes.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_next_doc_other_routes.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesWithNextDoc2
 {
@@ -20,7 +20,7 @@ class TwoRoutesWithNextDoc2
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesWithNextDoc2

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesWithPrevDoc
 {
@@ -19,7 +19,7 @@ class TwoRoutesWithPrevDoc
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesWithPrevDoc

--- a/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc_with_description_multiline.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/two_routes_with_prev_doc_with_description_multiline.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 class TwoRoutesWithPrevDocWithDescriptionMultiline
 {
@@ -21,7 +21,7 @@ class TwoRoutesWithPrevDocWithDescriptionMultiline
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture\DocBlock;
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
 
 use Symfony\Component\Routing\Annotation\Route;
 class TwoRoutesWithPrevDocWithDescriptionMultiline

--- a/tests/Issues/AutoImport/Fixture/auto_import_in_alias.php.inc
+++ b/tests/Issues/AutoImport/Fixture/auto_import_in_alias.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 use stdClass as SomeObject;
 
@@ -12,7 +12,7 @@ final class AutoImport extends \stdClass
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 use stdClass as SomeObject;
 

--- a/tests/Issues/AutoImport/Fixture/auto_import_in_alias_same_last_name.php.inc
+++ b/tests/Issues/AutoImport/Fixture/auto_import_in_alias_same_last_name.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 use PhpParser\Node\Expr\BinaryOp\Plus;
 use PhpParser\Node\Expr\AssignOp\Plus as AssignPlus;
@@ -20,7 +20,7 @@ final class AutoImportSameLastName
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 use PhpParser\Node\Expr\BinaryOp\Plus;
 use PhpParser\Node\Expr\AssignOp\Plus as AssignPlus;

--- a/tests/Issues/AutoImport/Fixture/auto_import_in_groupuse.php.inc
+++ b/tests/Issues/AutoImport/Fixture/auto_import_in_groupuse.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportGroupUse\Fixture;
+namespace Rector\Tests\Issues\AutoImportGroupUse\Fixture;
 
-use Rector\Core\Tests\Issues\AutoImportGroupUse\Source\{ SomeClass };
+use Rector\Tests\Issues\AutoImportGroupUse\Source\{ SomeClass };
 
 final class AutoImportInGroupUse extends \Rector\Core\Tests\Issues\AutoImportGroupUse\Source\SomeClass
 {
@@ -12,9 +12,9 @@ final class AutoImportInGroupUse extends \Rector\Core\Tests\Issues\AutoImportGro
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportGroupUse\Fixture;
+namespace Rector\Tests\Issues\AutoImportGroupUse\Fixture;
 
-use Rector\Core\Tests\Issues\AutoImportGroupUse\Source\{ SomeClass };
+use Rector\Tests\Issues\AutoImportGroupUse\Source\{ SomeClass };
 
 final class AutoImportInGroupUse extends SomeClass
 {

--- a/tests/Issues/AutoImport/Fixture/auto_import_in_groupuse.php.inc
+++ b/tests/Issues/AutoImport/Fixture/auto_import_in_groupuse.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Issues\AutoImportGroupUse\Fixture;
 
 use Rector\Tests\Issues\AutoImportGroupUse\Source\{ SomeClass };
 
-final class AutoImportInGroupUse extends \Rector\Core\Tests\Issues\AutoImportGroupUse\Source\SomeClass
+final class AutoImportInGroupUse extends \Rector\Tests\Issues\AutoImportGroupUse\Source\SomeClass
 {
 }
 

--- a/tests/Issues/AutoImport/Fixture/fixture.php.inc
+++ b/tests/Issues/AutoImport/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 /**
  * License
@@ -24,7 +24,7 @@ final class DemoFile
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 /**
  * License

--- a/tests/Issues/AutoImport/Fixture/skip_auto_import_doc_in_use_namespace.php.inc
+++ b/tests/Issues/AutoImport/Fixture/skip_auto_import_doc_in_use_namespace.php.inc
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Rector\Core\Tests\Issues\AutoImport\Source\Annotation;
+use Rector\Tests\Issues\AutoImport\Source\Annotation;
 
 final class SkipAutoImportNamespace extends AbstractController
 {

--- a/tests/Issues/AutoImport/Fixture/skip_auto_import_in_alias_same_last_name_different_fqcn.php.inc
+++ b/tests/Issues/AutoImport/Fixture/skip_auto_import_in_alias_same_last_name_different_fqcn.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImport\Fixture;
+namespace Rector\Tests\Issues\AutoImport\Fixture;
 
 use PhpParser\Node\Expr\BinaryOp\Plus;
 use PhpParser\Node\Expr\AssignOp\Plus as AssignPlus;

--- a/tests/Issues/AutoImport/Source/Annotation/SomeEnum.php
+++ b/tests/Issues/AutoImport/Source/Annotation/SomeEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImport\Source\Annotation;
+namespace Rector\Tests\Issues\AutoImport\Source\Annotation;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 

--- a/tests/Issues/AutoImport/Source/Annotation/SomeEnum2.php
+++ b/tests/Issues/AutoImport/Source/Annotation/SomeEnum2.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImport\Source\Annotation;
+namespace Rector\Tests\Issues\AutoImport\Source\Annotation;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 

--- a/tests/Issues/AutoImport/Source/SomeClass.php
+++ b/tests/Issues/AutoImport/Source/SomeClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImport\Source;
+namespace Rector\Tests\Issues\AutoImport\Source;
 
 class SomeClass
 {

--- a/tests/Issues/AutoImportShortName/AutoImportShortNameTest.php
+++ b/tests/Issues/AutoImportShortName/AutoImportShortNameTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName;
+namespace Rector\Tests\Issues\AutoImportShortName;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/AutoImportShortName/DisableShortClassNameAutoImportTest.php
+++ b/tests/Issues/AutoImportShortName/DisableShortClassNameAutoImportTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName;
+namespace Rector\Tests\Issues\AutoImportShortName;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/AutoImportShortName/Fixture/import_short_name.php.inc
+++ b/tests/Issues/AutoImportShortName/Fixture/import_short_name.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Fixture;
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
 class ImportShortName
 {
@@ -13,7 +13,7 @@ class ImportShortName
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Fixture;
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
 use DateTime;
 class ImportShortName

--- a/tests/Issues/AutoImportShortName/Fixture/same_last_name_not_imported.php.inc
+++ b/tests/Issues/AutoImportShortName/Fixture/same_last_name_not_imported.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Fixture;
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
 class SameLastNameNotImported
 {
@@ -17,7 +17,7 @@ class SameLastNameNotImported
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Fixture;
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
 use DateTime;
 class SameLastNameNotImported

--- a/tests/Issues/AutoImportShortName/Fixture/skip_same_last_name_imported.php.inc
+++ b/tests/Issues/AutoImportShortName/Fixture/skip_same_last_name_imported.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Fixture;
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
-use Rector\Core\Tests\Issues\AutoImportShortName\Source\DateTime;
+use Rector\Tests\Issues\AutoImportShortName\Source\DateTime;
 
 class SkipSameLastNameImported
 {

--- a/tests/Issues/AutoImportShortName/Fixture/use_existing_imported_short_name.php.inc
+++ b/tests/Issues/AutoImportShortName/Fixture/use_existing_imported_short_name.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Fixture;
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
 use DateTime;
 
@@ -10,7 +10,7 @@ new \DateTime;
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Fixture;
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
 use DateTime;
 

--- a/tests/Issues/AutoImportShortName/FixtureDisableShortClassNameAutoImport/skip_import_disabled_short_class_name.php.inc
+++ b/tests/Issues/AutoImportShortName/FixtureDisableShortClassNameAutoImport/skip_import_disabled_short_class_name.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\FixtureDisableShortClassNameAutoImport;
+namespace Rector\Tests\Issues\AutoImportShortName\FixtureDisableShortClassNameAutoImport;
 
 class SkipImportDisabledShortClassName
 {

--- a/tests/Issues/AutoImportShortName/Source/DateTime.php
+++ b/tests/Issues/AutoImportShortName/Source/DateTime.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\AutoImportShortName\Source;
+namespace Rector\Tests\Issues\AutoImportShortName\Source;
 
 class DateTime
 {

--- a/tests/Issues/ChangeToDifferentExpr/ChangeToDifferentExprTest.php
+++ b/tests/Issues/ChangeToDifferentExpr/ChangeToDifferentExprTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr;
+namespace Rector\Tests\Issues\ChangeToDifferentExpr;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ChangeToDifferentExpr/Fixture/change_string_to_assign.php.inc
+++ b/tests/Issues/ChangeToDifferentExpr/Fixture/change_string_to_assign.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr\Fixture;
+namespace Rector\Tests\Issues\ChangeToDifferentExpr\Fixture;
 
 final class ChangeStringToAssign
 {
@@ -14,7 +14,7 @@ final class ChangeStringToAssign
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr\Fixture;
+namespace Rector\Tests\Issues\ChangeToDifferentExpr\Fixture;
 
 final class ChangeStringToAssign
 {

--- a/tests/Issues/ChangeToDifferentExpr/Source/TestRector.php
+++ b/tests/Issues/ChangeToDifferentExpr/Source/TestRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentExpr\Source;
+namespace Rector\Tests\Issues\ChangeToDifferentExpr\Source;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;

--- a/tests/Issues/ChangeToDifferentExpr/config/configured_rule.php
+++ b/tests/Issues/ChangeToDifferentExpr/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\ChangeToDifferentExpr\Source\TestRector;
+use Rector\Tests\Issues\ChangeToDifferentExpr\Source\TestRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(TestRector::class);

--- a/tests/Issues/ChangeToDifferentStmt/ChangeToDifferentStmtTest.php
+++ b/tests/Issues/ChangeToDifferentStmt/ChangeToDifferentStmtTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt;
+namespace Rector\Tests\Issues\ChangeToDifferentStmt;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ChangeToDifferentStmt/Fixture/change_if_to_echo.php.inc
+++ b/tests/Issues/ChangeToDifferentStmt/Fixture/change_if_to_echo.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt\Fixture;
+namespace Rector\Tests\Issues\ChangeToDifferentStmt\Fixture;
 
 final class ChangeIfToEcho
 {
@@ -15,7 +15,7 @@ final class ChangeIfToEcho
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt\Fixture;
+namespace Rector\Tests\Issues\ChangeToDifferentStmt\Fixture;
 
 final class ChangeIfToEcho
 {

--- a/tests/Issues/ChangeToDifferentStmt/Source/TestRector.php
+++ b/tests/Issues/ChangeToDifferentStmt/Source/TestRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ChangeToDifferentStmt\Source;
+namespace Rector\Tests\Issues\ChangeToDifferentStmt\Source;
 
 use PhpParser\Node;
 use PhpParser\Node\Scalar\String_;

--- a/tests/Issues/ChangeToDifferentStmt/config/configured_rule.php
+++ b/tests/Issues/ChangeToDifferentStmt/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\ChangeToDifferentStmt\Source\TestRector;
+use Rector\Tests\Issues\ChangeToDifferentStmt\Source\TestRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(TestRector::class);

--- a/tests/Issues/ClassOnObjectGetDebugType/ClassOnObjectGetDebugTypeTest.php
+++ b/tests/Issues/ClassOnObjectGetDebugType/ClassOnObjectGetDebugTypeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ClassOnObjectGetDebugType;
+namespace Rector\Tests\Issues\ClassOnObjectGetDebugType;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ClassOnObjectGetDebugType/Fixture/fixture.php.inc
+++ b/tests/Issues/ClassOnObjectGetDebugType/Fixture/fixture.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ClassOnObjectGetDebugType;
+namespace Rector\Tests\Issues\ClassOnObjectGetDebugType;
 
 final class Fixture
 {
@@ -18,7 +18,7 @@ final class Fixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ClassOnObjectGetDebugType;
+namespace Rector\Tests\Issues\ClassOnObjectGetDebugType;
 
 final class Fixture
 {

--- a/tests/Issues/ConstructorPromoAnnotationToAttribute/ConstructorPromoAnnotationToAttributeTest.php
+++ b/tests/Issues/ConstructorPromoAnnotationToAttribute/ConstructorPromoAnnotationToAttributeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ConstructorPromoAnnotationToAttribute;
+namespace Rector\Tests\Issues\ConstructorPromoAnnotationToAttribute;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ConstructorPromoAnnotationToAttribute/Fixture/fixture.php.inc
+++ b/tests/Issues/ConstructorPromoAnnotationToAttribute/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ConstructorPromoAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\ConstructorPromoAnnotationToAttribute\Fixture;
 
 use OpenApi\Annotations as OA;
 
@@ -23,7 +23,7 @@ class TestResponse
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ConstructorPromoAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\ConstructorPromoAnnotationToAttribute\Fixture;
 
 use OpenApi\Annotations as OA;
 

--- a/tests/Issues/ContinueToBreakSwitch/ContinueToBreakSwitchTest.php
+++ b/tests/Issues/ContinueToBreakSwitch/ContinueToBreakSwitchTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ContinueToBreakSwitch;
+namespace Rector\Tests\Issues\ContinueToBreakSwitch;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ContinueToBreakSwitch/Fixture/fixture.php.inc
+++ b/tests/Issues/ContinueToBreakSwitch/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ContinueToBreakSwitch\Fixture;
+namespace Rector\Tests\Issues\ContinueToBreakSwitch\Fixture;
 
 final class Fixture
 {
@@ -25,7 +25,7 @@ final class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ContinueToBreakSwitch\Fixture;
+namespace Rector\Tests\Issues\ContinueToBreakSwitch\Fixture;
 
 final class Fixture
 {

--- a/tests/Issues/DeadInstanceFlip/DeadInstanceFlipTest.php
+++ b/tests/Issues/DeadInstanceFlip/DeadInstanceFlipTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\DeadInstanceFlip;
+namespace Rector\Tests\Issues\DeadInstanceFlip;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/DeadInstanceFlip/Fixture/fixture.php.inc
+++ b/tests/Issues/DeadInstanceFlip/Fixture/fixture.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\DeadInstanceFlip\Fixture;
+namespace Rector\Tests\Issues\DeadInstanceFlip\Fixture;
 
-use Rector\Core\Tests\Issues\DeadInstanceFlip\Source\SomeEvent;
+use Rector\Tests\Issues\DeadInstanceFlip\Source\SomeEvent;
 
 final class Fixture
 {
@@ -18,9 +18,9 @@ final class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\DeadInstanceFlip\Fixture;
+namespace Rector\Tests\Issues\DeadInstanceFlip\Fixture;
 
-use Rector\Core\Tests\Issues\DeadInstanceFlip\Source\SomeEvent;
+use Rector\Tests\Issues\DeadInstanceFlip\Source\SomeEvent;
 
 final class Fixture
 {

--- a/tests/Issues/DeadInstanceFlip/Source/SomeEvent.php
+++ b/tests/Issues/DeadInstanceFlip/Source/SomeEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\DeadInstanceFlip\Source;
+namespace Rector\Tests\Issues\DeadInstanceFlip\Source;
 
 class SomeEvent
 {

--- a/tests/Issues/DeadInstanceFlip/Source/SomeEventType.php
+++ b/tests/Issues/DeadInstanceFlip/Source/SomeEventType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\DeadInstanceFlip\Source;
+namespace Rector\Tests\Issues\DeadInstanceFlip\Source;
 
 final class SomeEventType
 {

--- a/tests/Issues/DoubleRun/DoubleRunTest.php
+++ b/tests/Issues/DoubleRun/DoubleRunTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\DoubleRun;
+namespace Rector\Tests\Issues\DoubleRun;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/DoubleRun/Fixture/fixture.php.inc
+++ b/tests/Issues/DoubleRun/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+namespace Rector\Tests\Issues\DoubleRun\Fixture;
 
 final class RemoveAll
 {
@@ -14,7 +14,7 @@ final class RemoveAll
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+namespace Rector\Tests\Issues\DoubleRun\Fixture;
 
 final class RemoveAll
 {

--- a/tests/Issues/DowngradeNullableReflectionProperty/DowngradeNullableReflectionPropertyTest.php
+++ b/tests/Issues/DowngradeNullableReflectionProperty/DowngradeNullableReflectionPropertyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\DowngradeNullableReflectionProperty;
+namespace Rector\Tests\Issues\DowngradeNullableReflectionProperty;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/DowngradeNullableReflectionProperty/Fixture/use_nullable_reflection_property.php.inc
+++ b/tests/Issues/DowngradeNullableReflectionProperty/Fixture/use_nullable_reflection_property.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\DowngradeNullableReflectionProperty\Fixture;
+namespace Rector\Tests\Issues\DowngradeNullableReflectionProperty\Fixture;
 
 class UseNullableReflectionProperty
 {
@@ -18,7 +18,7 @@ class UseNullableReflectionProperty
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\DowngradeNullableReflectionProperty\Fixture;
+namespace Rector\Tests\Issues\DowngradeNullableReflectionProperty\Fixture;
 
 class UseNullableReflectionProperty
 {

--- a/tests/Issues/EmptyBooleanCompare/EmptyBooleanCompareTest.php
+++ b/tests/Issues/EmptyBooleanCompare/EmptyBooleanCompareTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare;
+namespace Rector\Tests\Issues\EmptyBooleanCompare;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/EmptyBooleanCompare/Fixture/always_exists_array_dim_fetch_item.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/always_exists_array_dim_fetch_item.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class AlwaysExistsArrayDimFetchItem
 {
@@ -28,7 +28,7 @@ final class AlwaysExistsArrayDimFetchItem
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class AlwaysExistsArrayDimFetchItem
 {

--- a/tests/Issues/EmptyBooleanCompare/Fixture/fixture.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class SomeFixture
 {
@@ -20,7 +20,7 @@ final class SomeFixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class SomeFixture
 {

--- a/tests/Issues/EmptyBooleanCompare/Fixture/on_array_object.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/on_array_object.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class OnArrayObject
 {
@@ -20,7 +20,7 @@ final class OnArrayObject
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class OnArrayObject
 {

--- a/tests/Issues/EmptyBooleanCompare/Fixture/skip_array_dim_fetch_from_docblock.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/skip_array_dim_fetch_from_docblock.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class SkipArrayDimFetchFromDocblock
 {

--- a/tests/Issues/EmptyBooleanCompare/Fixture/skip_mixed_array_dim_fetch.php.inc
+++ b/tests/Issues/EmptyBooleanCompare/Fixture/skip_mixed_array_dim_fetch.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\EmptyBooleanCompare\Fixture;
+namespace Rector\Tests\Issues\EmptyBooleanCompare\Fixture;
 
 final class SkipMixedArrayDimFetch
 {

--- a/tests/Issues/EmptyLongArraySyntax/EmptyLongArraySyntaxTest.php
+++ b/tests/Issues/EmptyLongArraySyntax/EmptyLongArraySyntaxTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax;
+namespace Rector\Tests\Issues\EmptyLongArraySyntax;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/EmptyLongArraySyntax/Fixture/empty_long_array.php.inc
+++ b/tests/Issues/EmptyLongArraySyntax/Fixture/empty_long_array.php.inc
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax\Fixture;
+namespace Rector\Tests\Issues\EmptyLongArraySyntax\Fixture;
 
-use Rector\Core\Tests\Issues\EmptyLongArraySyntax\Source\ParentWithEmptyLongArray;
+use Rector\Tests\Issues\EmptyLongArraySyntax\Source\ParentWithEmptyLongArray;
 
 final class EmptyLongArray extends ParentWithEmptyLongArray
 {
@@ -19,9 +19,9 @@ final class EmptyLongArray extends ParentWithEmptyLongArray
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax\Fixture;
+namespace Rector\Tests\Issues\EmptyLongArraySyntax\Fixture;
 
-use Rector\Core\Tests\Issues\EmptyLongArraySyntax\Source\ParentWithEmptyLongArray;
+use Rector\Tests\Issues\EmptyLongArraySyntax\Source\ParentWithEmptyLongArray;
 
 final class EmptyLongArray extends ParentWithEmptyLongArray
 {

--- a/tests/Issues/EmptyLongArraySyntax/Source/ParentWithEmptyLongArray.php
+++ b/tests/Issues/EmptyLongArraySyntax/Source/ParentWithEmptyLongArray.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\EmptyLongArraySyntax\Source;
+namespace Rector\Tests\Issues\EmptyLongArraySyntax\Source;
 
 class ParentWithEmptyLongArray
 {

--- a/tests/Issues/ExtendsNotReadOnlyClass/ExtendsNotReadOnlyClassTest.php
+++ b/tests/Issues/ExtendsNotReadOnlyClass/ExtendsNotReadOnlyClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ExtendsNotReadOnlyClass;
+namespace Rector\Tests\Issues\ExtendsNotReadOnlyClass;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ExtendsNotReadOnlyClass/Fixture/fixture.php.inc
+++ b/tests/Issues/ExtendsNotReadOnlyClass/Fixture/fixture.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ExtendsNotReadOnlyClass\Fixture;
+namespace Rector\Tests\Issues\ExtendsNotReadOnlyClass\Fixture;
 
-use Rector\Core\Tests\Issues\ExtendsNotReadOnlyClass\Source\ParentIsNonReadOnlyClass;
+use Rector\Tests\Issues\ExtendsNotReadOnlyClass\Source\ParentIsNonReadOnlyClass;
 
 class Fixture extends ParentIsNonReadOnlyClass
 {
@@ -20,9 +20,9 @@ class Fixture extends ParentIsNonReadOnlyClass
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ExtendsNotReadOnlyClass\Fixture;
+namespace Rector\Tests\Issues\ExtendsNotReadOnlyClass\Fixture;
 
-use Rector\Core\Tests\Issues\ExtendsNotReadOnlyClass\Source\ParentIsNonReadOnlyClass;
+use Rector\Tests\Issues\ExtendsNotReadOnlyClass\Source\ParentIsNonReadOnlyClass;
 
 final class Fixture extends ParentIsNonReadOnlyClass
 {

--- a/tests/Issues/ExtendsNotReadOnlyClass/Source/ParentIsNonReadOnlyClass.php
+++ b/tests/Issues/ExtendsNotReadOnlyClass/Source/ParentIsNonReadOnlyClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ExtendsNotReadOnlyClass\Source;
+namespace Rector\Tests\Issues\ExtendsNotReadOnlyClass\Source;
 
 class ParentIsNonReadOnlyClass
 {

--- a/tests/Issues/FqcnAnnotationToAttribute/Fixture/aliased_and_sub_namespace.php.inc
+++ b/tests/Issues/FqcnAnnotationToAttribute/Fixture/aliased_and_sub_namespace.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints;
@@ -32,7 +32,7 @@ class AliasedAndSubNamespace
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints;

--- a/tests/Issues/FqcnAnnotationToAttribute/Fixture/fixture.php.inc
+++ b/tests/Issues/FqcnAnnotationToAttribute/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 /**
  * @\Doctrine\ORM\Mapping\Entity()
@@ -27,7 +27,7 @@ class Entity
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 #[\Doctrine\ORM\Mapping\Entity]
 #[\Doctrine\ORM\Mapping\Index(name: 'name_index', columns: ['name'])]

--- a/tests/Issues/FqcnAnnotationToAttribute/Fixture/single_quote.php.inc
+++ b/tests/Issues/FqcnAnnotationToAttribute/Fixture/single_quote.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 /**
  * @\Doctrine\ORM\Mapping\Entity()
@@ -27,7 +27,7 @@ class SingleQuote
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 #[\Doctrine\ORM\Mapping\Entity]
 #[\Doctrine\ORM\Mapping\Index(name: 'name_index', columns: ['name'])]

--- a/tests/Issues/FqcnAnnotationToAttribute/Fixture/sub_namespace_from_use.php.inc
+++ b/tests/Issues/FqcnAnnotationToAttribute/Fixture/sub_namespace_from_use.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 use Doctrine\ORM\Mapping;
 
@@ -15,7 +15,7 @@ class SubNamespaceFromUse
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute\Fixture;
 
 use Doctrine\ORM\Mapping;
 

--- a/tests/Issues/FqcnAnnotationToAttribute/FqcnAnnotationToAttributeTest.php
+++ b/tests/Issues/FqcnAnnotationToAttribute/FqcnAnnotationToAttributeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\FqcnAnnotationToAttribute;
+namespace Rector\Tests\Issues\FqcnAnnotationToAttribute;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/GetCalledClassToSelfAndStatic/Fixture/on_final_class.php.inc
+++ b/tests/Issues/GetCalledClassToSelfAndStatic/Fixture/on_final_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
+namespace Rector\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
 
 final class OnFinalClass
 {
@@ -14,7 +14,7 @@ final class OnFinalClass
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
+namespace Rector\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
 
 final class OnFinalClass
 {

--- a/tests/Issues/GetCalledClassToSelfAndStatic/Fixture/on_non_final_class.php.inc
+++ b/tests/Issues/GetCalledClassToSelfAndStatic/Fixture/on_non_final_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
+namespace Rector\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
 
 class OnNonFinalClass
 {
@@ -14,7 +14,7 @@ class OnNonFinalClass
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
+namespace Rector\Tests\Issues\GetCalledClassToSelfAndStatic\Fixture;
 
 class OnNonFinalClass
 {

--- a/tests/Issues/GetCalledClassToSelfAndStatic/GetCalledClassToSelfAndStaticTest.php
+++ b/tests/Issues/GetCalledClassToSelfAndStatic/GetCalledClassToSelfAndStaticTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\GetCalledClassToSelfAndStatic;
+namespace Rector\Tests\Issues\GetCalledClassToSelfAndStatic;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IfElseAssignReturnUsed/Fixture/use_on_return_after_if_else_assign.php.inc
+++ b/tests/Issues/IfElseAssignReturnUsed/Fixture/use_on_return_after_if_else_assign.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
+namespace Rector\Tests\Issues\IfElseAssignReturnUsed\Fixture;
 
 final class UseOnReturnAfterIfElseAssign
 {
@@ -24,7 +24,7 @@ final class UseOnReturnAfterIfElseAssign
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed\Fixture;
+namespace Rector\Tests\Issues\IfElseAssignReturnUsed\Fixture;
 
 final class UseOnReturnAfterIfElseAssign
 {

--- a/tests/Issues/IfElseAssignReturnUsed/IfElseAssignReturnUsedTest.php
+++ b/tests/Issues/IfElseAssignReturnUsed/IfElseAssignReturnUsedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IfElseAssignReturnUsed;
+namespace Rector\Tests\Issues\IfElseAssignReturnUsed;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IndentationCrash/CodeQualityCodingStyleIndentationCrashTest.php
+++ b/tests/Issues/IndentationCrash/CodeQualityCodingStyleIndentationCrashTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IndentationCrash;
+namespace Rector\Tests\Issues\IndentationCrash;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IndentationCrash/FixtureTab/if_else_tab_indentation.php.inc
+++ b/tests/Issues/IndentationCrash/FixtureTab/if_else_tab_indentation.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IndentationCrash\FixtureTab;
+namespace Rector\Tests\Issues\IndentationCrash\FixtureTab;
 
 final class IfElseTabIndentation
 {

--- a/tests/Issues/IndentationCrash/TabIndentationCrashTest.php
+++ b/tests/Issues/IndentationCrash/TabIndentationCrashTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IndentationCrash;
+namespace Rector\Tests\Issues\IndentationCrash;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/InfiniteLoop/InfiniteLoopTest.php
+++ b/tests/Issues/InfiniteLoop/InfiniteLoopTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InfiniteLoop;
+namespace Rector\Tests\Issues\InfiniteLoop;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/InfiniteLoop/Rector/MethodCall/InfinityLoopRector.php
+++ b/tests/Issues/InfiniteLoop/Rector/MethodCall/InfinityLoopRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InfiniteLoop\Rector\MethodCall;
+namespace Rector\Tests\Issues\InfiniteLoop\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
@@ -12,7 +12,7 @@ use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Core\Tests\Issues\InfiniteLoop\InfiniteLoopTest
+ * @see \Rector\Tests\Issues\InfiniteLoop\InfiniteLoopTest
  */
 final class InfinityLoopRector extends AbstractRector
 {

--- a/tests/Issues/InfiniteLoop/config/infinite_loop.php
+++ b/tests/Issues/InfiniteLoop/config/infinite_loop.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\InfiniteLoop\Rector\MethodCall\InfinityLoopRector;
+use Rector\Tests\Issues\InfiniteLoop\Rector\MethodCall\InfinityLoopRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(InfinityLoopRector::class);

--- a/tests/Issues/InfiniteSwapParams/Fixture/fixture.php.inc
+++ b/tests/Issues/InfiniteSwapParams/Fixture/fixture.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InfiniteSwapParams\Fixture;
+namespace Rector\Tests\Issues\InfiniteSwapParams\Fixture;
 
 class Fixture
 {
@@ -16,7 +16,7 @@ class Fixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InfiniteSwapParams\Fixture;
+namespace Rector\Tests\Issues\InfiniteSwapParams\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/InfiniteSwapParams/InfiniteSwapParamsTest.php
+++ b/tests/Issues/InfiniteSwapParams/InfiniteSwapParamsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InfiniteSwapParams;
+namespace Rector\Tests\Issues\InfiniteSwapParams;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/InlineTypedFromConstructorDefaultValue/Fixture/inlined_typed_property.php.inc
+++ b/tests/Issues/InlineTypedFromConstructorDefaultValue/Fixture/inlined_typed_property.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InlineTypedFromConstructorDefaultValue\Fixture;
+namespace Rector\Tests\Issues\InlineTypedFromConstructorDefaultValue\Fixture;
 
 final class InlinedTypedProperty
 {
@@ -20,7 +20,7 @@ final class InlinedTypedProperty
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InlineTypedFromConstructorDefaultValue\Fixture;
+namespace Rector\Tests\Issues\InlineTypedFromConstructorDefaultValue\Fixture;
 
 final class InlinedTypedProperty
 {

--- a/tests/Issues/InlineTypedFromConstructorDefaultValue/InlineTypedFromConstructorDefaultValueTest.php
+++ b/tests/Issues/InlineTypedFromConstructorDefaultValue/InlineTypedFromConstructorDefaultValueTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\InlineTypedFromConstructorDefaultValue;
+namespace Rector\Tests\Issues\InlineTypedFromConstructorDefaultValue;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue6420/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6420/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6420\Fixture;
+namespace Rector\Tests\Issues\Issue6420\Fixture;
 
 class Fixture
 {
@@ -14,7 +14,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6420\Fixture;
+namespace Rector\Tests\Issues\Issue6420\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/Issue6420/RenameFunctionWithRemoveDeadStmtRectorTest.php
+++ b/tests/Issues/Issue6420/RenameFunctionWithRemoveDeadStmtRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue6420;
+namespace Rector\Tests\Issues\Issue6420;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue6480/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6480/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6480\Fixture;
+namespace Rector\Tests\Issues\Issue6480\Fixture;
 
 class Fixture
 {
@@ -15,7 +15,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6480\Fixture;
+namespace Rector\Tests\Issues\Issue6480\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/Issue6480/NegatedTernaryInsideDeadInstanceTest.php
+++ b/tests/Issues/Issue6480/NegatedTernaryInsideDeadInstanceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue6480;
+namespace Rector\Tests\Issues\Issue6480;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue6481/EncapsedStringsInsideDeadInstanceTest.php
+++ b/tests/Issues/Issue6481/EncapsedStringsInsideDeadInstanceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue6481;
+namespace Rector\Tests\Issues\Issue6481;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue6481/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6481/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6481\Fixture;
+namespace Rector\Tests\Issues\Issue6481\Fixture;
 
 class Fixture
 {
@@ -18,7 +18,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6481\Fixture;
+namespace Rector\Tests\Issues\Issue6481\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/Issue6561/CountArrayOnTruthyEmptyArrayCompareTest.php
+++ b/tests/Issues/Issue6561/CountArrayOnTruthyEmptyArrayCompareTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue6561;
+namespace Rector\Tests\Issues\Issue6561;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue6561/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6561/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6561\Fixture;
+namespace Rector\Tests\Issues\Issue6561\Fixture;
 
 final class Fixture
 {
@@ -17,7 +17,7 @@ final class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6561\Fixture;
+namespace Rector\Tests\Issues\Issue6561\Fixture;
 
 final class Fixture
 {

--- a/tests/Issues/Issue6561/Fixture/on_call_method_return_array.php.inc
+++ b/tests/Issues/Issue6561/Fixture/on_call_method_return_array.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6561\Fixture;
+namespace Rector\Tests\Issues\Issue6561\Fixture;
 
 final class OnCallMethodReturnArray
 {
@@ -25,7 +25,7 @@ final class OnCallMethodReturnArray
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6561\Fixture;
+namespace Rector\Tests\Issues\Issue6561\Fixture;
 
 final class OnCallMethodReturnArray
 {

--- a/tests/Issues/Issue6670/Fixture/do_not_remove_used_class_method.php.inc
+++ b/tests/Issues/Issue6670/Fixture/do_not_remove_used_class_method.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
+namespace Rector\Tests\Issues\Issue6670\Fixture;
 
 final class DoNotRemoveUsedClassMethod
 {
@@ -23,7 +23,7 @@ final class DoNotRemoveUsedClassMethod
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6670\Fixture;
+namespace Rector\Tests\Issues\Issue6670\Fixture;
 
 final class DoNotRemoveUsedClassMethod
 {

--- a/tests/Issues/Issue6670/RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest.php
+++ b/tests/Issues/Issue6670/RemoveAlwaysElseAndUnusedPrivateMethodsRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue6670;
+namespace Rector\Tests\Issues\Issue6670;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue6840/ClassPropertyPromotionAndNewLineAfterStatementRectorTest.php
+++ b/tests/Issues/Issue6840/ClassPropertyPromotionAndNewLineAfterStatementRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue6840;
+namespace Rector\Tests\Issues\Issue6840;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue6840/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue6840/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6840\Fixture;
+namespace Rector\Tests\Issues\Issue6840\Fixture;
 
 class Fixture
 {
@@ -17,7 +17,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue6840\Fixture;
+namespace Rector\Tests\Issues\Issue6840\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/Issue7099/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7099/Fixture/fixture.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7099\Fixture;
+namespace Rector\Tests\Issues\Issue7099\Fixture;
 
-use Rector\Core\Tests\Issues\Issue7099\Source\Document;
+use Rector\Tests\Issues\Issue7099\Source\Document;
 
 class Controller
 {
@@ -22,9 +22,9 @@ class Controller
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7099\Fixture;
+namespace Rector\Tests\Issues\Issue7099\Fixture;
 
-use Rector\Core\Tests\Issues\Issue7099\Source\Document;
+use Rector\Tests\Issues\Issue7099\Source\Document;
 
 class Controller
 {

--- a/tests/Issues/Issue7099/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7099/Fixture/fixture.php.inc
@@ -32,7 +32,7 @@ class Controller
     {
         $document = $id === 1 ? new Document() : null;
 
-        if (!$document instanceof \Rector\Core\Tests\Issues\Issue7099\Source\Document) {
+        if (!$document instanceof \Rector\Tests\Issues\Issue7099\Source\Document) {
             return null;
         }
 

--- a/tests/Issues/Issue7099/RuleCombinationShouldNotRemoveIfEmptyStmtRectorTest.php
+++ b/tests/Issues/Issue7099/RuleCombinationShouldNotRemoveIfEmptyStmtRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue7099;
+namespace Rector\Tests\Issues\Issue7099;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue7099/Source/Document.php
+++ b/tests/Issues/Issue7099/Source/Document.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7099\Source;
+namespace Rector\Tests\Issues\Issue7099\Source;
 
 class Document
 {

--- a/tests/Issues/Issue7112/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7112/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7112\Fixture;
+namespace Rector\Tests\Issues\Issue7112\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/Issue7112/RuleCombinationShouldNotAddVoidReturnTypeWhereReturnExistsRectorTest.php
+++ b/tests/Issues/Issue7112/RuleCombinationShouldNotAddVoidReturnTypeWhereReturnExistsRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue7112;
+namespace Rector\Tests\Issues\Issue7112;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue7306/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7306/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7306\Fixture;
+namespace Rector\Tests\Issues\Issue7306\Fixture;
 
 class Fixture
 {
@@ -19,7 +19,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7306\Fixture;
+namespace Rector\Tests\Issues\Issue7306\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/Issue7306/RuleCombinationShouldNotSimplifyIfNotNullReturnTest.php
+++ b/tests/Issues/Issue7306/RuleCombinationShouldNotSimplifyIfNotNullReturnTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue7306;
+namespace Rector\Tests\Issues\Issue7306;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue7374/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7374/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7374\Fixture;
+namespace Rector\Tests\Issues\Issue7374\Fixture;
 
 final class ClassWithTwoMethods
 {
@@ -22,7 +22,7 @@ final class ClassWithTwoMethods
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7374\Fixture;
+namespace Rector\Tests\Issues\Issue7374\Fixture;
 
 final class ClassWithTwoMethods
 {

--- a/tests/Issues/Issue7374/RuleCombinationShouldNotReturnGetAttributeOnNullReturnTest.php
+++ b/tests/Issues/Issue7374/RuleCombinationShouldNotReturnGetAttributeOnNullReturnTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue7374;
+namespace Rector\Tests\Issues\Issue7374;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/Issue7495/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue7495/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7495\Fixture;
+namespace Rector\Tests\Issues\Issue7495\Fixture;
 
 class Fixture
 {
@@ -36,7 +36,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\Issue7495\Fixture;
+namespace Rector\Tests\Issues\Issue7495\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/Issue7495/RemoveUnusedPrivateJustPropertyFetchTest.php
+++ b/tests/Issues/Issue7495/RemoveUnusedPrivateJustPropertyFetchTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\Issue7495;
+namespace Rector\Tests\Issues\Issue7495;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/Fixture/fixture.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
+namespace Rector\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
 
-use Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Source\ParentClassWithLetter;
+use Rector\Tests\Issues\IssueAndIfCompleteDeMorgan\Source\ParentClassWithLetter;
 
 final class Fixture extends ParentClassWithLetter
 {
@@ -18,9 +18,9 @@ final class Fixture extends ParentClassWithLetter
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
+namespace Rector\Tests\Issues\IssueAndIfCompleteDeMorgan\Fixture;
 
-use Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Source\ParentClassWithLetter;
+use Rector\Tests\Issues\IssueAndIfCompleteDeMorgan\Source\ParentClassWithLetter;
 
 final class Fixture extends ParentClassWithLetter
 {

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/IssueAndIfCompleteDeMorganTest.php
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/IssueAndIfCompleteDeMorganTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan;
+namespace Rector\Tests\Issues\IssueAndIfCompleteDeMorgan;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueAndIfCompleteDeMorgan/Source/ParentClassWithLetter.php
+++ b/tests/Issues/IssueAndIfCompleteDeMorgan/Source/ParentClassWithLetter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueAndIfCompleteDeMorgan\Source;
+namespace Rector\Tests\Issues\IssueAndIfCompleteDeMorgan\Source;
 
 abstract class ParentClassWithLetter
 {

--- a/tests/Issues/IssueAnnotation/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueAnnotation/Fixture/fixture.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueAnnotation\Fixture;
+namespace Rector\Tests\Issues\IssueAnnotation\Fixture;
 
-use Rector\Core\Tests\Issues\IssueAnnotation\Source\SomeAttributes;
+use Rector\Tests\Issues\IssueAnnotation\Source\SomeAttributes;
 
 final class Anything extends SomeAttributes
 {
@@ -18,9 +18,9 @@ final class Anything extends SomeAttributes
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueAnnotation\Fixture;
+namespace Rector\Tests\Issues\IssueAnnotation\Fixture;
 
-use Rector\Core\Tests\Issues\IssueAnnotation\Source\SomeAttributes;
+use Rector\Tests\Issues\IssueAnnotation\Source\SomeAttributes;
 
 final class Anything extends SomeAttributes
 {

--- a/tests/Issues/IssueAnnotation/IssueAnnotationTest.php
+++ b/tests/Issues/IssueAnnotation/IssueAnnotationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueAnnotation;
+namespace Rector\Tests\Issues\IssueAnnotation;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueAnnotation/Source/SomeAttributes.php
+++ b/tests/Issues/IssueAnnotation/Source/SomeAttributes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueAnnotation\Source;
+namespace Rector\Tests\Issues\IssueAnnotation\Source;
 
 class SomeAttributes
 {

--- a/tests/Issues/IssueConditionalType/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueConditionalType/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueConditionalType\Fixture;
+namespace Rector\Tests\Issues\IssueConditionalType\Fixture;
 
 class Fixture
 {
@@ -18,7 +18,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueConditionalType\Fixture;
+namespace Rector\Tests\Issues\IssueConditionalType\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/IssueConditionalType/IssueConditionalTypeTest.php
+++ b/tests/Issues/IssueConditionalType/IssueConditionalTypeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueConditionalType;
+namespace Rector\Tests\Issues\IssueConditionalType;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueConstructorPromotionRename/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueConstructorPromotionRename/Fixture/fixture.php.inc
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueConstructorPromotionRename\Fixture;
+namespace Rector\Tests\Issues\IssueConstructorPromotionRename\Fixture;
 
-use Rector\Core\Tests\Issues\IssueConstructorPromotionRename\Source\PromotedPropertyObject;
+use Rector\Tests\Issues\IssueConstructorPromotionRename\Source\PromotedPropertyObject;
 
 final class Fixture
 {
@@ -24,9 +24,9 @@ final class Fixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueConstructorPromotionRename\Fixture;
+namespace Rector\Tests\Issues\IssueConstructorPromotionRename\Fixture;
 
-use Rector\Core\Tests\Issues\IssueConstructorPromotionRename\Source\PromotedPropertyObject;
+use Rector\Tests\Issues\IssueConstructorPromotionRename\Source\PromotedPropertyObject;
 
 final class Fixture
 {

--- a/tests/Issues/IssueConstructorPromotionRename/IssueConstructorPromotionRenameTest.php
+++ b/tests/Issues/IssueConstructorPromotionRename/IssueConstructorPromotionRenameTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueConstructorPromotionRename;
+namespace Rector\Tests\Issues\IssueConstructorPromotionRename;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueConstructorPromotionRename/Source/PromotedPropertyObject.php
+++ b/tests/Issues/IssueConstructorPromotionRename/Source/PromotedPropertyObject.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueConstructorPromotionRename\Source;
+namespace Rector\Tests\Issues\IssueConstructorPromotionRename\Source;
 
 final class PromotedPropertyObject
 {

--- a/tests/Issues/IssueCreatePublicPropertyOnRename/CreatePublicPropertyOnRenameTest.php
+++ b/tests/Issues/IssueCreatePublicPropertyOnRename/CreatePublicPropertyOnRenameTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueCreatePublicPropertyOnRename;
+namespace Rector\Tests\Issues\IssueCreatePublicPropertyOnRename;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueCreatePublicPropertyOnRename/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueCreatePublicPropertyOnRename/Fixture/fixture.php.inc
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueCreatePublicPropertyOnRename\Fixture;
+namespace Rector\Tests\Issues\IssueCreatePublicPropertyOnRename\Fixture;
 
-use Rector\Core\Tests\Issues\IssueCreatePublicPropertyOnRename\Source\SomePropertyObject;
+use Rector\Tests\Issues\IssueCreatePublicPropertyOnRename\Source\SomePropertyObject;
 
 final class Fixture
 {
@@ -23,9 +23,9 @@ final class Fixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueCreatePublicPropertyOnRename\Fixture;
+namespace Rector\Tests\Issues\IssueCreatePublicPropertyOnRename\Fixture;
 
-use Rector\Core\Tests\Issues\IssueCreatePublicPropertyOnRename\Source\SomePropertyObject;
+use Rector\Tests\Issues\IssueCreatePublicPropertyOnRename\Source\SomePropertyObject;
 
 final class Fixture
 {

--- a/tests/Issues/IssueCreatePublicPropertyOnRename/Source/SomePropertyObject.php
+++ b/tests/Issues/IssueCreatePublicPropertyOnRename/Source/SomePropertyObject.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueCreatePublicPropertyOnRename\Source;
+namespace Rector\Tests\Issues\IssueCreatePublicPropertyOnRename\Source;
 
 final class SomePropertyObject
 {

--- a/tests/Issues/IssueDoubleNestedAnnotatoinDocBlock/Fixture/some_fixture.php.inc
+++ b/tests/Issues/IssueDoubleNestedAnnotatoinDocBlock/Fixture/some_fixture.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock\Fixture;
+namespace Rector\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock\Fixture;
 
-use Rector\Core\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock\Source\SomeAnnotation;
+use Rector\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock\Source\SomeAnnotation;
 
 /**
  * @SomeAnnotation(

--- a/tests/Issues/IssueDoubleNestedAnnotatoinDocBlock/IssueDoubleNestedAnnotatoinDocBlockTest.php
+++ b/tests/Issues/IssueDoubleNestedAnnotatoinDocBlock/IssueDoubleNestedAnnotatoinDocBlockTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock;
+namespace Rector\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueDoubleNestedAnnotatoinDocBlock/Source/SomeAnnotation.php
+++ b/tests/Issues/IssueDoubleNestedAnnotatoinDocBlock/Source/SomeAnnotation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock\Source;
+namespace Rector\Tests\Issues\IssueDoubleNestedAnnotatoinDocBlock\Source;
 
 /**
  * @annotation

--- a/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable\Fixture;
+namespace Rector\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable\Fixture;
 
 final class Fixture
 {
@@ -26,7 +26,7 @@ final class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable\Fixture;
+namespace Rector\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable\Fixture;
 
 final class Fixture
 {

--- a/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/IssueRemoveAlwaysElseReturnEarlyIfVariableTest.php
+++ b/tests/Issues/IssueRemoveAlwaysElseReturnEarlyIfVariable/IssueRemoveAlwaysElseReturnEarlyIfVariableTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable;
+namespace Rector\Tests\Issues\IssueRemoveAlwaysElseReturnEarlyIfVariable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueReturnBeforeElseIf/FixtureAnd/complex_if_cond_and.php.inc
+++ b/tests/Issues/IssueReturnBeforeElseIf/FixtureAnd/complex_if_cond_and.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndInsideCase\Fixture;
+namespace Rector\Tests\Issues\IssueEarlyReturnAndInsideCase\Fixture;
 
 class ComplexIfCondAnd
 {
@@ -26,7 +26,7 @@ class ComplexIfCondAnd
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueEarlyReturnAndInsideCase\Fixture;
+namespace Rector\Tests\Issues\IssueEarlyReturnAndInsideCase\Fixture;
 
 class ComplexIfCondAnd
 {

--- a/tests/Issues/IssueReturnBeforeElseIf/IssueReturnBeforeElseIfAndTest.php
+++ b/tests/Issues/IssueReturnBeforeElseIf/IssueReturnBeforeElseIfAndTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueReturnBeforeElseIf;
+namespace Rector\Tests\Issues\IssueReturnBeforeElseIf;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueTraitUseKey/Fixture/fixture.php.inc
+++ b/tests/Issues/IssueTraitUseKey/Fixture/fixture.php.inc
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueTraitUseKey\Fixture;
+namespace Rector\Tests\Issues\IssueTraitUseKey\Fixture;
 
-use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitA;
-use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitB;
+use Rector\Tests\Issues\IssueTraitUseKey\TraitA;
+use Rector\Tests\Issues\IssueTraitUseKey\TraitB;
 
 class Fixture
 {
@@ -37,10 +37,10 @@ class Fixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueTraitUseKey\Fixture;
+namespace Rector\Tests\Issues\IssueTraitUseKey\Fixture;
 
-use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitA;
-use Rector\Core\Tests\Issues\IssueTraitUseKey\TraitB;
+use Rector\Tests\Issues\IssueTraitUseKey\TraitA;
+use Rector\Tests\Issues\IssueTraitUseKey\TraitB;
 
 final class Fixture
 {

--- a/tests/Issues/IssueTraitUseKey/IssueTraitUseKeyTest.php
+++ b/tests/Issues/IssueTraitUseKey/IssueTraitUseKeyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueTraitUseKey;
+namespace Rector\Tests\Issues\IssueTraitUseKey;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/IssueTraitUseKey/Source/TraitA.php
+++ b/tests/Issues/IssueTraitUseKey/Source/TraitA.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueTraitUseKey;
+namespace Rector\Tests\Issues\IssueTraitUseKey;
 
 trait TraitA
 {

--- a/tests/Issues/IssueTraitUseKey/Source/TraitB.php
+++ b/tests/Issues/IssueTraitUseKey/Source/TraitB.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\IssueTraitUseKey;
+namespace Rector\Tests\Issues\IssueTraitUseKey;
 
 trait TraitB
 {

--- a/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
+++ b/tests/Issues/JsonThrowWithChangeAndIf/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
+namespace Rector\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
 
 function f()
 {
@@ -13,7 +13,7 @@ function f()
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
+namespace Rector\Tests\Issues\JsonThrowWithChangeAndIf\Fixture;
 
 function f()
 {

--- a/tests/Issues/JsonThrowWithChangeAndIf/JsonThrowWithChangeAndIfTest.php
+++ b/tests/Issues/JsonThrowWithChangeAndIf/JsonThrowWithChangeAndIfTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\JsonThrowWithChangeAndIf;
+namespace Rector\Tests\Issues\JsonThrowWithChangeAndIf;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/LocallyThis/Fixture/fixture.php.inc
+++ b/tests/Issues/LocallyThis/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\LocallyThis\Fixture;
+namespace Rector\Tests\Issues\LocallyThis\Fixture;
 
 class Fixture
 {
@@ -18,7 +18,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\LocallyThis\Fixture;
+namespace Rector\Tests\Issues\LocallyThis\Fixture;
 
 class Fixture
 {

--- a/tests/Issues/LocallyThis/LocallyThisTest.php
+++ b/tests/Issues/LocallyThis/LocallyThisTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\LocallyThis;
+namespace Rector\Tests\Issues\LocallyThis;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar\String_ as Foo;
 use PhpParser\Node\Stmt\Expression as Bar;
@@ -17,7 +17,7 @@ class NamespacedClassAliased
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar\String_ as Foo;
 

--- a/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased_docblock.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased_docblock.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar\String_ as Foo;
 use PhpParser\Node\Stmt\Expression as Bar;
@@ -19,7 +19,7 @@ class NamespacedClassAliasedDocblock
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar\String_ as Foo;
 

--- a/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased_part.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased_part.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar as Foo;
 use PhpParser\Node\Stmt\Expression as Bar;
@@ -17,7 +17,7 @@ class NamespacedClassAliasedPart
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar as Foo;
 

--- a/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased_part_docblock.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/namespaced_class_aliased_part_docblock.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar as Foo;
 use PhpParser\Node\Stmt\Expression as Bar;
@@ -19,7 +19,7 @@ class NamespacedClassAliasedPartDocblock
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use PhpParser\Node\Scalar as Foo;
 

--- a/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_class.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_class.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
-use Rector\Core\Tests\Issues\NamespacedUse\Source;
+use Rector\Tests\Issues\NamespacedUse\Source;
 
 final class SkipNamespacedUse extends Source\SomeClass
 {

--- a/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_single_namespace.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_namespaced_use_single_namespace.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use Foo2;
 

--- a/tests/Issues/NamespacedUse/Fixture/skip_used_as_const_fetch_node.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_used_as_const_fetch_node.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 

--- a/tests/Issues/NamespacedUse/Fixture/skip_used_see.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_used_see.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Fixture;
+namespace Rector\Tests\Issues\NamespacedUse\Fixture;
 
 use Rector\Renaming\Rector\Name\RenameClassRector;
 

--- a/tests/Issues/NamespacedUse/NamespacedUseTest.php
+++ b/tests/Issues/NamespacedUse/NamespacedUseTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\NamespacedUse;
+namespace Rector\Tests\Issues\NamespacedUse;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/NamespacedUse/Source/SomeClass.php
+++ b/tests/Issues/NamespacedUse/Source/SomeClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\NamespacedUse\Source;
+namespace Rector\Tests\Issues\NamespacedUse\Source;
 
 class SomeClass
 {

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/namespace_use_single_imported.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/namespace_use_single_imported.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
 use Foo2\Storage;
 use Foo2;
@@ -17,7 +17,7 @@ final class NamespacedUseSingleNamespaceImported
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
 use Foo2\Storage;
 

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_class.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_class.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
-use Rector\Core\Tests\Issues\NamespacedUseAutoImport\Source;
+use Rector\Tests\Issues\NamespacedUseAutoImport\Source;
 
 final class NamespacedUse extends Source\SomeClass
 {
@@ -12,9 +12,9 @@ final class NamespacedUse extends Source\SomeClass
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
-use Rector\Core\Tests\Issues\NamespacedUseAutoImport\Source\SomeClass;
+use Rector\Tests\Issues\NamespacedUseAutoImport\Source\SomeClass;
 
 final class NamespacedUse extends SomeClass
 {

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_single_namespace.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/namespaced_use_single_namespace.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
 use Foo2;
 
@@ -16,7 +16,7 @@ final class NamespacedUseSingleNamespace
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Fixture;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
 
 use Foo2\Storage;
 

--- a/tests/Issues/NamespacedUseAutoImport/NamespacedUseAutoImportTest.php
+++ b/tests/Issues/NamespacedUseAutoImport/NamespacedUseAutoImportTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/NamespacedUseAutoImport/Source/SomeClass.php
+++ b/tests/Issues/NamespacedUseAutoImport/Source/SomeClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\NamespacedUseAutoImport\Source;
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Source;
 
 class SomeClass
 {

--- a/tests/Issues/NoNamespaced/NoNamespacedTest.php
+++ b/tests/Issues/NoNamespaced/NoNamespacedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\NoNamespaced;
+namespace Rector\Tests\Issues\NoNamespaced;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/NoNamespaced/Source/SomeClass.php
+++ b/tests/Issues/NoNamespaced/Source/SomeClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\NoNamespaced\Source;
+namespace Rector\Tests\Issues\NoNamespaced\Source;
 
 class SomeClass
 {

--- a/tests/Issues/PartialValueDocblockUpdate/Fixture/add_default_value_to_route.php.inc
+++ b/tests/Issues/PartialValueDocblockUpdate/Fixture/add_default_value_to_route.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\PartialValueDocblockUpdate\Fixture;
+namespace Rector\Tests\Issues\PartialValueDocblockUpdate\Fixture;
 
 use Rector\Tests\Transform\Rector\StaticCall\StaticCallToNewRector\Source\SomeJsonResponse;
 use Shopware\Core\Framework\Routing\Annotation\Since;
@@ -23,7 +23,7 @@ final class AddDefaultValueToRoute
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\PartialValueDocblockUpdate\Fixture;
+namespace Rector\Tests\Issues\PartialValueDocblockUpdate\Fixture;
 
 use Rector\Tests\Transform\Rector\StaticCall\StaticCallToNewRector\Source\SomeJsonResponse;
 use Shopware\Core\Framework\Routing\Annotation\Since;

--- a/tests/Issues/PartialValueDocblockUpdate/Fixture/add_default_value_to_route2.php.inc
+++ b/tests/Issues/PartialValueDocblockUpdate/Fixture/add_default_value_to_route2.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\PartialValueDocblockUpdate\Fixture;
+namespace Rector\Tests\Issues\PartialValueDocblockUpdate\Fixture;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Routing\Annotation\Since;
@@ -24,7 +24,7 @@ class AddDefaultValueToRoute2 {
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\PartialValueDocblockUpdate\Fixture;
+namespace Rector\Tests\Issues\PartialValueDocblockUpdate\Fixture;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Routing\Annotation\Since;

--- a/tests/Issues/PartialValueDocblockUpdate/PartialValueDocblockUpdateTest.php
+++ b/tests/Issues/PartialValueDocblockUpdate/PartialValueDocblockUpdateTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\PartialValueDocblockUpdate;
+namespace Rector\Tests\Issues\PartialValueDocblockUpdate;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/PartialValueDocblockUpdate/Source/PartialUpdateTestRector.php
+++ b/tests/Issues/PartialValueDocblockUpdate/Source/PartialUpdateTestRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\PartialValueDocblockUpdate\Source;
+namespace Rector\Tests\Issues\PartialValueDocblockUpdate\Source;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;

--- a/tests/Issues/PartialValueDocblockUpdate/config/configured_rule.php
+++ b/tests/Issues/PartialValueDocblockUpdate/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\PartialValueDocblockUpdate\Source\PartialUpdateTestRector;
+use Rector\Tests\Issues\PartialValueDocblockUpdate\Source\PartialUpdateTestRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(PartialUpdateTestRector::class);

--- a/tests/Issues/PlainValueParser/Fixture/fixture.php.inc
+++ b/tests/Issues/PlainValueParser/Fixture/fixture.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\PlainValueParser\Fixture;
+namespace Rector\Tests\Issues\PlainValueParser\Fixture;
 
-use Rector\Core\Tests\Issues\PlainValueParser\Source\CustomAnnotation;
+use Rector\Tests\Issues\PlainValueParser\Source\CustomAnnotation;
 
 final class SomeFixture
 {
@@ -19,9 +19,9 @@ final class SomeFixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\PlainValueParser\Fixture;
+namespace Rector\Tests\Issues\PlainValueParser\Fixture;
 
-use Rector\Core\Tests\Issues\PlainValueParser\Source\CustomAnnotation;
+use Rector\Tests\Issues\PlainValueParser\Source\CustomAnnotation;
 
 final class SomeFixture
 {

--- a/tests/Issues/PlainValueParser/PlainValueParserTest.php
+++ b/tests/Issues/PlainValueParser/PlainValueParserTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\PlainValueParser;
+namespace Rector\Tests\Issues\PlainValueParser;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/PlainValueParser/Source/CustomAnnotation.php
+++ b/tests/Issues/PlainValueParser/Source/CustomAnnotation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\PlainValueParser\Source;
+namespace Rector\Tests\Issues\PlainValueParser\Source;
 
 class CustomAnnotation
 {

--- a/tests/Issues/PlainValueParser/config/configured_rule.php
+++ b/tests/Issues/PlainValueParser/config/configured_rule.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\PlainValueParser\Source\CustomAnnotation;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector as AnnotationToAttributeRectorAlias;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\Tests\Issues\PlainValueParser\Source\CustomAnnotation;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRectorAlias::class, [

--- a/tests/Issues/PrintMatchPhpstan/Fixture/fixture.php.inc
+++ b/tests/Issues/PrintMatchPhpstan/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\PrintMatchPhpstan\Fixture;
+namespace Rector\Tests\Issues\PrintMatchPhpstan\Fixture;
 
 use ReflectionParameter;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;

--- a/tests/Issues/PrintMatchPhpstan/PrintMatchPhpstanTest.php
+++ b/tests/Issues/PrintMatchPhpstan/PrintMatchPhpstanTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\PrintMatchPhpstan;
+namespace Rector\Tests\Issues\PrintMatchPhpstan;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/RemoveUnusedParamInMiddle/Fixture/do_not_remove_parameter_in_middle.php.inc
+++ b/tests/Issues/RemoveUnusedParamInMiddle/Fixture/do_not_remove_parameter_in_middle.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedParamInMiddle\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedParamInMiddle\Fixture;
 
 final class DoNotRemoveParameterInMiddle
 {
@@ -30,7 +30,7 @@ final class DoNotRemoveParameterInMiddle
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedParamInMiddle\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedParamInMiddle\Fixture;
 
 final class DoNotRemoveParameterInMiddle
 {

--- a/tests/Issues/RemoveUnusedParamInMiddle/RemoveUnusedParamInMiddleTest.php
+++ b/tests/Issues/RemoveUnusedParamInMiddle/RemoveUnusedParamInMiddleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedParamInMiddle;
+namespace Rector\Tests\Issues\RemoveUnusedParamInMiddle;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/RemoveUnusedVariableAlwaysElse/Fixture/fixture.php.inc
+++ b/tests/Issues/RemoveUnusedVariableAlwaysElse/Fixture/fixture.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
 
 final class Fixture
 {
@@ -25,7 +25,7 @@ final class Fixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
 
 final class Fixture
 {

--- a/tests/Issues/RemoveUnusedVariableAlwaysElse/Fixture/next_node_changed.php.inc
+++ b/tests/Issues/RemoveUnusedVariableAlwaysElse/Fixture/next_node_changed.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
 
 class NextNodeChanged
 {
@@ -26,7 +26,7 @@ class NextNodeChanged
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedVariableAlwaysElse\Fixture;
 
 class NextNodeChanged
 {

--- a/tests/Issues/RemoveUnusedVariableAlwaysElse/RemoveUnusedVariableAlwaysElseTest.php
+++ b/tests/Issues/RemoveUnusedVariableAlwaysElse/RemoveUnusedVariableAlwaysElseTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableAlwaysElse;
+namespace Rector\Tests\Issues\RemoveUnusedVariableAlwaysElse;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/RemoveUnusedVariableDouble/Fixture/fixture.php.inc
+++ b/tests/Issues/RemoveUnusedVariableDouble/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableDouble\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedVariableDouble\Fixture;
 
 final class Fixture
 {
@@ -24,7 +24,7 @@ final class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableDouble\Fixture;
+namespace Rector\Tests\Issues\RemoveUnusedVariableDouble\Fixture;
 
 final class Fixture
 {

--- a/tests/Issues/RemoveUnusedVariableDouble/RemoveUnusedVariableDoubleTest.php
+++ b/tests/Issues/RemoveUnusedVariableDouble/RemoveUnusedVariableDoubleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RemoveUnusedVariableDouble;
+namespace Rector\Tests\Issues\RemoveUnusedVariableDouble;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_curly_braces.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
+namespace Rector\Tests\Issues\AliasedImportDouble\Fixture;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -16,7 +16,7 @@ final class CallbackWithCuryBraces
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
+namespace Rector\Tests\Issues\AliasedImportDouble\Fixture;
 
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/Fixture/callback_with_string_value.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\AliasedImportDouble\Fixture;
+namespace Rector\Tests\Issues\AliasedImportDouble\Fixture;
 
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/tests/Issues/RenameClassInCallbackFromAssertAnnotation/RenameClassInCallbackFromAssertAnnotationTest.php
+++ b/tests/Issues/RenameClassInCallbackFromAssertAnnotation/RenameClassInCallbackFromAssertAnnotationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RenameClassInCallbackFromAssertAnnotation;
+namespace Rector\Tests\Issues\RenameClassInCallbackFromAssertAnnotation;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/RenameString/Fixture/rename_string.php.inc
+++ b/tests/Issues/RenameString/Fixture/rename_string.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+namespace Rector\Tests\Issues\DoubleRun\Fixture;
 
 final class RenameString
 {
@@ -18,7 +18,7 @@ final class RenameString
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\DoubleRun\Fixture;
+namespace Rector\Tests\Issues\DoubleRun\Fixture;
 
 final class RenameString
 {

--- a/tests/Issues/RenameString/RenameStringTest.php
+++ b/tests/Issues/RenameString/RenameStringTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RenameString;
+namespace Rector\Tests\Issues\RenameString;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ReplaceStmtToExpr/Fixture/some_fixture.php.inc
+++ b/tests/Issues/ReplaceStmtToExpr/Fixture/some_fixture.php.inc
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ReplaceStmtToExpr\Fixture;
+namespace Rector\Tests\Issues\ReplaceStmtToExpr\Fixture;
 
-use Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser;
+use Rector\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser;
 
 final class SomeFixture
 {
@@ -33,9 +33,9 @@ final class SomeFixture
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ReplaceStmtToExpr\Fixture;
+namespace Rector\Tests\Issues\ReplaceStmtToExpr\Fixture;
 
-use Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser;
+use Rector\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser;
 
 final class SomeFixture
 {

--- a/tests/Issues/ReplaceStmtToExpr/Fixture/some_fixture.php.inc
+++ b/tests/Issues/ReplaceStmtToExpr/Fixture/some_fixture.php.inc
@@ -49,7 +49,7 @@ final class SomeFixture
     ): bool {
         $user = $this->getUser($user);
 
-        if (!$user instanceof \Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser) {
+        if (!$user instanceof \Rector\Tests\Issues\ReplaceStmtToExpr\Source\SomeUser) {
             return false;
         }
         if ($user->isFoo()) {

--- a/tests/Issues/ReplaceStmtToExpr/ReplaceStmtToExprTest.php
+++ b/tests/Issues/ReplaceStmtToExpr/ReplaceStmtToExprTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ReplaceStmtToExpr;
+namespace Rector\Tests\Issues\ReplaceStmtToExpr;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ReplaceStmtToExpr/Source/SomeUser.php
+++ b/tests/Issues/ReplaceStmtToExpr/Source/SomeUser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ReplaceStmtToExpr\Source;
+namespace Rector\Tests\Issues\ReplaceStmtToExpr\Source;
 
 class SomeUser
 {

--- a/tests/Issues/ReturnEmptyNodes/Fixture/empty_if_stmts.php.inc
+++ b/tests/Issues/ReturnEmptyNodes/Fixture/empty_if_stmts.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ReturnEmptyNodes\Fixture;
+namespace Rector\Tests\Issues\ReturnEmptyNodes\Fixture;
 
 final class EmptyIfStmts
 {

--- a/tests/Issues/ReturnEmptyNodes/ReturnEmptyNodesTest.php
+++ b/tests/Issues/ReturnEmptyNodes/ReturnEmptyNodesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ReturnEmptyNodes;
+namespace Rector\Tests\Issues\ReturnEmptyNodes;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ReturnEmptyNodes/Source/ReturnEmptyStmtsRector.php
+++ b/tests/Issues/ReturnEmptyNodes/Source/ReturnEmptyStmtsRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ReturnEmptyNodes\Source;
+namespace Rector\Tests\Issues\ReturnEmptyNodes\Source;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\If_;

--- a/tests/Issues/ReturnEmptyNodes/config/configured_rule.php
+++ b/tests/Issues/ReturnEmptyNodes/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\ReturnEmptyNodes\Source\ReturnEmptyStmtsRector;
+use Rector\Tests\Issues\ReturnEmptyNodes\Source\ReturnEmptyStmtsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ReturnEmptyStmtsRector::class);

--- a/tests/Issues/RuleWithConfigurationAfterSet/Fixture/skip_doctrine_class_string.php.inc
+++ b/tests/Issues/RuleWithConfigurationAfterSet/Fixture/skip_doctrine_class_string.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\RuleWithConfigurationAfterSet\Fixture;
+namespace Rector\Tests\Issues\RuleWithConfigurationAfterSet\Fixture;
 
 final class SkipDoctrineClassString
 {

--- a/tests/Issues/RuleWithConfigurationAfterSet/RuleWithConfigurationAfterSetTest.php
+++ b/tests/Issues/RuleWithConfigurationAfterSet/RuleWithConfigurationAfterSetTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\RuleWithConfigurationAfterSet;
+namespace Rector\Tests\Issues\RuleWithConfigurationAfterSet;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/ArrayAnnotationToAttributeTest.php
+++ b/tests/Issues/ScopeNotAvailable/ArrayAnnotationToAttributeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/CallableThisTest.php
+++ b/tests/Issues/ScopeNotAvailable/CallableThisTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/FirstClassCallableTest.php
+++ b/tests/Issues/ScopeNotAvailable/FirstClassCallableTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/Fixture/callable_this.php.inc
+++ b/tests/Issues/ScopeNotAvailable/Fixture/callable_this.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Fixture;
 
 class CallableThis
 {
@@ -14,7 +14,7 @@ class CallableThis
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Fixture;
 
 class CallableThis
 {

--- a/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
+++ b/tests/Issues/ScopeNotAvailable/Fixture/count_array.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Fixture;
 
 class CountArray
 {
@@ -24,7 +24,7 @@ class CountArray
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Fixture;
 
 class CountArray
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureArrayAnnotationToAttribute/array_in_attribute.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureArrayAnnotationToAttribute/array_in_attribute.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\FixtureArrayAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FixtureArrayAnnotationToAttribute\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 
@@ -21,7 +21,7 @@ class ArrayInAttribtue
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\FixtureArrayAnnotationToAttribute\Fixture;
+namespace Rector\Tests\Issues\FixtureArrayAnnotationToAttribute\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 

--- a/tests/Issues/ScopeNotAvailable/FixtureDowngradePregUnmatched/preg_unmatched.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureDowngradePregUnmatched/preg_unmatched.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Fixture;
 
 function test()
 {
@@ -12,7 +12,7 @@ function test()
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Fixture;
 
 function test()
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
 final class FirstClassCallableAsKey
 {
@@ -16,7 +16,7 @@ final class FirstClassCallableAsKey
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
 final class FirstClassCallableAsKey
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key2.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/first_class_callable_as_key2.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
 final class FirstClassCallableAsKey2
 {
@@ -16,7 +16,7 @@ final class FirstClassCallableAsKey2
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
 final class FirstClassCallableAsKey2
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureFirstClassCallable/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
 final class Fixture
 {
@@ -16,7 +16,7 @@ final class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureFirstClassCallable;
 
 final class Fixture
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureForeachValue/fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureForeachValue/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Fixture;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Fixture;
 
 class FixtureForeachValue
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureJsonThrowCaseSensitiveConstFetch/fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureJsonThrowCaseSensitiveConstFetch/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureJsonThrowCaseSensitiveConstFetch;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureJsonThrowCaseSensitiveConstFetch;
 
 class Fixture
 {
@@ -26,7 +26,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureJsonThrowCaseSensitiveConstFetch;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureJsonThrowCaseSensitiveConstFetch;
 
 class Fixture
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureMatchToSwitchReflection/fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureMatchToSwitchReflection/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureMatchToSwitchReflection;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureMatchToSwitchReflection;
 
 final class ServiceValueResolver
 {
@@ -22,7 +22,7 @@ final class ServiceValueResolver
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureMatchToSwitchReflection;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureMatchToSwitchReflection;
 
 final class ServiceValueResolver
 {

--- a/tests/Issues/ScopeNotAvailable/FixtureThrowOptionalParams/fixture.php.inc
+++ b/tests/Issues/ScopeNotAvailable/FixtureThrowOptionalParams/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureThrowOptionalParams;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureThrowOptionalParams;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,7 +24,7 @@ class TestCommand extends Command
 -----
 <?php
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\FixtureThrowOptionalParams;
+namespace Rector\Tests\Issues\ScopeNotAvailable\FixtureThrowOptionalParams;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/tests/Issues/ScopeNotAvailable/ForeachValueScopeTest.php
+++ b/tests/Issues/ScopeNotAvailable/ForeachValueScopeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/JsonThrowCaseSensitiveConstFetchTest.php
+++ b/tests/Issues/ScopeNotAvailable/JsonThrowCaseSensitiveConstFetchTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/MatchToSwitchReflectionTest.php
+++ b/tests/Issues/ScopeNotAvailable/MatchToSwitchReflectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/PregUnmatchedTest.php
+++ b/tests/Issues/ScopeNotAvailable/PregUnmatchedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/ThrowOptionalParamsTest.php
+++ b/tests/Issues/ScopeNotAvailable/ThrowOptionalParamsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable;
+namespace Rector\Tests\Issues\ScopeNotAvailable;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/ScopeNotAvailable/Variable/ArrayItemForeachValueRector.php
+++ b/tests/Issues/ScopeNotAvailable/Variable/ArrayItemForeachValueRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\ScopeNotAvailable\Variable;
+namespace Rector\Tests\Issues\ScopeNotAvailable\Variable;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;

--- a/tests/Issues/ScopeNotAvailable/config/foreach_value_configured.php
+++ b/tests/Issues/ScopeNotAvailable/config/foreach_value_configured.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\Tests\Issues\ScopeNotAvailable\Variable\ArrayItemForeachValueRector;
+use Rector\Tests\Issues\ScopeNotAvailable\Variable\ArrayItemForeachValueRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ArrayItemForeachValueRector::class);

--- a/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
+++ b/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SimplifyEmpty\Fixture;
+namespace Rector\Tests\Issues\SimplifyEmpty\Fixture;
 
 class Fixture {
 
@@ -35,7 +35,7 @@ class Fixture {
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SimplifyEmpty\Fixture;
+namespace Rector\Tests\Issues\SimplifyEmpty\Fixture;
 
 class Fixture {
 

--- a/tests/Issues/SimplifyEmpty/SimplifyEmptyTest.php
+++ b/tests/Issues/SimplifyEmpty/SimplifyEmptyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SimplifyEmpty;
+namespace Rector\Tests\Issues\SimplifyEmpty;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/SimplifyVariableIfElseTernary/Fixture/do_not_duplicated_expr.php.inc
+++ b/tests/Issues/SimplifyVariableIfElseTernary/Fixture/do_not_duplicated_expr.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
+namespace Rector\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
 
 final class DoNotDuplicateExpr
 {
@@ -24,7 +24,7 @@ final class DoNotDuplicateExpr
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
+namespace Rector\Tests\Issues\SimplifyVariableIfElseTernary\Fixture;
 
 final class DoNotDuplicateExpr
 {

--- a/tests/Issues/SimplifyVariableIfElseTernary/SimplifyVariableIfElseTernaryTest.php
+++ b/tests/Issues/SimplifyVariableIfElseTernary/SimplifyVariableIfElseTernaryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SimplifyVariableIfElseTernary;
+namespace Rector\Tests\Issues\SimplifyVariableIfElseTernary;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/extracted_assign.php.inc
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/extracted_assign.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+namespace Rector\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
 
 final class ExtractedAssign
 {
@@ -23,7 +23,7 @@ final class ExtractedAssign
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+namespace Rector\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
 
 final class ExtractedAssign
 {

--- a/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/multi_assign_extract.php.inc
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/Fixture/multi_assign_extract.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+namespace Rector\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
 
 final class MultiAssignExtract
 {
@@ -22,7 +22,7 @@ final class MultiAssignExtract
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
+namespace Rector\Tests\Issues\SplitMultiAssignRemovePrivate\Fixture;
 
 final class MultiAssignExtract
 {

--- a/tests/Issues/SplitMultiAssignRemovePrivate/SplitMultiAssignRemovePrivateTest.php
+++ b/tests/Issues/SplitMultiAssignRemovePrivate/SplitMultiAssignRemovePrivateTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\SplitMultiAssignRemovePrivate;
+namespace Rector\Tests\Issues\SplitMultiAssignRemovePrivate;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Issues/UndefinedStmtIndex/Fixture/undefined_stmts_index.php.inc
+++ b/tests/Issues/UndefinedStmtIndex/Fixture/undefined_stmts_index.php.inc
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\UndefinedStmtIndex\Fixture;
+namespace Rector\Tests\Issues\UndefinedStmtIndex\Fixture;
 
 final class UndefinedStmtsIndex
 {
@@ -23,7 +23,7 @@ final class UndefinedStmtsIndex
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\UndefinedStmtIndex\Fixture;
+namespace Rector\Tests\Issues\UndefinedStmtIndex\Fixture;
 
 final class UndefinedStmtsIndex
 {

--- a/tests/Issues/UndefinedStmtIndex/UndefinedStmtIndexTest.php
+++ b/tests/Issues/UndefinedStmtIndex/UndefinedStmtIndexTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Issues\UndefinedStmtIndex;
+namespace Rector\Tests\Issues\UndefinedStmtIndex;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
+++ b/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Naming\ExpectedNameResolver;
+namespace Rector\Tests\Naming\ExpectedNameResolver;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Php/PhpVersionProviderTest.php
+++ b/tests/Php/PhpVersionProviderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Php;
+namespace Rector\Tests\Php;
 
 use Rector\Core\Configuration\Option;
 use Rector\Core\Configuration\Parameter\SimpleParameterProvider;

--- a/tests/Php/PhpVersionResolver/ProjectComposerJsonPhpVersionResolver/ProjectComposerJsonPhpVersionResolverTest.php
+++ b/tests/Php/PhpVersionResolver/ProjectComposerJsonPhpVersionResolver/ProjectComposerJsonPhpVersionResolverTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Php\PhpVersionResolver\ProjectComposerJsonPhpVersionResolver;
+namespace Rector\Tests\Php\PhpVersionResolver\ProjectComposerJsonPhpVersionResolver;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/PhpParser/Node/BetterNodeFinder/BetterNodeFinderTest.php
+++ b/tests/PhpParser/Node/BetterNodeFinder/BetterNodeFinderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Node\BetterNodeFinder;
+namespace Rector\Tests\PhpParser\Node\BetterNodeFinder;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;

--- a/tests/PhpParser/Node/NodeFactoryTest.php
+++ b/tests/PhpParser/Node/NodeFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Node;
+namespace Rector\Tests\PhpParser\Node;
 
 use Iterator;
 use PhpParser\Node\Expr\Array_;

--- a/tests/PhpParser/Node/Value/Source/ClassForConstant.php
+++ b/tests/PhpParser/Node/Value/Source/ClassForConstant.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Node\Value\Source;
+namespace Rector\Tests\PhpParser\Node\Value\Source;
 
 final class ClassForConstant
 {

--- a/tests/PhpParser/Node/Value/ValueResolverTest.php
+++ b/tests/PhpParser/Node/Value/ValueResolverTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Node\Value;
+namespace Rector\Tests\PhpParser\Node\Value;
 
 use Iterator;
 use PhpParser\BuilderFactory;
@@ -10,8 +10,8 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Plus;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
-use Rector\Core\Tests\PhpParser\Node\Value\Source\ClassForConstant;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Tests\PhpParser\Node\Value\Source\ClassForConstant;
 
 final class ValueResolverTest extends AbstractLazyTestCase
 {

--- a/tests/PhpParser/Printer/BetterStandardPrinterTest.php
+++ b/tests/PhpParser/Printer/BetterStandardPrinterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Printer;
+namespace Rector\Tests\PhpParser\Printer;
 
 use Iterator;
 use PhpParser\Comment;

--- a/tests/PhpParser/Printer/CommentPreserving/CommentPreservingTest.php
+++ b/tests/PhpParser/Printer/CommentPreserving/CommentPreservingTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Printer\CommentPreserving;
+namespace Rector\Tests\PhpParser\Printer\CommentPreserving;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/PhpParser/Printer/CommentPreserving/Fixture/comments_for_typed_property.php.inc
+++ b/tests/PhpParser/Printer/CommentPreserving/Fixture/comments_for_typed_property.php.inc
@@ -64,7 +64,7 @@ use Rector\Tests\PhpParser\Printer\CommentPreserving\Source\LocalEventDispatcher
 
 final class CommentsForTypedProperty
 {
-    private \Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Source\LocalEventDispatcher $eventDispatcher;
+    private \Rector\Tests\PhpParser\Printer\CommentPreserving\Source\LocalEventDispatcher $eventDispatcher;
 
     public function __construct(LocalEventDispatcher $eventDispatcher)
     {

--- a/tests/PhpParser/Printer/CommentPreserving/Fixture/comments_for_typed_property.php.inc
+++ b/tests/PhpParser/Printer/CommentPreserving/Fixture/comments_for_typed_property.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Fixture;
+namespace Rector\Tests\PhpParser\Printer\CommentPreserving\Fixture;
 
-use Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Source\LocalEventDispatcher;
+use Rector\Tests\PhpParser\Printer\CommentPreserving\Source\LocalEventDispatcher;
 
 /**
  * This docblock is being deleted when there's an empty docblock after it.
@@ -38,9 +38,9 @@ final class CommentsForTypedProperty
 -----
 <?php
 
-namespace Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Fixture;
+namespace Rector\Tests\PhpParser\Printer\CommentPreserving\Fixture;
 
-use Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Source\LocalEventDispatcher;
+use Rector\Tests\PhpParser\Printer\CommentPreserving\Source\LocalEventDispatcher;
 
 /**
  * This docblock is being deleted when there's an empty docblock after it.

--- a/tests/PhpParser/Printer/CommentPreserving/Fixture/keep_comment.php.inc
+++ b/tests/PhpParser/Printer/CommentPreserving/Fixture/keep_comment.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Fixture;
+namespace Rector\Tests\PhpParser\Printer\CommentPreserving\Fixture;
 
 class KeepComment
 {

--- a/tests/PhpParser/Printer/CommentPreserving/Fixture/keep_double_comments.php.inc
+++ b/tests/PhpParser/Printer/CommentPreserving/Fixture/keep_double_comments.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Fixture;
+namespace Rector\Tests\PhpParser\Printer\CommentPreserving\Fixture;
 
 class KeepDoubleComments
 {

--- a/tests/PhpParser/Printer/CommentPreserving/Fixture/keep_multiline_single_asterisk.php.inc
+++ b/tests/PhpParser/Printer/CommentPreserving/Fixture/keep_multiline_single_asterisk.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Fixture;
+namespace Rector\Tests\PhpParser\Printer\CommentPreserving\Fixture;
 
 class KeepMultilineSingleAsterisk
 {

--- a/tests/PhpParser/Printer/CommentPreserving/Source/LocalEventDispatcher.php
+++ b/tests/PhpParser/Printer/CommentPreserving/Source/LocalEventDispatcher.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Printer\CommentPreserving\Source;
+namespace Rector\Tests\PhpParser\Printer\CommentPreserving\Source;
 
 final class LocalEventDispatcher
 {

--- a/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
+++ b/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\PhpParser\Printer;
+namespace Rector\Tests\PhpParser\Printer;
 
 use Nette\Utils\FileSystem;
 use Rector\Core\PhpParser\Printer\FormatPerservingPrinter;

--- a/tests/Util/FileHasherTest.php
+++ b/tests/Util/FileHasherTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Util;
+namespace Rector\Tests\Util;
 
 use Rector\Core\Util\FileHasher;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;

--- a/tests/Util/Reflection/Fixture/AbstractPrivateProperty.php
+++ b/tests/Util/Reflection/Fixture/AbstractPrivateProperty.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Util\Reflection\Fixture;
+namespace Rector\Tests\Util\Reflection\Fixture;
 
 abstract class AbstractPrivateProperty
 {

--- a/tests/Util/Reflection/Fixture/SomeClassWithPrivateMethods.php
+++ b/tests/Util/Reflection/Fixture/SomeClassWithPrivateMethods.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Util\Reflection\Fixture;
+namespace Rector\Tests\Util\Reflection\Fixture;
 
 final class SomeClassWithPrivateMethods
 {

--- a/tests/Util/Reflection/Fixture/SomeClassWithPrivateProperty.php
+++ b/tests/Util/Reflection/Fixture/SomeClassWithPrivateProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Util\Reflection\Fixture;
+namespace Rector\Tests\Util\Reflection\Fixture;
 
 use stdClass;
 

--- a/tests/Util/Reflection/PrivatesAccessorTest.php
+++ b/tests/Util/Reflection/PrivatesAccessorTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Util\Reflection;
+namespace Rector\Tests\Util\Reflection;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Rector\Core\Tests\Util\Reflection\Fixture\SomeClassWithPrivateMethods;
-use Rector\Core\Tests\Util\Reflection\Fixture\SomeClassWithPrivateProperty;
 use Rector\Core\Util\Reflection\PrivatesAccessor;
+use Rector\Tests\Util\Reflection\Fixture\SomeClassWithPrivateMethods;
+use Rector\Tests\Util\Reflection\Fixture\SomeClassWithPrivateProperty;
 use stdClass;
 
 final class PrivatesAccessorTest extends TestCase

--- a/tests/Validation/RectorAssertTest.php
+++ b/tests/Validation/RectorAssertTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Core\Tests\Validation;
+namespace Rector\Tests\Validation;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;


### PR DESCRIPTION
Separating /src and /packages does not make really sense, as one directory has ~50 files and other ~120, often mixed together. It only makes working with files complicated and non-standard.

I'll merge these into one /src directory with `Rector\\` namespace to make our project slim and fit :+1: 