### PR TITLE
[PHPStan] Fix missingType.generics notice on phpstan.neon on PHPStan 1.11

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,7 +32,6 @@ parameters:
     scanFiles:
         - src/Contract/PhpParser/Node/StmtsAwareInterface.php
 
-    checkGenericClassInNonGenericObjectType: false
 
     excludePaths:
         - '*tests/*/Fixture/*'
@@ -46,6 +45,8 @@ parameters:
         - src/functions
 
     ignoreErrors:
+        -
+            identifier: missingType.generics
         -
             message: '#Class cognitive complexity is \d+, keep it under \d+#'
             paths:


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/5883#issuecomment-2115388457