### PR TITLE
Add support for YieldFrom into places where Yield_ is checked

### DIFF
--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/AlwaysStrictReturnAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/AlwaysStrictReturnAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer;
 
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Function_;
@@ -31,7 +32,7 @@ final readonly class AlwaysStrictReturnAnalyzer
             return [];
         }
 
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, [Yield_::class])) {
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, [Yield_::class, YieldFrom::class])) {
             return [];
         }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictNativeFunctionReturnTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictNativeFunctionReturnTypeAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
@@ -32,7 +33,7 @@ final readonly class StrictNativeFunctionReturnTypeAnalyzer
             return null;
         }
 
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, [Yield_::class])) {
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, [Yield_::class, YieldFrom::class])) {
             return null;
         }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -37,7 +38,7 @@ final readonly class StrictReturnNewAnalyzer
             return null;
         }
 
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, [Yield_::class])) {
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, [Yield_::class, YieldFrom::class])) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnNeverTypeRector.php
@@ -7,6 +7,7 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -135,7 +136,7 @@ CODE_SAMPLE
 
         return $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
             $node,
-            [Yield_::class, ...ControlStructure::CONDITIONAL_NODE_SCOPE_TYPES]
+            [Yield_::class, YieldFrom::class, ...ControlStructure::CONDITIONAL_NODE_SCOPE_TYPES]
         );
     }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -109,7 +110,7 @@ CODE_SAMPLE
         }
 
         // 2. skip yields
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, [Yield_::class])) {
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, [Yield_::class, YieldFrom::class])) {
             return null;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -37,7 +38,7 @@ final readonly class SilentVoidResolver
             return false;
         }
 
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, Yield_::class)) {
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($functionLike, [Yield_::class, YieldFrom::class])) {
             return false;
         }
 


### PR DESCRIPTION
I was guided to this change by debugging why `AddVoidReturnTypeWhereNoReturnRector` generates errors on code like this: 
```php
$sheet->method('nextRow')->willReturn((function () {
    yield from  [1, 2, 3];
})());
```
Output with `--dry-run` before fix:
```php
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) tests/...shorten..../Test.php:147

    ---------- begin diff ----------
@@ @@
             'sheet without values' => [
                 'sheetCallResult' => self::returnValue((function () use ($sheet) {
                     $sheet = clone $sheet;
-                    $sheet->method('nextRow')->willReturn((function () {
+                    $sheet->method('nextRow')->willReturn((function (): void {
                         yield from [1, 2, 3];
                     })());
                     return $sheet;
    ----------- end diff -----------

Applied rules:
 * AddVoidReturnTypeWhereNoReturnRector

 [OK] 1 file would have changed (dry-run) by Rector

```

So I add Checking for `PhpParser\Node\Expr\YieldFrom` into places where more common `PhpParser\Node\Expr\Yield_` was checked.