### PR TITLE
[CodeQuality] Skip surplus open square bracket on SimplifyRegexPatternRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/skip_surplus_open_square_bracket.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/skip_surplus_open_square_bracket.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector\Fixture;
+
+class SkipSurplusOpenSquareBracket
+{
+    public function run()
+    {
+        $purln = preg_replace("/[^[a-zA-Z0-9_]/", "", "test");
+    }
+}

--- a/rules/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SimplifyRegexPatternRector.php
@@ -92,6 +92,11 @@ CODE_SAMPLE
                 continue;
             }
 
+            $countSqureOpenBracket = substr_count($simplifiedValue, '[');
+            if ($countSqureOpenBracket % 2 === 1) {
+                continue;
+            }
+
             $node->value = $simplifiedValue;
             return $node;
         }


### PR DESCRIPTION
@gemal @pkvach this skip if the transformation has surplus open squre backet 

Closes https://github.com/rectorphp/rector/issues/8402