### PR TITLE
[Naming] Handle nullable object @var docblock on RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/nullable_object_type_doc.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/nullable_object_type_doc.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper;
+
+class NullableObjectTypeDoc
+{
+    /**
+     * @var ?\Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper
+     */
+    private $wrapper;
+
+    public function __construct(GitWrapper $wrapper)
+    {
+        $this->wrapper = $wrapper;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper;
+
+class NullableObjectTypeDoc
+{
+    /**
+     * @var ?\Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper
+     */
+    private $gitWrapper;
+
+    public function __construct(GitWrapper $wrapper)
+    {
+        $this->gitWrapper = $wrapper;
+    }
+}
+
+?>

--- a/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
+++ b/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
@@ -73,8 +73,8 @@ final readonly class MatchPropertyTypeExpectedNameResolver
 
         // fallback to docblock
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
-        $isVarTypeObjectType = $phpDocInfo instanceof PhpDocInfo && $phpDocInfo->getVarType() instanceof ObjectType;
-        if ($isVarTypeObjectType) {
+        $hasVarTag = $phpDocInfo instanceof PhpDocInfo && $phpDocInfo->getVarTagValueNode();
+        if ($hasVarTag) {
             return $this->propertyNaming->getExpectedNameFromType($phpDocInfo->getVarType());
         }
 

--- a/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
+++ b/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Naming\Naming\PropertyNaming;

--- a/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
+++ b/rules/Naming/ExpectedNameResolver/MatchPropertyTypeExpectedNameResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -73,7 +74,7 @@ final readonly class MatchPropertyTypeExpectedNameResolver
 
         // fallback to docblock
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
-        $hasVarTag = $phpDocInfo instanceof PhpDocInfo && $phpDocInfo->getVarTagValueNode();
+        $hasVarTag = $phpDocInfo instanceof PhpDocInfo && $phpDocInfo->getVarTagValueNode() instanceof VarTagValueNode;
         if ($hasVarTag) {
             return $this->propertyNaming->getExpectedNameFromType($phpDocInfo->getVarType());
         }


### PR DESCRIPTION
Continue of :

- https://github.com/rectorphp/rector-src/pull/5945

this handle with nullable `@var` doc as nullable is covered by `propertyNaming->getExpectedNameFromType()` functionality which handle if passed nullable, then object type checked there.