### PR TITLE
Exclude StaticClosureRector and StaticArrowFunctionRector from rector-preset

### DIFF
--- a/config/set/rector-preset.php
+++ b/config/set/rector-preset.php
@@ -6,8 +6,6 @@ use Rector\CodeQuality\Rector\FuncCall\BoolvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\FloatvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\IntvalToTypeCastRector;
 use Rector\CodeQuality\Rector\FuncCall\StrvalToTypeCastRector;
-use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
-use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
 use Rector\CodingStyle\Rector\Plus\UseIncrementAssignRector;
 use Rector\CodingStyle\Rector\PostInc\PostIncDecToPreIncDecRector;
 use Rector\Config\RectorConfig;
@@ -25,8 +23,6 @@ return static function (RectorConfig $rectorConfig): void {
         StrvalToTypeCastRector::class,
         BoolvalToTypeCastRector::class,
         FloatvalToTypeCastRector::class,
-        StaticClosureRector::class,
-        StaticArrowFunctionRector::class,
         PostIncDecToPreIncDecRector::class,
         UseIncrementAssignRector::class,
         FinalizeTestCaseClassRector::class,

--- a/utils/Command/MissingInSetCommand.php
+++ b/utils/Command/MissingInSetCommand.php
@@ -6,6 +6,8 @@ namespace Rector\Utils\Command;
 
 use Nette\Utils\Strings;
 use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
+use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
+use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
 use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
@@ -33,6 +35,8 @@ final class MissingInSetCommand extends Command
         ConfigurableRectorInterface::class,
         // optional
         IncreaseDeclareStrictTypesRector::class,
+        StaticClosureRector::class,
+        StaticArrowFunctionRector::class,
         CallableThisArrayToAnonymousFunctionRector::class,
         // changes behavior, should be applied on purpose regardless PHP 7.3 level
         JsonThrowOnErrorRector::class,


### PR DESCRIPTION
per https://github.com/rectorphp/rector-symfony/pull/607#pullrequestreview-2087496491