### PR TITLE
[DX] Ommit static functions/closure from coding-style, as often ignored and depends on personal preference

### DIFF
--- a/config/set/coding-style.php
+++ b/config/set/coding-style.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
 use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
@@ -10,7 +9,6 @@ use Rector\CodingStyle\Rector\ClassConst\SplitGroupedClassConstantsRector;
 use Rector\CodingStyle\Rector\ClassMethod\FuncGetArgsToVariadicParamRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncArrayToVariadicRector;
@@ -60,8 +58,6 @@ return static function (RectorConfig $rectorConfig): void {
         MakeInheritedMethodVisibilitySameAsParentRector::class,
         CallUserFuncArrayToVariadicRector::class,
         VersionCompareFuncCallToConstantRector::class,
-        StaticArrowFunctionRector::class,
-        StaticClosureRector::class,
         CountArrayToEmptyArrayComparisonRector::class,
         CallUserFuncToMethodCallRector::class,
         FuncGetArgsToVariadicParamRector::class,

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -9,6 +9,8 @@ use Rector\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\IntvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector;
+use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
+use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
 use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
@@ -47,6 +49,8 @@ final class MissingInSetCommand extends Command
         BoolvalToTypeCastRector::class,
         FloatvalToTypeCastRector::class,
         IncreaseDeclareStrictTypesRector::class,
+        StaticClosureRector::class,
+        StaticArrowFunctionRector::class,
         // changes behavior, should be applied on purpose regardless PHP 7.3 level
         JsonThrowOnErrorRector::class,
         // in confront with sub type safe belt detection on RemoveUseless*TagRector


### PR DESCRIPTION
Based on community feedback from Twitter tweets, I'm going through rules that are often ignored to make them optional and Rector easier to use: https://x.com/WilsenHC/status/1793344778991763880 :+1: 

I often excluded these rules myself as overly detailed and bringing more noise than practical value. Let's keep them as optiona for those who prefer them :+1: 