### PR TITLE
 [Php81] Skip execution operator on NullToStrictStringFuncCallArgRector 

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_execution_op.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_execution_op.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipExecutionOp
+{
+    public function run(string $search, string $replace)
+    {
+        str_replace($search, $replace, `ls -l`);
+    }
+}

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Cast\String_ as CastString_;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\ShellExec;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
@@ -173,6 +174,10 @@ CODE_SAMPLE
         }
 
         $argValue = $args[$position]->value;
+
+        if ($argValue instanceof ShellExec) {
+            return null;
+        }
 
         if ($argValue instanceof ConstFetch && $this->valueResolver->isNull($argValue)) {
             $args[$position]->value = new String_('');


### PR DESCRIPTION
The following code should be skipped:

```php
    public function run(string $search, string $replace)
    {
        echo str_replace($search, $replace, `ls -l`);
    }
```

as `ls -l` returns string output of `ShellExec`, ref https://www.php.net/manual/en/language.operators.execution.php