### PR TITLE
[Configuration] Do not sets, skip, rules on empty array on RectorConfigBuilder

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -149,7 +149,9 @@ final class RectorConfigBuilder
             ));
         }
 
-        $rectorConfig->sets($uniqueSets);
+        if ($uniqueSets !== []) {
+            $rectorConfig->sets($uniqueSets);
+        }
 
         if ($this->paths !== []) {
             $rectorConfig->paths($this->paths);
@@ -168,8 +170,13 @@ final class RectorConfigBuilder
             }
         }
 
-        $rectorConfig->skip($this->skip);
-        $rectorConfig->rules($this->rules);
+        if ($this->skip !== []) {
+            $rectorConfig->skip($this->skip);
+        }
+
+        if ($this->rules !== []) {
+            $rectorConfig->rules($this->rules);
+        }
 
         foreach ($this->rulesWithConfigurations as $rectorClass => $configurations) {
             foreach ($configurations as $configuration) {


### PR DESCRIPTION
No need to add/merge with empty array data.