### PR TITLE
Fix xdebug handling

### DIFF
--- a/src/Console/ConsoleApplication.php
+++ b/src/Console/ConsoleApplication.php
@@ -41,7 +41,6 @@ final class ConsoleApplication extends Application
 
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        // @fixes https://github.com/rectorphp/rector/issues/2205
         $isXdebugAllowed = $input->hasParameterOption('--xdebug');
         if (!$isXdebugAllowed) {
             $xdebugHandler = new XdebugHandler('rector');

--- a/src/Console/ConsoleApplication.php
+++ b/src/Console/ConsoleApplication.php
@@ -43,8 +43,9 @@ final class ConsoleApplication extends Application
     {
         // @fixes https://github.com/rectorphp/rector/issues/2205
         $isXdebugAllowed = $input->hasParameterOption('--xdebug');
-        if ($isXdebugAllowed) {
+        if (!$isXdebugAllowed) {
             $xdebugHandler = new XdebugHandler('rector');
+            $xdebugHandler->setPersistent();
             $xdebugHandler->check();
             unset($xdebugHandler);
         }


### PR DESCRIPTION
before this PR 

- the debugger halts in the main process even without the `--xdebug` flag (opposite of how PHPStan behaves)
- the debugger does **not** halt in the main process when `--xdebug` flag is passed (opposite of how PHPStan behaves)

after this PR it behaves like PHPStan, see https://github.com/phpstan/phpstan-src/blob/29a68b75ce9fa885886395df1acd23c06cff2a14/src/Command/CommandHelper.php#L99-L104

refs https://github.com/rectorphp/rector/issues/8060#issuecomment-1920823632

---

so to sum up: if you want to debug something with the step-debugger you need to invoke rector with `--xdebug` option. thats expected and thats how PHPStan behaves.

just having `xdebug` extension loaded is not enough.