### PR TITLE
[Php82] Adds a AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector rule

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 355 Rules Overview
+# 359 Rules Overview
 
 <br>
 
@@ -42,7 +42,7 @@
 
 - [Php81](#php81) (9)
 
-- [Php82](#php82) (4)
+- [Php82](#php82) (5)
 
 - [Php83](#php83) (3)
 
@@ -54,9 +54,9 @@
 
 - [Strict](#strict) (5)
 
-- [Transform](#transform) (22)
+- [Transform](#transform) (23)
 
-- [TypeDeclaration](#typedeclaration) (40)
+- [TypeDeclaration](#typedeclaration) (42)
 
 - [Visibility](#visibility) (3)
 
@@ -5180,6 +5180,25 @@ Refactor Spatie enum method calls
 
 ## Php82
 
+### AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector
+
+Add missing dynamic properties
+
+- class: [`Rector\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector`](../rules/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector.php)
+
+```diff
++#[AllowDynamicProperties]
+ class SomeClass
+ {
+     public function set()
+     {
+         $this->value = 5;
+     }
+ }
+```
+
+<br>
+
 ### AddSensitiveParameterAttributeRector
 
 Add SensitiveParameter attribute to method and function configured parameters
@@ -6085,6 +6104,21 @@ Replaces properties assign calls be defined methods.
 
 <br>
 
+### RectorConfigBuilderRector
+
+Change RectorConfig to RectorConfigBuilder
+
+- class: [`Rector\Transform\Rector\FileWithoutNamespace\RectorConfigBuilderRector`](../rules/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector.php)
+
+```diff
+-return static function (RectorConfig $rectorConfig): void {
+-    $rectorConfig->rule(SomeRector::class);
+-};
++return RectorConfig::configure()->rules([SomeRector::class]);
+```
+
+<br>
+
 ### ReplaceParentCallByPropertyCallRector
 
 Changes method calls in child of specific types to defined property method call
@@ -6249,6 +6283,34 @@ Add known return type to arrow function
 ```diff
 -fn () => [];
 +fn (): array => [];
+```
+
+<br>
+
+### AddClosureVoidReturnTypeWhereNoReturnRector
+
+Add closure return type void if there is no return
+
+- class: [`Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector`](../rules/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector.php)
+
+```diff
+-function () {
++function (): void {
+ }
+```
+
+<br>
+
+### AddFunctionVoidReturnTypeWhereNoReturnRector
+
+Add function return type void if there is no return
+
+- class: [`Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector`](../rules/TypeDeclaration/Rector/Function_/AddFunctionVoidReturnTypeWhereNoReturnRector.php)
+
+```diff
+-function restore() {
++function restore(): void {
+ }
 ```
 
 <br>

--- a/config/set/php82.php
+++ b/config/set/php82.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\Php82\Rector\FuncCall\Utf8DecodeEncodeToMbConvertEncodingRector;
 use Rector\Php82\Rector\New_\FilesystemIteratorSkipDotsRector;
@@ -12,5 +13,6 @@ return static function (RectorConfig $rectorConfig): void {
         ReadOnlyClassRector::class,
         Utf8DecodeEncodeToMbConvertEncodingRector::class,
         FilesystemIteratorSkipDotsRector::class,
+        AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector::class,
     ]);
 };

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRectorTest.php
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+class Fixture
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+#[\AllowDynamicProperties]
+class Fixture
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}
+
+?>

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_allow_dynamic_attribute.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_allow_dynamic_attribute.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+#[\AllowDynamicProperties]
+class SkipAllowDynamicAttribute
+{
+    public function set()
+    {
+        $this->value = 5;
+
+        $this->value = 'hey';
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_anonymous_class.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+
+class SkipAnonymousClass
+{
+    /**
+     * @param Node|Node[] $nodes
+     */
+    public function traverseNodesWithCallable($nodes, callable $callable): void
+    {
+        if (! is_array($nodes)) {
+            $nodes = $nodes ? [$nodes] : [];
+        }
+
+        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser->addVisitor($this->createNodeVisitor($callable));
+        $nodeTraverser->traverse($nodes);
+    }
+
+    private function createNodeVisitor(callable $callable): NodeVisitor
+    {
+        return new class($callable) extends NodeVisitorAbstract {
+            /**
+             * @var callable
+             */
+            private $callable;
+
+            public function __construct(callable $callable)
+            {
+                $this->callable = $callable;
+            }
+
+            /**
+             * @return int|Node|null
+             */
+            public function enterNode(Node $node)
+            {
+                $callable = $this->callable;
+                return $callable($node);
+            }
+        };
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_closure_bind_to.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_closure_bind_to.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use stdClass;
+
+class SkipClosureBindTo
+{
+    // see https://stackoverflow.com/q/39884308/1348344
+    public function getPrivateProperty()
+    {
+        $randomGenerator = new stdClass();
+
+        (function () {
+            return $this->uuidV4Generator;
+        })->bindTo($randomGenerator);
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_closure_call.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_closure_call.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use stdClass;
+
+class SkipClosureCall
+{
+    public function getPrivateProperty()
+    {
+        $randomGenerator = new stdClass();
+
+        (function () {
+            return $this->uuidV4Generator;
+        })->call($randomGenerator);
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_closure_property.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_closure_property.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use stdClass;
+
+class SkipClosureProperty
+{
+    // see https://ocramius.github.io/blog/accessing-private-php-class-members-without-reflection/
+    public function getPrivateProperty()
+    {
+        $randomGenerator = new stdClass();
+
+        $setUuidV4Generator = \Closure::bind(function () {
+            return $this->uuidV4Generator;
+        }, $randomGenerator, $randomGenerator)();
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_defined.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_defined.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+class SkipDefined
+{
+    private $value;
+    public function set()
+    {
+        $this->value = 5;
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_dynamic_properties.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_dynamic_properties.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+class SkipDynamicProperties
+{
+    public function unserialize($serialized)
+    {
+        $data = \unserialize($serialized);
+        foreach ($data as $k => $v) {
+            $this->$k = $v;
+        }
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_extending_stdClass.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_extending_stdClass.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+class SkipExtendingStdClass extends \stdClass
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}
+
+?>

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_inner_class.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_inner_class.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+final class SkipInnerClass
+{
+    public function run()
+    {
+        $box = new class () {
+            public $logged;
+
+            public function hold(string $value)
+            {
+                $this->logged = $value;
+            }
+        };
+
+        echo $box->logged;
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_laravel_closure_binding.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_laravel_closure_binding.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use Illuminate\Support\Collection;
+
+class SkipLaravelClosureBinding
+{
+    /**
+     * @return void
+     */
+    public function registerCollectionMacros(): void
+    {
+        Collection::macro('ksort', function (): Collection {
+            // macros callbacks are bound to collection so we can safely access
+            // protected Collection::items
+            $list = $this->items;
+            ksort($list);
+
+            return new static($list);
+        });
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_magic.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_magic.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+class SkipMagic
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+
+    public function __set($key, $value)
+    {
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_magic_parent.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_magic_parent.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Source\MagicParent;
+
+class SkipMagicParent extends MagicParent
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_parent_property.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_parent_property.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+class SomeChildClass extends SomeParentClassWithProperty
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}
+
+class SomeParentClassWithProperty
+{
+    public $value;
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_pull_from_different_class.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_pull_from_different_class.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Source\DifferentClass;
+
+class SkipPullFromDifferentClass
+{
+    public function run()
+    {
+        $obj = new DifferentClass();
+        echo $obj->property;
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_static_return_object.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_static_return_object.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+use Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Source\StaticFactory;
+
+final class SkipStaticReturnObject
+{
+    public function getCurrentTimestamp()
+    {
+        return StaticFactory::now()->timestamp;
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_trait_used.php.inc
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Fixture/skip_trait_used.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Fixture;
+
+class AddicatedClass
+{
+    use PropertyInjection;
+
+    public function set()
+    {
+        $this->value = 5;
+    }
+}
+
+trait PropertyInjection
+{
+    private $value;
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Source/DifferentClass.php
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Source/DifferentClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Source;
+
+class DifferentClass
+{
+    public $property = 'some value';
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Source/MagicParent.php
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Source/MagicParent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Source;
+
+class MagicParent
+{
+    public function __set($key, $value)
+    {
+    }
+
+    public function __get($key)
+    {
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Source/StaticFactory.php
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/Source/StaticFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\Source;
+
+final class StaticFactory
+{
+    public $timestamp;
+
+    public static function now()
+    {
+        return new static();
+    }
+}

--- a/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/config/configured_rule.php
+++ b/rules-tests/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector::class);
+
+    $rectorConfig->phpVersion(PhpVersionFeature::ALLOW_DYNAMIC_PROPERTIES_ATTRIBUTE);
+};

--- a/rules/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector.php
+++ b/rules/Php82/Rector/Class_/AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php82\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Rector\CodeQuality\NodeAnalyzer\ClassLikeAnalyzer;
+use Rector\CodeQuality\NodeAnalyzer\LocalPropertyAnalyzer;
+use Rector\NodeAnalyzer\ClassAnalyzer;
+use Rector\NodeAnalyzer\PropertyPresenceChecker;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\PostRector\ValueObject\PropertyMetadata;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Php82\Rector\Class_\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector\AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRectorTest
+ */
+final class AddAllowDynamicPropertiesAttributeToClassMissingPropertiesRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly LocalPropertyAnalyzer $localPropertyAnalyzer,
+        private readonly ClassLikeAnalyzer $classLikeAnalyzer,
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassAnalyzer $classAnalyzer,
+        private readonly PropertyPresenceChecker $propertyPresenceChecker,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add missing dynamic properties', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+#[\AllowDynamicProperties]
+class SomeClass
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkipClass($node)) {
+            return null;
+        }
+
+        $className = $this->getName($node);
+        if ($className === null) {
+            return null;
+        }
+
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        // special case for Laravel Collection macro magic
+        $fetchedLocalPropertyNameToTypes = $this->localPropertyAnalyzer->resolveFetchedPropertiesToTypesFromClass(
+            $node
+        );
+
+        if (! $this->hasMissingProperties($node, $classReflection, $fetchedLocalPropertyNameToTypes)) {
+            return null;
+        }
+
+        $node->attrGroups[] = new AttributeGroup([new Attribute(new FullyQualified('AllowDynamicProperties'))]);
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ALLOW_DYNAMIC_PROPERTIES_ATTRIBUTE;
+    }
+
+    private function shouldSkipClass(Class_ $class): bool
+    {
+        if ($this->classAnalyzer->isAnonymousClass($class)) {
+            return true;
+        }
+
+        if ($this->isObjectType($class, new ObjectType('\stdClass'))) {
+            return true;
+        }
+
+        $className = (string) $this->nodeNameResolver->getName($class);
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return true;
+        }
+
+        if ($this->phpAttributeAnalyzer->hasPhpAttribute($class, 'AllowDynamicProperties')) {
+            return true;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        // properties are accessed via magic, nothing we can do
+        if ($classReflection->hasMethod('__set')) {
+            return true;
+        }
+
+        return $classReflection->hasMethod('__get');
+    }
+
+    /**
+     * @param array<string, Type> $fetchedLocalPropertyNameToTypes
+     */
+    private function hasMissingProperties(
+        Class_ $class,
+        ClassReflection $classReflection,
+        array $fetchedLocalPropertyNameToTypes
+    ): bool {
+        $propertyNames = $this->classLikeAnalyzer->resolvePropertyNames($class);
+
+        /** @var string[] $fetchedLocalPropertyNames */
+        $fetchedLocalPropertyNames = array_keys($fetchedLocalPropertyNameToTypes);
+
+        $propertiesToComplete = array_diff($fetchedLocalPropertyNames, $propertyNames);
+
+        $propertiesToComplete = $this->filterOutExistingProperties($class, $classReflection, $propertiesToComplete);
+
+        return $propertiesToComplete !== [];
+    }
+
+    /**
+     * @param string[] $propertiesToComplete
+     * @return string[]
+     */
+    private function filterOutExistingProperties(
+        Class_ $class,
+        ClassReflection $classReflection,
+        array $propertiesToComplete
+    ): array {
+        $missingPropertyNames = [];
+
+        $className = $classReflection->getName();
+        // remove other properties that are accessible from this scope
+        foreach ($propertiesToComplete as $propertyToComplete) {
+            if ($classReflection->hasProperty($propertyToComplete)) {
+                continue;
+            }
+
+            $propertyMetadata = new PropertyMetadata($propertyToComplete, new ObjectType($className));
+
+            $hasClassContextProperty = $this->propertyPresenceChecker->hasClassContextProperty(
+                $class,
+                $propertyMetadata
+            );
+            if ($hasClassContextProperty) {
+                continue;
+            }
+
+            $missingPropertyNames[] = $propertyToComplete;
+        }
+
+        return $missingPropertyNames;
+    }
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -645,6 +645,12 @@ final class PhpVersionFeature
     public const SENSITIVE_PARAMETER_ATTRIBUTE = PhpVersion::PHP_82;
 
     /**
+     * @see https://wiki.php.net/rfc/deprecate_dynamic_properties
+     * @var int
+     */
+    public const ALLOW_DYNAMIC_PROPERTIES_ATTRIBUTE = PhpVersion::PHP_82;
+
+    /**
      * @see https://wiki.php.net/rfc/marking_overriden_methods
      * @var int
      */


### PR DESCRIPTION
# Changes

* adds a PHP82 rule based on the same logic used for the CodeQuality rule for adding missing properties. Instead, this rule will apply the AllowDynamicProperties to the class. One key difference is that this rule will ignore classes extending `stdClass` as any child of this class should not require the AllowDynamicProperties attribute.
* adds tests for the new rule.
* updates the docs.
* Adds the AllowDynamicPropertiesAttribute const to the PHPVersionFeatures class.
* Adds the rule to the PHP82 set

# Why

Although using the CodeQuality rule is better in my opinion, the suggested upgrade path would be to add the attribute. In some cases it will make the process to upgrade easier to just apply the attribute instead.

Example code:

```diff
+#[\AllowDynamicProperties]
 class SomeClass
 {
     public function set()
     {
         $this->value = 5;
     }
 }
```