### PR TITLE
[Performance] Move collect class names collection cache to FamilyRelationsAnalyzer when service is used

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -106,9 +106,6 @@ final class ApplicationFileProcessor
             $preFileCallback = null;
         }
 
-        // trigger cache class names collection
-        $this->dynamicSourceLocatorProvider->provide();
-
         if ($configuration->isParallel()) {
             $processResult = $this->runParallel($filePaths, $configuration, $input, $postFileCallback);
         } else {

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -471,7 +471,6 @@ final class LazyContainerFactory
             DynamicSourceLocatorProvider::class,
             static function (DynamicSourceLocatorProvider $dynamicSourceLocatorProvider, Container $container): void {
                 $dynamicSourceLocatorProvider->autowire(
-                    $container->make(Cache::class),
                     $container->make(FileHasher::class)
                 );
             }


### PR DESCRIPTION
@mfn @dorrogeray here continuation of PR:

- https://github.com/rectorphp/rector-src/pull/5879

to improve performance, to ensure  move cache class names collection to `FamilyRelationsAnalyzer::getChildrenOfClassReflection()` when service is actually used.

**Before** **_58.689 seconds_**

```
time bin/rector     
 2180/2180 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!    
```

**After** **_33.575_**

```
time bin/rector process --clear-cache
 2180/2180 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        

bin/rector process --clear-cache  222.05s user 9.24s system 688% cpu 33.575 total
```
