### PR TITLE
[NodeTypeResolver] Clean up check ConstFetch on getType() on no scope

### DIFF
--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\NullsafeMethodCall;
@@ -173,13 +172,6 @@ final class NodeTypeResolver
         $scope = $node->getAttribute(AttributeKey::SCOPE);
 
         if (! $scope instanceof Scope) {
-            if ($node instanceof ConstFetch) {
-                $name = $node->name->toString();
-                if (strtolower($name) === 'null') {
-                    return new NullType();
-                }
-            }
-
             return new MixedType();
         }
 


### PR DESCRIPTION
On our tests code base, `ConstFetch` seems always has `Scope`, and current check is only on `null` value, which possibly incomplete, it can be `true` or `false`, so better remove the check on no scope, directly use `MixedType`, this sync with `getNativeType()` usage, just use `MixedType` when no scope.