### PR TITLE
Revert broken load Phar support on BootstrapFilesIncluder

### DIFF
--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -39,7 +39,7 @@ final class BootstrapFilesIncluder
             require $bootstrapFile;
         }
 
-        $this->requireRectorStubs($isLoadPHPUnitPhar);
+        $this->requireRectorStubs();
     }
 
     private function requireRectorStubs(): void

--- a/src/Autoloading/BootstrapFilesIncluder.php
+++ b/src/Autoloading/BootstrapFilesIncluder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Autoloading;
 
 use FilesystemIterator;
-use Phar;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Exception\ShouldNotHappenException;
@@ -37,24 +36,13 @@ final class BootstrapFilesIncluder
                 throw new ShouldNotHappenException(sprintf('Bootstrap file "%s" does not exist.', $bootstrapFile));
             }
 
-            // load phar file
-            if (str_ends_with($bootstrapFile, '.phar')) {
-                Phar::loadPhar($bootstrapFile);
-
-                if (str_ends_with($bootstrapFile, 'phpunit.phar')) {
-                    $isLoadPHPUnitPhar = true;
-                }
-
-                continue;
-            }
-
             require $bootstrapFile;
         }
 
         $this->requireRectorStubs($isLoadPHPUnitPhar);
     }
 
-    private function requireRectorStubs(bool $isLoadPHPUnitPhar): void
+    private function requireRectorStubs(): void
     {
         /** @var false|string $stubsRectorDirectory */
         $stubsRectorDirectory = realpath(__DIR__ . '/../../stubs-rector');
@@ -70,13 +58,7 @@ final class BootstrapFilesIncluder
         $stubs = new RecursiveIteratorIterator($dir);
 
         foreach ($stubs as $stub) {
-            $realPath = $stub->getRealPath();
-
-            if ($isLoadPHPUnitPhar && str_ends_with($realPath, 'TestCase.php')) {
-                continue;
-            }
-
-            require_once $realPath;
+            require_once $stub->getRealPath();
         }
     }
 }


### PR DESCRIPTION
It doesn't really work well, it looks like working OK, while actually not, on issue:

- https://github.com/rectorphp/rector/issues/8435

parent never detected, so it skipped, which make false positive.