### PR TITLE
[DeadCode] Move RemoveNullTagValueNodeRector after RemoveUseless*TagRector

### DIFF
--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -96,6 +96,8 @@ final class DeadCodeLevel
         RemoveUselessReadOnlyTagRector::class,
         RemoveNonExistingVarAnnotationRector::class,
         RemoveUselessVarTagRector::class,
+        // prioritize safe belt on RemoveUseless*TagRector that registered previously first
+        RemoveNullTagValueNodeRector::class,
         RemovePhpVersionIdCheckRector::class,
 
         RemoveAlwaysTrueIfConditionRector::class,
@@ -126,8 +128,5 @@ final class DeadCodeLevel
         RemoveUnusedConstructorParamRector::class,
         RemoveEmptyClassMethodRector::class,
         RemoveDeadReturnRector::class,
-
-        // prioritize safe belt on RemoveUseless*TagRector that registered previously first
-        RemoveNullTagValueNodeRector::class,
     ];
 }

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -72,7 +72,6 @@ final class DeadCodeLevel
      */
     public const RULES = [
         // easy picks
-        RemoveNullTagValueNodeRector::class,
         RemoveUnusedForeachKeyRector::class,
         RemoveDuplicatedArrayKeyRector::class,
         RecastingRemovalRector::class,
@@ -127,5 +126,8 @@ final class DeadCodeLevel
         RemoveUnusedConstructorParamRector::class,
         RemoveEmptyClassMethodRector::class,
         RemoveDeadReturnRector::class,
+
+        // prioritize safe belt on RemoveUseless*TagRector that registered previously first
+        RemoveNullTagValueNodeRector::class,
     ];
 }


### PR DESCRIPTION
per my comment on https://github.com/rectorphp/rector-src/pull/5998#pullrequestreview-2132729064 , if this needs to be added to dead code set, this need to be added to the last over safe belt `RemoveUseless*TagRector` :)

see this PR for reasoning:

- https://github.com/rectorphp/rector-src/pull/5350 

