### PR TITLE
Early-return NullSafeMethodCall in NodeNameResolver

### DIFF
--- a/src/NodeNameResolver/NodeNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver.php
@@ -73,10 +73,6 @@ final class NodeNameResolver
      */
     public function isName(Node | array $node, string $name): bool
     {
-        if ($node instanceof CallLike) {
-            return false;
-        }
-
         $nodes = is_array($node) ? $node : [$node];
 
         foreach ($nodes as $node) {
@@ -239,7 +235,7 @@ final class NodeNameResolver
 
     private function isSingleName(Node $node, string $desiredName): bool
     {
-        if ($node instanceof CallLike) {
+        if ($node instanceof CallLike && !$node instanceof Expr\FuncCall) {
             // method call cannot have a name, only the variable or method name
             return false;
         }

--- a/src/NodeNameResolver/NodeNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver.php
@@ -7,6 +7,7 @@ namespace Rector\NodeNameResolver;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -94,7 +95,7 @@ final class NodeNameResolver
             return false;
         }
 
-        if ($node instanceof CallLike) {
+        if ($node instanceof CallLike && !$node instanceof FuncCall) {
             return false;
         }
 
@@ -235,7 +236,7 @@ final class NodeNameResolver
 
     private function isSingleName(Node $node, string $desiredName): bool
     {
-        if ($node instanceof CallLike && !$node instanceof Expr\FuncCall) {
+        if ($node instanceof CallLike && !$node instanceof FuncCall) {
             // method call cannot have a name, only the variable or method name
             return false;
         }

--- a/src/NodeNameResolver/NodeNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver.php
@@ -240,6 +240,7 @@ final class NodeNameResolver
     private function isSingleName(Node $node, string $desiredName): bool
     {
         if ($node instanceof CallLike) {
+            // method call cannot have a name, only the variable or method name
             return false;
         }
 

--- a/src/NodeNameResolver/NodeNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver.php
@@ -7,6 +7,7 @@ namespace Rector\NodeNameResolver;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -75,6 +76,10 @@ final class NodeNameResolver
             return false;
         }
 
+        if ($node instanceof NullsafeMethodCall) {
+            return false;
+        }
+
         if ($node instanceof StaticCall) {
             return false;
         }
@@ -101,6 +106,10 @@ final class NodeNameResolver
         }
 
         if ($node instanceof MethodCall) {
+            return false;
+        }
+
+        if ($node instanceof NullsafeMethodCall) {
             return false;
         }
 
@@ -143,7 +152,7 @@ final class NodeNameResolver
             return $namespacedName;
         }
 
-        if (($node instanceof MethodCall || $node instanceof StaticCall) && $this->isCallOrIdentifier($node->name)) {
+        if (($node instanceof MethodCall || $node instanceof StaticCall || $node instanceof NullsafeMethodCall) && $this->isCallOrIdentifier($node->name)) {
             return null;
         }
 

--- a/src/NodeNameResolver/NodeNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver.php
@@ -6,6 +6,7 @@ namespace Rector\NodeNameResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -72,15 +73,7 @@ final class NodeNameResolver
      */
     public function isName(Node | array $node, string $name): bool
     {
-        if ($node instanceof MethodCall) {
-            return false;
-        }
-
-        if ($node instanceof NullsafeMethodCall) {
-            return false;
-        }
-
-        if ($node instanceof StaticCall) {
+        if ($node instanceof CallLike) {
             return false;
         }
 
@@ -105,15 +98,7 @@ final class NodeNameResolver
             return false;
         }
 
-        if ($node instanceof MethodCall) {
-            return false;
-        }
-
-        if ($node instanceof NullsafeMethodCall) {
-            return false;
-        }
-
-        if ($node instanceof StaticCall) {
+        if ($node instanceof CallLike) {
             return false;
         }
 
@@ -152,7 +137,7 @@ final class NodeNameResolver
             return $namespacedName;
         }
 
-        if (($node instanceof MethodCall || $node instanceof StaticCall || $node instanceof NullsafeMethodCall) && $this->isCallOrIdentifier($node->name)) {
+        if (($node instanceof CallLike) && $this->isCallOrIdentifier($node->name)) {
             return null;
         }
 
@@ -251,8 +236,7 @@ final class NodeNameResolver
 
     private function isSingleName(Node $node, string $desiredName): bool
     {
-        if ($node instanceof MethodCall) {
-            // method call cannot have a name, only the variable or method name
+        if ($node instanceof CallLike) {
             return false;
         }
 

--- a/src/NodeNameResolver/NodeNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver.php
@@ -137,7 +137,10 @@ final class NodeNameResolver
             return $namespacedName;
         }
 
-        if (($node instanceof CallLike) && $this->isCallOrIdentifier($node->name)) {
+        if (
+            ($node instanceof MethodCall || $node instanceof StaticCall || $node instanceof NullsafeMethodCall)
+            && $this->isCallOrIdentifier($node->name)
+        ) {
             return null;
         }
 


### PR DESCRIPTION
Prevent unnecessary work for `NullSafeMethodCall`. Instead handle it like other MethodCall's and early return.