### PR TITLE
SimplifyTautologyTernaryRector breaks logic

### DIFF
--- a/rules-tests/CodeQuality/Rector/Ternary/SimplifyTautologyTernaryRector/Fixture/demo_file.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/SimplifyTautologyTernaryRector/Fixture/demo_file.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\SimplifyTautologyTernaryRector\Fixture;
+
+final class DemoFile
+{
+    public function run(string $param)
+    {
+        $foo = $this->bar($param) === '' ? '' : $this->bar($param);
+		    echo 'asd' . $foo . 'def';
+    }
+
+    private function bar(string $value)
+    {
+        return trim($value);
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\SimplifyTautologyTernaryRector\Fixture;
+
+final class DemoFile
+{
+    public function run(string $param)
+    {
+        $foo = $this->bar($param);
+		    echo 'asd' . $foo . 'def';
+    }
+
+    private function bar(string $value)
+    {
+        return trim($value);
+    }
+}
+
+?>


### PR DESCRIPTION
It handles the "===" case incorrectly here, as it treats it as if it were "!==" (which leads to the same output, but in that case it's correct)