### PR TITLE
[DeadCode] Remove param docblock on RemoveUnusedPromotedPropertyRector when exists

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/remove_also_param_doc.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/remove_also_param_doc.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector\Fixture;
+
+class RemoveAlsoParamDoc
+{
+    /**
+     * @param non-empty-string $someUnusedDependency
+     */
+    public function __construct(
+        private $someUnusedDependency,
+        private $usedDependency
+    ) {
+    }
+
+    public function get()
+    {
+    	return $this->usedDependency;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector\Fixture;
+
+class RemoveAlsoParamDoc
+{
+    public function __construct(
+        private $usedDependency
+    ) {
+    }
+
+    public function get()
+    {
+    	return $this->usedDependency;
+    }
+}
+
+?>


### PR DESCRIPTION
It currently left over on the code https://getrector.com/demo/bda73d66-86b1-4b5f-956f-54b32e8fd383 which no longer needed.