### PR TITLE
[Templates] Fix syntax error on templates/rector.php.dist

### DIFF
--- a/templates/rector.php.dist
+++ b/templates/rector.php.dist
@@ -17,4 +17,3 @@ __PATHS__
         // define sets of rules
         // LevelSetList::UP_TO_PHP_XY
     ]);
-};


### PR DESCRIPTION
Latest rector dev-main got error:

```bash
✗ bin/rector                                 
                                                                   
 [ERROR] Unmatched '}'             
```

on generating new config. This PR fix it.