### PR TITLE
RectorConfigBuilder: skip and rules can be called multiple times 

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -266,7 +266,7 @@ final class RectorConfigBuilder
      */
     public function withSkip(array $skip): self
     {
-        $this->skip = $skip;
+        $this->skip = array_merge($this->skip, $skip);
 
         return $this;
     }
@@ -480,7 +480,7 @@ final class RectorConfigBuilder
      */
     public function withRules(array $rules): self
     {
-        $this->rules = $rules;
+        $this->rules = array_merge($this->rules, $rules);
 
         return $this;
     }


### PR DESCRIPTION
RectorConfigBuilder: skip and rules can be called multiple times and parameters are merged.

This idea was mentioned in https://github.com/rectorphp/rector/issues/8489 

I cannot find tests for RectorConfigBuilder. I found only tests for `RectorConfigBuilderRector` with fixture https://github.com/rectorphp/rector-src/blob/main/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_rules.php.inc
This fixture merges multiple calls `->rule()` into one `->withRules()`.

My change has as same logic as rules and `withTypeCoverageLevel` and existing tests on my local machine stay green