### PR TITLE
[Performance][Php81] Ensure check readonly on param only on __construct() method

### DIFF
--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -103,7 +103,8 @@ CODE_SAMPLE
 
         $hasChanged = false;
 
-        foreach ($node->getMethods() as $classMethod) {
+        $classMethod = $node->getMethod(MethodName::CONSTRUCT);
+        if ($classMethod instanceof ClassMethod) {
             foreach ($classMethod->params as $param) {
                 $justChanged = $this->refactorParam($node, $classMethod, $param, $scope);
                 // different variable to ensure $hasRemoved not replaced


### PR DESCRIPTION
non `__construct()` method is not allowed to have `readonly` flag on param, see https://3v4l.org/bRhku