### PR TITLE
[Printer] Apply configurable multiline on Fluent Method Call on print after method call created/re-printed

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -38,4 +38,6 @@ return static function (RectorConfig $rectorConfig): void {
     foreach ($extensionConfigResolver->provide() as $extensionConfigFile) {
         $rectorConfig->import($extensionConfigFile);
     }
+
+    $rectorConfig->newLineOnFluentCall(false);
 };

--- a/config/config.php
+++ b/config/config.php
@@ -39,5 +39,6 @@ return static function (RectorConfig $rectorConfig): void {
         $rectorConfig->import($extensionConfigFile);
     }
 
+    // use original php-parser printer to avoid BC break on fluent call
     $rectorConfig->newLineOnFluentCall(false);
 };

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/disable_parallel_to_without_parallel.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/disable_parallel_to_without_parallel.php.inc
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-return \Rector\Config\RectorConfig::configure()->withoutParallel();
+return \Rector\Config\RectorConfig::configure()
+    ->withoutParallel();
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/file_extensions_to_with_file_extensions.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/file_extensions_to_with_file_extensions.php.inc
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-return \Rector\Config\RectorConfig::configure()->withFileExtensions(['php', 'phtml']);
+return \Rector\Config\RectorConfig::configure()
+    ->withFileExtensions(['php', 'phtml']);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/rule_with_configuration_to_with_configured_rule.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/rule_with_configuration_to_with_configured_rule.php.inc
@@ -21,8 +21,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 
-return \Rector\Config\RectorConfig::configure()->withConfiguredRule(RenameFunctionRector::class, [
-    'is_real' => 'is_float',
-]);
+return \Rector\Config\RectorConfig::configure()
+    ->withConfiguredRule(RenameFunctionRector::class, ['is_real' => 'is_float']);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/rules_to_with_rules.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/rules_to_with_rules.php.inc
@@ -26,6 +26,7 @@ use Rector\Transform\Rector\FileWithoutNamespace\RectorConfigBuilderRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
-return \Rector\Config\RectorConfig::configure()->withRules([ReturnUnionTypeRector::class, RectorConfigBuilderRector::class, TypedPropertyFromAssignsRector::class]);
+return \Rector\Config\RectorConfig::configure()
+    ->withRules([ReturnUnionTypeRector::class, RectorConfigBuilderRector::class, TypedPropertyFromAssignsRector::class]);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/sets_to_with_sets.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/sets_to_with_sets.php.inc
@@ -18,6 +18,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
 
-return \Rector\Config\RectorConfig::configure()->withSets([SetList::DEAD_CODE]);
+return \Rector\Config\RectorConfig::configure()
+    ->withSets([SetList::DEAD_CODE]);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_autoload_paths.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_autoload_paths.php.inc
@@ -18,8 +18,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-return \Rector\Config\RectorConfig::configure()->withAutoloadPaths([
-    __DIR__  . '/../autoload.php',
-]);
+return \Rector\Config\RectorConfig::configure()
+    ->withAutoloadPaths([__DIR__  . '/../autoload.php']);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_bootstrap_files.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_bootstrap_files.php.inc
@@ -18,8 +18,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-return \Rector\Config\RectorConfig::configure()->withBootstrapFiles([
-    __DIR__  . '/constants.php',
-]);
+return \Rector\Config\RectorConfig::configure()
+    ->withBootstrapFiles([__DIR__  . '/constants.php']);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_path.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_path.php.inc
@@ -21,8 +21,8 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 
-return \Rector\Config\RectorConfig::configure()->withPaths([
-    __DIR__ . '/src',
-])->withRules([ReturnUnionTypeRector::class]);
+return \Rector\Config\RectorConfig::configure()
+    ->withPaths([__DIR__ . '/src'])
+    ->withRules([ReturnUnionTypeRector::class]);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_phpversion.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_phpversion.php.inc
@@ -18,6 +18,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\ValueObject\PhpVersion;
 
-return \Rector\Config\RectorConfig::configure()->withPhpVersion(PhpVersion::PHP_74);
+return \Rector\Config\RectorConfig::configure()
+    ->withPhpVersion(PhpVersion::PHP_74);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_rule.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_rule.php.inc
@@ -18,6 +18,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Transform\Rector\FileWithoutNamespace\RectorConfigBuilderRector;
 
-return \Rector\Config\RectorConfig::configure()->withRules([RectorConfigBuilderRector::class]);
+return \Rector\Config\RectorConfig::configure()
+    ->withRules([RectorConfigBuilderRector::class]);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_rules.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_rules.php.inc
@@ -21,6 +21,7 @@ use Rector\Config\RectorConfig;
 use Rector\Transform\Rector\FileWithoutNamespace\RectorConfigBuilderRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
-return \Rector\Config\RectorConfig::configure()->withRules([RectorConfigBuilderRector::class, TypedPropertyFromAssignsRector::class]);
+return \Rector\Config\RectorConfig::configure()
+    ->withRules([RectorConfigBuilderRector::class, TypedPropertyFromAssignsRector::class]);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_rules_class_constant_value.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_rules_class_constant_value.php.inc
@@ -36,6 +36,7 @@ class SomeClass
     ];
 }
 
-return \Rector\Config\RectorConfig::configure()->withRules(SomeClass::RULES);
+return \Rector\Config\RectorConfig::configure()
+    ->withRules(SomeClass::RULES);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_skip.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_skip.php.inc
@@ -21,8 +21,10 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 
-return \Rector\Config\RectorConfig::configure()->withSkip([
+return \Rector\Config\RectorConfig::configure()
+    ->withSkip([
     __DIR__ . '/src/migrations',
-])->withRules([ReturnUnionTypeRector::class]);
+])
+    ->withRules([ReturnUnionTypeRector::class]);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_skip.php.inc
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/Fixture/with_skip.php.inc
@@ -22,9 +22,7 @@ use Rector\Config\RectorConfig;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 
 return \Rector\Config\RectorConfig::configure()
-    ->withSkip([
-    __DIR__ . '/src/migrations',
-])
+    ->withSkip([__DIR__ . '/src/migrations'])
     ->withRules([ReturnUnionTypeRector::class]);
 
 ?>

--- a/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/FileWithoutNamespace/RectorConfigBuilderRector/config/configured_rule.php
@@ -6,4 +6,5 @@ use Rector\Config\RectorConfig;
 use Rector\Transform\Rector\FileWithoutNamespace\RectorConfigBuilderRector;
 
 return RectorConfig::configure()
+    ->withFluentCallNewLine()
     ->withRules([RectorConfigBuilderRector::class]);

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -313,9 +313,9 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::SYMFONY_CONTAINER_PHP_PATH_PARAMETER, $filePath);
     }
 
-    public function newLineOnFluentCall(): void
+    public function newLineOnFluentCall(bool $enabled = true): void
     {
-        SimpleParameterProvider::setParameter(Option::NEW_LINE_ON_FLUENT_CALL, true);
+        SimpleParameterProvider::setParameter(Option::NEW_LINE_ON_FLUENT_CALL, $enabled);
     }
 
     /**

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -313,6 +313,11 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::SYMFONY_CONTAINER_PHP_PATH_PARAMETER, $filePath);
     }
 
+    public function newLineOnFluentCall(): void
+    {
+        SimpleParameterProvider::setParameter(Option::NEW_LINE_ON_FLUENT_CALL, true);
+    }
+
     /**
      * @param string[] $extensions
      */

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -88,6 +88,12 @@ final class Option
     public const SYMFONY_CONTAINER_PHP_PATH_PARAMETER = 'symfony_container_php_path';
 
     /**
+     * @internal Use @see \Rector\Config\RectorConfig::newLineOnFluentCall()
+     * @var string
+     */
+    public const NEW_LINE_ON_FLUENT_CALL = 'new_line_on_fluent_call';
+
+    /**
      * @var string
      */
     public const CLEAR_CACHE = 'clear-cache';

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -126,6 +126,8 @@ final class RectorConfigBuilder
 
     private bool $isDeadCodeLevelUsed = false;
 
+    private bool $isFluentNewLine = false;
+
     /**
      * @var RegisteredService[]
      */
@@ -255,6 +257,10 @@ final class RectorConfigBuilder
 
         if ($this->symfonyContainerPhpFile !== null) {
             $rectorConfig->symfonyContainerPhp($this->symfonyContainerPhpFile);
+        }
+
+        if ($this->isFluentNewLine) {
+            $rectorConfig->newLineOnFluentCall();
         }
     }
 
@@ -685,6 +691,12 @@ final class RectorConfigBuilder
 
         $this->rules = array_merge($this->rules, $levelRules);
 
+        return $this;
+    }
+
+    public function withFluentCallNewLine(): self
+    {
+        $this->isFluentNewLine = true;
         return $this;
     }
 

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -137,14 +137,14 @@ final class RectorConfigBuilder
     {
         $uniqueSets = array_unique($this->sets);
 
-        if (in_array(SetList::TYPE_DECLARATION, $uniqueSets, true) && $this->isTypeCoverageLevelUsed) {
+        if (in_array(SetList::TYPE_DECLARATION, $uniqueSets, true) && $this->isTypeCoverageLevelUsed === true) {
             throw new InvalidConfigurationException(sprintf(
                 'Your config already enables type declarations set.%sRemove "->withTypeCoverageLevel()" as it only duplicates it, or remove type declaration set.',
                 PHP_EOL
             ));
         }
 
-        if (in_array(SetList::DEAD_CODE, $uniqueSets, true) && $this->isDeadCodeLevelUsed) {
+        if (in_array(SetList::DEAD_CODE, $uniqueSets, true) && $this->isDeadCodeLevelUsed === true) {
             throw new InvalidConfigurationException(sprintf(
                 'Your config already enables dead code set.%sRemove "->withDeadCodeLevel()" as it only duplicates it, or remove dead code set.',
                 PHP_EOL

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -259,7 +259,7 @@ final class RectorConfigBuilder
             $rectorConfig->symfonyContainerPhp($this->symfonyContainerPhpFile);
         }
 
-        if ($this->isFluentNewLine) {
+        if ($this->isFluentNewLine === true) {
             $rectorConfig->newLineOnFluentCall();
         }
     }

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -259,8 +259,8 @@ final class RectorConfigBuilder
             $rectorConfig->symfonyContainerPhp($this->symfonyContainerPhpFile);
         }
 
-        if ($this->isFluentNewLine === true) {
-            $rectorConfig->newLineOnFluentCall();
+        if ($this->isFluentNewLine !== null) {
+            $rectorConfig->newLineOnFluentCall($this->isFluentNewLine);
         }
     }
 
@@ -694,9 +694,9 @@ final class RectorConfigBuilder
         return $this;
     }
 
-    public function withFluentCallNewLine(): self
+    public function withFluentCallNewLine(bool $isFluentNewLine = true): self
     {
-        $this->isFluentNewLine = true;
+        $this->isFluentNewLine = $isFluentNewLine;
         return $this;
     }
 

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -122,11 +122,11 @@ final class RectorConfigBuilder
      * To make sure type declarations set and level are not duplicated,
      * as both contain same rules
      */
-    private bool $isTypeCoverageLevelUsed = false;
+    private ?bool $isTypeCoverageLevelUsed = null;
 
-    private bool $isDeadCodeLevelUsed = false;
+    private ?bool $isDeadCodeLevelUsed = null;
 
-    private bool $isFluentNewLine = false;
+    private ?bool $isFluentNewLine = null;
 
     /**
      * @var RegisteredService[]

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -486,8 +486,7 @@ final class BetterStandardPrinter extends Standard
             . '(' . $this->pMaybeMultiline($methodCall->args) . ')';
         }
 
-        return $this->pDereferenceLhs($methodCall->var) . '->' . $this->pObjectProperty($methodCall->name)
-             . '(' . $this->pMaybeMultiline($methodCall->args) . ')';
+        return parent::pExpr_MethodCall($methodCall);
     }
 
     /**

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -467,25 +467,25 @@ final class BetterStandardPrinter extends Standard
             str_repeat($this->getIndentCharacter(), $indentSize);
     }
 
-    protected function pExpr_MethodCall(Expr\MethodCall $node): string
+    protected function pExpr_MethodCall(MethodCall $methodCall): string
     {
-        if ($node->var instanceof CallLike) {
-            foreach ($node->args as $key => $arg) {
+        if ($methodCall->var instanceof CallLike) {
+            foreach ($methodCall->args as $key => $arg) {
                 if (! $arg instanceof Arg) {
                     continue;
                 }
 
                 if ($arg->value instanceof Array_) {
-                    $node->args[$key]->value->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                    $methodCall->args[$key]->value->setAttribute(AttributeKey::ORIGINAL_NODE, null);
                 }
             }
 
-            return $this->pDereferenceLhs($node->var) . "\n" . $this->resolveIndentSpaces() . "->" . $this->pObjectProperty($node->name)
-            . '(' . $this->pMaybeMultiline($node->args) . ')';
+            return $this->pDereferenceLhs($methodCall->var) . "\n" . $this->resolveIndentSpaces() . "->" . $this->pObjectProperty($methodCall->name)
+            . '(' . $this->pMaybeMultiline($methodCall->args) . ')';
         }
 
-        return $this->pDereferenceLhs($node->var) . '->' . $this->pObjectProperty($node->name)
-             . '(' . $this->pMaybeMultiline($node->args) . ')';
+        return $this->pDereferenceLhs($methodCall->var) . '->' . $this->pObjectProperty($methodCall->name)
+             . '(' . $this->pMaybeMultiline($methodCall->args) . ')';
     }
 
     /**

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -475,9 +475,7 @@ final class BetterStandardPrinter extends Standard
                     continue;
                 }
 
-                if ($arg->value instanceof Array_) {
-                    $methodCall->args[$key]->value->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-                }
+                $methodCall->args[$key]->value->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 
             return $this->pDereferenceLhs($methodCall->var) . "\n" . $this->resolveIndentSpaces() . "->" . $this->pObjectProperty($methodCall->name)

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -469,7 +469,7 @@ final class BetterStandardPrinter extends Standard
 
     protected function pExpr_MethodCall(MethodCall $methodCall): string
     {
-        if ((bool) SimpleParameterProvider::provideBoolParameter(Option::NEW_LINE_ON_FLUENT_CALL) === false) {
+        if (SimpleParameterProvider::provideBoolParameter(Option::NEW_LINE_ON_FLUENT_CALL) === false) {
             return parent::pExpr_MethodCall($methodCall);
         }
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -474,12 +474,12 @@ final class BetterStandardPrinter extends Standard
         }
 
         if ($methodCall->var instanceof CallLike) {
-            foreach ($methodCall->args as $key => $arg) {
+            foreach ($methodCall->args as $arg) {
                 if (! $arg instanceof Arg) {
                     continue;
                 }
 
-                $methodCall->args[$key]->value->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                $arg->value->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 
             return $this->pDereferenceLhs($methodCall->var) . "\n" . $this->resolveIndentSpaces() . "->" . $this->pObjectProperty($methodCall->name)

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -469,6 +469,10 @@ final class BetterStandardPrinter extends Standard
 
     protected function pExpr_MethodCall(MethodCall $methodCall): string
     {
+        if ((bool) SimpleParameterProvider::provideBoolParameter(Option::NEW_LINE_ON_FLUENT_CALL) === false) {
+            return parent::pExpr_MethodCall($methodCall);
+        }
+
         if ($methodCall->var instanceof CallLike) {
             foreach ($methodCall->args as $key => $arg) {
                 if (! $arg instanceof Arg) {

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -58,6 +58,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         SimpleParameterProvider::setParameter(Option::INDENT_CHAR, ' ');
         SimpleParameterProvider::setParameter(Option::INDENT_SIZE, 4);
         SimpleParameterProvider::setParameter(Option::POLYFILL_PACKAGES, []);
+        SimpleParameterProvider::setParameter(Option::NEW_LINE_ON_FLUENT_CALL, false);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Can be enabled via Rector config:

```php
return RectorConfig::configure()
     // ...
    ->withFluentCallNewLine()
    // ..
;
```

to ensure no BC break on rector extensions.
