### PR TITLE
dump_node helper function

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -426,3 +426,8 @@ parameters:
         -
             message: '#Offset \(int\|string\) on non\-empty\-array<PHPStan\\PhpDocParser\\Ast\\PhpDoc\\PhpDocChildNode> in isset\(\) always exists and is not nullable#'
             path: src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+
+        # false positive
+        -
+            message: '#Parameters should use "array" types as the only types passed to this method#'
+            path: src/Util/PrintNodes.php

--- a/src/Console/Command/DetectNodeCommand.php
+++ b/src/Console/Command/DetectNodeCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Console\Command;
 
-use Nette\Utils\Strings;
-use Rector\CustomRules\SimpleNodeDumper;
 use Rector\PhpParser\Parser\SimplePhpParser;
 use Rector\Util\PrintNodes;
 use Symfony\Component\Console\Command\Command;
@@ -21,6 +19,7 @@ final class DetectNodeCommand extends Command
     public function __construct(
         private readonly SimplePhpParser $simplePhpParser,
         private readonly PrintNodes $printNodes,
+        private readonly SymfonyStyle $symfonyStyle
     ) {
         parent::__construct();
     }

--- a/src/Util/PrintNodes.php
+++ b/src/Util/PrintNodes.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Rector\Util;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use Rector\CustomRules\SimpleNodeDumper;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class PrintNodes
+{
+    /**
+     * @var string
+     * @see https://regex101.com/r/Fe8n73/1
+     */
+    private const CLASS_NAME_REGEX = '#(?<class_name>PhpParser(.*?))\(#ms';
+
+    /**
+     * @var string
+     * @see https://regex101.com/r/uQFuvL/1
+     */
+    private const PROPERTY_KEY_REGEX = '#(?<key>[\w\d]+)\:#';
+
+    public function __construct(private readonly SymfonyStyle $symfonyStyle)
+    {
+    }
+
+    public function outputNodes(Node|array $nodes)
+    {
+        $dumpedNodesContents = SimpleNodeDumper::dump($nodes);
+
+        // colorize
+        $colorContents = $this->addConsoleColors($dumpedNodesContents);
+        $this->symfonyStyle->writeln($colorContents);
+
+        $this->symfonyStyle->newLine();
+    }
+
+
+    private function addConsoleColors(string $contents): string
+    {
+        // decorate class names
+        $colorContents = Strings::replace(
+            $contents,
+            self::CLASS_NAME_REGEX,
+            static fn (array $match): string => '<fg=green>' . $match['class_name'] . '</>('
+        );
+
+        // decorate keys
+        return Strings::replace(
+            $colorContents,
+            self::PROPERTY_KEY_REGEX,
+            static fn (array $match): string => '<fg=yellow>' . $match['key'] . '</>:'
+        );
+    }
+}

--- a/src/Util/PrintNodes.php
+++ b/src/Util/PrintNodes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rector\Util;
 
 use Nette\Utils\Strings;
@@ -25,7 +27,10 @@ class PrintNodes
     {
     }
 
-    public function outputNodes(Node|array $nodes)
+    /**
+     * @param Node|Node[] $nodes
+     */
+    public function outputNodes(Node|array $nodes): void
     {
         $dumpedNodesContents = SimpleNodeDumper::dump($nodes);
 

--- a/src/functions/node_helper.php
+++ b/src/functions/node_helper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
+use Symfony\Component\Console\Output\OutputInterface;
 
 if (! function_exists('print_node')) {
     /**
@@ -19,5 +20,25 @@ if (! function_exists('print_node')) {
             $printedContent = $standard->prettyPrint([$node]);
             var_dump($printedContent);
         }
+    }
+}
+
+if (! function_exists('dump_node')) {
+    /**
+     * @param Node|Node[] $node
+     */
+    function dump_node(Node|array $node)
+    {
+        $styler = \Illuminate\Container\Container::getInstance()
+            ->make(\Rector\Console\Style\SymfonyStyleFactory::class)
+            ->create();
+
+        // we turn up the verbosity so it's visible in tests overriding the
+        // default which is to be quite during tests
+        $styler->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+
+        $styler->newLine();
+
+        (new \Rector\Util\PrintNodes($styler))->outputNodes($node);
     }
 }

--- a/src/functions/node_helper.php
+++ b/src/functions/node_helper.php
@@ -1,6 +1,9 @@
 <?php
 
 declare(strict_types=1);
+use Illuminate\Container\Container;
+use Rector\Console\Style\SymfonyStyleFactory;
+use Rector\Util\PrintNodes;
 
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
@@ -27,10 +30,10 @@ if (! function_exists('dump_node')) {
     /**
      * @param Node|Node[] $node
      */
-    function dump_node(Node|array $node)
+    function dump_node(Node|array $node): void
     {
-        $styler = \Illuminate\Container\Container::getInstance()
-            ->make(\Rector\Console\Style\SymfonyStyleFactory::class)
+        $styler = Container::getInstance()
+            ->make(SymfonyStyleFactory::class)
             ->create();
 
         // we turn up the verbosity so it's visible in tests overriding the
@@ -39,6 +42,6 @@ if (! function_exists('dump_node')) {
 
         $styler->newLine();
 
-        (new \Rector\Util\PrintNodes($styler))->outputNodes($node);
+        (new PrintNodes($styler))->outputNodes($node);
     }
 }


### PR DESCRIPTION
# Changes

* Adds a helper function called `dump_node()` function
* Refactors some of the detect node command functionality into a separate service

# Why

I've found it difficult when writing new rules at times when I want to just dump the nodes out. Using PHP's `var_dump()` doesn't work due to recursion. Having the console colours etc. should make it a lot easier to work with.

Let me know if there are further tests that should be worked on. I wasn't sure what to work on.