### PR TITLE
[CodeQuality] Skip dynamic second arg or has uppercase second arg on SimplifyStrposLowerRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector/Fixture/skip_dynamic_second_arg.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector/Fixture/skip_dynamic_second_arg.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector\Fixture;
+
+final class SkipDynamicSecondArg
+{
+    public function run(string $findMe)
+    {
+        $string = 'hey';
+        strpos(strtolower($string), $findMe);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector/Fixture/skip_has_uppercase_second_arg.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector/Fixture/skip_has_uppercase_second_arg.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector\Fixture;
+
+final class SkipHasUppercaseSecondArg
+{
+    public function run()
+    {
+        $string = 'hey';
+        strpos(strtolower($string), 'findME1');
+    }
+}

--- a/rules/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector.php
@@ -74,7 +74,7 @@ final class SimplifyStrposLowerRector extends AbstractRector
             return null;
         }
 
-        if (Strings::match($secondArg->value->value, self::UPPERCASE_REGEX)) {
+        if (Strings::match($secondArg->value->value, self::UPPERCASE_REGEX) !== null && Strings::match($secondArg->value->value, self::UPPERCASE_REGEX) !== []) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector.php
@@ -74,7 +74,7 @@ final class SimplifyStrposLowerRector extends AbstractRector
             return null;
         }
 
-        if (Strings::match($secondArg->value->value, self::UPPERCASE_REGEX) !== null && Strings::match($secondArg->value->value, self::UPPERCASE_REGEX) !== []) {
+        if (Strings::match($secondArg->value->value, self::UPPERCASE_REGEX) !== null) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SimplifyStrposLowerRector.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\Rector\FuncCall;
 
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -16,6 +18,12 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyStrposLowerRector extends AbstractRector
 {
+    /**
+     * @var string
+     * @see https://regex101.com/r/Jokjt8/1
+     */
+    private const UPPERCASE_REGEX = '#[A-Z]#';
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -45,11 +53,12 @@ final class SimplifyStrposLowerRector extends AbstractRector
             return null;
         }
 
-        if (! isset($node->getArgs()[0])) {
+        $args = $node->getArgs();
+        if (! isset($args[0], $args[1])) {
             return null;
         }
 
-        $firstArg = $node->getArgs()[0];
+        $firstArg = $args[0];
         if (! $firstArg->value instanceof FuncCall) {
             return null;
         }
@@ -57,6 +66,15 @@ final class SimplifyStrposLowerRector extends AbstractRector
         /** @var FuncCall $innerFuncCall */
         $innerFuncCall = $firstArg->value;
         if (! $this->isName($innerFuncCall, 'strtolower')) {
+            return null;
+        }
+
+        $secondArg = $args[1];
+        if (! $secondArg->value instanceof String_) {
+            return null;
+        }
+
+        if (Strings::match($secondArg->value->value, self::UPPERCASE_REGEX)) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8618