### PR TITLE
[CodeQuality] Skip private static call from static:: on LocallyCalledStaticMethodToNonStaticRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_static_call_from_static.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_static_call_from_static.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture;
+
+final class SkipPrivateStaticCallFromStatic
+{
+    public static function clear(string $input)
+    {
+        return static::reallyClear($input);
+    }
+
+    private static function reallyClear($input)
+    {
+        return $input . ' - clean';
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
@@ -129,7 +129,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            if (! $this->isName($node->class, 'self')) {
+            if (! $this->isNames($node->class, ['self', 'static'])) {
                 return null;
             }
 
@@ -170,7 +170,7 @@ CODE_SAMPLE
                     return null;
                 }
 
-                if (! $this->isName($node->class, 'self')) {
+                if (! $this->isNames($node->class, ['self', 'static'])) {
                     return null;
                 }
 

--- a/tests/Issues/EmptyLineNestedAnnotationToAttribute/Fixture/fixture.php.inc
+++ b/tests/Issues/EmptyLineNestedAnnotationToAttribute/Fixture/fixture.php.inc
@@ -38,7 +38,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'representation_started_at', columns: ['representation', 'started_at'])]
 #[ORM\Index(name: 'channel_started_at_status_representation_sequence', columns: ['channel', 'started_at', 'status', 'representation', 'sequence'])]
 #[ORM\UniqueConstraint(name: 'unique_channel_representation_started_at', columns: ['channel', 'representation', 'started_at'])]
-#[ORM\Entity(repositoryClass: 'App\Repository\SegmentRepository')]
+#[ORM\Entity(repositoryClass: \App\Repository\SegmentRepository::class)]
 class Segment
 {
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8495
Ref https://getrector.com/demo/2cbedcd0-9752-4b81-a72e-c7b49b1a6b4a
Ref https://3v4l.org/vhgTJ that cause fatal error.