### PR TITLE
Fix make ReadOnlyPropertyRector skip if traits are used, as not reliable

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_write_in_trait_property.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_write_in_trait_property.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use stdClass;
+
+final class SkipWriteInTraitProperty
+{
+    use WritableTrait;
+    
+    public function __construct(private stdClass $myProperty)
+    {
+    }
+}
+
+trait WritableTrait
+{
+    public function setProperty(stdClass $myProperty): void
+    {
+        $this->myProperty = $myProperty;
+    }
+}

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -240,6 +240,11 @@ CODE_SAMPLE
             return true;
         }
 
+        // not safe
+        if ($class->getTraitUses() !== []) {
+            return true;
+        }
+
         // skip "clone $this" cases, as can create unexpected write to local constructor property
         return $this->hasCloneThis($class);
     }


### PR DESCRIPTION
* Closes https://github.com/rectorphp/rector-src/pull/5546
* Fixes https://github.com/rectorphp/rector/issues/8453
