### PR TITLE
chore: bump min version of github actions (fix deprecations)

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -82,6 +82,6 @@ jobs:
                     php-version: 8.2
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v2"
+            -   uses: "ramsey/composer-install@v3"
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -40,7 +40,7 @@ jobs:
 
             -
                 # commit only to core contributors who have repository access
-                uses: stefanzweifel/git-auto-commit-action@v4
+                uses: stefanzweifel/git-auto-commit-action@v5
                 with:
                     commit_message: '[ci-review] Rector Rectify'
                     commit_author: 'GitHub Action <actions@github.com>'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,6 @@ jobs:
                     # and check against first class callable strlen(...)
                     ini-values: zend.assertions=1
 
-            -   uses: "ramsey/composer-install@v2"
+            -   uses: "ramsey/composer-install@v3"
 
             -   run: vendor/bin/phpunit --colors

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -49,7 +49,7 @@ jobs:
                     php-version: 8.2
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v2"
+            -   uses: "ramsey/composer-install@v3"
 
             -   run: ${{ matrix.actions.run }}
 

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -56,7 +56,7 @@ jobs:
             # see https://github.com/peter-evans/create-pull-request
             -
                 name: Create pull-request
-                uses: peter-evans/create-pull-request@v5
+                uses: peter-evans/create-pull-request@v6
                 id: cpr
                 with:
                     token: ${{ secrets.ACCESS_TOKEN }}

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -22,14 +22,14 @@ jobs:
                     php-version: 8.2
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v2"
+            -   uses: "ramsey/composer-install@v3"
 
             -   run: vendor/bin/rector --ansi
             # @todo apply coding standard if used
 
             -
                 # commit only to core contributors who have repository access
-                uses: stefanzweifel/git-auto-commit-action@v4
+                uses: stefanzweifel/git-auto-commit-action@v5
                 with:
                     commit_message: '[rector] Rector fixes'
                     commit_author: 'GitHub Action <actions@github.com>'


### PR DESCRIPTION
https://github.com/stefanzweifel/git-auto-commit-action/blob/master/CHANGELOG.md#v500---2023-10-06

https://github.com/ramsey/composer-install/releases/tag/3.0.0

https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.0
