### PR TITLE
Remove --skip-type Rector\Core\Rector\AbstractCollectorRector on composer docs command as no longer exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "vendor/bin/phpstan analyse --ansi --error-format symplify --memory-limit=512M",
         "docs": [
-            "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3 --skip-type 'Rector\\Core\\Rector\\AbstractCollectorRector'",
+            "vendor/bin/rule-doc-generator generate rules --output-file build/rector_rules_overview.md --ansi --categorize 3",
             "mv build/rector_rules_overview.md build/target-repository/docs/rector_rules_overview.md"
         ],
         "rector": "bin/rector process --ansi",


### PR DESCRIPTION
There is no longer class "Rector\Core\Rector\AbstractCollectorRector" so the `--skip-type` argument no longer needed on composer docs command.

Ref https://github.com/rectorphp/rector/issues/8548#issuecomment-1996869294