### PR TITLE
Add const fetch to class const fetch rector.

### DIFF
--- a/rules-tests/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector/ConstFetchToClassConstFetchTest.php
+++ b/rules-tests/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector/ConstFetchToClassConstFetchTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\ConstFetch\ConstFetchToClassConstFetchRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class ConstFetchToClassConstFetchTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector/Fixture/fixture1.php.inc
+++ b/rules-tests/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector/Fixture/fixture1.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\ConstFetch\ConstFetchToClassConstFetchRector;
+
+$x = CONTEXT_COURSE;
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\ConstFetch\ConstFetchToClassConstFetchRector;
+
+$x = \core\context\course::LEVEL;

--- a/rules-tests/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Transform\Rector\ConstFetch\ConstFetchToClassConstFetchRector;
+use Rector\Transform\ValueObject\ConstFetchToClassConstFetch;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ConstFetchToClassConstFetchRector::class, [
+            new ConstFetchToClassConstFetch('CONTEXT_COURSE', 'core\context\course', 'LEVEL'),
+        ]);
+};

--- a/rules/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector.php
+++ b/rules/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Rector\Transform\Rector\ConstFetch;
+
+use PhpParser\Node;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Rector\Transform\ValueObject\ConstFetchToClassConstFetch;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see Rector\Tests\Transform\Rector\ConstFetch\ConstFetchToClassConstFetchRector\ConstFetchToClassConstFetchTest
+ */
+final class ConstFetchToClassConstFetchRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ConstFetchToClassConstFetch[]
+     */
+    private array $constFetchToClassConsts = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change const fetch to class const fetch', [
+            new ConfiguredCodeSample('$x = CONTEXT_COURSE', '$x = course::LEVEL', [
+                new ConstFetchToClassConstFetch('CONTEXT_COURSE', 'course', 'LEVEL'),
+            ]),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\ConstFetch::class];
+    }
+
+    public function refactor(Node $node)
+    {
+        foreach ($this->constFetchToClassConsts as $constFetchToClassConst) {
+            if (! $this->isName($node, $constFetchToClassConst->getOldConstName())) {
+                continue;
+            }
+            return $this->nodeFactory->createClassConstFetch(
+                $constFetchToClassConst->getNewClassName(),
+                $constFetchToClassConst->getNewConstName()
+            );
+        }
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, ConstFetchToClassConstFetch::class);
+        $this->constFetchToClassConsts = $configuration;
+    }
+}

--- a/rules/Transform/ValueObject/ConstFetchToClassConstFetch.php
+++ b/rules/Transform/ValueObject/ConstFetchToClassConstFetch.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Transform\ValueObject;
+
+use Rector\Validation\RectorAssert;
+
+final class ConstFetchToClassConstFetch
+{
+    private string $oldConstName;
+
+    private string $newClassName;
+
+    private string $newConstName;
+
+    public function __construct(string $oldConstName, string $newClassName, string $newConstName)
+    {
+        $this->oldConstName = $oldConstName;
+        $this->newClassName = $newClassName;
+        $this->newConstName = $newConstName;
+        RectorAssert::constantName($oldConstName);
+        RectorAssert::className($newClassName);
+        RectorAssert::constantName($newConstName);
+    }
+
+    public function getOldConstName(): string
+    {
+        return $this->oldConstName;
+    }
+
+    public function getNewClassName(): string
+    {
+        return $this->newClassName;
+    }
+
+    public function getNewConstName(): string
+    {
+        return $this->newConstName;
+    }
+}


### PR DESCRIPTION
This is a new rector for transforming the use of global constants (i.e. created with define()) into class constants. This is useful where global constants are being moved into classes as part of a refactoring.