### PR TITLE
Real fix paths The given paths do not match any files on RectorConfigBuilder

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -48,7 +48,6 @@ final class RectorConfig extends Container
      */
     public function paths(array $paths): void
     {
-        Assert::isNonEmptyList($paths, 'paths must not be empty');
         Assert::allString($paths);
 
         // ensure paths exist

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -48,6 +48,7 @@ final class RectorConfig extends Container
      */
     public function paths(array $paths): void
     {
+        Assert::isNonEmptyList($paths, 'paths must not be empty');
         Assert::allString($paths);
 
         // ensure paths exist

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -124,7 +124,11 @@ final class RectorConfigBuilder
         $uniqueSets = array_unique($this->sets);
 
         $rectorConfig->sets($uniqueSets);
-        $rectorConfig->paths($this->paths);
+
+        if ($this->paths !== []) {
+            $rectorConfig->paths($this->paths);
+        }
+
         $rectorConfig->skip($this->skip);
         $rectorConfig->rules($this->rules);
 


### PR DESCRIPTION
@jlherren @TomasVotruba here the real fix for https://github.com/rectorphp/rector/issues/8461 

The `paths()` should not be called when `paths` is still empty, which existing previous config may already filled it, which should not be overridden.