### PR TITLE
[Php83] add type to final class constant

### DIFF
--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_type_to_class_const_when_const_final.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/apply_type_to_class_const_when_const_final.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
+class ApplyTypesWhenConstFinal
+{
+    final public const STRING = 'some_type';
+
+    final public const INT = 1;
+
+    final public const FLOAT = 1.0;
+
+    final public const BOOL = true;
+
+    final public const NULL = null;
+
+    final public const ARRAY = [];
+
+    final public const CONCAT = self::STRING . 'concat';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
+class ApplyTypesWhenConstFinal
+{
+    final public const string STRING = 'some_type';
+
+    final public const int INT = 1;
+
+    final public const float FLOAT = 1.0;
+
+    final public const bool BOOL = true;
+
+    final public const null NULL = null;
+
+    final public const array ARRAY = [];
+
+    final public const string CONCAT = self::STRING . 'concat';
+}
+
+?>

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -191,6 +191,6 @@ CODE_SAMPLE
 
     private function canBeInherited(ClassConst $classConst, Class_ $class): bool
     {
-        return ! $class->isFinal() && ! $classConst->isPrivate();
+        return ! $class->isFinal() && ! $classConst->isPrivate() && !$classConst->isFinal();
     }
 }


### PR DESCRIPTION
Since PHP8.1 it has been possible to mark a class constant as `final`. A `final public const FOO` should be treated the same as a `public const FOO` within a `final class` and the type should be added, which isn't currently the case.