### PR TITLE
[Php81] Skip __invoke() usage from non-class code on FirstClassCallableRector

### DIFF
--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_invoke_from_non_class_code.php.inc
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_invoke_from_non_class_code.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+
+Route::get('verify-email', [SomeExternalObject::class, '__invoke'])
+    ->name('verification.notice');

--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Source/SomeExternalObject.php
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Source/SomeExternalObject.php
@@ -16,4 +16,9 @@ final class SomeExternalObject
     private static function sleepPrivateStatic()
     {
     }
+
+    public function __invoke(bool $param)
+    {
+        return $param === true;
+    }
 }

--- a/rules/Php81/Rector/Array_/FirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/FirstClassCallableRector.php
@@ -131,11 +131,7 @@ CODE_SAMPLE
         Scope $scope
     ): bool {
         $classReflection = $scope->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
-            return false;
-        }
-
-        if ($classReflection->getName() === $fullyQualifiedObjectType->getClassName()) {
+        if ($classReflection instanceof ClassReflection && $classReflection->getName() === $fullyQualifiedObjectType->getClassName()) {
             return false;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8594