### PR TITLE
Explicitly add keys to the rules in the levels

### DIFF
--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -49,8 +49,7 @@ use Rector\DeadCode\Rector\Ternary\TernaryToBooleanOrFalseToBooleanAndRector;
 use Rector\DeadCode\Rector\TryCatch\RemoveDeadTryCatchRector;
 
 /**
- * Key 0 = level 0
- * Key 50 = level 50
+ * Use the index to find which rules are applied for each withDeadCodeLevel() level
  *
  * Start at 0, go slowly higher, one level per PR, and improve your rule coverage
  *
@@ -69,57 +68,57 @@ final class DeadCodeLevel
      */
     public const RULES = [
         // easy picks
-        RemoveUnusedForeachKeyRector::class,
-        RemoveDuplicatedArrayKeyRector::class,
-        RecastingRemovalRector::class,
-        RemoveAndTrueRector::class,
-        SimplifyMirrorAssignRector::class,
-        RemoveDeadContinueRector::class,
-        RemoveUnusedNonEmptyArrayBeforeForeachRector::class,
-        RemoveNullPropertyInitializationRector::class,
-        RemoveUselessReturnExprInConstructRector::class,
+        0 => RemoveUnusedForeachKeyRector::class,
+        1 => RemoveDuplicatedArrayKeyRector::class,
+        2 => RecastingRemovalRector::class,
+        3 => RemoveAndTrueRector::class,
+        4 => SimplifyMirrorAssignRector::class,
+        5 => RemoveDeadContinueRector::class,
+        6 => RemoveUnusedNonEmptyArrayBeforeForeachRector::class,
+        7 => RemoveNullPropertyInitializationRector::class,
+        8 => RemoveUselessReturnExprInConstructRector::class,
 
-        RemoveTypedPropertyDeadInstanceOfRector::class,
-        TernaryToBooleanOrFalseToBooleanAndRector::class,
-        RemoveDoubleAssignRector::class,
-        RemoveConcatAutocastRector::class,
-        SimplifyIfElseWithSameContentRector::class,
-        SimplifyUselessVariableRector::class,
-        RemoveDeadZeroAndOneOperationRector::class,
+        9 => RemoveTypedPropertyDeadInstanceOfRector::class,
+        10 => TernaryToBooleanOrFalseToBooleanAndRector::class,
+        11 => RemoveDoubleAssignRector::class,
+        12 => RemoveConcatAutocastRector::class,
+        13 => SimplifyIfElseWithSameContentRector::class,
+        14 => SimplifyUselessVariableRector::class,
+        15 => RemoveDeadZeroAndOneOperationRector::class,
 
         // docblock
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
-        RemoveNonExistingVarAnnotationRector::class,
-        RemoveUselessVarTagRector::class,
-        RemovePhpVersionIdCheckRector::class,
+        16 => RemoveUselessParamTagRector::class,
+        17 => RemoveUselessReturnTagRector::class,
+        18 => RemoveNonExistingVarAnnotationRector::class,
+        19 => RemoveUselessVarTagRector::class,
+        20 => RemovePhpVersionIdCheckRector::class,
 
-        RemoveAlwaysTrueIfConditionRector::class,
-        ReduceAlwaysFalseIfOrRector::class,
-        RemoveUnusedPrivateClassConstantRector::class,
-        RemoveUnusedPrivatePropertyRector::class,
+        21 => RemoveAlwaysTrueIfConditionRector::class,
+        22 => ReduceAlwaysFalseIfOrRector::class,
+        23 => RemoveUnusedPrivateClassConstantRector::class,
+        24 => RemoveUnusedPrivatePropertyRector::class,
 
-        RemoveDuplicatedCaseInSwitchRector::class,
-        RemoveDeadInstanceOfRector::class,
+        25 => RemoveDuplicatedCaseInSwitchRector::class,
+        26 => RemoveDeadInstanceOfRector::class,
 
-        RemoveDeadTryCatchRector::class,
-        RemoveDeadIfForeachForRector::class,
-        RemoveDeadStmtRector::class,
-        UnwrapFutureCompatibleIfPhpVersionRector::class,
-        RemoveParentCallWithoutParentRector::class,
-        RemoveDeadConditionAboveReturnRector::class,
-        RemoveDeadLoopRector::class,
+        27 => RemoveDeadTryCatchRector::class,
+        28 => RemoveDeadIfForeachForRector::class,
+        29 => RemoveDeadStmtRector::class,
+        30 => UnwrapFutureCompatibleIfPhpVersionRector::class,
+        31 => RemoveParentCallWithoutParentRector::class,
+        32 => RemoveDeadConditionAboveReturnRector::class,
+        33 => RemoveDeadLoopRector::class,
 
         // removing methods could be risky if there is some magic loading them
-        RemoveUnusedPromotedPropertyRector::class,
-        RemoveUnusedPrivateMethodParameterRector::class,
-        RemoveUnusedPrivateMethodRector::class,
-        RemoveUnreachableStatementRector::class,
-        RemoveUnusedVariableAssignRector::class,
+        34 => RemoveUnusedPromotedPropertyRector::class,
+        35 => RemoveUnusedPrivateMethodParameterRector::class,
+        36 => RemoveUnusedPrivateMethodRector::class,
+        37 => RemoveUnreachableStatementRector::class,
+        38 => RemoveUnusedVariableAssignRector::class,
 
         // this could break framework magic autowiring in some cases
-        RemoveUnusedConstructorParamRector::class,
-        RemoveEmptyClassMethodRector::class,
-        RemoveDeadReturnRector::class,
+        39 => RemoveUnusedConstructorParamRector::class,
+        40 => RemoveEmptyClassMethodRector::class,
+        41 => RemoveDeadReturnRector::class,
     ];
 }

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -50,60 +50,62 @@ final class TypeDeclarationLevel
      * The rule order matters, as its used in withTypeCoverageLevel() method
      * Place the safest rules first, follow by more complex ones
      *
+     * Use the index to find which rules are applied for each withTypeCoverageLevel() level
+     *
      * @var array<class-string<RectorInterface>>
      */
     public const RULES = [
         // php 7.0
         // start with closure first, as safest
-        AddClosureVoidReturnTypeWhereNoReturnRector::class,
-        AddFunctionVoidReturnTypeWhereNoReturnRector::class,
-        AddTestsVoidReturnTypeWhereNoReturnRector::class,
+        0 => AddClosureVoidReturnTypeWhereNoReturnRector::class,
+        1 => AddFunctionVoidReturnTypeWhereNoReturnRector::class,
+        2 => AddTestsVoidReturnTypeWhereNoReturnRector::class,
 
-        AddArrowFunctionReturnTypeRector::class,
-        ReturnTypeFromStrictConstantReturnRector::class,
-        ReturnTypeFromStrictNewArrayRector::class,
-        ReturnTypeFromStrictBoolReturnExprRector::class,
-        NumericReturnTypeFromStrictScalarReturnsRector::class,
-        BoolReturnTypeFromStrictScalarReturnsRector::class,
-        ReturnTypeFromStrictTernaryRector::class,
-        ReturnTypeFromStrictScalarReturnExprRector::class,
-        ReturnTypeFromReturnDirectArrayRector::class,
-        ReturnTypeFromReturnNewRector::class,
+        3 => AddArrowFunctionReturnTypeRector::class,
+        4 => ReturnTypeFromStrictConstantReturnRector::class,
+        5 => ReturnTypeFromStrictNewArrayRector::class,
+        6 => ReturnTypeFromStrictBoolReturnExprRector::class,
+        7 => NumericReturnTypeFromStrictScalarReturnsRector::class,
+        8 => BoolReturnTypeFromStrictScalarReturnsRector::class,
+        9 => ReturnTypeFromStrictTernaryRector::class,
+        10 => ReturnTypeFromStrictScalarReturnExprRector::class,
+        11 => ReturnTypeFromReturnDirectArrayRector::class,
+        12 => ReturnTypeFromReturnNewRector::class,
 
-        AddVoidReturnTypeWhereNoReturnRector::class,
-
-        // php 7.4
-        EmptyOnNullableObjectToInstanceOfRector::class,
+        13 => AddVoidReturnTypeWhereNoReturnRector::class,
 
         // php 7.4
-        TypedPropertyFromStrictConstructorRector::class,
-        ReturnTypeFromStrictTypedPropertyRector::class,
-        AddParamTypeSplFixedArrayRector::class,
-        AddReturnTypeDeclarationFromYieldsRector::class,
-        AddParamTypeBasedOnPHPUnitDataProviderRector::class,
+        14 => EmptyOnNullableObjectToInstanceOfRector::class,
 
         // php 7.4
-        TypedPropertyFromStrictSetUpRector::class,
-        ReturnTypeFromStrictNativeCallRector::class,
-        ReturnTypeFromStrictTypedCallRector::class,
-        ChildDoctrineRepositoryClassTypeRector::class,
+        15 => TypedPropertyFromStrictConstructorRector::class,
+        16 => ReturnTypeFromStrictTypedPropertyRector::class,
+        17 => AddParamTypeSplFixedArrayRector::class,
+        18 => AddReturnTypeDeclarationFromYieldsRector::class,
+        19 => AddParamTypeBasedOnPHPUnitDataProviderRector::class,
+
+        // php 7.4
+        20 => TypedPropertyFromStrictSetUpRector::class,
+        21 => ReturnTypeFromStrictNativeCallRector::class,
+        22 => ReturnTypeFromStrictTypedCallRector::class,
+        23 => ChildDoctrineRepositoryClassTypeRector::class,
 
         // param
-        AddMethodCallBasedStrictParamTypeRector::class,
-        ParamTypeByParentCallTypeRector::class,
-        ReturnUnionTypeRector::class,
+        24 => AddMethodCallBasedStrictParamTypeRector::class,
+        25 => ParamTypeByParentCallTypeRector::class,
+        26 => ReturnUnionTypeRector::class,
 
         // more risky rules
-        ReturnTypeFromStrictParamRector::class,
-        AddParamTypeFromPropertyTypeRector::class,
-        MergeDateTimePropertyTypeDeclarationRector::class,
-        PropertyTypeFromStrictSetterGetterRector::class,
-        ParamTypeByMethodCallTypeRector::class,
-        TypedPropertyFromAssignsRector::class,
-        AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
-        ReturnTypeFromStrictFluentReturnRector::class,
-        ReturnNeverTypeRector::class,
-        StrictArrayParamDimFetchRector::class,
-        StrictStringParamConcatRector::class,
+        27 => ReturnTypeFromStrictParamRector::class,
+        28 => AddParamTypeFromPropertyTypeRector::class,
+        29 => MergeDateTimePropertyTypeDeclarationRector::class,
+        30 => PropertyTypeFromStrictSetterGetterRector::class,
+        31 => ParamTypeByMethodCallTypeRector::class,
+        32 => TypedPropertyFromAssignsRector::class,
+        33 => AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
+        34 => ReturnTypeFromStrictFluentReturnRector::class,
+        35 => ReturnNeverTypeRector::class,
+        36 => StrictArrayParamDimFetchRector::class,
+        37 => StrictStringParamConcatRector::class,
     ];
 }


### PR DESCRIPTION
Explicitly add keys to each rule in the `DeadCodeLevel` and `TypeDeclarationLevel` classes list of rules. This makes it easier to see which rules are being applied for each `withDeadCodeLevel()` and `withTypeCoverageLevel()` level