### PR TITLE
[AutoImport] No need RenamedClassesDataCollector usage on UsesClassNameImportSkipVoter

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/UsesClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/UsesClassNameImportSkipVoter.php
@@ -31,11 +31,6 @@ final readonly class UsesClassNameImportSkipVoter implements ClassNameImportSkip
         $useImportTypes = $this->useNodesToAddCollector->getUseImportTypesByNode($file, $node);
 
         foreach ($useImportTypes as $useImportType) {
-            // if the class is renamed, the use import is no longer blocker
-            if ($this->renamedClassesDataCollector->hasOldClass($useImportType->getClassName())) {
-                continue;
-            }
-
             if (! $useImportType->equals($fullyQualifiedObjectType) && $useImportType->areShortNamesEqual(
                 $fullyQualifiedObjectType
             )) {

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/UsesClassNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/UsesClassNameImportSkipVoter.php
@@ -6,7 +6,6 @@ namespace Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter;
 
 use PhpParser\Node;
 use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
-use Rector\Configuration\RenamedClassesDataCollector;
 use Rector\PostRector\Collector\UseNodesToAddCollector;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\ValueObject\Application\File;
@@ -21,8 +20,7 @@ use Rector\ValueObject\Application\File;
 final readonly class UsesClassNameImportSkipVoter implements ClassNameImportSkipVoterInterface
 {
     public function __construct(
-        private UseNodesToAddCollector $useNodesToAddCollector,
-        private RenamedClassesDataCollector $renamedClassesDataCollector
+        private UseNodesToAddCollector $useNodesToAddCollector
     ) {
     }
 

--- a/src/Configuration/RenamedClassesDataCollector.php
+++ b/src/Configuration/RenamedClassesDataCollector.php
@@ -46,12 +46,11 @@ final class RenamedClassesDataCollector implements ResetableInterface
     {
         $className = $objectType->getClassName();
 
-        $renamedClassName = $this->oldToNewClasses[$className] ?? null;
-        if ($renamedClassName === null) {
+        if (! $this->hasOldClass($className)) {
             return null;
         }
 
-        return new ObjectType($renamedClassName);
+        return new ObjectType($this->oldToNewClasses[$className]);
     }
 
     /**

--- a/src/Configuration/RenamedClassesDataCollector.php
+++ b/src/Configuration/RenamedClassesDataCollector.php
@@ -19,6 +19,10 @@ final class RenamedClassesDataCollector implements ResetableInterface
         $this->oldToNewClasses = [];
     }
 
+    /**
+     * keep public modifier and use internally on matchClassName() method
+     * to keep API as on Configuration level
+     */
     public function hasOldClass(string $oldClass): bool
     {
         return isset($this->oldToNewClasses[$oldClass]);


### PR DESCRIPTION
It seems no longer needed as early cleaned up on `ClassRenamingPostRector`

https://github.com/rectorphp/rector-src/blob/f987c4df60c792fabd875cdccd678a5ce2a4eda5/src/PostRector/Rector/ClassRenamingPostRector.php#L83-L84