### PR TITLE
 [Php81] Skip possible array on NullToStrictStringFuncCallArgRector 

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_possible_array.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_possible_array.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipPossibleArray
+{
+    public function run(string|array|null $value): array|string
+    {
+        return str_replace('for', 'bar', $value);
+    }
+}

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -219,7 +219,7 @@ CODE_SAMPLE
     {
         return ! $type instanceof MixedType &&
             ! $type instanceof NullType &&
-            ! ($type instanceof UnionType && $this->unionTypeAnalyzer->isNullable($type));
+            ! ($type instanceof UnionType && $this->unionTypeAnalyzer->isNullable($type, true));
     }
 
     private function shouldSkipTrait(Expr $expr, Type $type, bool $isTrait): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8473