### PR TITLE
[Naming] Skip DateTime as individual in name resolver

### DIFF
--- a/rules-tests/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector/Fixture/allow_date_suffix.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameVariableToMatchNewTypeRector/Fixture/allow_date_suffix.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector\Fixture;
+
+final class AlloweDateSuffix
+{
+    public function run()
+    {
+        $someDate = new \DateTime('...');
+    }
+}

--- a/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/IsClassMethodUsedAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\NodeAnalyzer;
 
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
@@ -95,7 +96,7 @@ final readonly class IsClassMethodUsedAnalyzer
         $className = (string) $this->nodeNameResolver->getName($class);
 
         /** @var Node\Expr\NullsafeMethodCall[] $methodCalls */
-        $methodCalls = $this->betterNodeFinder->findInstanceOf($class, Node\Expr\NullsafeMethodCall::class);
+        $methodCalls = $this->betterNodeFinder->findInstanceOf($class, NullsafeMethodCall::class);
         return $this->callCollectionAnalyzer->isExists($methodCalls, $classMethodName, $className);
     }
 

--- a/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
@@ -23,7 +23,7 @@ final readonly class PropertyWriteonlyAnalyzer
     public function hasClassDynamicPropertyNames(Class_ $class): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($class, static function (Node $node): bool {
-            if (! $node instanceof PropertyFetch && !$node instanceof NullsafePropertyFetch) {
+            if (! $node instanceof PropertyFetch && ! $node instanceof NullsafePropertyFetch) {
                 return false;
             }
 

--- a/rules/Naming/Naming/ExpectedNameResolver.php
+++ b/rules/Naming/Naming/ExpectedNameResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Naming\Naming;
 
+use DateTimeInterface;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -89,7 +90,7 @@ final readonly class ExpectedNameResolver
         $className = $this->nodeNameResolver->getName($new->class);
         $fullyQualifiedObjectType = new FullyQualifiedObjectType($className);
 
-        if ($fullyQualifiedObjectType->isInstanceOf(\DateTimeInterface::class)->yes()) {
+        if ($fullyQualifiedObjectType->isInstanceOf(DateTimeInterface::class)->yes()) {
             return null;
         }
 

--- a/rules/Naming/Naming/ExpectedNameResolver.php
+++ b/rules/Naming/Naming/ExpectedNameResolver.php
@@ -89,6 +89,10 @@ final readonly class ExpectedNameResolver
         $className = $this->nodeNameResolver->getName($new->class);
         $fullyQualifiedObjectType = new FullyQualifiedObjectType($className);
 
+        if ($fullyQualifiedObjectType->isInstanceOf(\DateTimeInterface::class)->yes()) {
+            return null;
+        }
+
         $expectedName = $this->propertyNaming->getExpectedNameFromType($fullyQualifiedObjectType);
         if (! $expectedName instanceof ExpectedName) {
             return null;


### PR DESCRIPTION
The variable naming for DateTime is very individuali. Some projects prefer createdAt, some createdDate, some dateCreated etc. That's why those types should be skipped completelly, to avoid manual fixing of these variables :+1: 