### PR TITLE
Add git to Dockerfile to allow running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,5 +48,22 @@ Do you want to **contribute a failing test**? [This tutorial will show you how](
 
 We would be happy to accept PRs that follow these guidelines.
 
+### Using Docker
+
+A `docker-compose.yml` file is provided to make it easier to run the CI checks locally.
+To use it, you need to have Docker installed on your machine, then you can build the image and execute the
+above commands in a docker container:
+
+```bash
+# Build the docker image
+docker compose build
+
+# Run the entire CI suite
+compose compose run php complete-check
+
+# Fix the coding standards
+docker compose run php fix-cs
+```
+
 ## Repository layout
 Documentation goes into `build/target-repository/docs`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM php:8-cli-alpine
 WORKDIR /etc/rector
 
 # required for composer patches
-RUN apk add --no-cache patch
+RUN apk add --no-cache patch git
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 RUN mkdir -p /etc/rector
+RUN git config --global --add safe.directory /etc/rector


### PR DESCRIPTION
When working on #5979 I was trying to run the CI suite in the provided docker image and ran into the unsafe git repository issue.

Fortunately it's a very simple fix. This makes it much easier to run the CI suite locally as you no longer have to worry about which PHP version you have installed.