### PR TITLE
[Performance][PhpParser] Deprecate InlineCodeParser::parse(), extract into parseFile() and parseString()

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -480,3 +480,6 @@ parameters:
 
         # will be used in rector-downgrade-php
         - '#Public method "Rector\\PhpParser\\Parser\\InlineCodeParser\:\:parseFile\(\)" is never used#'
+
+        # deprecated
+        - '#Public method "Rector\\PhpParser\\Parser\\InlineCodeParser\:\:parse\(\)" is never used#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -477,3 +477,6 @@ parameters:
 
         # closure detailed
         - '#Method Rector\\Config\\RectorConfig\:\:singleton\(\) has parameter \$concrete with no signature specified for Closure#'
+
+        # will be used in rector-downgrade-php
+        - '#Public method "Rector\\PhpParser\\Parser\\InlineCodeParser\:\:parseFile\(\)" is never used#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -480,6 +480,3 @@ parameters:
 
         # will be used in rector-downgrade-php
         - '#Public method "Rector\\PhpParser\\Parser\\InlineCodeParser\:\:parseFile\(\)" is never used#'
-
-        # deprecated
-        - '#Public method "Rector\\PhpParser\\Parser\\InlineCodeParser\:\:parse\(\)" is never used#'

--- a/rules/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
+++ b/rules/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
@@ -162,7 +162,7 @@ CODE_SAMPLE
         }
 
         $content = $this->inlineCodeParser->stringify($expr);
-        return $this->inlineCodeParser->parse($content);
+        return $this->inlineCodeParser->parseString($content);
     }
 
     private function createEval(Expr $expr): Expression

--- a/rules/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
+++ b/rules/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
@@ -135,7 +135,7 @@ CODE_SAMPLE
         $content = $this->inlineCodeParser->stringify($expr);
         $content = '<?php $value = function(' . $content . ') {};';
 
-        $nodes = $this->inlineCodeParser->parse($content);
+        $nodes = $this->inlineCodeParser->parseString($content);
 
         /** @var Expression $expression */
         $expression = $nodes[0];
@@ -161,8 +161,8 @@ CODE_SAMPLE
             return [$this->createEval($expr)];
         }
 
-        $expr = $this->inlineCodeParser->stringify($expr);
-        return $this->inlineCodeParser->parse($expr);
+        $content = $this->inlineCodeParser->stringify($expr);
+        return $this->inlineCodeParser->parse($content);
     }
 
     private function createEval(Expr $expr): Expression

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -68,6 +68,8 @@ final readonly class InlineCodeParser
 
     /**
      * @return Stmt[]
+     *
+     * @deprecate use parseFile() or parseString() instead
      */
     public function parse(string $content): array
     {
@@ -76,11 +78,24 @@ final readonly class InlineCodeParser
             $content = FileSystem::read($content);
         }
 
-        // wrap code so php-parser can interpret it
-        $content = StringUtils::isMatch($content, self::OPEN_PHP_TAG_REGEX) ? $content : '<?php ' . $content;
-        $content = StringUtils::isMatch($content, self::ENDING_SEMI_COLON_REGEX) ? $content : $content . ';';
+        return $this->parseCode($content);
+    }
 
-        return $this->simplePhpParser->parseString($content);
+    /**
+     * @return Stmt[]
+     */
+    public function parseFile(string $fileName): array
+    {
+        $fileContent = FileSystem::read($fileName);
+        return $this->parseCode($fileContent);
+    }
+
+    /**
+     * @return Stmt[]
+     */
+    public function parseString(string $fileContent): array
+    {
+        return $this->parseCode($fileContent);
     }
 
     public function stringify(Expr $expr): string
@@ -110,6 +125,18 @@ final readonly class InlineCodeParser
         }
 
         return $this->betterStandardPrinter->print($expr);
+    }
+
+    /**
+     * @return Stmt[]
+     */
+    private function parseCode(string $code): array
+    {
+        // wrap code so php-parser can interpret it
+        $code = StringUtils::isMatch($code, self::OPEN_PHP_TAG_REGEX) ? $code : '<?php ' . $code;
+        $code = StringUtils::isMatch($code, self::ENDING_SEMI_COLON_REGEX) ? $code : $code . ';';
+
+        return $this->simplePhpParser->parseString($code);
     }
 
     private function resolveEncapsedValue(Encapsed $encapsed): string

--- a/src/PhpParser/Parser/InlineCodeParser.php
+++ b/src/PhpParser/Parser/InlineCodeParser.php
@@ -69,7 +69,8 @@ final readonly class InlineCodeParser
     /**
      * @return Stmt[]
      *
-     * @deprecate use parseFile() or parseString() instead
+     * @api
+     * @deprecated use parseFile() or parseString() instead
      */
     public function parse(string $content): array
     {


### PR DESCRIPTION
Avoid unnecessary  IO for`is_file()` when it actually just content, make consistent with other 3: `SimplePhpParser` and `RectorParser`, and `SmartPhpParser` which has 2 methods:

- `parseFile()`
- `parseString()`