### PR TITLE
[DX] Soft-deprecate CallableThisArrayToAnonymousFunctionRector, as FirstClassCallableRector  handles the same case better

### DIFF
--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/CallableThisArrayToAnonymousFunctionRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/CallableThisArrayToAnonymousFunctionRectorTest.php
@@ -8,6 +8,10 @@ use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+/**
+ * @deprecated This rule is surpassed by more advanced one
+ * Use @see FirstClassCallableRector instead
+ */
 final class CallableThisArrayToAnonymousFunctionRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
+++ b/rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php
@@ -25,6 +25,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @changelog https://3v4l.org/KM1Ji
  *
  * @see \Rector\Tests\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\CallableThisArrayToAnonymousFunctionRectorTest
+ *
+ * @deprecated This rule is surpassed by more advanced one
+ * Use @see FirstClassCallableRector instead
  */
 final class CallableThisArrayToAnonymousFunctionRector extends AbstractScopeAwareRector
 {

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Config\Level;
 
-use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
 use Rector\CodeQuality\Rector\Assign\CombinedAssignRector;
 use Rector\CodeQuality\Rector\BooleanAnd\RemoveUselessIsObjectCheckRector;
 use Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector;
@@ -131,7 +130,6 @@ final class CodeQualityLevel
         SimplifyBoolIdenticalTrueRector::class,
         SimplifyRegexPatternRector::class,
         BooleanNotIdenticalToNotIdenticalRector::class,
-        CallableThisArrayToAnonymousFunctionRector::class,
         AndAssignsToSeparateLinesRector::class,
         CompactToVariablesRector::class,
         CompleteDynamicPropertiesRector::class,

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Utils\Command;
 
 use Nette\Utils\Strings;
+use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
 use Rector\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\IntvalToTypeCastRector;
@@ -53,6 +54,7 @@ final class MissingInSetCommand extends Command
         StaticClosureRector::class,
         StaticArrowFunctionRector::class,
         PostIncDecToPreIncDecRector::class,
+        CallableThisArrayToAnonymousFunctionRector::class,
         // changes behavior, should be applied on purpose regardless PHP 7.3 level
         JsonThrowOnErrorRector::class,
         // in confront with sub type safe belt detection on RemoveUseless*TagRector


### PR DESCRIPTION
Based on commonly-ignored rules in https://github.com/rectorphp/rector-src/pull/5916,
it seems the CallableThisArrayToAnonymousFunctionRector is not used. 

No surprise there, as it adds lot of duplicated, clutter code and makes code more precise, but even more less readable. 

The `FirstClassCallableRector` rule handles the same case much better in PHP 8.1+ onward :+1: lets use it instead