### PR TITLE
Faster FileInfoMatcher

### DIFF
--- a/src/Skipper/Matcher/FileInfoMatcher.php
+++ b/src/Skipper/Matcher/FileInfoMatcher.php
@@ -61,6 +61,11 @@ final readonly class FileInfoMatcher
             return true;
         }
 
+        // realpathMatcher cannot resolve wildcards -> return early to prevent unnecessary IO
+        if ($ignoredPath[0] === '*' && $ignoredPath[strlen($ignoredPath) - 1] === '*') {
+            return false;
+        }
+
         return $this->realpathMatcher->match($ignoredPath, $filePath);
     }
 }


### PR DESCRIPTION
another try on detecting unsuccessfull fnmatches earlier and prevent realpath matching.

idea is that skip patterns like `'*/Fixture/*'` are [pretty common](https://github.com/rectorphp/rector-src/blob/b81ef2f28aee9da0861eb67d90d134ec1c537786/rector.php#L41-L45) and therefore we can optimize for them.

re-implements https://github.com/rectorphp/rector-src/pull/5830 in a not as-fast way, but more correct form.