### PR TITLE
[Performance] Fix filter cache on SkippedClassResolver

### DIFF
--- a/rules/CodeQuality/Rector/Switch_/SingularSwitchToIfRector.php
+++ b/rules/CodeQuality/Rector/Switch_/SingularSwitchToIfRector.php
@@ -88,10 +88,9 @@ CODE_SAMPLE
         // only default → basically unwrap
         if (! $onlyCase->cond instanceof Expr) {
             // remove default clause because it cause syntax error
-            return array_filter($onlyCase->stmts, function (Stmt $statement) {
-                return ! $statement instanceof Break_;
-            });
+            return array_filter($onlyCase->stmts, static fn(Stmt $stmt): bool => ! $stmt instanceof Break_);
         }
+
         $if = new If_(new Identical($node->cond, $onlyCase->cond));
         $if->stmts = $this->switchManipulator->removeBreakNodes($onlyCase->stmts);
 

--- a/src/Skipper/SkipCriteriaResolver/SkippedClassResolver.php
+++ b/src/Skipper/SkipCriteriaResolver/SkippedClassResolver.php
@@ -11,7 +11,7 @@ use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
 final class SkippedClassResolver
 {
     /**
-     * @var array<string, string[]|null>
+     * @var null|array<string, string[]|null>
      */
     private null|array $skippedClasses = null;
 

--- a/src/Skipper/SkipCriteriaResolver/SkippedClassResolver.php
+++ b/src/Skipper/SkipCriteriaResolver/SkippedClassResolver.php
@@ -13,24 +13,26 @@ final class SkippedClassResolver
     /**
      * @var array<string, string[]|null>
      */
-    private array $skippedClasses = [];
+    private null|array $skippedClasses = null;
 
     /**
      * @return array<string, string[]|null>
      */
     public function resolve(): array
     {
+        // disable cache in tests
         if (StaticPHPUnitEnvironment::isPHPUnitRun()) {
             // disable cache in tests
-            $this->skippedClasses = [];
+            $this->skippedClasses = null;
         }
 
-        // skip cache in tests
-        if ($this->skippedClasses !== []) {
+        // already cached, even only empty array
+        if ($this->skippedClasses !== null) {
             return $this->skippedClasses;
         }
 
         $skip = SimpleParameterProvider::provideArrayParameter(Option::SKIP);
+        $this->skippedClasses = [];
 
         foreach ($skip as $key => $value) {
             // e.g. [SomeClass::class] → shift values to [SomeClass::class => null]

--- a/src/Skipper/SkipCriteriaResolver/SkippedPathsResolver.php
+++ b/src/Skipper/SkipCriteriaResolver/SkippedPathsResolver.php
@@ -34,7 +34,7 @@ final class SkippedPathsResolver
             $this->skippedPaths = null;
         }
 
-        // already filled, even empty array
+        // already cached, even only empty array
         if ($this->skippedPaths !== null) {
             return $this->skippedPaths;
         }


### PR DESCRIPTION
cache data need to be nullable so it can be returned if it not null, even filled with cache with only empty array, just return as is.