### PR TITLE
[Internal] Remove recipe-based generator as not used

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -49,13 +49,6 @@ jobs:
                         name: 'Compatible PHPStan versions'
                         run: php bin/validate-phpstan-version.php
 
-                    # see https://github.com/rectorphp/rector-generator
-                    -
-                        name: 'Rector Generate From Recipe'
-                        run: |
-                            bin/rector init-recipe --ansi
-                            bin/rector generate --ansi
-
                     -
                         name: 'Detect composer dependency issues'
                         run: vendor/bin/composer-dependency-analyser

--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,6 @@ composer.lock
 # since PHPUnit 10
 .phpunit.cache
 
-# often customized locally - example on Github is just fine
-rector-recipe.php
-
-# testing
-abz
-
 # scoped & downgraded version
 php-scoper.phar
 box.phar

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-webmozart-assert": "^1.2.6",
         "phpunit/phpunit": "^10.5",
-        "rector/rector-generator": "^0.7.12",
         "rector/release-notes-generator": "^0.1.1",
         "rector/swiss-knife": "^0.2.16",
         "rector/type-perfect": "^0.1.6",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -284,10 +284,12 @@ parameters:
                 # designed for extension
                 - src/Skipper/Contract/SkipVoterInterface.php
 
-        # wider types for external use
+        # generated class in /vendor
         -
-            message: '#Parameters should have "array" types as the only types passed to this method#'
-            path: src/Util/NodePrinter.php
+             message: '#Offset (.*?) on null on left side of \?\? does not exist#'
+             path: src/Bootstrap/ExtensionConfigResolver.php
+
+        # wider types for external use
         -
             message: '#Parameters should have "PhpParser\\Node\\Stmt\\ClassMethod" types as the only types passed to this method#'
             path: src/Reflection/ClassModifierChecker.php

--- a/src/Bootstrap/RectorConfigsResolver.php
+++ b/src/Bootstrap/RectorConfigsResolver.php
@@ -15,29 +15,7 @@ final class RectorConfigsResolver
         $argvInput = new ArgvInput();
         $mainConfigFile = $this->resolveFromInputWithFallback($argvInput, 'rector.php');
 
-        $rectorRecipeConfigFile = $this->resolveRectorRecipeConfig($argvInput);
-
-        $configFiles = [];
-        if ($rectorRecipeConfigFile !== null) {
-            $configFiles[] = $rectorRecipeConfigFile;
-        }
-
-        return new BootstrapConfigs($mainConfigFile, $configFiles);
-    }
-
-    private function resolveRectorRecipeConfig(ArgvInput $argvInput): ?string
-    {
-        if ($argvInput->getFirstArgument() !== 'generate') {
-            return null;
-        }
-
-        // autoload rector recipe file if present, just for \Rector\RectorGenerator\Command\GenerateCommand
-        $rectorRecipeFilePath = getcwd() . '/rector-recipe.php';
-        if (! file_exists($rectorRecipeFilePath)) {
-            return null;
-        }
-
-        return $rectorRecipeFilePath;
+        return new BootstrapConfigs($mainConfigFile, []);
     }
 
     private function resolveFromInput(ArgvInput $argvInput): ?string


### PR DESCRIPTION
We've had a custom package for creating Rector rules from simple file: https://github.com/rectorphp/rector-generator
Yet in recent years, we practically never used it and only copy-paste old rule to new one :) package has no value, time to let go.