### PR TITLE
Fixes typo in FinalizeTestCaseClassRector.php

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -5459,10 +5459,10 @@ PHPUnit test case will be finalized
 - class: [`Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector`](../rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php)
 
 ```diff
--use PHPUnit\Framework\TestCase;
-+final use PHPUnit\Framework\TestCase;
+ use PHPUnit\Framework\TestCase;
 
- class SomeClass extends TestCase
+-class SomeClass extends TestCase
++final class SomeClass extends TestCase
  {
  }
 ```

--- a/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
@@ -38,9 +38,9 @@ CODE_SAMPLE
 
                 ,
                 <<<'CODE_SAMPLE'
-final use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SomeClass extends TestCase
+final class SomeClass extends TestCase
 {
 }
 CODE_SAMPLE


### PR DESCRIPTION
Fixes a typo that suggests the Rector rule puts a `final` keyword before `use` keyword (which is an invalid syntax) rather than before `class` keyword.

Closes https://github.com/rectorphp/rector/issues/8616