### PR TITLE
[Config] Make sure only one of type-declaration/dead-code or with*Level() is used to avoid duplicates

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -69,30 +69,12 @@ parameters:
                 - src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
                 - src/Parallel/Application/ParallelFileProcessor.php
                 # rector rules
-                - rules/CodeQuality/Rector/If_/SimplifyIfNullableReturnRector.php
-                - rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
-                - rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+                - rules/*/Rector/*Rector.php
                 - utils/Rector/MoveAbstractRectorToChildrenRector.php
                 - rules/TypeDeclaration/Rector/*
-                - rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
-                - rules/Transform/Rector/FuncCall/FuncCallToMethodCallRector.php
-                - rules/Renaming/Rector/ClassMethod/RenameAnnotationRector.php
-                - rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
-                - rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
-                - rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
-                - rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
-                - rules/DeadCode/Rector/If_/RemoveTypedPropertyDeadInstanceOfRector.php
-                - rules/CodeQuality/Rector/If_/ConsecutiveNullCompareReturnsToNullCoalesceQueueRector.php
                 - src/PhpDocParser/PhpDocParser/PhpDocNodeTraverser.php
                 - src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
-                - rules/Php80/Rector/Switch_/ChangeSwitchToMatchRector.php
-                - rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
-                - rules/EarlyReturn/Rector/If_/ChangeAndIfToEarlyReturnRector.php
-                - rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
-                - rules/CodeQuality/Rector/Foreach_/SimplifyForeachToCoalescingRector.php
-                - rules/CodeQuality/Rector/Foreach_/ForeachToInArrayRector.php
                 - src/Configuration/RectorConfigBuilder.php
-                - rules/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector.php
 
         # is nested expr
         -

--- a/rector.php
+++ b/rector.php
@@ -22,8 +22,6 @@ return RectorConfig::configure()
         earlyReturn: true,
         naming: true
     )
-    // @experimental since 0.19.7 for more smooth Rector integration to new project
-    ->withTypeCoverageLevel(10)
     ->withPhpSets()
     ->withRules([DeclareStrictTypesRector::class])
     ->withPaths([

--- a/rules/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector.php
+++ b/rules/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector.php
@@ -116,10 +116,12 @@ CODE_SAMPLE
                     $rules->items = array_merge($rules->items, $rectorConfigStmt->expr->getArgs()[0]->value->items);
                 } elseif ($this->isName($rectorConfigStmt->expr->name, 'paths')) {
                     Assert::isAOf($rectorConfigStmt->expr->getArgs()[0]->value, Array_::class);
-                    $paths = $rectorConfigStmt->expr->getArgs()[0]->value;
+                    $paths = $rectorConfigStmt->expr->getArgs()[0]
+->value;
                 } elseif ($this->isName($rectorConfigStmt->expr->name, 'skip')) {
                     Assert::isAOf($rectorConfigStmt->expr->getArgs()[0]->value, Array_::class);
-                    $skips = $rectorConfigStmt->expr->getArgs()[0]->value;
+                    $skips = $rectorConfigStmt->expr->getArgs()[0]
+->value;
                 } else {
                     // implementing method by method
                     return null;

--- a/src/Console/Command/DetectNodeCommand.php
+++ b/src/Console/Command/DetectNodeCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Console\Command;
 
-use Throwable;
 use Nette\Utils\Strings;
 use Rector\CustomRules\SimpleNodeDumper;
 use Rector\PhpParser\Parser\SimplePhpParser;
@@ -14,6 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
 
 final class DetectNodeCommand extends Command
 {
@@ -64,10 +64,18 @@ final class DetectNodeCommand extends Command
     private function addConsoleColors(string $contents): string
     {
         // decorate class names
-        $colorContents = Strings::replace($contents, self::CLASS_NAME_REGEX, static fn(array $match): string => '<fg=green>' . $match['class_name'] . '</>(');
+        $colorContents = Strings::replace(
+            $contents,
+            self::CLASS_NAME_REGEX,
+            static fn (array $match): string => '<fg=green>' . $match['class_name'] . '</>('
+        );
 
         // decorate keys
-        return Strings::replace($colorContents, self::PROPERTY_KEY_REGEX, static fn(array $match): string => '<fg=yellow>' . $match['key'] . '</>:');
+        return Strings::replace(
+            $colorContents,
+            self::PROPERTY_KEY_REGEX,
+            static fn (array $match): string => '<fg=yellow>' . $match['key'] . '</>:'
+        );
     }
 
     private function askQuestionAndDumpNode(): void


### PR DESCRIPTION
The set and superset should never be used together, to avoid duplications.