### PR TITLE
[TypeDeclarations] Add IncreaseDeclareStrictTypesRector to raise level of declare() coverage

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/Fixture/skip_already_with_strict_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/Fixture/skip_already_with_strict_types.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector\Fixture;
+
+function anotherFunction()
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/Fixture/some_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/Fixture/some_class.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector\Fixture;
+
+function someFunction()
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector\Fixture;
+
+function someFunction()
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/IncreaseDeclareStrictTypesRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/IncreaseDeclareStrictTypesRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class IncreaseDeclareStrictTypesRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
+
+return RectorConfig::configure()
+    ->withRules([IncreaseDeclareStrictTypesRector::class]);

--- a/rules/TypeDeclaration/NodeAnalyzer/DeclareStrictTypeFinder.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/DeclareStrictTypeFinder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeAnalyzer;
+
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Declare_;
+
+final readonly class DeclareStrictTypeFinder
+{
+    public function hasDeclareStrictTypes(Stmt $stmt): bool
+    {
+        // when first stmt is Declare_, verify if there is strict_types definition already,
+        // as multiple declare is allowed, with declare(strict_types=1) only allowed on very first stmt
+        if (! $stmt instanceof Declare_) {
+            return false;
+        }
+
+        foreach ($stmt->declares as $declare) {
+            if ($declare->key->toString() === 'strict_types') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -32,7 +32,7 @@ final class IncreaseDeclareStrictTypesRector extends AbstractRector implements C
     private int $changedItemCount = 0;
 
     public function __construct(
-        private DeclareStrictTypeFinder $declareStrictTypeFinder
+        private readonly DeclareStrictTypeFinder $declareStrictTypeFinder
     ) {
     }
 

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\StmtsAwareInterface;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\DeclareDeclare;
+use PhpParser\Node\Stmt\Nop;
+use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
+use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\Rector\AbstractRector;
+use Rector\TypeDeclaration\NodeAnalyzer\DeclareStrictTypeFinder;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector\IncreaseDeclareStrictTypesRectorTest
+ */
+final class IncreaseDeclareStrictTypesRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    private const LIMIT = 'limit';
+
+    private int $limit = 10;
+
+    private int $changedItemCount = 0;
+
+    public function __construct(
+        private DeclareStrictTypeFinder $declareStrictTypeFinder
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add declare strict types to a limited amount of classes at a time, to try out in the wild and increase level gradually',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+function someFunction()
+{
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+declare(strict_types=1);
+
+function someFunction()
+{
+}
+CODE_SAMPLE
+                    ,
+                    [
+                        self::LIMIT => 10,
+                    ],
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param Node[] $nodes
+     * @return Node[]|null
+     */
+    public function beforeTraverse(array $nodes): ?array
+    {
+        parent::beforeTraverse($nodes);
+
+        $newStmts = $this->file->getNewStmts();
+        if ($newStmts === []) {
+            return null;
+        }
+
+        $rootStmt = \current($newStmts);
+        $stmt = $rootStmt;
+
+        // skip classes without namespace for safety reasons
+        if ($rootStmt instanceof FileWithoutNamespace) {
+            return null;
+        }
+
+        if ($this->declareStrictTypeFinder->hasDeclareStrictTypes($stmt)) {
+            return null;
+        }
+
+        // keep change withing a limit
+        if ($this->changedItemCount >= $this->limit) {
+            return null;
+        }
+
+        ++$this->changedItemCount;
+
+        $strictTypesDeclare = $this->creteStrictTypesDeclare();
+
+        $rectorWithLineChange = new RectorWithLineChange(self::class, $stmt->getLine());
+        $this->file->addRectorClassWithLine($rectorWithLineChange);
+
+        return \array_merge([$strictTypesDeclare, new Nop()], $nodes);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [StmtsAwareInterface::class];
+    }
+
+    /**
+     * @param StmtsAwareInterface $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // workaround, as Rector now only hooks to specific nodes, not arrays
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::keyExists($configuration, self::LIMIT);
+        $this->limit = (int) $configuration[self::LIMIT];
+    }
+
+    private function creteStrictTypesDeclare(): Declare_
+    {
+        $declareDeclare = new DeclareDeclare(new Identifier('strict_types'), new LNumber(1));
+        return new Declare_([$declareDeclare]);
+    }
+}

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -21,6 +21,7 @@ use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
 use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
 use Rector\Utils\Enum\RectorDirectoryToSetFileMap;
 use Rector\Utils\Finder\RectorClassFinder;
@@ -45,6 +46,7 @@ final class MissingInSetCommand extends Command
         StrvalToTypeCastRector::class,
         BoolvalToTypeCastRector::class,
         FloatvalToTypeCastRector::class,
+        IncreaseDeclareStrictTypesRector::class,
         // changes behavior, should be applied on purpose regardless PHP 7.3 level
         JsonThrowOnErrorRector::class,
         // in confront with sub type safe belt detection on RemoveUseless*TagRector


### PR DESCRIPTION
This rule helps with increasing strict declares in your code, in the amount you define per run.

```php
use Rector\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;

return RectorConfig::configure()
    ->withConfiguredRule(IncreaseDeclareStrictTypesRector::class, [
        'limit' => 10,
    ]);
```

This configuration will add `declare(strict_types=1)` to 10 new files per Rector run. Then CI will report feedback and show, if files need type fixes. 

The idea is to improve code coverage in gradual, safe and steady way, as any type change could be very sensistive. 
See https://tomasvotruba.com/blog/master-the-change for more


---

Use only manually with combination of cusotm PHPStan rule :slightly_smiling_face: 
https://github.com/TomasVotruba/type-coverage/pull/35