### PR TITLE
Create keep_used_method.php.inc #8382

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/keep_used_method.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/keep_used_method.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+class Foo {
+	public function bar() {
+		$this->gaz();
+	}
+
+	private function gaz() {
+	}
+}
+
+(new Foo())->bar();


### PR DESCRIPTION
Rector should not remove empty private methods that are called from somewhere