### PR TITLE
Fix "method x was not found in reflection of class"

### DIFF
--- a/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -89,11 +89,11 @@ final readonly class ClassMethodReturnTypeOverrideGuard
     ): bool {
         $methodName = $classMethod->name->toString();
         foreach ($childrenClassReflections as $childClassReflection) {
-            $methodReflection = $childClassReflection->getNativeMethod($methodName);
-            if (! $methodReflection instanceof PhpMethodReflection) {
+            if (!$childClassReflection->hasNativeMethod($methodName)) {
                 continue;
             }
 
+            $methodReflection = $childClassReflection->getNativeMethod($methodName);
             $parametersAcceptor = ParametersAcceptorSelector::combineAcceptors($methodReflection->getVariants());
             $childReturnType = $parametersAcceptor->getNativeReturnType();
             if (! $returnType->isSuperTypeOf($childReturnType)->yes()) {

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -47,6 +47,9 @@ final readonly class ClassMethodReturnVendorLockResolver
             if (! $nativeClassReflection->hasMethod($methodName)) {
                 continue;
             }
+            if (! $ancestorClassReflections->hasNativeMethod($methodName)) {
+                continue;
+            }
 
             $parentClassMethodReflection = $ancestorClassReflections->getNativeMethod($methodName);
             $parametersAcceptor = $parentClassMethodReflection->getVariants()[0];


### PR DESCRIPTION
before calling `$classReflection->getNativeMethod()` we need to check `$classReflection->hasNativeMethod()`, because otherwise a exception might be thrown, depending on autoloading state.

fixes exceptions like

```
  ERROR] Could not process "C:\dvl\Workspace\logitel\app\import\controllers\ApplicationController.php" file, due to:
              em error: "Method is_allowed() was not found in reflection of class CmsfrontendController."


         #0
         C:\dvl\Workspace\logitel\vendor\rector\rector\src\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGu
         ard.php(106): PHPStan\Reflection\ClassReflection->getNativeMethod()
         #1
         C:\dvl\Workspace\logitel\vendor\rector\rector\src\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGu
         ard.php(97):
         Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard->hasChildrenDifferentTypeClassMethod()
         #2
         C:\dvl\Workspace\logitel\vendor\rector\rector\rules\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictCons
         tantReturnRector.php(86):
         Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard->shouldSkipClassMethod()
         #3 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Rector\AbstractScopeAwareRector.php(27):
         Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictConstantReturnRector->refactorWithScope()
         #4 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Rector\AbstractRector.php(136):
         Rector\Rector\AbstractScopeAwareRector->refactor()
         #5 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(176):
         Rector\Rector\AbstractRector->enterNode()
         #6 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(105):
         PhpParser\NodeTraverser->traverseArray()
         #7 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(196):
         PhpParser\NodeTraverser->traverseNode()
         #8 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(105):
         PhpParser\NodeTraverser->traverseArray()
         #9 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(196):
         PhpParser\NodeTraverser->traverseNode()
         #10 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(85):
         PhpParser\NodeTraverser->traverseArray()
         #11 C:\dvl\Workspace\logitel\vendor\rector\rector\src\PhpParser\NodeTraverser\RectorNodeTraverser.php(41):
         PhpParser\NodeTraverser->traverse()
         #12 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Application\FileProcessor.php(110):
         Rector\PhpParser\NodeTraverser\RectorNodeTraverser->traverse()
         #13 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Application\ApplicationFileProcessor.php(184):
         Rector\Application\FileProcessor->processFile()
         #14 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Application\ApplicationFileProcessor.php(161):
         Rector\Application\ApplicationFileProcessor->processFile()
         #15 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Console\Command\WorkerCommand.php(118):
         Rector\Application\ApplicationFileProcessor->processFiles()
         #16 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\evenement\evenement\src\EventEmitterTrait.php(111):
         Rector\Console\Command\WorkerCommand->Rector\Console\Command\{closure}()
         #17 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\clue\ndjson-react\src\Decoder.php(117):
         RectorPrefix202405\Evenement\EventEmitter->emit()
         #18 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\evenement\evenement\src\EventEmitterTrait.php(111):
         RectorPrefix202405\Clue\React\NDJson\Decoder->handleData()
         #19 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\react\stream\src\Util.php(62):
         RectorPrefix202405\Evenement\EventEmitter->emit()
         #20 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\evenement\evenement\src\EventEmitterTrait.php(111):
         RectorPrefix202405\React\Stream\Util::RectorPrefix202405\React\Stream\{closure}()
         #21 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\react\stream\src\DuplexResourceStream.php(154):
         RectorPrefix202405\Evenement\EventEmitter->emit()
         #22 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\react\event-loop\src\StreamSelectLoop.php(201):
         RectorPrefix202405\React\Stream\DuplexResourceStream->handleData()
         #23 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\react\event-loop\src\StreamSelectLoop.php(173):
         RectorPrefix202405\React\EventLoop\StreamSelectLoop->waitForStreamActivity()
         #24 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Console\Command\WorkerCommand.php(89):
         RectorPrefix202405\React\EventLoop\StreamSelectLoop->run()
         #25 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\symfony\console\Command\Command.php(327):
         Rector\Console\Command\WorkerCommand->execute()
         #26 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\symfony\console\Application.php(960):
         RectorPrefix202405\Symfony\Component\Console\Command\Command->run()
         #27 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\symfony\console\Application.php(333):
         RectorPrefix202405\Symfony\Component\Console\Application->doRunCommand()
         #28 C:\dvl\Workspace\logitel\vendor\rector\rector\src\Console\ConsoleApplication.php(53):
         RectorPrefix202405\Symfony\Component\Console\Application->doRun()
         #29 C:\dvl\Workspace\logitel\vendor\rector\rector\vendor\symfony\console\Application.php(216):
         Rector\Console\ConsoleApplication->doRun()
         #30 C:\dvl\Workspace\logitel\vendor\rector\rector\bin\rector.php(130):
         RectorPrefix202405\Symfony\Component\Console\Application->run()
         #31 C:\dvl\Workspace\logitel\vendor\rector\rector\bin\rector(5): require_once('...')
         #32 C:\dvl\Workspace\logitel\vendor\bin\rector(119): include('...')
         #33 {main}". On line: 558
```