### PR TITLE
[php74] Remove the renaming of apache_request_headers #8666

### DIFF
--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -22,9 +22,6 @@ return static function (RectorConfig $rectorConfig): void {
             #the_real_type
             # https://wiki.php.net/rfc/deprecations_php_7_4
             'is_real' => 'is_float',
-            #apache_request_headers_function
-            # https://wiki.php.net/rfc/deprecations_php_7_4
-            'apache_request_headers' => 'getallheaders',
             //'hebrevc' => ['nl2br', 'hebrev'],
         ]);
 


### PR DESCRIPTION
Fixes rectorphp/rector/issues/8666

The deprecation of the `apache_request_headers()` function has been reverted in [PHP RFC: Deprecations for PHP 7.4](https://wiki.php.net/rfc/deprecations_php_7_4), see the changelog at the bottom.