### PR TITLE
[TypeDeclaration] Skip unitialized property on EmptyOnNullableObjectToInstanceOfRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
@@ -10,7 +10,7 @@ final class SkipUnitializedProperty
 
     public function setId(AnotherObject $data): self
     {
-        if (!empty($this->data) && !$data->equals($this->id)) {
+        if (!empty($this->data) && !$data->equals($this->data)) {
             throw new \InvalidArgumentException('The ID is already set.');
         }
 

--- a/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector\Fixture;
+
+final class SkipUnitializedProperty
+{
+    private \stdClass $data;
+
+    public function setId(\stdClass $data): self
+    {
+        if (!empty($this->data) && !$data->data($this->id)) {
+            throw new \InvalidArgumentException('The ID is already set.');
+        }
+
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
@@ -6,15 +6,15 @@ use Rector\Tests\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOf
 
 final class SkipUnitializedProperty
 {
-    private AnotherObject $data;
+    private AnotherObject $id;
 
-    public function setId(AnotherObject $data): self
+    public function setId(AnotherObject $id): self
     {
-        if (!empty($this->data) && !$data->equals($this->data)) {
+        if (!empty($this->id) && !$id->equals($this->id)) {
             throw new \InvalidArgumentException('The ID is already set.');
         }
 
-        $this->data = $data;
+        $this->id = $id;
 
         return $this;
     }

--- a/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Fixture/skip_unitialized_property.php.inc
@@ -2,13 +2,15 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector\Fixture;
 
+use Rector\Tests\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector\Source\AnotherObject;
+
 final class SkipUnitializedProperty
 {
-    private \stdClass $data;
+    private AnotherObject $data;
 
-    public function setId(\stdClass $data): self
+    public function setId(AnotherObject $data): self
     {
-        if (!empty($this->data) && !$data->data($this->id)) {
+        if (!empty($this->data) && !$data->equals($this->id)) {
             throw new \InvalidArgumentException('The ID is already set.');
         }
 

--- a/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Source/AnotherObject.php
+++ b/rules-tests/TypeDeclaration/Rector/Empty_/EmptyOnNullableObjectToInstanceOfRector/Source/AnotherObject.php
@@ -4,5 +4,8 @@ namespace Rector\Tests\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInst
 
 final class AnotherObject
 {
-
+    public function equals(AnotherObject $anotherObject)
+    {
+        return (bool) rand(0, 1);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8643