### PR TITLE
[DeadCode] Allow pass stmts instead of $node on StmtsManipulator::isVariableUsedInNextStmt()

### DIFF
--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -142,6 +142,9 @@ CODE_SAMPLE
         );
     }
 
+    /**
+     * @param Stmt[] $stmts
+     */
     private function isVariableUsedInFollowingStmts(
         array $stmts,
         int $assignStmtPosition,

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($assignedVariableNamesByStmtPosition as $stmtPosition => $variableName) {
-            if ($this->isVariableUsedInFollowingStmts($node, $stmtPosition, $variableName)) {
+            if ($this->isVariableUsedInFollowingStmts($stmts, $stmtPosition, $variableName)) {
                 continue;
             }
 
@@ -143,15 +143,11 @@ CODE_SAMPLE
     }
 
     private function isVariableUsedInFollowingStmts(
-        ClassMethod|Function_ $functionLike,
+        array $stmts,
         int $assignStmtPosition,
         string $variableName
     ): bool {
-        if ($functionLike->stmts === null) {
-            return false;
-        }
-
-        foreach ($functionLike->stmts as $key => $stmt) {
+        foreach ($stmts as $key => $stmt) {
             // do not look yet
             if ($key <= $assignStmtPosition) {
                 continue;
@@ -162,12 +158,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $foundVariable = $this->betterNodeFinder->findVariableOfName($stmt, $variableName);
-            if ($foundVariable instanceof Variable) {
-                return true;
-            }
-
-            if ($this->stmtsManipulator->isVariableUsedInNextStmt($functionLike, $key, $variableName)) {
+            if ($this->stmtsManipulator->isVariableUsedInNextStmt($stmts, $key, $variableName)) {
                 return true;
             }
         }

--- a/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
+++ b/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
@@ -139,6 +139,7 @@ CODE_SAMPLE
 
     private function processForForeach(For_|Foreach_ $for, int $key, StmtsAwareInterface $stmtsAware): void
     {
+        $stmts = (array) $stmtsAware->stmts;
         if ($for instanceof For_) {
             $variables = $this->betterNodeFinder->findInstanceOf(
                 [...$for->init, ...$for->cond, ...$for->loop],
@@ -146,7 +147,7 @@ CODE_SAMPLE
             );
             foreach ($variables as $variable) {
                 if ($this->stmtsManipulator->isVariableUsedInNextStmt(
-                    $stmtsAware,
+                    $stmts,
                     $key + 1,
                     (string) $this->getName($variable)
                 )) {
@@ -164,7 +165,7 @@ CODE_SAMPLE
         $variables = $this->betterNodeFinder->findInstanceOf($exprs, Variable::class);
         foreach ($variables as $variable) {
             if ($this->stmtsManipulator->isVariableUsedInNextStmt(
-                $stmtsAware,
+                $stmts,
                 $key + 1,
                 (string) $this->getName($variable)
             )) {

--- a/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -63,7 +63,9 @@ final readonly class ClassChildAnalyzer
      */
     private function resolveParentClassMethods(ClassReflection $classReflection, string $methodName): array
     {
-        if ($classReflection->hasNativeMethod($methodName) && $classReflection->getNativeMethod($methodName)->isPrivate()) {
+        if ($classReflection->hasNativeMethod($methodName) && $classReflection->getNativeMethod(
+            $methodName
+        )->isPrivate()) {
             return [];
         }
 

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -64,16 +64,24 @@ final readonly class StmtsManipulator
         return $stmts;
     }
 
+    /**
+     * @param StmtsAwareInterface|Stmt[] $stmtsAware
+     */
     public function isVariableUsedInNextStmt(
-        StmtsAwareInterface $stmtsAware,
+        StmtsAwareInterface|array $stmtsAware,
         int $jumpToKey,
         string $variableName
     ): bool {
-        if ($stmtsAware->stmts === null) {
+        if ($stmtsAware instanceof StmtsAwareInterface && $stmtsAware->stmts === null) {
             return false;
         }
 
-        $stmts = array_slice($stmtsAware->stmts, $jumpToKey, null, true);
+        $stmts = array_slice(
+            $stmtsAware instanceof StmtsAwareInterface ? $stmtsAware->stmts : $stmtsAware,
+            $jumpToKey,
+            null,
+            true
+        );
         if ((bool) $this->betterNodeFinder->findVariableOfName($stmts, $variableName)) {
             return true;
         }


### PR DESCRIPTION
when the stmts is unset in the middle, it may cause reset key with `array_slice()`, even with `preserve_keys` true, see

https://3v4l.org/eojhk

so allow to use assigned variable `$stmts = $node->stmts` before it unsetted.