### PR TITLE
[PHP81] Skip after is_string on object call on NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_after_is_string_on_object_call.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_after_is_string_on_object_call.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipAfterIsStringOnObjectCall
+{
+    public ?string $stringNull = 'foo';
+}
+
+$demo = new SkipAfterIsStringOnObjectCall();
+
+if (is_string($demo->stringNull) && trim($demo->stringNull) !== '') {
+    echo $demo->stringNull;
+}

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -188,9 +188,14 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $type instanceof MixedType && ! $type instanceof NullType && ! ($type instanceof UnionType && $this->unionTypeAnalyzer->isNullable(
-            $type
-        ))) {
+        $nativeType = $this->nodeTypeResolver->getNativeType($argValue);
+        if ($nativeType->isString()->yes()) {
+            return null;
+        }
+
+        if (! $type instanceof MixedType &&
+            ! $type instanceof NullType &&
+            ! ($type instanceof UnionType && $this->unionTypeAnalyzer->isNullable($type))) {
             return null;
         }
 

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -193,9 +193,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $type instanceof MixedType &&
-            ! $type instanceof NullType &&
-            ! ($type instanceof UnionType && $this->unionTypeAnalyzer->isNullable($type))) {
+        if ($this->shouldSkipType($type)) {
             return null;
         }
 
@@ -215,6 +213,13 @@ CODE_SAMPLE
         $funcCall->args = $args;
 
         return $funcCall;
+    }
+
+    private function shouldSkipType(Type $type): bool
+    {
+        return ! $type instanceof MixedType &&
+            ! $type instanceof NullType &&
+            ! ($type instanceof UnionType && $this->unionTypeAnalyzer->isNullable($type));
     }
 
     private function shouldSkipTrait(Expr $expr, Type $type, bool $isTrait): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8468