### PR TITLE
[Scope] No need to set Scope on PHPStan VirtualNode on PHPStanNodeScopeResolver

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
+use PHPStan\Node\VirtualNode;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -192,7 +193,7 @@ final class PHPStanNodeScopeResolver
             // special case for unreachable nodes
             if ($node instanceof UnreachableStatementNode) {
                 $this->processUnreachableStatementNode($node, $filePath, $mutatingScope);
-            } elseif (! $node instanceof \PHPStan\Node\VirtualNode) {
+            } elseif (! $node instanceof VirtualNode) {
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
         };

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -192,7 +192,7 @@ final class PHPStanNodeScopeResolver
             // special case for unreachable nodes
             if ($node instanceof UnreachableStatementNode) {
                 $this->processUnreachableStatementNode($node, $filePath, $mutatingScope);
-            } else {
+            } elseif (! $node instanceof \PHPStan\Node\VirtualNode) {
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
         };

--- a/src/StaticTypeMapper/Naming/NameScopeFactory.php
+++ b/src/StaticTypeMapper/Naming/NameScopeFactory.php
@@ -67,9 +67,11 @@ final class NameScopeFactory
     {
         $nameScope = $this->createNameScopeFromNodeWithoutTemplateTypes($node);
         $templateTypeMap = $this->templateTemplateTypeMap($node);
-
+        /** @var non-empty-string|null $namespace */
+        $namespace = $nameScope->getNamespace();
+        
         return new NameScope(
-            $nameScope->getNamespace(),
+            $namespace,
             $nameScope->getUses(),
             $nameScope->getClassName(),
             null,


### PR DESCRIPTION
Rector doesn't process PHPStan VirtualNode, so no need to set scope on them, even exists, that unwrapped later at 

https://github.com/rectorphp/rector-src/blob/a3ed07f8c8c0b2f7cbd78ce7711871d31bad3998/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php#L203

so we only serving phpparser Node