### PR TITLE
Added failling ReturnTypeFromStrictTypedPropertyRector test

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector/Fixture/non-nullable-property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedPropertyRector/Fixture/non-nullable-property.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector\Fixture;
+
+final class DemoFile
+{
+    private ?DemoFile $demo = null;
+    
+    public function getDemo() {
+        if ($this->demo === null) {
+            $this->demo = new DemoFile();
+        }
+        return $this->demo;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector\Fixture;
+
+final class DemoFile
+{
+    private ?DemoFile $demo = null;
+    
+    public function getDemo(): DemoFile {
+        if ($this->demo === null) {
+            $this->demo = new DemoFile();
+        }
+        return $this->demo;
+    }
+}
+?>


### PR DESCRIPTION
I think the rector should be smart enough to add a non-nullable type in the given case