### PR TITLE
[CodingStyle] Skip anonymous class on MakeInheritedMethodVisibilitySameAsParentRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_anonymous_class.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Source\ParentWithProtectedMethod;
+
+class SkipAnonymousClass
+{
+    public function run()
+    {
+        $obj = new class extends ParentWithProtectedMethod {
+            public function run()
+            {
+                return 1;
+            }
+        };
+
+        var_dump($obj->run() === 1);
+    }
+}

--- a/rules-tests/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Source/ParentWithProtectedMethod.php
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Source/ParentWithProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Source;
+
+class ParentWithProtectedMethod
+{
+    protected function run()
+    {
+    }
+}

--- a/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
@@ -85,6 +85,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($classReflection->isAnonymous()) {
+            return null;
+        }
+
         $parentClassReflections = $classReflection->getParents();
 
         if ($parentClassReflections === []) {


### PR DESCRIPTION
anonymous class may be used for testing, so I think it needs to be skipped, eg:

```php
$obj = new class extends ParentWithProtectedMethod {
            public function run()
            {
                return 1;
            }
        };

$this->assertSame(1, $obj->run());
```