### PR TITLE
[TypeDeclaration] Handle double declare(strict_types=1) addition on DeclareStrictTypesRector + IncreaseDeclareStrictTypesRector

### DIFF
--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
@@ -64,13 +64,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $newStmts = $this->file->getNewStmts();
-
-        if ($newStmts === []) {
+        if ($nodes === []) {
             return null;
         }
 
-        $rootStmt = current($newStmts);
+        $rootStmt = \current($nodes);
         $stmt = $rootStmt;
 
         if ($rootStmt instanceof FileWithoutNamespace) {

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
@@ -52,8 +52,8 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Node[] $nodes
-     * @return Node[]|null
+     * @param Stmt[] $nodes
+     * @return Stmt[]|null
      */
     public function beforeTraverse(array $nodes): ?array
     {
@@ -64,13 +64,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $newStmts = $this->file->getNewStmts();
-
-        if ($newStmts === []) {
+        if ($nodes === []) {
             return null;
         }
 
-        $rootStmt = current($newStmts);
+        $rootStmt = current($nodes);
         $stmt = $rootStmt;
 
         if ($rootStmt instanceof FileWithoutNamespace) {
@@ -87,12 +85,6 @@ CODE_SAMPLE
         // when first stmt is Declare_, verify if there is strict_types definition already,
         // as multiple declare is allowed, with declare(strict_types=1) only allowed on very first stmt
         if ($this->declareStrictTypeFinder->hasDeclareStrictTypes($stmt)) {
-            return null;
-        }
-
-        // just added nodes
-        $currentNode = current($nodes);
-        if ($currentNode instanceof Declare_ && $this->declareStrictTypeFinder->hasDeclareStrictTypes($currentNode)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
@@ -90,6 +90,11 @@ CODE_SAMPLE
             return null;
         }
 
+        $currentNode = current($nodes);
+        if ($currentNode instanceof Declare_ && $this->declareStrictTypeFinder->hasDeclareStrictTypes($currentNode)) {
+            return null;
+        }
+
         $declareDeclare = new DeclareDeclare(new Identifier('strict_types'), new LNumber(1));
         $strictTypesDeclare = new Declare_([$declareDeclare]);
 

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
@@ -90,6 +90,7 @@ CODE_SAMPLE
             return null;
         }
 
+        // just added nodes
         $currentNode = current($nodes);
         if ($currentNode instanceof Declare_ && $this->declareStrictTypeFinder->hasDeclareStrictTypes($currentNode)) {
             return null;

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
@@ -64,11 +64,13 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($nodes === []) {
+        $newStmts = $this->file->getNewStmts();
+
+        if ($newStmts === []) {
             return null;
         }
 
-        $rootStmt = \current($nodes);
+        $rootStmt = current($newStmts);
         $stmt = $rootStmt;
 
         if ($rootStmt instanceof FileWithoutNamespace) {

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -89,6 +89,7 @@ CODE_SAMPLE
             return null;
         }
 
+        // just added nodes
         $currentNode = current($nodes);
         if ($currentNode instanceof Declare_ && $this->declareStrictTypeFinder->hasDeclareStrictTypes($currentNode)) {
             return null;

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -7,6 +7,7 @@ namespace Rector\TypeDeclaration\Rector\StmtsAwareInterface;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\DeclareDeclare;
 use PhpParser\Node\Stmt\Nop;
@@ -65,19 +66,18 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Node[] $nodes
-     * @return Node[]|null
+     * @param Stmt[] $nodes
+     * @return Stmt[]|null
      */
     public function beforeTraverse(array $nodes): ?array
     {
         parent::beforeTraverse($nodes);
 
-        $newStmts = $this->file->getNewStmts();
-        if ($newStmts === []) {
+        if ($nodes === []) {
             return null;
         }
 
-        $rootStmt = \current($newStmts);
+        $rootStmt = \current($nodes);
         $stmt = $rootStmt;
 
         // skip classes without namespace for safety reasons
@@ -86,12 +86,6 @@ CODE_SAMPLE
         }
 
         if ($this->declareStrictTypeFinder->hasDeclareStrictTypes($stmt)) {
-            return null;
-        }
-
-        // just added nodes
-        $currentNode = current($nodes);
-        if ($currentNode instanceof Declare_ && $this->declareStrictTypeFinder->hasDeclareStrictTypes($currentNode)) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -89,6 +89,11 @@ CODE_SAMPLE
             return null;
         }
 
+        $currentNode = current($nodes);
+        if ($currentNode instanceof Declare_ && $this->declareStrictTypeFinder->hasDeclareStrictTypes($currentNode)) {
+            return null;
+        }
+
         // keep change withing a limit
         if ($this->changedItemCount >= $this->limit) {
             return null;

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -72,11 +72,12 @@ CODE_SAMPLE
     {
         parent::beforeTraverse($nodes);
 
-        if ($nodes === []) {
+        $newStmts = $this->file->getNewStmts();
+        if ($newStmts === []) {
             return null;
         }
 
-        $rootStmt = \current($nodes);
+        $rootStmt = \current($newStmts);
         $stmt = $rootStmt;
 
         // skip classes without namespace for safety reasons

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -72,12 +72,11 @@ CODE_SAMPLE
     {
         parent::beforeTraverse($nodes);
 
-        $newStmts = $this->file->getNewStmts();
-        if ($newStmts === []) {
+        if ($nodes === []) {
             return null;
         }
 
-        $rootStmt = \current($newStmts);
+        $rootStmt = \current($nodes);
         $stmt = $rootStmt;
 
         // skip classes without namespace for safety reasons

--- a/tests/Issues/DoubleDeclare/DoubleDeclareTest.php
+++ b/tests/Issues/DoubleDeclare/DoubleDeclareTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\DoubleDeclare;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DoubleDeclareTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DoubleDeclare/Fixture/fixture.php.inc
+++ b/tests/Issues/DoubleDeclare/Fixture/fixture.php.inc
@@ -17,5 +17,3 @@ namespace Rector\Tests\Issues\DoubleDeclare\Fixture;
 final class Fixture
 {
 }
-
-?>

--- a/tests/Issues/DoubleDeclare/Fixture/fixture.php.inc
+++ b/tests/Issues/DoubleDeclare/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Issues\DoubleDeclare\Fixture;
+
+final class Fixture
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\DoubleDeclare\Fixture;
+
+final class Fixture
+{
+}
+
+?>

--- a/tests/Issues/DoubleDeclare/config/configured_rule.php
+++ b/tests/Issues/DoubleDeclare/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        DeclareStrictTypesRector::class,
+        IncreaseDeclareStrictTypesRector::class,
+    ]);
+};


### PR DESCRIPTION
While user should choose one of the rules, when it added both, it cause double addition:

```diff
 <?php

+declare(strict_types=1);
+
+declare(strict_types=1);
+
```

which should only one, ref https://github.com/rectorphp/rector-src/pull/5926
