### PR TITLE
[Test] Fix typo file extension test for ArrayItemNodeTest

### DIFF
--- a/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
+++ b/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
@@ -6,9 +6,11 @@ namespace Rector\Tests\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 
 use Nette\Utils\FileSystem as UtilsFileSystem;
 use PhpParser\Node\Stmt\Class_;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 use Rector\PhpParser\Parser\RectorParser;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
@@ -47,6 +49,10 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
         $classDocComment = null;
 
         foreach ($newStmts as $newStmt) {
+            if (! $newStmt instanceof StmtsAwareInterface) {
+                continue;
+            }
+
             if ($newStmt->stmts === null) {
                 continue;
             }
@@ -57,6 +63,10 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
                 }
 
                 $phpDocInfo = $this->phpDocInfoFactory->createFromNode($stmt);
+                if (! $phpDocInfo instanceof PhpDocInfo) {
+                    continue;
+                }
+
                 $phpDocNode = $phpDocInfo->getPhpDocNode();
 
                 foreach ($phpDocNode->children as $key => $phpDocChildNode) {
@@ -66,6 +76,10 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
 
                 $classStmt = $stmt;
                 break;
+            }
+
+            if (! $classStmt instanceof Class_) {
+                continue;
             }
 
             $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($classStmt);
@@ -80,7 +94,7 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
         );
     }
 
-    private function printNodePhpDocInfoToString(?Class_ $class): string
+    private function printNodePhpDocInfoToString(Class_ $class): string
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);
         return $this->phpDocInfoPrinter->printFormatPreserving($phpDocInfo);

--- a/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
+++ b/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace Rector\Tests\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 
 use Nette\Utils\FileSystem as UtilsFileSystem;
-use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
 use Rector\PhpParser\Parser\RectorParser;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
-use Rector\ValueObject\Application\File;
 
-class ArrayItemNodeTest extends AbstractLazyTestCase
+final class ArrayItemNodeTest extends AbstractLazyTestCase
 {
     private DocBlockUpdater $docBlockUpdater;
 
@@ -39,7 +38,6 @@ class ArrayItemNodeTest extends AbstractLazyTestCase
     {
         $filePath = __DIR__ . '/FixtureNested/DoctrineNestedClassAnnotation.php.inc';
         $fileContent = UtilsFileSystem::read($filePath);
-        $file = new File($filePath, $fileContent);
 
         $stmtsAndTokens = $this->rectorParser->parseFileContentToStmtsAndTokens($fileContent);
         $oldStmts = $stmtsAndTokens->getStmts();
@@ -48,13 +46,13 @@ class ArrayItemNodeTest extends AbstractLazyTestCase
         $classStmt = null;
         $classDocComment = null;
 
-        foreach ($newStmts as $node) {
-            if ($node->stmts === null) {
+        foreach ($newStmts as $newStmt) {
+            if ($newStmt->stmts === null) {
                 continue;
             }
 
-            foreach ($node->stmts as $stmt) {
-                if (! $stmt instanceof Node\Stmt\Class_) {
+            foreach ($newStmt->stmts as $stmt) {
+                if (! $stmt instanceof Class_) {
                     continue;
                 }
 
@@ -82,9 +80,9 @@ class ArrayItemNodeTest extends AbstractLazyTestCase
         );
     }
 
-    private function printNodePhpDocInfoToString(Node $node): string
+    private function printNodePhpDocInfoToString(?Class_ $class): string
     {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);
         return $this->phpDocInfoPrinter->printFormatPreserving($phpDocInfo);
     }
 }

--- a/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
+++ b/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
@@ -87,9 +87,9 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
         }
 
         $this->assertEquals(
-            '/**
+            str_replace("\r\n", "\n", '/**
  * @ORM\Table(name="doctrine_entity", uniqueConstraints={@ORM\UniqueConstraint(name="property")})
- */',
+ */'),
             str_replace("\r\n", "\n", $classDocComment)
         );
     }

--- a/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
+++ b/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
@@ -90,7 +90,7 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
             '/**
  * @ORM\Table(name="doctrine_entity", uniqueConstraints={@ORM\UniqueConstraint(name="property")})
  */',
-            $classDocComment
+            str_replace("\r\n", "\n", $classDocComment)
         );
     }
 

--- a/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
+++ b/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
@@ -90,7 +90,7 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
             str_replace("\r\n", "\n", '/**
  * @ORM\Table(name="doctrine_entity", uniqueConstraints={@ORM\UniqueConstraint(name="property")})
  */'),
-            str_replace("\r\n", "\n", $classDocComment)
+            str_replace("\r\n", "\n", (string) $classDocComment)
         );
     }
 


### PR DESCRIPTION
It should not have `.php.inc` extension as a test class.