### PR TITLE
[Performance] Call cached class names collection on FamilyRelationsAnalyzer

### DIFF
--- a/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/ParamTagRemover.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\PhpDoc\TagRemover;
 
-use PHPStan\Type\Type;
 use PhpParser\Node\FunctionLike;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\DeadCode\PhpDoc\DeadParamTagValueNodeAnalyzer;
@@ -22,8 +22,11 @@ final readonly class ParamTagRemover
     ) {
     }
 
-    public function removeParamTagsIfUseless(PhpDocInfo $phpDocInfo, FunctionLike $functionLike, ?Type $type = null): bool
-    {
+    public function removeParamTagsIfUseless(
+        PhpDocInfo $phpDocInfo,
+        FunctionLike $functionLike,
+        ?Type $type = null
+    ): bool {
         $hasChanged = false;
 
         $phpDocNodeTraverser = new PhpDocNodeTraverser();

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -471,7 +471,6 @@ final class LazyContainerFactory
             DynamicSourceLocatorProvider::class,
             static function (DynamicSourceLocatorProvider $dynamicSourceLocatorProvider, Container $container): void {
                 $dynamicSourceLocatorProvider->autowire(
-                    $container->make(ReflectionProvider::class),
                     $container->make(Cache::class),
                     $container->make(FileHasher::class)
                 );

--- a/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -9,16 +9,48 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Interface_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use Rector\Caching\Cache;
+use Rector\Caching\Enum\CacheKey;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
 use Rector\Util\Reflection\PrivatesAccessor;
 
-final readonly class FamilyRelationsAnalyzer
+final class FamilyRelationsAnalyzer
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider,
-        private NodeNameResolver $nodeNameResolver,
-        private PrivatesAccessor $privatesAccessor
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly NodeNameResolver $nodeNameResolver,
+        private readonly PrivatesAccessor $privatesAccessor,
+        private readonly DynamicSourceLocatorProvider $dynamicSourceLocatorProvider,
+        private readonly Cache $cache,
+        private bool $hasClassNamesCached = false
     ) {
+    }
+
+    private function loadClasses(): void
+    {
+        if ($this->hasClassNamesCached) {
+            return;
+        }
+
+        $key = CacheKey::CLASSNAMES_HASH_KEY . '_' . $this->dynamicSourceLocatorProvider->getCacheClassNameKey();
+        $classNamesCache = $this->cache->load($key, CacheKey::CLASSNAMES_HASH_KEY);
+
+        if (is_string($classNamesCache)) {
+            $classNamesCache = json_decode($classNamesCache);
+            if (is_array($classNamesCache)) {
+                foreach ($classNamesCache as $classNameCache) {
+                    try {
+                        $this->reflectionProvider->getClass($classNameCache);
+                    } catch (ClassNotFoundException) {
+                    }
+                }
+
+                return;
+            }
+        }
+
+        $this->hasClassNamesCached = true;
     }
 
     /**
@@ -29,6 +61,8 @@ final readonly class FamilyRelationsAnalyzer
         if ($desiredClassReflection->isFinalByKeyword()) {
             return [];
         }
+
+        $this->loadClasses();
 
         /** @var ClassReflection[] $classReflections */
         $classReflections = $this->privatesAccessor->getPrivateProperty($this->reflectionProvider, 'classes');

--- a/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -7,6 +7,7 @@ namespace Rector\FamilyTree\Reflection;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Interface_;
+use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Caching\Cache;
@@ -25,32 +26,6 @@ final class FamilyRelationsAnalyzer
         private readonly Cache $cache,
         private bool $hasClassNamesCached = false
     ) {
-    }
-
-    private function loadClasses(): void
-    {
-        if ($this->hasClassNamesCached) {
-            return;
-        }
-
-        $key = CacheKey::CLASSNAMES_HASH_KEY . '_' . $this->dynamicSourceLocatorProvider->getCacheClassNameKey();
-        $classNamesCache = $this->cache->load($key, CacheKey::CLASSNAMES_HASH_KEY);
-
-        if (is_string($classNamesCache)) {
-            $classNamesCache = json_decode($classNamesCache);
-            if (is_array($classNamesCache)) {
-                foreach ($classNamesCache as $classNameCache) {
-                    try {
-                        $this->reflectionProvider->getClass($classNameCache);
-                    } catch (ClassNotFoundException) {
-                    }
-                }
-
-                return;
-            }
-        }
-
-        $this->hasClassNamesCached = true;
     }
 
     /**
@@ -123,5 +98,31 @@ final class FamilyRelationsAnalyzer
 
         /** @var string[] $ancestorNames */
         return $ancestorNames;
+    }
+
+    private function loadClasses(): void
+    {
+        if ($this->hasClassNamesCached) {
+            return;
+        }
+
+        $key = CacheKey::CLASSNAMES_HASH_KEY . '_' . $this->dynamicSourceLocatorProvider->getCacheClassNameKey();
+        $classNamesCache = $this->cache->load($key, CacheKey::CLASSNAMES_HASH_KEY);
+
+        if (is_string($classNamesCache)) {
+            $classNamesCache = json_decode($classNamesCache);
+            if (is_array($classNamesCache)) {
+                foreach ($classNamesCache as $classNameCache) {
+                    try {
+                        $this->reflectionProvider->getClass($classNameCache);
+                    } catch (ClassNotFoundException) {
+                    }
+                }
+
+                return;
+            }
+        }
+
+        $this->hasClassNamesCached = true;
     }
 }

--- a/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -118,8 +118,6 @@ final class FamilyRelationsAnalyzer
                     } catch (ClassNotFoundException) {
                     }
                 }
-
-                return;
             }
         }
 

--- a/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -24,7 +24,7 @@ final class FamilyRelationsAnalyzer
         private readonly PrivatesAccessor $privatesAccessor,
         private readonly DynamicSourceLocatorProvider $dynamicSourceLocatorProvider,
         private readonly Cache $cache,
-        private bool $hasClassNamesCached = false
+        private bool $hasClassNamesCachedOrLoadOneLocator = false
     ) {
     }
 
@@ -102,7 +102,7 @@ final class FamilyRelationsAnalyzer
 
     private function loadClasses(): void
     {
-        if ($this->hasClassNamesCached) {
+        if ($this->hasClassNamesCachedOrLoadOneLocator) {
             return;
         }
 
@@ -121,6 +121,6 @@ final class FamilyRelationsAnalyzer
             }
         }
 
-        $this->hasClassNamesCached = true;
+        $this->hasClassNamesCachedOrLoadOneLocator = true;
     }
 }

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -7,7 +7,6 @@ namespace Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvi
 use PHPStan\BetterReflection\Reflector\DefaultReflector;
 use PHPStan\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
-use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\File\CouldNotReadFileException;
 use PHPStan\Reflection\BetterReflection\SourceLocator\FileNodesFetcher;
 use PHPStan\Reflection\BetterReflection\SourceLocator\NewOptimizedDirectorySourceLocator;
@@ -49,11 +48,7 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
     ) {
     }
 
-    public function autowire(
-        ReflectionProvider $reflectionProvider,
-        Cache $cache,
-        FileHasher $fileHasher
-    ): void
+    public function autowire(ReflectionProvider $reflectionProvider, Cache $cache, FileHasher $fileHasher): void
     {
         $this->reflectionProvider = $reflectionProvider;
         $this->cache = $cache;

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -139,19 +139,6 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
     }
 
     /**
-     * @param class-string[] $classNamesCache
-     */
-    private function locateCachedClassNames(array $classNamesCache): void
-    {
-        foreach ($classNamesCache as $classNameCache) {
-            try {
-                $this->reflectionProvider->getClass($classNameCache);
-            } catch (ClassNotFoundException) {
-            }
-        }
-    }
-
-    /**
      * @param OptimizedSingleFileSourceLocator[]|NewOptimizedDirectorySourceLocator[] $sourceLocators
      */
     private function collectClasses(AggregateSourceLocator $aggregateSourceLocator, array $sourceLocators): void
@@ -169,11 +156,7 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
         $classNamesCache = $this->cache->load($key, CacheKey::CLASSNAMES_HASH_KEY);
 
         if (is_string($classNamesCache)) {
-            $classNamesCache = json_decode($classNamesCache);
-            if (is_array($classNamesCache)) {
-                $this->locateCachedClassNames($classNamesCache);
-                return;
-            }
+            return;
         }
 
         $reflector = new DefaultReflector($aggregateSourceLocator);
@@ -183,16 +166,7 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
         try {
             $reflections = $reflector->reflectAllClasses();
             foreach ($reflections as $reflection) {
-                $className = $reflection->getName();
-
-                // make 'classes' collection
-                try {
-                    $this->reflectionProvider->getClass($className);
-                } catch (ClassNotFoundException) {
-                    continue;
-                }
-
-                $classNames[] = $className;
+                $classNames[] = $reflection->getName();
             }
         } catch (CouldNotReadFileException) {
         }

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -12,7 +12,6 @@ use PHPStan\Reflection\BetterReflection\SourceLocator\FileNodesFetcher;
 use PHPStan\Reflection\BetterReflection\SourceLocator\NewOptimizedDirectorySourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedDirectorySourceLocatorFactory;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedSingleFileSourceLocator;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Caching\Cache;
 use Rector\Caching\Enum\CacheKey;
 use Rector\Contract\DependencyInjection\ResetableInterface;
@@ -36,8 +35,6 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
 
     private ?AggregateSourceLocator $aggregateSourceLocator = null;
 
-    private ReflectionProvider $reflectionProvider;
-
     private Cache $cache;
 
     private FileHasher $fileHasher;
@@ -48,9 +45,8 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
     ) {
     }
 
-    public function autowire(ReflectionProvider $reflectionProvider, Cache $cache, FileHasher $fileHasher): void
+    public function autowire(Cache $cache, FileHasher $fileHasher): void
     {
-        $this->reflectionProvider = $reflectionProvider;
         $this->cache = $cache;
         $this->fileHasher = $fileHasher;
     }

--- a/src/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/src/NodeTypeResolver/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -17,6 +17,7 @@ final readonly class ArrayTypeAnalyzer
     public function isArrayType(Expr $expr): bool
     {
         $nodeType = $this->nodeTypeResolver->getNativeType($expr);
-        return $nodeType->isArray()->yes();
+        return $nodeType->isArray()
+            ->yes();
     }
 }

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -88,7 +88,7 @@ final readonly class ClassMethodReturnTypeOverrideGuard
     ): bool {
         $methodName = $classMethod->name->toString();
         foreach ($childrenClassReflections as $childClassReflection) {
-            if (!$childClassReflection->hasNativeMethod($methodName)) {
+            if (! $childClassReflection->hasNativeMethod($methodName)) {
                 continue;
             }
 


### PR DESCRIPTION
@mfn @dorrogeray here continuation of PR:

- https://github.com/rectorphp/rector-src/pull/5878

to improve performance, to ensure call `$this->reflectionProvider->getClass()` on service that only use it, which is `FamilyRelationsAnalyzer`, and as `FamilyRelationsAnalyzer` is shared service, create a flag for it that it already cached.

**Before** **_58.689 seconds_**

```
➜  rector-src git:(main) time bin/rector     
 2180/2180 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!    
```

**After** **_37.014_**

```
time bin/rector process --clear-cache
 2180/2180 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

bin/rector process --clear-cache  223.62s user 9.74s system 630% cpu 37.014 total
```

Closes https://github.com/rectorphp/rector/issues/8637
Closes https://github.com/rectorphp/rector/issues/8638