### PR TITLE
[Arguments] Skip First class callable on FunctionArgumentDefaultValueReplacerRector

### DIFF
--- a/rules-tests/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\FuncCall\FunctionArgumentDefaultValueReplacerRector\Fixture;
+
+class SkipFirstClassCallable
+{
+    public function run()
+    {
+        some_function(...);
+    }
+}

--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -97,6 +97,10 @@ final readonly class ArgumentDefaultValueReplacer
         MethodCall | StaticCall | FuncCall | New_ $expr,
         ReplaceArgumentDefaultValueInterface $replaceArgumentDefaultValue
     ): ?Expr {
+        if ($expr->isFirstClassCallable()) {
+            return null;
+        }
+
         $position = $replaceArgumentDefaultValue->getPosition();
         $particularArg = $expr->getArgs()[$position] ?? null;
         if (! $particularArg instanceof Arg) {


### PR DESCRIPTION
To avoid crash:

```
There was 1 failure:

1) Rector\Tests\Arguments\Rector\FuncCall\FunctionArgumentDefaultValueReplacerRector\FunctionArgumentDefaultValueReplacerRectorTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())
```