### PR TITLE
[Printer] Ensure use array_values() on FileWithoutNamespace stmts to make consistent with namespaced file on BetterStandardPrinter

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -527,7 +527,7 @@ final class BetterStandardPrinter extends Standard
         $stmts = array_values($stmts);
 
         if (count($stmts) === 1 && $stmts[0] instanceof FileWithoutNamespace) {
-            return $stmts[0]->stmts;
+            return array_values($stmts[0]->stmts);
         }
 
         return $stmts;


### PR DESCRIPTION
same with namespaced one 

https://github.com/rectorphp/rector-src/blob/2cdf4bc783081cb52c602b989577756e4782d18f/src/PhpParser/Printer/BetterStandardPrinter.php#L527