### PR TITLE
Keep comments in annotations when converting them to attributes

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/with_comment.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/with_comment.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
+
+final class WithDescription
+{
+    /**
+     * This comment is before the annotations
+     * @GenericAnnotation this is a simple annotation
+     * @GenericAnnotation(key="value") this annotation has parameters
+     * @GenericAnnotation(
+     *     "some" = "item",
+     *     "summary" = "item",
+     * ) this annotation is multi-line
+     * @GenericAnnotation(key="value") (this comment is within parentheses)
+     * @GenericAnnotation(key="value") "this comment is within quotes"
+     * This comment does not belong to an annotation and will be ignored
+     */
+    protected $someColumn;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
+
+final class WithDescription
+{
+    /**
+     * This comment is before the annotations
+     */
+    #[GenericAnnotation] // this is a simple annotation
+    #[GenericAnnotation(key: 'value')] // this annotation has parameters
+    #[GenericAnnotation(some: 'item', summary: 'item')] // this annotation is multi-line
+    #[GenericAnnotation(key: 'value')] // (this comment is within parentheses)
+    #[GenericAnnotation(key: 'value')] // "this comment is within quotes"
+    protected $someColumn;
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
+++ b/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
@@ -154,7 +154,9 @@ CODE_SAMPLE
             return true;
         }
 
-        return $class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass($class->extends->toString());
+        return $class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
+            $class->extends->toString()
+        );
     }
 
     /**

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -76,7 +76,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SymfonyRoute
 {
     /**
-     * @Route("/path", name="action")
+     * @Route("/path", name="action") api route
      */
     public function action()
     {
@@ -89,7 +89,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class SymfonyRoute
 {
-    #[Route(path: '/path', name: 'action')]
+    #[Route(path: '/path', name: 'action')] // api route
     public function action()
     {
     }

--- a/rules/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector.php
+++ b/rules/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Transform\Rector\ConstFetch;
 
-use PhpParser\Node\Expr\ConstFetch;
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Rector\Transform\ValueObject\ConstFetchToClassConstFetch;

--- a/rules/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector.php
+++ b/rules/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector.php
@@ -188,11 +188,7 @@ CODE_SAMPLE
 
                 if ($name === 'fileExtensions') {
                     Assert::isAOf($value, Array_::class);
-                    $newExpr = $this->nodeFactory->createMethodCall(
-                        $newExpr,
-                        'withFileExtensions',
-                        [$value]
-                    );
+                    $newExpr = $this->nodeFactory->createMethodCall($newExpr, 'withFileExtensions', [$value]);
                     $hasChanged = true;
 
                     continue;

--- a/rules/Transform/ValueObject/ConstFetchToClassConstFetch.php
+++ b/rules/Transform/ValueObject/ConstFetchToClassConstFetch.php
@@ -8,8 +8,11 @@ use Rector\Validation\RectorAssert;
 
 final readonly class ConstFetchToClassConstFetch
 {
-    public function __construct(private string $oldConstName, private string $newClassName, private string $newConstName)
-    {
+    public function __construct(
+        private string $oldConstName,
+        private string $newClassName,
+        private string $newConstName
+    ) {
         RectorAssert::constantName($this->oldConstName);
         RectorAssert::className($this->newClassName);
         RectorAssert::constantName($this->newConstName);

--- a/src/BetterPhpDocParser/PhpDoc/DoctrineAnnotationTagValueNode.php
+++ b/src/BetterPhpDocParser/PhpDoc/DoctrineAnnotationTagValueNode.php
@@ -26,7 +26,7 @@ final class DoctrineAnnotationTagValueNode extends AbstractValuesAwareNode imple
 
         parent::__construct($values, $originalContent, $silentKey);
 
-        if ($comment) {
+        if (! in_array($comment, ['', null], true)) {
             $this->setAttribute(AttributeKey::ATTRIBUTE_COMMENT, $comment);
         }
     }

--- a/src/BetterPhpDocParser/PhpDoc/DoctrineAnnotationTagValueNode.php
+++ b/src/BetterPhpDocParser/PhpDoc/DoctrineAnnotationTagValueNode.php
@@ -7,6 +7,7 @@ namespace Rector\BetterPhpDocParser\PhpDoc;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\AbstractValuesAwareNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Stringable;
 
 final class DoctrineAnnotationTagValueNode extends AbstractValuesAwareNode implements Stringable
@@ -18,11 +19,16 @@ final class DoctrineAnnotationTagValueNode extends AbstractValuesAwareNode imple
         public IdentifierTypeNode $identifierTypeNode,
         ?string $originalContent = null,
         array $values = [],
-        ?string $silentKey = null
+        ?string $silentKey = null,
+        ?string $comment = null
     ) {
         $this->hasChanged = true;
 
         parent::__construct($values, $originalContent, $silentKey);
+
+        if ($comment) {
+            $this->setAttribute(AttributeKey::ATTRIBUTE_COMMENT, $comment);
+        }
     }
 
     public function __toString(): string

--- a/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -409,6 +409,11 @@ final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorI
             $currentPhpNode
         );
 
+        $comment = $this->staticDoctrineAnnotationParser->getCommentFromRestOfAnnotation(
+            $nestedTokenIterator,
+            $annotationContent
+        );
+
         $identifierTypeNode = new IdentifierTypeNode($tagName);
         $identifierTypeNode->setAttribute(PhpDocAttributeKey::RESOLVED_CLASS, $fullyQualifiedAnnotationClass);
 
@@ -416,7 +421,8 @@ final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorI
             $identifierTypeNode,
             $annotationContent,
             $values,
-            SilentKeyMap::CLASS_NAMES_TO_SILENT_KEYS[$fullyQualifiedAnnotationClass] ?? null
+            SilentKeyMap::CLASS_NAMES_TO_SILENT_KEYS[$fullyQualifiedAnnotationClass] ?? null,
+            $comment
         );
 
         $doctrineAnnotationTagValueNode->setAttribute(PhpDocAttributeKey::START_AND_END, $startAndEnd);

--- a/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
+++ b/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
@@ -32,7 +32,7 @@ final readonly class StaticDoctrineAnnotationParser
      * @var string
      * @see https://regex101.com/r/Pthg5d/1
      */
-    private const END_OF_VALUE_CHARACTERS_REGEX = '/^[)} \n"\']+$/i';
+    private const END_OF_VALUE_CHARACTERS_REGEX = '/^[)} \r\n"\']+$/i';
 
     public function __construct(
         private PlainValueParser $plainValueParser,

--- a/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
+++ b/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
@@ -24,9 +24,9 @@ final readonly class StaticDoctrineAnnotationParser
 {
     /**
      * @var string
-     * @see https://regex101.com/r/qduj2O/1
+     * @see https://regex101.com/r/aU2knc/1
      */
-    private const NEWLINES_REGEX = "#\n\r|\n#";
+    private const NEWLINES_REGEX = "#\r?\n#";
 
     /**
      * @var string

--- a/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
+++ b/src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\BetterPhpDocParser\PhpDocParser;
 
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
@@ -21,6 +22,12 @@ use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNod
  */
 final readonly class StaticDoctrineAnnotationParser
 {
+    /**
+     * @var string
+     * @see https://regex101.com/r/qduj2O/1
+     */
+    private const NEWLINES_REGEX = "#\n\r|\n#";
+
     /**
      * @var string
      * @see https://regex101.com/r/Pthg5d/1
@@ -100,7 +107,7 @@ final readonly class StaticDoctrineAnnotationParser
         // the remaining of the annotation content is the comment
         $comment = substr($annotationContent, $tokenIterator->currentTokenOffset());
         // we only keep the first line as this will be added as a line comment at the end of the attribute
-        $commentLines = explode("\n", $comment);
+        $commentLines = Strings::split($comment, self::NEWLINES_REGEX);
         return $commentLines[0];
     }
 

--- a/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\DependencyInjection;
 
-use Throwable;
 use PhpParser\Lexer;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeFactory;
@@ -20,6 +19,7 @@ use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\Dy
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
 use Webmozart\Assert\Assert;
 
 /**
@@ -29,8 +29,6 @@ use Webmozart\Assert\Assert;
  */
 final readonly class PHPStanServicesFactory
 {
-    private Container $container;
-
     /**
      * @var string
      */
@@ -43,6 +41,8 @@ includes:
 in your included phpstan configuration.
 
 MESSAGE_ERROR;
+
+    private Container $container;
 
     public function __construct()
     {
@@ -57,7 +57,6 @@ MESSAGE_ERROR;
             );
         } catch (Throwable $throwable) {
             if ($throwable->getMessage() === "File 'phar://phpstan.phar/conf/bleedingEdge.neon' is missing or is not readable.") {
-
                 $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
                 $symfonyStyle->error(sprintf(self::INVALID_BLEEDING_EDGE_PATH_MESSAGE, $throwable->getMessage()));
 

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -301,4 +301,9 @@ final class AttributeKey
      * @var string
      */
     public const IS_USED_AS_ARG_BY_REF_VALUE = 'is_used_as_arg_by_ref_value';
+
+    /**
+     * @var string
+     */
+    public const ATTRIBUTE_COMMENT = 'attribute_comment';
 }

--- a/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -87,7 +87,12 @@ final readonly class PhpAttributeGroupFactory
         $attributeName->setAttribute(AttributeKey::PHP_ATTRIBUTE_NAME, $annotationToAttribute->getAttributeClass());
 
         $attribute = new Attribute($attributeName, $args);
-        return new AttributeGroup([$attribute]);
+        $attributeGroup = new AttributeGroup([$attribute]);
+        $comment = $doctrineAnnotationTagValueNode->getAttribute(AttributeKey::ATTRIBUTE_COMMENT);
+        if ($comment) {
+            $attributeGroup->setAttribute(AttributeKey::ATTRIBUTE_COMMENT, $comment);
+        }
+        return $attributeGroup;
     }
 
     /**

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -139,6 +139,16 @@ final class BetterStandardPrinter extends Standard
             : $content;
     }
 
+    protected function pAttributeGroup(Node\AttributeGroup $node): string
+    {
+        $ret = '#[' . $this->pCommaSeparated($node->attrs) . ']';
+        $comment = $node->getAttribute(AttributeKey::ATTRIBUTE_COMMENT);
+        if ($comment) {
+            $ret .= ' // ' . $comment;
+        }
+        return $ret;
+    }
+
     protected function pExpr_ArrowFunction(ArrowFunction $arrowFunction): string
     {
         if (! $arrowFunction->hasAttribute(AttributeKey::COMMENT_CLOSURE_RETURN_MIRRORED)) {

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -141,7 +141,7 @@ final class BetterStandardPrinter extends Standard
 
     protected function pAttributeGroup(Node\AttributeGroup $node): string
     {
-        $ret = '#[' . $this->pCommaSeparated($node->attrs) . ']';
+        $ret = parent::pAttributeGroup($node);
         $comment = $node->getAttribute(AttributeKey::ATTRIBUTE_COMMENT);
         if ($comment) {
             $ret .= ' // ' . $comment;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -143,7 +143,7 @@ final class BetterStandardPrinter extends Standard
     {
         $ret = parent::pAttributeGroup($node);
         $comment = $node->getAttribute(AttributeKey::ATTRIBUTE_COMMENT);
-        if ($comment) {
+        if (! in_array($comment, ['', null], true)) {
             $ret .= ' // ' . $comment;
         }
         return $ret;


### PR DESCRIPTION
Sometimes annotations may include some comments after the annotation definition. For example:

```php
    /**
     * @Route("/path", name="action") api route
     */
```

The current rector rule that converts annotations to attributes ignores these comments which are lost. This PR modifies the code so that these comments are preserved as line comments added after the attribute like this:

```php
    #[Route(path: '/path', name: 'action')] // api route
```

See the comments in the PR for more info