### PR TITLE
Adds ReplaceAttributeUseWithAnotherAttributeRector rule

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 381 Rules Overview
+# 380 Rules Overview
 
 <br>
 
@@ -8,7 +8,7 @@
 
 - [Carbon](#carbon) (4)
 
-- [CodeQuality](#codequality) (75)
+- [CodeQuality](#codequality) (73)
 
 - [CodingStyle](#codingstyle) (28)
 
@@ -58,7 +58,7 @@
 
 - [Strict](#strict) (5)
 
-- [Transform](#transform) (25)
+- [Transform](#transform) (26)
 
 - [TypeDeclaration](#typedeclaration) (50)
 
@@ -358,35 +358,6 @@ Refactor `call_user_func()` with arrow function to direct call
      {
 -        $result = \call_user_func(fn () => 100);
 +        $result = 100;
-     }
- }
-```
-
-<br>
-
-### CallableThisArrayToAnonymousFunctionRector
-
-Convert [$this, "method"] to proper anonymous function
-
-- class: [`Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector`](../rules/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector.php)
-
-```diff
- class SomeClass
- {
-     public function run()
-     {
-         $values = [1, 5, 3];
--        usort($values, [$this, 'compareSize']);
-+        usort($values, function ($first, $second) {
-+            return $this->compareSize($first, $second);
-+        });
-
-         return $values;
-     }
-
-     private function compareSize($first, $second)
-     {
-         return $first <=> $second;
      }
  }
 ```
@@ -748,19 +719,6 @@ Simplify `foreach` loops into `in_array` when possible
 -
 -return false;
 +return in_array('something', $items, true);
-```
-
-<br>
-
-### GetClassToInstanceOfRector
-
-Changes comparison with get_class to instanceof
-
-- class: [`Rector\CodeQuality\Rector\Identical\GetClassToInstanceOfRector`](../rules/CodeQuality/Rector/Identical/GetClassToInstanceOfRector.php)
-
-```diff
--if (EventsListener::class === get_class($event->job)) { }
-+if ($event->job instanceof EventsListener) { }
 ```
 
 <br>
@@ -6370,6 +6328,25 @@ Change RectorConfig to RectorConfigBuilder
 -    $rectorConfig->rule(SomeRector::class);
 -};
 +return RectorConfig::configure()->rules([SomeRector::class]);
+```
+
+<br>
+
+### ReplaceAttributeUseWithAnotherAttributeRector
+
+Replaces one attribute with another
+
+:wrench: **configure it!**
+
+- class: [`Rector\Transform\Rector\Attribute\ReplaceAttributeUseWithAnotherAttributeRector`](../rules/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector.php)
+
+```diff
+ class Foobar
+ {
+-    #[\Foobar('parameter')]
++    #[\Barfoo('parameter')]
+     public $foobar;
+ }
 ```
 
 <br>

--- a/rules-tests/Renaming/Rector/Class_/RenameAttributeRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Class_/RenameAttributeRector/config/configured_rule.php
@@ -1,10 +1,10 @@
 <?php
 
 declare(strict_types=1);
-use Rector\Renaming\ValueObject\RenameAttribute;
 
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Class_\RenameAttributeRector;
+use Rector\Renaming\ValueObject\RenameAttribute;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig

--- a/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/Fixture/fixture.php.inc
+++ b/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\Attribute\ReplaceAttributeUseWithAnotherAttributeRector\Fixture;
+
+class SomeClass
+{
+    #[\FooBar('some-parameter')]
+    public string $name;
+}
+
+?>
+----
+<?php
+
+namespace Rector\Tests\Transform\Rector\Attribute\ReplaceAttributeUseWithAnotherAttributeRector\Fixture;
+
+class SomeClass
+{
+    #[\BarFoo('some-parameter')]
+    public string $name;
+}
+
+?>

--- a/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/Fixture/skips_non_matching_attributes.php.inc
+++ b/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/Fixture/skips_non_matching_attributes.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\Attribute\ReplaceAttributeUseWithAnotherAttributeRector\Fixture;
+
+class SomeClass
+{
+    #[\Something\FooBar()]
+    public string $name;
+}
+
+?>

--- a/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/ReplaceAttributeUseWithAnotherAttributeRectorTest.php
+++ b/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/ReplaceAttributeUseWithAnotherAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\Attribute\ReplaceAttributeUseWithAnotherAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceAttributeUseWithAnotherAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node\Name\FullyQualified;
+use Rector\Config\RectorConfig;
+use Rector\Transform\Rector\Attribute\ReplaceAttributeUseWithAnotherAttributeRector;
+use Rector\Transform\ValueObject\ReplaceAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ReplaceAttributeUseWithAnotherAttributeRector::class, [
+            new ReplaceAttribute(new FullyQualified('Foobar'), new FullyQualified('Barfoo')),
+        ]);
+};

--- a/rules/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector.php
+++ b/rules/Transform/Rector/Attribute/ReplaceAttributeUseWithAnotherAttributeRector.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Transform\Rector\Attribute;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Name\FullyQualified;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Rector\Transform\ValueObject\ReplaceAttribute;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\Transform\Rector\Attribute\ReplaceAttributeUseWithAnotherAttributeRector\ReplaceAttributeUseWithAnotherAttributeRectorTest
+ */
+class ReplaceAttributeUseWithAnotherAttributeRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ReplaceAttribute[]
+     */
+    private array $configuration;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replaces one attribute with another', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+class Foobar
+{
+    #[\Foobar('parameter')]
+    public $foobar;
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class Foobar
+{
+    #[\Barfoo('parameter')]
+    public $foobar;
+}
+CODE_SAMPLE
+                ,
+                [new ReplaceAttribute(new FullyQualified('Foobar'), new FullyQualified('Barfoo'))]
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Attribute::class];
+    }
+
+    /**
+     * @param Node\Attribute $node
+     */
+    public function refactor(Node $node): ?Attribute
+    {
+        foreach ($this->configuration as $item) {
+            if ($item->original->toString() === $node->name->toString()) {
+                return new Attribute($item->replacement, $node->args, []);
+            }
+        }
+
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, ReplaceAttribute::class);
+        $this->configuration = $configuration;
+    }
+}

--- a/rules/Transform/ValueObject/ReplaceAttribute.php
+++ b/rules/Transform/ValueObject/ReplaceAttribute.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Transform\ValueObject;
+
+use PhpParser\Node\Name\FullyQualified;
+
+class ReplaceAttribute
+{
+    public function __construct(
+        public FullyQualified $original,
+        public FullyQualified $replacement
+    ) {
+    }
+}


### PR DESCRIPTION
# Changes

- Adds a new transformation rule to be able to swap out Attributes
- Adds a value object for configuration with the rule
- Adds tests
- Updates the autogenerated docs

# Why

I've had a use case where one attribute was renamed/changed namespace due to collisions. Rather than making a rule for that specific case I thought it best to contribute this so it can be reused in a number of cases where an Attribute might be renamed.

Example:

```diff
 class Foobar
 {
-    #[\Foobar('parameter')]
+    #[\Barfoo('parameter')]
     public $foobar;
 }
```