### PR TITLE
[CodeQuality] Allow check in current Class_ with multiple props on CompleteDynamicPropertiesRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/multiple_props.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/multiple_props.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+class MultipleProps
+{
+    public $a, $value;
+
+    public function set()
+    {
+        $this->c = 5;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+class MultipleProps
+{
+    /**
+     * @var int
+     */
+    public $c;
+    public $a, $value;
+
+    public function set()
+    {
+        $this->c = 5;
+    }
+}
+
+?>

--- a/rules/CodeQuality/NodeAnalyzer/ClassLikeAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/ClassLikeAnalyzer.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\NodeAnalyzer;
 
 use PhpParser\Node\Stmt\Class_;
-use Rector\NodeNameResolver\NodeNameResolver;
 
 final readonly class ClassLikeAnalyzer
 {
-    public function __construct(
-        private NodeNameResolver $nodeNameResolver
-    ) {
-    }
-
     /**
      * @return string[]
      */
@@ -22,7 +16,9 @@ final readonly class ClassLikeAnalyzer
         $propertyNames = [];
 
         foreach ($class->getProperties() as $property) {
-            $propertyNames[] = $this->nodeNameResolver->getName($property);
+            foreach ($property->props as $prop) {
+                $propertyNames[] = $prop->name->toString();
+            }
         }
 
         return $propertyNames;


### PR DESCRIPTION
No need additional check on `ClassReflection` when already exists in `Class_`