### PR TITLE
[DX] Report rules that registered in withSkip() but never registered in withRules()

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -70,6 +70,23 @@ final class ApplicationFileProcessor
             sleep(3);
         }
 
+        $registeredRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
+        $skippedRules = SimpleParameterProvider::provideArrayParameter(Option::SKIPPED_RECTOR_RULES);
+
+        $neverRegisteredSkippedRules = array_unique(array_diff($skippedRules, $registeredRules));
+        if ($neverRegisteredSkippedRules !== []) {
+            $total = count($neverRegisteredSkippedRules);
+            $reportNeverRegisteredRules = implode(PHP_EOL, $neverRegisteredSkippedRules);
+            $this->symfonyStyle->warning(sprintf(
+                '[Note] The the following rule%s %s ignored, but its actually never registered. You can remove it from the skip([...]) or withSkip([...]) method%s',
+                $total > 1 ? 's' : '',
+                $total > 1 ? 'are' : 'is',
+                PHP_EOL . PHP_EOL . $reportNeverRegisteredRules
+            ));
+
+            sleep(3);
+        }
+
         // no files found
         if ($filePaths === []) {
             return new ProcessResult([], []);

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -78,7 +78,7 @@ final class ApplicationFileProcessor
             $total = count($neverRegisteredSkippedRules);
             $reportNeverRegisteredRules = implode(PHP_EOL, $neverRegisteredSkippedRules);
             $this->symfonyStyle->warning(sprintf(
-                '[Note] The the following rule%s %s ignored, but its actually never registered. You can remove it from the skip([...]) or withSkip([...]) method%s',
+                '[Note] The the following rule%s %s ignored, but its actually never registered. You can remove it from the withSkip([...]) method%s',
                 $total > 1 ? 's' : '',
                 $total > 1 ? 'are' : 'is',
                 PHP_EOL . PHP_EOL . $reportNeverRegisteredRules

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -126,11 +126,9 @@ final class ApplicationFileProcessor
         // trigger cache class names collection
         $this->dynamicSourceLocatorProvider->provide();
 
-        if ($configuration->isParallel()) {
-            $processResult = $this->runParallel($filePaths, $configuration, $input, $postFileCallback);
-        } else {
-            $processResult = $this->processFiles($filePaths, $configuration, $preFileCallback, $postFileCallback);
-        }
+        $processResult = $configuration->isParallel()
+            ? $this->runParallel($filePaths, $configuration, $input, $postFileCallback)
+            : $this->processFiles($filePaths, $configuration, $preFileCallback, $postFileCallback);
 
         $processResult->addSystemErrors($this->systemErrors);
 

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -78,9 +78,10 @@ final class ApplicationFileProcessor
             $total = count($neverRegisteredSkippedRules);
             $reportNeverRegisteredRules = implode(PHP_EOL, $neverRegisteredSkippedRules);
             $this->symfonyStyle->warning(sprintf(
-                '[Note] The the following rule%s %s ignored, but its actually never registered. You can remove it from the withSkip([...]) method%s',
+                '[Note] The the following rule%s %s ignored, but its actually never registered. You can remove %s from the withSkip([...]) method%s',
                 $total > 1 ? 's' : '',
                 $total > 1 ? 'are' : 'is',
+                $total > 1 ? 'them' : 'it',
                 PHP_EOL . PHP_EOL . $reportNeverRegisteredRules
             ));
 

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -78,11 +78,13 @@ final class ApplicationFileProcessor
             $total = count($neverRegisteredSkippedRules);
             $reportNeverRegisteredRules = implode(PHP_EOL, $neverRegisteredSkippedRules);
             $this->symfonyStyle->warning(sprintf(
-                '[Note] The the following rule%s %s ignored, but its actually never registered. You can remove %s from the withSkip([...]) method%s',
+                '[Note] The following rule%s %s ignored, but %s actually never registered. You can remove %s from the withSkip([...]) method.%s%s',
                 $total > 1 ? 's' : '',
                 $total > 1 ? 'are' : 'is',
+                $total > 1 ? 'they are' : 'it is',
                 $total > 1 ? 'them' : 'it',
-                PHP_EOL . PHP_EOL . $reportNeverRegisteredRules
+                PHP_EOL,
+                PHP_EOL . $reportNeverRegisteredRules
             ));
 
             sleep(3);

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -61,34 +61,8 @@ final class ApplicationFileProcessor
     {
         $filePaths = $this->fileFactory->findFilesInPaths($configuration->getPaths(), $configuration);
 
-        if ($this->vendorMissAnalyseGuard->isVendorAnalyzed($filePaths)) {
-            $this->symfonyStyle->warning(sprintf(
-                'Rector has detected a "/vendor" directory in your configured paths. If this is Composer\'s vendor directory, this is not necessary as it will be autoloaded. Scanning the Composer vendor directory will cause Rector to run much slower and possibly with errors.%sRemove "/vendor" from Rector paths and run again.',
-                PHP_EOL . PHP_EOL
-            ));
-
-            sleep(3);
-        }
-
-        $registeredRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
-        $skippedRules = SimpleParameterProvider::provideArrayParameter(Option::SKIPPED_RECTOR_RULES);
-
-        $neverRegisteredSkippedRules = array_unique(array_diff($skippedRules, $registeredRules));
-        if ($neverRegisteredSkippedRules !== []) {
-            $total = count($neverRegisteredSkippedRules);
-            $reportNeverRegisteredRules = implode(PHP_EOL, $neverRegisteredSkippedRules);
-            $this->symfonyStyle->warning(sprintf(
-                '[Note] The following rule%s %s ignored, but %s actually never registered. You can remove %s from the withSkip([...]) method.%s%s',
-                $total > 1 ? 's' : '',
-                $total > 1 ? 'are' : 'is',
-                $total > 1 ? 'they are' : 'it is',
-                $total > 1 ? 'them' : 'it',
-                PHP_EOL,
-                PHP_EOL . $reportNeverRegisteredRules
-            ));
-
-            sleep(3);
-        }
+        $this->verifyVendor($filePaths);
+        $this->verifySkippedRules();
 
         // no files found
         if ($filePaths === []) {
@@ -193,6 +167,44 @@ final class ApplicationFileProcessor
         }
 
         return new ProcessResult($systemErrors, $fileDiffs);
+    }
+
+    /**
+     * @param string[] $filePaths
+     */
+    private function verifyVendor(array $filePaths): void
+    {
+        if ($this->vendorMissAnalyseGuard->isVendorAnalyzed($filePaths)) {
+            $this->symfonyStyle->warning(sprintf(
+                'Rector has detected a "/vendor" directory in your configured paths. If this is Composer\'s vendor directory, this is not necessary as it will be autoloaded. Scanning the Composer vendor directory will cause Rector to run much slower and possibly with errors.%sRemove "/vendor" from Rector paths and run again.',
+                PHP_EOL . PHP_EOL
+            ));
+
+            sleep(3);
+        }
+    }
+
+    private function verifySkippedRules(): void
+    {
+        $registeredRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
+        $skippedRules = SimpleParameterProvider::provideArrayParameter(Option::SKIPPED_RECTOR_RULES);
+
+        $neverRegisteredSkippedRules = array_unique(array_diff($skippedRules, $registeredRules));
+        if ($neverRegisteredSkippedRules !== []) {
+            $total = count($neverRegisteredSkippedRules);
+            $reportNeverRegisteredRules = implode(PHP_EOL, $neverRegisteredSkippedRules);
+            $this->symfonyStyle->warning(sprintf(
+                '[Note] The following rule%s %s ignored, but %s actually never registered. You can remove %s from the withSkip([...]) method.%s%s',
+                $total > 1 ? 's' : '',
+                $total > 1 ? 'are' : 'is',
+                $total > 1 ? 'they are' : 'it is',
+                $total > 1 ? 'them' : 'it',
+                PHP_EOL,
+                PHP_EOL . $reportNeverRegisteredRules
+            ));
+
+            sleep(3);
+        }
     }
 
     private function processFile(File $file, Configuration $configuration): FileProcessResult

--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -103,9 +103,11 @@ final class ApplicationFileProcessor
         // trigger cache class names collection
         $this->dynamicSourceLocatorProvider->provide();
 
-        $processResult = $configuration->isParallel()
-            ? $this->runParallel($filePaths, $configuration, $input, $postFileCallback)
-            : $this->processFiles($filePaths, $configuration, $preFileCallback, $postFileCallback);
+        if ($configuration->isParallel()) {
+            $processResult = $this->runParallel($filePaths, $configuration, $input, $postFileCallback);
+        } else {
+            $processResult = $this->processFiles($filePaths, $configuration, $preFileCallback, $postFileCallback);
+        }
 
         $processResult->addSystemErrors($this->systemErrors);
 

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -242,4 +242,10 @@ final class Option
      * @var string
      */
     public const REGISTERED_RECTOR_SETS = 'registered_rector_sets';
+
+    /**
+     * @internal For verify skipped rules exists in registered rules
+     * @var string
+     */
+    public const SKIPPED_RECTOR_RULES = 'skipped_rector_rules';
 }

--- a/src/Validation/RectorConfigValidator.php
+++ b/src/Validation/RectorConfigValidator.php
@@ -32,7 +32,7 @@ final class RectorConfigValidator
     public static function ensureRectorRulesExist(array $skip): void
     {
         $nonExistingRules = [];
-        $existingRules = [];
+        $skippedRectorRules = [];
 
         foreach ($skip as $key => $value) {
             if (self::isRectorClassValue($key) && ! class_exists($key)) {
@@ -45,14 +45,14 @@ final class RectorConfigValidator
             }
 
             if (class_exists($value)) {
-                $existingRules[] = $value;
+                $skippedRectorRules[] = $value;
                 continue;
             }
 
             $nonExistingRules[] = $value;
         }
 
-        SimpleParameterProvider::addParameter(Option::SKIPPED_RECTOR_RULES, $existingRules);
+        SimpleParameterProvider::addParameter(Option::SKIPPED_RECTOR_RULES, $skippedRectorRules);
 
         if ($nonExistingRules === []) {
             return;

--- a/src/Validation/RectorConfigValidator.php
+++ b/src/Validation/RectorConfigValidator.php
@@ -35,8 +35,13 @@ final class RectorConfigValidator
         $skippedRectorRules = [];
 
         foreach ($skip as $key => $value) {
-            if (self::isRectorClassValue($key) && ! class_exists($key)) {
-                $nonExistingRules[] = $key;
+            if (self::isRectorClassValue($key)) {
+                if (class_exists($key)) {
+                    $skippedRectorRules[] = $key;
+                } else {
+                    $nonExistingRules[] = $key;
+                }
+
                 continue;
             }
 

--- a/src/Validation/RectorConfigValidator.php
+++ b/src/Validation/RectorConfigValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Validation;
 
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Exception\ShouldNotHappenException;
 
 final class RectorConfigValidator
@@ -30,6 +32,7 @@ final class RectorConfigValidator
     public static function ensureRectorRulesExist(array $skip): void
     {
         $nonExistingRules = [];
+        $existingRules = [];
 
         foreach ($skip as $key => $value) {
             if (self::isRectorClassValue($key) && ! class_exists($key)) {
@@ -42,11 +45,14 @@ final class RectorConfigValidator
             }
 
             if (class_exists($value)) {
+                $existingRules[] = $value;
                 continue;
             }
 
             $nonExistingRules[] = $value;
         }
+
+        SimpleParameterProvider::addParameter(Option::SKIPPED_RECTOR_RULES, $existingRules);
 
         if ($nonExistingRules === []) {
             return;


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/8657

It shows the never registered in `withRules()` but registered in `withSkip()`

![Screenshot 2024-05-29 at 11 25 40](https://github.com/rectorphp/rector-src/assets/459648/b1355396-a0d3-47ec-8a1a-62905b590e79)



