### PR TITLE
Test case for "`ReadOnlyPropertyRector` ignores properties being written inside a used trait" #8453

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_write_in_trait_property.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_write_in_trait_property.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use stdClass;
+
+final class SkipWriteInTraitProperty
+{
+    use WritableTrait;
+    
+    public function __construct(private stdClass $myProperty)
+    {
+    }
+}
+
+trait WritableTrait
+{
+    public function setProperty(stdClass $myProperty): void
+    {
+        $this->myProperty = $myProperty;
+    }
+}


### PR DESCRIPTION
See #8453