### PR TITLE
[Config] Restore default values for RectorConfig->parallel() config similar to original <=0.18.x version

### DIFF
--- a/rules/Php81/Rector/Class_/SpatieEnumClassToEnumRector.php
+++ b/rules/Php81/Rector/Class_/SpatieEnumClassToEnumRector.php
@@ -13,6 +13,10 @@ use Rector\Php81\NodeFactory\EnumFactory;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+<<<<<<< HEAD
+=======
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+>>>>>>> 3b6a960c85 (regenerate docs)
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -29,7 +33,11 @@ final class SpatieEnumClassToEnumRector extends AbstractRector implements MinPhp
     /**
      * @var string
      */
+<<<<<<< HEAD
     public const TO_UPPER_SNAKE_CASE = 'toUpperSnakeCase';
+=======
+    public const TO_UPPER_SNAKE_CASE = 'to_upper_snake_case';
+>>>>>>> 3b6a960c85 (regenerate docs)
 
     public function __construct(
         private readonly EnumFactory $enumFactory

--- a/rules/Php81/Rector/Class_/SpatieEnumClassToEnumRector.php
+++ b/rules/Php81/Rector/Class_/SpatieEnumClassToEnumRector.php
@@ -13,10 +13,6 @@ use Rector\Php81\NodeFactory\EnumFactory;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
-<<<<<<< HEAD
-=======
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
->>>>>>> 3b6a960c85 (regenerate docs)
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -33,11 +29,7 @@ final class SpatieEnumClassToEnumRector extends AbstractRector implements MinPhp
     /**
      * @var string
      */
-<<<<<<< HEAD
     public const TO_UPPER_SNAKE_CASE = 'toUpperSnakeCase';
-=======
-    public const TO_UPPER_SNAKE_CASE = 'to_upper_snake_case';
->>>>>>> 3b6a960c85 (regenerate docs)
 
     public function __construct(
         private readonly EnumFactory $enumFactory

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -79,7 +79,7 @@ final class RectorConfig extends Container
      * Defaults in sync with https://phpstan.org/config-reference#parallel-processing
      * as we run PHPStan as well
      */
-    public function parallel(int $processTimeout = 120, int $maxNumberOfProcess = 32, int $jobSize = 20): void
+    public function parallel(int $processTimeout = 120, int $maxNumberOfProcess = 16, int $jobSize = 15): void
     {
         SimpleParameterProvider::setParameter(Option::PARALLEL, true);
         SimpleParameterProvider::setParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $processTimeout);

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -75,7 +75,7 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::PARALLEL, false);
     }
 
-    public function parallel(int $processTimeout = 120, int $maxNumberOfProcess = 16, int $jobSize = 15): void
+    public function parallel(int $processTimeout = 120, int $maxNumberOfProcess = 16, int $jobSize = 16): void
     {
         SimpleParameterProvider::setParameter(Option::PARALLEL, true);
         SimpleParameterProvider::setParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS, $processTimeout);

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -75,10 +75,6 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::PARALLEL, false);
     }
 
-    /**
-     * Defaults in sync with https://phpstan.org/config-reference#parallel-processing
-     * as we run PHPStan as well
-     */
     public function parallel(int $processTimeout = 120, int $maxNumberOfProcess = 16, int $jobSize = 15): void
     {
         SimpleParameterProvider::setParameter(Option::PARALLEL, true);


### PR DESCRIPTION
`120, 16, 15` is mostly working on CI, which has big files (3000-4000 lines per file) so I propose to rollback it.