### PR TITLE
[Php83] Skip multiple consts on AddTypeToConstRector when types are different

### DIFF
--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/multiple_const_same_type.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/multiple_const_same_type.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
+final class MultipleConstSameType
+{
+    public const TYPE = 'some_type', OTHER_TYPE = 'some_other_type';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
+final class MultipleConstSameType
+{
+    public const string TYPE = 'some_type', OTHER_TYPE = 'some_other_type';
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_multiple_const.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_multiple_const.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
+final class SkipMultipleConst
+{
+    public const TYPE = 'some_type', OTHER_TYPE = 1;
+}

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_multiple_const_different_types.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_multiple_const_different_types.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
 
-final class SkipMultipleConst
+final class SkipMultipleConstDifferentTypes
 {
     public const TYPE = 'some_type', OTHER_TYPE = 1;
 }

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($classConsts  as $classConst) {
-            $valueType = null;
+            $valueTypes = [];
 
             // If a type is set, skip
             if ($classConst->type !== null) {
@@ -106,10 +106,24 @@ CODE_SAMPLE
                     continue;
                 }
 
-                $valueType = $this->findValueType($constNode->value);
+                $valueTypes[] = $this->findValueType($constNode->value);
             }
 
-            if (! ($valueType ?? null) instanceof Identifier) {
+            if ($valueTypes === []) {
+                continue;
+            }
+
+            if (count($valueTypes) > 1) {
+                $valueTypes = array_unique($valueTypes, SORT_REGULAR);
+            }
+
+            // once more verify after uniquate
+            if (count($valueTypes) > 1) {
+                continue;
+            }
+
+            $valueType = current($valueTypes);
+            if (! $valueType instanceof Identifier) {
                 continue;
             }
 


### PR DESCRIPTION
Ref https://getrector.com/demo/079f81e9-5c4e-4648-8f85-019846bea38e
Ref https://3v4l.org/kn3ZF

that cause fatal error:

```
Fatal error: Cannot use string as value for class constant SomeClass::TYPE of type int in /in/kn3ZF on line 6
```