### PR TITLE
[DeadCode] Clean up TypeHasher on Union Type

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
@@ -23,7 +23,7 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 class MultipleTypes
 {
     /**
-     * @var int|string|bool
+     * @var bool|int|string
      */
     public $value;
     public function set()

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/union_unsorted.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/union_unsorted.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class UnionUnsorted
+{
+    /**
+     * @param bool|int|string $param
+     */
+    function foo(string|int|bool $param)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+class UnionUnsorted
+{
+    function foo(string|int|bool $param)
+    {
+
+    }
+}
+
+?>

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc;
 
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -41,6 +43,10 @@ final readonly class DeadParamTagValueNodeAnalyzer
         }
 
         if ($paramTagValueNode->description !== '') {
+            return false;
+        }
+
+        if ($paramTagValueNode->type instanceof UnionTypeNode && $param->type instanceof FullyQualified) {
             return false;
         }
 

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -70,10 +70,15 @@ final readonly class DeadParamTagValueNodeAnalyzer
             return true;
         }
 
-        if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($paramTagValueNode->type)) {
+        return $this->isAllowedBracketAwareUnion($paramTagValueNode->type);
+    }
+
+    private function isAllowedBracketAwareUnion(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
+    {
+        if ($this->mixedArrayTypeNodeAnalyzer->hasMixedArrayType($bracketsAwareUnionTypeNode)) {
             return false;
         }
 
-        return ! $this->genericTypeNodeAnalyzer->hasGenericType($paramTagValueNode->type);
+        return ! $this->genericTypeNodeAnalyzer->hasGenericType($bracketsAwareUnionTypeNode);
     }
 }

--- a/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
@@ -8,7 +8,6 @@ use PhpParser\Node\FunctionLike;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\DeadCode\PhpDoc\DeadParamTagValueNodeAnalyzer;

--- a/src/NodeTypeResolver/PHPStan/TypeHasher.php
+++ b/src/NodeTypeResolver/PHPStan/TypeHasher.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\PHPStan;
 
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\BooleanType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IterableType;
@@ -14,7 +13,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeWithClassName;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -49,10 +47,6 @@ final class TypeHasher
             return $type::class;
         }
 
-        if ($type instanceof UnionType) {
-            return $this->createUnionTypeHash($type);
-        }
-
         $type = $this->normalizeObjectType($type);
 
         // normalize iterable
@@ -82,30 +76,6 @@ final class TypeHasher
         }
 
         return $typeWithClassName->getClassName();
-    }
-
-    private function createUnionTypeHash(UnionType $unionType): string
-    {
-        $booleanType = new BooleanType();
-        if ($booleanType->isSuperTypeOf($unionType)->yes()) {
-            return $booleanType->describe(VerbosityLevel::precise());
-        }
-
-        $normalizedUnionType = clone $unionType;
-
-        // change alias to non-alias
-        TypeTraverser::map(
-            $normalizedUnionType,
-            static function (Type $type, callable $callable): Type {
-                if (! $type instanceof AliasedObjectType && ! $type instanceof ShortenedObjectType) {
-                    return $callable($type);
-                }
-
-                return new FullyQualifiedObjectType($type->getFullyQualifiedName());
-            }
-        );
-
-        return $normalizedUnionType->describe(VerbosityLevel::precise());
     }
 
     private function normalizeObjectType(Type $type): Type


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/5684

For clean up `TypeHasher` on Union type, and specific on dead param, keep mark `SomeClass|SomeInterface` as not dead param as before with Union vs FullyQualified check.