### PR TITLE
[Performance] Avoid $reflector->reflectAllClasses() in every worker on DynamicSourceLocatorProvider

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -432,3 +432,7 @@ parameters:
             message: '#Parameters should use "array" types as the only types passed to this method#'
             path: src/Util/NodePrinter.php
         - '#Cognitive complexity for "Rector\\TypeDeclaration\\NodeAnalyzer\\CallerParamMatcher\:\:matchCallParamType\(\)" is 12, keep it under 11#'
+
+        -
+            message: '#Use required typed property over of nullable array property#'
+            path: src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -79,6 +79,9 @@ final class ProcessCommand extends Command
             return ExitCode::FAILURE;
         }
 
+        $classNames = $this->dynamicSourceLocatorDecorator->getClassNames();
+        $configuration->setClassNames($classNames);
+
         // MAIN PHASE
         // 2. run Rector
         $processResult = $this->applicationFileProcessor->run($configuration, $input);

--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -98,6 +98,7 @@ final class WorkerCommand extends Command
         OutputInterface $output
     ): void {
         $this->dynamicSourceLocatorDecorator->addPaths($configuration->getPaths());
+        $this->dynamicSourceLocatorDecorator->setClassNames($configuration->getClassNames());
 
         if ($configuration->isDebug()) {
             $preFileCallback = static function (string $filePath) use ($output): void {

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -162,6 +162,11 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
             return;
         }
 
+        $this->reflectAndGetAllClasses($aggregateSourceLocator);
+    }
+
+    private function reflectAndGetAllClasses(AggregateSourceLocator $aggregateSourceLocator): void
+    {
         $reflector = new DefaultReflector($aggregateSourceLocator);
         $this->classNames = [];
 

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -87,7 +87,10 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
      */
     public function getClassNames(): array
     {
-        Assert::isArray($this->classNames, 'provide() need to be called early');
+        if ($this->classNames === null) {
+            return [];
+        }
+
         return $this->classNames;
     }
 

--- a/src/StaticReflection/DynamicSourceLocatorDecorator.php
+++ b/src/StaticReflection/DynamicSourceLocatorDecorator.php
@@ -39,6 +39,23 @@ final readonly class DynamicSourceLocatorDecorator
         $this->dynamicSourceLocatorProvider->addDirectories($directories);
     }
 
+    /**
+     * @param class-string[]
+     */
+    public function setClassNames(array $classNames): void
+    {
+        $this->dynamicSourceLocatorProvider->setClassNames($classNames);
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getClassNames(): array
+    {
+        $this->dynamicSourceLocatorProvider->provide();
+        return $this->dynamicSourceLocatorProvider->getClassNames();
+    }
+
     public function isPathsEmpty(): bool
     {
         return $this->dynamicSourceLocatorProvider->isPathsEmpty();

--- a/src/StaticReflection/DynamicSourceLocatorDecorator.php
+++ b/src/StaticReflection/DynamicSourceLocatorDecorator.php
@@ -40,7 +40,7 @@ final readonly class DynamicSourceLocatorDecorator
     }
 
     /**
-     * @param class-string[]
+     * @param class-string[] $classNames
      */
     public function setClassNames(array $classNames): void
     {

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -43,7 +43,7 @@ final class Configuration
     }
 
     /**
-     * @param class-string[] $classNames
+     * @return class-string[]
      */
     public function getClassNames(): array
     {

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -7,26 +7,47 @@ namespace Rector\ValueObject;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Webmozart\Assert\Assert;
 
-final readonly class Configuration
+final class Configuration
 {
+    /**
+     * @var class-string[]
+     */
+    private array $classNames = [];
+
     /**
      * @param string[] $fileExtensions
      * @param string[] $paths
      */
     public function __construct(
-        private bool $isDryRun = false,
-        private bool $showProgressBar = true,
-        private bool $shouldClearCache = false,
-        private string $outputFormat = ConsoleOutputFormatter::NAME,
-        private array $fileExtensions = ['php'],
-        private array $paths = [],
-        private bool $showDiffs = true,
-        private string | null $parallelPort = null,
-        private string | null $parallelIdentifier = null,
-        private bool $isParallel = false,
-        private string|null $memoryLimit = null,
-        private bool $isDebug = false,
+        private readonly bool $isDryRun = false,
+        private readonly bool $showProgressBar = true,
+        private readonly bool $shouldClearCache = false,
+        private readonly string $outputFormat = ConsoleOutputFormatter::NAME,
+        private readonly array $fileExtensions = ['php'],
+        private readonly array $paths = [],
+        private readonly bool $showDiffs = true,
+        private readonly string | null $parallelPort = null,
+        private readonly string | null $parallelIdentifier = null,
+        private readonly bool $isParallel = false,
+        private readonly string|null $memoryLimit = null,
+        private readonly bool $isDebug = false,
     ) {
+    }
+
+    /**
+     * @param class-string[] $classNames
+     */
+    public function setClassNames(array $classNames): void
+    {
+        $this->classNames = $classNames;
+    }
+
+    /**
+     * @param class-string[] $classNames
+     */
+    public function getClassNames(): array
+    {
+        return $this->classNames;
     }
 
     public function isDryRun(): bool


### PR DESCRIPTION
This should improve performance to avoid `$reflector->reflectAllClasses()` called on every worker on parallel process which scan every single files to get Class like.

Closes https://github.com/rectorphp/rector/issues/8637
Closes https://github.com/rectorphp/rector/issues/8638

/cc @mfn @dorrogeray 

**Before**

```bash
➜  rector-src git:(main) time bin/rector process --clear-cache                                                                             
 2180/2180 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

bin/rector process --clear-cache  378.25s user 15.69s system 706% cpu 55.720 total
```

**After**

```bash
➜  rector-src git:(avoid-reflect) time bin/rector process --clear-cache
 2180/2180 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

bin/rector process --clear-cache  227.14s user 9.48s system 621% cpu 38.062 total
```