### PR TITLE
[DX] Depreate heavy and conflicting Symfony/Twig/PHPUnit level sets

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -81,7 +81,7 @@ final class RectorConfig extends Container
                 // show warning, to avoid confusion
                 $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
                 $symfonyStyle->warning(
-                    "The Symfony/Twig/PHPUnit level sets are deprecated since Rector 0.19.2, because of heavy performance load and conflicting overrides. Instead, use latest major set instead.\n\nFor more, see https://getrector.com/blog/5-common-mistakes-in-rector-config-and-how-to-avoid-them"
+                    "The Symfony/Twig/PHPUnit level sets have been deprecated since Rector 0.19.2 due to heavy performance loads and conflicting overrides. Instead, please use the latest major set.\n\nFor more information, visit https://getrector.com/blog/5-common-mistakes-in-rector-config-and-how-to-avoid-them"
                 );
 
                 break;


### PR DESCRIPTION
It's not best practise to use `UP_TO_*` sets in `rector.php` longer than is their single-run. They run dozens of rules with very complex logic, as it take to get from Symfony 2 to 7. It's like running a Tesla control and checking all elements available since the first horse ride :) 

Also, the tools we build upon - php-parser and PHPStan - traverse tree from top to bottom. That means if Symfony 4.4 changes a class, and then Symfony 3.4 changed a method, the changes would crash with each other.

We published post about this, but we should do more to have a DX that is useful and practical:
https://getrector.com/blog/5-common-mistakes-in-rector-config-and-how-to-avoid-them

The best practice - and we use it this way since the first Symfony rule set - to run those just once and remove :+1: 


<br>

Instead use only the latest major sets, to keep up to date and get fast and reliable Rector run  :rocket: 

Thank you

* Resolves https://github.com/rectorphp/rector/issues/8403
* Resolves https://github.com/rectorphp/rector-symfony/pull/547