### PR TITLE
[DX] Enable polyfill rules on withPhpSets() config

### DIFF
--- a/config/set/php-polyfills.php
+++ b/config/set/php-polyfills.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php73\Rector\BooleanOr\IsCountableRector;
+use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
+use Rector\Php80\Rector\Identical\StrEndsWithRector;
+use Rector\Php80\Rector\Identical\StrStartsWithRector;
+use Rector\Php80\Rector\NotIdentical\StrContainsRector;
+use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
+
+// these rules can be used ahead of PHP version,
+// as long composer.json includes particular symfony/php-polyfill package
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        ArrayKeyFirstLastRector::class,
+        IsCountableRector::class,
+        GetDebugTypeRector::class,
+        StrStartsWithRector::class,
+        StrEndsWithRector::class,
+        StrContainsRector::class,
+    ]);
+};

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -457,6 +457,9 @@ final class RectorConfigBuilder
             $this->sets[] = LevelSetList::UP_TO_PHP_84;
         }
 
+        // make use of polyfill packages in composer.json
+        $this->sets[] = SetList::PHP_POLYFILLS;
+
         return $this;
     }
 

--- a/src/Set/ValueObject/SetList.php
+++ b/src/Set/ValueObject/SetList.php
@@ -14,6 +14,11 @@ final class SetList implements SetListInterface
     /**
      * @var string
      */
+    public const PHP_POLYFILLS = __DIR__ . '/../../../config/set/php-polyfills.php';
+
+    /**
+     * @var string
+     */
     public const CODE_QUALITY = __DIR__ . '/../../../config/set/code-quality.php';
 
     /**


### PR DESCRIPTION
Polyfill rules  are now enabled, once withPhpSets() is in the place. To pick up used packages in `composer.json` :+1: 

Follow up to https://github.com/rectorphp/rector-src/pull/5388