### PR TITLE
[DeadCode] Skip isset() from property fetch from docblock on RemoveAlwaysTrueIfConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_property_fetch_doc.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_property_fetch_doc.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class SkipPropertyFetchDoc
+{
+    /**
+     * @var string
+     */
+    public $bodyFormat = '';
+
+    public function run()
+    {
+        if (isset($this->bodyFormat) && $this->bodyFormat !== '') {
+        }
+    }
+
+    public function reset()
+    {
+        $this->bodyFormat = null;
+    }
+}

--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_property_fetch_doc2.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_property_fetch_doc2.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class SkipPropertyFetchDoc2
+{
+    /**
+     * @var array<int, int>
+     */
+    public $data = [];
+
+    public function run($key)
+    {
+        if (is_int($this->data[$key]) && $this->data[$key] > 0) {
+        }
+    }
+}

--- a/rules/DeadCode/NodeAnalyzer/SafeLeftTypeBooleanAndOrAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/SafeLeftTypeBooleanAndOrAnalyzer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\NodeAnalyzer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use Rector\NodeAnalyzer\ExprAnalyzer;
+use Rector\PhpParser\Node\BetterNodeFinder;
+
+final readonly class SafeLeftTypeBooleanAndOrAnalyzer
+{
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ExprAnalyzer $exprAnalyzer
+    ) {
+    }
+
+    public function isSafe(BooleanAnd|BooleanOr $booleanAnd): bool
+    {
+        $hasNonTypedFromParam = (bool) $this->betterNodeFinder->findFirst(
+            $booleanAnd->left,
+            fn (Node $node): bool => $node instanceof Variable && $this->exprAnalyzer->isNonTypedFromParam($node)
+        );
+
+        if ($hasNonTypedFromParam) {
+            return false;
+        }
+
+        // get type from Property and ArrayDimFetch is unreliable
+        return ! (bool) $this->betterNodeFinder->findFirst(
+            $booleanAnd->left,
+            static fn (Node $node): bool => $node instanceof PropertyFetch || $node instanceof StaticPropertyFetch || $node instanceof ArrayDimFetch
+        );
+    }
+}

--- a/rules/DeadCode/Rector/If_/ReduceAlwaysFalseIfOrRector.php
+++ b/rules/DeadCode/Rector/If_/ReduceAlwaysFalseIfOrRector.php
@@ -6,11 +6,9 @@ namespace Rector\DeadCode\Rector\If_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\If_;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use Rector\NodeAnalyzer\ExprAnalyzer;
-use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\DeadCode\NodeAnalyzer\SafeLeftTypeBooleanAndOrAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -21,8 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReduceAlwaysFalseIfOrRector extends AbstractRector
 {
     public function __construct(
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ExprAnalyzer $exprAnalyzer
+        private readonly SafeLeftTypeBooleanAndOrAnalyzer $safeLeftTypeBooleanAndOrAnalyzer
     ) {
     }
 
@@ -90,12 +87,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $hasNonTypedFromParam = $this->betterNodeFinder->findFirst(
-            $booleanOr->left,
-            fn (Node $node): bool => $node instanceof Variable && $this->exprAnalyzer->isNonTypedFromParam($node)
-        );
-
-        if ($hasNonTypedFromParam instanceof Node) {
+        if (! $this->safeLeftTypeBooleanAndOrAnalyzer->isSafe($booleanOr)) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\If_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\Isset_;
@@ -180,6 +181,11 @@ CODE_SAMPLE
         $booleanAnd = $if->cond;
 
         if ($booleanAnd->left instanceof Isset_) {
+            return null;
+        }
+
+        $hasArrayDimFetch = (bool) $this->betterNodeFinder->findFirst($booleanAnd->left, fn (Node $node): bool => $node instanceof ArrayDimFetch);
+        if ($hasArrayDimFetch) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -180,12 +180,8 @@ CODE_SAMPLE
 
         $booleanAnd = $if->cond;
 
-        if ($booleanAnd->left instanceof Isset_) {
-            return null;
-        }
-
-        $hasArrayDimFetch = (bool) $this->betterNodeFinder->findFirst($booleanAnd->left, fn (Node $node): bool => $node instanceof ArrayDimFetch);
-        if ($hasArrayDimFetch) {
+        $hasArrayDimFetchOrIsset = (bool) $this->betterNodeFinder->findFirst($booleanAnd->left, fn (Node $node): bool => $node instanceof ArrayDimFetch || $node instanceof Isset_);
+        if ($hasArrayDimFetchOrIsset) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
@@ -177,6 +178,11 @@ CODE_SAMPLE
         }
 
         $booleanAnd = $if->cond;
+
+        if ($booleanAnd->left instanceof Isset_) {
+            return null;
+        }
+
         $leftType = $this->getType($booleanAnd->left);
         if (! $leftType instanceof ConstantBooleanType) {
             return null;

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -180,7 +180,10 @@ CODE_SAMPLE
 
         $booleanAnd = $if->cond;
 
-        $hasArrayDimFetchOrIsset = (bool) $this->betterNodeFinder->findFirst($booleanAnd->left, fn (Node $node): bool => $node instanceof ArrayDimFetch || $node instanceof Isset_);
+        $hasArrayDimFetchOrIsset = (bool) $this->betterNodeFinder->findFirst(
+            $booleanAnd->left,
+            static fn (Node $node): bool => $node instanceof ArrayDimFetch || $node instanceof Isset_
+        );
         if ($hasArrayDimFetchOrIsset) {
             return null;
         }


### PR DESCRIPTION
The following code should be skipped as rely to docblock

```php
class SkipPropertyFetchDoc
{
    /**
     * @var string
     */
    public $bodyFormat = '';

    public function run()
    {
        if (isset($this->bodyFormat) && $this->bodyFormat !== '') {
        }
    }

    public function reset()
    {
        $this->bodyFormat = null;
    }
}
```