### PR TITLE
[CodingStyle] Remove usage of Reflection::expandClassName() from nette/utils 4.0 as cause bug on downgrade

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -148,8 +148,6 @@ final class ShortNameResolver
      */
     private function resolveFromStmtsDocBlocks(array $stmts): array
     {
-        $classReflection = $this->resolveClassReflection($stmts);
-
         $shortNames = [];
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, function (Node $node) use (
             &$shortNames
@@ -185,7 +183,7 @@ final class ShortNameResolver
             return null;
         });
 
-        return $this->fqnizeShortNames($shortNames, $classReflection, $stmts);
+        return $this->fqnizeShortNames($shortNames, $stmts);
     }
 
     /**
@@ -211,20 +209,14 @@ final class ShortNameResolver
      * @param Stmt[] $stmts
      * @return array<string, string>
      */
-    private function fqnizeShortNames(array $shortNames, ?ClassReflection $classReflection, array $stmts): array
+    private function fqnizeShortNames(array $shortNames, array $stmts): array
     {
         $shortNamesToFullyQualifiedNames = [];
-
-        $nativeReflectionClass = $classReflection instanceof ClassReflection && ! $classReflection->isAnonymous()
-            ? $classReflection->getNativeReflection()
-            : null;
 
         foreach ($shortNames as $shortName) {
             $stmtsMatchedName = $this->useImportNameMatcher->matchNameWithStmts($shortName, $stmts);
 
-            if ($nativeReflectionClass instanceof ReflectionClass) {
-                $fullyQualifiedName = Reflection::expandClassName($shortName, $nativeReflectionClass);
-            } elseif (is_string($stmtsMatchedName)) {
+            if (is_string($stmtsMatchedName)) {
                 $fullyQualifiedName = $stmtsMatchedName;
             } else {
                 $fullyQualifiedName = $shortName;

--- a/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
+++ b/rules/CodingStyle/ClassNameImport/ShortNameResolver.php
@@ -122,7 +122,7 @@ final class ShortNameResolver
             }
 
             // already short
-            if (\str_contains((string) $originalName->toString(), '\\')) {
+            if (\str_contains($originalName->toString(), '\\')) {
                 return null;
             }
 

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/already_attributed.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/already_attributed.php.inc
@@ -2,14 +2,11 @@
 
 namespace Rector\Tests\Issues\RenameAnnotationToAttributeAutoImport\Fixture;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @IsGranted("TEST")
- */
 #[Route(path: '/pro/{id}/networks/{networkId}/sectors', name: 'api_network_sectors', requirements: ['id' => '\d+', 'networkId' => '\d+'])]
+#[\Symfony\Component\Security\Http\Attribute\IsGranted('TEST')]
 class WithExistingAttribute extends AbstractController
 {
 }
@@ -20,11 +17,12 @@ class WithExistingAttribute extends AbstractController
 
 namespace Rector\Tests\Issues\RenameAnnotationToAttributeAutoImport\Fixture;
 
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route(path: '/pro/{id}/networks/{networkId}/sectors', name: 'api_network_sectors', requirements: ['id' => '\d+', 'networkId' => '\d+'])]
-#[\Symfony\Component\Security\Http\Attribute\IsGranted('TEST')]
+#[IsGranted('TEST')]
 class WithExistingAttribute extends AbstractController
 {
 }


### PR DESCRIPTION
The syntax of downgrade `PhpToken::tokenize()` and it usage call another method with `->is()` usage is too complex to downgrade. 

I think this usage can be removed.

Closes https://github.com/rectorphp/getrector-com/issues/2142
Closes https://github.com/rectorphp/rector/issues/8565