### PR TITLE
Add minimal memory limit for local run phpstan without result cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         ],
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
-        "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify",
+        "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify --memory-limit=512M",
         "docs": [
             "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3 --skip-type 'Rector\\Core\\Rector\\AbstractCollectorRector'",
             "mv build/rector_rules_overview.md build/target-repository/docs/rector_rules_overview.md"


### PR DESCRIPTION
Without specified memory limit phpstan can fail wit errors like this (because too low default memory-limit in local php.ini):

```
<error>Child process error</error> (exit code 255): Fatal error: Allowed memory size of 268435456 bytes      
           exhausted (tried to allocate 262144 bytes) in                                                                
           phar:///......
```

Another options should be granting phpstan unlimited memory (`memory-limit=-1`).