### PR TITLE
[Carbon] Skip first class callable on Carbon rules

### DIFF
--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
+
+class SkipFirstClassCallable
+{
+    public function run()
+    {
+        $date = date(...);
+    }
+}

--- a/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
@@ -65,6 +65,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (count($node->getArgs()) !== 1) {
             return null;
         }

--- a/rules/Carbon/Rector/MethodCall/DateTimeMethodCallToCarbonRector.php
+++ b/rules/Carbon/Rector/MethodCall/DateTimeMethodCallToCarbonRector.php
@@ -79,6 +79,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($new->isFirstClassCallable()) {
+            return null;
+        }
+
         if (count($new->getArgs()) !== 1) {
             // @todo handle in separate static call
             return null;

--- a/rules/Carbon/Rector/New_/DateTimeInstanceToCarbonRector.php
+++ b/rules/Carbon/Rector/New_/DateTimeInstanceToCarbonRector.php
@@ -60,6 +60,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         // no arg? ::now()
         $carbonFullyQualified = new FullyQualified('Carbon\Carbon');
         if ($node->args === []) {


### PR DESCRIPTION
to avoid error:

```
There was 1 failure:

1) Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\DateFuncCallToCarbonRectorTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())
```

on first class callable.
