### PR TITLE
feat(callable-this-to-function-rector): allow for CallableThisArrayToAnonymousFunctionRector to replace anonymous function by an arrow function

### DIFF
--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/CallableThisArrayToArrowFunctionRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/CallableThisArrayToArrowFunctionRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CallableThisArrayToArrowFunctionRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureArrowFunction');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_arrow_function.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/another_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/another_class.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\SortingClass;
+
+final class AnotherClass
+{
+    /**
+     * @var SortingClass
+     */
+    private $sortingClass;
+
+    public function __construct(SortingClass $sortingClass)
+    {
+        $this->sortingClass = $sortingClass;
+    }
+
+    public function go($values)
+    {
+        $sortingClass = new SortingClass();
+
+        usort($values, [$this->sortingClass, 'publicSort']);
+
+        usort($values, [$sortingClass, 'publicSort']);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\SortingClass;
+
+final class AnotherClass
+{
+    /**
+     * @var SortingClass
+     */
+    private $sortingClass;
+
+    public function __construct(SortingClass $sortingClass)
+    {
+        $this->sortingClass = $sortingClass;
+    }
+
+    public function go($values)
+    {
+        $sortingClass = new SortingClass();
+
+        usort($values, fn($a, $b) => $this->sortingClass->publicSort($a, $b));
+
+        usort($values, fn($a, $b) => $sortingClass->publicSort($a, $b));
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/default_of_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/default_of_array.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class DefaultOfArray
+{
+    public function run($values)
+    {
+        usort($values, [$this, 'sortMe']);
+    }
+
+    public function sortMe($values = [])
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class DefaultOfArray
+{
+    public function run($values)
+    {
+        usort($values, fn($values = []) => $this->sortMe($values));
+    }
+
+    public function sortMe($values = [])
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/do_not_add_backslash_static.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/do_not_add_backslash_static.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class DoNotAddBackslashStatic
+{
+    public function run(callable $transform)
+    {
+        $transform();
+    }
+
+    public function run2()
+    {
+        $this->run([static::class, 'test']);
+    }
+
+    public static function test(): void
+    {
+        echo 'test';
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class DoNotAddBackslashStatic
+{
+    public function run(callable $transform)
+    {
+        $transform();
+    }
+
+    public function run2()
+    {
+        $this->run(function () : void {
+            static::test();
+        });
+    }
+
+    public static function test(): void
+    {
+        echo 'test';
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/external_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/external_class.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\SortingClass;
+
+final class ExternalClass
+{
+    /**
+     * @var SortingClass
+     */
+    private $sortingClass;
+
+    public function __construct(SortingClass $sortingClass)
+    {
+        $this->sortingClass = $sortingClass;
+    }
+
+    public function noGo($values)
+    {
+        $sortingClass = new SortingClass();
+
+        usort($values, [$this->sortingClass, 'protectedSort']);
+        usort($values, [$sortingClass, 'privateSort']);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\SortingClass;
+
+final class ExternalClass
+{
+    /**
+     * @var SortingClass
+     */
+    private $sortingClass;
+
+    public function __construct(SortingClass $sortingClass)
+    {
+        $this->sortingClass = $sortingClass;
+    }
+
+    public function noGo($values)
+    {
+        $sortingClass = new SortingClass();
+
+        usort($values, fn($a, $b) => $this->sortingClass->protectedSort($a, $b));
+        usort($values, fn($a, $b) => $sortingClass->privateSort($a, $b));
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class Fixture
+{
+    public function run(array $values)
+    {
+        usort($values, [$this, 'compareSize']);
+
+        return $values;
+    }
+
+    private function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class Fixture
+{
+    public function run(array $values)
+    {
+        usort($values, fn(int $first, $second): bool => $this->compareSize($first, $second));
+
+        return $values;
+    }
+
+    private function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/has_construct_with_default_value_parameter.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/has_construct_with_default_value_parameter.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass3;
+
+final class HasConstructWithDefaultValueParameter
+{
+    public function run()
+    {
+        return [OtherClass3::class, 'someMethod'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass3;
+
+final class HasConstructWithDefaultValueParameter
+{
+    public function run()
+    {
+        return fn() => (new \Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass3())->someMethod();
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/no_return_for_void.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/no_return_for_void.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class NoReturnForVoid
+{
+    public function run(array $values)
+    {
+        usort($values, [$this, 'thisReturnsVoid']);
+        usort($values, [$this, 'thisReturnsNothing']);
+
+        return $values;
+    }
+
+    private function thisReturnsVoid(): void
+    {
+    }
+
+    private function thisReturnsNothing(): void
+    {
+        return;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class NoReturnForVoid
+{
+    public function run(array $values)
+    {
+        usort($values, function () : void {
+            $this->thisReturnsVoid();
+        });
+        usort($values, function () : void {
+            $this->thisReturnsNothing();
+        });
+
+        return $values;
+    }
+
+    private function thisReturnsVoid(): void
+    {
+    }
+
+    private function thisReturnsNothing(): void
+    {
+        return;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/other_class_not_has_construct_parameter.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/other_class_not_has_construct_parameter.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass2;
+
+final class OtherClassNotHasConstructParameter
+{
+    public function run()
+    {
+        return [OtherClass2::class, 'someMethod'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass2;
+
+final class OtherClassNotHasConstructParameter
+{
+    public function run()
+    {
+        return fn() => (new \Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass2())->someMethod();
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/param_by_reference_in_target_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/param_by_reference_in_target_method.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class ParamByReferenceInTargetMethod
+{
+    public function run()
+    {
+        $arr = ['string'];
+        array_walk_recursive($arr, [$this, 'append']);
+        var_dump($arr);
+    }
+
+    private function append (string &$str) {
+        $str .= " append this";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class ParamByReferenceInTargetMethod
+{
+    public function run()
+    {
+        $arr = ['string'];
+        array_walk_recursive($arr, fn(string &$str) => $this->append($str));
+        var_dump($arr);
+    }
+
+    private function append (string &$str) {
+        $str .= " append this";
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/same_class_not_has_construct_parameter.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/same_class_not_has_construct_parameter.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SameClassNotHasConstructParameter
+{
+    public function __construct()
+    {
+    }
+
+    public function run()
+    {
+        return [SameClassNotHasConstructParameter::class, 'someMethod'];
+    }
+
+    public function someMethod()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SameClassNotHasConstructParameter
+{
+    public function __construct()
+    {
+    }
+
+    public function run()
+    {
+        return fn() => (new \Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture\SameClassNotHasConstructParameter())->someMethod();
+    }
+
+    public function someMethod()
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class Skip
+{
+    public function run(array $values)
+    {
+        usort($values, [$this, 'compareSizeA']);
+        usort($values, [$that, 'compareSize']);
+
+        return $values;
+    }
+
+    private function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_associative_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_associative_array.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class SkipAssociativeArray
+{
+    public function run()
+    {
+        $data = ['extends' => $this, 'methods' => 'compareSize'];
+    }
+
+    protected function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_attribute_on_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_attribute_on_trait.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\UniqueConstraint(columns: ['public_id', 'tenant_id'])]
+trait SkipAttributeOnTrait
+{
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_empty_first_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_empty_first_array.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SkipEmptyFirstArray
+{
+    public function refactor($node)
+    {
+        [, $comparedNode] = $node;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_error_handler_shutdown.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_error_handler_shutdown.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class SkipErrorHandlerShutdown
+{
+    public function run()
+    {
+        register_shutdown_function([$this, 'shutdown_function']);
+    }
+
+    public function shutdown_function()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_foreach_callable_no_scope.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_foreach_callable_no_scope.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\PostRector\Collector\NodesToReplaceCollector;
+
+final class SkipForeachCallableNoScope
+{
+    public function run(NodesToReplaceCollector $nodesToReplaceCollector, \PhpParser\Node $node)
+    {
+        foreach ($nodesToReplaceCollector->getNodes() as [$nodeToFind, $replacement]) {
+            if ($node === $nodeToFind) {
+                return $replacement;
+            }
+        }
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_forward_static_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_forward_static_call.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SkipForwardStaticCall
+{
+    public function run()
+    {
+        forward_static_call([$this, 'static_function']);
+    }
+
+    public static function static_function()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_in_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_in_attribute.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\LocaleUtils;
+
+class SkipInAttribute
+{
+    #[Assert\Choice(callback: [LocaleUtils::class, 'getAllLocales'])]
+    private ?string $locale = null;
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(?string $locale): Account
+    {
+        $this->locale = $locale;
+        return $this;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_in_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_in_trait.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+trait SkipInTrait
+{
+    public function run(array $values)
+    {
+        usort($values, [$this, 'compareSize']);
+
+        return $values;
+    }
+
+    private function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_other_class_construct.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_other_class_construct.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass3;
+
+final class OtherClassConstruct
+{
+    public function run()
+    {
+        return [OtherClass3::class, '__construct'];
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_other_class_has_construct_parameter.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_other_class_has_construct_parameter.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\OtherClass;
+
+final class SkipOtherClassHasConstructParameter
+{
+    public function run()
+    {
+        return [OtherClass::class, 'someMethod'];
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_same_class_has_construct_parameter.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_same_class_has_construct_parameter.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SkipSameClassHasConstructParameter
+{
+    private $property;
+
+    public function __construct($property)
+    {
+        $this->property = $property;
+    }
+
+    public function run()
+    {
+        return [SkipSameClassHasConstructParameter::class, 'someMethod'];
+    }
+
+    public function someMethod()
+    {
+
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_twig_function.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/skip_twig_function.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Manual\Twig\TwigFilter;
+use Twig\Extension\AbstractExtension;
+
+final class SkipTwigFunction extends AbstractExtension
+{
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('runLocal', [$this, 'runLocal']),
+        ];
+    }
+
+    public function runLocal(): int
+    {
+        return 1000;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/some_static_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/some_static_call.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SomeStaticCall
+{
+    public function run(array $values)
+    {
+        usort($values, [SomeStaticCall::class, 'compareSize']);
+
+        return $values;
+    }
+
+    private static function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SomeStaticCall
+{
+    public function run(array $values)
+    {
+        usort($values, fn(int $first, $second): bool => \Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture\SomeStaticCall::compareSize($first, $second));
+
+        return $values;
+    }
+
+    private static function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/with_parent.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/FixtureArrowFunction/with_parent.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\ParentClass;
+
+class WithParent extends ParentClass
+{
+    public function run(array $values)
+    {
+        usort($values, [$this, 'compareSize']);
+
+        return $values;
+    }
+
+    private function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Source\ParentClass;
+
+class WithParent extends ParentClass
+{
+    public function run(array $values)
+    {
+        usort($values, fn(int $first, $second): bool => $this->compareSize($first, $second));
+
+        return $values;
+    }
+
+    private function compareSize(int $first, $second): bool
+    {
+        return $first <=> $second;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/config/configured_rule_arrow_function.php
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/config/configured_rule_arrow_function.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(CallableThisArrayToAnonymousFunctionRector::class, [
+        CallableThisArrayToAnonymousFunctionRector::ARROW_FUNCTION => true,
+    ]);
+};

--- a/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
+++ b/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
@@ -19,7 +19,7 @@ final readonly class ClosureArrowFunctionAnalyzer
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,
         private NodeComparator $nodeComparator,
-        private ArrayChecker $arrayChecker
+        private ArrayChecker $arrayChecker,
     ) {
     }
 

--- a/rules/Php74/NodeConverter/ClosureToArrowFunctionConverter.php
+++ b/rules/Php74/NodeConverter/ClosureToArrowFunctionConverter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php74\NodeConverter;
+
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use Rector\Php74\NodeAnalyzer\ClosureArrowFunctionAnalyzer;
+
+final readonly class ClosureToArrowFunctionConverter
+{
+    public function __construct(
+        private ClosureArrowFunctionAnalyzer $closureArrowFunctionAnalyzer,
+    ) {
+    }
+
+    public function convert(Closure $closure): ?ArrowFunction
+    {
+        if (! (version_compare(PHP_VERSION, '7.4.0') >= 0)) {
+            return null;
+        }
+
+        $expression = $this->closureArrowFunctionAnalyzer->matchArrowFunctionExpr($closure);
+        if ($expression === null) {
+            return null;
+        }
+
+        return new ArrowFunction([
+            'expr' => $expression,
+            'returnType' => $closure->returnType,
+            'byRef' => $closure->byRef,
+            'params' => $closure->params,
+            'attrGroups' => $closure->attrGroups,
+            'static' => $closure->static,
+        ]);
+    }
+}


### PR DESCRIPTION
## Description

- Add a 'arrow_function' (bool) configuration on the CallableThisArrayToAnonymousFunctionRector 
- If this configuration is passed to true, then the rule will replace by an arrow function when possible (mainly when the function doesn't have the void return type)

## Steps follow for this PR

- duplicate `rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture` directory to ensure the tests have the same coverage. Also add `CallableThisArrayToArrowFunctionRectorTest` test case to have the rule configured with our new parameter `arrow_function`. 
- Modify the code. We decided to translate the closure to an arrow function to avoid adding much complexity and also to reuse existing code. I aggree that we could translate `[$this, 'func']` to arrow function directly and avoid the middle step with the closure.


Co authored with [Catrixb](https://github.com/Catrixb) 