### PR TITLE
Fix SingularSwitchToIfRector when switch have only a default clause that contains a break statement

### DIFF
--- a/rules-tests/CodeQuality/Rector/Switch_/SingularSwitchToIfRector/Fixture/default_only_with_a_break.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SingularSwitchToIfRector/Fixture/default_only_with_a_break.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SingularSwitchToIfRector\Fixture;
+
+final class DefaultOnly
+{
+    public function run($value)
+    {
+        $result = 1;
+        switch ($value) {
+            default:
+                $result = 1000;
+                break;
+        }
+
+        return $result;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SingularSwitchToIfRector\Fixture;
+
+final class DefaultOnly
+{
+    public function run($value)
+    {
+        $result = 1;
+        $result = 1000;
+
+        return $result;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Switch_/SingularSwitchToIfRector.php
+++ b/rules/CodeQuality/Rector/Switch_/SingularSwitchToIfRector.php
@@ -7,6 +7,8 @@ namespace Rector\CodeQuality\Rector\Switch_;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Switch_;
 use Rector\Rector\AbstractRector;
@@ -85,9 +87,11 @@ CODE_SAMPLE
 
         // only default → basically unwrap
         if (! $onlyCase->cond instanceof Expr) {
-            return $onlyCase->stmts;
+            // remove default clause because it cause syntax error
+            return array_filter($onlyCase->stmts, function (Stmt $statement) {
+                return ! $statement instanceof Break_;
+            });
         }
-
         $if = new If_(new Identical($node->cond, $onlyCase->cond));
         $if->stmts = $this->switchManipulator->removeBreakNodes($onlyCase->stmts);
 


### PR DESCRIPTION
```
switch ($value) {
    default:
        $result = 1000;
        break;
}
```

translated to 

```
$result = 1000;
break;
```

that cause a php syntax error to occur.