### PR TITLE
[DeadCode] Skip implements interface __construct() on RemoveUnusedPromotedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/skip_implements_interface_construct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/skip_implements_interface_construct.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector\Source\SomeInterfaceWithConstruct;
+
+final class SkipImplementsInterfaceConstruct implements SomeInterfaceWithConstruct
+{
+    public function __construct(private string $a, private string $b)
+    {
+        echo $a;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Source/SomeInterfaceWithConstruct.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Source/SomeInterfaceWithConstruct.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector\Source;
+
+interface SomeInterfaceWithConstruct
+{
+    public function __construct(string $a, string $b);
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector.php
@@ -6,11 +6,11 @@ namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Scalar\MagicConst\Method;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\TraitUse;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
 use Rector\DeadCode\NodeAnalyzer\PropertyWriteonlyAnalyzer;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\NodeFinder\PropertyFetchFinder;
@@ -161,7 +161,7 @@ CODE_SAMPLE
         }
 
         $classReflection = $this->reflectionResolver->resolveClassReflection($class);
-        if ($classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+        if ($classReflection instanceof ClassReflection) {
             $interfaces = $classReflection->getInterfaces();
             foreach ($interfaces as $interface) {
                 if ($interface->hasNativeMethod(MethodName::CONSTRUCT)) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8511