### PR TITLE
[Performance] Cache classname collection on DynamicSourceLocatorProvider

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, macos-13, windows-latest]
+                os: [ubuntu-latest, macos-latest, windows-latest]
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, macos-latest, windows-latest]
+                os: [ubuntu-latest, macos-latest-large, windows-latest]
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, macos-12, windows-latest]
+                os: [ubuntu-latest, macos-13, windows-latest]
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, macos-latest-large, windows-latest]
+                os: [ubuntu-latest, macos-12, windows-latest]
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 3

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "symplify/phpstan-rules": "^12.4.5",
         "symplify/rule-doc-generator": "^12.1.10",
         "symplify/vendor-patches": "^11.2",
-        "tomasvotruba/class-leak": "^0.2",
+        "tomasvotruba/class-leak": "0.2.11",
         "tomasvotruba/cognitive-complexity": "^0.2",
         "tomasvotruba/unused-public": "^0.3",
         "tracy/tracy": "^2.9"

--- a/src/Caching/Enum/CacheKey.php
+++ b/src/Caching/Enum/CacheKey.php
@@ -22,5 +22,5 @@ final class CacheKey
     /**
      * @var string
      */
-    public const PATHS_HASH_KEY = 'paths_hash';
+    public const CLASSNAMES_HASH_KEY = 'classnames_hash';
 }

--- a/src/Caching/Enum/CacheKey.php
+++ b/src/Caching/Enum/CacheKey.php
@@ -18,4 +18,9 @@ final class CacheKey
      * @var string
      */
     public const FILE_HASH_KEY = 'file_hash';
+
+    /**
+     * @var string
+     */
+    public const PATHS_HASH_KEY = 'paths_hash';
 }

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -180,6 +180,7 @@ use Rector\StaticTypeMapper\PhpParser\NullableTypeNodeMapper;
 use Rector\StaticTypeMapper\PhpParser\StringNodeMapper;
 use Rector\StaticTypeMapper\PhpParser\UnionTypeNodeMapper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\Util\FileHasher;
 use Rector\Utils\Command\MissingInSetCommand;
 use Rector\Utils\Command\OutsideAnySetCommand;
 use Symfony\Component\Console\Application;
@@ -471,7 +472,8 @@ final class LazyContainerFactory
             static function (DynamicSourceLocatorProvider $dynamicSourceLocatorProvider, Container $container): void {
                 $dynamicSourceLocatorProvider->autowire(
                     $container->make(ReflectionProvider::class),
-                    $container->make(Cache::class)
+                    $container->make(Cache::class),
+                    $container->make(FileHasher::class)
                 );
             }
         );

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -469,7 +469,10 @@ final class LazyContainerFactory
         $rectorConfig->afterResolving(
             DynamicSourceLocatorProvider::class,
             static function (DynamicSourceLocatorProvider $dynamicSourceLocatorProvider, Container $container): void {
-                $dynamicSourceLocatorProvider->autowire($container->make(ReflectionProvider::class));
+                $dynamicSourceLocatorProvider->autowire(
+                    $container->make(ReflectionProvider::class),
+                    $container->make(Cache::class)
+                );
             }
         );
 

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -27,11 +27,6 @@ use Rector\Util\FileHasher;
 final class DynamicSourceLocatorProvider implements ResetableInterface
 {
     /**
-     * @var string
-     */
-    private const CLASSNAMES_CACHE = 'classname_cache';
-
-    /**
      * @var string[]
      */
     private array $filePaths = [];

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -179,7 +179,10 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
     private function locateCachedClassNames(array $classNamesCache): void
     {
         foreach ($classNamesCache as $classNameCache) {
-            $this->reflectionProvider->getClass($classNameCache);
+            try {
+                $this->reflectionProvider->getClass($classNameCache);
+            } catch (ClassNotFoundException) {
+            }
         }
     }
 }

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -124,6 +124,19 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
 
     /**
      * @param OptimizedSingleFileSourceLocator[]|NewOptimizedDirectorySourceLocator[] $sourceLocators
+     */
+    private function shouldSkipCollectClasses(array $sourceLocators): bool
+    {
+        if ($sourceLocators === []) {
+            return true;
+        }
+
+        // no need to collect classes on single file, will auto collected
+        return count($sourceLocators) === 1 && $sourceLocators[0] instanceof OptimizedSingleFileSourceLocator;
+    }
+
+    /**
+     * @param OptimizedSingleFileSourceLocator[]|NewOptimizedDirectorySourceLocator[] $sourceLocators
      * @param string[] $paths
      */
     private function collectClasses(
@@ -131,12 +144,7 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
         array $sourceLocators,
         array $paths
     ): void {
-        if ($sourceLocators === []) {
-            return;
-        }
-
-        // no need to collect classes on single file, will auto collected
-        if (count($sourceLocators) === 1 && $sourceLocators[0] instanceof OptimizedSingleFileSourceLocator) {
+        if ($this->shouldSkipCollectClasses($sourceLocators)) {
             return;
         }
 
@@ -145,8 +153,10 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
 
         if (is_string($classNamesCache)) {
             $classNamesCache = unserialize($classNamesCache);
-            $this->locateCachedClassNames($classNamesCache);
-            return;
+            if (is_array($classNamesCache)) {
+                $this->locateCachedClassNames($classNamesCache);
+                return;
+            }
         }
 
         $reflector = new DefaultReflector($aggregateSourceLocator);

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -148,11 +148,11 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
             return;
         }
 
-        $key = CacheKey::CLASSNAMES_HASH_KEY . '_' . $this->fileHasher->hash(serialize($paths));
+        $key = CacheKey::CLASSNAMES_HASH_KEY . '_' . $this->fileHasher->hash(json_encode($paths));
         $classNamesCache = $this->cache->load($key, CacheKey::CLASSNAMES_HASH_KEY);
 
         if (is_string($classNamesCache)) {
-            $classNamesCache = unserialize($classNamesCache);
+            $classNamesCache = json_decode($classNamesCache);
             if (is_array($classNamesCache)) {
                 $this->locateCachedClassNames($classNamesCache);
                 return;
@@ -184,7 +184,7 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
             }
         }
 
-        $this->cache->save($key, CacheKey::CLASSNAMES_HASH_KEY, serialize($classNames));
+        $this->cache->save($key, CacheKey::CLASSNAMES_HASH_KEY, json_encode($classNames));
     }
 
     /**


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/5735

this ensure classname collection on `DynamicSourceLocatorProvider` to be cached, ensure no more `$sourceLocator->locateIdentifiersByType()` if already cached, just call the `$this->reflectionProvider->getClass($classNameCache)`

On parallel process, the `DynamicSourceLocatorDecorator` always new instance due to Worker usage.

**Before** => 56 seconds

```
➜  rector-src git:(main) time bin/rector process --clear-cache 
 2176/2176 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

bin/rector process --clear-cache  381.72s user 15.69s system 703% cpu 56.459 total
```

**After**  => 32 seconds.

```
➜  rector-src git:(cache-classname) time bin/rector process --clear-cache
 2176/2176 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

bin/rector process --clear-cache  221.64s user 9.05s system 716% cpu 32.190 total
```