### PR TITLE
[CodeQuality] Skip do { } while always returned on ExplicitReturnNullRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip_do_while_always_returned.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip_do_while_always_returned.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector\Fixture;
+
+final class SkipDoWhileAlwaysReturned
+{
+    public function run(int $i)
+    {
+		do {
+    		if (rand(0,1)) {
+                return 1;
+    		}
+
+		    return 2;
+		} while (++$i < 1);
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Finally_;
@@ -90,6 +91,10 @@ final readonly class SilentVoidResolver
             }
 
             if ($this->isIfReturn($stmt)) {
+                return true;
+            }
+
+            if ($stmt instanceof Do_ && $this->hasStmtsAlwaysReturnOrExit($stmt->stmts)) {
                 return true;
             }
         }


### PR DESCRIPTION
Ref https://getrector.com/demo/f5c7b395-72d7-424a-add5-193e456db4b4

do while always executed at least once, see https://3v4l.org/iYu6i