### PR TITLE
[NodeTypeResolver] Remove Property->type instanceof Node check on NodeTypeResolver->getType()

### DIFF
--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -19,7 +19,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\UnionType as NodeUnionType;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\ClassAutoloadingException;
@@ -129,16 +128,13 @@ final class NodeTypeResolver
 
     public function getType(Node $node): Type
     {
-        if ($node instanceof Property && $node->type instanceof Node) {
-            return $this->getType($node->type);
+        if ($node instanceof Name && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
+            return $this->getType(new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME)));
         }
 
         if ($node instanceof NullableType) {
-            if ($node->type instanceof Name && $node->type->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
-                $node->type = new FullyQualified($node->type->getAttribute(AttributeKey::NAMESPACED_NAME));
-            }
-
             $type = $this->getType($node->type);
+
             if (! $type instanceof MixedType) {
                 return new UnionType([$type, new NullType()]);
             }


### PR DESCRIPTION
- [x] The check `Property->type instanceof Node` seems no longer needed
- [x] and avoid replace node into another node on `Name` with `NAMESPACED_NAME` attribute, use to `getType()` instead.