### PR TITLE
[Privatization] Skip with suffix "TestCase" on FinalizeTestCaseClassRector

### DIFF
--- a/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/skip_suffix_test_case.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/skip_suffix_test_case.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SkipSuffixTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        echo 'init';
+    }
+}
+
+?>

--- a/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
@@ -71,6 +71,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (str_ends_with($className, 'TestCase')) {
+            return null;
+        }
+
         if (! $this->reflectionProvider->hasClass($className)) {
             return null;
         }


### PR DESCRIPTION
with `TestCase` suffix is part of phpunit 10 upgrade which the class can be extended.