### PR TITLE
[Php83] add string type to concat constant

### DIFF
--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_type_to_class_const_when_class_final.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_type_to_class_const_when_class_final.php.inc
@@ -15,6 +15,8 @@ final class ApplyTypesWhenClassFinal
     public const NULL = null;
 
     public const ARRAY = [];
+
+    public const CONCAT = self::STRING . 'concat';
 }
 
 ?>
@@ -36,6 +38,8 @@ final class ApplyTypesWhenClassFinal
     public const null NULL = null;
 
     public const array ARRAY = [];
+
+    public const string CONCAT = self::STRING . 'concat';
 }
 
 ?>

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_type_to_class_const_when_const_protected.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_type_to_class_const_when_const_protected.php.inc
@@ -15,6 +15,8 @@ class ApplyTypesToPrivateConsts
     private const NULL = null;
 
     private const ARRAY = [];
+
+    private const CONCAT = self::STRING . 'concat';
 }
 
 ?>
@@ -36,6 +38,8 @@ class ApplyTypesToPrivateConsts
     private const null NULL = null;
 
     private const array ARRAY = [];
+
+    private const string CONCAT = self::STRING . 'concat';
 }
 
 ?>

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_when_operations_used.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_when_operations_used.php.inc
@@ -6,7 +6,7 @@ final class SomeClass
 {
     public const string A = 'A';
 
-    public const B = self::A . 'b';
+    public const string B = self::A . 'b';
 
     public const int INT = 1;
 

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\DNumber;
@@ -163,6 +164,10 @@ CODE_SAMPLE
 
         if ($expr instanceof Array_) {
             return new Identifier('array');
+        }
+
+        if ($expr instanceof Concat) {
+            return new Identifier('string');
         }
 
         return null;


### PR DESCRIPTION
This PR update the rule `AddTypeToConstRector` to set `string` type for `Concat` expression.

(assuming that a Concat expression is always a string)