### PR TITLE
[DeadCode] Skip Array Callable dynamic method using __CLASS__ with constructor (no default args) on RemoveUnusedPrivateMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_array_callables_magic_constant_with_constructor.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_array_callables_magic_constant_with_constructor.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+final class SkipArrayCallablesMagicConstantWithConstructor
+{
+    private $args;
+
+    public function __construct(...$args)
+    {
+        $this->args = $args;
+    }
+
+    public function run()
+    {
+        $array  = [3, 2, 1];
+
+        usort($array, [__CLASS__, 'sort']);
+
+        return $array;
+    }
+
+    private function sort($a, $b)
+    {
+        return $a <=> $b;
+    }
+}

--- a/src/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/src/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -208,8 +208,7 @@ final readonly class ArrayCallableMethodMatcher
         if ($classConstantReference === ObjectReference::STATIC) {
             return true;
         }
-        $magicConstantClassName = (new Class_())->getName();
-        if ($classConstantReference === $magicConstantClassName) {
+        if ($classConstantReference === '__CLASS__') {
             return true;
         }
         return false;


### PR DESCRIPTION
fix https://github.com/rectorphp/rector/issues/8577