### PR TITLE
[Scoper] Handle use nette/utils 4.0 on php < 7.4 on 6th param on preg_replace_callback()

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -110,13 +110,13 @@ return [
 
             return str_replace(
                 'return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit, 0, $flags]);',
-                <<<'CODE_SAMPLE'
+                <<<'CODE_REPLACE'
 if (PHP_VERSION_ID < 70400) {
     return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit]);
 }
 
 return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit, 0, $flags]);
-CODE_SAMPLE,
+CODE_REPLACE,
                 $content
             );
         },

--- a/scoper.php
+++ b/scoper.php
@@ -108,6 +108,7 @@ return [
                 return $content;
             }
 
+            # see https://github.com/rectorphp/rector/issues/8564
             return str_replace(
                 'return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit, 0, $flags]);',
                 <<<'CODE_REPLACE'

--- a/scoper.php
+++ b/scoper.php
@@ -102,5 +102,23 @@ return [
 
             return Unprefixer::unprefixQuoted($content, $prefix);
         },
+
+        static function (string $filePath, string $prefix, string $content): string {
+            if (! \str_ends_with($filePath, 'vendor/nette/utils/src/Utils/Strings.php')) {
+                return $content;
+            }
+
+            return str_replace(
+                'return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit, 0, $flags]);',
+                <<<'CODE_SAMPLE'
+if (PHP_VERSION_ID < 70400) {
+    return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit]);
+}
+
+return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit, 0, $flags]);
+CODE_SAMPLE,
+                $content
+            );
+        },
     ],
 ];


### PR DESCRIPTION
@TomasVotruba let's see if it works to cover https://github.com/rectorphp/rector/issues/8564