### PR TITLE
[Configuration] Use array_merge() on RectorConfigBuilder::withSets()

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -226,7 +226,7 @@ final class RectorConfigBuilder
      */
     public function withSets(array $sets): self
     {
-        $this->sets = $sets;
+        $this->sets = array_merge($this->sets, $sets);
 
         return $this;
     }


### PR DESCRIPTION
On PR:

- https://github.com/rectorphp/rector-src/pull/5506

with addition of `withPreparedSets()`, the `withSets()` is replace it, This PR fix it.