### PR TITLE
add failing test for InlineArrayReturnAssignRector when using dynamic array definition

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/dynamic_array_definition.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/dynamic_array_definition.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+final class DynamicArrayDefinition
+{
+    public function run()
+    {
+        $arr = [];
+        $arr['foo']['bar']['baz'] = ['a' => 1, 'b' => 2];
+
+        return $arr;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+final class DynamicArrayDefinition
+{
+    public function run()
+    {
+        return ['foo' => ['bar' => ['baz' => ['a' => 1, 'b' => 2]]]];
+    }
+}
+
+?>


### PR DESCRIPTION
I'm running rector on a big project in our company, it pointed to me some edge cases like this one. 
I'm opening this PR to describe the problem and also facilitate the bug fix. I'll try to have a look at this soon