### PR TITLE
[Transform] Adds ArrayDimFetchToMethodCallRector rule

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 364 Rules Overview
+# 365 Rules Overview
 
 <br>
 
@@ -54,7 +54,7 @@
 
 - [Strict](#strict) (5)
 
-- [Transform](#transform) (24)
+- [Transform](#transform) (25)
 
 - [TypeDeclaration](#typedeclaration) (45)
 
@@ -5848,6 +5848,21 @@ Add interface by used trait
  {
      use SomeTrait;
  }
+```
+
+<br>
+
+### ArrayDimFetchToMethodCallRector
+
+Change array dim fetch to method call
+
+:wrench: **configure it!**
+
+- class: [`Rector\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector`](../rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php)
+
+```diff
+-$app['someService'];
++$app->make('someService');
 ```
 
 <br>

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/ArrayDimFetchToMethodCallRectorTest.php
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/ArrayDimFetchToMethodCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ArrayDimFetchToMethodCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/fixture.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/fixture.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
+
+/** @var \SomeClass $object */
+$object['key']->get()
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
+
+/** @var \SomeClass $object */
+$object->make('key')->get()
+
+?>

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/skip_non_matching_object.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/skip_non_matching_object.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
+
+/** @var \SomeOtherClass $object */
+$object['key']->get()
+
+?>

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Source/ChoiceControl.php
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Source/ChoiceControl.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Source;
+
+final class ChoiceControl
+{
+
+}

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector;
+use Rector\Transform\ValueObject\ArrayDimFetchToMethodCall;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ArrayDimFetchToMethodCallRector::class, [
+            new ArrayDimFetchToMethodCall('SomeClass', 'make'),
+        ]);
+};

--- a/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
@@ -59,11 +59,11 @@ CODE_SAMPLE
         }
 
         foreach ($this->arrayDimFetchToMethodCalls as $arrayDimFetchToMethodCall) {
-            if (! $this->isObjectType($node->var, new ObjectType($arrayDimFetchToMethodCall->getClass()))) {
+            if (! $node->dim instanceof Node) {
                 return null;
             }
 
-            if (! $node->dim instanceof Node) {
+            if (! $this->isObjectType($node->var, new ObjectType($arrayDimFetchToMethodCall->getClass()))) {
                 return null;
             }
 

--- a/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Transform\Rector\ArrayDimFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Rector\Transform\ValueObject\ArrayDimFetchToMethodCall;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\ArrayDimFetchToMethodCallRectorTest
+ */
+class ArrayDimFetchToMethodCallRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ArrayDimFetchToMethodCall[]
+     */
+    private array $arrayDimFetchToMethodCalls;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change array dim fetch to method call', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+$app['someService'];
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$app->make('someService');
+CODE_SAMPLE
+                ,
+                [new ArrayDimFetchToMethodCall('SomeClass', 'make')]
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ArrayDimFetch::class];
+    }
+
+    /**
+     * @param ArrayDimFetch $node
+     */
+    public function refactor(Node $node): ?MethodCall
+    {
+        if (! $node->var instanceof Variable) {
+            return null;
+        }
+
+        foreach ($this->arrayDimFetchToMethodCalls as $arrayDimFetchToMethodCall) {
+            if (! $this->isObjectType($node->var, new ObjectType($arrayDimFetchToMethodCall->getClass()))) {
+                return null;
+            }
+
+            if (! $node->dim instanceof Node) {
+                return null;
+            }
+
+            return new MethodCall($node->var, $arrayDimFetchToMethodCall->getMethod(), [new Arg($node->dim)]);
+        }
+
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, ArrayDimFetchToMethodCall::class);
+
+        $this->arrayDimFetchToMethodCalls = $configuration;
+    }
+}

--- a/rules/Transform/ValueObject/ArrayDimFetchToMethodCall.php
+++ b/rules/Transform/ValueObject/ArrayDimFetchToMethodCall.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Transform\ValueObject;
+
+class ArrayDimFetchToMethodCall
+{
+    public function __construct(
+        private readonly string $class,
+        private readonly string $method
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+}


### PR DESCRIPTION
# Changes

* Adds the new rule.
* Adds a value object to be used as a configuration option for the rule.
* Adds tests.
* Updates the docs.

# Why

In Laravel there's a few classes that use ArrayAccess to grab from the service container or config keys but it's not an overly popular way to do things anymore. This rule will be helpful to a few people I think who want to replace ArrayAccess implementing classes to use a specific method instead.

```diff
-$app['someService'];
+$app->make('someService');
```