### PR TITLE
Faster FileInfoMatcher

### DIFF
--- a/src/Skipper/Matcher/FileInfoMatcher.php
+++ b/src/Skipper/Matcher/FileInfoMatcher.php
@@ -61,6 +61,11 @@ final readonly class FileInfoMatcher
             return true;
         }
 
+        // realpathMatcher cannot resolve wildcards -> return early to prevent unnecessary IO
+        if (str_contains($ignoredPath, '*')) {
+            return false;
+        }
+
         return $this->realpathMatcher->match($ignoredPath, $filePath);
     }
 }


### PR DESCRIPTION
RealpathMatcher cannot resolve wildcards -> early return to prevent unnecessary IO

analog https://github.com/easy-coding-standard/easy-coding-standard/pull/196