### PR TITLE
[VendorLocker] Move Magic method safe unsafe check into ClassMethodReturnVendorLockResolver from AddVoidReturnTypeWhereNoReturnRector

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddVoidReturnTypeWhereNoReturnRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Throw_;
-use Rector\NodeAnalyzer\MagicClassMethodAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ClassModifierChecker;
 use Rector\TypeDeclaration\TypeInferer\SilentVoidResolver;
@@ -26,7 +25,6 @@ final class AddVoidReturnTypeWhereNoReturnRector extends AbstractRector implemen
     public function __construct(
         private readonly SilentVoidResolver $silentVoidResolver,
         private readonly ClassMethodReturnVendorLockResolver $classMethodReturnVendorLockResolver,
-        private readonly MagicClassMethodAnalyzer $magicClassMethodAnalyzer,
         private readonly ClassModifierChecker $classModifierChecker,
     ) {
     }
@@ -102,10 +100,6 @@ CODE_SAMPLE
 
     private function shouldSkipClassMethod(ClassMethod $classMethod): bool
     {
-        if ($this->magicClassMethodAnalyzer->isUnsafeOverridden($classMethod)) {
-            return true;
-        }
-
         if ($classMethod->isAbstract()) {
             return true;
         }

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodReturnVendorLockResolver.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Type\MixedType;
+use Rector\NodeAnalyzer\MagicClassMethodAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Reflection\ReflectionResolver;
 
@@ -15,12 +16,17 @@ final readonly class ClassMethodReturnVendorLockResolver
 {
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
-        private ReflectionResolver $reflectionResolver
+        private ReflectionResolver $reflectionResolver,
+        private MagicClassMethodAnalyzer $magicClassMethodAnalyzer
     ) {
     }
 
     public function isVendorLocked(ClassMethod $classMethod): bool
     {
+        if ($this->magicClassMethodAnalyzer->isUnsafeOverridden($classMethod)) {
+            return true;
+        }
+
         if ($classMethod->isPrivate()) {
             return false;
         }


### PR DESCRIPTION
same like other vendor locker services.