### PR TITLE
[CodeQuality] Add StaticToSelfStaticMethodCallOnFinalClassRector

### DIFF
--- a/config/set/code-quality.php
+++ b/config/set/code-quality.php
@@ -11,6 +11,7 @@ use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
 use Rector\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector;
 use Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
@@ -192,5 +193,6 @@ return static function (RectorConfig $rectorConfig): void {
         NumberCompareToMaxFuncCallRector::class,
         CompleteMissingIfElseBracketRector::class,
         RemoveUselessIsObjectCheckRector::class,
+        StaticToSelfStaticMethodCallOnFinalClassRector::class,
     ]);
 };

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/call_statically.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/call_statically.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+final class CallStatically
+{
+    public function execute()
+    {
+        static::run();
+    }
+
+    private static function run()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+final class CallStatically
+{
+    public function execute()
+    {
+        self::run();
+    }
+
+    private static function run()
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/call_statically.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/call_statically.php.inc
@@ -6,10 +6,11 @@ final class CallStatically
 {
     public function execute()
     {
-        static::run();
+        $a = 1;
+        static::run($a);
     }
 
-    private static function run()
+    private static function run($a)
     {
     }
 }
@@ -24,10 +25,11 @@ final class CallStatically
 {
     public function execute()
     {
-        self::run();
+        $a = 1;
+        self::run($a);
     }
 
-    private static function run()
+    private static function run($a)
     {
     }
 }

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_already_self.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_already_self.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+final class CallStatically
+{
+    public function execute()
+    {
+        self::run();
+    }
+
+    private static function run()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_call_non_existence_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_call_non_existence_method.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+final class SkipCallNonExistenceMethod
+{
+    public function execute($execute)
+    {
+        static::run();
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_dynamic_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_dynamic_method.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+final class SkipDynamicMethod
+{
+    public function execute($execute)
+    {
+        static::{$execute}();
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_from_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_from_variable.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+final class SkipFromVariable
+{
+    public function execute($static)
+    {
+        $static::run();
+    }
+
+    private function run()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_non_final.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_non_final.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+class SkipNonFinal
+{
+    public function execute()
+    {
+        static::run();
+    }
+
+    private static function run()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_non_static_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_non_static_call.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+final class SkipNonStaticCall
+{
+    public function execute()
+    {
+        $this->run();
+    }
+
+    private function run()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/StaticToSelfStaticMethodCallOnFinalClassRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/StaticToSelfStaticMethodCallOnFinalClassRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class StaticToSelfStaticMethodCallOnFinalClassRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([StaticToSelfStaticMethodCallOnFinalClassRector::class]);

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -6,6 +6,7 @@ namespace Rector\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Enum\ObjectReference;
@@ -84,13 +85,12 @@ CODE_SAMPLE
                 return null;
             }
 
-            $methodName = $this->getName($subNode->name);
-
             // skip dynamic method
-            if ($methodName === null) {
+            if (! $subNode->name instanceof Identifier) {
                 return null;
             }
 
+            $methodName = $this->getName($subNode->name);
             // skip call non-existing method from current class to ensure transformation is safe
             if (! $node->getMethod($methodName) instanceof ClassMethod) {
                 return null;

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -91,8 +91,15 @@ CODE_SAMPLE
             }
 
             $methodName = $this->getName($subNode->name);
+
+            $classMethod = $node->getMethod($methodName);
             // skip call non-existing method from current class to ensure transformation is safe
-            if (! $node->getMethod($methodName) instanceof ClassMethod) {
+            if (! $classMethod instanceof ClassMethod) {
+                return null;
+            }
+
+            // avoid overlapped change
+            if (! $classMethod->isStatic()) {
                 return null;
             }
 

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -92,14 +92,14 @@ CODE_SAMPLE
 
             $methodName = $this->getName($subNode->name);
 
-            $classMethod = $node->getMethod($methodName);
+            $targetClassMethod = $node->getMethod($methodName);
             // skip call non-existing method from current class to ensure transformation is safe
-            if (! $classMethod instanceof ClassMethod) {
+            if (! $targetClassMethod instanceof ClassMethod) {
                 return null;
             }
 
             // avoid overlapped change
-            if (! $classMethod->isStatic()) {
+            if (! $targetClassMethod->isStatic()) {
                 return null;
             }
 

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -7,6 +7,7 @@ namespace Rector\CodeQuality\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Enum\ObjectReference;
@@ -104,7 +105,8 @@ CODE_SAMPLE
             }
 
             $hasChanged = true;
-            return $this->nodeFactory->createSelfMethod($methodName);
+            $subNode->class = new Name('self');
+            return $subNode;
         });
 
         if ($hasChanged) {

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            if (! $this->isName($subNode->class, ObjectReference::STATIC)) {
+            if (! $subNode->class instanceof Name || ! $this->isName($subNode->class, ObjectReference::STATIC)) {
                 return null;
             }
 

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -90,9 +90,9 @@ CODE_SAMPLE
                 return null;
             }
 
-            $methodName = $this->getName($subNode->name);
-
+            $methodName = (string) $this->getName($subNode->name);
             $targetClassMethod = $node->getMethod($methodName);
+
             // skip call non-existing method from current class to ensure transformation is safe
             if (! $targetClassMethod instanceof ClassMethod) {
                 return null;

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -82,7 +82,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            if (! $subNode->class instanceof Name || ! $this->isName($subNode->class, ObjectReference::STATIC)) {
+            if (! $this->isName($subNode->class, ObjectReference::STATIC)) {
                 return null;
             }
 

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Enum\ObjectReference;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://3v4l.org/JK1g2#v5.0.0
+ * @see \Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\StaticToSelfStaticMethodCallOnFinalClassRectorTest
+ */
+final class StaticToSelfStaticMethodCallOnFinalClassRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change `static::methodCall()` to `self::methodCall()` on final class', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function d()
+    {
+        echo static::run();
+    }
+
+    private static function run()
+    {
+        echo 'test';
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function d()
+    {
+        echo self::run();
+    }
+
+    private static function run()
+    {
+        echo 'test';
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        if (! $node->isFinal()) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        $this->traverseNodesWithCallable($node->stmts, function (Node $subNode) use (&$hasChanged, $node): ?StaticCall {
+            if (! $subNode instanceof StaticCall) {
+                return null;
+            }
+
+            if (! $this->isName($subNode->class, ObjectReference::STATIC)) {
+                return null;
+            }
+
+            $methodName = $this->getName($subNode->name);
+
+            // skip dynamic method
+            if ($methodName === null) {
+                return null;
+            }
+
+            // skip call non-existing method from current class to ensure transformation is safe
+            if (! $node->getMethod($methodName) instanceof ClassMethod) {
+                return null;
+            }
+
+            $hasChanged = true;
+            return $this->nodeFactory->createSelfMethod($methodName);
+        });
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -264,6 +264,13 @@ final readonly class NodeFactory
         return new ClassConstFetch($name, $constantName);
     }
 
+    public function createSelfMethod(string $methodName): StaticCall
+    {
+        $name = new Name(ObjectReference::SELF);
+
+        return new StaticCall($name, $methodName);
+    }
+
     /**
      * @param Param[] $params
      * @return Arg[]

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -264,13 +264,6 @@ final readonly class NodeFactory
         return new ClassConstFetch($name, $constantName);
     }
 
-    public function createSelfMethod(string $methodName): StaticCall
-    {
-        $name = new Name(ObjectReference::SELF);
-
-        return new StaticCall($name, $methodName);
-    }
-
     /**
      * @param Param[] $params
      * @return Arg[]


### PR DESCRIPTION
On final class, call `static::execute()` to static method can be changed to `self::execute()`, and the feature exists since php 5.0 https://3v4l.org/JK1g2#v5.0.0

so I add this to `CodeQuality` set.