### PR TITLE
fix: Strip left spaces from opening tags when comparing output for changes

### DIFF
--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -150,13 +150,12 @@ final readonly class FileProcessor
              * On very first content level
              */
             $ltrimOriginalFileContent = ltrim($file->getOriginalFileContent());
-            $ltrimNewContent = ltrim($newContent);
-            if ($ltrimOriginalFileContent === $ltrimNewContent) {
+            if ($ltrimOriginalFileContent === $newContent) {
                 return;
             }
 
             // handle space before <?php
-            $ltrimNewContent = Strings::replace($ltrimNewContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
+            $ltrimNewContent = Strings::replace($newContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
             $ltrimOriginalFileContent = Strings::replace($ltrimOriginalFileContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
             if ($ltrimOriginalFileContent === $ltrimNewContent) {
                 return;

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -31,7 +31,7 @@ final readonly class FileProcessor
      * @var string
      * @see https://regex101.com/r/llm7XZ/1
      */
-    private const OPEN_TAG_SPACED_REGEX = '/^[ \t]+<\?php/m';
+    private const OPEN_TAG_SPACED_REGEX = '#^[ \t]+<\?php#m';
 
     public function __construct(
         private FormatPerservingPrinter $formatPerservingPrinter,

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -24,6 +24,7 @@ use Rector\ValueObject\FileProcessResult;
 use Rector\ValueObject\Reporting\FileDiff;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
+use Nette\Utils\Strings;
 
 final readonly class FileProcessor
 {
@@ -148,10 +149,15 @@ final readonly class FileProcessor
              * Handle new line or space before <?php or InlineHTML node wiped on print format preserving
              * On very first content level
              */
-            $originalFileContent = $file->getOriginalFileContent();
-            $ltrimOriginalFileContent = preg_replace(self::OPEN_TAG_SPACED_REGEX, '<?php', ltrim($originalFileContent));
-            $ltrimNewContent = preg_replace(self::OPEN_TAG_SPACED_REGEX, '<?php', ltrim($newContent));
+            $ltrimOriginalFileContent = ltrim($file->getOriginalFileContent());
+            $ltrimNewContent = ltrim($newContent);
+            if ($ltrimOriginalFileContent === $ltrimNewContent) {
+                return;
+            }
 
+            // handle space before <?php
+            $ltrimNewContent = Strings::replace($ltrimNewContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
+            $ltrimOriginalFileContent = Strings::replace($ltrimOriginalFileContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
             if ($ltrimOriginalFileContent === $ltrimNewContent) {
                 return;
             }

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -27,6 +27,12 @@ use Throwable;
 
 final readonly class FileProcessor
 {
+    /**
+     * @var string
+     * @see https://regex101.com/r/llm7XZ/1
+     */
+    private const OPEN_TAG_SPACED_REGEX = '/^[ \t]+<\?php/m';
+
     public function __construct(
         private FormatPerservingPrinter $formatPerservingPrinter,
         private RectorNodeTraverser $rectorNodeTraverser,
@@ -143,9 +149,10 @@ final readonly class FileProcessor
              * On very first content level
              */
             $originalFileContent = $file->getOriginalFileContent();
-            $ltrimOriginalFileContent = ltrim($originalFileContent);
+            $ltrimOriginalFileContent = preg_replace(self::OPEN_TAG_SPACED_REGEX, '<?php', ltrim($originalFileContent));
+            $ltrimNewContent = preg_replace(self::OPEN_TAG_SPACED_REGEX, '<?php', ltrim($newContent));
 
-            if ($ltrimOriginalFileContent === $newContent) {
+            if ($ltrimOriginalFileContent === $ltrimNewContent) {
                 return;
             }
         }

--- a/tests/Issues/NoNamespaced/Fixture/open_tag_spaced_with_comment.php.inc
+++ b/tests/Issues/NoNamespaced/Fixture/open_tag_spaced_with_comment.php.inc
@@ -1,0 +1,5 @@
+<ul>
+    <?php if (true) { /* comment */ ?>
+        <li><a href="/test">test</a></li>
+    <?php } ?>
+</ul>


### PR DESCRIPTION
When checking for changes, spaces can be temp removed from before the opening PHP tags in both the original and new content to cut down on whitespace only changes. 

Fixes: https://github.com/rectorphp/rector/issues/8533

Should be safe & unit tests pass, however I could wrap this in a config check and make it an opt in thing to ignore whitespace before opening tags if needed?

Let me know what you think, thanks. 