### PR TITLE
[TypeDeclaration] Handle crash on interface Mixin on ReturnTypeFromStrictConstantReturnRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector/Fixture/skip_interface_mixin.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector/Fixture/skip_interface_mixin.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+// the namespace Webmozart\Assert on purpose to reproduce crash
+// @see https://github.com/rectorphp/rector/issues/8624
+// @see https://getrector.com/demo/e6b2e871-1b41-4897-8864-2f9aaad48de1
+namespace Webmozart\Assert;
+
+interface Mixin
+{
+    public static function nullOrString($value, $message = '');
+}

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -385,7 +385,15 @@ final class PHPStanNodeScopeResolver
         $context = $this->privatesAccessor->getPrivateProperty($mutatingScope, 'context');
         $this->privatesAccessor->setPrivateProperty($context, 'classReflection', null);
 
-        return $mutatingScope->enterClass($classReflection);
+        try {
+            return $mutatingScope->enterClass($classReflection);
+        } catch (\Throwable $throwable) {
+            if ($throwable->getMessage() !== 'Internal error.') {
+                throw $throwable;
+            }
+
+            return $mutatingScope;
+        }
     }
 
     private function resolveClassName(Class_ | Interface_ | Trait_| Enum_ $classLike): string

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -80,6 +80,11 @@ final class PHPStanNodeScopeResolver
     private bool $hasUnreachableStatementNode = false;
 
     /**
+     * @var string
+     */
+    private const PHPSTAN_INTERNAL_ERROR_MESSAGE = 'Internal error.';
+
+    /**
      * @param ScopeResolverNodeVisitorInterface[] $nodeVisitors
      */
     public function __construct(
@@ -230,7 +235,7 @@ final class PHPStanNodeScopeResolver
         try {
             $this->nodeScopeResolver->processNodes($stmts, $mutatingScope, $nodeCallback);
         } catch (Throwable $throwable) {
-            if ($throwable->getMessage() !== 'Internal error.') {
+            if ($throwable->getMessage() !== self::PHPSTAN_INTERNAL_ERROR_MESSAGE) {
                 throw $throwable;
             }
         }
@@ -388,7 +393,7 @@ final class PHPStanNodeScopeResolver
         try {
             return $mutatingScope->enterClass($classReflection);
         } catch (Throwable $throwable) {
-            if ($throwable->getMessage() !== 'Internal error.') {
+            if ($throwable->getMessage() !== self::PHPSTAN_INTERNAL_ERROR_MESSAGE) {
                 throw $throwable;
             }
 

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -387,7 +387,7 @@ final class PHPStanNodeScopeResolver
 
         try {
             return $mutatingScope->enterClass($classReflection);
-        } catch (\Throwable $throwable) {
+        } catch (Throwable $throwable) {
             if ($throwable->getMessage() !== 'Internal error.') {
                 throw $throwable;
             }


### PR DESCRIPTION
While there is no longer `Mixin` interface on latest webmozart/assert, the issue is reproduced at :

- https://github.com/rectorphp/rector/issues/8624

Fixes https://github.com/rectorphp/rector/issues/8624

due to `Internal error.` on PHPStan `enterClass()` on `MutatingScope`