### PR TITLE
[Config] Add withPhpPolyfill() method to load php polyfill set on RectorConfigBuilder

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -380,6 +380,15 @@ final class RectorConfigBuilder
     }
 
     /**
+     * make use of polyfill packages in composer.json
+     */
+    public function withPhpPolyfill(): self
+    {
+        $this->sets[] = SetList::PHP_POLYFILLS;
+        return $this;
+    }
+
+    /**
      * What PHP sets should be applied? By default the same version
      * as composer.json has is used
      */
@@ -456,9 +465,6 @@ final class RectorConfigBuilder
         } elseif ($php84) {
             $this->sets[] = LevelSetList::UP_TO_PHP_84;
         }
-
-        // make use of polyfill packages in composer.json
-        $this->sets[] = SetList::PHP_POLYFILLS;
 
         return $this;
     }


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/5981#pullrequestreview-2129544346, this is to avoid too many changes on step by step process upgrade, this can be enabled manually by enable it:

```php
<?php

use Rector\Config\RectorConfig;
use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;

return RectorConfig::configure()
     // ...
    ->withPhpPolyfill();
```