### PR TITLE
Create demo_file.php.inc with return type for abs function

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/demo_file.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/demo_file.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class DemoFile
+{
+    
+    function aa($param)
+    {
+        return abs($param);
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+final class DemoFile
+{
+    
+    function aa($param): int|float
+    {
+        return abs($param);
+    }
+}
+?>


### PR DESCRIPTION
Function [abs](https://www.php.net/manual/en/function.abs.php) returns int or float (depends on input parameter). For PHP versions without support union return types this rule should only add return type into docBlock.

Rector PHP looks like this: 

```php
<?php

use Rector\Config\RectorConfig;
use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;

return RectorConfig::configure()
    ->withRules([ReturnTypeFromStrictTypedCallRector::class]);
```

https://getrector.com/demo/d37c5f15-d9f4-4fef-8a51-96eee30c7241

