### PR TITLE
Added contao/contao-rector to the README

### DIFF
--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -101,6 +101,7 @@ Among there projects belong:
 * [laminas/laminas-servicemanager-migration](https://github.com/laminas/laminas-servicemanager-migration)
 * [cakephp/upgrade](https://github.com/cakephp/upgrade)
 * [driftingly/rector-laravel](https://github.com/driftingly/rector-laravel)
+* [contao/contao-rector](https://github.com/contao/contao-rector)
 
 <br>
 


### PR DESCRIPTION
I couldn't find anything about what projects are listed here, but [Contao Open Source CMS](https://contao.org) also offers an official Rector repository.