### PR TITLE
Rollback RectorConfig::configure()->withRules() on config/set/privatization.php config set to old style config

### DIFF
--- a/config/set/privatization.php
+++ b/config/set/privatization.php
@@ -7,9 +7,10 @@ use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 
-return RectorConfig::configure()
-    ->withRules([
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
         PrivatizeLocalGetterToPropertyRector::class,
         PrivatizeFinalClassPropertyRector::class,
         PrivatizeFinalClassMethodRector::class,
     ]);
+};


### PR DESCRIPTION
@jlherren @TomasVotruba this is a quick fix to fix https://github.com/rectorphp/rector/issues/8461

the existing `RectorConfig` is overriden when `RectorConfig::configure()` is not called in the root config, using this config:

```php
use Rector\Config\RectorConfig;
use Rector\Set\ValueObject\SetList;

return static function (RectorConfig $config): void {
    $config->paths([__DIR__ . '/src']);
    // The following seems to overwrite the paths.  Swapping the two lines makes it work again.
    $config->sets([SetList::PRIVATIZATION]);
};
```

cause error:

```
 [ERROR] The given paths do not match any files
``` 

this patch resolve it.