### PR TITLE
[DX] PHP sets should not disable all other version-based rules

### DIFF
--- a/config/set/level/up-to-php53.php
+++ b/config/set/level/up-to-php53.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_53, SetList::PHP_52]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_53);
 };

--- a/config/set/level/up-to-php54.php
+++ b/config/set/level/up-to-php54.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_54, LevelSetList::UP_TO_PHP_53]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_54);
 };

--- a/config/set/level/up-to-php55.php
+++ b/config/set/level/up-to-php55.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_55, LevelSetList::UP_TO_PHP_54]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_55);
 };

--- a/config/set/level/up-to-php56.php
+++ b/config/set/level/up-to-php56.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_56, LevelSetList::UP_TO_PHP_55]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_56);
 };

--- a/config/set/level/up-to-php70.php
+++ b/config/set/level/up-to-php70.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_70, LevelSetList::UP_TO_PHP_56]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_70);
 };

--- a/config/set/level/up-to-php71.php
+++ b/config/set/level/up-to-php71.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_71, LevelSetList::UP_TO_PHP_70]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_71);
 };

--- a/config/set/level/up-to-php72.php
+++ b/config/set/level/up-to-php72.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_72, LevelSetList::UP_TO_PHP_71]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_72);
 };

--- a/config/set/level/up-to-php73.php
+++ b/config/set/level/up-to-php73.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_73, LevelSetList::UP_TO_PHP_72]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_73);
 };

--- a/config/set/level/up-to-php74.php
+++ b/config/set/level/up-to-php74.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_74, LevelSetList::UP_TO_PHP_73]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
 };

--- a/config/set/level/up-to-php80.php
+++ b/config/set/level/up-to-php80.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_80, LevelSetList::UP_TO_PHP_74]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_80);
 };

--- a/config/set/level/up-to-php81.php
+++ b/config/set/level/up-to-php81.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_81, LevelSetList::UP_TO_PHP_80]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_81);
 };

--- a/config/set/level/up-to-php82.php
+++ b/config/set/level/up-to-php82.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_82, LevelSetList::UP_TO_PHP_81]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_82);
 };

--- a/config/set/level/up-to-php83.php
+++ b/config/set/level/up-to-php83.php
@@ -5,11 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([SetList::PHP_83, LevelSetList::UP_TO_PHP_82]);
-
-    // parameter must be defined after import, to override imported param version
-    $rectorConfig->phpVersion(PhpVersion::PHP_83);
 };

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -118,7 +118,9 @@ final class RectorConfigBuilder
 
     public function __invoke(RectorConfig $rectorConfig): void
     {
-        $rectorConfig->sets($this->sets);
+        $uniqueSets = array_unique($this->sets);
+
+        $rectorConfig->sets($uniqueSets);
         $rectorConfig->paths($this->paths);
         $rectorConfig->skip($this->skip);
         $rectorConfig->rules($this->rules);


### PR DESCRIPTION
This parameter disables all other features that depends on PHP version, e.g. type rules.
Then users have to override value explicitly in `rector.php` again, which doesn't make sense. 

Instead the default PHP value should be used instead, based on `composer.json`, regardless used PHP set.