### PR TITLE
[TypeDeclaration] Include MockObject&ClassName docblock with IntersectionTypeNode on TypedPropertyFromStrictSetUpRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictSetUpRector/Fixture/include_mock_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictSetUpRector/Fixture/include_mock_doc.php.inc
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 final class IncludeMockDoc extends TestCase
 {
-    /** @var \stdClass */
+    /** @var \DateTime */
     private $value;
 
     public function setUp(): void
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
 
 final class IncludeMockDoc extends TestCase
 {
-    /** @var (\PHPUnit\Framework\MockObject\MockObject & \stdClass) */
+    /** @var (\PHPUnit\Framework\MockObject\MockObject & \DateTime) */
     private \PHPUnit\Framework\MockObject\MockObject $value;
 
     public function setUp(): void

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictSetUpRector/Fixture/include_mock_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictSetUpRector/Fixture/include_mock_doc.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IncludeMockDoc extends TestCase
+{
+    /** @var \stdClass */
+    private $value;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->value = $this->createMock(\DateTime::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class IncludeMockDoc extends TestCase
+{
+    /** @var (\PHPUnit\Framework\MockObject\MockObject & \stdClass) */
+    private \PHPUnit\Framework\MockObject\MockObject $value;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->value = $this->createMock(\DateTime::class);
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictSetUpRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictSetUpRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\Rector\Property;
 
+use PHPStan\Type\ObjectType;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -116,12 +117,12 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($propertyType instanceof \PHPStan\Type\ObjectType && $propertyType->getClassName() === 'PHPUnit\Framework\MockObject\MockObject') {
+            if ($propertyType instanceof ObjectType && $propertyType->getClassName() === 'PHPUnit\Framework\MockObject\MockObject') {
                 $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
                 $varTag = $phpDocInfo->getVarTagValueNode();
                 $varType = $phpDocInfo->getVarType();
 
-                if ($varTag instanceof VarTagValueNode && $varType instanceof \PHPStan\Type\ObjectType && $varType->getClassName() !== 'PHPUnit\Framework\MockObject\MockObject') {
+                if ($varTag instanceof VarTagValueNode && $varType instanceof ObjectType && $varType->getClassName() !== 'PHPUnit\Framework\MockObject\MockObject') {
                     $varTag->type = new IntersectionTypeNode([
                         new FullyQualifiedIdentifierTypeNode($propertyType->getClassName()),
                         new FullyQualifiedIdentifierTypeNode($varType->getClassName())


### PR DESCRIPTION
Ref with intersection: https://phpstan.org/r/70920a60-44eb-4d14-a726-ebe65ed99c54 (OK)
Ref without intersection: https://phpstan.org/r/65dd418d-11cd-4734-a10b-f881b1a946c8 (not OK)

To avoid notice in phpstan :

```
PHPDoc tag @var for property IncludeMockDoc::$value with type DateTime is not subtype of native type MockObject.
```