### PR TITLE
Clean up parallel-lint exclude on downgrade build

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -73,7 +73,7 @@ jobs:
                     php-version: 7.2
                     coverage: none
             -   run: composer global require php-parallel-lint/php-parallel-lint --ansi
-            -   run: /home/runner/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/console/Debug/CliRequest.php --exclude rector-prefixed-downgraded/vendor/symplify/easy-parallel/ecs.php
+            -   run: /home/runner/.composer/vendor/bin/parallel-lint rector-prefixed-downgraded --exclude rector-prefixed-downgraded/stubs --exclude rector-prefixed-downgraded/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded/vendor/rector/rector-generator/templates --exclude rector-prefixed-downgraded/vendor/symfony/console/Debug/CliRequest.php
 
             # 5. copy repository meta files
             -   run: |

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/filesystem": "^6.3",
         "symfony/finder": "^6.3",
         "symfony/process": "^6.3",
-        "symplify/easy-parallel": "^11.1",
+        "symplify/easy-parallel": "^11.2.2",
         "symplify/rule-doc-generator-contracts": "^11.1",
         "webmozart/assert": "^1.11"
     },


### PR DESCRIPTION
Bump easy-parallel to `1.2.2` to clean up downgrade build exclude on parallel lint, ref

- https://github.com/symplify/easy-parallel/pull/6