### PR TITLE
[NodeTypeResolver] Move UnionType doc vs FullyQualified native type as not equal to TypeComparator

### DIFF
--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc;
 
-use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -43,10 +41,6 @@ final readonly class DeadParamTagValueNodeAnalyzer
         }
 
         if ($paramTagValueNode->description !== '') {
-            return false;
-        }
-
-        if ($paramTagValueNode->type instanceof UnionTypeNode && $param->type instanceof FullyQualified) {
             return false;
         }
 

--- a/src/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/src/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\TypeComparator;
 
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassReflection;
@@ -81,6 +83,10 @@ final readonly class TypeComparator
         TypeNode $phpStanDocTypeNode,
         Node $node
     ): bool {
+        if ($phpStanDocTypeNode instanceof UnionTypeNode && $phpParserNode instanceof FullyQualified) {
+            return false;
+        }
+
         $phpParserNodeType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($phpParserNode);
         $phpStanDocType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
             $phpStanDocTypeNode,


### PR DESCRIPTION
continue of https://github.com/rectorphp/rector-src/pull/5792, to have same behaviour on `@return` and `@var` removal usage.