### PR TITLE
[PHPStan] Clean up VirtualNode check on ExprScopeFromStmtNodeVisitor

### DIFF
--- a/src/PHPStan/NodeVisitor/ExprScopeFromStmtNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/ExprScopeFromStmtNodeVisitor.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\MutatingScope;
-use PHPStan\Node\VirtualNode;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -44,10 +43,6 @@ final class ExprScopeFromStmtNodeVisitor extends NodeVisitorAbstract
 
         if ($node instanceof Stmt) {
             $this->currentStmt = $node;
-            return null;
-        }
-
-        if ($node instanceof VirtualNode) {
             return null;
         }
 


### PR DESCRIPTION
on `AlwaysRememberedExpr`, as `VirtualNode`, wrapped at `WrappedNodeRestoringNodeVisitor`