### PR TITLE
[DeadCode] Use existing detectCallExpr() in SideEffectNodeDetector::detect()

### DIFF
--- a/rules-tests/DeadCode/Rector/Return_/RemoveDeadConditionAboveReturnRector/Fixture/skip_method_call_in_condition_with_concat.php.inc
+++ b/rules-tests/DeadCode/Rector/Return_/RemoveDeadConditionAboveReturnRector/Fixture/skip_method_call_in_condition_with_concat.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Return_\RemoveDeadConditionAboveReturnRector\Fixture;
+
+final class SkipMethodCallInConditionWithConcat
+{
+    public function saveMyEntity($a, $entity): bool
+    {
+        if ($a . $entity->save()) {
+            return true;
+        }
+
+        return true;
+    }
+}

--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -19,7 +19,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ObjectType;
-use Rector\NodeTypeResolver\NodeTypeResolver;
 
 final readonly class SideEffectNodeDetector
 {
@@ -34,7 +33,6 @@ final readonly class SideEffectNodeDetector
     ];
 
     public function __construct(
-        private NodeTypeResolver $nodeTypeResolver,
         private PureFunctionDetector $pureFunctionDetector
     ) {
     }

--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ObjectType;
+use Rector\PhpParser\Node\BetterNodeFinder;
 
 final readonly class SideEffectNodeDetector
 {
@@ -33,7 +34,8 @@ final readonly class SideEffectNodeDetector
     ];
 
     public function __construct(
-        private PureFunctionDetector $pureFunctionDetector
+        private PureFunctionDetector $pureFunctionDetector,
+        private BetterNodeFinder $betterNodeFinder,
     ) {
     }
 
@@ -43,7 +45,10 @@ final readonly class SideEffectNodeDetector
             return true;
         }
 
-        return $this->detectCallExpr($expr, $scope);
+        return (bool) $this->betterNodeFinder->findFirst(
+            $expr,
+            fn (Node $subNode): bool => $this->detectCallExpr($subNode, $scope)
+        );
     }
 
     public function detectCallExpr(Node $node, Scope $scope): bool


### PR DESCRIPTION
There are 2 methods on `SideEffectNodeDetector` service:

- `detect()`
- `detectCallExpr()`

which the different is the `detect` early return on `Assign` expr, which `detectCallExpr` mostly used inside `findFirst()` usage.

This merge existing functionality and move to `detectCallExpr()`, and it seems get type detection no longer needed, just use pure Node detection of it.