### PR TITLE
`ExplicitNullableParamTypeRector` can be applied from PHP 7.1

### DIFF
--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -75,6 +75,6 @@ CODE_SAMPLE
 
     public function provideMinPhpVersion(): int
     {
-        return PhpVersionFeature::DEPRECATE_IMPLICIT_NULLABLE_PARAM_TYPE;
+        return PhpVersionFeature::NULLABLE_TYPE;
     }
 }


### PR DESCRIPTION
PHP 8.4 deprecates implicit nullable parameters, but the transformation can be applied with PHP 7.1+ compatibility.

This change is necessary in order to use the `ExplicitNullableParamTypeRector` with projects that allows PHP < 8.3 (i.e. all projects that currently exist), to make them compatible with PHP 8.4.