### PR TITLE
[Php72][TypeDeclaration] Rollback tweak infinite loop handling on DeclareStrictTypesRector

### DIFF
--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
@@ -64,13 +64,11 @@ CODE_SAMPLE
             return null;
         }
 
-        // use 0 index to avoid infinite loop
-        $rootStmt = $newStmts[0] ?? null;
+        $rootStmt = current($newStmts);
         $stmt = $rootStmt;
 
         if ($rootStmt instanceof FileWithoutNamespace) {
-            // use 0 index to avoid infinite loop
-            $currentStmt = $rootStmt->stmts[0] ?? null;
+            $currentStmt = current($rootStmt->stmts);
 
             if (! $currentStmt instanceof Stmt) {
                 return null;


### PR DESCRIPTION
@kapersoft @TomasVotruba here rollback tweak infinite loop on `DeclareStrictTypesRector` as properly handled on rector-downgrade-php that ensure `reset()` called after go to `end()` and get the `key()`:

- https://github.com/rectorphp/rector-downgrade-php/pull/214