### PR TITLE
[Php81] Skip always string if else DomElement on NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_always_string_if_else_dom_element.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_always_string_if_else_dom_element.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipAlwaysStringIfElseDomElement {
+    public function getTitle(string $html): string {
+        $dom = new \DOMDocument();
+        $dom->loadHTML($html);
+        $titleElement = $dom->getElementsByTagName('title')->item(0);
+        if ($titleElement?->nodeValue !== null) {
+            return trim($titleElement->nodeValue);
+        } else {
+            return 'Unnamed document';
+        }
+    }
+}

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -199,7 +199,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isAnErrorTypeFromParentScope($argValue, $scope)) {
+        if ($this->isAnErrorType($argValue, $nativeType, $scope)) {
             return null;
         }
 
@@ -251,10 +251,6 @@ CODE_SAMPLE
             return false;
         }
 
-        if ($type instanceof ErrorType) {
-            return true;
-        }
-
         if ($type->isExplicitMixed()) {
             return false;
         }
@@ -266,8 +262,12 @@ CODE_SAMPLE
         return true;
     }
 
-    private function isAnErrorTypeFromParentScope(Expr $expr, Scope $scope): bool
+    private function isAnErrorType(Expr $expr, Type $type, Scope $scope): bool
     {
+        if ($type instanceof ErrorType) {
+            return true;
+        }
+
         $parentScope = $scope->getParentScope();
         if ($parentScope instanceof Scope) {
             return $parentScope->getType($expr) instanceof ErrorType;


### PR DESCRIPTION
The native type is detected as ErrorType, so skip the ErrorType when detected.

Fixes https://github.com/rectorphp/rector/issues/8597