### PR TITLE
Adds a link to the PHP Static Analysis Attributes rector rules

### DIFF
--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -101,6 +101,7 @@ Among there projects belong:
 * [cakephp/upgrade](https://github.com/cakephp/upgrade)
 * [driftingly/rector-laravel](https://github.com/driftingly/rector-laravel)
 * [contao/contao-rector](https://github.com/contao/contao-rector)
+* [php-static-analysis/rector-rule](https://github.com/php-static-analysis/rector-rule)
 
 <br>
 


### PR DESCRIPTION
Adds a link to the [PHP Static Analysis Attributes rector rules](https://github.com/php-static-analysis/rector-rule) that allow you to convert your existing static analysis annotations to the attributes provided by the [PHP Static Analysis Attributes library](https://github.com/php-static-analysis/attributes)