### PR TITLE
feat: add an option to skip renaming promoted property

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureRenamingDisabled/fixture.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureRenamingDisabled/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+class Fixture
+{
+    public float $x;
+    public float $y;
+    public float $z;
+
+    public function __construct(
+        float $x = 0.0,
+        float $y = 0.0,
+        float $z = 0.0
+    ) {
+        $this->x = $x;
+        $this->y = $y;
+        $this->z = $z;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+class Fixture
+{
+    public function __construct(public float $x = 0.0, public float $y = 0.0, public float $z = 0.0)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureRenamingDisabled/skip_if_different_names.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureRenamingDisabled/skip_if_different_names.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Source\Fixer;
+use Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Source\SkipParentPublic as BaseSkipParentPublic;
+
+final class SkipWhenNameIsDifferent
+{
+    private Fixer $fixer;
+
+    public function __construct(Fixer $notSameName)
+    {
+        $this->fixer = $notSameName;
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/RenamePropertyDisabledTest.php
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/RenamePropertyDisabledTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenamePropertyDisabledTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureRenamingDisabled');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_disabled_renaming.php';
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/config/configured_rule_disabled_renaming.php
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/config/configured_rule_disabled_renaming.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ClassPropertyAssignToConstructorPromotionRector::class, [
+        ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
+    ]);
+};

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -118,31 +118,6 @@ CODE_SAMPLE
                     ,
                     [
                         ClassPropertyAssignToConstructorPromotionRector::INLINE_PUBLIC => false,
-                    ]
-                ),
-                new ConfiguredCodeSample(
-                    <<<'CODE_SAMPLE'
-class SomeClass
-{
-    private HttpClientInterface $client;
-
-    public function __construct(HttpClientInterface $githubClient)
-    {
-        $this->client = $githubClient;
-    }
-}
-CODE_SAMPLE
-                    ,
-                    <<<'CODE_SAMPLE'
-class SomeClass
-{
-    public function __construct(private HttpClientInterface $client)
-    {
-    }
-}
-CODE_SAMPLE
-                    ,
-                    [
                         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => true,
                     ]
                 ),

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -120,6 +120,32 @@ CODE_SAMPLE
                         ClassPropertyAssignToConstructorPromotionRector::INLINE_PUBLIC => false,
                     ]
                 ),
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    private HttpClientInterface $client;
+
+    public function __construct(HttpClientInterface $githubClient)
+    {
+        $this->client = $githubClient;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __construct(private HttpClientInterface $client)
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    [
+                        ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => true,
+                    ]
+                ),
             ]
         );
     }


### PR DESCRIPTION
Add an option to skip property promotion when property and param names are different:

If for example your param name follow a convention for autowiring:

```php
final class MyService
{
    private HttpClientInterface $client;

    public function __construct(HttpClientInterface $githubClient)
    {
        $this->client = $githubClient;
    }
}
```

This will be modified to :
```php
final class MyService
{
    public function __construct(private HttpClientInterface $client)
    {
    }
}
```
Which will be a problem in a Symfony application for example.

This PR add an option to skip promotion when naming is different