### PR TITLE
Exclude IncreaseDeclareStrictTypesRector from rector-preset set as conflict with DeclareStrictTypesRector

### DIFF
--- a/config/set/rector-preset.php
+++ b/config/set/rector-preset.php
@@ -14,7 +14,6 @@ use Rector\Config\RectorConfig;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
-use Rector\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
 use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -26,7 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
         StrvalToTypeCastRector::class,
         BoolvalToTypeCastRector::class,
         FloatvalToTypeCastRector::class,
-        IncreaseDeclareStrictTypesRector::class,
         StaticClosureRector::class,
         StaticArrowFunctionRector::class,
         PostIncDecToPreIncDecRector::class,

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -15,6 +15,7 @@ use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php81\Rector\ClassConst\FinalizePublicClassConstantRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddCoversClassAttributeRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
 use Rector\Utils\Enum\RectorDirectoryToSetFileMap;
 use Rector\Utils\Finder\RectorClassFinder;
 use Rector\Utils\Finder\SetRectorClassesResolver;
@@ -31,6 +32,7 @@ final class MissingInSetCommand extends Command
     private const SKIPPED_RULES = [
         ConfigurableRectorInterface::class,
         // optional
+        IncreaseDeclareStrictTypesRector::class,
         CallableThisArrayToAnonymousFunctionRector::class,
         // changes behavior, should be applied on purpose regardless PHP 7.3 level
         JsonThrowOnErrorRector::class,


### PR DESCRIPTION
It may cause invalid change:

```diff
 <?php

+declare(strict_types=1);
+
+declare(strict_types=1);
+
```