### PR TITLE
[TypeDeclaration] Skip more detailed type on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_more_detail_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_more_detail_type.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+
+final class SkipMoreDetailType
+{
+    /**
+     * @param Name $node
+     */
+    public function run(Node $node)
+    {
+        if ($node instanceof FullyQualified) {
+            return;
+        }
+
+        $this->execute($node);
+    }
+
+    private function execute(Name $node)
+    {
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -18,13 +18,15 @@ use PHPStan\Type\UnionType;
 use Rector\NodeCollector\ValueObject\ArrayCallable;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 
 final readonly class CallTypesResolver
 {
     public function __construct(
         private NodeTypeResolver $nodeTypeResolver,
         private TypeFactory $typeFactory,
-        private ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider,
+        private TypeComparator $typeComparator
     ) {
     }
 
@@ -72,6 +74,11 @@ final readonly class CallTypesResolver
         // fix false positive generic type on string
         if (! $this->reflectionProvider->hasClass($argValueType->getClassName())) {
             return new MixedType();
+        }
+
+        $type = $this->nodeTypeResolver->getType($arg->value);
+        if (! $type->equals($argValueType) && $this->typeComparator->isSubtype($type, $argValueType)) {
+            return $type;
         }
 
         return $argValueType;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8629