### PR TITLE
[BetterPhpDocParser] Remove unnecessary PrivatesAccessor usage on BetterTokenIterator and TokenIteratorFactory

### DIFF
--- a/src/BetterPhpDocParser/PhpDocInfo/TokenIteratorFactory.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/TokenIteratorFactory.php
@@ -7,18 +7,11 @@ namespace Rector\BetterPhpDocParser\PhpDocInfo;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use Rector\BetterPhpDocParser\ValueObject\Parser\BetterTokenIterator;
-use Rector\Util\Reflection\PrivatesAccessor;
 
 final readonly class TokenIteratorFactory
 {
-    /**
-     * @var string
-     */
-    private const INDEX = 'index';
-
     public function __construct(
-        private Lexer $lexer,
-        private PrivatesAccessor $privatesAccessor
+        private Lexer $lexer
     ) {
     }
 
@@ -34,13 +27,10 @@ final readonly class TokenIteratorFactory
             return $tokenIterator;
         }
 
-        $tokens = $this->privatesAccessor->getPrivateProperty($tokenIterator, 'tokens');
-        $betterTokenIterator = new BetterTokenIterator($tokens);
+        // keep original tokens and index position
+        $tokens = $tokenIterator->getTokens();
+        $currentIndex = $tokenIterator->currentTokenIndex();
 
-        // keep original position
-        $currentIndex = $this->privatesAccessor->getPrivateProperty($tokenIterator, self::INDEX);
-        $this->privatesAccessor->setPrivateProperty($betterTokenIterator, self::INDEX, $currentIndex);
-
-        return $betterTokenIterator;
+        return new BetterTokenIterator($tokens, $currentIndex);
     }
 }

--- a/src/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
+++ b/src/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
@@ -6,33 +6,19 @@ namespace Rector\BetterPhpDocParser\ValueObject\Parser;
 
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use Rector\Exception\ShouldNotHappenException;
-use Rector\Util\Reflection\PrivatesAccessor;
 
 final class BetterTokenIterator extends TokenIterator
 {
-    /**
-     * @var string
-     */
-    private const TOKENS = 'tokens';
-
-    /**
-     * @var string
-     */
-    private const INDEX = 'index';
-
     /**
      * @param array<int, mixed> $tokens
      */
     public function __construct(array $tokens, int $index = 0)
     {
-        $privatesAccessor = new PrivatesAccessor();
-
         if ($tokens === []) {
-            $privatesAccessor->setPrivateProperty($this, self::TOKENS, []);
-            $privatesAccessor->setPrivateProperty($this, self::INDEX, 0);
-        } else {
-            parent::__construct($tokens, $index);
+            $index = 0;
         }
+
+        parent::__construct($tokens, $index);
     }
 
     /**


### PR DESCRIPTION
- [x] There are methods already for: `getTokens()` and `currentTokenIndex()`
- [x] Just use `parent::__construct()` and fill current index as 0 for empty tokens.