### PR TITLE
add failing test when using array deconstruction for ArrayMergeOfNonArraysToSimpleArrayRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/ArrayMergeOfNonArraysToSimpleArrayRector/Fixture/destructuring_arrays.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/ArrayMergeOfNonArraysToSimpleArrayRector/Fixture/destructuring_arrays.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\ArrayMergeOfNonArraysToSimpleArrayRector\Fixture;
+
+class NestedArrays
+{
+    public function go()
+    {
+        $values = array_merge(
+            [
+                ['foo' => 'bar'],
+                ...$this->deconstructable(),
+            ]
+        );
+
+        return $values;
+    }
+
+    private function deconstructable()
+    {
+        return ['rector'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\ArrayMergeOfNonArraysToSimpleArrayRector\Fixture;
+
+class NestedArrays
+{
+    public function go()
+    {
+        $values = [['foo' => 'bar'], ...$this->deconstructable()];
+
+        return $values;
+    }
+
+    private function deconstructable()
+    {
+        return ['rector'];
+    }
+}
+
+?>


### PR DESCRIPTION
I'm running rector on a big project in our company, it pointed to me some edge cases like this one. 
I'm opening this PR to describe the problem and also facilitate the bug fix. I'll try to have a look at this soon