### PR TITLE
Create skip_not_readonly_function_call_in_condition.php.inc #8381

### DIFF
--- a/rules-tests/DeadCode/Rector/Return_/RemoveDeadConditionAboveReturnRector/Fixture/skip_not_readonly_function_call_in_condition.php.inc
+++ b/rules-tests/DeadCode/Rector/Return_/RemoveDeadConditionAboveReturnRector/Fixture/skip_not_readonly_function_call_in_condition.php.inc
@@ -1,0 +1,11 @@
+<?php
+$Entity = new Entity();
+saveMyEntity($Entity);
+
+function saveMyEntity($Entity) {
+  if($Entity->save()) {
+    return true;
+  }
+
+  return true;
+}


### PR DESCRIPTION
Rector should not remove if() conditions if they contain a function call that is not proven read-only