### PR TITLE
Bump min. version to PHP 8.2 - readonly classes

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -84,7 +84,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"

--- a/.github/workflows/code_analysis_no_dev.yaml
+++ b/.github/workflows/code_analysis_no_dev.yaml
@@ -17,7 +17,7 @@ jobs:
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
 
             -  run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['8.1']
+                php_version: ['8.2']
                 directory:
                     - 'e2e/applied-rule-change-docblock'
                     - 'e2e/applied-rule-return-array-nodes'

--- a/.github/workflows/e2e_consecutive_changes.yaml
+++ b/.github/workflows/e2e_consecutive_changes.yaml
@@ -21,7 +21,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['8.1']
+                php_version: ['8.2']
                 rector_disable_parallel: ['true', 'false']
                 directory:
                     - 'e2e/consecutive-changes-with-cache'

--- a/.github/workflows/e2e_with_cache.yaml
+++ b/.github/workflows/e2e_with_cache.yaml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['8.1']
+                php_version: ['8.2']
                 directory:
                     - 'e2e/applied-rule-removed-node-with-cache'
                     - 'e2e/timeout-file-not-cached'

--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -45,7 +45,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
 
             -   run: composer config minimum-stability dev

--- a/.github/workflows/php_linter.yaml
+++ b/.github/workflows/php_linter.yaml
@@ -18,7 +18,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
                     tools: cs2pr
 

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -29,7 +29,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    # PHP 8.1 is required, so Rector's code is PHP 8.1 compatible even after refactoring
+                    # PHP 8.2 is required, so Rector's code is PHP 8.2 compatible even after refactoring
                     php-version: 8.2
                     coverage: none
 

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -30,7 +30,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     # PHP 8.1 is required, so Rector's code is PHP 8.1 compatible even after refactoring
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
 
             -   run: composer install --no-progress --ansi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
                     # to display warning when assert() is called, eg: on direct getArgs() on CallLike
                     # and check against first class callable strlen(...)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         timeout-minutes: 3
 
-        name: PHP 8.1 tests
+        name: PHP 8.2 tests
         steps:
             -   uses: actions/checkout@v4
 

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -46,7 +46,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "homepage": "https://getrector.com",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
         "clue/ndjson-react": "^1.3",
         "composer/semver": "^3.3.2",

--- a/rector.php
+++ b/rector.php
@@ -18,7 +18,7 @@ use Rector\Utils\Rector\MoveAbstractRectorToChildrenRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_82,
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
         SetList::PRIVATIZATION,

--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -19,11 +19,11 @@ use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class ArgumentDefaultValueReplacer
+final readonly class ArgumentDefaultValueReplacer
 {
     public function __construct(
-        private readonly NodeFactory $nodeFactory,
-        private readonly ValueResolver $valueResolver
+        private NodeFactory $nodeFactory,
+        private ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Arguments/NodeAnalyzer/ArgumentAddingScope.php
+++ b/rules/Arguments/NodeAnalyzer/ArgumentAddingScope.php
@@ -12,7 +12,7 @@ use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
 use Rector\Enum\ObjectReference;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ArgumentAddingScope
+final readonly class ArgumentAddingScope
 {
     /**
      * @api
@@ -33,7 +33,7 @@ final class ArgumentAddingScope
     public const SCOPE_CLASS_METHOD = 'class_method';
 
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Arguments/NodeAnalyzer/ChangedArgumentsDetector.php
+++ b/rules/Arguments/NodeAnalyzer/ChangedArgumentsDetector.php
@@ -11,12 +11,12 @@ use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class ChangedArgumentsDetector
+final readonly class ChangedArgumentsDetector
 {
     public function __construct(
-        private readonly ValueResolver $valueResolver,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly TypeComparator $typeComparator
+        private ValueResolver $valueResolver,
+        private StaticTypeMapper $staticTypeMapper,
+        private TypeComparator $typeComparator
     ) {
     }
 

--- a/rules/Arguments/ValueObject/ArgumentAdderWithoutDefaultValue.php
+++ b/rules/Arguments/ValueObject/ArgumentAdderWithoutDefaultValue.php
@@ -8,15 +8,15 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Validation\RectorAssert;
 
-final class ArgumentAdderWithoutDefaultValue
+final readonly class ArgumentAdderWithoutDefaultValue
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method,
-        private readonly int $position,
-        private readonly ?string $argumentName = null,
-        private readonly Type | null $argumentType = null,
-        private readonly ?string $scope = null
+        private string $class,
+        private string $method,
+        private int $position,
+        private ?string $argumentName = null,
+        private Type | null $argumentType = null,
+        private ?string $scope = null
     ) {
         RectorAssert::className($class);
     }

--- a/rules/Arguments/ValueObject/RemoveMethodCallParam.php
+++ b/rules/Arguments/ValueObject/RemoveMethodCallParam.php
@@ -7,12 +7,12 @@ namespace Rector\Arguments\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class RemoveMethodCallParam
+final readonly class RemoveMethodCallParam
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $methodName,
-        private readonly int $paramPosition
+        private string $class,
+        private string $methodName,
+        private int $paramPosition
     ) {
         RectorAssert::className($class);
         RectorAssert::methodName($methodName);

--- a/rules/Arguments/ValueObject/ReplaceArgumentDefaultValue.php
+++ b/rules/Arguments/ValueObject/ReplaceArgumentDefaultValue.php
@@ -8,7 +8,7 @@ use PHPStan\Type\ObjectType;
 use Rector\Arguments\Contract\ReplaceArgumentDefaultValueInterface;
 use Rector\Validation\RectorAssert;
 
-final class ReplaceArgumentDefaultValue implements ReplaceArgumentDefaultValueInterface
+final readonly class ReplaceArgumentDefaultValue implements ReplaceArgumentDefaultValueInterface
 {
     /**
      * @var string
@@ -19,11 +19,11 @@ final class ReplaceArgumentDefaultValue implements ReplaceArgumentDefaultValueIn
      * @param int<0, max> $position
      */
     public function __construct(
-        private readonly string $class,
-        private readonly string $method,
-        private readonly int $position,
-        private readonly mixed $valueBefore,
-        private readonly mixed $valueAfter
+        private string $class,
+        private string $method,
+        private int $position,
+        private mixed $valueBefore,
+        private mixed $valueAfter
     ) {
         RectorAssert::className($class);
     }

--- a/rules/Arguments/ValueObject/ReplaceFuncCallArgumentDefaultValue.php
+++ b/rules/Arguments/ValueObject/ReplaceFuncCallArgumentDefaultValue.php
@@ -6,13 +6,13 @@ namespace Rector\Arguments\ValueObject;
 
 use Rector\Arguments\Contract\ReplaceArgumentDefaultValueInterface;
 
-final class ReplaceFuncCallArgumentDefaultValue implements ReplaceArgumentDefaultValueInterface
+final readonly class ReplaceFuncCallArgumentDefaultValue implements ReplaceArgumentDefaultValueInterface
 {
     public function __construct(
-        private readonly string $function,
-        private readonly int $position,
-        private readonly mixed $valueBefore,
-        private readonly mixed $valueAfter
+        private string $function,
+        private int $position,
+        private mixed $valueBefore,
+        private mixed $valueAfter
     ) {
     }
 

--- a/rules/CodeQuality/CompactConverter.php
+++ b/rules/CodeQuality/CompactConverter.php
@@ -13,10 +13,10 @@ use PhpParser\Node\Scalar\String_;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class CompactConverter
+final readonly class CompactConverter
 {
     public function __construct(
-        private readonly ValueResolver $valueResolver
+        private ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/CodeQuality/NodeAnalyzer/ClassLikeAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/ClassLikeAnalyzer.php
@@ -7,10 +7,10 @@ namespace Rector\CodeQuality\NodeAnalyzer;
 use PhpParser\Node\Stmt\Class_;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ClassLikeAnalyzer
+final readonly class ClassLikeAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/CodeQuality/NodeAnalyzer/ForeachAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/ForeachAnalyzer.php
@@ -11,10 +11,10 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class ForeachAnalyzer
+final readonly class ForeachAnalyzer
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator,
+        private NodeComparator $nodeComparator,
     ) {
     }
 

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -26,7 +26,7 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
-final class LocalPropertyAnalyzer
+final readonly class LocalPropertyAnalyzer
 {
     /**
      * @var string
@@ -34,12 +34,12 @@ final class LocalPropertyAnalyzer
     private const LARAVEL_COLLECTION_CLASS = 'Illuminate\Support\Collection';
 
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ArrayDimFetchTypeResolver $arrayDimFetchTypeResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private readonly TypeFactory $typeFactory,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver,
+        private ArrayDimFetchTypeResolver $arrayDimFetchTypeResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private TypeFactory $typeFactory,
     ) {
     }
 

--- a/rules/CodeQuality/NodeAnalyzer/VariableDimFetchAssignResolver.php
+++ b/rules/CodeQuality/NodeAnalyzer/VariableDimFetchAssignResolver.php
@@ -15,11 +15,11 @@ use Rector\CodeQuality\ValueObject\KeyAndExpr;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class VariableDimFetchAssignResolver
+final readonly class VariableDimFetchAssignResolver
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private NodeComparator $nodeComparator,
+        private BetterNodeFinder $betterNodeFinder
     ) {
     }
 

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use PHPStan\Type\Type;
 
-final class MissingPropertiesFactory
+final readonly class MissingPropertiesFactory
 {
     public function __construct(
-        private readonly PropertyTypeDecorator $propertyTypeDecorator
+        private PropertyTypeDecorator $propertyTypeDecorator
     ) {
     }
 

--- a/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
+++ b/rules/CodeQuality/NodeFactory/PropertyTypeDecorator.php
@@ -10,12 +10,12 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Privatization\TypeManipulator\TypeNormalizer;
 
-final class PropertyTypeDecorator
+final readonly class PropertyTypeDecorator
 {
     public function __construct(
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly TypeNormalizer $typeNormalizer
+        private PhpDocTypeChanger $phpDocTypeChanger,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private TypeNormalizer $typeNormalizer
     ) {
     }
 

--- a/rules/CodeQuality/NodeManipulator/ExprBoolCaster.php
+++ b/rules/CodeQuality/NodeManipulator/ExprBoolCaster.php
@@ -17,13 +17,13 @@ use Rector\NodeTypeResolver\PHPStan\Type\StaticTypeAnalyzer;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 
-final class ExprBoolCaster
+final readonly class ExprBoolCaster
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly TypeUnwrapper $typeUnwrapper,
-        private readonly StaticTypeAnalyzer $staticTypeAnalyzer,
-        private readonly NodeFactory $nodeFactory
+        private NodeTypeResolver $nodeTypeResolver,
+        private TypeUnwrapper $typeUnwrapper,
+        private StaticTypeAnalyzer $staticTypeAnalyzer,
+        private NodeFactory $nodeFactory
     ) {
     }
 

--- a/rules/CodeQuality/TypeResolver/ArrayDimFetchTypeResolver.php
+++ b/rules/CodeQuality/TypeResolver/ArrayDimFetchTypeResolver.php
@@ -12,10 +12,10 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class ArrayDimFetchTypeResolver
+final readonly class ArrayDimFetchTypeResolver
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/rules/CodeQuality/TypeResolver/AssignVariableTypeResolver.php
+++ b/rules/CodeQuality/TypeResolver/AssignVariableTypeResolver.php
@@ -9,10 +9,10 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class AssignVariableTypeResolver
+final readonly class AssignVariableTypeResolver
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/rules/CodeQuality/ValueObject/KeyAndExpr.php
+++ b/rules/CodeQuality/ValueObject/KeyAndExpr.php
@@ -7,15 +7,15 @@ namespace Rector\CodeQuality\ValueObject;
 use PhpParser\Comment;
 use PhpParser\Node\Expr;
 
-final class KeyAndExpr
+final readonly class KeyAndExpr
 {
     /**
      * @param Comment[] $comments
      */
     public function __construct(
-        private readonly ?Expr $keyExpr,
-        private readonly Expr $expr,
-        private readonly array $comments
+        private ?Expr $keyExpr,
+        private Expr $expr,
+        private array $comments
     ) {
     }
 

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -19,11 +19,11 @@ use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
-final class UseImportsAdder
+final readonly class UseImportsAdder
 {
     public function __construct(
-        private readonly UsedImportsResolver $usedImportsResolver,
-        private readonly TypeFactory $typeFactory
+        private UsedImportsResolver $usedImportsResolver,
+        private TypeFactory $typeFactory
     ) {
     }
 

--- a/rules/CodingStyle/Application/UseImportsRemover.php
+++ b/rules/CodingStyle/Application/UseImportsRemover.php
@@ -8,10 +8,10 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Use_;
 use Rector\Renaming\Collector\RenamedNameCollector;
 
-final class UseImportsRemover
+final readonly class UseImportsRemover
 {
     public function __construct(
-        private readonly RenamedNameCollector $renamedNameCollector
+        private RenamedNameCollector $renamedNameCollector
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/AliasUsesResolver.php
+++ b/rules/CodingStyle/ClassNameImport/AliasUsesResolver.php
@@ -11,10 +11,10 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
 
-final class AliasUsesResolver
+final readonly class AliasUsesResolver
 {
     public function __construct(
-        private readonly UseImportsTraverser $useImportsTraverser
+        private UseImportsTraverser $useImportsTraverser
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/AliasClassNameImportSkipVoter.php
@@ -19,10 +19,10 @@ use Rector\ValueObject\Application\File;
  *
  * use App\Something as SomeClass;
  */
-final class AliasClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
+final readonly class AliasClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
 {
     public function __construct(
-        private readonly AliasUsesResolver $aliasUsesResolver
+        private AliasUsesResolver $aliasUsesResolver
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ClassLikeNameClassNameImportSkipVoter.php
@@ -19,10 +19,10 @@ use Rector\ValueObject\Application\File;
  *
  * class SomeClass {}
  */
-final class ClassLikeNameClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
+final readonly class ClassLikeNameClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
 {
     public function __construct(
-        private readonly ShortNameResolver $shortNameResolver
+        private ShortNameResolver $shortNameResolver
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -21,11 +21,11 @@ use Rector\ValueObject\Application\File;
  *
  * SomeClass::callThis();
  */
-final class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
+final readonly class FullyQualifiedNameClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
 {
     public function __construct(
-        private readonly ShortNameResolver $shortNameResolver,
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
+        private ShortNameResolver $shortNameResolver,
+        private RenamedClassesDataCollector $renamedClassesDataCollector
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/UsesClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/UsesClassNameImportSkipVoter.php
@@ -18,11 +18,11 @@ use Rector\ValueObject\Application\File;
  * if there is already:
  * - use App\Another\Product
  */
-final class UsesClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
+final readonly class UsesClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
 {
     public function __construct(
-        private readonly UseNodesToAddCollector $useNodesToAddCollector,
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
+        private UseNodesToAddCollector $useNodesToAddCollector,
+        private RenamedClassesDataCollector $renamedClassesDataCollector
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
@@ -15,14 +15,14 @@ use Rector\Naming\Naming\UseImportsResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\ValueObject\Application\File;
 
-final class ClassNameImportSkipper
+final readonly class ClassNameImportSkipper
 {
     /**
      * @param ClassNameImportSkipVoterInterface[] $classNameImportSkipVoters
      */
     public function __construct(
-        private readonly iterable $classNameImportSkipVoters,
-        private readonly UseImportsResolver $useImportsResolver
+        private iterable $classNameImportSkipVoters,
+        private UseImportsResolver $useImportsResolver
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -105,7 +105,7 @@ final class ShortNameResolver
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, function (Node $node) use (
             &$shortNamesToFullyQualifiedNames
-        ) {
+        ): null {
             // class name is used!
             if ($node instanceof ClassLike && $node->name instanceof Identifier) {
                 $fullyQualifiedName = $this->nodeNameResolver->getName($node);
@@ -153,7 +153,7 @@ final class ShortNameResolver
         $shortNames = [];
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, function (Node $node) use (
             &$shortNames
-        ) {
+        ): null {
             // speed up for nodes that are
             $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
             if (! $phpDocInfo instanceof PhpDocInfo) {
@@ -164,7 +164,7 @@ final class ShortNameResolver
             $phpDocNodeTraverser->traverseWithCallable(
                 $phpDocInfo->getPhpDocNode(),
                 '',
-                static function ($node) use (&$shortNames) {
+                static function ($node) use (&$shortNames): null {
                     if ($node instanceof PhpDocTagNode) {
                         $shortName = trim($node->name, '@');
                         if (ucfirst($shortName) === $shortName) {

--- a/rules/CodingStyle/ClassNameImport/UseImportsTraverser.php
+++ b/rules/CodingStyle/ClassNameImport/UseImportsTraverser.php
@@ -15,11 +15,11 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
 
-final class UseImportsTraverser
+final readonly class UseImportsTraverser
 {
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly NodeNameResolver $nodeNameResolver
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
+++ b/rules/CodingStyle/ClassNameImport/UsedImportsResolver.php
@@ -15,12 +15,12 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
-final class UsedImportsResolver
+final readonly class UsedImportsResolver
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly UseImportsTraverser $useImportsTraverser,
-        private readonly NodeNameResolver $nodeNameResolver
+        private BetterNodeFinder $betterNodeFinder,
+        private UseImportsTraverser $useImportsTraverser,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/CodingStyle/ClassNameImport/ValueObject/UsedImports.php
+++ b/rules/CodingStyle/ClassNameImport/ValueObject/UsedImports.php
@@ -7,7 +7,7 @@ namespace Rector\CodingStyle\ClassNameImport\ValueObject;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
-final class UsedImports
+final readonly class UsedImports
 {
     /**
      * @param array<FullyQualifiedObjectType|AliasedObjectType> $useImports
@@ -15,9 +15,9 @@ final class UsedImports
      * @param FullyQualifiedObjectType[] $constantImports
      */
     public function __construct(
-        private readonly array $useImports,
-        private readonly array $functionImports,
-        private readonly array $constantImports
+        private array $useImports,
+        private array $functionImports,
+        private array $constantImports
     ) {
     }
 

--- a/rules/CodingStyle/Guard/StaticGuard.php
+++ b/rules/CodingStyle/Guard/StaticGuard.php
@@ -13,11 +13,11 @@ use PHPStan\Reflection\MethodReflection;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Reflection\ReflectionResolver;
 
-final class StaticGuard
+final readonly class StaticGuard
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReflectionResolver $reflectionResolver
+        private BetterNodeFinder $betterNodeFinder,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -15,12 +15,12 @@ use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\ValueObject\Application\File;
 
-final class NameImporter
+final readonly class NameImporter
 {
     public function __construct(
-        private readonly ClassNameImportSkipper $classNameImportSkipper,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly UseNodesToAddCollector $useNodesToAddCollector
+        private ClassNameImportSkipper $classNameImportSkipper,
+        private StaticTypeMapper $staticTypeMapper,
+        private UseNodesToAddCollector $useNodesToAddCollector
     ) {
     }
 

--- a/rules/CodingStyle/NodeAnalyzer/UseImportNameMatcher.php
+++ b/rules/CodingStyle/NodeAnalyzer/UseImportNameMatcher.php
@@ -16,7 +16,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Util\StringUtils;
 
-final class UseImportNameMatcher
+final readonly class UseImportNameMatcher
 {
     /**
      * @var string
@@ -27,8 +27,8 @@ final class UseImportNameMatcher
     private const SHORT_NAME_REGEX = '#^%s(\\\\[\w]+)?$#i';
 
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly UseImportsResolver $useImportsResolver
+        private BetterNodeFinder $betterNodeFinder,
+        private UseImportsResolver $useImportsResolver
     ) {
     }
 

--- a/rules/CodingStyle/NodeFactory/ArrayCallableToMethodCallFactory.php
+++ b/rules/CodingStyle/NodeFactory/ArrayCallableToMethodCallFactory.php
@@ -13,10 +13,10 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\TypeWithClassName;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class ArrayCallableToMethodCallFactory
+final readonly class ArrayCallableToMethodCallFactory
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -222,7 +222,7 @@ CODE_SAMPLE
         $this->traverseNodesWithCallable($catch->stmts, function (Node $node) use (
             $oldVariableName,
             $newVariableName
-        ) {
+        ): null {
             if (! $node instanceof Variable) {
                 return null;
             }

--- a/rules/CodingStyle/Reflection/VendorLocationDetector.php
+++ b/rules/CodingStyle/Reflection/VendorLocationDetector.php
@@ -7,10 +7,10 @@ namespace Rector\CodingStyle\Reflection;
 use PHPStan\Reflection\MethodReflection;
 use Rector\FileSystem\FilePathHelper;
 
-final class VendorLocationDetector
+final readonly class VendorLocationDetector
 {
     public function __construct(
-        private readonly FilePathHelper $filePathHelper
+        private FilePathHelper $filePathHelper
     ) {
     }
 

--- a/rules/DeadCode/ConditionEvaluator.php
+++ b/rules/DeadCode/ConditionEvaluator.php
@@ -14,10 +14,10 @@ use Rector\DeadCode\ValueObject\VersionCompareCondition;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\Php\PhpVersionProvider;
 
-final class ConditionEvaluator
+final readonly class ConditionEvaluator
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/rules/DeadCode/ConditionResolver.php
+++ b/rules/DeadCode/ConditionResolver.php
@@ -19,13 +19,13 @@ use Rector\Php\PhpVersionProvider;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Util\PhpVersionFactory;
 
-final class ConditionResolver
+final readonly class ConditionResolver
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly ValueResolver $valueResolver,
-        private readonly PhpVersionFactory $phpVersionFactory
+        private NodeNameResolver $nodeNameResolver,
+        private PhpVersionProvider $phpVersionProvider,
+        private ValueResolver $valueResolver,
+        private PhpVersionFactory $phpVersionFactory
     ) {
     }
 

--- a/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
@@ -13,11 +13,11 @@ use Rector\Enum\ObjectReference;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class CallCollectionAnalyzer
+final readonly class CallCollectionAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/DeadCode/NodeAnalyzer/ExprUsedInNodeAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/ExprUsedInNodeAnalyzer.php
@@ -11,12 +11,12 @@ use PhpParser\Node\Expr\Variable;
 use Rector\NodeAnalyzer\CompactFuncCallAnalyzer;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
 
-final class ExprUsedInNodeAnalyzer
+final readonly class ExprUsedInNodeAnalyzer
 {
     public function __construct(
-        private readonly UsedVariableNameAnalyzer $usedVariableNameAnalyzer,
-        private readonly CompactFuncCallAnalyzer $compactFuncCallAnalyzer,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private UsedVariableNameAnalyzer $usedVariableNameAnalyzer,
+        private CompactFuncCallAnalyzer $compactFuncCallAnalyzer,
+        private BetterStandardPrinter $betterStandardPrinter
     ) {
     }
 

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -30,17 +30,17 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Reflection\ReflectionResolver;
 
-final class IsClassMethodUsedAnalyzer
+final readonly class IsClassMethodUsedAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly AstResolver $astResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ValueResolver $valueResolver,
-        private readonly ArrayCallableMethodMatcher $arrayCallableMethodMatcher,
-        private readonly CallCollectionAnalyzer $callCollectionAnalyzer,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+        private NodeNameResolver $nodeNameResolver,
+        private AstResolver $astResolver,
+        private BetterNodeFinder $betterNodeFinder,
+        private ValueResolver $valueResolver,
+        private ArrayCallableMethodMatcher $arrayCallableMethodMatcher,
+        private CallCollectionAnalyzer $callCollectionAnalyzer,
+        private ReflectionResolver $reflectionResolver,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
     ) {
     }
 

--- a/rules/DeadCode/NodeAnalyzer/JustPropertyFetchVariableAssignMatcher.php
+++ b/rules/DeadCode/NodeAnalyzer/JustPropertyFetchVariableAssignMatcher.php
@@ -13,10 +13,10 @@ use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\DeadCode\ValueObject\VariableAndPropertyFetchAssign;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class JustPropertyFetchVariableAssignMatcher
+final readonly class JustPropertyFetchVariableAssignMatcher
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator
+        private NodeComparator $nodeComparator
     ) {
     }
 

--- a/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
@@ -12,10 +12,10 @@ use PhpParser\Node\Stmt\Class_;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class PropertyWriteonlyAnalyzer
+final readonly class PropertyWriteonlyAnalyzer
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder
+        private BetterNodeFinder $betterNodeFinder
     ) {
     }
 

--- a/rules/DeadCode/NodeAnalyzer/UsedVariableNameAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/UsedVariableNameAnalyzer.php
@@ -10,10 +10,10 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class UsedVariableNameAnalyzer
+final readonly class UsedVariableNameAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
+++ b/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
@@ -8,10 +8,10 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeAnalyzer\ParamAnalyzer;
 
-final class UnusedParameterResolver
+final readonly class UnusedParameterResolver
 {
     public function __construct(
-        private readonly ParamAnalyzer $paramAnalyzer
+        private ParamAnalyzer $paramAnalyzer
     ) {
     }
 

--- a/rules/DeadCode/NodeManipulator/ControllerClassMethodManipulator.php
+++ b/rules/DeadCode/NodeManipulator/ControllerClassMethodManipulator.php
@@ -11,11 +11,11 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ControllerClassMethodManipulator
+final readonly class ControllerClassMethodManipulator
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private NodeNameResolver $nodeNameResolver,
+        private PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/DeadCode/NodeManipulator/CountManipulator.php
+++ b/rules/DeadCode/NodeManipulator/CountManipulator.php
@@ -16,12 +16,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class CountManipulator
+final readonly class CountManipulator
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly NodeComparator $nodeComparator,
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeNameResolver $nodeNameResolver,
+        private NodeComparator $nodeComparator,
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
+++ b/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
@@ -32,10 +32,10 @@ use PhpParser\Node\Scalar;
 use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class LivingCodeManipulator
+final readonly class LivingCodeManipulator
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/rules/DeadCode/NodeManipulator/VariadicFunctionLikeDetector.php
+++ b/rules/DeadCode/NodeManipulator/VariadicFunctionLikeDetector.php
@@ -11,7 +11,7 @@ use PhpParser\NodeTraverser;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
-final class VariadicFunctionLikeDetector
+final readonly class VariadicFunctionLikeDetector
 {
     /**
      * @var string[]
@@ -19,8 +19,8 @@ final class VariadicFunctionLikeDetector
     private const VARIADIC_FUNCTION_NAMES = ['func_get_arg', 'func_get_args', 'func_num_args'];
 
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly NodeNameResolver $nodeNameResolver
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -17,15 +17,15 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\TypeDeclaration\NodeAnalyzer\ParamAnalyzer;
 
-final class DeadParamTagValueNodeAnalyzer
+final readonly class DeadParamTagValueNodeAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly TypeComparator $typeComparator,
-        private readonly GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer,
-        private readonly MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer,
-        private readonly ParamAnalyzer $paramAnalyzer,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private NodeNameResolver $nodeNameResolver,
+        private TypeComparator $typeComparator,
+        private GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer,
+        private MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer,
+        private ParamAnalyzer $paramAnalyzer,
+        private PhpDocTypeChanger $phpDocTypeChanger,
     ) {
     }
 

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -23,15 +23,15 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class DeadReturnTagValueNodeAnalyzer
+final readonly class DeadReturnTagValueNodeAnalyzer
 {
     public function __construct(
-        private readonly TypeComparator $typeComparator,
-        private readonly GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer,
-        private readonly MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer,
-        private readonly StandaloneTypeRemovalGuard $standaloneTypeRemovalGuard,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly StaticTypeMapper $staticTypeMapper
+        private TypeComparator $typeComparator,
+        private GenericTypeNodeAnalyzer $genericTypeNodeAnalyzer,
+        private MixedArrayTypeNodeAnalyzer $mixedArrayTypeNodeAnalyzer,
+        private StandaloneTypeRemovalGuard $standaloneTypeRemovalGuard,
+        private PhpDocTypeChanger $phpDocTypeChanger,
+        private StaticTypeMapper $staticTypeMapper
     ) {
     }
 

--- a/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
@@ -12,11 +12,11 @@ use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class DeadVarTagValueNodeAnalyzer
+final readonly class DeadVarTagValueNodeAnalyzer
 {
     public function __construct(
-        private readonly TypeComparator $typeComparator,
-        private readonly StaticTypeMapper $staticTypeMapper,
+        private TypeComparator $typeComparator,
+        private StaticTypeMapper $staticTypeMapper,
     ) {
     }
 

--- a/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
@@ -14,11 +14,11 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\DeadCode\PhpDoc\DeadParamTagValueNodeAnalyzer;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 
-final class ParamTagRemover
+final readonly class ParamTagRemover
 {
     public function __construct(
-        private readonly DeadParamTagValueNodeAnalyzer $deadParamTagValueNodeAnalyzer,
-        private readonly DocBlockUpdater $docBlockUpdater,
+        private DeadParamTagValueNodeAnalyzer $deadParamTagValueNodeAnalyzer,
+        private DocBlockUpdater $docBlockUpdater,
     ) {
     }
 

--- a/rules/DeadCode/PhpDoc/TagRemover/ReturnTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/ReturnTagRemover.php
@@ -10,10 +10,10 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\DeadCode\PhpDoc\DeadReturnTagValueNodeAnalyzer;
 
-final class ReturnTagRemover
+final readonly class ReturnTagRemover
 {
     public function __construct(
-        private readonly DeadReturnTagValueNodeAnalyzer $deadReturnTagValueNodeAnalyzer
+        private DeadReturnTagValueNodeAnalyzer $deadReturnTagValueNodeAnalyzer
     ) {
     }
 

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -17,14 +17,14 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\DeadCode\PhpDoc\DeadVarTagValueNodeAnalyzer;
 use Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer;
 
-final class VarTagRemover
+final readonly class VarTagRemover
 {
     public function __construct(
-        private readonly DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly DeadVarTagValueNodeAnalyzer $deadVarTagValueNodeAnalyzer,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly DocBlockUpdater $docBlockUpdater,
+        private DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private DeadVarTagValueNodeAnalyzer $deadVarTagValueNodeAnalyzer,
+        private PhpDocTypeChanger $phpDocTypeChanger,
+        private DocBlockUpdater $docBlockUpdater,
     ) {
     }
 

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -11,7 +11,7 @@ use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class PureFunctionDetector
+final readonly class PureFunctionDetector
 {
     /**
      * @see https://github.com/vimeo/psalm/blob/d470903722cfcbc1cd04744c5491d3e6d13ec3d9/src/Psalm/Internal/Codebase/Functions.php#L288
@@ -121,8 +121,8 @@ final class PureFunctionDetector
     ];
 
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionProvider $reflectionProvider
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -25,7 +25,7 @@ use PHPStan\Type\ConstantType;
 use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class SideEffectNodeDetector
+final readonly class SideEffectNodeDetector
 {
     /**
      * @var array<class-string<Expr>>
@@ -43,8 +43,8 @@ final class SideEffectNodeDetector
     ];
 
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly PureFunctionDetector $pureFunctionDetector
+        private NodeTypeResolver $nodeTypeResolver,
+        private PureFunctionDetector $pureFunctionDetector
     ) {
     }
 

--- a/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
+++ b/rules/DeadCode/UselessIfCondBeforeForeachDetector.php
@@ -15,10 +15,10 @@ use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class UselessIfCondBeforeForeachDetector
+final readonly class UselessIfCondBeforeForeachDetector
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator
+        private NodeComparator $nodeComparator
     ) {
     }
 

--- a/rules/DeadCode/ValueObject/BinaryToVersionCompareCondition.php
+++ b/rules/DeadCode/ValueObject/BinaryToVersionCompareCondition.php
@@ -6,12 +6,12 @@ namespace Rector\DeadCode\ValueObject;
 
 use Rector\DeadCode\Contract\ConditionInterface;
 
-final class BinaryToVersionCompareCondition implements ConditionInterface
+final readonly class BinaryToVersionCompareCondition implements ConditionInterface
 {
     public function __construct(
-        private readonly VersionCompareCondition $versionCompareCondition,
-        private readonly string $binaryClass,
-        private readonly mixed $expectedValue
+        private VersionCompareCondition $versionCompareCondition,
+        private string $binaryClass,
+        private mixed $expectedValue
     ) {
     }
 

--- a/rules/DeadCode/ValueObject/VariableAndPropertyFetchAssign.php
+++ b/rules/DeadCode/ValueObject/VariableAndPropertyFetchAssign.php
@@ -7,11 +7,11 @@ namespace Rector\DeadCode\ValueObject;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 
-final class VariableAndPropertyFetchAssign
+final readonly class VariableAndPropertyFetchAssign
 {
     public function __construct(
-        private readonly Variable $variable,
-        private readonly PropertyFetch $propertyFetch
+        private Variable $variable,
+        private PropertyFetch $propertyFetch
     ) {
     }
 

--- a/rules/DeadCode/ValueObject/VersionCompareCondition.php
+++ b/rules/DeadCode/ValueObject/VersionCompareCondition.php
@@ -6,12 +6,12 @@ namespace Rector\DeadCode\ValueObject;
 
 use Rector\DeadCode\Contract\ConditionInterface;
 
-final class VersionCompareCondition implements ConditionInterface
+final readonly class VersionCompareCondition implements ConditionInterface
 {
     public function __construct(
-        private readonly int $firstVersion,
-        private readonly int $secondVersion,
-        private readonly ?string $compareSign
+        private int $firstVersion,
+        private int $secondVersion,
+        private ?string $compareSign
     ) {
     }
 

--- a/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
+++ b/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
@@ -13,11 +13,11 @@ use PhpParser\Node\Stmt\Return_;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class IfAndAnalyzer
+final readonly class IfAndAnalyzer
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeComparator $nodeComparator,
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeComparator $nodeComparator,
     ) {
     }
 

--- a/rules/EarlyReturn/NodeFactory/InvertedIfFactory.php
+++ b/rules/EarlyReturn/NodeFactory/InvertedIfFactory.php
@@ -13,11 +13,11 @@ use Rector\EarlyReturn\NodeTransformer\ConditionInverter;
 use Rector\NodeNestingScope\ContextAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
-final class InvertedIfFactory
+final readonly class InvertedIfFactory
 {
     public function __construct(
-        private readonly ConditionInverter $conditionInverter,
-        private readonly ContextAnalyzer $contextAnalyzer
+        private ConditionInverter $conditionInverter,
+        private ContextAnalyzer $contextAnalyzer
     ) {
     }
 

--- a/rules/EarlyReturn/NodeTransformer/ConditionInverter.php
+++ b/rules/EarlyReturn/NodeTransformer/ConditionInverter.php
@@ -10,10 +10,10 @@ use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BooleanNot;
 use Rector\NodeManipulator\BinaryOpManipulator;
 
-final class ConditionInverter
+final readonly class ConditionInverter
 {
     public function __construct(
-        private readonly BinaryOpManipulator $binaryOpManipulator
+        private BinaryOpManipulator $binaryOpManipulator
     ) {
     }
 

--- a/rules/EarlyReturn/ValueObject/BareSingleAssignIf.php
+++ b/rules/EarlyReturn/ValueObject/BareSingleAssignIf.php
@@ -8,11 +8,11 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\If_;
 
-final class BareSingleAssignIf
+final readonly class BareSingleAssignIf
 {
     public function __construct(
-        private readonly If_ $if,
-        private readonly Assign $assign
+        private If_ $if,
+        private Assign $assign
     ) {
     }
 

--- a/rules/Naming/AssignVariableNameResolver/NewAssignVariableNameResolver.php
+++ b/rules/Naming/AssignVariableNameResolver/NewAssignVariableNameResolver.php
@@ -13,10 +13,10 @@ use Rector\NodeNameResolver\NodeNameResolver;
 /**
  * @implements AssignVariableNameResolverInterface<New_>
  */
-final class NewAssignVariableNameResolver implements AssignVariableNameResolverInterface
+final readonly class NewAssignVariableNameResolver implements AssignVariableNameResolverInterface
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Naming/AssignVariableNameResolver/PropertyFetchAssignVariableNameResolver.php
+++ b/rules/Naming/AssignVariableNameResolver/PropertyFetchAssignVariableNameResolver.php
@@ -13,10 +13,10 @@ use Rector\NodeNameResolver\NodeNameResolver;
 /**
  * @implements AssignVariableNameResolverInterface<PropertyFetch>
  */
-final class PropertyFetchAssignVariableNameResolver implements AssignVariableNameResolverInterface
+final readonly class PropertyFetchAssignVariableNameResolver implements AssignVariableNameResolverInterface
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -11,7 +11,7 @@ use Rector\Util\StringUtils;
 /**
  * @see \Rector\Tests\Naming\ExpectedNameResolver\InflectorSingularResolverTest
  */
-final class InflectorSingularResolver
+final readonly class InflectorSingularResolver
 {
     /**
      * @var array<string, string>
@@ -38,7 +38,7 @@ final class InflectorSingularResolver
     private const CAMELCASE = 'camelcase';
 
     public function __construct(
-        private readonly Inflector $inflector
+        private Inflector $inflector
     ) {
     }
 

--- a/rules/Naming/ExpectedNameResolver/MatchParamTypeExpectedNameResolver.php
+++ b/rules/Naming/ExpectedNameResolver/MatchParamTypeExpectedNameResolver.php
@@ -11,12 +11,12 @@ use Rector\Naming\ValueObject\ExpectedName;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class MatchParamTypeExpectedNameResolver
+final readonly class MatchParamTypeExpectedNameResolver
 {
     public function __construct(
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly PropertyNaming $propertyNaming,
-        private readonly NodeTypeResolver $nodeTypeResolver,
+        private StaticTypeMapper $staticTypeMapper,
+        private PropertyNaming $propertyNaming,
+        private NodeTypeResolver $nodeTypeResolver,
     ) {
     }
 

--- a/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
+++ b/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
@@ -19,15 +19,15 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class MatchPropertyTypeExpectedNameResolver
+final readonly class MatchPropertyTypeExpectedNameResolver
 {
     public function __construct(
-        private readonly PropertyNaming $propertyNaming,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PropertyManipulator $propertyManipulator,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly StaticTypeMapper $staticTypeMapper
+        private PropertyNaming $propertyNaming,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private NodeNameResolver $nodeNameResolver,
+        private PropertyManipulator $propertyManipulator,
+        private ReflectionResolver $reflectionResolver,
+        private StaticTypeMapper $staticTypeMapper
     ) {
     }
 

--- a/rules/Naming/Guard/BreakingVariableRenameGuard.php
+++ b/rules/Naming/Guard/BreakingVariableRenameGuard.php
@@ -28,7 +28,7 @@ use Rector\Util\StringUtils;
 /**
  * This class check if a variable name change breaks existing code in class method
  */
-final class BreakingVariableRenameGuard
+final readonly class BreakingVariableRenameGuard
 {
     /**
      * @var string
@@ -37,12 +37,12 @@ final class BreakingVariableRenameGuard
     public const AT_NAMING_REGEX = '#[\w+]At$#';
 
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ConflictingNameResolver $conflictingNameResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly OverridenExistingNamesResolver $overridenExistingNamesResolver,
-        private readonly TypeUnwrapper $typeUnwrapper,
-        private readonly NodeNameResolver $nodeNameResolver
+        private BetterNodeFinder $betterNodeFinder,
+        private ConflictingNameResolver $conflictingNameResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private OverridenExistingNamesResolver $overridenExistingNamesResolver,
+        private TypeUnwrapper $typeUnwrapper,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Naming/Guard/DateTimeAtNamingConventionGuard.php
+++ b/rules/Naming/Guard/DateTimeAtNamingConventionGuard.php
@@ -11,11 +11,11 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 use Rector\Util\StringUtils;
 
-final class DateTimeAtNamingConventionGuard
+final readonly class DateTimeAtNamingConventionGuard
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly TypeUnwrapper $typeUnwrapper
+        private NodeTypeResolver $nodeTypeResolver,
+        private TypeUnwrapper $typeUnwrapper
     ) {
     }
 

--- a/rules/Naming/Guard/HasMagicGetSetGuard.php
+++ b/rules/Naming/Guard/HasMagicGetSetGuard.php
@@ -7,10 +7,10 @@ namespace Rector\Naming\Guard;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Naming\ValueObject\PropertyRename;
 
-final class HasMagicGetSetGuard
+final readonly class HasMagicGetSetGuard
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/rules/Naming/Guard/PropertyConflictingNameGuard/MatchPropertyTypeConflictingNameGuard.php
+++ b/rules/Naming/Guard/PropertyConflictingNameGuard/MatchPropertyTypeConflictingNameGuard.php
@@ -10,12 +10,12 @@ use Rector\Naming\PhpArray\ArrayFilter;
 use Rector\Naming\ValueObject\PropertyRename;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class MatchPropertyTypeConflictingNameGuard
+final readonly class MatchPropertyTypeConflictingNameGuard
 {
     public function __construct(
-        private readonly MatchPropertyTypeExpectedNameResolver $matchPropertyTypeExpectedNameResolver,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ArrayFilter $arrayFilter
+        private MatchPropertyTypeExpectedNameResolver $matchPropertyTypeExpectedNameResolver,
+        private NodeNameResolver $nodeNameResolver,
+        private ArrayFilter $arrayFilter
     ) {
     }
 

--- a/rules/Naming/Matcher/ForeachMatcher.php
+++ b/rules/Naming/Matcher/ForeachMatcher.php
@@ -13,11 +13,11 @@ use PhpParser\Node\Stmt\Function_;
 use Rector\Naming\ValueObject\VariableAndCallForeach;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ForeachMatcher
+final readonly class ForeachMatcher
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly CallMatcher $callMatcher,
+        private NodeNameResolver $nodeNameResolver,
+        private CallMatcher $callMatcher,
     ) {
     }
 

--- a/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
+++ b/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
@@ -14,12 +14,12 @@ use Rector\Naming\ValueObject\VariableAndCallAssign;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class VariableAndCallAssignMatcher
+final readonly class VariableAndCallAssignMatcher
 {
     public function __construct(
-        private readonly CallMatcher $callMatcher,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
+        private CallMatcher $callMatcher,
+        private NodeNameResolver $nodeNameResolver,
+        private BetterNodeFinder $betterNodeFinder,
     ) {
     }
 

--- a/rules/Naming/Naming/AliasNameResolver.php
+++ b/rules/Naming/Naming/AliasNameResolver.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Use_;
 
-final class AliasNameResolver
+final readonly class AliasNameResolver
 {
     public function __construct(
-        private readonly UseImportsResolver $useImportsResolver,
+        private UseImportsResolver $useImportsResolver,
     ) {
     }
 

--- a/rules/Naming/Naming/ExpectedNameResolver.php
+++ b/rules/Naming/Naming/ExpectedNameResolver.php
@@ -23,13 +23,13 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
-final class ExpectedNameResolver
+final readonly class ExpectedNameResolver
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly PropertyNaming $propertyNaming,
-        private readonly MatchParamTypeExpectedNameResolver $matchParamTypeExpectedNameResolver
+        private NodeNameResolver $nodeNameResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private PropertyNaming $propertyNaming,
+        private MatchParamTypeExpectedNameResolver $matchParamTypeExpectedNameResolver
     ) {
     }
 

--- a/rules/Naming/Naming/PropertyNaming.php
+++ b/rules/Naming/Naming/PropertyNaming.php
@@ -23,7 +23,7 @@ use Rector\Util\StringUtils;
 /**
  * @see \Rector\Tests\Naming\Naming\PropertyNamingTest
  */
-final class PropertyNaming
+final readonly class PropertyNaming
 {
     /**
      * @var string[]
@@ -55,8 +55,8 @@ final class PropertyNaming
     private const GET_PREFIX_REGEX = '#^get(?<root_name>[A-Z].+)#';
 
     public function __construct(
-        private readonly RectorNamingInflector $rectorNamingInflector,
-        private readonly NodeTypeResolver $nodeTypeResolver,
+        private RectorNamingInflector $rectorNamingInflector,
+        private NodeTypeResolver $nodeTypeResolver,
     ) {
     }
 

--- a/rules/Naming/Naming/UseImportsResolver.php
+++ b/rules/Naming/Naming/UseImportsResolver.php
@@ -13,10 +13,10 @@ use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Provider\CurrentFileProvider;
 use Rector\ValueObject\Application\File;
 
-final class UseImportsResolver
+final readonly class UseImportsResolver
 {
     public function __construct(
-        private readonly CurrentFileProvider $currentFileProvider
+        private CurrentFileProvider $currentFileProvider
     ) {
     }
 

--- a/rules/Naming/NamingConvention/NamingConventionAnalyzer.php
+++ b/rules/Naming/NamingConvention/NamingConventionAnalyzer.php
@@ -10,10 +10,10 @@ use PhpParser\Node\Expr\StaticCall;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Util\StringUtils;
 
-final class NamingConventionAnalyzer
+final readonly class NamingConventionAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Naming/ParamRenamer/ParamRenamer.php
+++ b/rules/Naming/ParamRenamer/ParamRenamer.php
@@ -12,12 +12,12 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Naming\ValueObject\ParamRename;
 use Rector\Naming\VariableRenamer;
 
-final class ParamRenamer
+final readonly class ParamRenamer
 {
     public function __construct(
-        private readonly VariableRenamer $variableRenamer,
-        private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private VariableRenamer $variableRenamer,
+        private DocBlockUpdater $docBlockUpdater,
+        private PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/Naming/PropertyRenamer/MatchTypePropertyRenamer.php
+++ b/rules/Naming/PropertyRenamer/MatchTypePropertyRenamer.php
@@ -10,12 +10,12 @@ use Rector\Naming\Guard\PropertyConflictingNameGuard\MatchPropertyTypeConflictin
 use Rector\Naming\RenameGuard\PropertyRenameGuard;
 use Rector\Naming\ValueObject\PropertyRename;
 
-final class MatchTypePropertyRenamer
+final readonly class MatchTypePropertyRenamer
 {
     public function __construct(
-        private readonly MatchPropertyTypeConflictingNameGuard $matchPropertyTypeConflictingNameGuard,
-        private readonly PropertyRenameGuard $propertyRenameGuard,
-        private readonly PropertyFetchRenamer $propertyFetchRenamer,
+        private MatchPropertyTypeConflictingNameGuard $matchPropertyTypeConflictingNameGuard,
+        private PropertyRenameGuard $propertyRenameGuard,
+        private PropertyFetchRenamer $propertyFetchRenamer,
     ) {
     }
 

--- a/rules/Naming/PropertyRenamer/PropertyFetchRenamer.php
+++ b/rules/Naming/PropertyRenamer/PropertyFetchRenamer.php
@@ -13,11 +13,11 @@ use PhpParser\Node\VarLikeIdentifier;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
-final class PropertyFetchRenamer
+final readonly class PropertyFetchRenamer
 {
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 

--- a/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
+++ b/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
@@ -25,18 +25,18 @@ use Rector\Php\PhpVersionProvider;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
 
-final class PropertyPromotionRenamer
+final readonly class PropertyPromotionRenamer
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly MatchParamTypeExpectedNameResolver $matchParamTypeExpectedNameResolver,
-        private readonly ParamRenameFactory $paramRenameFactory,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly ParamRenamer $paramRenamer,
-        private readonly PropertyFetchRenamer $propertyFetchRenamer,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly VariableRenamer $variableRenamer,
-        private readonly DocBlockUpdater $docBlockUpdater,
+        private PhpVersionProvider $phpVersionProvider,
+        private MatchParamTypeExpectedNameResolver $matchParamTypeExpectedNameResolver,
+        private ParamRenameFactory $paramRenameFactory,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private ParamRenamer $paramRenamer,
+        private PropertyFetchRenamer $propertyFetchRenamer,
+        private NodeNameResolver $nodeNameResolver,
+        private VariableRenamer $variableRenamer,
+        private DocBlockUpdater $docBlockUpdater,
     ) {
     }
 

--- a/rules/Naming/RectorNamingInflector.php
+++ b/rules/Naming/RectorNamingInflector.php
@@ -7,7 +7,7 @@ namespace Rector\Naming;
 use Doctrine\Inflector\Inflector;
 use Nette\Utils\Strings;
 
-final class RectorNamingInflector
+final readonly class RectorNamingInflector
 {
     /**
      * @var string
@@ -16,7 +16,7 @@ final class RectorNamingInflector
     private const DATA_INFO_SUFFIX_REGEX = '#^(?<prefix>.+)(?<suffix>Data|Info)$#';
 
     public function __construct(
-        private readonly Inflector $inflector
+        private Inflector $inflector
     ) {
     }
 

--- a/rules/Naming/RenameGuard/PropertyRenameGuard.php
+++ b/rules/Naming/RenameGuard/PropertyRenameGuard.php
@@ -10,12 +10,12 @@ use Rector\Naming\Guard\HasMagicGetSetGuard;
 use Rector\Naming\ValueObject\PropertyRename;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class PropertyRenameGuard
+final readonly class PropertyRenameGuard
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly DateTimeAtNamingConventionGuard $dateTimeAtNamingConventionGuard,
-        private readonly HasMagicGetSetGuard $hasMagicGetSetGuard,
+        private NodeTypeResolver $nodeTypeResolver,
+        private DateTimeAtNamingConventionGuard $dateTimeAtNamingConventionGuard,
+        private HasMagicGetSetGuard $hasMagicGetSetGuard,
     ) {
     }
 

--- a/rules/Naming/ValueObject/ExpectedName.php
+++ b/rules/Naming/ValueObject/ExpectedName.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\Naming\ValueObject;
 
-final class ExpectedName
+final readonly class ExpectedName
 {
     public function __construct(
-        private readonly string $name,
-        private readonly string $singularized
+        private string $name,
+        private string $singularized
     ) {
     }
 

--- a/rules/Naming/ValueObject/ParamRename.php
+++ b/rules/Naming/ValueObject/ParamRename.php
@@ -9,14 +9,14 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use Rector\Naming\Contract\RenameParamValueObjectInterface;
 
-final class ParamRename implements RenameParamValueObjectInterface
+final readonly class ParamRename implements RenameParamValueObjectInterface
 {
     public function __construct(
-        private readonly string $currentName,
-        private readonly string $expectedName,
-        private readonly Param $param,
-        private readonly Variable $variable,
-        private readonly FunctionLike $functionLike
+        private string $currentName,
+        private string $expectedName,
+        private Param $param,
+        private Variable $variable,
+        private FunctionLike $functionLike
     ) {
     }
 

--- a/rules/Naming/ValueObject/PropertyRename.php
+++ b/rules/Naming/ValueObject/PropertyRename.php
@@ -10,15 +10,15 @@ use PhpParser\Node\Stmt\PropertyProperty;
 use Rector\Naming\Contract\RenamePropertyValueObjectInterface;
 use Rector\Validation\RectorAssert;
 
-final class PropertyRename implements RenamePropertyValueObjectInterface
+final readonly class PropertyRename implements RenamePropertyValueObjectInterface
 {
     public function __construct(
-        private readonly Property $property,
-        private readonly string $expectedName,
-        private readonly string $currentName,
-        private readonly ClassLike $classLike,
-        private readonly string $classLikeName,
-        private readonly PropertyProperty $propertyProperty
+        private Property $property,
+        private string $expectedName,
+        private string $currentName,
+        private ClassLike $classLike,
+        private string $classLikeName,
+        private PropertyProperty $propertyProperty
     ) {
         // name must be valid
         RectorAssert::propertyName($currentName);

--- a/rules/Naming/ValueObject/VariableAndCallAssign.php
+++ b/rules/Naming/ValueObject/VariableAndCallAssign.php
@@ -13,14 +13,14 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 
-final class VariableAndCallAssign
+final readonly class VariableAndCallAssign
 {
     public function __construct(
-        private readonly Variable $variable,
-        private readonly FuncCall | StaticCall | MethodCall $expr,
-        private readonly Assign $assign,
-        private readonly string $variableName,
-        private readonly ClassMethod | Function_ | Closure $functionLike
+        private Variable $variable,
+        private FuncCall | StaticCall | MethodCall $expr,
+        private Assign $assign,
+        private string $variableName,
+        private ClassMethod | Function_ | Closure $functionLike
     ) {
     }
 

--- a/rules/Naming/ValueObject/VariableAndCallForeach.php
+++ b/rules/Naming/ValueObject/VariableAndCallForeach.php
@@ -12,13 +12,13 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 
-final class VariableAndCallForeach
+final readonly class VariableAndCallForeach
 {
     public function __construct(
-        private readonly Variable $variable,
-        private readonly FuncCall | StaticCall | MethodCall $expr,
-        private readonly string $variableName,
-        private readonly ClassMethod | Function_ | Closure $functionLike
+        private Variable $variable,
+        private FuncCall | StaticCall | MethodCall $expr,
+        private string $variableName,
+        private ClassMethod | Function_ | Closure $functionLike
     ) {
     }
 

--- a/rules/Naming/ValueObjectFactory/ParamRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/ParamRenameFactory.php
@@ -10,10 +10,10 @@ use PhpParser\Node\Param;
 use Rector\Naming\ValueObject\ParamRename;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ParamRenameFactory
+final readonly class ParamRenameFactory
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Naming\ValueObject\PropertyRename;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class PropertyRenameFactory
+final readonly class PropertyRenameFactory
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
+        private NodeNameResolver $nodeNameResolver,
     ) {
     }
 

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -18,13 +18,13 @@ use Rector\Naming\PhpDoc\VarTagValueNodeRenamer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
-final class VariableRenamer
+final readonly class VariableRenamer
 {
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly VarTagValueNodeRenamer $varTagValueNodeRenamer,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver,
+        private VarTagValueNodeRenamer $varTagValueNodeRenamer,
+        private PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 
@@ -78,7 +78,7 @@ final class VariableRenamer
                 }
 
                 // TODO: Should be implemented in BreakingVariableRenameGuard::shouldSkipParam()
-                if ($this->isParamInParentFunction($node, $currentClosure)) {
+                if ($this->isParamInParentFunction()) {
                     return null;
                 }
 
@@ -98,23 +98,8 @@ final class VariableRenamer
         return $hasRenamed;
     }
 
-    private function isParamInParentFunction(Variable $variable, ?Closure $closure): bool
+    private function isParamInParentFunction(): bool
     {
-        if (! $closure instanceof Closure) {
-            return false;
-        }
-
-        $variableName = $this->nodeNameResolver->getName($variable);
-        if ($variableName === null) {
-            return false;
-        }
-
-        foreach ($closure->params as $param) {
-            if ($this->nodeNameResolver->isName($param, $variableName)) {
-                return true;
-            }
-        }
-
         return false;
     }
 

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -78,7 +78,7 @@ final readonly class VariableRenamer
                 }
 
                 // TODO: Should be implemented in BreakingVariableRenameGuard::shouldSkipParam()
-                if ($this->isParamInParentFunction()) {
+                if ($this->isParamInParentFunction($node, $currentClosure)) {
                     return null;
                 }
 
@@ -98,8 +98,23 @@ final readonly class VariableRenamer
         return $hasRenamed;
     }
 
-    private function isParamInParentFunction(): bool
+    private function isParamInParentFunction(Variable $variable, ?Closure $closure): bool
     {
+        if (! $closure instanceof Closure) {
+            return false;
+        }
+
+        $variableName = $this->nodeNameResolver->getName($variable);
+        if ($variableName === null) {
+            return false;
+        }
+
+        foreach ($closure->params as $param) {
+            if ($this->nodeNameResolver->isName($param, $variableName)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -205,7 +205,7 @@ CODE_SAMPLE
 
     private function decorateClassConst(ClassConst $classConst): void
     {
-        $this->traverseNodesWithCallable($classConst->consts, static function (Node $subNode) {
+        $this->traverseNodesWithCallable($classConst->consts, static function (Node $subNode): null {
             if ($subNode instanceof String_) {
                 $subNode->setAttribute(self::IS_UNDER_CLASS_CONST, true);
             }

--- a/rules/Php55/RegexMatcher.php
+++ b/rules/Php55/RegexMatcher.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Scalar\String_;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class RegexMatcher
+final readonly class RegexMatcher
 {
     /**
      * @var string
@@ -31,7 +31,7 @@ final class RegexMatcher
     private const ALL_MODIFIERS_VALUES = ['i', 'm', 's', 'x', 'e', 'A', 'D', 'S', 'U', 'X', 'J', 'u'];
 
     public function __construct(
-        private readonly ValueResolver $valueResolver
+        private ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Php70/NodeAnalyzer/BattleshipTernaryAnalyzer.php
+++ b/rules/Php70/NodeAnalyzer/BattleshipTernaryAnalyzer.php
@@ -13,11 +13,11 @@ use Rector\Php70\ValueObject\ComparedExprs;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class BattleshipTernaryAnalyzer
+final readonly class BattleshipTernaryAnalyzer
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator,
-        private readonly ValueResolver $valueResolver,
+        private NodeComparator $nodeComparator,
+        private ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Php70/ValueObject/ComparedExprs.php
+++ b/rules/Php70/ValueObject/ComparedExprs.php
@@ -6,11 +6,11 @@ namespace Rector\Php70\ValueObject;
 
 use PhpParser\Node\Expr;
 
-final class ComparedExprs
+final readonly class ComparedExprs
 {
     public function __construct(
-        private readonly Expr $firstExpr,
-        private readonly Expr $secondExpr,
+        private Expr $firstExpr,
+        private Expr $secondExpr,
     ) {
     }
 

--- a/rules/Php71/IsArrayAndDualCheckToAble.php
+++ b/rules/Php71/IsArrayAndDualCheckToAble.php
@@ -15,12 +15,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Php71\ValueObject\TwoNodeMatch;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class IsArrayAndDualCheckToAble
+final readonly class IsArrayAndDualCheckToAble
 {
     public function __construct(
-        private readonly BinaryOpManipulator $binaryOpManipulator,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly NodeComparator $nodeComparator
+        private BinaryOpManipulator $binaryOpManipulator,
+        private NodeNameResolver $nodeNameResolver,
+        private NodeComparator $nodeComparator
     ) {
     }
 

--- a/rules/Php71/ValueObject/TwoNodeMatch.php
+++ b/rules/Php71/ValueObject/TwoNodeMatch.php
@@ -6,11 +6,11 @@ namespace Rector\Php71\ValueObject;
 
 use PhpParser\Node\Expr;
 
-final class TwoNodeMatch
+final readonly class TwoNodeMatch
 {
     public function __construct(
-        private readonly Expr $firstExpr,
-        private readonly Expr $secondExpr
+        private Expr $firstExpr,
+        private Expr $secondExpr
     ) {
     }
 

--- a/rules/Php72/NodeFactory/AnonymousFunctionFactory.php
+++ b/rules/Php72/NodeFactory/AnonymousFunctionFactory.php
@@ -45,7 +45,7 @@ use Rector\PhpParser\Parser\SimplePhpParser;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class AnonymousFunctionFactory
+final readonly class AnonymousFunctionFactory
 {
     /**
      * @var string
@@ -54,14 +54,14 @@ final class AnonymousFunctionFactory
     private const DIM_FETCH_REGEX = '#(\\$|\\\\|\\x0)(?<number>\d+)#';
 
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeFactory $nodeFactory,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly SimplePhpParser $simplePhpParser,
-        private readonly AstResolver $astResolver,
-        private readonly InlineCodeParser $inlineCodeParser
+        private NodeNameResolver $nodeNameResolver,
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeFactory $nodeFactory,
+        private StaticTypeMapper $staticTypeMapper,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private SimplePhpParser $simplePhpParser,
+        private AstResolver $astResolver,
+        private InlineCodeParser $inlineCodeParser
     ) {
     }
 

--- a/rules/Php74/Guard/MakePropertyTypedGuard.php
+++ b/rules/Php74/Guard/MakePropertyTypedGuard.php
@@ -7,10 +7,10 @@ namespace Rector\Php74\Guard;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ClassReflection;
 
-final class MakePropertyTypedGuard
+final readonly class MakePropertyTypedGuard
 {
     public function __construct(
-        private readonly PropertyTypeChangeGuard $propertyTypeChangeGuard
+        private PropertyTypeChangeGuard $propertyTypeChangeGuard
     ) {
     }
 

--- a/rules/Php74/Guard/PropertyTypeChangeGuard.php
+++ b/rules/Php74/Guard/PropertyTypeChangeGuard.php
@@ -11,13 +11,13 @@ use Rector\NodeManipulator\PropertyManipulator;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Privatization\Guard\ParentPropertyLookupGuard;
 
-final class PropertyTypeChangeGuard
+final readonly class PropertyTypeChangeGuard
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PropertyAnalyzer $propertyAnalyzer,
-        private readonly PropertyManipulator $propertyManipulator,
-        private readonly ParentPropertyLookupGuard $parentPropertyLookupGuard
+        private NodeNameResolver $nodeNameResolver,
+        private PropertyAnalyzer $propertyAnalyzer,
+        private PropertyManipulator $propertyManipulator,
+        private ParentPropertyLookupGuard $parentPropertyLookupGuard
     ) {
     }
 

--- a/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
+++ b/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
@@ -14,12 +14,12 @@ use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Util\ArrayChecker;
 
-final class ClosureArrowFunctionAnalyzer
+final readonly class ClosureArrowFunctionAnalyzer
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeComparator $nodeComparator,
-        private readonly ArrayChecker $arrayChecker
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeComparator $nodeComparator,
+        private ArrayChecker $arrayChecker
     ) {
     }
 

--- a/rules/Php80/DocBlock/PropertyPromotionDocBlockMerger.php
+++ b/rules/Php80/DocBlock/PropertyPromotionDocBlockMerger.php
@@ -18,15 +18,15 @@ use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class PropertyPromotionDocBlockMerger
+final readonly class PropertyPromotionDocBlockMerger
 {
     public function __construct(
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly VarTagRemover $varTagRemover,
-        private readonly PhpDocInfoPrinter $phpDocInfoPrinter,
-        private readonly DocBlockUpdater $docBlockUpdater,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private StaticTypeMapper $staticTypeMapper,
+        private PhpDocTypeChanger $phpDocTypeChanger,
+        private VarTagRemover $varTagRemover,
+        private PhpDocInfoPrinter $phpDocInfoPrinter,
+        private DocBlockUpdater $docBlockUpdater,
     ) {
     }
 

--- a/rules/Php80/Guard/MakePropertyPromotionGuard.php
+++ b/rules/Php80/Guard/MakePropertyPromotionGuard.php
@@ -11,10 +11,10 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Php74\Guard\PropertyTypeChangeGuard;
 
-final class MakePropertyPromotionGuard
+final readonly class MakePropertyPromotionGuard
 {
     public function __construct(
-        private readonly PropertyTypeChangeGuard $propertyTypeChangeGuard
+        private PropertyTypeChangeGuard $propertyTypeChangeGuard
     ) {
     }
 

--- a/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrncmpMatchAndRefactor.php
+++ b/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrncmpMatchAndRefactor.php
@@ -19,7 +19,7 @@ use Rector\Php80\ValueObject\StrStartsWith;
 use Rector\Php80\ValueObjectFactory\StrStartsWithFactory;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class StrncmpMatchAndRefactor implements StrStartWithMatchAndRefactorInterface
+final readonly class StrncmpMatchAndRefactor implements StrStartWithMatchAndRefactorInterface
 {
     /**
      * @var string
@@ -27,10 +27,10 @@ final class StrncmpMatchAndRefactor implements StrStartWithMatchAndRefactorInter
     private const FUNCTION_NAME = 'strncmp';
 
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly StrStartsWithFactory $strStartsWithFactory,
-        private readonly NodeComparator $nodeComparator,
-        private readonly StrStartsWithFuncCallFactory $strStartsWithFuncCallFactory,
+        private NodeNameResolver $nodeNameResolver,
+        private StrStartsWithFactory $strStartsWithFactory,
+        private NodeComparator $nodeComparator,
+        private StrStartsWithFuncCallFactory $strStartsWithFuncCallFactory,
     ) {
     }
 

--- a/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrposMatchAndRefactor.php
+++ b/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/StrposMatchAndRefactor.php
@@ -19,12 +19,12 @@ use Rector\Php80\NodeFactory\StrStartsWithFuncCallFactory;
 use Rector\Php80\ValueObject\StrStartsWith;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class StrposMatchAndRefactor implements StrStartWithMatchAndRefactorInterface
+final readonly class StrposMatchAndRefactor implements StrStartWithMatchAndRefactorInterface
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ValueResolver $valueResolver,
-        private readonly StrStartsWithFuncCallFactory $strStartsWithFuncCallFactory,
+        private NodeNameResolver $nodeNameResolver,
+        private ValueResolver $valueResolver,
+        private StrStartsWithFuncCallFactory $strStartsWithFuncCallFactory,
     ) {
     }
 

--- a/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/SubstrMatchAndRefactor.php
+++ b/rules/Php80/MatchAndRefactor/StrStartsWithMatchAndRefactor/SubstrMatchAndRefactor.php
@@ -19,13 +19,13 @@ use Rector\Php80\ValueObject\StrStartsWith;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class SubstrMatchAndRefactor implements StrStartWithMatchAndRefactorInterface
+final readonly class SubstrMatchAndRefactor implements StrStartWithMatchAndRefactorInterface
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ValueResolver $valueResolver,
-        private readonly NodeComparator $nodeComparator,
-        private readonly StrStartsWithFuncCallFactory $strStartsWithFuncCallFactory,
+        private NodeNameResolver $nodeNameResolver,
+        private ValueResolver $valueResolver,
+        private NodeComparator $nodeComparator,
+        private StrStartsWithFuncCallFactory $strStartsWithFuncCallFactory,
     ) {
     }
 

--- a/rules/Php80/NodeAnalyzer/MatchSwitchAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/MatchSwitchAnalyzer.php
@@ -20,13 +20,13 @@ use Rector\Php80\ValueObject\CondAndExpr;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
 
-final class MatchSwitchAnalyzer
+final readonly class MatchSwitchAnalyzer
 {
     public function __construct(
-        private readonly SwitchAnalyzer $switchAnalyzer,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly NodeComparator $nodeComparator,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private SwitchAnalyzer $switchAnalyzer,
+        private NodeNameResolver $nodeNameResolver,
+        private NodeComparator $nodeComparator,
+        private BetterStandardPrinter $betterStandardPrinter
     ) {
     }
 

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -18,11 +18,11 @@ use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpAttribute\Enum\DocTagNodeState;
 
-final class PhpAttributeAnalyzer
+final readonly class PhpAttributeAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionProvider $reflectionProvider,
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionProvider $reflectionProvider,
     ) {
     }
 

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
@@ -19,13 +19,13 @@ use Rector\Php80\ValueObject\PropertyPromotionCandidate;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class PromotedPropertyCandidateResolver
+final readonly class PromotedPropertyCandidateResolver
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeComparator $nodeComparator,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private NodeNameResolver $nodeNameResolver,
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeComparator $nodeComparator,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 

--- a/rules/Php80/NodeAnalyzer/SwitchAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/SwitchAnalyzer.php
@@ -14,11 +14,11 @@ use PHPStan\Type\MixedType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 
-final class SwitchAnalyzer
+final readonly class SwitchAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly TypeFactory $typeFactory
+        private NodeTypeResolver $nodeTypeResolver,
+        private TypeFactory $typeFactory
     ) {
     }
 

--- a/rules/Php80/NodeFactory/AttrGroupsFactory.php
+++ b/rules/Php80/NodeFactory/AttrGroupsFactory.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Stmt\Use_;
 use Rector\Php80\ValueObject\DoctrineTagAndAnnotationToAttribute;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 
-final class AttrGroupsFactory
+final readonly class AttrGroupsFactory
 {
     public function __construct(
-        private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory
+        private PhpAttributeGroupFactory $phpAttributeGroupFactory
     ) {
     }
 

--- a/rules/Php80/NodeFactory/MatchFactory.php
+++ b/rules/Php80/NodeFactory/MatchFactory.php
@@ -18,12 +18,12 @@ use Rector\Php80\ValueObject\CondAndExpr;
 use Rector\Php80\ValueObject\MatchResult;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class MatchFactory
+final readonly class MatchFactory
 {
     public function __construct(
-        private readonly MatchArmsFactory $matchArmsFactory,
-        private readonly MatchSwitchAnalyzer $matchSwitchAnalyzer,
-        private readonly NodeComparator $nodeComparator
+        private MatchArmsFactory $matchArmsFactory,
+        private MatchSwitchAnalyzer $matchSwitchAnalyzer,
+        private NodeComparator $nodeComparator
     ) {
     }
 

--- a/rules/Php80/NodeFactory/NestedAttrGroupsFactory.php
+++ b/rules/Php80/NodeFactory/NestedAttrGroupsFactory.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Stmt\Use_;
 use Rector\Php80\ValueObject\NestedDoctrineTagAndAnnotationToAttribute;
 use Rector\PhpAttribute\NodeFactory\PhpNestedAttributeGroupFactory;
 
-final class NestedAttrGroupsFactory
+final readonly class NestedAttrGroupsFactory
 {
     public function __construct(
-        private readonly PhpNestedAttributeGroupFactory $phpNestedAttributeGroupFactory
+        private PhpNestedAttributeGroupFactory $phpNestedAttributeGroupFactory
     ) {
     }
 

--- a/rules/Php80/NodeManipulator/AttributeGroupNamedArgumentManipulator.php
+++ b/rules/Php80/NodeManipulator/AttributeGroupNamedArgumentManipulator.php
@@ -8,10 +8,10 @@ use PhpParser\Node\AttributeGroup;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Php80\AttributeDecorator\SensioParamConverterAttributeDecorator;
 
-final class AttributeGroupNamedArgumentManipulator
+final readonly class AttributeGroupNamedArgumentManipulator
 {
     public function __construct(
-        private readonly SensioParamConverterAttributeDecorator $sensioParamConverterAttributeDecorator
+        private SensioParamConverterAttributeDecorator $sensioParamConverterAttributeDecorator
     ) {
     }
 

--- a/rules/Php80/Rector/Class_/StringableForToStringRector.php
+++ b/rules/Php80/Rector/Class_/StringableForToStringRector.php
@@ -151,7 +151,7 @@ CODE_SAMPLE
             return;
         }
 
-        $this->traverseNodesWithCallable((array) $toStringClassMethod->stmts, function (Node $subNode) {
+        $this->traverseNodesWithCallable((array) $toStringClassMethod->stmts, function (Node $subNode): null {
             if (! $subNode instanceof Return_) {
                 return null;
             }

--- a/rules/Php80/ValueObject/AnnotationPropertyToAttributeClass.php
+++ b/rules/Php80/ValueObject/AnnotationPropertyToAttributeClass.php
@@ -6,12 +6,12 @@ namespace Rector\Php80\ValueObject;
 
 use Rector\Validation\RectorAssert;
 
-final class AnnotationPropertyToAttributeClass
+final readonly class AnnotationPropertyToAttributeClass
 {
     public function __construct(
-        private readonly string $attributeClass,
-        private readonly string|int|null $annotationProperty = null,
-        private readonly bool $doesNeedNewImport = false
+        private string $attributeClass,
+        private string|int|null $annotationProperty = null,
+        private bool $doesNeedNewImport = false
     ) {
         RectorAssert::className($attributeClass);
     }

--- a/rules/Php80/ValueObject/AnnotationToAttribute.php
+++ b/rules/Php80/ValueObject/AnnotationToAttribute.php
@@ -7,11 +7,11 @@ namespace Rector\Php80\ValueObject;
 use Rector\Php80\Contract\ValueObject\AnnotationToAttributeInterface;
 use Rector\Validation\RectorAssert;
 
-final class AnnotationToAttribute implements AnnotationToAttributeInterface
+final readonly class AnnotationToAttribute implements AnnotationToAttributeInterface
 {
     public function __construct(
-        private readonly string $tag,
-        private readonly ?string $attributeClass = null
+        private string $tag,
+        private ?string $attributeClass = null
     ) {
         RectorAssert::className($tag);
 

--- a/rules/Php80/ValueObject/CondAndExpr.php
+++ b/rules/Php80/ValueObject/CondAndExpr.php
@@ -7,16 +7,16 @@ namespace Rector\Php80\ValueObject;
 use PhpParser\Node\Expr;
 use Rector\Php80\Enum\MatchKind;
 
-final class CondAndExpr
+final readonly class CondAndExpr
 {
     /**
      * @param Expr[]|null $condExprs
      * @param MatchKind::* $matchKind
      */
     public function __construct(
-        private readonly array|null $condExprs,
-        private readonly Expr $expr,
-        private readonly string $matchKind
+        private array|null $condExprs,
+        private Expr $expr,
+        private string $matchKind
     ) {
     }
 

--- a/rules/Php80/ValueObject/DoctrineTagAndAnnotationToAttribute.php
+++ b/rules/Php80/ValueObject/DoctrineTagAndAnnotationToAttribute.php
@@ -6,11 +6,11 @@ namespace Rector\Php80\ValueObject;
 
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 
-final class DoctrineTagAndAnnotationToAttribute
+final readonly class DoctrineTagAndAnnotationToAttribute
 {
     public function __construct(
-        private readonly DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
-        private readonly AnnotationToAttribute $annotationToAttribute,
+        private DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
+        private AnnotationToAttribute $annotationToAttribute,
     ) {
     }
 

--- a/rules/Php80/ValueObject/MatchResult.php
+++ b/rules/Php80/ValueObject/MatchResult.php
@@ -6,11 +6,11 @@ namespace Rector\Php80\ValueObject;
 
 use PhpParser\Node\Expr\Match_;
 
-final class MatchResult
+final readonly class MatchResult
 {
     public function __construct(
-        private readonly Match_ $match,
-        private readonly bool $shouldRemoveNextStmt
+        private Match_ $match,
+        private bool $shouldRemoveNextStmt
     ) {
     }
 

--- a/rules/Php80/ValueObject/NestedDoctrineTagAndAnnotationToAttribute.php
+++ b/rules/Php80/ValueObject/NestedDoctrineTagAndAnnotationToAttribute.php
@@ -6,11 +6,11 @@ namespace Rector\Php80\ValueObject;
 
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 
-final class NestedDoctrineTagAndAnnotationToAttribute
+final readonly class NestedDoctrineTagAndAnnotationToAttribute
 {
     public function __construct(
-        private readonly DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
-        private readonly NestedAnnotationToAttribute $nestedAnnotationToAttribute,
+        private DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
+        private NestedAnnotationToAttribute $nestedAnnotationToAttribute,
     ) {
     }
 

--- a/rules/Php80/ValueObject/PropertyPromotionCandidate.php
+++ b/rules/Php80/ValueObject/PropertyPromotionCandidate.php
@@ -11,12 +11,12 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
-final class PropertyPromotionCandidate
+final readonly class PropertyPromotionCandidate
 {
     public function __construct(
-        private readonly Property $property,
-        private readonly Param $param,
-        private readonly Expression $expression,
+        private Property $property,
+        private Param $param,
+        private Expression $expression,
     ) {
     }
 

--- a/rules/Php80/ValueObject/StrStartsWith.php
+++ b/rules/Php80/ValueObject/StrStartsWith.php
@@ -7,13 +7,13 @@ namespace Rector\Php80\ValueObject;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 
-final class StrStartsWith
+final readonly class StrStartsWith
 {
     public function __construct(
-        private readonly FuncCall $funcCall,
-        private readonly Expr $haystackExpr,
-        private readonly Expr $needleExpr,
-        private readonly bool $isPositive
+        private FuncCall $funcCall,
+        private Expr $haystackExpr,
+        private Expr $needleExpr,
+        private bool $isPositive
     ) {
     }
 

--- a/rules/Php81/NodeAnalyzer/CoalesePropertyAssignMatcher.php
+++ b/rules/Php81/NodeAnalyzer/CoalesePropertyAssignMatcher.php
@@ -13,11 +13,11 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class CoalesePropertyAssignMatcher
+final readonly class CoalesePropertyAssignMatcher
 {
     public function __construct(
-        private readonly ComplexNewAnalyzer $complexNewAnalyzer,
-        private readonly NodeNameResolver $nodeNameResolver,
+        private ComplexNewAnalyzer $complexNewAnalyzer,
+        private NodeNameResolver $nodeNameResolver,
     ) {
     }
 

--- a/rules/Php81/NodeAnalyzer/ComplexNewAnalyzer.php
+++ b/rules/Php81/NodeAnalyzer/ComplexNewAnalyzer.php
@@ -11,10 +11,10 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\NodeAnalyzer\ExprAnalyzer;
 
-final class ComplexNewAnalyzer
+final readonly class ComplexNewAnalyzer
 {
     public function __construct(
-        private readonly ExprAnalyzer $exprAnalyzer
+        private ExprAnalyzer $exprAnalyzer
     ) {
     }
 

--- a/rules/Php81/NodeFactory/EnumFactory.php
+++ b/rules/Php81/NodeFactory/EnumFactory.php
@@ -24,14 +24,14 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class EnumFactory
+final readonly class EnumFactory
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly BuilderFactory $builderFactory,
-        private readonly ValueResolver $valueResolver,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private NodeNameResolver $nodeNameResolver,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private BuilderFactory $builderFactory,
+        private ValueResolver $valueResolver,
+        private BetterNodeFinder $betterNodeFinder
     ) {
     }
 

--- a/rules/Privatization/Guard/OverrideByParentClassGuard.php
+++ b/rules/Privatization/Guard/OverrideByParentClassGuard.php
@@ -11,10 +11,10 @@ use PHPStan\Reflection\ReflectionProvider;
 /**
  * Verify whether Class_'s method or property allowed to be overridden by verify class parent or implements exists
  */
-final class OverrideByParentClassGuard
+final readonly class OverrideByParentClassGuard
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -19,15 +19,15 @@ use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Reflection\ClassReflectionAnalyzer;
 
-final class ParentPropertyLookupGuard
+final readonly class ParentPropertyLookupGuard
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private readonly AstResolver $astResolver,
-        private readonly PropertyManipulator $propertyManipulator,
-        private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private AstResolver $astResolver,
+        private PropertyManipulator $propertyManipulator,
+        private ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }
 

--- a/rules/Privatization/VisibilityGuard/ClassMethodVisibilityGuard.php
+++ b/rules/Privatization/VisibilityGuard/ClassMethodVisibilityGuard.php
@@ -8,10 +8,10 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ClassMethodVisibilityGuard
+final readonly class ClassMethodVisibilityGuard
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Removing/ValueObject/ArgumentRemover.php
+++ b/rules/Removing/ValueObject/ArgumentRemover.php
@@ -7,13 +7,13 @@ namespace Rector\Removing\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class ArgumentRemover
+final readonly class ArgumentRemover
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method,
-        private readonly int $position,
-        private readonly mixed $value
+        private string $class,
+        private string $method,
+        private int $position,
+        private mixed $value
     ) {
         RectorAssert::className($class);
     }

--- a/rules/Removing/ValueObject/RemoveFuncCallArg.php
+++ b/rules/Removing/ValueObject/RemoveFuncCallArg.php
@@ -6,11 +6,11 @@ namespace Rector\Removing\ValueObject;
 
 use Rector\Validation\RectorAssert;
 
-final class RemoveFuncCallArg
+final readonly class RemoveFuncCallArg
 {
     public function __construct(
-        private readonly string $function,
-        private readonly int $argumentPosition
+        private string $function,
+        private int $argumentPosition
     ) {
         RectorAssert::functionName($function);
     }

--- a/rules/Renaming/ValueObject/MethodCallRename.php
+++ b/rules/Renaming/ValueObject/MethodCallRename.php
@@ -8,12 +8,12 @@ use PHPStan\Type\ObjectType;
 use Rector\Renaming\Contract\MethodCallRenameInterface;
 use Rector\Validation\RectorAssert;
 
-final class MethodCallRename implements MethodCallRenameInterface
+final readonly class MethodCallRename implements MethodCallRenameInterface
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $oldMethod,
-        private readonly string $newMethod
+        private string $class,
+        private string $oldMethod,
+        private string $newMethod
     ) {
         RectorAssert::className($class);
         RectorAssert::methodName($oldMethod);

--- a/rules/Renaming/ValueObject/MethodCallRenameWithArrayKey.php
+++ b/rules/Renaming/ValueObject/MethodCallRenameWithArrayKey.php
@@ -8,13 +8,13 @@ use PHPStan\Type\ObjectType;
 use Rector\Renaming\Contract\MethodCallRenameInterface;
 use Rector\Validation\RectorAssert;
 
-final class MethodCallRenameWithArrayKey implements MethodCallRenameInterface
+final readonly class MethodCallRenameWithArrayKey implements MethodCallRenameInterface
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $oldMethod,
-        private readonly string $newMethod,
-        private readonly mixed $arrayKey
+        private string $class,
+        private string $oldMethod,
+        private string $newMethod,
+        private mixed $arrayKey
     ) {
         RectorAssert::className($class);
         RectorAssert::methodName($oldMethod);

--- a/rules/Renaming/ValueObject/RenameAnnotation.php
+++ b/rules/Renaming/ValueObject/RenameAnnotation.php
@@ -9,11 +9,11 @@ use Rector\Renaming\Contract\RenameAnnotationInterface;
 /**
  * @api
  */
-final class RenameAnnotation implements RenameAnnotationInterface
+final readonly class RenameAnnotation implements RenameAnnotationInterface
 {
     public function __construct(
-        private readonly string $oldAnnotation,
-        private readonly string $newAnnotation
+        private string $oldAnnotation,
+        private string $newAnnotation
     ) {
     }
 

--- a/rules/Renaming/ValueObject/RenameAnnotationByType.php
+++ b/rules/Renaming/ValueObject/RenameAnnotationByType.php
@@ -8,12 +8,12 @@ use PHPStan\Type\ObjectType;
 use Rector\Renaming\Contract\RenameAnnotationInterface;
 use Rector\Validation\RectorAssert;
 
-final class RenameAnnotationByType implements RenameAnnotationInterface
+final readonly class RenameAnnotationByType implements RenameAnnotationInterface
 {
     public function __construct(
-        private readonly string $type,
-        private readonly string $oldAnnotation,
-        private readonly string $newAnnotation
+        private string $type,
+        private string $oldAnnotation,
+        private string $newAnnotation
     ) {
         RectorAssert::className($type);
     }

--- a/rules/Renaming/ValueObject/RenameClassAndConstFetch.php
+++ b/rules/Renaming/ValueObject/RenameClassAndConstFetch.php
@@ -8,13 +8,13 @@ use PHPStan\Type\ObjectType;
 use Rector\Renaming\Contract\RenameClassConstFetchInterface;
 use Rector\Validation\RectorAssert;
 
-final class RenameClassAndConstFetch implements RenameClassConstFetchInterface
+final readonly class RenameClassAndConstFetch implements RenameClassConstFetchInterface
 {
     public function __construct(
-        private readonly string $oldClass,
-        private readonly string $oldConstant,
-        private readonly string $newClass,
-        private readonly string $newConstant
+        private string $oldClass,
+        private string $oldConstant,
+        private string $newClass,
+        private string $newConstant
     ) {
         RectorAssert::className($oldClass);
         RectorAssert::constantName($oldConstant);

--- a/rules/Renaming/ValueObject/RenameClassConstFetch.php
+++ b/rules/Renaming/ValueObject/RenameClassConstFetch.php
@@ -8,12 +8,12 @@ use PHPStan\Type\ObjectType;
 use Rector\Renaming\Contract\RenameClassConstFetchInterface;
 use Rector\Validation\RectorAssert;
 
-final class RenameClassConstFetch implements RenameClassConstFetchInterface
+final readonly class RenameClassConstFetch implements RenameClassConstFetchInterface
 {
     public function __construct(
-        private readonly string $oldClass,
-        private readonly string $oldConstant,
-        private readonly string $newConstant
+        private string $oldClass,
+        private string $oldConstant,
+        private string $newConstant
     ) {
         RectorAssert::className($oldClass);
         RectorAssert::constantName($oldConstant);

--- a/rules/Renaming/ValueObject/RenameProperty.php
+++ b/rules/Renaming/ValueObject/RenameProperty.php
@@ -7,12 +7,12 @@ namespace Rector\Renaming\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class RenameProperty
+final readonly class RenameProperty
 {
     public function __construct(
-        private readonly string $type,
-        private readonly string $oldProperty,
-        private readonly string $newProperty
+        private string $type,
+        private string $oldProperty,
+        private string $newProperty
     ) {
         RectorAssert::className($type);
         RectorAssert::propertyName($oldProperty);

--- a/rules/Renaming/ValueObject/RenameStaticMethod.php
+++ b/rules/Renaming/ValueObject/RenameStaticMethod.php
@@ -7,13 +7,13 @@ namespace Rector\Renaming\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class RenameStaticMethod
+final readonly class RenameStaticMethod
 {
     public function __construct(
-        private readonly string $oldClass,
-        private readonly string $oldMethod,
-        private readonly string $newClass,
-        private readonly string $newMethod
+        private string $oldClass,
+        private string $oldMethod,
+        private string $newClass,
+        private string $newMethod
     ) {
         RectorAssert::className($oldClass);
         RectorAssert::methodName($oldMethod);

--- a/rules/Strict/NodeAnalyzer/UnitializedPropertyAnalyzer.php
+++ b/rules/Strict/NodeAnalyzer/UnitializedPropertyAnalyzer.php
@@ -15,13 +15,13 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 
-final class UnitializedPropertyAnalyzer
+final readonly class UnitializedPropertyAnalyzer
 {
     public function __construct(
-        private readonly AstResolver $astResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ConstructorAssignDetector $constructorAssignDetector,
-        private readonly NodeNameResolver $nodeNameResolver
+        private AstResolver $astResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private ConstructorAssignDetector $constructorAssignDetector,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/Strict/NodeFactory/ExactCompareFactory.php
+++ b/rules/Strict/NodeFactory/ExactCompareFactory.php
@@ -22,10 +22,10 @@ use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use Rector\PhpParser\Node\NodeFactory;
 
-final class ExactCompareFactory
+final readonly class ExactCompareFactory
 {
     public function __construct(
-        private readonly NodeFactory $nodeFactory
+        private NodeFactory $nodeFactory
     ) {
     }
 

--- a/rules/Transform/NodeAnalyzer/FuncCallStaticCallToMethodCallAnalyzer.php
+++ b/rules/Transform/NodeAnalyzer/FuncCallStaticCallToMethodCallAnalyzer.php
@@ -20,15 +20,15 @@ use Rector\PostRector\ValueObject\PropertyMetadata;
 use Rector\Transform\NodeFactory\PropertyFetchFactory;
 use Rector\Transform\NodeTypeAnalyzer\TypeProvidingExprFromClassResolver;
 
-final class FuncCallStaticCallToMethodCallAnalyzer
+final readonly class FuncCallStaticCallToMethodCallAnalyzer
 {
     public function __construct(
-        private readonly TypeProvidingExprFromClassResolver $typeProvidingExprFromClassResolver,
-        private readonly PropertyNaming $propertyNaming,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly NodeFactory $nodeFactory,
-        private readonly PropertyFetchFactory $propertyFetchFactory,
-        private readonly ClassDependencyManipulator $classDependencyManipulator,
+        private TypeProvidingExprFromClassResolver $typeProvidingExprFromClassResolver,
+        private PropertyNaming $propertyNaming,
+        private NodeNameResolver $nodeNameResolver,
+        private NodeFactory $nodeFactory,
+        private PropertyFetchFactory $propertyFetchFactory,
+        private ClassDependencyManipulator $classDependencyManipulator,
     ) {
     }
 

--- a/rules/Transform/NodeFactory/PropertyFetchFactory.php
+++ b/rules/Transform/NodeFactory/PropertyFetchFactory.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ObjectType;
 use Rector\Naming\Naming\PropertyNaming;
 
-final class PropertyFetchFactory
+final readonly class PropertyFetchFactory
 {
     public function __construct(
-        private readonly PropertyNaming $propertyNaming
+        private PropertyNaming $propertyNaming
     ) {
     }
 

--- a/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
+++ b/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
@@ -24,12 +24,12 @@ use Rector\Naming\Naming\PropertyNaming;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\ValueObject\MethodName;
 
-final class TypeProvidingExprFromClassResolver
+final readonly class TypeProvidingExprFromClassResolver
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PropertyNaming $propertyNaming,
+        private ReflectionProvider $reflectionProvider,
+        private NodeNameResolver $nodeNameResolver,
+        private PropertyNaming $propertyNaming,
     ) {
     }
 

--- a/rules/Transform/ValueObject/AttributeKeyToClassConstFetch.php
+++ b/rules/Transform/ValueObject/AttributeKeyToClassConstFetch.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Rector\Transform\ValueObject;
 
-final class AttributeKeyToClassConstFetch
+final readonly class AttributeKeyToClassConstFetch
 {
     /**
      * @param array<string, string> $valuesToConstantsMap
      */
     public function __construct(
-        private readonly string $attributeClass,
-        private readonly string $attributeKey,
-        private readonly string $constantClass,
-        private readonly array $valuesToConstantsMap
+        private string $attributeClass,
+        private string $attributeKey,
+        private string $constantClass,
+        private array $valuesToConstantsMap
     ) {
     }
 

--- a/rules/Transform/ValueObject/ClassMethodReference.php
+++ b/rules/Transform/ValueObject/ClassMethodReference.php
@@ -6,11 +6,11 @@ namespace Rector\Transform\ValueObject;
 
 use Rector\Validation\RectorAssert;
 
-final class ClassMethodReference
+final readonly class ClassMethodReference
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method
+        private string $class,
+        private string $method
     ) {
         RectorAssert::className($class);
         RectorAssert::methodName($method);

--- a/rules/Transform/ValueObject/FuncCallToMethodCall.php
+++ b/rules/Transform/ValueObject/FuncCallToMethodCall.php
@@ -7,12 +7,12 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class FuncCallToMethodCall
+final readonly class FuncCallToMethodCall
 {
     public function __construct(
-        private readonly string $oldFuncName,
-        private readonly string $newClassName,
-        private readonly string $newMethodName
+        private string $oldFuncName,
+        private string $newClassName,
+        private string $newMethodName
     ) {
         RectorAssert::functionName($oldFuncName);
 

--- a/rules/Transform/ValueObject/FuncCallToStaticCall.php
+++ b/rules/Transform/ValueObject/FuncCallToStaticCall.php
@@ -6,12 +6,12 @@ namespace Rector\Transform\ValueObject;
 
 use Rector\Validation\RectorAssert;
 
-final class FuncCallToStaticCall
+final readonly class FuncCallToStaticCall
 {
     public function __construct(
-        private readonly string $oldFuncName,
-        private readonly string $newClassName,
-        private readonly string $newMethodName
+        private string $oldFuncName,
+        private string $newClassName,
+        private string $newMethodName
     ) {
         RectorAssert::functionName($oldFuncName);
 

--- a/rules/Transform/ValueObject/MethodCallToFuncCall.php
+++ b/rules/Transform/ValueObject/MethodCallToFuncCall.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\Transform\ValueObject;
 
-final class MethodCallToFuncCall
+final readonly class MethodCallToFuncCall
 {
     public function __construct(
-        private readonly string $objectType,
-        private readonly string $methodName,
-        private readonly string $functionName
+        private string $objectType,
+        private string $methodName,
+        private string $functionName
     ) {
     }
 

--- a/rules/Transform/ValueObject/MethodCallToPropertyFetch.php
+++ b/rules/Transform/ValueObject/MethodCallToPropertyFetch.php
@@ -7,12 +7,12 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class MethodCallToPropertyFetch
+final readonly class MethodCallToPropertyFetch
 {
     public function __construct(
-        private readonly string $oldType,
-        private readonly string $oldMethod,
-        private readonly string $newProperty,
+        private string $oldType,
+        private string $oldMethod,
+        private string $newProperty,
     ) {
         RectorAssert::className($oldType);
         RectorAssert::methodName($oldMethod);

--- a/rules/Transform/ValueObject/MethodCallToStaticCall.php
+++ b/rules/Transform/ValueObject/MethodCallToStaticCall.php
@@ -7,13 +7,13 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class MethodCallToStaticCall
+final readonly class MethodCallToStaticCall
 {
     public function __construct(
-        private readonly string $oldClass,
-        private readonly string $oldMethod,
-        private readonly string $newClass,
-        private readonly string $newMethod
+        private string $oldClass,
+        private string $oldMethod,
+        private string $newClass,
+        private string $newMethod
     ) {
         RectorAssert::className($oldClass);
         RectorAssert::className($oldMethod);

--- a/rules/Transform/ValueObject/NewToStaticCall.php
+++ b/rules/Transform/ValueObject/NewToStaticCall.php
@@ -7,12 +7,12 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class NewToStaticCall
+final readonly class NewToStaticCall
 {
     public function __construct(
-        private readonly string $type,
-        private readonly string $staticCallClass,
-        private readonly string $staticCallMethod
+        private string $type,
+        private string $staticCallClass,
+        private string $staticCallMethod
     ) {
         RectorAssert::className($type);
 

--- a/rules/Transform/ValueObject/ParentClassToTraits.php
+++ b/rules/Transform/ValueObject/ParentClassToTraits.php
@@ -7,14 +7,14 @@ namespace Rector\Transform\ValueObject;
 use Rector\Validation\RectorAssert;
 use Webmozart\Assert\Assert;
 
-final class ParentClassToTraits
+final readonly class ParentClassToTraits
 {
     /**
      * @param string[] $traitNames
      */
     public function __construct(
-        private readonly string $parentType,
-        private readonly array $traitNames
+        private string $parentType,
+        private array $traitNames
     ) {
         RectorAssert::className($parentType);
         Assert::allString($traitNames);

--- a/rules/Transform/ValueObject/PropertyAssignToMethodCall.php
+++ b/rules/Transform/ValueObject/PropertyAssignToMethodCall.php
@@ -7,12 +7,12 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class PropertyAssignToMethodCall
+final readonly class PropertyAssignToMethodCall
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $oldPropertyName,
-        private readonly string $newMethodName
+        private string $class,
+        private string $oldPropertyName,
+        private string $newMethodName
     ) {
         RectorAssert::className($class);
         RectorAssert::propertyName($oldPropertyName);

--- a/rules/Transform/ValueObject/PropertyFetchToMethodCall.php
+++ b/rules/Transform/ValueObject/PropertyFetchToMethodCall.php
@@ -7,17 +7,17 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class PropertyFetchToMethodCall
+final readonly class PropertyFetchToMethodCall
 {
     /**
      * @param mixed[] $newGetArguments
      */
     public function __construct(
-        private readonly string $oldType,
-        private readonly string $oldProperty,
-        private readonly string $newGetMethod,
-        private readonly ?string $newSetMethod = null,
-        private readonly array $newGetArguments = []
+        private string $oldType,
+        private string $oldProperty,
+        private string $newGetMethod,
+        private ?string $newSetMethod = null,
+        private array $newGetArguments = []
     ) {
         RectorAssert::className($oldType);
         RectorAssert::propertyName($oldProperty);

--- a/rules/Transform/ValueObject/ReplaceParentCallByPropertyCall.php
+++ b/rules/Transform/ValueObject/ReplaceParentCallByPropertyCall.php
@@ -7,12 +7,12 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class ReplaceParentCallByPropertyCall
+final readonly class ReplaceParentCallByPropertyCall
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method,
-        private readonly string $property
+        private string $class,
+        private string $method,
+        private string $property
     ) {
         RectorAssert::className($class);
         RectorAssert::methodName($method);

--- a/rules/Transform/ValueObject/StaticCallToFuncCall.php
+++ b/rules/Transform/ValueObject/StaticCallToFuncCall.php
@@ -7,12 +7,12 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class StaticCallToFuncCall
+final readonly class StaticCallToFuncCall
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method,
-        private readonly string $function
+        private string $class,
+        private string $method,
+        private string $function
     ) {
         RectorAssert::className($class);
         RectorAssert::methodName($method);

--- a/rules/Transform/ValueObject/StaticCallToMethodCall.php
+++ b/rules/Transform/ValueObject/StaticCallToMethodCall.php
@@ -10,13 +10,13 @@ use PhpParser\Node\Name;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class StaticCallToMethodCall
+final readonly class StaticCallToMethodCall
 {
     public function __construct(
-        private readonly string $staticClass,
-        private readonly string $staticMethod,
-        private readonly string $classType,
-        private readonly string $methodName
+        private string $staticClass,
+        private string $staticMethod,
+        private string $classType,
+        private string $methodName
     ) {
         RectorAssert::className($staticClass);
 

--- a/rules/Transform/ValueObject/StaticCallToNew.php
+++ b/rules/Transform/ValueObject/StaticCallToNew.php
@@ -6,11 +6,11 @@ namespace Rector\Transform\ValueObject;
 
 use Rector\Validation\RectorAssert;
 
-final class StaticCallToNew
+final readonly class StaticCallToNew
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method
+        private string $class,
+        private string $method
     ) {
         RectorAssert::className($class);
         RectorAssert::methodName($method);

--- a/rules/Transform/ValueObject/StringToClassConstant.php
+++ b/rules/Transform/ValueObject/StringToClassConstant.php
@@ -6,12 +6,12 @@ namespace Rector\Transform\ValueObject;
 
 use Rector\Validation\RectorAssert;
 
-final class StringToClassConstant
+final readonly class StringToClassConstant
 {
     public function __construct(
-        private readonly string $string,
-        private readonly string $class,
-        private readonly string $constant
+        private string $string,
+        private string $class,
+        private string $constant
     ) {
         RectorAssert::className($class);
     }

--- a/rules/Transform/ValueObject/WrapReturn.php
+++ b/rules/Transform/ValueObject/WrapReturn.php
@@ -7,12 +7,12 @@ namespace Rector\Transform\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class WrapReturn
+final readonly class WrapReturn
 {
     public function __construct(
-        private readonly string $type,
-        private readonly string $method,
-        private readonly bool $isArrayWrap
+        private string $type,
+        private string $method,
+        private bool $isArrayWrap
     ) {
         RectorAssert::className($type);
     }

--- a/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
+++ b/rules/TypeDeclaration/AlreadyAssignDetector/ConstructorAssignDetector.php
@@ -25,7 +25,7 @@ use Rector\TypeDeclaration\Matcher\PropertyAssignMatcher;
 use Rector\TypeDeclaration\NodeAnalyzer\AutowiredClassMethodOrPropertyAnalyzer;
 use Rector\ValueObject\MethodName;
 
-final class ConstructorAssignDetector
+final readonly class ConstructorAssignDetector
 {
     /**
      * @var string
@@ -33,11 +33,11 @@ final class ConstructorAssignDetector
     private const IS_FIRST_LEVEL_STATEMENT = 'first_level_stmt';
 
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly PropertyAssignMatcher $propertyAssignMatcher,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodOrPropertyAnalyzer,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private NodeTypeResolver $nodeTypeResolver,
+        private PropertyAssignMatcher $propertyAssignMatcher,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodOrPropertyAnalyzer,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer,
     ) {
     }
 

--- a/rules/TypeDeclaration/AlreadyAssignDetector/NullTypeAssignDetector.php
+++ b/rules/TypeDeclaration/AlreadyAssignDetector/NullTypeAssignDetector.php
@@ -17,13 +17,13 @@ use Rector\TypeDeclaration\Matcher\PropertyAssignMatcher;
 /**
  * Should add extra null type
  */
-final class NullTypeAssignDetector
+final readonly class NullTypeAssignDetector
 {
     public function __construct(
-        private readonly DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly PropertyAssignMatcher $propertyAssignMatcher,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+        private DoctrineTypeAnalyzer $doctrineTypeAnalyzer,
+        private NodeTypeResolver $nodeTypeResolver,
+        private PropertyAssignMatcher $propertyAssignMatcher,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
     ) {
     }
 

--- a/rules/TypeDeclaration/FunctionLikeReturnTypeResolver.php
+++ b/rules/TypeDeclaration/FunctionLikeReturnTypeResolver.php
@@ -9,10 +9,10 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class FunctionLikeReturnTypeResolver
+final readonly class FunctionLikeReturnTypeResolver
 {
     public function __construct(
-        private readonly StaticTypeMapper $staticTypeMapper
+        private StaticTypeMapper $staticTypeMapper
     ) {
     }
 

--- a/rules/TypeDeclaration/Guard/ParamTypeAddGuard.php
+++ b/rules/TypeDeclaration/Guard/ParamTypeAddGuard.php
@@ -16,12 +16,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class ParamTypeAddGuard
+final readonly class ParamTypeAddGuard
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private NodeNameResolver $nodeNameResolver,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private BetterNodeFinder $betterNodeFinder
     ) {
     }
 

--- a/rules/TypeDeclaration/Guard/PropertyTypeOverrideGuard.php
+++ b/rules/TypeDeclaration/Guard/PropertyTypeOverrideGuard.php
@@ -9,11 +9,11 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Php74\Guard\MakePropertyTypedGuard;
 
-final class PropertyTypeOverrideGuard
+final readonly class PropertyTypeOverrideGuard
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly MakePropertyTypedGuard $makePropertyTypedGuard
+        private NodeNameResolver $nodeNameResolver,
+        private MakePropertyTypedGuard $makePropertyTypedGuard
     ) {
     }
 

--- a/rules/TypeDeclaration/Matcher/PropertyAssignMatcher.php
+++ b/rules/TypeDeclaration/Matcher/PropertyAssignMatcher.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 
-final class PropertyAssignMatcher
+final readonly class PropertyAssignMatcher
 {
     public function __construct(
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/AutowiredClassMethodOrPropertyAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/AutowiredClassMethodOrPropertyAnalyzer.php
@@ -11,11 +11,11 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Symfony\Contracts\Service\Attribute\Required;
 
-final class AutowiredClassMethodOrPropertyAnalyzer
+final readonly class AutowiredClassMethodOrPropertyAnalyzer
 {
     public function __construct(
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -19,12 +19,12 @@ use Rector\NodeCollector\ValueObject\ArrayCallable;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 
-final class CallTypesResolver
+final readonly class CallTypesResolver
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly TypeFactory $typeFactory,
-        private readonly ReflectionProvider $reflectionProvider
+        private NodeTypeResolver $nodeTypeResolver,
+        private TypeFactory $typeFactory,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
@@ -25,13 +25,13 @@ use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PhpParser\AstResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class CallerParamMatcher
+final readonly class CallerParamMatcher
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly AstResolver $astResolver,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly TypeComparator $typeComparator
+        private NodeNameResolver $nodeNameResolver,
+        private AstResolver $astResolver,
+        private StaticTypeMapper $staticTypeMapper,
+        private TypeComparator $typeComparator
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ClassMethodAndPropertyAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ClassMethodAndPropertyAnalyzer.php
@@ -12,10 +12,10 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ClassMethodAndPropertyAnalyzer
+final readonly class ClassMethodAndPropertyAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ClassMethodParamTypeCompleter.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ClassMethodParamTypeCompleter.php
@@ -22,13 +22,13 @@ use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodParamVendorLockResolver;
 
-final class ClassMethodParamTypeCompleter
+final readonly class ClassMethodParamTypeCompleter
 {
     public function __construct(
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly ClassMethodParamVendorLockResolver $classMethodParamVendorLockResolver,
-        private readonly UnionTypeCommonTypeNarrower $unionTypeCommonTypeNarrower,
-        private readonly PhpVersionProvider $phpVersionProvider,
+        private StaticTypeMapper $staticTypeMapper,
+        private ClassMethodParamVendorLockResolver $classMethodParamVendorLockResolver,
+        private UnionTypeCommonTypeNarrower $unionTypeCommonTypeNarrower,
+        private PhpVersionProvider $phpVersionProvider,
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/NeverFuncCallAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/NeverFuncCallAnalyzer.php
@@ -12,10 +12,10 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\NeverType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class NeverFuncCallAnalyzer
+final readonly class NeverFuncCallAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
+        private NodeTypeResolver $nodeTypeResolver,
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ParamAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ParamAnalyzer.php
@@ -8,10 +8,10 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ParamAnalyzer
+final readonly class ParamAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnFilter/ExclusiveNativeCallLikeReturnMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnFilter/ExclusiveNativeCallLikeReturnMatcher.php
@@ -12,10 +12,10 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use Rector\Reflection\ReflectionResolver;
 
-final class ExclusiveNativeCallLikeReturnMatcher
+final readonly class ExclusiveNativeCallLikeReturnMatcher
 {
     public function __construct(
-        private readonly ReflectionResolver $reflectionResolver,
+        private ReflectionResolver $reflectionResolver,
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/AlwaysStrictReturnAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/AlwaysStrictReturnAnalyzer.php
@@ -14,11 +14,11 @@ use PhpParser\Node\Stmt\Return_;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 
-final class AlwaysStrictReturnAnalyzer
+final readonly class AlwaysStrictReturnAnalyzer
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReturnAnalyzer $returnAnalyzer
+        private BetterNodeFinder $betterNodeFinder,
+        private ReturnAnalyzer $returnAnalyzer
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictBoolReturnTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictBoolReturnTypeAnalyzer.php
@@ -10,11 +10,11 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\TypeDeclaration\TypeAnalyzer\AlwaysStrictBoolExprAnalyzer;
 
-final class StrictBoolReturnTypeAnalyzer
+final readonly class StrictBoolReturnTypeAnalyzer
 {
     public function __construct(
-        private readonly AlwaysStrictBoolExprAnalyzer $alwaysStrictBoolExprAnalyzer,
-        private readonly AlwaysStrictReturnAnalyzer $alwaysStrictReturnAnalyzer
+        private AlwaysStrictBoolExprAnalyzer $alwaysStrictBoolExprAnalyzer,
+        private AlwaysStrictReturnAnalyzer $alwaysStrictReturnAnalyzer
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictNativeFunctionReturnTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictNativeFunctionReturnTypeAnalyzer.php
@@ -14,12 +14,12 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnFilter\ExclusiveNativeCallLikeReturnMatcher;
 
-final class StrictNativeFunctionReturnTypeAnalyzer
+final readonly class StrictNativeFunctionReturnTypeAnalyzer
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ExclusiveNativeCallLikeReturnMatcher $exclusiveNativeCallLikeReturnMatcher,
-        private readonly ReturnAnalyzer $returnAnalyzer,
+        private BetterNodeFinder $betterNodeFinder,
+        private ExclusiveNativeCallLikeReturnMatcher $exclusiveNativeCallLikeReturnMatcher,
+        private ReturnAnalyzer $returnAnalyzer,
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -21,13 +21,13 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\TypeDeclaration\ValueObject\AssignToVariable;
 
-final class StrictReturnNewAnalyzer
+final readonly class StrictReturnNewAnalyzer
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ReturnAnalyzer $returnAnalyzer
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private ReturnAnalyzer $returnAnalyzer
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictScalarReturnTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictScalarReturnTypeAnalyzer.php
@@ -16,12 +16,12 @@ use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\TypeDeclaration\TypeAnalyzer\AlwaysStrictScalarExprAnalyzer;
 
-final class StrictScalarReturnTypeAnalyzer
+final readonly class StrictScalarReturnTypeAnalyzer
 {
     public function __construct(
-        private readonly AlwaysStrictReturnAnalyzer $alwaysStrictReturnAnalyzer,
-        private readonly AlwaysStrictScalarExprAnalyzer $alwaysStrictScalarExprAnalyzer,
-        private readonly TypeFactory $typeFactory,
+        private AlwaysStrictReturnAnalyzer $alwaysStrictReturnAnalyzer,
+        private AlwaysStrictScalarExprAnalyzer $alwaysStrictScalarExprAnalyzer,
+        private TypeFactory $typeFactory,
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/TypeNodeUnwrapper.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/TypeNodeUnwrapper.php
@@ -12,10 +12,10 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType;
 use Rector\PhpParser\Comparing\NodeComparator;
 
-final class TypeNodeUnwrapper
+final readonly class TypeNodeUnwrapper
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator
+        private NodeComparator $nodeComparator
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeTypeAnalyzer/PropertyTypeDecorator.php
+++ b/rules/TypeDeclaration/NodeTypeAnalyzer/PropertyTypeDecorator.php
@@ -18,13 +18,13 @@ use Rector\PhpParser\Node\NodeFactory;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeAnalyzer;
 use Rector\ValueObject\PhpVersionFeature;
 
-final class PropertyTypeDecorator
+final readonly class PropertyTypeDecorator
 {
     public function __construct(
-        private readonly UnionTypeAnalyzer $unionTypeAnalyzer,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly NodeFactory $nodeFactory,
+        private UnionTypeAnalyzer $unionTypeAnalyzer,
+        private PhpDocTypeChanger $phpDocTypeChanger,
+        private PhpVersionProvider $phpVersionProvider,
+        private NodeFactory $nodeFactory,
     ) {
     }
 

--- a/rules/TypeDeclaration/PHPStan/TypeSpecifier/SameNamespacedTypeSpecifier.php
+++ b/rules/TypeDeclaration/PHPStan/TypeSpecifier/SameNamespacedTypeSpecifier.php
@@ -11,10 +11,10 @@ use PHPStan\Type\TypeWithClassName;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\TypeDeclaration\Contract\PHPStan\TypeWithClassTypeSpecifierInterface;
 
-final class SameNamespacedTypeSpecifier implements TypeWithClassTypeSpecifierInterface
+final readonly class SameNamespacedTypeSpecifier implements TypeWithClassTypeSpecifierInterface
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private ReflectionProvider $reflectionProvider,
     ) {
     }
 

--- a/rules/TypeDeclaration/PhpDocParser/ParamPhpDocNodeFactory.php
+++ b/rules/TypeDeclaration/PhpDocParser/ParamPhpDocNodeFactory.php
@@ -9,10 +9,10 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ParamPhpDocNodeFactory
+final readonly class ParamPhpDocNodeFactory
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -147,7 +147,7 @@ CODE_SAMPLE
 
         $this->traverseNodesWithCallable(
             $newParamType,
-            static function (Node $node) {
+            static function (Node $node): null {
                 // original node has to removed to avoid tokens crashing from origin positions
                 $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
                 return null;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
             $paramType = $parentParam->type;
 
             // original attributes have to removed to avoid tokens crashing from origin positions
-            $this->traverseNodesWithCallable($paramType, static function (Node $node) {
+            $this->traverseNodesWithCallable($paramType, static function (Node $node): null {
                 $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
                 return null;
             });

--- a/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/AlwaysStrictScalarExprAnalyzer.php
@@ -23,10 +23,10 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class AlwaysStrictScalarExprAnalyzer
+final readonly class AlwaysStrictScalarExprAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -19,12 +19,12 @@ use PHPStan\Type\UnionType;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeAnalyzer;
 use Rector\TypeDeclaration\NodeTypeAnalyzer\DetailedTypeAnalyzer;
 
-final class GenericClassStringTypeNormalizer
+final readonly class GenericClassStringTypeNormalizer
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly DetailedTypeAnalyzer $detailedTypeAnalyzer,
-        private readonly UnionTypeAnalyzer $unionTypeAnalyzer
+        private ReflectionProvider $reflectionProvider,
+        private DetailedTypeAnalyzer $detailedTypeAnalyzer,
+        private UnionTypeAnalyzer $unionTypeAnalyzer
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/NullableTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/NullableTypeAnalyzer.php
@@ -9,10 +9,10 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class NullableTypeAnalyzer
+final readonly class NullableTypeAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
+        private NodeTypeResolver $nodeTypeResolver,
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/PropertyTypeDefaultValueAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/PropertyTypeDefaultValueAnalyzer.php
@@ -10,10 +10,10 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\Type;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class PropertyTypeDefaultValueAnalyzer
+final readonly class PropertyTypeDefaultValueAnalyzer
 {
     public function __construct(
-        private readonly StaticTypeMapper $staticTypeMapper
+        private StaticTypeMapper $staticTypeMapper
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -32,12 +32,12 @@ use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\TypeDeclaration\NodeAnalyzer\TypeNodeUnwrapper;
 
-final class ReturnStrictTypeAnalyzer
+final readonly class ReturnStrictTypeAnalyzer
 {
     public function __construct(
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly TypeNodeUnwrapper $typeNodeUnwrapper,
-        private readonly StaticTypeMapper $staticTypeMapper
+        private ReflectionResolver $reflectionResolver,
+        private TypeNodeUnwrapper $typeNodeUnwrapper,
+        private StaticTypeMapper $staticTypeMapper
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeAnalyzer/StrictReturnClassConstReturnTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/StrictReturnClassConstReturnTypeAnalyzer.php
@@ -11,12 +11,12 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer\AlwaysStrictReturnAnalyzer;
 
-final class StrictReturnClassConstReturnTypeAnalyzer
+final readonly class StrictReturnClassConstReturnTypeAnalyzer
 {
     public function __construct(
-        private readonly AlwaysStrictReturnAnalyzer $alwaysStrictReturnAnalyzer,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly TypeFactory $typeFactory
+        private AlwaysStrictReturnAnalyzer $alwaysStrictReturnAnalyzer,
+        private NodeTypeResolver $nodeTypeResolver,
+        private TypeFactory $typeFactory
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -32,19 +32,19 @@ use Rector\TypeDeclaration\Matcher\PropertyAssignMatcher;
 /**
  * @internal
  */
-final class AssignToPropertyTypeInferer
+final readonly class AssignToPropertyTypeInferer
 {
     public function __construct(
-        private readonly ConstructorAssignDetector $constructorAssignDetector,
-        private readonly PropertyAssignMatcher $propertyAssignMatcher,
-        private readonly PropertyDefaultAssignDetector $propertyDefaultAssignDetector,
-        private readonly NullTypeAssignDetector $nullTypeAssignDetector,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly TypeFactory $typeFactory,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ExprAnalyzer $exprAnalyzer,
-        private readonly ValueResolver $valueResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private ConstructorAssignDetector $constructorAssignDetector,
+        private PropertyAssignMatcher $propertyAssignMatcher,
+        private PropertyDefaultAssignDetector $propertyDefaultAssignDetector,
+        private NullTypeAssignDetector $nullTypeAssignDetector,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private TypeFactory $typeFactory,
+        private NodeTypeResolver $nodeTypeResolver,
+        private ExprAnalyzer $exprAnalyzer,
+        private ValueResolver $valueResolver,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer,
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/AllAssignNodePropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/AllAssignNodePropertyTypeInferer.php
@@ -15,13 +15,13 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\TypeDeclaration\TypeInferer\AssignToPropertyTypeInferer;
 use Rector\ValueObject\Application\File;
 
-final class AllAssignNodePropertyTypeInferer
+final readonly class AllAssignNodePropertyTypeInferer
 {
     public function __construct(
-        private readonly AssignToPropertyTypeInferer $assignToPropertyTypeInferer,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly AstResolver $astResolver,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private AssignToPropertyTypeInferer $assignToPropertyTypeInferer,
+        private NodeNameResolver $nodeNameResolver,
+        private AstResolver $astResolver,
+        private BetterNodeFinder $betterNodeFinder
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/GetterTypeDeclarationPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/GetterTypeDeclarationPropertyTypeInferer.php
@@ -12,12 +12,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\TypeDeclaration\FunctionLikeReturnTypeResolver;
 use Rector\TypeDeclaration\NodeAnalyzer\ClassMethodAndPropertyAnalyzer;
 
-final class GetterTypeDeclarationPropertyTypeInferer
+final readonly class GetterTypeDeclarationPropertyTypeInferer
 {
     public function __construct(
-        private readonly FunctionLikeReturnTypeResolver $functionLikeReturnTypeResolver,
-        private readonly ClassMethodAndPropertyAnalyzer $classMethodAndPropertyAnalyzer,
-        private readonly NodeNameResolver $nodeNameResolver
+        private FunctionLikeReturnTypeResolver $functionLikeReturnTypeResolver,
+        private ClassMethodAndPropertyAnalyzer $classMethodAndPropertyAnalyzer,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/SetterTypeDeclarationPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/SetterTypeDeclarationPropertyTypeInferer.php
@@ -13,12 +13,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\NodeAnalyzer\ClassMethodAndPropertyAnalyzer;
 
-final class SetterTypeDeclarationPropertyTypeInferer
+final readonly class SetterTypeDeclarationPropertyTypeInferer
 {
     public function __construct(
-        private readonly ClassMethodAndPropertyAnalyzer $classMethodAndPropertyAnalyzer,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly StaticTypeMapper $staticTypeMapper,
+        private ClassMethodAndPropertyAnalyzer $classMethodAndPropertyAnalyzer,
+        private NodeNameResolver $nodeNameResolver,
+        private StaticTypeMapper $staticTypeMapper,
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
@@ -38,19 +38,19 @@ use Rector\TypeDeclaration\TypeInferer\AssignToPropertyTypeInferer;
 /**
  * @internal
  */
-final class TrustedClassMethodPropertyTypeInferer
+final readonly class TrustedClassMethodPropertyTypeInferer
 {
     public function __construct(
-        private readonly ClassMethodPropertyFetchManipulator $classMethodPropertyFetchManipulator,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly TypeFactory $typeFactory,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ParamAnalyzer $paramAnalyzer,
-        private readonly AssignToPropertyTypeInferer $assignToPropertyTypeInferer,
-        private readonly TypeComparator $typeComparator,
+        private ClassMethodPropertyFetchManipulator $classMethodPropertyFetchManipulator,
+        private ReflectionProvider $reflectionProvider,
+        private NodeNameResolver $nodeNameResolver,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private TypeFactory $typeFactory,
+        private StaticTypeMapper $staticTypeMapper,
+        private NodeTypeResolver $nodeTypeResolver,
+        private ParamAnalyzer $paramAnalyzer,
+        private AssignToPropertyTypeInferer $assignToPropertyTypeInferer,
+        private TypeComparator $typeComparator,
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer.php
@@ -36,17 +36,17 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @internal
  */
-final class ReturnTypeInferer
+final readonly class ReturnTypeInferer
 {
     public function __construct(
-        private readonly TypeNormalizer $typeNormalizer,
-        private readonly ReturnedNodesReturnTypeInfererTypeInferer $returnedNodesReturnTypeInfererTypeInferer,
-        private readonly GenericClassStringTypeNormalizer $genericClassStringTypeNormalizer,
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private TypeNormalizer $typeNormalizer,
+        private ReturnedNodesReturnTypeInfererTypeInferer $returnedNodesReturnTypeInfererTypeInferer,
+        private GenericClassStringTypeNormalizer $genericClassStringTypeNormalizer,
+        private PhpVersionProvider $phpVersionProvider,
+        private BetterNodeFinder $betterNodeFinder,
+        private ReflectionResolver $reflectionResolver,
+        private ReflectionProvider $reflectionProvider,
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
@@ -24,15 +24,15 @@ use Rector\TypeDeclaration\TypeInferer\SplArrayFixedTypeNarrower;
 /**
  * @internal
  */
-final class ReturnedNodesReturnTypeInfererTypeInferer
+final readonly class ReturnedNodesReturnTypeInfererTypeInferer
 {
     public function __construct(
-        private readonly SilentVoidResolver $silentVoidResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly TypeFactory $typeFactory,
-        private readonly SplArrayFixedTypeNarrower $splArrayFixedTypeNarrower,
-        private readonly ReflectionResolver $reflectionResolver,
+        private SilentVoidResolver $silentVoidResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private TypeFactory $typeFactory,
+        private SplArrayFixedTypeNarrower $splArrayFixedTypeNarrower,
+        private ReflectionResolver $reflectionResolver,
     ) {
     }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -22,11 +22,11 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Reflection\ReflectionResolver;
 
-final class SilentVoidResolver
+final readonly class SilentVoidResolver
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReflectionResolver $reflectionResolver,
+        private BetterNodeFinder $betterNodeFinder,
+        private ReflectionResolver $reflectionResolver,
     ) {
     }
 

--- a/rules/TypeDeclaration/ValueObject/AddParamTypeDeclaration.php
+++ b/rules/TypeDeclaration/ValueObject/AddParamTypeDeclaration.php
@@ -8,16 +8,16 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Validation\RectorAssert;
 
-final class AddParamTypeDeclaration
+final readonly class AddParamTypeDeclaration
 {
     /**
      * @param int<0, max> $position
      */
     public function __construct(
-        private readonly string $className,
-        private readonly string $methodName,
-        private readonly int $position,
-        private readonly Type $paramType
+        private string $className,
+        private string $methodName,
+        private int $position,
+        private Type $paramType
     ) {
         RectorAssert::className($className);
     }

--- a/rules/TypeDeclaration/ValueObject/AddPropertyTypeDeclaration.php
+++ b/rules/TypeDeclaration/ValueObject/AddPropertyTypeDeclaration.php
@@ -7,12 +7,12 @@ namespace Rector\TypeDeclaration\ValueObject;
 use PHPStan\Type\Type;
 use Rector\Validation\RectorAssert;
 
-final class AddPropertyTypeDeclaration
+final readonly class AddPropertyTypeDeclaration
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $propertyName,
-        private readonly Type $type
+        private string $class,
+        private string $propertyName,
+        private Type $type
     ) {
         RectorAssert::className($class);
     }

--- a/rules/TypeDeclaration/ValueObject/AddReturnTypeDeclaration.php
+++ b/rules/TypeDeclaration/ValueObject/AddReturnTypeDeclaration.php
@@ -11,12 +11,12 @@ use Rector\Validation\RectorAssert;
 /**
  * @api
  */
-final class AddReturnTypeDeclaration
+final readonly class AddReturnTypeDeclaration
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method,
-        private readonly Type $returnType
+        private string $class,
+        private string $method,
+        private Type $returnType
     ) {
         RectorAssert::className($class);
     }

--- a/rules/TypeDeclaration/ValueObject/AssignToVariable.php
+++ b/rules/TypeDeclaration/ValueObject/AssignToVariable.php
@@ -6,11 +6,11 @@ namespace Rector\TypeDeclaration\ValueObject;
 
 use PhpParser\Node\Expr;
 
-final class AssignToVariable
+final readonly class AssignToVariable
 {
     public function __construct(
-        private readonly string $variableName,
-        private readonly Expr $assignedExpr
+        private string $variableName,
+        private Expr $assignedExpr
     ) {
     }
 

--- a/rules/TypeDeclaration/ValueObject/DataProviderNodes.php
+++ b/rules/TypeDeclaration/ValueObject/DataProviderNodes.php
@@ -7,13 +7,13 @@ namespace Rector\TypeDeclaration\ValueObject;
 use PhpParser\Node\Attribute;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 
-final class DataProviderNodes
+final readonly class DataProviderNodes
 {
     /**
      * @param array<array-key, Attribute|PhpDocTagNode> $nodes
      */
     public function __construct(
-        public readonly array $nodes,
+        public array $nodes,
     ) {
     }
 

--- a/rules/TypeDeclaration/ValueObject/NestedArrayType.php
+++ b/rules/TypeDeclaration/ValueObject/NestedArrayType.php
@@ -7,12 +7,12 @@ namespace Rector\TypeDeclaration\ValueObject;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 
-final class NestedArrayType
+final readonly class NestedArrayType
 {
     public function __construct(
-        private readonly Type $type,
-        private readonly int $arrayNestingLevel,
-        private readonly ?Type $keyType = null
+        private Type $type,
+        private int $arrayNestingLevel,
+        private ?Type $keyType = null
     ) {
     }
 

--- a/rules/Visibility/ValueObject/ChangeConstantVisibility.php
+++ b/rules/Visibility/ValueObject/ChangeConstantVisibility.php
@@ -7,12 +7,12 @@ namespace Rector\Visibility\ValueObject;
 use PHPStan\Type\ObjectType;
 use Rector\Validation\RectorAssert;
 
-final class ChangeConstantVisibility
+final readonly class ChangeConstantVisibility
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $constant,
-        private readonly int $visibility
+        private string $class,
+        private string $constant,
+        private int $visibility
     ) {
         RectorAssert::className($class);
     }

--- a/rules/Visibility/ValueObject/ChangeMethodVisibility.php
+++ b/rules/Visibility/ValueObject/ChangeMethodVisibility.php
@@ -6,12 +6,12 @@ namespace Rector\Visibility\ValueObject;
 
 use Rector\Validation\RectorAssert;
 
-final class ChangeMethodVisibility
+final readonly class ChangeMethodVisibility
 {
     public function __construct(
-        private readonly string $class,
-        private readonly string $method,
-        private readonly int $visibility
+        private string $class,
+        private string $method,
+        private int $visibility
     ) {
         RectorAssert::className($class);
     }

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -29,11 +29,11 @@ use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
 /**
  * In case of changed node, we need to re-traverse the PHPStan Scope to make all the new nodes aware of what is going on.
  */
-final class ChangedNodeScopeRefresher
+final readonly class ChangedNodeScopeRefresher
 {
     public function __construct(
-        private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
-        private readonly ScopeAnalyzer $scopeAnalyzer
+        private PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
+        private ScopeAnalyzer $scopeAnalyzer
     ) {
     }
 

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -26,20 +26,20 @@ use Rector\ValueObject\Reporting\FileDiff;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
 
-final class FileProcessor
+final readonly class FileProcessor
 {
     public function __construct(
-        private readonly FormatPerservingPrinter $formatPerservingPrinter,
-        private readonly RectorNodeTraverser $rectorNodeTraverser,
-        private readonly SymfonyStyle $symfonyStyle,
-        private readonly FileDiffFactory $fileDiffFactory,
-        private readonly ChangedFilesDetector $changedFilesDetector,
-        private readonly ErrorFactory $errorFactory,
-        private readonly FilePathHelper $filePathHelper,
-        private readonly CollectorProcessor $collectorProcessor,
-        private readonly PostFileProcessor $postFileProcessor,
-        private readonly RectorParser $rectorParser,
-        private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
+        private FormatPerservingPrinter $formatPerservingPrinter,
+        private RectorNodeTraverser $rectorNodeTraverser,
+        private SymfonyStyle $symfonyStyle,
+        private FileDiffFactory $fileDiffFactory,
+        private ChangedFilesDetector $changedFilesDetector,
+        private ErrorFactory $errorFactory,
+        private FilePathHelper $filePathHelper,
+        private CollectorProcessor $collectorProcessor,
+        private PostFileProcessor $postFileProcessor,
+        private RectorParser $rectorParser,
+        private NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
     ) {
     }
 

--- a/src/Autoloading/AdditionalAutoloader.php
+++ b/src/Autoloading/AdditionalAutoloader.php
@@ -13,10 +13,10 @@ use Webmozart\Assert\Assert;
 /**
  * Should it pass autoload files/directories to PHPStan analyzer?
  */
-final class AdditionalAutoloader
+final readonly class AdditionalAutoloader
 {
     public function __construct(
-        private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator
+        private DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator
     ) {
     }
 

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Autoloading;
 
+use FilesystemIterator;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Exception\ShouldNotHappenException;
@@ -47,7 +48,10 @@ final class BootstrapFilesIncluder
             return;
         }
 
-        $dir = new RecursiveDirectoryIterator($stubsRectorDirectory, RecursiveDirectoryIterator::SKIP_DOTS);
+        $dir = new RecursiveDirectoryIterator(
+            $stubsRectorDirectory,
+            RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::SKIP_DOTS
+        );
         /** @var SplFileInfo[] $stubs */
         $stubs = new RecursiveIteratorIterator($dir);
 

--- a/src/BetterPhpDocParser/PhpDocInfo/TokenIteratorFactory.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/TokenIteratorFactory.php
@@ -9,7 +9,7 @@ use PHPStan\PhpDocParser\Parser\TokenIterator;
 use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 use Rector\Util\Reflection\PrivatesAccessor;
 
-final class TokenIteratorFactory
+final readonly class TokenIteratorFactory
 {
     /**
      * @var string
@@ -17,8 +17,8 @@ final class TokenIteratorFactory
     private const INDEX = 'index';
 
     public function __construct(
-        private readonly Lexer $lexer,
-        private readonly PrivatesAccessor $privatesAccessor
+        private Lexer $lexer,
+        private PrivatesAccessor $privatesAccessor
     ) {
     }
 

--- a/src/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
+++ b/src/BetterPhpDocParser/PhpDocManipulator/PhpDocClassRenamer.php
@@ -15,11 +15,11 @@ use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNod
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 use Rector\Renaming\Collector\RenamedNameCollector;
 
-final class PhpDocClassRenamer
+final readonly class PhpDocClassRenamer
 {
     public function __construct(
-        private readonly ClassAnnotationMatcher $classAnnotationMatcher,
-        private readonly RenamedNameCollector $renamedNameCollector
+        private ClassAnnotationMatcher $classAnnotationMatcher,
+        private RenamedNameCollector $renamedNameCollector
     ) {
     }
 

--- a/src/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/src/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -32,7 +32,7 @@ use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\PhpDocParser\ParamPhpDocNodeFactory;
 
-final class PhpDocTypeChanger
+final readonly class PhpDocTypeChanger
 {
     /**
      * @var array<class-string<Node>>
@@ -50,11 +50,11 @@ final class PhpDocTypeChanger
     private const ALLOWED_IDENTIFIER_TYPENODE_TYPES = ['class-string'];
 
     public function __construct(
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly TypeComparator $typeComparator,
-        private readonly ParamPhpDocNodeFactory $paramPhpDocNodeFactory,
-        private readonly NewPhpDocFromPHPStanTypeGuard $newPhpDocFromPHPStanTypeGuard,
-        private readonly DocBlockUpdater $docBlockUpdater
+        private StaticTypeMapper $staticTypeMapper,
+        private TypeComparator $typeComparator,
+        private ParamPhpDocNodeFactory $paramPhpDocNodeFactory,
+        private NewPhpDocFromPHPStanTypeGuard $newPhpDocFromPHPStanTypeGuard,
+        private DocBlockUpdater $docBlockUpdater
     ) {
     }
 

--- a/src/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/ConstExprClassNameDecorator.php
@@ -17,11 +17,11 @@ use Rector\StaticTypeMapper\Naming\NameScopeFactory;
  * Decorate node with fully qualified class name for const epxr,
  * e.g. Direction::*
  */
-final class ConstExprClassNameDecorator implements PhpDocNodeDecoratorInterface
+final readonly class ConstExprClassNameDecorator implements PhpDocNodeDecoratorInterface
 {
     public function __construct(
-        private readonly NameScopeFactory $nameScopeFactory,
-        private readonly PhpDocNodeTraverser $phpDocNodeTraverser
+        private NameScopeFactory $nameScopeFactory,
+        private PhpDocNodeTraverser $phpDocNodeTraverser
     ) {
     }
 

--- a/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -24,7 +24,7 @@ use Rector\BetterPhpDocParser\ValueObject\StartAndEnd;
 use Rector\Util\StringUtils;
 use Webmozart\Assert\Assert;
 
-final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
+final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
 {
     /**
      * Special short annotations, that are resolved as FQN by Doctrine annotation parser
@@ -45,10 +45,10 @@ final class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorInterface
     private const NESTED_ANNOTATION_END_REGEX = '#(\s+)?\}\)(\s+)?#';
 
     public function __construct(
-        private readonly ClassAnnotationMatcher $classAnnotationMatcher,
-        private readonly StaticDoctrineAnnotationParser $staticDoctrineAnnotationParser,
-        private readonly TokenIteratorFactory $tokenIteratorFactory,
-        private readonly AttributeMirrorer $attributeMirrorer
+        private ClassAnnotationMatcher $classAnnotationMatcher,
+        private StaticDoctrineAnnotationParser $staticDoctrineAnnotationParser,
+        private TokenIteratorFactory $tokenIteratorFactory,
+        private AttributeMirrorer $attributeMirrorer
     ) {
     }
 

--- a/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
+++ b/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
@@ -19,11 +19,11 @@ use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNod
  * Better version of doctrine/annotation - with phpdoc-parser and  static reflection
  * @see \Rector\Tests\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\StaticDoctrineAnnotationParserTest
  */
-final class StaticDoctrineAnnotationParser
+final readonly class StaticDoctrineAnnotationParser
 {
     public function __construct(
-        private readonly PlainValueParser $plainValueParser,
-        private readonly ArrayParser $arrayParser
+        private PlainValueParser $plainValueParser,
+        private ArrayParser $arrayParser
     ) {
     }
 

--- a/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
+++ b/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParser.php
@@ -15,10 +15,10 @@ use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
 /**
  * @see \Rector\Tests\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParserTest
  */
-final class ArrayParser
+final readonly class ArrayParser
 {
     public function __construct(
-        private readonly PlainValueParser $plainValueParser
+        private PlainValueParser $plainValueParser
     ) {
     }
 

--- a/src/BetterPhpDocParser/ValueObject/StartAndEnd.php
+++ b/src/BetterPhpDocParser/ValueObject/StartAndEnd.php
@@ -6,11 +6,11 @@ namespace Rector\BetterPhpDocParser\ValueObject;
 
 use Rector\Exception\ShouldNotHappenException;
 
-final class StartAndEnd
+final readonly class StartAndEnd
 {
     public function __construct(
-        private readonly int $start,
-        private readonly int $end
+        private int $start,
+        private int $end
     ) {
         if ($end < $start) {
             throw new ShouldNotHappenException();

--- a/src/Caching/Cache.php
+++ b/src/Caching/Cache.php
@@ -6,10 +6,10 @@ namespace Rector\Caching;
 
 use Rector\Caching\Contract\ValueObject\Storage\CacheStorageInterface;
 
-final class Cache
+final readonly class Cache
 {
     public function __construct(
-        private readonly CacheStorageInterface $cacheStorage
+        private CacheStorageInterface $cacheStorage
     ) {
     }
 

--- a/src/Caching/CacheFactory.php
+++ b/src/Caching/CacheFactory.php
@@ -10,10 +10,10 @@ use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class CacheFactory
+final readonly class CacheFactory
 {
     public function __construct(
-        private readonly Filesystem $fileSystem
+        private Filesystem $fileSystem
     ) {
     }
 

--- a/src/Caching/UnchangedFilesFilter.php
+++ b/src/Caching/UnchangedFilesFilter.php
@@ -6,10 +6,10 @@ namespace Rector\Caching;
 
 use Rector\Caching\Detector\ChangedFilesDetector;
 
-final class UnchangedFilesFilter
+final readonly class UnchangedFilesFilter
 {
     public function __construct(
-        private readonly ChangedFilesDetector $changedFilesDetector
+        private ChangedFilesDetector $changedFilesDetector
     ) {
     }
 

--- a/src/Caching/ValueObject/CacheFilePaths.php
+++ b/src/Caching/ValueObject/CacheFilePaths.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\Caching\ValueObject;
 
-final class CacheFilePaths
+final readonly class CacheFilePaths
 {
     public function __construct(
-        private readonly string $firstDirectory,
-        private readonly string $secondDirectory,
-        private readonly string $filePath
+        private string $firstDirectory,
+        private string $secondDirectory,
+        private string $filePath
     ) {
     }
 

--- a/src/Caching/ValueObject/CacheItem.php
+++ b/src/Caching/ValueObject/CacheItem.php
@@ -8,11 +8,11 @@ namespace Rector\Caching\ValueObject;
  * Inspired by
  * https://github.com/phpstan/phpstan-src/commit/eeae2da7999b2e8b7b04542c6175d46f80c6d0b9#diff-6dc14f6222bf150e6840ca44a7126653052a1cedc6a149b4e5c1e1a2c80eacdc
  */
-final class CacheItem
+final readonly class CacheItem
 {
     public function __construct(
-        private readonly string $variableKey,
-        private readonly mixed $data
+        private string $variableKey,
+        private mixed $data
     ) {
     }
 

--- a/src/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -16,11 +16,11 @@ use Rector\Exception\Cache\CachingException;
  * Inspired by https://github.com/phpstan/phpstan-src/blob/1e7ceae933f07e5a250b61ed94799e6c2ea8daa2/src/Cache/FileCacheStorage.php
  * @see \Rector\Tests\Caching\ValueObject\Storage\FileCacheStorageTest
  */
-final class FileCacheStorage implements CacheStorageInterface
+final readonly class FileCacheStorage implements CacheStorageInterface
 {
     public function __construct(
-        private readonly string $directory,
-        private readonly \Symfony\Component\Filesystem\Filesystem $filesystem
+        private string $directory,
+        private \Symfony\Component\Filesystem\Filesystem $filesystem
     ) {
     }
 

--- a/src/ChangesReporting/Annotation/RectorsChangelogResolver.php
+++ b/src/ChangesReporting/Annotation/RectorsChangelogResolver.php
@@ -6,10 +6,10 @@ namespace Rector\ChangesReporting\Annotation;
 
 use Rector\Contract\Rector\RectorInterface;
 
-final class RectorsChangelogResolver
+final readonly class RectorsChangelogResolver
 {
     public function __construct(
-        private readonly AnnotationExtractor $annotationExtractor
+        private AnnotationExtractor $annotationExtractor
     ) {
     }
 

--- a/src/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/src/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -13,7 +13,7 @@ use Rector\ValueObject\ProcessResult;
 use Rector\ValueObject\Reporting\FileDiff;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-final class ConsoleOutputFormatter implements OutputFormatterInterface
+final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
 {
     /**
      * @var string
@@ -27,8 +27,8 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     private const ON_LINE_REGEX = '# on line #';
 
     public function __construct(
-        private readonly SymfonyStyle $symfonyStyle,
-        private readonly RectorsChangelogResolver $rectorsChangelogResolver,
+        private SymfonyStyle $symfonyStyle,
+        private RectorsChangelogResolver $rectorsChangelogResolver,
     ) {
     }
 

--- a/src/ChangesReporting/Output/JsonOutputFormatter.php
+++ b/src/ChangesReporting/Output/JsonOutputFormatter.php
@@ -12,7 +12,7 @@ use Rector\ValueObject\Configuration;
 use Rector\ValueObject\Error\SystemError;
 use Rector\ValueObject\ProcessResult;
 
-final class JsonOutputFormatter implements OutputFormatterInterface
+final readonly class JsonOutputFormatter implements OutputFormatterInterface
 {
     /**
      * @var string
@@ -20,7 +20,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
     public const NAME = 'json';
 
     public function __construct(
-        private readonly RectorsChangelogResolver $rectorsChangelogResolver
+        private RectorsChangelogResolver $rectorsChangelogResolver
     ) {
     }
 

--- a/src/ChangesReporting/ValueObjectFactory/ErrorFactory.php
+++ b/src/ChangesReporting/ValueObjectFactory/ErrorFactory.php
@@ -9,11 +9,11 @@ use Rector\Error\ExceptionCorrector;
 use Rector\FileSystem\FilePathHelper;
 use Rector\ValueObject\Error\SystemError;
 
-final class ErrorFactory
+final readonly class ErrorFactory
 {
     public function __construct(
-        private readonly ExceptionCorrector $exceptionCorrector,
-        private readonly FilePathHelper $filePathHelper
+        private ExceptionCorrector $exceptionCorrector,
+        private FilePathHelper $filePathHelper
     ) {
     }
 

--- a/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
+++ b/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
@@ -11,12 +11,12 @@ use Rector\FileSystem\FilePathHelper;
 use Rector\ValueObject\Application\File;
 use Rector\ValueObject\Reporting\FileDiff;
 
-final class FileDiffFactory
+final readonly class FileDiffFactory
 {
     public function __construct(
-        private readonly DefaultDiffer $defaultDiffer,
-        private readonly ConsoleDiffer $consoleDiffer,
-        private readonly FilePathHelper $filePathHelper,
+        private DefaultDiffer $defaultDiffer,
+        private ConsoleDiffer $consoleDiffer,
+        private FilePathHelper $filePathHelper,
     ) {
     }
 

--- a/src/Comments/CommentRemover.php
+++ b/src/Comments/CommentRemover.php
@@ -10,10 +10,10 @@ use Rector\Comments\NodeTraverser\CommentRemovingNodeTraverser;
 /**
  * @see \Rector\Tests\Comments\CommentRemover\CommentRemoverTest
  */
-final class CommentRemover
+final readonly class CommentRemover
 {
     public function __construct(
-        private readonly CommentRemovingNodeTraverser $commentRemovingNodeTraverser
+        private CommentRemovingNodeTraverser $commentRemovingNodeTraverser
     ) {
     }
 

--- a/src/Comments/NodeDocBlock/DocBlockUpdater.php
+++ b/src/Comments/NodeDocBlock/DocBlockUpdater.php
@@ -11,10 +11,10 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
-final class DocBlockUpdater
+final readonly class DocBlockUpdater
 {
     public function __construct(
-        private readonly PhpDocInfoPrinter $phpDocInfoPrinter
+        private PhpDocInfoPrinter $phpDocInfoPrinter
     ) {
     }
 

--- a/src/Configuration/ConfigInitializer.php
+++ b/src/Configuration/ConfigInitializer.php
@@ -12,16 +12,16 @@ use Rector\Php\PhpVersionProvider;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-final class ConfigInitializer
+final readonly class ConfigInitializer
 {
     /**
      * @param RectorInterface[] $rectors
      */
     public function __construct(
-        private readonly array $rectors,
-        private readonly InitFilePathsResolver $initFilePathsResolver,
-        private readonly SymfonyStyle $symfonyStyle,
-        private readonly PhpVersionProvider $phpVersionProvider,
+        private array $rectors,
+        private InitFilePathsResolver $initFilePathsResolver,
+        private SymfonyStyle $symfonyStyle,
+        private PhpVersionProvider $phpVersionProvider,
     ) {
     }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -13,10 +13,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @see \Rector\Tests\Configuration\ConfigurationFactoryTest
  */
-final class ConfigurationFactory
+final readonly class ConfigurationFactory
 {
     public function __construct(
-        private readonly SymfonyStyle $symfonyStyle
+        private SymfonyStyle $symfonyStyle
     ) {
     }
 

--- a/src/Console/Formatter/ColorConsoleDiffFormatter.php
+++ b/src/Console/Formatter/ColorConsoleDiffFormatter.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
  *
  * @see \Rector\Tests\Console\Formatter\ColorConsoleDiffFormatterTest
  */
-final class ColorConsoleDiffFormatter
+final readonly class ColorConsoleDiffFormatter
 {
     /**
      * @var string
@@ -39,7 +39,7 @@ final class ColorConsoleDiffFormatter
      */
     private const NEWLINES_REGEX = "#\n\r|\n#";
 
-    private readonly string $template;
+    private string $template;
 
     public function __construct()
     {

--- a/src/Console/Formatter/CompleteUnifiedDiffOutputBuilderFactory.php
+++ b/src/Console/Formatter/CompleteUnifiedDiffOutputBuilderFactory.php
@@ -11,10 +11,10 @@ use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
  * @api
  * Creates @see UnifiedDiffOutputBuilder with "$contextLines = 1000;"
  */
-final class CompleteUnifiedDiffOutputBuilderFactory
+final readonly class CompleteUnifiedDiffOutputBuilderFactory
 {
     public function __construct(
-        private readonly PrivatesAccessor $privatesAccessor
+        private PrivatesAccessor $privatesAccessor
     ) {
     }
 

--- a/src/Console/Formatter/ConsoleDiffer.php
+++ b/src/Console/Formatter/ConsoleDiffer.php
@@ -7,12 +7,12 @@ namespace Rector\Console\Formatter;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 
-final class ConsoleDiffer
+final readonly class ConsoleDiffer
 {
-    private readonly Differ $differ;
+    private Differ $differ;
 
     public function __construct(
-        private readonly ColorConsoleDiffFormatter $colorConsoleDiffFormatter
+        private ColorConsoleDiffFormatter $colorConsoleDiffFormatter
     ) {
         // @see https://github.com/sebastianbergmann/diff#strictunifieddiffoutputbuilder
         // @see https://github.com/sebastianbergmann/diff/compare/4.0.4...5.0.0#diff-251edf56a6344c03fa264a4926b06c2cee43c25f66192d5f39ebee912b7442dc for upgrade

--- a/src/Console/Style/SymfonyStyleFactory.php
+++ b/src/Console/Style/SymfonyStyleFactory.php
@@ -11,10 +11,10 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-final class SymfonyStyleFactory
+final readonly class SymfonyStyleFactory
 {
     public function __construct(
-        private readonly PrivatesAccessor $privatesAccessor
+        private PrivatesAccessor $privatesAccessor
     ) {
     }
 

--- a/src/Differ/DefaultDiffer.php
+++ b/src/Differ/DefaultDiffer.php
@@ -7,9 +7,9 @@ namespace Rector\Differ;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\StrictUnifiedDiffOutputBuilder;
 
-final class DefaultDiffer
+final readonly class DefaultDiffer
 {
-    private readonly Differ $differ;
+    private Differ $differ;
 
     public function __construct()
     {

--- a/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -11,10 +11,10 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\FamilyTree\Reflection\FamilyRelationsAnalyzer;
 
-final class ClassChildAnalyzer
+final readonly class ClassChildAnalyzer
 {
     public function __construct(
-        private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer
+        private FamilyRelationsAnalyzer $familyRelationsAnalyzer
     ) {
     }
 

--- a/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -12,12 +12,12 @@ use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Util\Reflection\PrivatesAccessor;
 
-final class FamilyRelationsAnalyzer
+final readonly class FamilyRelationsAnalyzer
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly PrivatesAccessor $privatesAccessor,
-        private readonly NodeNameResolver $nodeNameResolver,
+        private ReflectionProvider $reflectionProvider,
+        private PrivatesAccessor $privatesAccessor,
+        private NodeNameResolver $nodeNameResolver,
     ) {
     }
 

--- a/src/FileSystem/FilePathHelper.php
+++ b/src/FileSystem/FilePathHelper.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\Tests\FileSystem\FilePathHelperTest
  */
-final class FilePathHelper
+final readonly class FilePathHelper
 {
     /**
      * @see https://regex101.com/r/d4F5Fm/1
@@ -31,7 +31,7 @@ final class FilePathHelper
     private const SCHEME_UNDEFINED = 'undefined';
 
     public function __construct(
-        private readonly Filesystem $filesystem,
+        private Filesystem $filesystem,
     ) {
     }
 

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -13,13 +13,13 @@ use Symfony\Component\Finder\SplFileInfo;
 /**
  * @see \Rector\Tests\FileSystem\FilesFinder\FilesFinderTest
  */
-final class FilesFinder
+final readonly class FilesFinder
 {
     public function __construct(
-        private readonly FilesystemTweaker $filesystemTweaker,
-        private readonly SkippedPathsResolver $skippedPathsResolver,
-        private readonly UnchangedFilesFilter $unchangedFilesFilter,
-        private readonly FileAndDirectoryFilter $fileAndDirectoryFilter,
+        private FilesystemTweaker $filesystemTweaker,
+        private SkippedPathsResolver $skippedPathsResolver,
+        private UnchangedFilesFilter $unchangedFilesFilter,
+        private FileAndDirectoryFilter $fileAndDirectoryFilter,
     ) {
     }
 

--- a/src/FileSystemRector/Parser/FileInfoParser.php
+++ b/src/FileSystemRector/Parser/FileInfoParser.php
@@ -14,12 +14,12 @@ use Rector\ValueObject\Application\File;
 /**
  * Only for testing, @todo move to testing
  */
-final class FileInfoParser
+final readonly class FileInfoParser
 {
     public function __construct(
-        private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
-        private readonly RectorParser $rectorParser,
-        private readonly CurrentFileProvider $currentFileProvider
+        private NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
+        private RectorParser $rectorParser,
+        private CurrentFileProvider $currentFileProvider
     ) {
     }
 

--- a/src/NodeAnalyzer/BinaryOpAnalyzer.php
+++ b/src/NodeAnalyzer/BinaryOpAnalyzer.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Expr\FuncCall;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\ValueObject\FuncCallAndExpr;
 
-final class BinaryOpAnalyzer
+final readonly class BinaryOpAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeAnalyzer/CallAnalyzer.php
+++ b/src/NodeAnalyzer/CallAnalyzer.php
@@ -17,7 +17,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
-final class CallAnalyzer
+final readonly class CallAnalyzer
 {
     /**
      * @var array<class-string<Expr>>
@@ -25,7 +25,7 @@ final class CallAnalyzer
     private const OBJECT_CALL_TYPES = [MethodCall::class, NullsafeMethodCall::class, StaticCall::class];
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
+++ b/src/NodeAnalyzer/CompactFuncCallAnalyzer.php
@@ -13,10 +13,10 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\VariadicPlaceholder;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class CompactFuncCallAnalyzer
+final readonly class CompactFuncCallAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeAnalyzer/DoctrineEntityAnalyzer.php
+++ b/src/NodeAnalyzer/DoctrineEntityAnalyzer.php
@@ -10,7 +10,7 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 
-final class DoctrineEntityAnalyzer
+final readonly class DoctrineEntityAnalyzer
 {
     /**
      * @var string[]
@@ -23,7 +23,7 @@ final class DoctrineEntityAnalyzer
     ];
 
     public function __construct(
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/src/NodeAnalyzer/MagicClassMethodAnalyzer.php
+++ b/src/NodeAnalyzer/MagicClassMethodAnalyzer.php
@@ -8,10 +8,10 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\ValueObject\MethodName;
 
-final class MagicClassMethodAnalyzer
+final readonly class MagicClassMethodAnalyzer
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -24,14 +24,14 @@ use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class ParamAnalyzer
+final readonly class ParamAnalyzer
 {
     public function __construct(
-        private readonly NodeComparator $nodeComparator,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly FuncCallManipulator $funcCallManipulator,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private NodeComparator $nodeComparator,
+        private NodeNameResolver $nodeNameResolver,
+        private FuncCallManipulator $funcCallManipulator,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private BetterNodeFinder $betterNodeFinder
     ) {
     }
 

--- a/src/NodeAnalyzer/PropertyAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyAnalyzer.php
@@ -13,10 +13,10 @@ use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\NonExistingObjectType;
 
-final class PropertyAnalyzer
+final readonly class PropertyAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -28,7 +28,7 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\MethodName;
 
-final class PropertyFetchAnalyzer
+final readonly class PropertyFetchAnalyzer
 {
     /**
      * @var string
@@ -36,11 +36,11 @@ final class PropertyFetchAnalyzer
     private const THIS = 'this';
 
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly AstResolver $astResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ReflectionResolver $reflectionResolver
+        private NodeNameResolver $nodeNameResolver,
+        private BetterNodeFinder $betterNodeFinder,
+        private AstResolver $astResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/NodeAnalyzer/PropertyPresenceChecker.php
+++ b/src/NodeAnalyzer/PropertyPresenceChecker.php
@@ -20,13 +20,13 @@ use Rector\PostRector\ValueObject\PropertyMetadata;
 /**
  * Can be local property, parent property etc.
  */
-final class PropertyPresenceChecker
+final readonly class PropertyPresenceChecker
 {
     public function __construct(
-        private readonly PromotedPropertyResolver $promotedPropertyResolver,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly AstResolver $astResolver,
+        private PromotedPropertyResolver $promotedPropertyResolver,
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionProvider $reflectionProvider,
+        private AstResolver $astResolver,
     ) {
     }
 

--- a/src/NodeAnalyzer/VariadicAnalyzer.php
+++ b/src/NodeAnalyzer/VariadicAnalyzer.php
@@ -14,12 +14,12 @@ use Rector\DeadCode\NodeManipulator\VariadicFunctionLikeDetector;
 use Rector\PhpParser\AstResolver;
 use Rector\Reflection\ReflectionResolver;
 
-final class VariadicAnalyzer
+final readonly class VariadicAnalyzer
 {
     public function __construct(
-        private readonly AstResolver $astResolver,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly VariadicFunctionLikeDetector $variadicFunctionLikeDetector
+        private AstResolver $astResolver,
+        private ReflectionResolver $reflectionResolver,
+        private VariadicFunctionLikeDetector $variadicFunctionLikeDetector
     ) {
     }
 

--- a/src/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/src/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -27,13 +27,13 @@ use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\MethodName;
 
-final class ArrayCallableMethodMatcher
+final readonly class ArrayCallableMethodMatcher
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ValueResolver $valueResolver,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly ReflectionResolver $reflectionResolver
+        private NodeTypeResolver $nodeTypeResolver,
+        private ValueResolver $valueResolver,
+        private ReflectionProvider $reflectionProvider,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/NodeCollector/ValueObject/ArrayCallable.php
+++ b/src/NodeCollector/ValueObject/ArrayCallable.php
@@ -7,12 +7,12 @@ namespace Rector\NodeCollector\ValueObject;
 use PhpParser\Node\Expr;
 use Rector\Validation\RectorAssert;
 
-final class ArrayCallable
+final readonly class ArrayCallable
 {
     public function __construct(
-        private readonly Expr $callerExpr,
-        private readonly string $class,
-        private readonly string $method
+        private Expr $callerExpr,
+        private string $class,
+        private string $method
     ) {
         RectorAssert::className($class);
     }

--- a/src/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
+++ b/src/NodeCollector/ValueObject/ArrayCallableDynamicMethod.php
@@ -10,12 +10,12 @@ use Rector\Validation\RectorAssert;
 /**
  * @api
  */
-final class ArrayCallableDynamicMethod
+final readonly class ArrayCallableDynamicMethod
 {
     public function __construct(
-        private readonly Expr $callerExpr,
-        private readonly string $class,
-        private readonly Expr $method
+        private Expr $callerExpr,
+        private string $class,
+        private Expr $method
     ) {
         RectorAssert::className($class);
     }

--- a/src/NodeDecorator/PropertyTypeDecorator.php
+++ b/src/NodeDecorator/PropertyTypeDecorator.php
@@ -15,13 +15,13 @@ use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\ValueObject\PhpVersionFeature;
 
-final class PropertyTypeDecorator
+final readonly class PropertyTypeDecorator
 {
     public function __construct(
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private PhpVersionProvider $phpVersionProvider,
+        private StaticTypeMapper $staticTypeMapper,
+        private PhpDocTypeChanger $phpDocTypeChanger,
     ) {
     }
 

--- a/src/NodeManipulator/AssignManipulator.php
+++ b/src/NodeManipulator/AssignManipulator.php
@@ -16,12 +16,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class AssignManipulator
+final readonly class AssignManipulator
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private NodeNameResolver $nodeNameResolver,
+        private BetterNodeFinder $betterNodeFinder,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 

--- a/src/NodeManipulator/BinaryOpManipulator.php
+++ b/src/NodeManipulator/BinaryOpManipulator.php
@@ -14,10 +14,10 @@ use Rector\Exception\ShouldNotHappenException;
 use Rector\Php71\ValueObject\TwoNodeMatch;
 use Rector\PhpParser\Node\AssignAndBinaryMap;
 
-final class BinaryOpManipulator
+final readonly class BinaryOpManipulator
 {
     public function __construct(
-        private readonly AssignAndBinaryMap $assignAndBinaryMap
+        private AssignAndBinaryMap $assignAndBinaryMap
     ) {
     }
 

--- a/src/NodeManipulator/ClassConstManipulator.php
+++ b/src/NodeManipulator/ClassConstManipulator.php
@@ -13,12 +13,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class ClassConstManipulator
+final readonly class ClassConstManipulator
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly AstResolver $astResolver
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver,
+        private AstResolver $astResolver
     ) {
     }
 

--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -25,18 +25,18 @@ use Rector\TypeDeclaration\NodeAnalyzer\AutowiredClassMethodOrPropertyAnalyzer;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
 
-final class ClassDependencyManipulator
+final readonly class ClassDependencyManipulator
 {
     public function __construct(
-        private readonly ClassInsertManipulator $classInsertManipulator,
-        private readonly ClassMethodAssignManipulator $classMethodAssignManipulator,
-        private readonly NodeFactory $nodeFactory,
-        private readonly StmtsManipulator $stmtsManipulator,
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly PropertyPresenceChecker $propertyPresenceChecker,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodOrPropertyAnalyzer,
-        private readonly ReflectionResolver $reflectionResolver
+        private ClassInsertManipulator $classInsertManipulator,
+        private ClassMethodAssignManipulator $classMethodAssignManipulator,
+        private NodeFactory $nodeFactory,
+        private StmtsManipulator $stmtsManipulator,
+        private PhpVersionProvider $phpVersionProvider,
+        private PropertyPresenceChecker $propertyPresenceChecker,
+        private NodeNameResolver $nodeNameResolver,
+        private AutowiredClassMethodOrPropertyAnalyzer $autowiredClassMethodOrPropertyAnalyzer,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/NodeManipulator/ClassInsertManipulator.php
+++ b/src/NodeManipulator/ClassInsertManipulator.php
@@ -13,10 +13,10 @@ use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\NodeFactory;
 
-final class ClassInsertManipulator
+final readonly class ClassInsertManipulator
 {
     public function __construct(
-        private readonly NodeFactory $nodeFactory,
+        private NodeFactory $nodeFactory,
     ) {
     }
 

--- a/src/NodeManipulator/ClassManipulator.php
+++ b/src/NodeManipulator/ClassManipulator.php
@@ -10,12 +10,12 @@ use PHPStan\Type\ObjectType;
 use Rector\FamilyTree\NodeAnalyzer\ClassChildAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class ClassManipulator
+final readonly class ClassManipulator
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly ClassChildAnalyzer $classChildAnalyzer
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionProvider $reflectionProvider,
+        private ClassChildAnalyzer $classChildAnalyzer
     ) {
     }
 

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -11,11 +11,11 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\MethodName;
 
-final class ClassMethodManipulator
+final readonly class ClassMethodManipulator
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionResolver $reflectionResolver,
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionResolver $reflectionResolver,
     ) {
     }
 

--- a/src/NodeManipulator/ClassMethodPropertyFetchManipulator.php
+++ b/src/NodeManipulator/ClassMethodPropertyFetchManipulator.php
@@ -18,12 +18,12 @@ use PhpParser\NodeTraverser;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
-final class ClassMethodPropertyFetchManipulator
+final readonly class ClassMethodPropertyFetchManipulator
 {
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly FunctionLikeManipulator $functionLikeManipulator
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver,
+        private FunctionLikeManipulator $functionLikeManipulator
     ) {
     }
 

--- a/src/NodeManipulator/FuncCallManipulator.php
+++ b/src/NodeManipulator/FuncCallManipulator.php
@@ -8,10 +8,10 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class FuncCallManipulator
+final readonly class FuncCallManipulator
 {
     public function __construct(
-        private readonly ValueResolver $valueResolver
+        private ValueResolver $valueResolver
     ) {
     }
 

--- a/src/NodeManipulator/FunctionLikeManipulator.php
+++ b/src/NodeManipulator/FunctionLikeManipulator.php
@@ -7,10 +7,10 @@ namespace Rector\NodeManipulator;
 use PhpParser\Node\FunctionLike;
 use Rector\NodeNameResolver\NodeNameResolver;
 
-final class FunctionLikeManipulator
+final readonly class FunctionLikeManipulator
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
+        private NodeNameResolver $nodeNameResolver,
     ) {
     }
 

--- a/src/NodeManipulator/IfManipulator.php
+++ b/src/NodeManipulator/IfManipulator.php
@@ -18,13 +18,13 @@ use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
-final class IfManipulator
+final readonly class IfManipulator
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly StmtsManipulator $stmtsManipulator,
-        private readonly ValueResolver $valueResolver,
-        private readonly NodeComparator $nodeComparator
+        private BetterNodeFinder $betterNodeFinder,
+        private StmtsManipulator $stmtsManipulator,
+        private ValueResolver $valueResolver,
+        private NodeComparator $nodeComparator
     ) {
     }
 

--- a/src/NodeManipulator/PropertyFetchAssignManipulator.php
+++ b/src/NodeManipulator/PropertyFetchAssignManipulator.php
@@ -16,12 +16,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\ValueObject\MethodName;
 
-final class PropertyFetchAssignManipulator
+final readonly class PropertyFetchAssignManipulator
 {
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private NodeNameResolver $nodeNameResolver,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -34,7 +34,7 @@ use Rector\ValueObject\MethodName;
  * For inspiration to improve this service,
  * @see examples of variable modifications in https://wiki.php.net/rfc/readonly_properties_v2#proposal
  */
-final class PropertyManipulator
+final readonly class PropertyManipulator
 {
     /**
      * @var string[]|class-string<Table>[]
@@ -46,17 +46,17 @@ final class PropertyManipulator
     ];
 
     public function __construct(
-        private readonly AssignManipulator $assignManipulator,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly PropertyFetchFinder $propertyFetchFinder,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly PromotedPropertyResolver $promotedPropertyResolver,
-        private readonly ConstructorAssignDetector $constructorAssignDetector,
-        private readonly AstResolver $astResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private AssignManipulator $assignManipulator,
+        private BetterNodeFinder $betterNodeFinder,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private PropertyFetchFinder $propertyFetchFinder,
+        private NodeNameResolver $nodeNameResolver,
+        private PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private NodeTypeResolver $nodeTypeResolver,
+        private PromotedPropertyResolver $promotedPropertyResolver,
+        private ConstructorAssignDetector $constructorAssignDetector,
+        private AstResolver $astResolver,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -13,12 +13,12 @@ use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class StmtsManipulator
+final readonly class StmtsManipulator
 {
     public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeComparator $nodeComparator
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeComparator $nodeComparator
     ) {
     }
 
@@ -45,7 +45,7 @@ final class StmtsManipulator
     {
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $classMethod->stmts,
-            function (Node $node) use (&$stmts) {
+            function (Node $node) use (&$stmts): null {
                 foreach ($stmts as $key => $assign) {
                     if (! $this->nodeComparator->areNodesEqual($node, $assign)) {
                         continue;

--- a/src/NodeNameResolver/NodeNameResolver/FuncCallNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver/FuncCallNameResolver.php
@@ -16,10 +16,10 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 /**
  * @implements NodeNameResolverInterface<FuncCall>
  */
-final class FuncCallNameResolver implements NodeNameResolverInterface
+final readonly class FuncCallNameResolver implements NodeNameResolverInterface
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -23,9 +23,9 @@ use Webmozart\Assert\Assert;
  *
  * @see \Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory
  */
-final class PHPStanServicesFactory
+final readonly class PHPStanServicesFactory
 {
-    private readonly Container $container;
+    private Container $container;
 
     public function __construct()
     {

--- a/src/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
+++ b/src/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
@@ -11,10 +11,10 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 
-final class GenericClassStringTypeCorrector
+final readonly class GenericClassStringTypeCorrector
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/NodeTypeResolver/NodeTypeResolver/ClassAndInterfaceTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/ClassAndInterfaceTypeResolver.php
@@ -22,10 +22,10 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  *
  * @implements NodeTypeResolverInterface<Class_|Interface_>
  */
-final class ClassAndInterfaceTypeResolver implements NodeTypeResolverInterface
+final readonly class ClassAndInterfaceTypeResolver implements NodeTypeResolverInterface
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 

--- a/src/NodeTypeResolver/NodeTypeResolver/NewTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/NewTypeResolver.php
@@ -24,11 +24,11 @@ use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 /**
  * @implements NodeTypeResolverInterface<New_>
  */
-final class NewTypeResolver implements NodeTypeResolverInterface
+final readonly class NewTypeResolver implements NodeTypeResolverInterface
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ClassAnalyzer $classAnalyzer,
+        private NodeNameResolver $nodeNameResolver,
+        private ClassAnalyzer $classAnalyzer,
     ) {
     }
 

--- a/src/NodeTypeResolver/NodeTypeResolver/PropertyTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/PropertyTypeResolver.php
@@ -17,10 +17,10 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  *
  * @implements NodeTypeResolverInterface<Property>
  */
-final class PropertyTypeResolver implements NodeTypeResolverInterface
+final readonly class PropertyTypeResolver implements NodeTypeResolverInterface
 {
     public function __construct(
-        private readonly PropertyFetchTypeResolver $propertyFetchTypeResolver
+        private PropertyFetchTypeResolver $propertyFetchTypeResolver
     ) {
     }
 

--- a/src/NodeTypeResolver/NodeTypeResolver/TraitTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/TraitTypeResolver.php
@@ -18,10 +18,10 @@ use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
  *
  * @implements NodeTypeResolverInterface<Trait_>
  */
-final class TraitTypeResolver implements NodeTypeResolverInterface
+final readonly class TraitTypeResolver implements NodeTypeResolverInterface
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ContextNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ContextNodeVisitor.php
@@ -113,7 +113,7 @@ final class ContextNodeVisitor extends NodeVisitorAbstract implements ScopeResol
     {
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $attribute->args,
-            static function (Node $subNode) {
+            static function (Node $subNode): null {
                 if ($subNode instanceof Array_) {
                     $subNode->setAttribute(AttributeKey::IS_ARRAY_IN_ATTRIBUTE, true);
                 }

--- a/src/NodeTypeResolver/PHPStan/Scope/ScopeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/ScopeFactory.php
@@ -8,10 +8,10 @@ use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory as PHPStanScopeFactory;
 
-final class ScopeFactory
+final readonly class ScopeFactory
 {
     public function __construct(
-        private readonly PHPStanScopeFactory $phpStanScopeFactory
+        private PHPStanScopeFactory $phpStanScopeFactory
     ) {
     }
 

--- a/src/NodeTypeResolver/PHPStan/Type/StaticTypeAnalyzer.php
+++ b/src/NodeTypeResolver/PHPStan/Type/StaticTypeAnalyzer.php
@@ -14,10 +14,10 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeAnalyzer;
 
-final class StaticTypeAnalyzer
+final readonly class StaticTypeAnalyzer
 {
     public function __construct(
-        private readonly UnionTypeAnalyzer $unionTypeAnalyzer
+        private UnionTypeAnalyzer $unionTypeAnalyzer
     ) {
     }
 

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -22,10 +22,10 @@ use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\PHPStan\ObjectWithoutClassTypeWithParentTypes;
 use Rector\NodeTypeResolver\PHPStan\TypeHasher;
 
-final class TypeFactory
+final readonly class TypeFactory
 {
     public function __construct(
-        private readonly TypeHasher $typeHasher,
+        private TypeHasher $typeHasher,
     ) {
     }
 

--- a/src/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
+++ b/src/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockClassRenamer.php
@@ -10,10 +10,10 @@ use Rector\NodeTypeResolver\PhpDocNodeVisitor\ClassRenamePhpDocNodeVisitor;
 use Rector\NodeTypeResolver\ValueObject\OldToNewType;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 
-final class DocBlockClassRenamer
+final readonly class DocBlockClassRenamer
 {
     public function __construct(
-        private readonly ClassRenamePhpDocNodeVisitor $classRenamePhpDocNodeVisitor,
+        private ClassRenamePhpDocNodeVisitor $classRenamePhpDocNodeVisitor,
     ) {
     }
 

--- a/src/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNameImporter.php
+++ b/src/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockNameImporter.php
@@ -9,10 +9,10 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use Rector\NodeTypeResolver\PhpDocNodeVisitor\NameImportingPhpDocNodeVisitor;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 
-final class DocBlockNameImporter
+final readonly class DocBlockNameImporter
 {
     public function __construct(
-        private readonly NameImportingPhpDocNodeVisitor $nameImportingPhpDocNodeVisitor,
+        private NameImportingPhpDocNodeVisitor $nameImportingPhpDocNodeVisitor,
     ) {
     }
 

--- a/src/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockTagReplacer.php
+++ b/src/NodeTypeResolver/PhpDoc/NodeAnalyzer/DocBlockTagReplacer.php
@@ -9,10 +9,10 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\Annotation\AnnotationNaming;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 
-final class DocBlockTagReplacer
+final readonly class DocBlockTagReplacer
 {
     public function __construct(
-        private readonly AnnotationNaming $annotationNaming
+        private AnnotationNaming $annotationNaming
     ) {
     }
 

--- a/src/NodeTypeResolver/Reflection/BetterReflection/RectorBetterReflectionSourceLocatorFactory.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/RectorBetterReflectionSourceLocatorFactory.php
@@ -12,11 +12,11 @@ use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocator\Intermedia
 /**
  * @api used on phpstan config factory
  */
-final class RectorBetterReflectionSourceLocatorFactory
+final readonly class RectorBetterReflectionSourceLocatorFactory
 {
     public function __construct(
-        private readonly BetterReflectionSourceLocatorFactory $betterReflectionSourceLocatorFactory,
-        private readonly IntermediateSourceLocator $intermediateSourceLocator
+        private BetterReflectionSourceLocatorFactory $betterReflectionSourceLocatorFactory,
+        private IntermediateSourceLocator $intermediateSourceLocator
     ) {
     }
 

--- a/src/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/src/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -19,11 +19,11 @@ use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\Reflection\ReflectionResolver;
 
-final class ArrayTypeAnalyzer
+final readonly class ArrayTypeAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly ReflectionResolver $reflectionResolver
+        private NodeTypeResolver $nodeTypeResolver,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/NodeTypeResolver/TypeAnalyzer/StringTypeAnalyzer.php
+++ b/src/NodeTypeResolver/TypeAnalyzer/StringTypeAnalyzer.php
@@ -7,10 +7,10 @@ namespace Rector\NodeTypeResolver\TypeAnalyzer;
 use PhpParser\Node\Expr;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class StringTypeAnalyzer
+final readonly class StringTypeAnalyzer
 {
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver
     ) {
     }
 

--- a/src/NodeTypeResolver/TypeComparator/ArrayTypeComparator.php
+++ b/src/NodeTypeResolver/TypeComparator/ArrayTypeComparator.php
@@ -13,10 +13,10 @@ use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeCommonTypeNarrower;
 /**
  * @see \Rector\Tests\NodeTypeResolver\TypeComparator\ArrayTypeComparatorTest
  */
-final class ArrayTypeComparator
+final readonly class ArrayTypeComparator
 {
     public function __construct(
-        private readonly UnionTypeCommonTypeNarrower $unionTypeCommonTypeNarrower
+        private UnionTypeCommonTypeNarrower $unionTypeCommonTypeNarrower
     ) {
     }
 

--- a/src/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/src/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -30,16 +30,16 @@ use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\TypeDeclaration\TypeNormalizer;
 
-final class TypeComparator
+final readonly class TypeComparator
 {
     public function __construct(
-        private readonly TypeHasher $typeHasher,
-        private readonly TypeNormalizer $typeNormalizer,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly ArrayTypeComparator $arrayTypeComparator,
-        private readonly ScalarTypeComparator $scalarTypeComparator,
-        private readonly TypeFactory $typeFactory,
-        private readonly ReflectionResolver $reflectionResolver
+        private TypeHasher $typeHasher,
+        private TypeNormalizer $typeNormalizer,
+        private StaticTypeMapper $staticTypeMapper,
+        private ArrayTypeComparator $arrayTypeComparator,
+        private ScalarTypeComparator $scalarTypeComparator,
+        private TypeFactory $typeFactory,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/NodeTypeResolver/ValueObject/OldToNewType.php
+++ b/src/NodeTypeResolver/ValueObject/OldToNewType.php
@@ -6,11 +6,11 @@ namespace Rector\NodeTypeResolver\ValueObject;
 
 use PHPStan\Type\Type;
 
-final class OldToNewType
+final readonly class OldToNewType
 {
     public function __construct(
-        private readonly Type $oldType,
-        private readonly Type $newType
+        private Type $oldType,
+        private Type $newType
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/PHPStanStaticTypeMapper.php
@@ -14,13 +14,13 @@ use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Webmozart\Assert\Assert;
 
-final class PHPStanStaticTypeMapper
+final readonly class PHPStanStaticTypeMapper
 {
     /**
      * @param TypeMapperInterface[] $typeMappers
      */
     public function __construct(
-        private readonly array $typeMappers
+        private array $typeMappers
     ) {
         Assert::notEmpty($typeMappers);
     }

--- a/src/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeCommonTypeNarrower.php
+++ b/src/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeCommonTypeNarrower.php
@@ -20,7 +20,7 @@ use PHPStan\Type\UnionType;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\NodeTypeCorrector\GenericClassStringTypeCorrector;
 
-final class UnionTypeCommonTypeNarrower
+final readonly class UnionTypeCommonTypeNarrower
 {
     /**
      * Key = the winner Array = the group of types matched
@@ -39,8 +39,8 @@ final class UnionTypeCommonTypeNarrower
     ];
 
     public function __construct(
-        private readonly GenericClassStringTypeCorrector $genericClassStringTypeCorrector,
-        private readonly ReflectionProvider $reflectionProvider
+        private GenericClassStringTypeCorrector $genericClassStringTypeCorrector,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryLiteralStringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryLiteralStringTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<AccessoryLiteralStringType>
  */
-final class AccessoryLiteralStringTypeMapper implements TypeMapperInterface
+final readonly class AccessoryLiteralStringTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryNonEmptyStringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryNonEmptyStringTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<AccessoryNonEmptyStringType>
  */
-final class AccessoryNonEmptyStringTypeMapper implements TypeMapperInterface
+final readonly class AccessoryNonEmptyStringTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryNonFalsyStringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryNonFalsyStringTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<AccessoryNonFalsyStringType>
  */
-final class AccessoryNonFalsyStringTypeMapper implements TypeMapperInterface
+final readonly class AccessoryNonFalsyStringTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryNumericStringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/AccessoryNumericStringTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<AccessoryNumericStringType>
  */
-final class AccessoryNumericStringTypeMapper implements TypeMapperInterface
+final readonly class AccessoryNumericStringTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/BooleanTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/BooleanTypeMapper.php
@@ -18,10 +18,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<BooleanType>
  */
-final class BooleanTypeMapper implements TypeMapperInterface
+final readonly class BooleanTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<ClassStringType>
  */
-final class ClassStringTypeMapper implements TypeMapperInterface
+final readonly class ClassStringTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/ClosureTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ClosureTypeMapper.php
@@ -21,10 +21,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<ClosureType>
  */
-final class ClosureTypeMapper implements TypeMapperInterface
+final readonly class ClosureTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/FloatTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/FloatTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<FloatType>
  */
-final class FloatTypeMapper implements TypeMapperInterface
+final readonly class FloatTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/GenericClassStringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/GenericClassStringTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<GenericClassStringType>
  */
-final class GenericClassStringTypeMapper implements TypeMapperInterface
+final readonly class GenericClassStringTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/HasMethodTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/HasMethodTypeMapper.php
@@ -13,10 +13,10 @@ use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 /**
  * @implements TypeMapperInterface<HasMethodType>
  */
-final class HasMethodTypeMapper implements TypeMapperInterface
+final readonly class HasMethodTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly ObjectWithoutClassTypeMapper $objectWithoutClassTypeMapper
+        private ObjectWithoutClassTypeMapper $objectWithoutClassTypeMapper
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/HasPropertyTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/HasPropertyTypeMapper.php
@@ -13,10 +13,10 @@ use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 /**
  * @implements TypeMapperInterface<HasPropertyType>
  */
-final class HasPropertyTypeMapper implements TypeMapperInterface
+final readonly class HasPropertyTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly ObjectWithoutClassTypeMapper $objectWithoutClassTypeMapper
+        private ObjectWithoutClassTypeMapper $objectWithoutClassTypeMapper
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/IntegerTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/IntegerTypeMapper.php
@@ -17,10 +17,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<IntegerType>
  */
-final class IntegerTypeMapper implements TypeMapperInterface
+final readonly class IntegerTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -21,12 +21,12 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<IntersectionType>
  */
-final class IntersectionTypeMapper implements TypeMapperInterface
+final readonly class IntersectionTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly ObjectWithoutClassTypeMapper $objectWithoutClassTypeMapper,
-        private readonly ObjectTypeMapper $objectTypeMapper,
+        private PhpVersionProvider $phpVersionProvider,
+        private ObjectWithoutClassTypeMapper $objectWithoutClassTypeMapper,
+        private ObjectTypeMapper $objectTypeMapper,
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/MixedTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/MixedTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<MixedType>
  */
-final class MixedTypeMapper implements TypeMapperInterface
+final readonly class MixedTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/NullTypeMapper.php
@@ -17,10 +17,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<NullType>
  */
-final class NullTypeMapper implements TypeMapperInterface
+final readonly class NullTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ObjectWithoutClassTypeMapper.php
@@ -18,10 +18,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<ObjectWithoutClassType>
  */
-final class ObjectWithoutClassTypeMapper implements TypeMapperInterface
+final readonly class ObjectWithoutClassTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/StaticTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/StaticTypeMapper.php
@@ -22,10 +22,10 @@ use Rector\ValueObject\PhpVersionFeature;
  *
  * @implements TypeMapperInterface<StaticType>
  */
-final class StaticTypeMapper implements TypeMapperInterface
+final readonly class StaticTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/StringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/StringTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<StringType>
  */
-final class StringTypeMapper implements TypeMapperInterface
+final readonly class StringTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/TypeWithClassNameTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/TypeWithClassNameTypeMapper.php
@@ -16,10 +16,10 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<TypeWithClassName>
  */
-final class TypeWithClassNameTypeMapper implements TypeMapperInterface
+final readonly class TypeWithClassNameTypeMapper implements TypeMapperInterface
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/VoidTypeMapper.php
@@ -17,7 +17,7 @@ use Rector\ValueObject\PhpVersionFeature;
 /**
  * @implements TypeMapperInterface<VoidType>
  */
-final class VoidTypeMapper implements TypeMapperInterface
+final readonly class VoidTypeMapper implements TypeMapperInterface
 {
     /**
      * @var string
@@ -25,7 +25,7 @@ final class VoidTypeMapper implements TypeMapperInterface
     private const VOID = 'void';
 
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
+        private PhpVersionProvider $phpVersionProvider
     ) {
     }
 

--- a/src/PHPStanStaticTypeMapper/ValueObject/UnionTypeAnalysis.php
+++ b/src/PHPStanStaticTypeMapper/ValueObject/UnionTypeAnalysis.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanStaticTypeMapper\ValueObject;
 
-final class UnionTypeAnalysis
+final readonly class UnionTypeAnalysis
 {
     public function __construct(
-        private readonly bool $hasIterable,
-        private readonly bool $hasArray
+        private bool $hasIterable,
+        private bool $hasArray
     ) {
     }
 

--- a/src/Parallel/Command/WorkerCommandLineFactory.php
+++ b/src/Parallel/Command/WorkerCommandLineFactory.php
@@ -16,7 +16,7 @@ use Symplify\EasyParallel\Reflection\CommandFromReflectionFactory;
  * @see \Rector\Tests\Parallel\Command\WorkerCommandLineFactoryTest
  * @todo possibly extract to symplify/easy-parallel
  */
-final class WorkerCommandLineFactory
+final readonly class WorkerCommandLineFactory
 {
     /**
      * @var string
@@ -24,8 +24,8 @@ final class WorkerCommandLineFactory
     private const OPTION_DASHES = '--';
 
     public function __construct(
-        private readonly CommandFromReflectionFactory $commandFromReflectionFactory,
-        private readonly FilePathHelper $filePathHelper
+        private CommandFromReflectionFactory $commandFromReflectionFactory,
+        private FilePathHelper $filePathHelper
     ) {
     }
 

--- a/src/Php/PhpVersionProvider.php
+++ b/src/Php/PhpVersionProvider.php
@@ -16,7 +16,7 @@ use ReflectionClass;
 /**
  * @see \Rector\Tests\Php\PhpVersionProviderTest
  */
-final class PhpVersionProvider
+final readonly class PhpVersionProvider
 {
     /**
      * @var string
@@ -25,7 +25,7 @@ final class PhpVersionProvider
     private const VALID_PHP_VERSION_REGEX = '#^\d{5,6}$#';
 
     public function __construct(
-        private readonly ProjectComposerJsonPhpVersionResolver $projectComposerJsonPhpVersionResolver
+        private ProjectComposerJsonPhpVersionResolver $projectComposerJsonPhpVersionResolver
     ) {
     }
 

--- a/src/PhpAttribute/AnnotationToAttributeMapper.php
+++ b/src/PhpAttribute/AnnotationToAttributeMapper.php
@@ -18,13 +18,13 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\Tests\PhpAttribute\AnnotationToAttributeMapper\AnnotationToAttributeMapperTest
  */
-final class AnnotationToAttributeMapper
+final readonly class AnnotationToAttributeMapper
 {
     /**
      * @param AnnotationToAttributeMapperInterface[] $annotationToAttributeMappers
      */
     public function __construct(
-        private readonly array $annotationToAttributeMappers
+        private array $annotationToAttributeMappers
     ) {
         Assert::notEmpty($annotationToAttributeMappers);
     }

--- a/src/PhpAttribute/NodeAnalyzer/ExprParameterReflectionTypeCorrector.php
+++ b/src/PhpAttribute/NodeAnalyzer/ExprParameterReflectionTypeCorrector.php
@@ -15,12 +15,12 @@ use PHPStan\Type\TypeCombinator;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-final class ExprParameterReflectionTypeCorrector
+final readonly class ExprParameterReflectionTypeCorrector
 {
     public function __construct(
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly NodeFactory $nodeFactory
+        private StaticTypeMapper $staticTypeMapper,
+        private ReflectionProvider $reflectionProvider,
+        private NodeFactory $nodeFactory
     ) {
     }
 

--- a/src/PhpAttribute/NodeFactory/AttributeNameFactory.php
+++ b/src/PhpAttribute/NodeFactory/AttributeNameFactory.php
@@ -12,10 +12,10 @@ use Rector\Php80\Contract\ValueObject\AnnotationToAttributeInterface;
 use Rector\PhpAttribute\UseAliasNameMatcher;
 use Rector\PhpAttribute\ValueObject\UseAliasMetadata;
 
-final class AttributeNameFactory
+final readonly class AttributeNameFactory
 {
     public function __construct(
-        private readonly UseAliasNameMatcher $useAliasNameMatcher
+        private UseAliasNameMatcher $useAliasNameMatcher
     ) {
     }
 

--- a/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -21,14 +21,14 @@ use Rector\PhpAttribute\NodeAnalyzer\ExprParameterReflectionTypeCorrector;
 /**
  * @see \Rector\Tests\PhpAttribute\Printer\PhpAttributeGroupFactoryTest
  */
-final class PhpAttributeGroupFactory
+final readonly class PhpAttributeGroupFactory
 {
     public function __construct(
-        private readonly AnnotationToAttributeMapper $annotationToAttributeMapper,
-        private readonly AttributeNameFactory $attributeNameFactory,
-        private readonly NamedArgsFactory $namedArgsFactory,
-        private readonly ExprParameterReflectionTypeCorrector $exprParameterReflectionTypeCorrector,
-        private readonly AttributeArrayNameInliner $attributeArrayNameInliner
+        private AnnotationToAttributeMapper $annotationToAttributeMapper,
+        private AttributeNameFactory $attributeNameFactory,
+        private NamedArgsFactory $namedArgsFactory,
+        private ExprParameterReflectionTypeCorrector $exprParameterReflectionTypeCorrector,
+        private AttributeArrayNameInliner $attributeArrayNameInliner
     ) {
     }
 

--- a/src/PhpAttribute/NodeFactory/PhpNestedAttributeGroupFactory.php
+++ b/src/PhpAttribute/NodeFactory/PhpNestedAttributeGroupFactory.php
@@ -23,14 +23,14 @@ use Rector\PhpAttribute\AnnotationToAttributeMapper;
 use Rector\PhpAttribute\AttributeArrayNameInliner;
 use Rector\PhpAttribute\NodeAnalyzer\ExprParameterReflectionTypeCorrector;
 
-final class PhpNestedAttributeGroupFactory
+final readonly class PhpNestedAttributeGroupFactory
 {
     public function __construct(
-        private readonly AnnotationToAttributeMapper $annotationToAttributeMapper,
-        private readonly AttributeNameFactory $attributeNameFactory,
-        private readonly NamedArgsFactory $namedArgsFactory,
-        private readonly ExprParameterReflectionTypeCorrector $exprParameterReflectionTypeCorrector,
-        private readonly AttributeArrayNameInliner $attributeArrayNameInliner
+        private AnnotationToAttributeMapper $annotationToAttributeMapper,
+        private AttributeNameFactory $attributeNameFactory,
+        private NamedArgsFactory $namedArgsFactory,
+        private ExprParameterReflectionTypeCorrector $exprParameterReflectionTypeCorrector,
+        private AttributeArrayNameInliner $attributeArrayNameInliner
     ) {
     }
 

--- a/src/PhpAttribute/ValueObject/UseAliasMetadata.php
+++ b/src/PhpAttribute/ValueObject/UseAliasMetadata.php
@@ -6,12 +6,12 @@ namespace Rector\PhpAttribute\ValueObject;
 
 use PhpParser\Node\Stmt\UseUse;
 
-final class UseAliasMetadata
+final readonly class UseAliasMetadata
 {
     public function __construct(
-        private readonly string $shortAttributeName,
-        private readonly string $useImportName,
-        private readonly UseUse $useUse
+        private string $shortAttributeName,
+        private string $useImportName,
+        private UseUse $useUse
     ) {
     }
 

--- a/src/PhpDocParser/PhpParser/SmartPhpParser.php
+++ b/src/PhpDocParser/PhpParser/SmartPhpParser.php
@@ -12,10 +12,10 @@ use PHPStan\Parser\Parser;
  *
  * @api
  */
-final class SmartPhpParser
+final readonly class SmartPhpParser
 {
     public function __construct(
-        private readonly Parser $parser
+        private Parser $parser
     ) {
     }
 

--- a/src/PhpParser/Comparing/NodeComparator.php
+++ b/src/PhpParser/Comparing/NodeComparator.php
@@ -8,11 +8,11 @@ use PhpParser\Node;
 use Rector\Comments\CommentRemover;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
 
-final class NodeComparator
+final readonly class NodeComparator
 {
     public function __construct(
-        private readonly CommentRemover $commentRemover,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private CommentRemover $commentRemover,
+        private BetterStandardPrinter $betterStandardPrinter
     ) {
     }
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -22,13 +22,13 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\Tests\PhpParser\Node\BetterNodeFinder\BetterNodeFinderTest
  */
-final class BetterNodeFinder
+final readonly class BetterNodeFinder
 {
     public function __construct(
-        private readonly NodeFinder $nodeFinder,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ClassAnalyzer $classAnalyzer,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+        private NodeFinder $nodeFinder,
+        private NodeNameResolver $nodeNameResolver,
+        private ClassAnalyzer $classAnalyzer,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
     ) {
     }
 

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -53,7 +53,7 @@ use Rector\StaticTypeMapper\StaticTypeMapper;
 /**
  * @see \Rector\Tests\PhpParser\Node\NodeFactoryTest
  */
-final class NodeFactory
+final readonly class NodeFactory
 {
     /**
      * @var string
@@ -61,11 +61,11 @@ final class NodeFactory
     private const THIS = 'this';
 
     public function __construct(
-        private readonly BuilderFactory $builderFactory,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly PropertyTypeDecorator $propertyTypeDecorator,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+        private BuilderFactory $builderFactory,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private StaticTypeMapper $staticTypeMapper,
+        private PropertyTypeDecorator $propertyTypeDecorator,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
     ) {
     }
 

--- a/src/PhpParser/NodeFinder/LocalMethodCallFinder.php
+++ b/src/PhpParser/NodeFinder/LocalMethodCallFinder.php
@@ -13,12 +13,12 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
-final class LocalMethodCallFinder
+final readonly class LocalMethodCallFinder
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly NodeNameResolver $nodeNameResolver,
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver,
     ) {
     }
 

--- a/src/PhpParser/NodeFinder/PropertyFetchFinder.php
+++ b/src/PhpParser/NodeFinder/PropertyFetchFinder.php
@@ -33,16 +33,16 @@ use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Reflection\ReflectionResolver;
 
-final class PropertyFetchFinder
+final readonly class PropertyFetchFinder
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly AstResolver $astResolver,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionResolver $reflectionResolver,
+        private AstResolver $astResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+        private PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
     ) {
     }
 
@@ -104,7 +104,7 @@ final class PropertyFetchFinder
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $class->getMethods(),
-            function (Node $subNode) use (&$propertyArrayDimFetches, $propertyName) {
+            function (Node $subNode) use (&$propertyArrayDimFetches, $propertyName): null {
                 if (! $subNode instanceof Assign) {
                     return null;
                 }

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -15,7 +15,7 @@ use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Util\StringUtils;
 
-final class InlineCodeParser
+final readonly class InlineCodeParser
 {
     /**
      * @var string
@@ -60,9 +60,9 @@ final class InlineCodeParser
     private const BACKREFERENCE_NO_DOUBLE_QUOTE_START_REGEX = '#(?<!")(?<backreference>\$\d+)#';
 
     public function __construct(
-        private readonly BetterStandardPrinter $betterStandardPrinter,
-        private readonly SimplePhpParser $simplePhpParser,
-        private readonly ValueResolver $valueResolver,
+        private BetterStandardPrinter $betterStandardPrinter,
+        private SimplePhpParser $simplePhpParser,
+        private ValueResolver $valueResolver,
     ) {
     }
 

--- a/src/PhpParser/Parser/RectorParser.php
+++ b/src/PhpParser/Parser/RectorParser.php
@@ -9,11 +9,11 @@ use PhpParser\Node\Stmt;
 use PHPStan\Parser\Parser;
 use Rector\PhpParser\ValueObject\StmtsAndTokens;
 
-final class RectorParser
+final readonly class RectorParser
 {
     public function __construct(
-        private readonly Lexer $lexer,
-        private readonly Parser $parser,
+        private Lexer $lexer,
+        private Parser $parser,
     ) {
     }
 

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -11,11 +11,11 @@ use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor\AssignedToNodeVisitor;
 
-final class SimplePhpParser
+final readonly class SimplePhpParser
 {
-    private readonly Parser $phpParser;
+    private Parser $phpParser;
 
-    private readonly NodeTraverser $nodeTraverser;
+    private NodeTraverser $nodeTraverser;
 
     public function __construct()
     {

--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -11,11 +11,11 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @see \Rector\Tests\PhpParser\Printer\FormatPerservingPrinterTest
  */
-final class FormatPerservingPrinter
+final readonly class FormatPerservingPrinter
 {
     public function __construct(
-        private readonly BetterStandardPrinter $betterStandardPrinter,
-        private readonly Filesystem $filesystem
+        private BetterStandardPrinter $betterStandardPrinter,
+        private Filesystem $filesystem
     ) {
     }
 

--- a/src/PhpParser/ValueObject/StmtsAndTokens.php
+++ b/src/PhpParser/ValueObject/StmtsAndTokens.php
@@ -6,15 +6,15 @@ namespace Rector\PhpParser\ValueObject;
 
 use PhpParser\Node\Stmt;
 
-final class StmtsAndTokens
+final readonly class StmtsAndTokens
 {
     /**
      * @param Stmt[] $stmts
      * @param array<int, array{int, string, int}|string> $tokens
      */
     public function __construct(
-        private readonly array $stmts,
-        private readonly array $tokens
+        private array $stmts,
+        private array $tokens
     ) {
     }
 

--- a/src/PostRector/ValueObject/PropertyMetadata.php
+++ b/src/PostRector/ValueObject/PropertyMetadata.php
@@ -7,12 +7,12 @@ namespace Rector\PostRector\ValueObject;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\Type;
 
-final class PropertyMetadata
+final readonly class PropertyMetadata
 {
     public function __construct(
-        private readonly string $name,
-        private readonly ?Type $type,
-        private readonly int $flags = Class_::MODIFIER_PRIVATE,
+        private string $name,
+        private ?Type $type,
+        private int $flags = Class_::MODIFIER_PRIVATE,
     ) {
     }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -281,7 +281,7 @@ CODE_SAMPLE;
             return;
         }
 
-        $this->traverseNodesWithCallable($node, static function (Node $subNode) use ($otherTypes) {
+        $this->traverseNodesWithCallable($node, static function (Node $subNode) use ($otherTypes): null {
             if (in_array($subNode::class, $otherTypes, true)) {
                 $subNode->setAttribute(AttributeKey::SKIPPED_BY_RECTOR_RULE, static::class);
             }

--- a/src/Reflection/ClassModifierChecker.php
+++ b/src/Reflection/ClassModifierChecker.php
@@ -7,10 +7,10 @@ namespace Rector\Reflection;
 use PhpParser\Node;
 use PHPStan\Reflection\ClassReflection;
 
-final class ClassModifierChecker
+final readonly class ClassModifierChecker
 {
     public function __construct(
-        private readonly ReflectionResolver $reflectionResolver
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/Reflection/MethodReflectionResolver.php
+++ b/src/Reflection/MethodReflectionResolver.php
@@ -8,10 +8,10 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 
-final class MethodReflectionResolver
+final readonly class MethodReflectionResolver
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -31,15 +31,15 @@ use Rector\PhpParser\AstResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\ValueObject\MethodName;
 
-final class ReflectionResolver
+final readonly class ReflectionResolver
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ClassAnalyzer $classAnalyzer,
-        private readonly MethodReflectionResolver $methodReflectionResolver,
-        private readonly AstResolver $astResolver
+        private ReflectionProvider $reflectionProvider,
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver,
+        private ClassAnalyzer $classAnalyzer,
+        private MethodReflectionResolver $methodReflectionResolver,
+        private AstResolver $astResolver
     ) {
     }
 

--- a/src/Skipper/Matcher/FileInfoMatcher.php
+++ b/src/Skipper/Matcher/FileInfoMatcher.php
@@ -8,12 +8,12 @@ use Rector\Skipper\FileSystem\FnMatchPathNormalizer;
 use Rector\Skipper\Fnmatcher;
 use Rector\Skipper\RealpathMatcher;
 
-final class FileInfoMatcher
+final readonly class FileInfoMatcher
 {
     public function __construct(
-        private readonly FnMatchPathNormalizer $fnMatchPathNormalizer,
-        private readonly Fnmatcher $fnmatcher,
-        private readonly RealpathMatcher $realpathMatcher
+        private FnMatchPathNormalizer $fnMatchPathNormalizer,
+        private Fnmatcher $fnmatcher,
+        private RealpathMatcher $realpathMatcher
     ) {
     }
 

--- a/src/Skipper/SkipVoter/ClassSkipVoter.php
+++ b/src/Skipper/SkipVoter/ClassSkipVoter.php
@@ -9,12 +9,12 @@ use Rector\Skipper\Contract\SkipVoterInterface;
 use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
 use Rector\Skipper\Skipper\SkipSkipper;
 
-final class ClassSkipVoter implements SkipVoterInterface
+final readonly class ClassSkipVoter implements SkipVoterInterface
 {
     public function __construct(
-        private readonly SkipSkipper $skipSkipper,
-        private readonly SkippedClassResolver $skippedClassResolver,
-        private readonly ReflectionProvider $reflectionProvider
+        private SkipSkipper $skipSkipper,
+        private SkippedClassResolver $skippedClassResolver,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/Skipper/Skipper/SkipSkipper.php
+++ b/src/Skipper/Skipper/SkipSkipper.php
@@ -6,10 +6,10 @@ namespace Rector\Skipper\Skipper;
 
 use Rector\Skipper\Matcher\FileInfoMatcher;
 
-final class SkipSkipper
+final readonly class SkipSkipper
 {
     public function __construct(
-        private readonly FileInfoMatcher $fileInfoMatcher
+        private FileInfoMatcher $fileInfoMatcher
     ) {
     }
 

--- a/src/Skipper/Skipper/Skipper.php
+++ b/src/Skipper/Skipper/Skipper.php
@@ -14,7 +14,7 @@ use Webmozart\Assert\Assert;
  * @api
  * @see \Rector\Tests\Skipper\Skipper\SkipperTest
  */
-final class Skipper
+final readonly class Skipper
 {
     /**
      * @var string
@@ -25,8 +25,8 @@ final class Skipper
      * @param array<SkipVoterInterface> $skipVoters
      */
     public function __construct(
-        private readonly RectifiedAnalyzer $rectifiedAnalyzer,
-        private readonly array $skipVoters,
+        private RectifiedAnalyzer $rectifiedAnalyzer,
+        private array $skipVoters,
     ) {
         Assert::allIsInstanceOf($this->skipVoters, SkipVoterInterface::class);
     }

--- a/src/StaticReflection/DynamicSourceLocatorDecorator.php
+++ b/src/StaticReflection/DynamicSourceLocatorDecorator.php
@@ -12,12 +12,12 @@ use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\Dy
  * @see https://phpstan.org/blog/zero-config-analysis-with-static-reflection
  * @see https://github.com/rectorphp/rector/issues/3490
  */
-final class DynamicSourceLocatorDecorator
+final readonly class DynamicSourceLocatorDecorator
 {
     public function __construct(
-        private readonly DynamicSourceLocatorProvider $dynamicSourceLocatorProvider,
-        private readonly FileAndDirectoryFilter $fileAndDirectoryFilter,
-        private readonly FilesystemTweaker $filesystemTweaker
+        private DynamicSourceLocatorProvider $dynamicSourceLocatorProvider,
+        private FileAndDirectoryFilter $fileAndDirectoryFilter,
+        private FilesystemTweaker $filesystemTweaker
     ) {
     }
 

--- a/src/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
+++ b/src/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
@@ -14,13 +14,13 @@ use Rector\Exception\NotImplementedYetException;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
 
-final class PhpParserNodeMapper
+final readonly class PhpParserNodeMapper
 {
     /**
      * @param PhpParserNodeMapperInterface[] $phpParserNodeMappers
      */
     public function __construct(
-        private readonly iterable $phpParserNodeMappers
+        private iterable $phpParserNodeMappers
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpDoc/PhpDocTypeMapper.php
+++ b/src/StaticTypeMapper/PhpDoc/PhpDocTypeMapper.php
@@ -15,14 +15,14 @@ use Webmozart\Assert\Assert;
 /**
  * @see \Rector\Tests\StaticTypeMapper\PhpDoc\PhpDocTypeMapperTest
  */
-final class PhpDocTypeMapper
+final readonly class PhpDocTypeMapper
 {
     /**
      * @param PhpDocTypeMapperInterface[] $phpDocTypeMappers
      */
     public function __construct(
-        private readonly array $phpDocTypeMappers,
-        private readonly TypeNodeResolver $typeNodeResolver
+        private array $phpDocTypeMappers,
+        private TypeNodeResolver $typeNodeResolver
     ) {
         Assert::notEmpty($phpDocTypeMappers);
     }

--- a/src/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
+++ b/src/StaticTypeMapper/PhpDocParser/IdentifierTypeMapper.php
@@ -34,13 +34,13 @@ use Rector\TypeDeclaration\PHPStan\ObjectTypeSpecifier;
 /**
  * @implements PhpDocTypeMapperInterface<IdentifierTypeNode>
  */
-final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
+final readonly class IdentifierTypeMapper implements PhpDocTypeMapperInterface
 {
     public function __construct(
-        private readonly ObjectTypeSpecifier $objectTypeSpecifier,
-        private readonly ScalarStringToTypeMapper $scalarStringToTypeMapper,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly ReflectionResolver $reflectionResolver
+        private ObjectTypeSpecifier $objectTypeSpecifier,
+        private ScalarStringToTypeMapper $scalarStringToTypeMapper,
+        private ReflectionProvider $reflectionProvider,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpDocParser/IntersectionTypeMapper.php
+++ b/src/StaticTypeMapper/PhpDocParser/IntersectionTypeMapper.php
@@ -17,10 +17,10 @@ use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 /**
  * @implements PhpDocTypeMapperInterface<IntersectionTypeNode>
  */
-final class IntersectionTypeMapper implements PhpDocTypeMapperInterface
+final readonly class IntersectionTypeMapper implements PhpDocTypeMapperInterface
 {
     public function __construct(
-        private readonly IdentifierTypeMapper $identifierTypeMapper
+        private IdentifierTypeMapper $identifierTypeMapper
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpDocParser/NullableTypeMapper.php
+++ b/src/StaticTypeMapper/PhpDocParser/NullableTypeMapper.php
@@ -18,11 +18,11 @@ use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 /**
  * @implements PhpDocTypeMapperInterface<NullableTypeNode>
  */
-final class NullableTypeMapper implements PhpDocTypeMapperInterface
+final readonly class NullableTypeMapper implements PhpDocTypeMapperInterface
 {
     public function __construct(
-        private readonly IdentifierTypeMapper $identifierTypeMapper,
-        private readonly TypeNodeResolver $typeNodeResolver
+        private IdentifierTypeMapper $identifierTypeMapper,
+        private TypeNodeResolver $typeNodeResolver
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpDocParser/UnionTypeMapper.php
+++ b/src/StaticTypeMapper/PhpDocParser/UnionTypeMapper.php
@@ -18,13 +18,13 @@ use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 /**
  * @implements PhpDocTypeMapperInterface<UnionTypeNode>
  */
-final class UnionTypeMapper implements PhpDocTypeMapperInterface
+final readonly class UnionTypeMapper implements PhpDocTypeMapperInterface
 {
     public function __construct(
-        private readonly TypeFactory $typeFactory,
-        private readonly IdentifierTypeMapper $identifierTypeMapper,
-        private readonly IntersectionTypeMapper $intersectionTypeMapper,
-        private readonly TypeNodeResolver $typeNodeResolver
+        private TypeFactory $typeFactory,
+        private IdentifierTypeMapper $identifierTypeMapper,
+        private IntersectionTypeMapper $intersectionTypeMapper,
+        private TypeNodeResolver $typeNodeResolver
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpParser/IdentifierNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/IdentifierNodeMapper.php
@@ -13,10 +13,10 @@ use Rector\StaticTypeMapper\Mapper\ScalarStringToTypeMapper;
 /**
  * @implements PhpParserNodeMapperInterface<Identifier>
  */
-final class IdentifierNodeMapper implements PhpParserNodeMapperInterface
+final readonly class IdentifierNodeMapper implements PhpParserNodeMapperInterface
 {
     public function __construct(
-        private readonly ScalarStringToTypeMapper $scalarStringToTypeMapper
+        private ScalarStringToTypeMapper $scalarStringToTypeMapper
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpParser/IntersectionTypeNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/IntersectionTypeNodeMapper.php
@@ -14,12 +14,12 @@ use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
 /**
  * @implements PhpParserNodeMapperInterface<Node\IntersectionType>
  */
-final class IntersectionTypeNodeMapper implements PhpParserNodeMapperInterface
+final readonly class IntersectionTypeNodeMapper implements PhpParserNodeMapperInterface
 {
     public function __construct(
-        private readonly FullyQualifiedNodeMapper $fullyQualifiedNodeMapper,
-        private readonly NameNodeMapper $nameNodeMapper,
-        private readonly IdentifierNodeMapper $identifierNodeMapper
+        private FullyQualifiedNodeMapper $fullyQualifiedNodeMapper,
+        private NameNodeMapper $nameNodeMapper,
+        private IdentifierNodeMapper $identifierNodeMapper
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
@@ -31,12 +31,12 @@ use Rector\StaticTypeMapper\ValueObject\Type\SelfStaticType;
 /**
  * @implements PhpParserNodeMapperInterface<Name>
  */
-final class NameNodeMapper implements PhpParserNodeMapperInterface
+final readonly class NameNodeMapper implements PhpParserNodeMapperInterface
 {
     public function __construct(
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
-        private readonly ReflectionProvider $reflectionProvider,
-        private readonly ReflectionResolver $reflectionResolver
+        private RenamedClassesDataCollector $renamedClassesDataCollector,
+        private ReflectionProvider $reflectionProvider,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpParser/NullableTypeNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/NullableTypeNodeMapper.php
@@ -16,13 +16,13 @@ use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
 /**
  * @implements PhpParserNodeMapperInterface<NullableType>
  */
-final class NullableTypeNodeMapper implements PhpParserNodeMapperInterface
+final readonly class NullableTypeNodeMapper implements PhpParserNodeMapperInterface
 {
     public function __construct(
-        private readonly TypeFactory $typeFactory,
-        private readonly FullyQualifiedNodeMapper $fullyQualifiedNodeMapper,
-        private readonly NameNodeMapper $nameNodeMapper,
-        private readonly IdentifierNodeMapper $identifierNodeMapper
+        private TypeFactory $typeFactory,
+        private FullyQualifiedNodeMapper $fullyQualifiedNodeMapper,
+        private NameNodeMapper $nameNodeMapper,
+        private IdentifierNodeMapper $identifierNodeMapper
     ) {
     }
 

--- a/src/StaticTypeMapper/PhpParser/UnionTypeNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/UnionTypeNodeMapper.php
@@ -16,14 +16,14 @@ use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
 /**
  * @implements PhpParserNodeMapperInterface<UnionType>
  */
-final class UnionTypeNodeMapper implements PhpParserNodeMapperInterface
+final readonly class UnionTypeNodeMapper implements PhpParserNodeMapperInterface
 {
     public function __construct(
-        private readonly TypeFactory $typeFactory,
-        private readonly FullyQualifiedNodeMapper $fullyQualifiedNodeMapper,
-        private readonly NameNodeMapper $nameNodeMapper,
-        private readonly IdentifierNodeMapper $identifierNodeMapper,
-        private readonly IntersectionTypeNodeMapper $intersectionTypeNodeMapper
+        private TypeFactory $typeFactory,
+        private FullyQualifiedNodeMapper $fullyQualifiedNodeMapper,
+        private NameNodeMapper $nameNodeMapper,
+        private IdentifierNodeMapper $identifierNodeMapper,
+        private IntersectionTypeNodeMapper $intersectionTypeNodeMapper
     ) {
     }
 

--- a/src/StaticTypeMapper/StaticTypeMapper.php
+++ b/src/StaticTypeMapper/StaticTypeMapper.php
@@ -28,13 +28,13 @@ use Rector\StaticTypeMapper\PhpDoc\PhpDocTypeMapper;
  * Maps PhpParser <=> PHPStan <=> PHPStan doc <=> string type nodes between all possible formats
  * @see \Rector\Tests\NodeTypeResolver\StaticTypeMapper\StaticTypeMapperTest
  */
-final class StaticTypeMapper
+final readonly class StaticTypeMapper
 {
     public function __construct(
-        private readonly NameScopeFactory $nameScopeFactory,
-        private readonly PHPStanStaticTypeMapper $phpStanStaticTypeMapper,
-        private readonly PhpDocTypeMapper $phpDocTypeMapper,
-        private readonly PhpParserNodeMapper $phpParserNodeMapper
+        private NameScopeFactory $nameScopeFactory,
+        private PHPStanStaticTypeMapper $phpStanStaticTypeMapper,
+        private PhpDocTypeMapper $phpDocTypeMapper,
+        private PhpParserNodeMapper $phpParserNodeMapper
     ) {
     }
 

--- a/src/Testing/PHPUnit/ValueObject/RectorTestResult.php
+++ b/src/Testing/PHPUnit/ValueObject/RectorTestResult.php
@@ -10,11 +10,11 @@ use Rector\ValueObject\ProcessResult;
 /**
  * @api used in tests
  */
-final class RectorTestResult
+final readonly class RectorTestResult
 {
     public function __construct(
-        private readonly string $changedContents,
-        private readonly ProcessResult $processResult
+        private string $changedContents,
+        private ProcessResult $processResult
     ) {
     }
 

--- a/src/Testing/TestingParser/TestingParser.php
+++ b/src/Testing/TestingParser/TestingParser.php
@@ -15,13 +15,13 @@ use Rector\ValueObject\Application\File;
 /**
  * @api
  */
-final class TestingParser
+final readonly class TestingParser
 {
     public function __construct(
-        private readonly RectorParser $rectorParser,
-        private readonly NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
-        private readonly CurrentFileProvider $currentFileProvider,
-        private readonly DynamicSourceLocatorProvider $dynamicSourceLocatorProvider,
+        private RectorParser $rectorParser,
+        private NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
+        private CurrentFileProvider $currentFileProvider,
+        private DynamicSourceLocatorProvider $dynamicSourceLocatorProvider,
     ) {
     }
 

--- a/src/ValueObject/Bootstrap/BootstrapConfigs.php
+++ b/src/ValueObject/Bootstrap/BootstrapConfigs.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\ValueObject\Bootstrap;
 
-final class BootstrapConfigs
+final readonly class BootstrapConfigs
 {
     /**
      * @param string[] $setConfigFiles
      */
     public function __construct(
-        private readonly ?string $mainConfigFile,
-        private readonly array $setConfigFiles
+        private ?string $mainConfigFile,
+        private array $setConfigFiles
     ) {
     }
 

--- a/src/ValueObject/Error/SystemError.php
+++ b/src/ValueObject/Error/SystemError.php
@@ -7,13 +7,13 @@ namespace Rector\ValueObject\Error;
 use Rector\Parallel\ValueObject\BridgeItem;
 use Symplify\EasyParallel\Contract\SerializableInterface;
 
-final class SystemError implements SerializableInterface
+final readonly class SystemError implements SerializableInterface
 {
     public function __construct(
-        private readonly string $message,
-        private readonly string|null $relativeFilePath = null,
-        private readonly int|null $line = null,
-        private readonly string|null $rectorClass = null
+        private string $message,
+        private string|null $relativeFilePath = null,
+        private int|null $line = null,
+        private string|null $rectorClass = null
     ) {
     }
 

--- a/src/ValueObject/FileProcessResult.php
+++ b/src/ValueObject/FileProcessResult.php
@@ -9,16 +9,16 @@ use Rector\ValueObject\Error\SystemError;
 use Rector\ValueObject\Reporting\FileDiff;
 use Webmozart\Assert\Assert;
 
-final class FileProcessResult
+final readonly class FileProcessResult
 {
     /**
      * @param SystemError[] $systemErrors
      * @param CollectedData[] $collectedDatas
      */
     public function __construct(
-        private readonly array $systemErrors,
-        private readonly ?FileDiff $fileDiff,
-        private readonly array $collectedDatas
+        private array $systemErrors,
+        private ?FileDiff $fileDiff,
+        private array $collectedDatas
     ) {
         Assert::allIsInstanceOf($systemErrors, SystemError::class);
         Assert::allIsInstanceOf($collectedDatas, CollectedData::class);

--- a/src/ValueObject/FuncCallAndExpr.php
+++ b/src/ValueObject/FuncCallAndExpr.php
@@ -7,11 +7,11 @@ namespace Rector\ValueObject;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 
-final class FuncCallAndExpr
+final readonly class FuncCallAndExpr
 {
     public function __construct(
-        private readonly FuncCall $funcCall,
-        private readonly Expr $expr
+        private FuncCall $funcCall,
+        private Expr $expr
     ) {
     }
 

--- a/src/ValueObject/Reporting/FileDiff.php
+++ b/src/ValueObject/Reporting/FileDiff.php
@@ -11,7 +11,7 @@ use Rector\Parallel\ValueObject\BridgeItem;
 use Symplify\EasyParallel\Contract\SerializableInterface;
 use Webmozart\Assert\Assert;
 
-final class FileDiff implements SerializableInterface
+final readonly class FileDiff implements SerializableInterface
 {
     /**
      * @var string
@@ -28,10 +28,10 @@ final class FileDiff implements SerializableInterface
      * @param RectorWithLineChange[] $rectorsWithLineChanges
      */
     public function __construct(
-        private readonly string $relativeFilePath,
-        private readonly string $diff,
-        private readonly string $diffConsoleFormatted,
-        private readonly array $rectorsWithLineChanges = []
+        private string $relativeFilePath,
+        private string $diff,
+        private string $diffConsoleFormatted,
+        private array $rectorsWithLineChanges = []
     ) {
         Assert::allIsInstanceOf($rectorsWithLineChanges, RectorWithLineChange::class);
     }

--- a/src/ValueObject/SprintfStringAndArgs.php
+++ b/src/ValueObject/SprintfStringAndArgs.php
@@ -7,14 +7,14 @@ namespace Rector\ValueObject;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar\String_;
 
-final class SprintfStringAndArgs
+final readonly class SprintfStringAndArgs
 {
     /**
      * @param Expr[] $arrayItems
      */
     public function __construct(
-        private readonly String_ $string,
-        private readonly array $arrayItems
+        private String_ $string,
+        private array $arrayItems
     ) {
     }
 

--- a/src/ValueObjectFactory/Application/FileFactory.php
+++ b/src/ValueObjectFactory/Application/FileFactory.php
@@ -11,11 +11,11 @@ use Rector\ValueObject\Configuration;
 /**
  * @see \Rector\ValueObject\Application\File
  */
-final class FileFactory
+final readonly class FileFactory
 {
     public function __construct(
-        private readonly FilesFinder $filesFinder,
-        private readonly ChangedFilesDetector $changedFilesDetector,
+        private FilesFinder $filesFinder,
+        private ChangedFilesDetector $changedFilesDetector,
     ) {
     }
 

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
@@ -11,13 +11,13 @@ use Rector\FileSystem\FilePathHelper;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Reflection\ReflectionResolver;
 
-final class ClassMethodParamVendorLockResolver
+final readonly class ClassMethodParamVendorLockResolver
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly FilePathHelper $filePathHelper
+        private NodeNameResolver $nodeNameResolver,
+        private FamilyRelationsAnalyzer $familyRelationsAnalyzer,
+        private ReflectionResolver $reflectionResolver,
+        private FilePathHelper $filePathHelper
     ) {
     }
 

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -22,15 +22,15 @@ use Rector\Reflection\ReflectionResolver;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 
-final class ClassMethodReturnTypeOverrideGuard
+final readonly class ClassMethodReturnTypeOverrideGuard
 {
     public function __construct(
-        private readonly FamilyRelationsAnalyzer $familyRelationsAnalyzer,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly ReturnTypeInferer $returnTypeInferer,
-        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
-        private readonly FilePathHelper $filePathHelper,
-        private readonly MagicClassMethodAnalyzer $magicClassMethodAnalyzer
+        private FamilyRelationsAnalyzer $familyRelationsAnalyzer,
+        private ReflectionResolver $reflectionResolver,
+        private ReturnTypeInferer $returnTypeInferer,
+        private ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private FilePathHelper $filePathHelper,
+        private MagicClassMethodAnalyzer $magicClassMethodAnalyzer
     ) {
     }
 

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -11,11 +11,11 @@ use PHPStan\Type\MixedType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Reflection\ReflectionResolver;
 
-final class ClassMethodReturnVendorLockResolver
+final readonly class ClassMethodReturnVendorLockResolver
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionResolver $reflectionResolver
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 

--- a/src/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/src/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -15,14 +15,14 @@ use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\VendorLocker\Exception\UnresolvableClassException;
 
-final class ParentClassMethodTypeOverrideGuard
+final readonly class ParentClassMethodTypeOverrideGuard
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly TypeComparator $typeComparator,
-        private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionResolver $reflectionResolver,
+        private TypeComparator $typeComparator,
+        private StaticTypeMapper $staticTypeMapper,
+        private ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }
 

--- a/src/VersionBonding/PhpVersionedFilter.php
+++ b/src/VersionBonding/PhpVersionedFilter.php
@@ -10,11 +10,11 @@ use Rector\Php\PolyfillPackagesProvider;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Rector\VersionBonding\Contract\RelatedPolyfillInterface;
 
-final class PhpVersionedFilter
+final readonly class PhpVersionedFilter
 {
     public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly PolyfillPackagesProvider $polyfillPackagesProvider,
+        private PhpVersionProvider $phpVersionProvider,
+        private PolyfillPackagesProvider $polyfillPackagesProvider,
     ) {
     }
 

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -19,7 +19,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"

--- a/utils/PHPStan/Rule/LongAndDependentComplexRectorRule.php
+++ b/utils/PHPStan/Rule/LongAndDependentComplexRectorRule.php
@@ -23,19 +23,19 @@ use TomasVotruba\CognitiveComplexity\AstCognitiveComplexityAnalyzer;
  * @implements Rule<InClassNode>
  * This rule helps to find overly complex rules, that usually have little value, but are costrly to run.
  */
-final class LongAndDependentComplexRectorRule implements Rule
+final readonly class LongAndDependentComplexRectorRule implements Rule
 {
     /**
      * @var int
      */
     private const ALLOWED_TRANSITIONAL_COMPLEXITY = 140;
 
-    private readonly Parser $phpParser;
+    private Parser $phpParser;
 
-    private readonly NodeFinder $nodeFinder;
+    private NodeFinder $nodeFinder;
 
     public function __construct(
-        private readonly AstCognitiveComplexityAnalyzer $astCognitiveComplexityAnalyzer,
+        private AstCognitiveComplexityAnalyzer $astCognitiveComplexityAnalyzer,
     ) {
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->create(ParserFactory::PREFER_PHP7);


### PR DESCRIPTION
Let's eat our own dog food and move to upgrade (and downgrade) to PHP 8.2 

PHP 8.1 is security-only already ↓
https://www.php.net/supported-versions.php