### PR TITLE
[TypeDeclaration] Change bool to false or true docblock when union has false/true standalone type on ReturnUnionTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/false_bool_docblock.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/false_bool_docblock.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class FalseBoolDocblock
+{
+    /**
+     * @return array|bool some description
+     */
+    public function run()
+    {
+        if (rand(0, 1)) {
+            return false;
+        }
+
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class FalseBoolDocblock
+{
+    /**
+     * @return array|false some description
+     */
+    public function run(): array|false
+    {
+        if (rand(0, 1)) {
+            return false;
+        }
+
+        return [];
+    }
+}
+
+?>


### PR DESCRIPTION
To avoid phpstan error after return type added:

```
79     PHPDoc tag @return with type array|bool is not subtype of native type  
         array|false.     
```

Fixes https://github.com/rectorphp/rector/issues/8450