### PR TITLE
[CI] Remove phpstan for fixtures job as cumbersome to run

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -38,13 +38,6 @@ jobs:
                         run: composer phpstan-config
 
                     -
-                        name: 'PHPStan for fixtures'
-                        run: |
-                           # disable auto discovering of rules
-                           composer remove phpstan/extension-installer --dev
-                           composer phpstan-fixtures
-
-                    -
                         name: 'Commented Code'
                         run: vendor/bin/easy-ci check-commented-code src packages rules tests rules-tests --line-limit 5 --ansi
 

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,6 @@
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify",
         "phpstan-config": "vendor/bin/phpstan analyse config --ansi --error-format symplify",
-        "phpstan-fixtures": "vendor/bin/phpstan analyse -c phpstan-for-fixtures.neon --ansi --error-format symplify",
         "docs": [
             "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3 --skip-type 'Rector\\Core\\Rector\\AbstractCollectorRector'",
             "mv build/rector_rules_overview.md build/target-repository/docs/rector_rules_overview.md"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -503,5 +503,5 @@ parameters:
         # closure detailed
         - '#Method Rector\\Config\\RectorConfig\:\:singleton\(\) has parameter \$concrete with no signature specified for Closure#'
 
-        # @todo handler later
+        # skip for now
         - '#Class with base "AutoImportTest" name is already used in "Rector\\Tests\\Issues\\AutoImport\\AutoImportTest", "Rector\\Tests\\TypeDeclaration\\Rector\\StmtsAwareInterface\\DeclareStrictTypesRector\\AutoImportTest"\. Use unique name to make classes easy to recognize#'


### PR DESCRIPTION
Part of new year code cleanup :)

I tried to debug this locally but it's pretty cumbersome as dependencies are modified on the fly.
The added value is not that much at the moment, and I want to keep single PHPStan run.

Untill PHPStan allows to disable loading all extensions on the fly, I'll remove this one.