### PR TITLE
[TypeDeclaration] Skip assign in construct with method call property same name on RestoreDefaultNullToNullableTypePropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_assign_with_method_call_property_same_name.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_assign_with_method_call_property_same_name.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Bookmarks;
+
+use PhpMyAdmin\ConfigStorage\Features\BookmarkFeature;
+use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\DatabaseInterface;
+
+class SkipAssignWithMethodCallPropertySameName
+{
+    private BookmarkFeature|null $bookmarkFeature;
+
+    public function __construct(private DatabaseInterface $dbi, Relation $relation)
+    {
+        $this->bookmarkFeature = $relation->getRelationParameters()->bookmarkFeature;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8456