### PR TITLE
[DX] Suggest to use withSets() when using multiple PHP version, eg both php 7.4 and 8.0 on CI on Notifier messages

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -20,7 +20,6 @@ final class InstalledPackageResolver
      */
     private array $resolvedInstalledPackages = [];
 
-
     /**
      * @return InstalledPackage[]
      */

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -512,7 +512,7 @@ final class RectorConfigBuilder
     // suitable for PHP 7.4 and lower, before named args
     public function withPhp53Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_53;
         return $this;
@@ -520,7 +520,7 @@ final class RectorConfigBuilder
 
     public function withPhp54Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_54;
         return $this;
@@ -528,7 +528,7 @@ final class RectorConfigBuilder
 
     public function withPhp55Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_55;
         return $this;
@@ -536,7 +536,7 @@ final class RectorConfigBuilder
 
     public function withPhp56Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_56;
         return $this;
@@ -544,7 +544,7 @@ final class RectorConfigBuilder
 
     public function withPhp70Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_70;
         return $this;
@@ -552,7 +552,7 @@ final class RectorConfigBuilder
 
     public function withPhp71Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_71;
         return $this;
@@ -560,7 +560,7 @@ final class RectorConfigBuilder
 
     public function withPhp72Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_72;
         return $this;
@@ -568,7 +568,7 @@ final class RectorConfigBuilder
 
     public function withPhp73Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_73;
         return $this;
@@ -576,7 +576,7 @@ final class RectorConfigBuilder
 
     public function withPhp74Sets(): self
     {
-        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__, 'withPhpSets');
+        Notifier::notifyNotSuitableMethodForPHP80(__METHOD__);
 
         $this->sets[] = LevelSetList::UP_TO_PHP_74;
         return $this;
@@ -610,7 +610,7 @@ final class RectorConfigBuilder
         // composer based
         bool $twig = false,
     ): self {
-        Notifier::notifyNotSuitableMethodForPHP74(__METHOD__, 'withSets');
+        Notifier::notifyNotSuitableMethodForPHP74(__METHOD__);
 
         if ($deadCode) {
             $this->sets[] = SetList::DEAD_CODE;

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -35,11 +35,10 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
+'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
 
     - "withPhpSets()"
-    - "withSets([...])" for use in both php ^7.2 and php 8.0+.
-            ',
+    - "withSets([...])" for use in both php ^7.2 and php 8.0+.',
             $calledMethod
         );
 
@@ -56,12 +55,12 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
+'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
 
     - "withPhp53Sets()" ... "withPhp74Sets()"
     - "withSets([...])" for use both php ^7.2 and php 8.0+.
 
-    One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
+One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL
         );
 

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Console;
 
+use Rector\Set\ValueObject\LevelSetList;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -17,7 +18,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
+            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead or withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
             $calledMethod,
             $recommendedMethod
         );
@@ -36,7 +37,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method is suitable for PHP 7.4 and lower. Use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
+            'The "%s()" method is suitable for PHP 7.4 and lower. Use "%s()" method instead or withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
             $calledMethod,
             $recommendedMethod
         );
@@ -54,7 +55,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0. One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
+            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0. One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL
         );
 

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -54,12 +54,10 @@ final class Notifier
             return;
         }
 
-        $message = sprintf(
-            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. use the following methods instead:
+        $message = 'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. use the following methods instead:
 
     - "withPhp53Sets()" ... "withPhp74Sets()" in lower PHP versions
-    - "withSets([...])" for use both PHP ^7.2 and php 8.0+.'
-        );
+    - "withSets([...])" for use both PHP ^7.2 and php 8.0+.';
 
         $symfonyStyle = new SymfonyStyle(new ArgvInput(), new ConsoleOutput());
         $symfonyStyle->warning($message);

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -38,7 +38,7 @@ final class Notifier
             'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
 
     - "withPhpSets()"
-    - "withSets([...])" for use in both php ^7.2 and php 8.0.
+    - "withSets([...])" for use in both php ^7.2 and php 8.0+.
             ',
             $calledMethod
         );
@@ -59,7 +59,7 @@ final class Notifier
             'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
 
     - "withPhp53Sets()" ... "withPhp74Sets()"
-    - "withSets([...])" for use both php ^7.2 and php 8.0.
+    - "withSets([...])" for use both php ^7.2 and php 8.0+.
 
     One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -35,7 +35,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
+            'The "%s()" method is suitable for PHP 7.4 and lower. Use the following methods instead:
 
     - "withPhpSets()" in PHP 8.0+
     - "withSets([...])" for use in both php ^7.2 and php 8.0+.',
@@ -54,7 +54,7 @@ final class Notifier
             return;
         }
 
-        $message = 'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. use the following methods instead:
+        $message = 'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. Use the following methods instead:
 
     - "withPhp53Sets()" ... "withPhp74Sets()" in lower PHP versions
     - "withSets([...])" for use both PHP ^7.2 and php 8.0+.';

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -35,7 +35,7 @@ final class Notifier
         }
 
         $message = sprintf(
-'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
+            'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
 
     - "withPhpSets()" in PHP 8.0+
     - "withSets([...])" for use in both php ^7.2 and php 8.0+.',
@@ -55,11 +55,10 @@ final class Notifier
         }
 
         $message = sprintf(
-'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. use the following methods instead:
+            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. use the following methods instead:
 
     - "withPhp53Sets()" ... "withPhp74Sets()" in lower PHP versions
-    - "withSets([...])" for use both PHP ^7.2 and php 8.0+.',
-            PHP_EOL
+    - "withSets([...])" for use both PHP ^7.2 and php 8.0+.'
         );
 
         $symfonyStyle = new SymfonyStyle(new ArgvInput(), new ConsoleOutput());

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -58,9 +58,7 @@ final class Notifier
 'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. use the following methods instead:
 
     - "withPhp53Sets()" ... "withPhp74Sets()" in lower PHP versions
-    - "withSets([...])" for use both PHP ^7.2 and php 8.0+.
-
-One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
+    - "withSets([...])" for use both PHP ^7.2 and php 8.0+.',
             PHP_EOL
         );
 

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -54,9 +54,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "withPhpSets()" method uses named arguments.
-            Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0
-            One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
+            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0. One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL
         );
 

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -4,23 +4,21 @@ declare(strict_types=1);
 
 namespace Rector\Console;
 
-use Rector\Set\ValueObject\LevelSetList;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class Notifier
 {
-    public static function notifyNotSuitableMethodForPHP74(string $calledMethod, string $recommendedMethod): void
+    public static function notifyNotSuitableMethodForPHP74(string $calledMethod): void
     {
         if (PHP_VERSION_ID >= 80000) {
             return;
         }
 
         $message = sprintf(
-            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead',
-            $calledMethod,
-            $recommendedMethod
+            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "withSets([...])" method instead',
+            $calledMethod
         );
 
         $symfonyStyle = new SymfonyStyle(new ArgvInput(), new ConsoleOutput());
@@ -29,7 +27,7 @@ final class Notifier
         sleep(3);
     }
 
-    public static function notifyNotSuitableMethodForPHP80(string $calledMethod, string $recommendedMethod): void
+    public static function notifyNotSuitableMethodForPHP80(string $calledMethod): void
     {
         // current project version check
         if (PHP_VERSION_ID < 80000) {
@@ -39,11 +37,10 @@ final class Notifier
         $message = sprintf(
             'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
 
-    - "%s()"
-    - "withSets([' . LevelSetList::class . '::UP_TO_PHP_XX])" for use in both php ^7.2 and php 8.0.
+    - "withPhpSets()"
+    - "withSets([...])" for use in both php ^7.2 and php 8.0.
             ',
-            $calledMethod,
-            $recommendedMethod
+            $calledMethod
         );
 
         $symfonyStyle = new SymfonyStyle(new ArgvInput(), new ConsoleOutput());
@@ -62,7 +59,7 @@ final class Notifier
             'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
 
     - "withPhp53Sets()" ... "withPhp74Sets()"
-    - "withSets([' . LevelSetList::class . '::UP_TO_PHP_XX])" for use both php ^7.2 and php 8.0.
+    - "withSets([...])" for use both php ^7.2 and php 8.0.
 
     One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -37,7 +37,7 @@ final class Notifier
         $message = sprintf(
 'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
 
-    - "withPhpSets()"
+    - "withPhpSets()" in PHP 8.0+
     - "withSets([...])" for use in both php ^7.2 and php 8.0+.',
             $calledMethod
         );
@@ -55,10 +55,10 @@ final class Notifier
         }
 
         $message = sprintf(
-'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
+'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. use the following methods instead:
 
-    - "withPhp53Sets()" ... "withPhp74Sets()"
-    - "withSets([...])" for use both php ^7.2 and php 8.0+.
+    - "withPhp53Sets()" ... "withPhp74Sets()" in lower PHP versions
+    - "withSets([...])" for use both PHP ^7.2 and php 8.0+.
 
 One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -17,7 +17,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead',
+            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0 on CI',
             $calledMethod,
             $recommendedMethod
         );
@@ -36,7 +36,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method is suitable for PHP 7.4 and lower. Use "%s()" method instead.',
+            'The "%s()" method is suitable for PHP 7.4 and lower. Use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0 on CI',
             $calledMethod,
             $recommendedMethod
         );
@@ -54,7 +54,9 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() method instead. One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
+            'The "withPhpSets()" method uses named arguments.
+            Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0 on CI
+            One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL
         );
 

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -17,7 +17,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0 on CI',
+            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
             $calledMethod,
             $recommendedMethod
         );
@@ -36,7 +36,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method is suitable for PHP 7.4 and lower. Use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0 on CI',
+            'The "%s()" method is suitable for PHP 7.4 and lower. Use "%s()" method instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
             $calledMethod,
             $recommendedMethod
         );
@@ -55,7 +55,7 @@ final class Notifier
 
         $message = sprintf(
             'The "withPhpSets()" method uses named arguments.
-            Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0 on CI
+            Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0
             One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL
         );

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -18,7 +18,11 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead or withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
+            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
+
+    - "%s()"
+    - withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) for use both php ^7.2 and php 8.0.
+            ',
             $calledMethod,
             $recommendedMethod
         );
@@ -37,7 +41,11 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method is suitable for PHP 7.4 and lower. Use "%s()" method instead or withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0',
+            'The "%s()" method is suitable for PHP 7.4 and lower. use the following methods instead:
+
+    - "%s()"
+    - "withSets([' . LevelSetList::class . '::UP_TO_PHP_XX])" for use in both php ^7.2 and php 8.0.
+            ',
             $calledMethod,
             $recommendedMethod
         );
@@ -55,7 +63,12 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use withPhp53Sets() ... withPhp74Sets() instead or withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) method instead for use both php ^7.2 and php 8.0. One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
+            'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
+
+    - "withPhp53Sets()" ... "withPhp74Sets()"
+    - "withSets([' . LevelSetList::class . '::UP_TO_PHP_XX])" for use both php ^7.2 and php 8.0.
+
+    One at a time.%sTo use your composer.json PHP version, keep arguments of this method.',
             PHP_EOL
         );
 

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -18,11 +18,7 @@ final class Notifier
         }
 
         $message = sprintf(
-            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use the following methods instead:
-
-    - "%s()"
-    - withSets([' . LevelSetList::class . '::UP_TO_PHP_XX]) for use both php ^7.2 and php 8.0.
-            ',
+            'The "%s()" method uses named arguments. Its suitable for PHP 8.0+. In lower PHP versions, use "%s()" method instead',
             $calledMethod,
             $recommendedMethod
         );


### PR DESCRIPTION
per https://github.com/rectorphp/rector-src/pull/5984#pullrequestreview-2130731172, this to ensure not cause confusion on usage on CI or system with both php 7.x and 8.x used.