### PR TITLE
[DX] Fix missing Rector\RectorGenerator\Exception\ConfigurationException

### DIFF
--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -33,7 +33,7 @@ use Rector\Php80\ValueObject\DoctrineTagAndAnnotationToAttribute;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\Rector\AbstractRector;
-use Rector\RectorGenerator\Exception\ConfigurationException;
+use Rector\Exception\Configuration\InvalidConfigurationException;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -124,7 +124,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         if ($this->annotationsToAttributes === []) {
-            throw new ConfigurationException(sprintf('The "%s" rule requires configuration.', self::class));
+            throw new InvalidConfigurationException(sprintf('The "%s" rule requires configuration.', self::class));
         }
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);

--- a/src/Util/MemoryLimiter.php
+++ b/src/Util/MemoryLimiter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\Util;
 
 use Nette\Utils\Strings;
-use Rector\RectorGenerator\Exception\ConfigurationException;
+use Rector\Exception\Configuration\InvalidConfigurationException;
 use Rector\ValueObject\Configuration;
 
 /**
@@ -32,7 +32,7 @@ final class MemoryLimiter
 
         if ($memorySetResult === false) {
             $errorMessage = sprintf('Memory limit "%s" cannot be set.', $memoryLimit);
-            throw new ConfigurationException($errorMessage);
+            throw new InvalidConfigurationException($errorMessage);
         }
     }
 
@@ -44,6 +44,6 @@ final class MemoryLimiter
         }
 
         $errorMessage = sprintf('Invalid memory limit format "%s".', $memoryLimit);
-        throw new ConfigurationException($errorMessage);
+        throw new InvalidConfigurationException($errorMessage);
     }
 }


### PR DESCRIPTION
`rector-generator` seems on require-dev, while it Exception used in various places in the code

https://github.com/search?q=repo%3Arectorphp%2Frector+RectorGenerator&type=code

I think the `ConfigurationException` should be replaced with `Rector\Exception\Configuration\InvalidConfigurationException`

Fixes https://github.com/rectorphp/rector/issues/8459