### PR TITLE
[StaticTypeMapper] Clean up NameNodeMapper check Scalar and class exists

### DIFF
--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -356,7 +356,6 @@ final class LazyContainerFactory
      * @var array<class-string<PhpParserNodeMapperInterface>>
      */
     private const PHP_PARSER_NODE_MAPPER_CLASSES = [
-        ExprNodeMapper::class,
         FullyQualifiedNodeMapper::class,
         IdentifierNodeMapper::class,
         IntersectionTypeNodeMapper::class,
@@ -364,6 +363,7 @@ final class LazyContainerFactory
         NullableTypeNodeMapper::class,
         StringNodeMapper::class,
         UnionTypeNodeMapper::class,
+        ExprNodeMapper::class,
     ];
 
     /**

--- a/src/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
+++ b/src/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Rector\StaticTypeMapper\Mapper;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\Type;
 use Rector\Exception\NotImplementedYetException;
 use Rector\NodeTypeResolver\Node\AttributeKey;

--- a/src/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
+++ b/src/StaticTypeMapper/Mapper/PhpParserNodeMapper.php
@@ -33,15 +33,7 @@ final readonly class PhpParserNodeMapper
                 continue;
             }
 
-            // do not let Expr collect all the types
-            // note: can be solve later with priorities on mapper interface, making this last
-            if ($phpParserNodeMapper->getNodeType() !== Expr::class) {
-                return $phpParserNodeMapper->mapToPHPStan($nameOrExpr);
-            }
-
-            if (! $nameOrExpr instanceof String_) {
-                return $phpParserNodeMapper->mapToPHPStan($nameOrExpr);
-            }
+            return $phpParserNodeMapper->mapToPHPStan($nameOrExpr);
         }
 
         throw new NotImplementedYetException($nameOrExpr::class);

--- a/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
@@ -57,7 +57,7 @@ final readonly class NameNodeMapper implements PhpParserNodeMapperInterface
     }
 
     private function createClassReferenceType(
-        Node $node,
+        Name $node,
         string $reference
     ): MixedType | StaticType | SelfStaticType | ObjectWithoutClassType {
         $classReflection = $this->reflectionResolver->resolveClassReflection($node);

--- a/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
@@ -57,7 +57,7 @@ final readonly class NameNodeMapper implements PhpParserNodeMapperInterface
     }
 
     private function createClassReferenceType(
-        Name $node,
+        Node $node,
         string $reference
     ): MixedType | StaticType | SelfStaticType | ObjectWithoutClassType {
         $classReflection = $this->reflectionResolver->resolveClassReflection($node);

--- a/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
@@ -57,10 +57,10 @@ final readonly class NameNodeMapper implements PhpParserNodeMapperInterface
     }
 
     private function createClassReferenceType(
-        Name $node,
+        Name $name,
         string $reference
     ): MixedType | StaticType | SelfStaticType | ObjectWithoutClassType {
-        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        $classReflection = $this->reflectionResolver->resolveClassReflection($name);
         if (! $classReflection instanceof ClassReflection) {
             return new MixedType();
         }

--- a/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
@@ -6,7 +6,6 @@ namespace Rector\StaticTypeMapper\PhpParser;
 
 use PhpParser\Node;
 use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -25,8 +24,7 @@ use Rector\StaticTypeMapper\ValueObject\Type\SelfStaticType;
 final readonly class NameNodeMapper implements PhpParserNodeMapperInterface
 {
     public function __construct(
-        private ReflectionResolver $reflectionResolver,
-        private FullyQualifiedNodeMapper $fullyQualifiedNodeMapper,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -40,13 +38,6 @@ final readonly class NameNodeMapper implements PhpParserNodeMapperInterface
      */
     public function mapToPHPStan(Node $node): Type
     {
-        // ensure loop of PhpParserNodeMapperInterface[] based on file system not overlapped
-        // with FullyQualifiedNodeMapper that need cover FullyQualified early
-        // when Name instance of FullyQualified
-        if ($node instanceof FullyQualified) {
-            return $this->fullyQualifiedNodeMapper->mapToPHPStan($node);
-        }
-
         $name = $node->toString();
 
         if ($node->isSpecialClassName()) {

--- a/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
+++ b/src/StaticTypeMapper/PhpParser/NameNodeMapper.php
@@ -57,10 +57,10 @@ final readonly class NameNodeMapper implements PhpParserNodeMapperInterface
     }
 
     private function createClassReferenceType(
-        Name $name,
+        Node $node,
         string $reference
     ): MixedType | StaticType | SelfStaticType | ObjectWithoutClassType {
-        $classReflection = $this->reflectionResolver->resolveClassReflection($name);
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
         if (! $classReflection instanceof ClassReflection) {
             return new MixedType();
         }


### PR DESCRIPTION
- scalar check should check on `Identifier`, which handled on `IdentifierNodeMapper`
- class exists seems not needed, test run test and seems still working ok