### PR TITLE
Add basic validation for skipped path

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -24,6 +24,7 @@ use Rector\Symfony\Set\SensiolabsSetList;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\ValueObject\PhpVersion;
 use Symfony\Component\Finder\Finder;
+use Webmozart\Assert\Assert;
 
 /**
  * @api
@@ -273,6 +274,10 @@ final class RectorConfigBuilder
 
     public function withSkipPath(string $skipPath): self
     {
+        if (!str_contains($skipPath, '*')) {
+            Assert::fileExists($skipPath);
+        }
+
         return $this->withSkip([$skipPath]);
     }
 


### PR DESCRIPTION
As mentioned at https://github.com/rectorphp/rector-src/pull/5626#issuecomment-1949138035 I add basic validation for skipPath values. `str_contains` is there for cases when path contains wildcards for `fnmatch`.