### PR TITLE
fixed issue when indent is not 4

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -203,9 +203,10 @@ final class BetterStandardPrinter extends Standard
     protected function outdent(): void
     {
         if ($this->getIndentCharacter() === ' ') {
+            $indentSize = SimpleParameterProvider::provideIntParameter(Option::INDENT_SIZE);
             // - 4 spaces
-            assert($this->indentLevel >= 4);
-            $this->indentLevel -= 4;
+            assert($this->indentLevel >= $indentSize);
+            $this->indentLevel -= $indentSize;
         } else {
             // - 1 tab
             assert($this->indentLevel >= 1);

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -204,7 +204,6 @@ final class BetterStandardPrinter extends Standard
     {
         if ($this->getIndentCharacter() === ' ') {
             $indentSize = SimpleParameterProvider::provideIntParameter(Option::INDENT_SIZE);
-            // - 4 spaces
             assert($this->indentLevel >= $indentSize);
             $this->indentLevel -= $indentSize;
         } else {


### PR DESCRIPTION
problem appear after migration to php 8 with following code block

```
<?php

namespace Libs;

class CategoryDataSource extends ExGenericDataSource
{
  protected function canModify(array $row, ?array $old = []): bool
  {
    if (!$row) {
      if ($model = br()->db()->getCachedRow('
        SELECT *
          FROM edoc_pbcs_model
         WHERE id = ?
      ',
        br($row, 'model_id')
      )) {
        return $account->isSameDistrict($model['district_id']);
      } else {
        return false;
      }
    } else {
      return false;
    }
  }
}
```

rector.php is

```
declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector;

return static function (RectorConfig $rectorConfig): void {
  $rectorConfig->parallel(512, 8, 8);
  $rectorConfig->paths([
    __DIR__ . '/',
  ]);

  $rectorConfig->rule(SimplifyIfElseWithSameContentRector::class);

  $rectorConfig->indent(' ', 2);
};
```

command to run

```
 php vendor/bin/rector process datasources/CategoryDataSource.php --debug
```

error report

```
 [ERROR] Could not process "datasources/CategoryDataSource.php" file, due to:
         "System error: "assert($this->indentLevel >= 4)"

         Stack trace:
         #0 vendor/rector/rector/src/PhpParser/Printer/BetterStandardPrinter.php(164): assert(false,
         'assert($this->i...')
         #1 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(296):
         Rector\PhpParser\Printer\BetterStandardPrinter->outdent()
         #2 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinter/Standard.php(721):
         PhpParser\PrettyPrinterAbstract->pStmts(Array)
         #3 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(503):
         PhpParser\PrettyPrinter\Standard->pStmt_If(Object(PhpParser\Node\Stmt\If_))
         #4 vendor/rector/rector/src/PhpParser/Printer/BetterStandardPrinter.php(116):
         PhpParser\PrettyPrinterAbstract->p(Object(PhpParser\Node\Stmt\If_), false)
         #5 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(293):
         Rector\PhpParser\Printer\BetterStandardPrinter->p(Object(PhpParser\Node\Stmt\If_))
         #6 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(207):
         PhpParser\PrettyPrinterAbstract->pStmts(Array, false)
         #7 vendor/rector/rector/src/PhpParser/Printer/BetterStandardPrinter.php(92):
         PhpParser\PrettyPrinterAbstract->prettyPrint(Array)
         #8 vendor/rector/rector/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php(79):
         Rector\PhpParser\Printer\BetterStandardPrinter->print(Array)
         #9 vendor/rector/rector/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php(71):
         Rector\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector->isIfWithConstantReturns(Object(PhpParser\Node\
         Stmt\If_))
         #10 vendor/rector/rector/src/Rector/AbstractRector.php(136):
         Rector\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector->refactor(Object(PhpParser\Node\Stmt\If_))
         #11 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(176):
         Rector\Rector\AbstractRector->enterNode(Object(PhpParser\Node\Stmt\If_))
         #12 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105):
         PhpParser\NodeTraverser->traverseArray(Array)
         #13 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196):
         PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\ClassMethod))
         #14 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105):
         PhpParser\NodeTraverser->traverseArray(Array)
         #15 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196):
         PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Class_))
         #16 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(105):
         PhpParser\NodeTraverser->traverseArray(Array)
         #17 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(196):
         PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))
         #18 vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(85):
         PhpParser\NodeTraverser->traverseArray(Array)
         #19 vendor/rector/rector/src/PhpParser/NodeTraverser/RectorNodeTraverser.php(50):
         PhpParser\NodeTraverser->traverse(Array)
         #20 vendor/rector/rector/src/Application/FileProcessor.php(116):
         Rector\PhpParser\NodeTraverser\RectorNodeTraverser->traverse(Array)
         #21 vendor/rector/rector/src/Application/ApplicationFileProcessor.php(177):
         Rector\Application\FileProcessor->processFile(Object(Rector\ValueObject\Application\File),
         Object(Rector\ValueObject\Configuration))
         #22 vendor/rector/rector/src/Application/ApplicationFileProcessor.php(153):
         Rector\Application\ApplicationFileProcessor->processFile(Object(Rector\ValueObject\Application\File),
         Object(Rector\ValueObject\Configuration))
         #23 vendor/rector/rector/src/Console/Command/WorkerCommand.php(132):
         Rector\Application\ApplicationFileProcessor->processFiles(Array, Object(Rector\ValueObject\Configuration),
         Object(Closure))
         #24 vendor/rector/rector/vendor/evenement/evenement/src/EventEmitterTrait.php(111):
         Rector\Console\Command\WorkerCommand->Rector\Console\Command\{closure}(Array)
         #25 vendor/rector/rector/vendor/clue/ndjson-react/src/Decoder.php(117):
         RectorPrefix202401\Evenement\EventEmitter->emit('data', Array)
         #26 vendor/rector/rector/vendor/evenement/evenement/src/EventEmitterTrait.php(111):
         RectorPrefix202401\Clue\React\NDJson\Decoder->handleData(Array)
         #27 vendor/rector/rector/vendor/react/stream/src/Util.php(62):
         RectorPrefix202401\Evenement\EventEmitter->emit('data', Array)
         #28 vendor/rector/rector/vendor/evenement/evenement/src/EventEmitterTrait.php(111):
         RectorPrefix202401\React\Stream\Util::RectorPrefix202401\React\Stream\{closure}('{"action":"main...')
         #29 vendor/rector/rector/vendor/react/stream/src/DuplexResourceStream.php(154):
         RectorPrefix202401\Evenement\EventEmitter->emit('data', Array)
         #30 vendor/rector/rector/vendor/react/event-loop/src/StreamSelectLoop.php(201):
         RectorPrefix202401\React\Stream\DuplexResourceStream->handleData(Resource id #1692)
         #31 vendor/rector/rector/vendor/react/event-loop/src/StreamSelectLoop.php(173):
         RectorPrefix202401\React\EventLoop\StreamSelectLoop->waitForStreamActivity(NULL)
         #32 vendor/rector/rector/src/Console/Command/WorkerCommand.php(90):
         RectorPrefix202401\React\EventLoop\StreamSelectLoop->run()
         #33 vendor/rector/rector/vendor/symfony/console/Command/Command.php(327):
         Rector\Console\Command\WorkerCommand->execute(Object(RectorPrefix202401\Symfony\Component\Console\Input\ArgvIn
         put), Object(RectorPrefix202401\Symfony\Component\Console\Output\ConsoleOutput))
         #34 vendor/rector/rector/vendor/symfony/console/Application.php(960):
         RectorPrefix202401\Symfony\Component\Console\Command\Command->run(Object(RectorPrefix202401\Symfony\Component\
         Console\Input\ArgvInput), Object(RectorPrefix202401\Symfony\Component\Console\Output\ConsoleOutput))
         #35 vendor/rector/rector/vendor/symfony/console/Application.php(333):
         RectorPrefix202401\Symfony\Component\Console\Application->doRunCommand(Object(Rector\Console\Command\WorkerCom
         mand), Object(RectorPrefix202401\Symfony\Component\Console\Input\ArgvInput),
         Object(RectorPrefix202401\Symfony\Component\Console\Output\ConsoleOutput))
         #36 vendor/rector/rector/src/Console/ConsoleApplication.php(53):
         RectorPrefix202401\Symfony\Component\Console\Application->doRun(Object(RectorPrefix202401\Symfony\Component\Co
         nsole\Input\ArgvInput), Object(RectorPrefix202401\Symfony\Component\Console\Output\ConsoleOutput))
         #37 vendor/rector/rector/vendor/symfony/console/Application.php(216):
         Rector\Console\ConsoleApplication->doRun(Object(RectorPrefix202401\Symfony\Component\Console\Input\ArgvInput),
         Object(RectorPrefix202401\Symfony\Component\Console\Output\ConsoleOutput))
         #38 vendor/rector/rector/bin/rector.php(131): RectorPrefix202401\Symfony\Component\Console\Application->run()
         #39 vendor/rector/rector/bin/rector(5): require_once('/Users/jagermes...')
         #40 vendor/bin/rector(119): include('/Users/jagermes...')
         #41 {main}". On line: 164
```