### PR TITLE
Add `rector` test suite to `phpunit.xml` or `phpunit.xml.dist`

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -22,5 +22,8 @@
         "rector/rector-downgrade-php": "*"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "suggest": {
+        "ext-dom": "Used to manupulate phpunit.xml via `custom-rule` command"
+    }
 }

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -24,6 +24,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "suggest": {
-        "ext-dom": "Used to manupulate phpunit.xml via `custom-rule` command"
+        "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "homepage": "https://getrector.com",
     "require": {
         "php": "^8.2",
-        "ext-dom": "*",
         "ext-json": "*",
         "clue/ndjson-react": "^1.3",
         "composer/semver": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "homepage": "https://getrector.com",
     "require": {
         "php": "^8.2",
+        "ext-dom": "*",
         "ext-json": "*",
         "clue/ndjson-react": "^1.3",
         "composer/semver": "^3.4",

--- a/src/Console/Command/CustomRuleCommand.php
+++ b/src/Console/Command/CustomRuleCommand.php
@@ -178,7 +178,7 @@ final class CustomRuleCommand extends Command
 
         $phpunitXML = $this->updatePHPUnitXMLFile($domDocument, $phpunitFilePath);
 
-        FileSystem::write($phpunitFilePath, $phpunitXML);
+FileSystem::write($phpunitFilePath, $phpunitXML, null);
 
         $this->symfonyStyle->success(
             'We also update ' . $phpunitFilePath . ", to add a rector test suite.\n You can run the rector tests by running: phpunit --testsuite rector"

--- a/src/Console/Command/CustomRuleCommand.php
+++ b/src/Console/Command/CustomRuleCommand.php
@@ -140,6 +140,14 @@ final class CustomRuleCommand extends Command
 
     private function setupRectorTestSuite(string $currentDirectory): void
     {
+        if (! extension_loaded('dom')) {
+            $this->symfonyStyle->warning(
+                'The "dom" extension is not loaded. Rector could not add the rector test suite to phpunit.xml'
+            );
+
+            return;
+        }
+
         $phpunitXmlExists = file_exists($currentDirectory . '/phpunit.xml');
         $phpunitXmlDistExists = file_exists($currentDirectory . '/phpunit.xml.dist');
 

--- a/src/Console/Command/CustomRuleCommand.php
+++ b/src/Console/Command/CustomRuleCommand.php
@@ -41,11 +41,6 @@ final class CustomRuleCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $currentDirectory = getcwd();
-        if ($currentDirectory === false) {
-            throw new ShouldNotHappenException('Cannot resolve current directory');
-        }
-
         // ask for rule name
         $rectorName = $this->symfonyStyle->ask(
             'What is the name of the rule class (e.g. "LegacyCallToDbalMethodCall")?',
@@ -94,6 +89,8 @@ final class CustomRuleCommand extends Command
                 ),
             ]);
         }
+
+        $currentDirectory = getcwd();
 
         $generatedFilePaths = [];
 

--- a/src/Console/Command/CustomRuleCommand.php
+++ b/src/Console/Command/CustomRuleCommand.php
@@ -163,7 +163,7 @@ final class CustomRuleCommand extends Command
                 $directory = $directoryNode->textContent;
                 if ($directory === 'utils/rector/tests') {
                     $this->symfonyStyle->success(
-                        "The rector test suite already exists in " . $phpunitFilePath . ". No changes were made.\n You can run the rector tests by running: phpunit --testsuite rector"
+                        'The rector test suite already exists in ' . $phpunitFilePath . ". No changes were made.\n You can run the rector tests by running: phpunit --testsuite rector"
                     );
 
                     return Command::SUCCESS;
@@ -186,7 +186,7 @@ final class CustomRuleCommand extends Command
         FileSystem::write($phpunitFilePath, $phpunitXML);
 
         $this->symfonyStyle->success(
-            "We also update " . $phpunitFilePath . ", to add a rector test suite.\n You can run the rector tests by running: phpunit --testsuite rector"
+            'We also update ' . $phpunitFilePath . ", to add a rector test suite.\n You can run the rector tests by running: phpunit --testsuite rector"
         );
 
         return Command::SUCCESS;
@@ -199,9 +199,15 @@ final class CustomRuleCommand extends Command
     {
         $xpath = new \DOMXPath($domDocument);
         $testSuiteNodes = $xpath->query('testsuites/testsuite');
+        if ($testSuiteNodes === false) {
+            return;
+        }
 
         if ($testSuiteNodes->length === 0) {
             $testSuiteNodes = $xpath->query('testsuite');
+            if ($testSuiteNodes === false) {
+                return;
+            }
         }
 
         if ($testSuiteNodes->length === 1) {


### PR DESCRIPTION
> It would be even better if this command setup `phpunit.xml`, in the same way `composer.json` is updated.
> 
> If all the following are true:
> 
> * `phpunit.xml` file exists.
> * there is NO `rector` test suite
> 
> Then Rector adds the rector testsuite to `phpunit.xml`. The `phpunit.xml` diff would look a bit like this:
> 
> ```diff
>     <testsuites>
>         <testsuite name="default">
> 	    <directory>tests</directory>
>         </testsuite>
> +       <testsuite name="rector">
> +          <directory>utils/rector/tests</directory>
> +       </testsuite>
>     <testsuites>
> ```
> 
> Rector would report is has done this, in a similar way to it reports updating `composer.json`. E.g.
> 
> ```
>  [OK] We also update phpunit.xml, to add a rector test suite. You can run the rector tests by running: phpunit --testsuite rector
> ```


Resolves rectorphp/rector#8486