### PR TITLE
[Php80] Skip var property usage on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_var_property.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_var_property.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+class SkipVarProperty
+{
+    var $id;
+
+    public function __construct($id) {
+        $this->id = $id;
+    }
+}

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
@@ -56,6 +56,10 @@ final readonly class PromotedPropertyCandidateResolver
         Property $property,
         ClassMethod $constructClassMethod
     ): ?PropertyPromotionCandidate {
+        if ($property->flags == 0) {
+            return null;
+        }
+
         $onlyProperty = $property->props[0];
 
         $propertyName = $this->nodeNameResolver->getName($onlyProperty);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8568