### PR TITLE
[Example Config] Use class reference instead of self:: on code example config to ease copy paste config 

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/FixtureWithLimit/skip_limited.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/FixtureWithLimit/skip_limited.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector\FixtureWithLimit;
+
+function skipLimited()
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/WithLimitTest.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/WithLimitTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class WithLimitTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureWithLimit');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_with_limit.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/config/configured_rule_with_limit.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector/config/configured_rule_with_limit.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\IncreaseDeclareStrictTypesRector;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(IncreaseDeclareStrictTypesRector::class, [
+        IncreaseDeclareStrictTypesRector::LIMIT => 0,
+    ]);

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -83,7 +83,7 @@ CODE_SAMPLE
                 [
                     'ClassName',
                     'AnotherClassName',
-                    self::SHOULD_KEEP_PRE_SLASH => false,
+                    StringClassNameToClassConstantRector::SHOULD_KEEP_PRE_SLASH => false,
                 ],
             ),
         ]);

--- a/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
+++ b/rules/Php74/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
@@ -83,7 +83,7 @@ class SomeClass
 CODE_SAMPLE
                     ,
                     [
-                        self::LIMIT_VALUE => 1_000_000,
+                        AddLiteralSeparatorToNumberRector::LIMIT_VALUE => 1_000_000,
                     ]
                 ),
             ]

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -115,8 +115,8 @@ class SomeClass
 CODE_SAMPLE
                     ,
                     [
-                        self::INLINE_PUBLIC => false,
-                        self::RENAME_PROPERTY => true,
+                        ClassPropertyAssignToConstructorPromotionRector::INLINE_PUBLIC => false,
+                        ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => true,
                     ]
                 ),
             ]

--- a/rules/Php81/Rector/Class_/SpatieEnumClassToEnumRector.php
+++ b/rules/Php81/Rector/Class_/SpatieEnumClassToEnumRector.php
@@ -66,7 +66,7 @@ enum StatusEnum : string
 CODE_SAMPLE
                 ,
                 [
-                    self::TO_UPPER_SNAKE_CASE => false,
+                    SpatieEnumClassToEnumRector::TO_UPPER_SNAKE_CASE => false,
                 ]
             ),
         ]);

--- a/rules/Php82/Rector/Param/AddSensitiveParameterAttributeRector.php
+++ b/rules/Php82/Rector/Param/AddSensitiveParameterAttributeRector.php
@@ -92,7 +92,7 @@ class SomeClass
 CODE_SAMPLE
                     ,
                     [
-                        self::SENSITIVE_PARAMETERS => ['password'],
+                        AddSensitiveParameterAttributeRector::SENSITIVE_PARAMETERS => ['password'],
                     ]
                 ),
 

--- a/rules/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector.php
+++ b/rules/Strict/Rector/BooleanNot/BooleanInBooleanNotRuleFixerRector.php
@@ -63,7 +63,7 @@ class SomeClass
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => true,
+                    BooleanInBooleanNotRuleFixerRector::TREAT_AS_NON_EMPTY => true,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
+++ b/rules/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector.php
@@ -62,7 +62,7 @@ final class SomeEmptyArray
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    DisallowedEmptyRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector.php
+++ b/rules/Strict/Rector/If_/BooleanInIfConditionRuleFixerRector.php
@@ -64,7 +64,7 @@ final class NegatedString
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    BooleanInIfConditionRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector.php
+++ b/rules/Strict/Rector/Ternary/BooleanInTernaryOperatorRuleFixerRector.php
@@ -55,7 +55,7 @@ final class ArrayCompare
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    BooleanInTernaryOperatorRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector.php
+++ b/rules/Strict/Rector/Ternary/DisallowedShortTernaryRuleFixerRector.php
@@ -58,7 +58,7 @@ final class ShortTernaryArray
 CODE_SAMPLE
                 ,
                 [
-                    self::TREAT_AS_NON_EMPTY => false,
+                    DisallowedShortTernaryRuleFixerRector::TREAT_AS_NON_EMPTY => false,
                 ]
             ),
         ]);

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictScalarReturnExprRector.php
@@ -86,7 +86,7 @@ final class SomeClass
 CODE_SAMPLE
                 ,
                 [
-                    self::HARD_CODED_ONLY => false,
+                    ReturnTypeFromStrictScalarReturnExprRector::HARD_CODED_ONLY => false,
                 ]
             ),
         ]);

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -99,7 +99,7 @@ final class SomeClass
 CODE_SAMPLE
                 ,
                 [
-                    self::INLINE_PUBLIC => false,
+                    TypedPropertyFromAssignsRector::INLINE_PUBLIC => false,
                 ]
             ),
         ]);

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/IncreaseDeclareStrictTypesRector.php
@@ -26,7 +26,7 @@ use Webmozart\Assert\Assert;
  */
 final class IncreaseDeclareStrictTypesRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    private const LIMIT = 'limit';
+    public const LIMIT = 'limit';
 
     private int $limit = 10;
 
@@ -58,7 +58,7 @@ function someFunction()
 CODE_SAMPLE
                     ,
                     [
-                        self::LIMIT => 10,
+                        IncreaseDeclareStrictTypesRector::LIMIT => 10,
                     ],
                 ),
             ]


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6035#pullrequestreview-2140382392 as they are public constant to copy on configure rector, something like:

```diff
    $rectorConfig
        ->ruleWithConfiguration(BooleanInTernaryOperatorRuleFixerRector::class, [
-            self::TREAT_AS_NON_EMPTY => false,
+            BooleanInTernaryOperatorRuleFixerRector::TREAT_AS_NON_EMPTY => false,
        ]);
```

`self` just pointed to invalid target class on rector config. 