### PR TITLE
[Php81] Skip another possible cast array to string on NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_possible_array2.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_possible_array2.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipPossibleArray2
+{
+    public function run(array|null $value)
+    {
+        return str_replace('for', 'bar', $value);
+    }
+}

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -28,7 +28,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\Php81\Enum\NameNullToStrictNullFunctionMap;
 use Rector\PhpParser\Node\Value\ValueResolver;
-use Rector\PHPStanStaticTypeMapper\TypeAnalyzer\UnionTypeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersionFeature;
@@ -45,8 +44,7 @@ final class NullToStrictStringFuncCallArgRector extends AbstractRector implement
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ArgsAnalyzer $argsAnalyzer,
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private readonly ValueResolver $valueResolver,
-        private readonly UnionTypeAnalyzer $unionTypeAnalyzer
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -215,11 +215,32 @@ CODE_SAMPLE
         return $funcCall;
     }
 
+    private function isValidUnionType(Type $type): bool
+    {
+        if (! $type instanceof UnionType) {
+            return false;
+        }
+
+        foreach ($type->getTypes() as $childType) {
+            if ($childType->isString()->yes()) {
+                continue;
+            }
+
+            if ($childType->isNull()->yes()) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
     private function shouldSkipType(Type $type): bool
     {
         return ! $type instanceof MixedType &&
             ! $type instanceof NullType &&
-            ! ($type instanceof UnionType && $this->unionTypeAnalyzer->isNullable($type, true));
+            ! $this->isValidUnionType($type);
     }
 
     private function shouldSkipTrait(Expr $expr, Type $type, bool $isTrait): bool


### PR DESCRIPTION
continue of PR:

- https://github.com/rectorphp/rector-src/pull/5587

this skip another possible cast array to string.

Ref https://getrector.com/demo/28993d64-974f-425e-88ed-519056ededcd