### PR TITLE
[Performance] Extract PathSkipVoter to dedicated service and call before Filesystem::read()

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -11,6 +11,7 @@ use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Parallel\Application\ParallelFileProcessor;
 use Rector\Provider\CurrentFileProvider;
+use Rector\Skipper\Skipper\PathSkipper;
 use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
 use Rector\Util\ArrayParametersMerger;
 use Rector\ValueObject\Application\File;
@@ -49,6 +50,7 @@ final class ApplicationFileProcessor
         private readonly CurrentFileProvider $currentFileProvider,
         private readonly FileProcessor $fileProcessor,
         private readonly ArrayParametersMerger $arrayParametersMerger,
+        private readonly PathSkipper $pathSkipper
     ) {
     }
 
@@ -122,6 +124,10 @@ final class ApplicationFileProcessor
         $collectedData = [];
 
         foreach ($filePaths as $filePath) {
+            if ($this->pathSkipper->shouldSkip($filePath)) {
+                continue;
+            }
+
             if ($preFileCallback !== null) {
                 $preFileCallback($filePath);
             }

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -159,7 +159,6 @@ use Rector\Rector\AbstractRector;
 use Rector\Skipper\Contract\SkipVoterInterface;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\Skipper\SkipVoter\ClassSkipVoter;
-use Rector\Skipper\SkipVoter\PathSkipVoter;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
 use Rector\StaticTypeMapper\Mapper\PhpParserNodeMapper;
@@ -366,7 +365,7 @@ final class LazyContainerFactory
     /**
      * @var array<class-string<SkipVoterInterface>>
      */
-    private const SKIP_VOTER_CLASSES = [ClassSkipVoter::class, PathSkipVoter::class];
+    private const SKIP_VOTER_CLASSES = [ClassSkipVoter::class];
 
     /**
      * @api used as next rectorConfig factory

--- a/src/Skipper/SkipCriteriaResolver/SkippedPathsResolver.php
+++ b/src/Skipper/SkipCriteriaResolver/SkippedPathsResolver.php
@@ -17,7 +17,7 @@ final class SkippedPathsResolver
     /**
      * @var null|string[]
      */
-    private ?array $skippedPaths = null;
+    private null|array $skippedPaths = null;
 
     public function __construct(
         private readonly FilePathHelper $filePathHelper

--- a/src/Skipper/SkipCriteriaResolver/SkippedPathsResolver.php
+++ b/src/Skipper/SkipCriteriaResolver/SkippedPathsResolver.php
@@ -15,9 +15,9 @@ use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
 final class SkippedPathsResolver
 {
     /**
-     * @var string[]
+     * @var null|string[]
      */
-    private array $skippedPaths = [];
+    private ?array $skippedPaths = null;
 
     public function __construct(
         private readonly FilePathHelper $filePathHelper
@@ -29,17 +29,18 @@ final class SkippedPathsResolver
      */
     public function resolve(): array
     {
+        // disable cache in tests
         if (StaticPHPUnitEnvironment::isPHPUnitRun()) {
-            // disable cache in tests
-            $this->skippedPaths = [];
+            $this->skippedPaths = null;
         }
 
-        // disable cache in tests
-        if ($this->skippedPaths !== []) {
+        // already filled, even empty array
+        if ($this->skippedPaths !== null) {
             return $this->skippedPaths;
         }
 
         $skip = SimpleParameterProvider::provideArrayParameter(Option::SKIP);
+        $this->skippedPaths = [];
 
         foreach ($skip as $key => $value) {
             if (! is_int($key)) {

--- a/src/Skipper/Skipper/PathSkipper.php
+++ b/src/Skipper/Skipper/PathSkipper.php
@@ -9,11 +9,6 @@ use Rector\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
 
 final class PathSkipper
 {
-    /**
-     * @var array<string, bool>
-     */
-    private array $skippedFiles = [];
-
     public function __construct(
         private readonly FileInfoMatcher $fileInfoMatcher,
         private readonly SkippedPathsResolver $skippedPathsResolver
@@ -22,12 +17,8 @@ final class PathSkipper
 
     public function shouldSkip(string $filePath): bool
     {
-        if (isset($this->skippedFiles[$filePath])) {
-            return $this->skippedFiles[$filePath];
-        }
-
         $skippedPaths = $this->skippedPathsResolver->resolve();
-        return $this->skippedFiles[$filePath] = $this->fileInfoMatcher->doesFileInfoMatchPatterns(
+        return $this->fileInfoMatcher->doesFileInfoMatchPatterns(
             $filePath,
             $skippedPaths
         );

--- a/src/Skipper/Skipper/PathSkipper.php
+++ b/src/Skipper/Skipper/PathSkipper.php
@@ -2,13 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Rector\Skipper\SkipVoter;
+namespace Rector\Skipper\Skipper;
 
-use Rector\Skipper\Contract\SkipVoterInterface;
 use Rector\Skipper\Matcher\FileInfoMatcher;
 use Rector\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
 
-final class PathSkipVoter implements SkipVoterInterface
+final class PathSkipper
 {
     /**
      * @var array<string, bool>
@@ -21,12 +20,7 @@ final class PathSkipVoter implements SkipVoterInterface
     ) {
     }
 
-    public function match(string | object $element): bool
-    {
-        return true;
-    }
-
-    public function shouldSkip(string | object $element, string $filePath): bool
+    public function shouldSkip(string $filePath): bool
     {
         if (isset($this->skippedFiles[$filePath])) {
             return $this->skippedFiles[$filePath];

--- a/src/Skipper/Skipper/PathSkipper.php
+++ b/src/Skipper/Skipper/PathSkipper.php
@@ -7,11 +7,11 @@ namespace Rector\Skipper\Skipper;
 use Rector\Skipper\Matcher\FileInfoMatcher;
 use Rector\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
 
-final class PathSkipper
+final readonly class PathSkipper
 {
     public function __construct(
-        private readonly FileInfoMatcher $fileInfoMatcher,
-        private readonly SkippedPathsResolver $skippedPathsResolver
+        private FileInfoMatcher $fileInfoMatcher,
+        private SkippedPathsResolver $skippedPathsResolver
     ) {
     }
 

--- a/src/Skipper/Skipper/Skipper.php
+++ b/src/Skipper/Skipper/Skipper.php
@@ -17,16 +17,12 @@ use Webmozart\Assert\Assert;
 final readonly class Skipper
 {
     /**
-     * @var string
-     */
-    private const FILE_ELEMENT = 'file_elements';
-
-    /**
      * @param array<SkipVoterInterface> $skipVoters
      */
     public function __construct(
         private RectifiedAnalyzer $rectifiedAnalyzer,
         private array $skipVoters,
+        private readonly PathSkipper $pathSkipper
     ) {
         Assert::allIsInstanceOf($this->skipVoters, SkipVoterInterface::class);
     }
@@ -38,7 +34,7 @@ final readonly class Skipper
 
     public function shouldSkipFilePath(string $filePath): bool
     {
-        return $this->shouldSkipElementAndFilePath(self::FILE_ELEMENT, $filePath);
+        return $this->pathSkipper->shouldSkip($filePath);
     }
 
     public function shouldSkipElementAndFilePath(string | object $element, string $filePath): bool

--- a/src/Skipper/Skipper/Skipper.php
+++ b/src/Skipper/Skipper/Skipper.php
@@ -22,7 +22,7 @@ final readonly class Skipper
     public function __construct(
         private RectifiedAnalyzer $rectifiedAnalyzer,
         private array $skipVoters,
-        private readonly PathSkipper $pathSkipper
+        private PathSkipper $pathSkipper
     ) {
         Assert::allIsInstanceOf($this->skipVoters, SkipVoterInterface::class);
     }

--- a/tests/Skipper/Skipper/SkipperTest.php
+++ b/tests/Skipper/Skipper/SkipperTest.php
@@ -63,6 +63,8 @@ final class SkipperTest extends AbstractLazyTestCase
         yield [__DIR__ . '/Fixture/SomeSkipped/any.txt', true];
         yield ['tests/Skipper/Skipper/Fixture/SomeSkippedPath/any.txt', true];
         yield ['tests/Skipper/Skipper/Fixture/SomeSkippedPathToFile/any.txt', true];
+        yield [__DIR__ . '/Fixture/AlwaysSkippedPath/some_file.txt', true];
+        yield [__DIR__ . '/Fixture/PathSkippedWithMask/another_file.txt', true];
     }
 
     /**
@@ -91,9 +93,6 @@ final class SkipperTest extends AbstractLazyTestCase
 
         yield [NotSkippedClass::class, __DIR__ . '/Fixture/someFile', false];
         yield [NotSkippedClass::class, __DIR__ . '/Fixture/someOtherFile', false];
-
-        yield ['anything', __DIR__ . '/Fixture/AlwaysSkippedPath/some_file.txt', true];
-        yield ['anything', __DIR__ . '/Fixture/PathSkippedWithMask/another_file.txt', true];
     }
 
     public static function provideDataShouldSkipElement(): Iterator


### PR DESCRIPTION
@TomasVotruba based on https://github.com/rectorphp/rector/issues/8396#issuecomment-1884627124 discussion, this is to improve performance to avoid doing `Filesystem::read()` when the file is skipped.