### PR TITLE
[config] Disable parallel on --debug

### DIFF
--- a/rules/Carbon/Rector/FuncCall/TimeFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/TimeFuncCallToCarbonRector.php
@@ -66,7 +66,7 @@ CODE_SAMPLE
 
         $firstClassCallable = $node->isFirstClassCallable();
 
-        if (!$firstClassCallable && count($node->getArgs()) !== 0) {
+        if (! $firstClassCallable && count($node->getArgs()) !== 0) {
             return null;
         }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -66,6 +66,11 @@ final readonly class ConfigurationFactory
         $parallelIdentifier = (string) $input->getOption(Option::PARALLEL_IDENTIFIER);
         $isDebug = (bool) $input->getOption(Option::DEBUG);
 
+        // using debug disables parallel, so emitting exception is straightforward and easier to debug
+        if ($isDebug) {
+            $isParallel = false;
+        }
+
         $memoryLimit = $this->resolveMemoryLimit($input);
 
         return new Configuration(


### PR DESCRIPTION
Currently, debug shows parallel runs and adds extra layer to Recto run. This run is most likely broken already, so we should make it easy to spot the bug as easy as possible.

PHPStan uses same approach and it makes finding bugs much easier - https://phpstan.org/user-guide/command-line-usage#--debug :+1: 

Let's do the same here :slightly_smiling_face: 