### PR TITLE
Add `only_direct_assign` config for SimplifyUselessVariableRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/FixtureSkipConcat/skip_assign_ops.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/FixtureSkipConcat/skip_assign_ops.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector\Fixture;
+
+function () {
+    $b += 1;
+    return $b;
+};
+
+function () {
+    $e /= 1;
+    return $e;
+};
+
+function () {
+    $f **= 1;
+    return $f;
+};
+
+function () {
+    $m .= 1;
+    return $m;
+};

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/FixtureSkipConcat/skip_multi_concat_string.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/FixtureSkipConcat/skip_multi_concat_string.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector\Fixture;
+
+class SkipMultiConcatString
+{
+    public function run()
+    {
+        $content = 'Hello, ';
+        $content .= 'World!';
+
+        return $content;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/SkipConcatTest.php
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/SkipConcatTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SkipConcatTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureSkipConcat');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/skip_concat.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/config/skip_concat.php
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/config/skip_concat.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(SimplifyUselessVariableRector::class, [
+            SimplifyUselessVariableRector::ONLY_DIRECT_ASSIGN => true,
+        ]);
+};


### PR DESCRIPTION
When a variable is assigned using concatenation it should not simplify the variable.

This looks weird:
```diff
 $content = 'Hello, ';
-$content .= 'World!';

-return $content;
+return $content . 'World!';
```

It would be better to keep the original:
```php
$content = 'Hello, ';
$content .= 'World!';

return $content;
```