### PR TITLE
[CodingStyle] Use array value for "comments" attribute to set on UseImportsAdder::mirrorUseComments()

### DIFF
--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -154,7 +154,7 @@ final readonly class UseImportsAdder
                     $stmts[$indexStmt]->getAttribute(AttributeKey::COMMENTS)
                 );
 
-                $stmts[$indexStmt]->setAttribute(AttributeKey::COMMENTS, null);
+                $stmts[$indexStmt]->setAttribute(AttributeKey::COMMENTS, []);
             }
         }
     }


### PR DESCRIPTION
Checking comments attribute always be array instead of null.