### PR TITLE
Add phpstan native cond types for getName() for nodes that always return a string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpstan/phpstan-webmozart-assert": "^1.2.2",
         "phpunit/phpunit": "^10.1",
-        "rector/phpstan-rules": "^0.7.1",
+        "rector/phpstan-rules": "dev-main",
         "rector/rector-generator": "^0.7",
         "spatie/enum": "^3.13",
         "symplify/easy-ci": "^11.3",

--- a/packages/NodeNameResolver/NodeNameResolver.php
+++ b/packages/NodeNameResolver/NodeNameResolver.php
@@ -10,7 +10,14 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Const_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Analyser\Scope;
 use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\Core\Exception\ShouldNotHappenException;
@@ -109,6 +116,21 @@ final class NodeNameResolver
         return $name === $resolvedName;
     }
 
+    /**
+     * Some nodes have always-known string name. This makes PHPStan smarter.
+     * @see https://phpstan.org/writing-php-code/phpdoc-types#conditional-return-types
+     *
+     * @return ($node is Param ? string :
+     *  ($node is ClassMethod ? string :
+     *  ($node is Property ? string :
+     *  ($node is PropertyProperty ? string :
+     *  ($node is Trait_ ? string :
+     *  ($node is Interface_ ? string :
+     *  ($node is Const_ ? string :
+     *  ($node is Node\Const_ ? string :
+     *  ($node is Name ? string :
+     *      string|null )))))))))
+     */
     public function getName(Node | string $node): ?string
     {
         if (is_string($node)) {

--- a/rules/Strict/NodeAnalyzer/UnitializedPropertyAnalyzer.php
+++ b/rules/Strict/NodeAnalyzer/UnitializedPropertyAnalyzer.php
@@ -6,7 +6,6 @@ namespace Rector\Strict\NodeAnalyzer;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\ThisType;
@@ -28,7 +27,7 @@ final class UnitializedPropertyAnalyzer
 
     public function isUnitialized(Expr $expr): bool
     {
-        if (! $expr instanceof PropertyFetch && ! $expr instanceof StaticPropertyFetch) {
+        if (! $expr instanceof PropertyFetch) {
             return false;
         }
 

--- a/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
+++ b/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
@@ -115,6 +115,10 @@ CODE_SAMPLE
             $this->treatAsNonEmpty
         );
 
+        if (! $result instanceof Expr) {
+            return null;
+        }
+
         if ($this->unitializedPropertyAnalyzer->isUnitialized($empty->expr)) {
             return new BooleanAnd(new Isset_([$empty->expr]), $result);
         }
@@ -130,6 +134,9 @@ CODE_SAMPLE
 
         $exprType = $scope->getNativeType($empty->expr);
         $result = $this->exactCompareFactory->createIdenticalFalsyCompare($exprType, $empty->expr, $treatAsNonEmpty);
+        if (! $result instanceof Expr) {
+            return null;
+        }
 
         if ($this->unitializedPropertyAnalyzer->isUnitialized($empty->expr)) {
             return new BooleanOr(new BooleanNot(new Isset_([$empty->expr])), $result);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Rector\Core\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Const_;
 use PhpParser\Node\Stmt\InlineHTML;
+use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Nop;
+use PhpParser\Node\Stmt\Trait_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\MutatingScope;
@@ -204,6 +208,21 @@ CODE_SAMPLE;
         return $this->nodeNameResolver->isNames($node, $names);
     }
 
+    /**
+     * Some nodes have always-known string name. This makes PHPStan smarter.
+     * @see https://phpstan.org/writing-php-code/phpdoc-types#conditional-return-types
+     *
+     * @return ($node is Node\Param ? string :
+     *  ($node is Node\Stmt\ClassMethod ? string :
+     *  ($node is Node\Stmt\Property ? string :
+     *  ($node is Node\Stmt\PropertyProperty ? string :
+     *  ($node is Trait_ ? string :
+     *  ($node is Interface_ ? string :
+     *  ($node is Const_ ? string :
+     *  ($node is Node\Const_ ? string :
+     *  ($node is Name ? string :
+     *      string|null )))))))))
+     */
     protected function getName(Node $node): ?string
     {
         return $this->nodeNameResolver->getName($node);


### PR DESCRIPTION
This allows us to drop custom name extension, that handled the same known-string return value improvements :party: 

E.g. `ClassMethod` name is always known and is `string`
