### PR TITLE
[CodeQuality] Skip __construct() method on ExplicitReturnNullRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip_construct.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip_construct.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector\Fixture;
+
+class SkipConstruct
+{
+    public function __construct(int $number)
+    {
+        if ($number > 50) {
+            return 'yes';
+        }
+
+        echo 'test';
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector.php
@@ -21,6 +21,7 @@ use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\TypeInferer\SilentVoidResolver;
+use Rector\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -97,6 +98,10 @@ CODE_SAMPLE
     {
         // known return type, nothing to improve
         if ($node->returnType instanceof Node) {
+            return null;
+        }
+
+        if ($this->isName($node, MethodName::CONSTRUCT)) {
             return null;
         }
 


### PR DESCRIPTION
`Return_`'s Expr is removed on  `__construct()` by rule: `RemoveUselessReturnExprInConstructRector`, see

https://getrector.com/demo/f8805b08-85cc-4052-a46d-23009d0ef575

so this need to be skipped on `ExplicitReturnNullRector`