### PR TITLE
[Performance] Remove duplicate filter extension files on FilesFinder

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -36,6 +36,14 @@ final readonly class FilesFinder
             fn (string $filePath): bool => ! $this->pathSkipper->shouldSkip($filePath)
         );
 
+        if ($suffixes !== []) {
+            $fileWithExtensionsFilter = static function (string $filePath) use ($suffixes): bool {
+                $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
+                return in_array($filePathExtension, $suffixes, true);
+            };
+            $filePaths = array_filter($filePaths, $fileWithExtensionsFilter);
+        }
+
         $currentAndDependentFilePaths = $this->unchangedFilesFilter->filterFileInfos($filePaths);
 
         $directories = $this->fileAndDirectoryFilter->filterDirectories($filesAndDirectories);

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -36,13 +36,11 @@ final readonly class FilesFinder
             fn (string $filePath): bool => ! $this->pathSkipper->shouldSkip($filePath)
         );
 
-        if ($suffixes !== []) {
-            $fileWithExtensionsFilter = static function (string $filePath) use ($suffixes): bool {
-                $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
-                return in_array($filePathExtension, $suffixes, true);
-            };
-            $filePaths = array_filter($filePaths, $fileWithExtensionsFilter);
-        }
+        $fileWithExtensionsFilter = static function (string $filePath) use ($suffixes): bool {
+            $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
+            return in_array($filePathExtension, $suffixes, true);
+        };
+        $filePaths = array_filter($filePaths, $fileWithExtensionsFilter);
 
         $currentAndDependentFilePaths = $this->unchangedFilesFilter->filterFileInfos($filePaths);
 

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -36,11 +36,13 @@ final readonly class FilesFinder
             fn (string $filePath): bool => ! $this->pathSkipper->shouldSkip($filePath)
         );
 
-        $fileWithExtensionsFilter = static function (string $filePath) use ($suffixes): bool {
-            $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
-            return in_array($filePathExtension, $suffixes, true);
-        };
-        $filePaths = array_filter($filePaths, $fileWithExtensionsFilter);
+        if ($suffixes !== []) {
+            $fileWithExtensionsFilter = static function (string $filePath) use ($suffixes): bool {
+                $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
+                return in_array($filePathExtension, $suffixes, true);
+            };
+            $filePaths = array_filter($filePaths, $fileWithExtensionsFilter);
+        }
 
         $currentAndDependentFilePaths = $this->unchangedFilesFilter->filterFileInfos($filePaths);
 

--- a/src/ValueObjectFactory/Application/FileFactory.php
+++ b/src/ValueObjectFactory/Application/FileFactory.php
@@ -30,13 +30,6 @@ final readonly class FileFactory
         }
 
         $supportedFileExtensions = $configuration->getFileExtensions();
-        $filePaths = $this->filesFinder->findInDirectoriesAndFiles($paths, $supportedFileExtensions);
-
-        $fileWithExtensionsFilter = static function (string $filePath) use ($supportedFileExtensions): bool {
-            $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);
-            return in_array($filePathExtension, $supportedFileExtensions, true);
-        };
-
-        return array_filter($filePaths, $fileWithExtensionsFilter);
+        return $this->filesFinder->findInDirectoriesAndFiles($paths, $supportedFileExtensions);
     }
 }


### PR DESCRIPTION
There are 2 kinds of search files:

- in collection of files
- in directories, it search using Symfony `Finder`

On Symfony Finder search dir, it already filter file extension:

https://github.com/rectorphp/rector-src/blob/9d310ce5daca61f51f35e3c8755a442998f1c536/src/FileSystem/FilesFinder.php#L66-L69

so, the rest should only filter collection of files, no need to re-filter that already filtered in directory search.

