### PR TITLE
Decouple AddClosureVoidReturnTypeWhereNoReturnRector to allow leveling by simple node first

### DIFF
--- a/config/set/type-declaration.php
+++ b/config/set/type-declaration.php
@@ -31,6 +31,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyR
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeSplFixedArrayRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector;
@@ -46,6 +47,7 @@ return static function (RectorConfig $rectorConfig): void {
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
         ReturnTypeFromStrictTypedPropertyRector::class,
         TypedPropertyFromStrictConstructorRector::class,
+        AddClosureVoidReturnTypeWhereNoReturnRector::class,
         AddVoidReturnTypeWhereNoReturnRector::class,
         ReturnTypeFromStrictFluentReturnRector::class,
         ReturnTypeFromReturnNewRector::class,

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector/AddClosureVoidReturnTypeWhereNoReturnRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector/AddClosureVoidReturnTypeWhereNoReturnRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureVoidReturnTypeWhereNoReturnRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector/Fixture/return_inside_inner_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector/Fixture/return_inside_inner_function.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector\Fixture;
+
+final class ReturnInsideInnerFunction
+{
+    public function getValues()
+    {
+        $result = function () {
+            $value = 1000;
+            if ($value) {
+                return;
+            }
+
+            return 10;
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector\Fixture;
+
+final class ReturnInsideInnerFunction
+{
+    public function getValues()
+    {
+        $result = function () {
+            $value = 1000;
+            if ($value) {
+                return;
+            }
+
+            return 10;
+        };
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddClosureVoidReturnTypeWhereNoReturnRector::class);
+};

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Closure;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Identifier;
+use Rector\Rector\AbstractRector;
+use Rector\TypeDeclaration\TypeInferer\SilentVoidResolver;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector\AddClosureVoidReturnTypeWhereNoReturnRectorTest
+ */
+final class AddClosureVoidReturnTypeWhereNoReturnRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly SilentVoidResolver $silentVoidResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add closure return type void if there is no return', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+function () {
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+function (): void {
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Closure::class];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // already has return type → skip
+        if ($node->returnType instanceof Node) {
+            return null;
+        }
+
+        if (! $this->silentVoidResolver->hasExclusiveVoid($node)) {
+            return null;
+        }
+
+        $node->returnType = new Identifier('void');
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::VOID_TYPE;
+    }
+}

--- a/src/Configuration/Levels/TypeCoverageLevel.php
+++ b/src/Configuration/Levels/TypeCoverageLevel.php
@@ -27,6 +27,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRecto
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeSplFixedArrayRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector;
@@ -53,7 +54,11 @@ final class TypeCoverageLevel
      */
     public const RULE_LIST = [
         // php 7.0
+        // start with closure first, as safest
+        AddClosureVoidReturnTypeWhereNoReturnRector::class,
+        // @todo continue with functions
         AddVoidReturnTypeWhereNoReturnRector::class,
+
         // php 7.4
         AddArrowFunctionReturnTypeRector::class,
         ReturnTypeFromStrictNewArrayRector::class,


### PR DESCRIPTION
This is complex rule split for upcoming type levels features, so upgrades can be done safer and without effort - internal knoledge of risk-rule order :+1: 

Here for .e.g. adding `void` to method can break extending classes or even mocks. While adidng `void` to closures is risk-free. Let's start with safer first :) 