### PR TITLE
[EarlyReturn] Clean up equal node check on IfAndAnalyzer::isIfStmtExprUsedInNextReturn()

### DIFF
--- a/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
+++ b/rules/EarlyReturn/NodeAnalyzer/IfAndAnalyzer.php
@@ -40,15 +40,7 @@ final readonly class IfAndAnalyzer
         $ifExprs = $this->betterNodeFinder->findInstanceOf($if->stmts, Expr::class);
         return (bool) $this->betterNodeFinder->findFirst(
             $return->expr,
-            function (Node $node) use ($ifExprs): bool {
-                foreach ($ifExprs as $ifExpr) {
-                    if ($this->nodeComparator->areNodesEqual($node, $ifExpr)) {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
+            fn (Node $node): bool => $this->nodeComparator->isNodeEqual($node, $ifExprs)
         );
     }
 }


### PR DESCRIPTION
Use existing `$this->nodeComparator->isNodeEqual()`