### PR TITLE
[Php83] Early check private method in child before check parent on AddOverrideAttributeToOverriddenMethodsRector

### DIFF
--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_private_method.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_private_method.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleParentClass;
+
+class SkipPrivateMethod extends ExampleParentClass
+{
+    private function bar()
+    {
+    }
+}
+
+?>

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -132,6 +132,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($classMethod->isPrivate()) {
+                continue;
+            }
+
             // ignore if it already uses the attribute
             if ($this->phpAttributeAnalyzer->hasPhpAttribute($classMethod, 'Override')) {
                 continue;


### PR DESCRIPTION
No need to loop parent ancestors when method already private, see https://3v4l.org/v0Cs8#v8.3.3