### PR TITLE
[code-quality] Remove intval/strval from sets, as no clear difference and personal preference

### DIFF
--- a/config/set/code-quality.php
+++ b/config/set/code-quality.php
@@ -33,7 +33,6 @@ use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
 use Rector\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\InlineIsAInstanceOfRector;
-use Rector\CodeQuality\Rector\FuncCall\IntvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\IsAWithStringWithThirdArgumentRector;
 use Rector\CodeQuality\Rector\FuncCall\RemoveSoleValueSprintfRector;
 use Rector\CodeQuality\Rector\FuncCall\SetTypeToCastRector;
@@ -42,7 +41,6 @@ use Rector\CodeQuality\Rector\FuncCall\SimplifyInArrayValuesRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector;
 use Rector\CodeQuality\Rector\FuncCall\SingleInArrayToCompareRector;
-use Rector\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\CodeQuality\Rector\Identical\BooleanNotIdenticalToNotIdenticalRector;
@@ -142,7 +140,6 @@ return static function (RectorConfig $rectorConfig): void {
         SimplifyBoolIdenticalTrueRector::class,
         SimplifyRegexPatternRector::class,
         BooleanNotIdenticalToNotIdenticalRector::class,
-        StrvalToTypeCastRector::class,
         FloatvalToTypeCastRector::class,
         CallableThisArrayToAnonymousFunctionRector::class,
         AndAssignsToSeparateLinesRector::class,
@@ -154,7 +151,6 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveSoleValueSprintfRector::class,
         ShortenElseIfRector::class,
         ArrayMergeOfNonArraysToSimpleArrayRector::class,
-        IntvalToTypeCastRector::class,
         BoolvalToTypeCastRector::class,
         ArrayKeyExistsTernaryThenValueToCoalescingRector::class,
         AbsolutizeRequireAndIncludePathRector::class,

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rector\Utils\Command;
 
 use Nette\Utils\Strings;
+use Rector\CodeQuality\Rector\FuncCall\IntvalToTypeCastRector;
+use Rector\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector;
 use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
@@ -34,6 +36,8 @@ final class MissingInSetCommand extends Command
         // optional
         BinaryOpNullableToInstanceofRector::class,
         WhileNullableToInstanceofRector::class,
+        IntvalToTypeCastRector::class,
+        StrvalToTypeCastRector::class,
         // changes behavior, should be applied on purpose regardless PHP 7.3 level
         JsonThrowOnErrorRector::class,
         // in confront with sub type safe belt detection on RemoveUseless*TagRector


### PR DESCRIPTION
These 2 rules were added to code-quality back in the early age, based on PHPStorm EA feedback. It reported one is 5x faster than another. It's not true, and it seems there is no clear difference between  https://stackoverflow.com/questions/7371991/php-string-cast-vs-strval-function-which-should-i-use

Let's keep this personal preference outside the default set, as few users reported the same no-diff reasoning :+1: 