### PR TITLE
[Naming] Handle rename property with only comment, without @var doc on RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/property_type_with_only_comment.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/property_type_with_only_comment.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use PhpParser\ParserFactory as NikicParserFactory;
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper;
+
+final class PropertyTypeWithOnlyComment
+{
+    /**
+     * only comment
+     */
+    private GitWrapper $whatever;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use PhpParser\ParserFactory as NikicParserFactory;
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper;
+
+final class PropertyTypeWithOnlyComment
+{
+    /**
+     * only comment
+     */
+    private GitWrapper $gitWrapper;
+}
+
+?>

--- a/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
+++ b/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
@@ -65,26 +65,16 @@ final readonly class MatchPropertyTypeExpectedNameResolver
 
     private function resolveExpectedName(Property $property): ?ExpectedName
     {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
-        $isPhpDocInfo = $phpDocInfo instanceof PhpDocInfo;
-
         // property type first
         if ($property->type instanceof Node) {
             $propertyType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($property->type);
-            // not has docblock, use property type
-            if (! $isPhpDocInfo) {
-                return $this->propertyNaming->getExpectedNameFromType($propertyType);
-            }
-
-            // @var type is ObjectType, use property type
-            $varType = $phpDocInfo->getVarType();
-            if ($varType instanceof ObjectType) {
-                return $this->propertyNaming->getExpectedNameFromType($propertyType);
-            }
+            return $this->propertyNaming->getExpectedNameFromType($propertyType);
         }
 
         // fallback to docblock
-        if ($isPhpDocInfo) {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
+        $isVarTypeObjectType = $phpDocInfo instanceof PhpDocInfo && $phpDocInfo->getVarType() instanceof ObjectType;
+        if ($isVarTypeObjectType) {
             return $this->propertyNaming->getExpectedNameFromType($phpDocInfo->getVarType());
         }
 


### PR DESCRIPTION
it currently skipped, ref https://getrector.com/demo/3ef924d5-6332-471d-acfa-ea0e89dd8a10

this should also make a change on property without doc, only comment.