### PR TITLE
Move StrictArrayParamDimFetchRector and StrictStringParamConcatRector to last rules on TypeDeclarationLevel

### DIFF
--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -95,12 +95,12 @@ final class TypeDeclarationLevel
         AddParamTypeFromPropertyTypeRector::class,
         MergeDateTimePropertyTypeDeclarationRector::class,
         PropertyTypeFromStrictSetterGetterRector::class,
-        StrictArrayParamDimFetchRector::class,
-        StrictStringParamConcatRector::class,
         ParamTypeByMethodCallTypeRector::class,
         TypedPropertyFromAssignsRector::class,
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
         ReturnTypeFromStrictFluentReturnRector::class,
         ReturnNeverTypeRector::class,
+        StrictArrayParamDimFetchRector::class,
+        StrictStringParamConcatRector::class,
     ];
 }


### PR DESCRIPTION
Ensure the external call `AddMethodCallBasedStrictParamTypeRector` and `ParamTypeByMethodCallTypeRector` executed before risky rely on concat or param dim fetch inside the method on updating param type.