### PR TITLE
Restore timeout to keep compatible with formater CI runs, based on community feedback

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -88,7 +88,7 @@ final class RectorConfig extends Container
      * Defaults in sync with https://phpstan.org/config-reference#parallel-processing
      * as we run PHPStan as well
      */
-    public function parallel(int $processTimeout = 60, int $maxNumberOfProcess = 32, int $jobSize = 20): void
+    public function parallel(int $processTimeout = 120, int $maxNumberOfProcess = 32, int $jobSize = 20): void
     {
         SimpleParameterProvider::setParameter(Option::PARALLEL, true);
         SimpleParameterProvider::setParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $processTimeout);


### PR DESCRIPTION
Based on various feedback after 0.19 release, it seems the best way to tackle timeout issues is to restore original 120 seconds.

Related to:

* https://github.com/rectorphp/rector/issues/8403#issuecomment-1892418947
* https://github.com/rectorphp/rector/issues/8404
* https://github.com/rectorphp/rector/issues/8396