### PR TITLE
[DX] Add error message information for include full path to load internal phpstan bleedingEdge.neon config

### DIFF
--- a/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -31,6 +31,19 @@ final readonly class PHPStanServicesFactory
 {
     private Container $container;
 
+    /**
+     * @var string
+     */
+    private const INVALID_BLEEDING_EDGE_PATH_MESSAGE = <<<MESSAGE_ERROR
+'%s, use full path bleedingEdge.neon config, eg:
+
+includes:
+    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
+
+in your included phpstan configuration.
+
+MESSAGE_ERROR;
+
     public function __construct()
     {
         $containerFactory = new ContainerFactory(getcwd());
@@ -44,19 +57,9 @@ final readonly class PHPStanServicesFactory
             );
         } catch (Throwable $throwable) {
             if ($throwable->getMessage() === "File 'phar://phpstan.phar/conf/bleedingEdge.neon' is missing or is not readable.") {
-                $messageError = <<<MESSAGE_ERROR
-
-{$throwable->getMessage()}, use full path bleedingEdge.neon config, eg:
-
-includes:
-    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
-
-in your included phpstan configuration.
-
-MESSAGE_ERROR;
 
                 $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
-                $symfonyStyle->error($messageError);
+                $symfonyStyle->error(sprintf(self::INVALID_BLEEDING_EDGE_PATH_MESSAGE, $throwable->getMessage()));
 
                 exit(-1);
             }

--- a/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\DependencyInjection;
 
+use Throwable;
 use PhpParser\Lexer;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeFactory;
@@ -15,7 +16,6 @@ use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
-use Rector\Exception\Configuration\InvalidConfigurationException;
 use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -42,14 +42,8 @@ final readonly class PHPStanServicesFactory
                 $additionalConfigFiles,
                 []
             );
-        } catch (\Throwable $throwable) {
-            if (in_array(
-                $throwable->getMessage(),
-                [
-                    'File \'phar://phpstan.phar/conf/bleedingEdge.neon\' is missing or is not readable.'
-                ],
-                true
-            )) {
+        } catch (Throwable $throwable) {
+            if ($throwable->getMessage() === "File 'phar://phpstan.phar/conf/bleedingEdge.neon' is missing or is not readable.") {
                 $messageError = <<<MESSAGE_ERROR
 
 {$throwable->getMessage()}, use full path bleedingEdge.neon config, eg:


### PR DESCRIPTION
@philbates35 @TomasVotruba here to inform to set full path for include phpstan bleedingEdge.neon for config to be:

```diff
includes:
-    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
```

**Before**

![Screenshot 2024-02-19 at 00 38 04](https://github.com/rectorphp/rector-src/assets/459648/dc964301-d8a4-4d12-90e6-00b8ae62d0d3)


**After**

![Screenshot 2024-02-19 at 00 38 23](https://github.com/rectorphp/rector-src/assets/459648/52b882b6-a461-4506-8748-7cd5810fdc46)

Fixes https://github.com/rectorphp/rector/issues/8492