### PR TITLE
[Autoloading] Allow to define bootstrapFiles([__DIR__ . '/some.phar']) on BootstrapFilesIncluder

### DIFF
--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -34,6 +34,12 @@ final class BootstrapFilesIncluder
                 throw new ShouldNotHappenException(sprintf('Bootstrap file "%s" does not exist.', $bootstrapFile));
             }
 
+            // load phar file
+            if (str_ends_with($bootstrapFile, '.phar')) {
+                \Phar::loadPhar($bootstrapFile);
+                continue;
+            }
+
             require $bootstrapFile;
         }
 

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Autoloading;
 
+use Phar;
 use FilesystemIterator;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
@@ -36,7 +37,7 @@ final class BootstrapFilesIncluder
 
             // load phar file
             if (str_ends_with($bootstrapFile, '.phar')) {
-                \Phar::loadPhar($bootstrapFile);
+                Phar::loadPhar($bootstrapFile);
                 continue;
             }
 


### PR DESCRIPTION
@rela589n this is to allow define:

```php
    $rectorConfig->bootstrapFiles([
        __DIR__ . '/bin/phpunit.phar',
    ]);
``` 

by that, you can remove `tests/autoload_dev.php` under `files` in composer.json

```diff
-        },
-        "files": [
-            "tests/autoload_dev.php"
-        ]
```

the, remove the file:

```
rm -rf tests/autoload_dev.php
```

and run:

```
composer install
```

then it will directly pointed to the file with `.phar` extension.

Fixes https://github.com/rectorphp/rector/issues/8435