### PR TITLE
[DeadCode] Use PHPStan $functionReflection->hasSideEffects()->yes() early when possible on PureFunctionDetector

### DIFF
--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -145,6 +145,12 @@ final readonly class PureFunctionDetector
             return false;
         }
 
+        // use PHPStan first check
+        if ($functionReflection->hasSideEffects()->yes()) {
+            return false;
+        }
+
+        // otherwise, use added defined here
         return ! in_array($funcCallName, self::IMPURE_FUNCTIONS, true);
     }
 }


### PR DESCRIPTION
this is to get win win solution between defined in native phpstan list and our own list on `PureFunctionDetector::IMPURE_FUNCTIONS` data.