### PR TITLE
[Privatization] Add FinalizeTestCaseClassRector

### DIFF
--- a/config/set/privatization.php
+++ b/config/set/privatization.php
@@ -7,10 +7,9 @@ use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
+return RectorConfig::configure()
+    ->withRules([
         PrivatizeLocalGetterToPropertyRector::class,
         PrivatizeFinalClassPropertyRector::class,
         PrivatizeFinalClassMethodRector::class,
     ]);
-};

--- a/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/FinalizeTestCaseClassRectorTest.php
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/FinalizeTestCaseClassRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FinalizeTestCaseClassRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/some_class.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/some_class.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SomeClass extends TestCase
+{
+}
+
+?>

--- a/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/config/configured_rule.php
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(FinalizeTestCaseClassRector::class);
+};

--- a/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Privatization\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\FinalizeTestCaseClassRectorTest
+ */
+final class FinalizeTestCaseClassRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly VisibilityManipulator $visibilityManipulator,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('PHPUnit test case will be finalized', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+final use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // skip obvious cases
+        if ($node->isAbstract() || $node->isAnonymous() || $node->isFinal()) {
+            return null;
+        }
+
+        $className = $this->getName($node);
+        if (! is_string($className)) {
+            return null;
+        }
+
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if (! $classReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
+            return null;
+        }
+
+        $this->visibilityManipulator->makeFinal($node);
+
+        return $node;
+    }
+}

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -11,6 +11,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php81\Rector\ClassConst\FinalizePublicClassConstantRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
+use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
@@ -39,6 +40,7 @@ final class MissingInSetCommand extends Command
         RemoveNullTagValueNodeRector::class,
         // personal preference, enable on purpose
         ArraySpreadInsteadOfArrayMergeRector::class,
+        FinalizeTestCaseClassRector::class,
         FinalizeClassesWithoutChildrenRector::class,
         // deprecated
         FinalizePublicClassConstantRector::class,


### PR DESCRIPTION
This is to keep at least some finalize functionality that does not require knowing the full family class tree.

Ref https://github.com/rectorphp/rector/issues/8439

One of the safe cases is to finalize cases is test classes.
