### PR TITLE
 [Php81] Handle with attribute on ReadOnlyPropertyRector on property promotion

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_on_property_promotion.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_on_property_promotion.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class WithAttributeOnPropertyPromotion
+{
+	private function __construct(
+        #[MyAttr]
+        private string $id
+    ){}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class WithAttributeOnPropertyPromotion
+{
+	private function __construct(
+        #[MyAttr]
+        private readonly string $id
+    ){}
+}
+
+?>

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -200,6 +200,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($param->attrGroups !== []) {
+            $param->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        }
+
         $this->visibilityManipulator->makeReadonly($param);
         return $param;
     }


### PR DESCRIPTION
Re-print if promoted property has attribute to avoid inlined.

Fixes https://github.com/rectorphp/rector/issues/8526