### PR TITLE
Fix removal of useless @param tag when string|null insteadof ?string is used.

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/remove_nullable_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/remove_nullable_type.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class WithNullableType
+{
+    /**
+     * @param string|null $nullable
+     */
+    function foo(?string $nullable)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class WithNullableType
+{
+    function foo(?string $nullable)
+    {
+    }
+}
+
+?>

--- a/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
@@ -44,11 +44,6 @@ final readonly class ParamTagRemover
                 return null;
             }
 
-            // skip union types
-            if ($docNode->value->type instanceof UnionTypeNode) {
-                return null;
-            }
-
             if (! $this->deadParamTagValueNodeAnalyzer->isDead($docNode->value, $functionLike)) {
                 return null;
             }

--- a/src/NodeTypeResolver/PHPStan/TypeHasher.php
+++ b/src/NodeTypeResolver/PHPStan/TypeHasher.php
@@ -94,7 +94,7 @@ final class TypeHasher
         $normalizedUnionType = clone $unionType;
 
         // change alias to non-alias
-        $normalizedUnionType = TypeTraverser::map(
+        TypeTraverser::map(
             $normalizedUnionType,
             static function (Type $type, callable $callable): Type {
                 if (! $type instanceof AliasedObjectType && ! $type instanceof ShortenedObjectType) {


### PR DESCRIPTION
Fixed by removing the "skip union types" in ParamTagRemover. This was added to fix a different bug, caused by a bug in TypeHasher, where the normalized UnionType was actually overwritten by the last element in the union,