### PR TITLE
ExplicitReturnNullRector should skip never return

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip-never-return.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip-never-return.php.inc
@@ -9,14 +9,11 @@ final class SkipNeverReturn
         if (rand(0,1)) {
             return 5;
         }
-        
+
         $this->neverReturns();
     }
 
-    /**
-      * @return never
-      */
-    private function neverReturns($value)
+    private function neverReturns($value): never
     {
         exit();
     }

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip-never-return.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip-never-return.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector\Fixture;
+
+final class SkipNeverReturn
+{
+    public function run(bool $param)
+    {
+        if (rand(0,1)) {
+            return 5;
+        }
+        
+        $this->neverReturns();
+    }
+
+    /**
+      * @return never
+      */
+    private function neverReturns($value)
+    {
+        exit();
+    }
+}
+?>

--- a/rules/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector.php
@@ -21,6 +21,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\Rector\AbstractRector;
+use Rector\TypeDeclaration\NodeAnalyzer\NeverFuncCallAnalyzer;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use Rector\TypeDeclaration\TypeInferer\SilentVoidResolver;
 use Rector\ValueObject\MethodName;
@@ -37,6 +38,7 @@ final class ExplicitReturnNullRector extends AbstractRector
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly TypeFactory $typeFactory,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private readonly NeverFuncCallAnalyzer $neverFuncCallAnalyzer,
         private readonly ReturnTypeInferer $returnTypeInferer
     ) {
     }
@@ -129,7 +131,9 @@ CODE_SAMPLE
             return null;
         });
 
-        if (! $this->silentVoidResolver->hasSilentVoid($node)) {
+        if (! $this->silentVoidResolver->hasSilentVoid($node)
+            || $this->neverFuncCallAnalyzer->hasNeverFuncCall($node)
+        ) {
             if ($hasChanged) {
                 $this->transformDocUnionVoidToUnionNull($node);
                 return $node;


### PR DESCRIPTION
see 
- ~~https://getrector.com/demo/36a85d33-233d-405e-be31-ca26b5f11d8d (phpdoc never return)~~
- https://getrector.com/demo/426718c5-259f-472e-8f30-a63b1d6d381f (native never return)

atm rector adds a `return null` which - when after a method which never returns - produces [a phpstan error](https://phpstan.org/r/fa5d021f-3909-4377-88cd-8c6102af795f)

> Unreachable statement - code above always terminates.
