### PR TITLE
[NodeTypeResolver] Ignore PHPStan internal error on PHPStanNodeScopeResolver on NodeScopeResolver::processNodes()

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -209,6 +209,7 @@ final class PHPStanNodeScopeResolver
     }
 
     /**
+     * @param Stmt[] $stmts
      * @param callable(Node $node, MutatingScope $scope): void $nodeCallback
      */
     private function nodeScopeResolverProcessNodes(array $stmts, MutatingScope $mutatingScope, callable $nodeCallback): void

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -119,10 +119,10 @@ final class PHPStanNodeScopeResolver
         $scope = $formerMutatingScope ?? $this->scopeFactory->createFromFile($filePath);
 
         // skip chain method calls, performance issue: https://github.com/phpstan/phpstan/issues/254
-        $nodeCallback = function (Node $node, MutatingScope $mutatingScope) use (&$nodeCallback, $filePath): void {
+        $nodeCallback = function (Node $node, MutatingScope $mutatingScope) use ($filePath): void {
             if ($node instanceof FileWithoutNamespace) {
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-                $this->processNodes($node->stmts,$filePath, $mutatingScope);
+                $this->processNodes($node->stmts, $filePath, $mutatingScope);
 
                 return;
             }

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
+use Throwable;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -121,7 +122,7 @@ final class PHPStanNodeScopeResolver
         $nodeCallback = function (Node $node, MutatingScope $mutatingScope) use (&$nodeCallback, $filePath): void {
             if ($node instanceof FileWithoutNamespace) {
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-                $this->nodeScopeResolver->processNodes($node->stmts, $mutatingScope, $nodeCallback);
+                $this->processNodes($node->stmts,$filePath, $mutatingScope);
 
                 return;
             }
@@ -178,7 +179,7 @@ final class PHPStanNodeScopeResolver
             }
 
             if ($node instanceof Trait_) {
-                $this->processTrait($node, $mutatingScope, $nodeCallback);
+                $this->processTrait($node, $mutatingScope, $filePath);
                 return;
             }
 
@@ -197,7 +198,13 @@ final class PHPStanNodeScopeResolver
             }
         };
 
-        $this->nodeScopeResolver->processNodes($stmts, $scope, $nodeCallback);
+        try {
+            $this->nodeScopeResolver->processNodes($stmts, $scope, $nodeCallback);
+        } catch (Throwable $throwable) {
+            if ($throwable->getMessage() !== 'Internal error.') {
+                throw $throwable;
+            }
+        }
 
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new WrappedNodeRestoringNodeVisitor());
@@ -382,10 +389,7 @@ final class PHPStanNodeScopeResolver
         return $classLike->name->toString();
     }
 
-    /**
-     * @param callable(Node $trait, MutatingScope $scope): void $nodeCallback
-     */
-    private function processTrait(Trait_ $trait, MutatingScope $mutatingScope, callable $nodeCallback): void
+    private function processTrait(Trait_ $trait, MutatingScope $mutatingScope, string $filePath): void
     {
         $traitName = $this->resolveClassName($trait);
 
@@ -403,7 +407,7 @@ final class PHPStanNodeScopeResolver
         $this->privatesAccessor->setPrivateProperty($traitScope, self::CONTEXT, $traitContext);
 
         $trait->setAttribute(AttributeKey::SCOPE, $traitScope);
-        $this->nodeScopeResolver->processNodes($trait->stmts, $traitScope, $nodeCallback);
+        $this->processNodes($trait->stmts, $filePath, $traitScope);
         $this->decorateTraitAttrGroups($trait, $traitScope);
     }
 }


### PR DESCRIPTION
@CosaroLisa this fixes https://github.com/rectorphp/rector/issues/8463 to ignore internal phpstan error