### PR TITLE
[Naming] Handle crash with numeric-string doc on RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_numeric_string.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_numeric_string.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+class SkipNumericString
+{
+    /**
+     * @var numeric-string|null
+     */
+    private ?string $value = null;
+}

--- a/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use Rector\Naming\ValueObject\PropertyRename;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\Validation\RectorAssert;
 use Webmozart\Assert\InvalidArgumentException;
 
 final readonly class PropertyRenameFactory

--- a/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
@@ -8,6 +8,8 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use Rector\Naming\ValueObject\PropertyRename;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\Validation\RectorAssert;
+use Webmozart\Assert\InvalidArgumentException;
 
 final readonly class PropertyRenameFactory
 {
@@ -23,6 +25,12 @@ final readonly class PropertyRenameFactory
     ): ?PropertyRename {
         $currentName = $this->nodeNameResolver->getName($property);
         $className = (string) $this->nodeNameResolver->getName($classLike);
+
+        try {
+            RectorAssert::propertyName($expectedName);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
 
         return new PropertyRename(
             $property,

--- a/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
@@ -27,18 +27,17 @@ final readonly class PropertyRenameFactory
         $className = (string) $this->nodeNameResolver->getName($classLike);
 
         try {
-            RectorAssert::propertyName($expectedName);
+            return new PropertyRename(
+                $property,
+                $expectedName,
+                $currentName,
+                $classLike,
+                $className,
+                $property->props[0]
+            );
         } catch (InvalidArgumentException) {
-            return null;
         }
 
-        return new PropertyRename(
-            $property,
-            $expectedName,
-            $currentName,
-            $classLike,
-            $className,
-            $property->props[0]
-        );
+        return null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8512