### PR TITLE
Add `RemoveUselessTypeInParamTagRector` rule

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 370 Rules Overview
+# 371 Rules Overview
 
 <br>
 
@@ -10,7 +10,7 @@
 
 - [CodingStyle](#codingstyle) (28)
 
-- [DeadCode](#deadcode) (44)
+- [DeadCode](#deadcode) (45)
 
 - [EarlyReturn](#earlyreturn) (9)
 
@@ -2954,6 +2954,29 @@ Remove `@return` docblock with same type as defined in PHP
 -     * @return stdClass
 -     */
      public function foo(): stdClass
+     {
+     }
+ }
+```
+
+<br>
+
+### RemoveUselessTypeInParamTagRector
+
+Remove the type of the `@param` docblock if the parameter type is defined in the function signature
+
+- class: [`Rector\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector`](../rules/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector.php)
+
+```diff
+ class SomeClass
+ {
+     /**
+-     * @param string $a
+-     * @param string $b description
++     * @param $a
++     * @param $b description
+      */
+     public function foo(string $a, string $b)
      {
      }
  }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class Fixture
+{
+    /**
+     * @param string $a
+     * @param string $b
+     * @param string $c description
+     */
+    function foo(string $a, string $b, string $c)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class Fixture
+{
+    /**
+     * @param $a
+     * @param $b
+     * @param $c description
+     */
+    function foo(string $a, string $b, string $c)
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/fixture_fqcn_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/fixture_fqcn_docblock.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use stdClass;
+
+class SomeClassFQCNDocblock
+{
+    /**
+     * @param \stdClass $a
+     */
+    function foo(stdClass $a)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use stdClass;
+
+class SomeClassFQCNDocblock
+{
+    /**
+     * @param $a
+     */
+    function foo(stdClass $a)
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/keep_const_float_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/keep_const_float_type.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeConstantFloatType;
+
+final class KeepConstantFloatType
+{
+    /**
+     * @param SomeConstantFloatType::* $type
+     */
+    public function run(float $type)
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/keep_const_integer_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/keep_const_integer_type.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeConstantIntegerType;
+
+final class KeepConstantIntegerType
+{
+    /**
+     * @param SomeConstantIntegerType::* $type
+     */
+    public function run(int $type)
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/keep_const_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/keep_const_type.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeConstantType;
+
+final class KeepConstantType
+{
+    /**
+     * @param SomeConstantType::* $type
+     */
+    public function run(string $type)
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+final class MultilineCommentForUserlandClassTypeHint
+{
+    /**
+     * @param string $primitiveValue start on first line
+     *   A primitive is fine.
+     * @param callable $callableValue start on first line
+     *   A PHP core class is fine.
+     * @param AnotherUserlandClass $userlandClass start on first line
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, AnotherUserlandClass $userlandClass)
+    {
+    }
+}
+
+class AnotherUserlandClass
+{
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+final class MultilineCommentForUserlandClassTypeHint
+{
+    /**
+     * @param $primitiveValue start on first line
+     *   A primitive is fine.
+     * @param $callableValue start on first line
+     *   A PHP core class is fine.
+     * @param $userlandClass start on first line
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, AnotherUserlandClass $userlandClass)
+    {
+    }
+}
+
+class AnotherUserlandClass
+{
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint_next_line.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/multiline_comment_for_userland_class_type_hint_next_line.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeConstantFloatType;
+
+final class SkipMultilineCommentForUserlandClassTypeHint
+{
+    /**
+     * @param string $primitiveValue
+     *   A primitive is fine.
+     * @param SomeConstantFloatType $userlandClass
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, SomeConstantFloatType $userlandClass)
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeConstantFloatType;
+
+final class SkipMultilineCommentForUserlandClassTypeHint
+{
+    /**
+     * @param $primitiveValue
+     *   A primitive is fine.
+     * @param $userlandClass
+     *   A user land class is not.
+     */
+    public function test(string $primitiveValue, callable $callableValue, SomeConstantFloatType $userlandClass)
+    {
+    }
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/on_function.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/on_function.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+/**
+ * @param string $a
+ */
+function foo(string $a)
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+/**
+ * @param $a
+ */
+function foo(string $a)
+{
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/remove_nullable_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/remove_nullable_type.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class WithNullableType
+{
+    /**
+     * @param string|null $nullable
+     */
+    function foo(?string $nullable)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class WithNullableType
+{
+    /**
+     * @param $nullable
+     */
+    function foo(?string $nullable)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_generic_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_generic_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+final class SkipGenericType
+{
+    /**
+     * @param iterable<stdClass> $foo
+     */
+    public function run(iterable $foo)
+    {
+    }
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_integer_range_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_integer_range_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+final class SkipIntegerRangeType
+{
+    /**
+     * @param positive-int $n
+     */
+    public function run(int $n)
+    {
+    }
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_param_null_with_description.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_param_null_with_description.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class SkipParamNullWithDescription
+{
+    /**
+     * @param null $a this is description
+     */
+    public function foo(int $a = null)
+    {
+
+    }
+}
+

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_param_true_sub_bool.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_param_true_sub_bool.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class SkipParamTrueSubBool
+{
+    /**
+     * @param true $param
+     */
+    public function run(bool $param): void
+    {
+		echo 'test';
+    }
+}
+

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_remove_null.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_remove_null.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class SkipRemoveNull
+{
+    /**
+     * @param null $a
+     */
+    public function foo(int $a = null)
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_remove_param_union.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_remove_param_union.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class SkipRemoveParamUnion
+{
+    /**
+     * @param array|string $a
+     */
+    function foo($a)
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_tag_with_generic_type.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Ds\Vector;
+use IteratorAggregate;
+
+/**
+ * @template TValue
+ *
+ * @implements IteratorAggregate<int, TValue>
+ */
+final class ImmutableVector implements IteratorAggregate
+{
+	/**
+	 * @var Vector<TValue>
+	 */
+	private Vector $vector;
+
+	/**
+	 * @param iterable<TValue>|null $values
+	 */
+	public function __construct(?iterable $values = null)
+	{
+		$this->vector = new Vector($values ?? []);
+	}
+}
+?>
+

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_typed_closure.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_typed_closure.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class SkipTypedClosure {
+	/**
+	 * @param \Closure(int): bool $filter
+	 */
+	static function filter(\Closure $filter): array {
+	}
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_untyped_param.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/skip_untyped_param.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+final class SkipUntypedParam
+{
+    /**
+     * @param $n
+     */
+    public function run(string $n)
+    {
+    }
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_object.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_object.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeClass;
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeConstantFloatType;
+
+class UnionObject
+{
+    /**
+     * @param SomeClass|SomeConstantFloatType $param
+     */
+    function foo(object $param)
+    {
+
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_of_interface.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_of_interface.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeInterface;
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeClass;
+
+class UnionOfInterface {
+    /**
+     * @param $someInterface
+     */
+    public function run(SomeInterface $someInterface)
+    {
+        if (method_exists($someInterface, 'run')) {
+            $someInterface->run();
+        }
+	}
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_of_interface_with_comment.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_of_interface_with_comment.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeInterface;
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source\SomeClass;
+
+class UnionOfInterface {
+    /**
+     * Some comment
+     *
+     * @param $someInterface
+     */
+    public function run(SomeInterface $someInterface)
+    {
+        if (method_exists($someInterface, 'run')) {
+            $someInterface->run();
+        }
+	}
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_unsorted.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Fixture/union_unsorted.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class UnionUnsorted
+{
+    /**
+     * @param bool|int|string $param
+     */
+    function foo(string|int|bool $param)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Fixture;
+
+class UnionUnsorted
+{
+    /**
+     * @param $param
+     */
+    function foo(string|int|bool $param)
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/RemoveUselessTypeInParamTagRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/RemoveUselessTypeInParamTagRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveUselessTypeInParamTagRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeClass.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source;
+
+class SomeClass implements SomeInterface
+{
+    public function run()
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeConstantFloatType.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeConstantFloatType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source;
+
+final class SomeConstantFloatType
+{
+    public const ONE_HALF = 1.5;
+
+    public const TWO_HALF = 2.5;
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeConstantIntegerType.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeConstantIntegerType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source;
+
+final class SomeConstantIntegerType
+{
+    public const ONE = 1;
+
+    public const TWO = 2;
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeConstantType.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeConstantType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source;
+
+final class SomeConstantType
+{
+    public const YES = 'yes';
+
+    public const NO = 'no';
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeInterface.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/Source/SomeInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\Source;
+
+interface SomeInterface
+{
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveUselessTypeInParamTagRector::class]);

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -31,8 +31,11 @@ final readonly class DeadParamTagValueNodeAnalyzer
     ) {
     }
 
-    public function isDead(ParamTagValueNode $paramTagValueNode, FunctionLike $functionLike): bool
-    {
+    public function isDead(
+        ParamTagValueNode $paramTagValueNode,
+        FunctionLike $functionLike,
+        bool $descriptionKeepsAlive = true
+    ): bool {
         $param = $this->paramAnalyzer->getParamByName($paramTagValueNode->parameterName, $functionLike);
         if (! $param instanceof Param) {
             return false;
@@ -42,7 +45,7 @@ final readonly class DeadParamTagValueNodeAnalyzer
             return false;
         }
 
-        if ($paramTagValueNode->description !== '') {
+        if ($paramTagValueNode->description !== '' && $descriptionKeepsAlive) {
             return false;
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessTypeInParamTagRector.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\DeadCode\PhpDoc\DeadParamTagValueNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\ValueObject\Type\NonExistingObjectType;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessTypeInParamTagRector\RemoveUselessTypeInParamTagRectorTest
+ */
+final class RemoveUselessTypeInParamTagRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DeadParamTagValueNodeAnalyzer $deadParamTagValueNodeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove the type of the @param docblock if the parameter type is defined in the function signature',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /**
+     * @param string $a
+     * @param string $b description
+     */
+    public function foo(string $a, string $b)
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /**
+     * @param $a
+     * @param $b description
+     */
+    public function foo(string $a, string $b)
+    {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $params = $node->getParams();
+        $hasChanged = false;
+        foreach ($params as $signatureParam) {
+            if ($signatureParam->type === null) {
+                continue;
+            }
+
+            $paramName = $this->getName($signatureParam->var);
+            if ($paramName === null) {
+                continue;
+            }
+
+            $paramTag = $phpDocInfo->getParamTagValueByName($paramName);
+            if ($paramTag === null) {
+                continue;
+            }
+
+            if (! $this->deadParamTagValueNodeAnalyzer->isDead($paramTag, $node, false)) {
+                continue;
+            }
+
+            $this->phpDocTypeChanger->changeParamType(
+                $node,
+                $phpDocInfo,
+                new NonExistingObjectType(''),
+                $signatureParam,
+                $paramName
+            );
+
+            $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -107,7 +107,7 @@ final readonly class SilentVoidResolver
                 return true;
             }
 
-            if (!$this->isDoOrWhileWithAlwaysReturnOrExit($stmt)) {
+            if (! $this->isDoOrWhileWithAlwaysReturnOrExit($stmt)) {
                 continue;
             }
 
@@ -151,7 +151,7 @@ final readonly class SilentVoidResolver
             return false;
         }
 
-        return ! $this->isFoundLoopControl($stmt);;
+        return ! $this->isFoundLoopControl($stmt);
     }
 
     private function isIfReturn(Stmt|Expr $stmt): bool


### PR DESCRIPTION
As discussed here https://github.com/symfony/symfony/pull/54489#discussion_r1553560582, this rule would help achieve this in the whole codebase. That would be great to see this rule bundled in Rector directly 🙂 