### PR TITLE
[Renaming][AutoImport] Handle after change annotation to attribute with rename on AnnotationToAttributeRector + RenameClassRector with auto import

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/FullyQualifiedNameClassNameImportSkipVoter.php
@@ -44,7 +44,7 @@ final readonly class FullyQualifiedNameClassNameImportSkipVoter implements Class
         $originalName = $node->getAttribute(AttributeKey::ORIGINAL_NAME);
         $originalNameToAttribute = null;
         if ($originalName instanceof Name && ! $originalName instanceof FullyQualified && $originalName->hasAttribute(AttributeKey::PHP_ATTRIBUTE_NAME)) {
-            $originalNameToAttribute = $originalName->toString();
+            $originalNameToAttribute = $originalName->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
         }
 
         foreach ($shortNamesToFullyQualifiedNames as $shortName => $fullyQualifiedName) {
@@ -62,7 +62,7 @@ final readonly class FullyQualifiedNameClassNameImportSkipVoter implements Class
             }
 
             if (! in_array($fullyQualifiedName, $removedUses, true)) {
-                return $originalNameToAttribute == null || in_array($originalNameToAttribute, $removedUses, true);
+                return $originalNameToAttribute == null || ! in_array($originalNameToAttribute, $removedUses, true);
             }
 
             return false;

--- a/src/PostRector/Rector/ClassRenamingPostRector.php
+++ b/src/PostRector/Rector/ClassRenamingPostRector.php
@@ -76,6 +76,9 @@ final class ClassRenamingPostRector extends AbstractPostRector
                     $oldToNewClasses,
                     $scope
                 );
+                if ($result instanceof FullyQualified) {
+                    $result->setAttribute(AttributeKey::ORIGINAL_NAME, $node);
+                }
             }
         }
 

--- a/src/PostRector/Rector/ClassRenamingPostRector.php
+++ b/src/PostRector/Rector/ClassRenamingPostRector.php
@@ -69,17 +69,7 @@ final class ClassRenamingPostRector extends AbstractPostRector
         if ($node instanceof FullyQualified) {
             $result = $this->classRenamer->renameNode($node, $oldToNewClasses, $scope);
         } else {
-            $phpAttributeName = $node->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
-            if (is_string($phpAttributeName)) {
-                $result = $this->classRenamer->renameNode(
-                    new FullyQualified($phpAttributeName, $node->getAttributes()),
-                    $oldToNewClasses,
-                    $scope
-                );
-                if ($result instanceof FullyQualified) {
-                    $result->setAttribute(AttributeKey::ORIGINAL_NAME, $node);
-                }
-            }
+            $result = $this->resolveResultWithPhpAttributeName($node, $oldToNewClasses, $scope);
         }
 
         if (! SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_NAMES)) {
@@ -104,5 +94,30 @@ final class ClassRenamingPostRector extends AbstractPostRector
     {
         $this->renamedNameCollector->reset();
         return $nodes;
+    }
+
+    /**
+     * @param array<string, string> $oldToNewClasses
+     */
+    private function resolveResultWithPhpAttributeName(
+        Name $name,
+        array $oldToNewClasses,
+        ?Scope $scope
+    ): ?FullyQualified {
+        $phpAttributeName = $name->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
+        if (is_string($phpAttributeName)) {
+            $result = $this->classRenamer->renameNode(
+                new FullyQualified($phpAttributeName, $name->getAttributes()),
+                $oldToNewClasses,
+                $scope
+            );
+            if ($result instanceof FullyQualified) {
+                $result->setAttribute(AttributeKey::ORIGINAL_NAME, $name);
+            }
+
+            return $result;
+        }
+
+        return null;
     }
 }

--- a/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/with_existing_attribute.php.inc
+++ b/tests/Issues/AnnotationToAttributeRenameAutoImport/Fixture/with_existing_attribute.php.inc
@@ -20,11 +20,12 @@ class WithExistingAttribute extends AbstractController
 
 namespace Rector\Tests\Issues\RenameAnnotationToAttributeAutoImport\Fixture;
 
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route(path: '/pro/{id}/networks/{networkId}/sectors', name: 'api_network_sectors', requirements: ['id' => '\d+', 'networkId' => '\d+'])]
-#[\Symfony\Component\Security\Http\Attribute\IsGranted('TEST')]
+#[IsGranted('TEST')]
 class WithExistingAttribute extends AbstractController
 {
 }


### PR DESCRIPTION
@TomasVotruba this is to cover removed `Reflection::expandClassName()` on PR:

- https://github.com/rectorphp/rector-src/pull/5740