### PR TITLE
[EarlyReturn] Improve RemoveAlwaysElseRector to handle multiple ElseIfs (#8178)

### DIFF
--- a/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/multiple_elseifs_return.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/multiple_elseifs_return.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+
+class MultipleElseifsReturn
+{
+    public function run($a)
+    {
+        if ($a == 1) {
+            return 1;
+        } elseif ($a == 2) {
+            return 2;
+        } elseif ($a == 3) {
+            return 3;
+        } elseif ($a == 4) {
+            return 4;
+        } elseif ($a == 5) {
+            return 5;
+        }
+        return 'more';
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+
+class MultipleElseifsReturn
+{
+    public function run($a)
+    {
+        if ($a == 1) {
+            return 1;
+        }
+        if ($a == 2) {
+            return 2;
+        }
+        if ($a == 3) {
+            return 3;
+        }
+        if ($a == 4) {
+            return 4;
+        }
+        if ($a == 5) {
+            return 5;
+        }
+        return 'more';
+    }
+}
+?>

--- a/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/multiple_elseifs_with_non_terminating_elseif.php.inc
+++ b/rules-tests/EarlyReturn/Rector/If_/RemoveAlwaysElseRector/Fixture/multiple_elseifs_with_non_terminating_elseif.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+
+class MultipleElseifsWithNonTerminatingElseif
+{
+    public function run($a)
+    {
+        if ($a == 1) {
+            return 1;
+        } elseif ($a == 2) {
+            return 2;
+        } elseif ($a == 3) {
+            echo 'Not returning';
+        } elseif ($a == 4) {
+            return 4;
+        } elseif ($a == 5) {
+            return 5;
+        }
+        return 'more';
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\If_\RemoveAlwaysElseRector\Fixture;
+
+class MultipleElseifsWithNonTerminatingElseif
+{
+    public function run($a)
+    {
+        if ($a == 1) {
+            return 1;
+        }
+        if ($a == 2) {
+            return 2;
+        }
+        if ($a == 3) {
+            echo 'Not returning';
+        }
+        elseif ($a == 4) {
+            return 4;
+        }
+        elseif ($a == 5) {
+            return 5;
+        }
+        return 'more';
+    }
+}
+?>

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -79,25 +79,7 @@ CODE_SAMPLE
         }
 
         if ($node->elseifs !== []) {
-            $originalNode = clone $node;
-            $if = new If_($node->cond);
-            $if->stmts = $node->stmts;
-
-            $this->mirrorComments($if, $node);
-
-            /** @var ElseIf_ $firstElseIf */
-            $firstElseIf = array_shift($node->elseifs);
-            $node->cond = $firstElseIf->cond;
-            $node->stmts = $firstElseIf->stmts;
-            $this->mirrorComments($node, $firstElseIf);
-
-            $nodesToReturnAfterNode = $this->getStatementsElseIfs($node);
-            if ($originalNode->else instanceof Else_) {
-                $node->else = null;
-                $nodesToReturnAfterNode = [...$nodesToReturnAfterNode, $originalNode->else];
-            }
-
-            return [$if, $node, ...$nodesToReturnAfterNode];
+            return $this->handleElseIfs($node);
         }
 
         if ($node->else instanceof Else_) {
@@ -108,6 +90,50 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    /**
+     * @return Node[]
+     */
+    private function handleElseIfs(If_ $if): array
+    {
+        $nodesToReturn = [];
+
+        $originalIf = clone $if;
+        $firstIf = $this->createIfFromNode($if);
+        $nodesToReturn[] = $firstIf;
+
+        while ($if->elseifs !== []) {
+            /** @var ElseIf_ $currentElseIf */
+            $currentElseIf = array_shift($if->elseifs);
+
+            // If the last statement in the `elseif` breaks flow, merge it into the original `if` and stop processing
+            if ($this->doesLastStatementBreakFlow($currentElseIf)) {
+                $this->updateIfWithElseIf($if, $currentElseIf);
+                $nodesToReturn = [...$nodesToReturn, $if, ...$this->getStatementsElseIfs($if)];
+
+                break;
+            }
+
+            $isLastElseIf = $if->elseifs === [];
+
+            // If it's the last `elseif`, merge it with the original `if` to keep the formatting
+            if ($isLastElseIf) {
+                $this->updateIfWithElseIf($if, $currentElseIf);
+                $nodesToReturn[] = $if;
+
+                break;
+            }
+
+            // Otherwise, create a separate `if` node for `elseif`
+            $nodesToReturn[] = $this->createIfFromNode($currentElseIf);
+        }
+
+        if ($originalIf->else instanceof Else_) {
+            $nodesToReturn[] = $originalIf->else;
+        }
+
+        return $nodesToReturn;
     }
 
     /**
@@ -150,5 +176,22 @@ CODE_SAMPLE
             || $lastStmt instanceof Throw_
             || $lastStmt instanceof Continue_
             || ($lastStmt instanceof Expression && $lastStmt->expr instanceof Exit_));
+    }
+
+    private function createIfFromNode(If_ | ElseIf_ $node): If_
+    {
+        $if = new If_($node->cond);
+        $if->stmts = $node->stmts;
+        $this->mirrorComments($if, $node);
+
+        return $if;
+    }
+
+    private function updateIfWithElseIf(If_ $if, ElseIf_ $elseIf): void
+    {
+        $if->cond = $elseIf->cond;
+        $if->stmts = $elseIf->stmts;
+        $this->mirrorComments($if, $elseIf);
+        $if->else = null;
     }
 }

--- a/tests/Issues/IssueReturnBeforeElseIf/FixtureAnd/complex_if_cond_and.php.inc
+++ b/tests/Issues/IssueReturnBeforeElseIf/FixtureAnd/complex_if_cond_and.php.inc
@@ -38,11 +38,13 @@ class ComplexIfCondAnd
         if ($d && $e) {
             return false;
         }
-        elseif ($f && $g) {
-            return 1;
+        if (!$f) {
+            return 0;
         }
-
-        return 0;
+        if (!$g) {
+            return 0;
+        }
+        return 1;
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/8178

This PR improves the `RemoveAlwaysElseRector` class to handle multiple `ElseIfs` in the code. It also includes new test cases to verify the changes.