### PR TITLE
CI: take utils/ into account in class-leak

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -40,7 +40,7 @@ jobs:
                     -
                         name: 'Active Classes'
                         run: |
-                            vendor/bin/class-leak check bin config src rules \
+                            vendor/bin/class-leak check bin config src rules utils \
                                 --skip-type="Rector\\NodeTypeResolver\\PHPStan\\Scope\\Contract\\NodeVisitor\\ScopeResolverNodeVisitorInterface" \
                                 --skip-type="Rector\\BetterPhpDocParser\\Contract\\BasePhpDocNodeVisitorInterface" \
                                 --skip-type="Rector\\BetterPhpDocParser\\Contract\\PhpDocParser\\PhpDocNodeDecoratorInterface" \

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -41,7 +41,10 @@ jobs:
                         name: 'Active Classes'
                         run: |
                             vendor/bin/class-leak check bin config src rules utils \
+                                --skip-suffix "Rector" \
+                                --skip-type="Rector\\Utils\\Compiler\\Unprefixer" \
                                 --skip-type="Rector\\NodeTypeResolver\\PHPStan\\Scope\\Contract\\NodeVisitor\\ScopeResolverNodeVisitorInterface" \
+                                --skip-type="Rector\\PhpDocParser\\PhpParser\\SmartPhpParserFactory" \
                                 --skip-type="Rector\\BetterPhpDocParser\\Contract\\BasePhpDocNodeVisitorInterface" \
                                 --skip-type="Rector\\BetterPhpDocParser\\Contract\\PhpDocParser\\PhpDocNodeDecoratorInterface" \
                                 --skip-type="Rector\\BetterPhpDocParser\\ValueObject\\Type\\FullyQualifiedIdentifierTypeNode"

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "symplify/phpstan-rules": "^12.4.5",
         "symplify/rule-doc-generator": "^12.1.10",
         "symplify/vendor-patches": "^11.2",
-        "tomasvotruba/class-leak": "^0.2.11",
+        "tomasvotruba/class-leak": "^0.2.13",
         "tomasvotruba/cognitive-complexity": "^0.2",
         "tomasvotruba/unused-public": "^0.3",
         "tracy/tracy": "^2.9"

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "symplify/phpstan-rules": "^12.4.5",
         "symplify/rule-doc-generator": "^12.1.10",
         "symplify/vendor-patches": "^11.2",
-        "tomasvotruba/class-leak": "0.2.11",
+        "tomasvotruba/class-leak": "^0.2.11",
         "tomasvotruba/cognitive-complexity": "^0.2",
         "tomasvotruba/unused-public": "^0.3",
         "tracy/tracy": "^2.9"


### PR DESCRIPTION
a few rector classes are not referenced anywhere in the codebase, except in `utils/Command/MissingInSetCommand.php`.

lets make class-leak aware these are used when referenced from `utils/Command/MissingInSetCommand.php`

refs https://github.com/TomasVotruba/class-leak/issues/43