### PR TITLE
Fix duplicated fixture class name on StaticToSelfStaticMethodCallOnFinalClassRector test

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_already_self.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/skip_already_self.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
 
-final class CallStatically
+final class SkipAlreadySelf
 {
     public function execute()
     {


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/actions/runs/8126666694/job/22210675992#step:5:83