### PR TITLE
fix: RenameMethodRector should handle NullsafeMethodCall

### DIFF
--- a/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/rename_nullsafe_method_call.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameMethodRector/Fixture/rename_nullsafe_method_call.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture;
+
+class RenameNullSafeMethodCall
+{
+    private function createHtml()
+    {
+        $html = new \Nette\Utils\Html();
+        $html?->add('someContent');
+
+        $anotherHtml = $html;
+        $anotherHtml?->add('someContent');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Fixture;
+
+class RenameNullSafeMethodCall
+{
+    private function createHtml()
+    {
+        $html = new \Nette\Utils\Html();
+        $html?->addHtml('someContent');
+
+        $anotherHtml = $html;
+        $anotherHtml?->addHtml('someContent');
+    }
+}
+
+?>

--- a/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
@@ -8,6 +8,7 @@ use PhpParser\BuilderHelpers;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
@@ -68,11 +69,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [MethodCall::class, StaticCall::class, Class_::class, Interface_::class];
+        return [MethodCall::class, NullsafeMethodCall::class, StaticCall::class, Class_::class, Interface_::class];
     }
 
     /**
-     * @param MethodCall|StaticCall|Class_|Interface_ $node
+     * @param MethodCall|NullsafeMethodCall|StaticCall|Class_|Interface_ $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
@@ -94,7 +95,7 @@ CODE_SAMPLE
     }
 
     private function shouldSkipClassMethod(
-        MethodCall | StaticCall $call,
+        MethodCall|NullsafeMethodCall|StaticCall $call,
         MethodCallRenameInterface $methodCallRename
     ): bool {
         $classReflection = $this->reflectionResolver->resolveClassReflectionSourceObject($call);
@@ -212,8 +213,8 @@ CODE_SAMPLE
     }
 
     private function refactorMethodCallAndStaticCall(
-        StaticCall|MethodCall $call
-    ): ArrayDimFetch|null|MethodCall|StaticCall {
+        StaticCall|MethodCall|NullsafeMethodCall $call
+    ): ArrayDimFetch|null|MethodCall|StaticCall|NullsafeMethodCall {
         $callName = $this->getName($call->name);
         if ($callName === null) {
             return null;

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -301,7 +301,7 @@ final class NodeTypeResolver
 
     public function isMethodStaticCallOrClassMethodObjectType(Node $node, ObjectType $objectType): bool
     {
-        if ($node instanceof MethodCall) {
+        if ($node instanceof MethodCall || $node instanceof Expr\NullsafeMethodCall) {
             // method call is variable return
             return $this->isObjectType($node->var, $objectType);
         }

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
@@ -174,9 +175,9 @@ final class AstResolver
         return $classMethod;
     }
 
-    public function resolveClassMethodFromCall(MethodCall | StaticCall $call): ?ClassMethod
+    public function resolveClassMethodFromCall(MethodCall | StaticCall | NullsafeMethodCall $call): ?ClassMethod
     {
-        $callerStaticType = $call instanceof MethodCall
+        $callerStaticType = ($call instanceof MethodCall || $call instanceof NullsafeMethodCall)
             ? $this->nodeTypeResolver->getType($call->var)
             : $this->nodeTypeResolver->getType($call->class);
 

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
@@ -76,7 +77,7 @@ final readonly class ReflectionResolver
     }
 
     public function resolveClassReflectionSourceObject(
-        MethodCall|StaticCall|PropertyFetch|StaticPropertyFetch $node
+        MethodCall|NullsafeMethodCall|StaticCall|PropertyFetch|StaticPropertyFetch $node
     ): ?ClassReflection {
         if ($node instanceof PropertyFetch || $node instanceof StaticPropertyFetch) {
             $objectType = $node instanceof PropertyFetch

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -204,7 +204,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         if (file_exists(__DIR__ . '/../../../preload.php')) {
             if (file_exists(__DIR__ . '/../../../vendor')) {
                 require_once __DIR__ . '/../../../preload.php';
-            // test case in rector split package
+                // test case in rector split package
             } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
                 require_once __DIR__ . '/../../../preload-split-package.php';
             }


### PR DESCRIPTION
Hello!

I think `RenameMethodRector` should also be applied on nullsafe method calls.

WDYT?

