### PR TITLE
 [TypeDeclaration] Add AddClosureNeverReturnTypeRector 

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/AddClosureNeverReturnTypeRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/AddClosureNeverReturnTypeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureNeverReturnTypeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector\Fixture;
+
+use Exception;
+
+final class Fixture
+{
+    public function run()
+    {
+        function () {
+            throw new Exception('test');
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector\Fixture;
+
+use Exception;
+
+final class Fixture
+{
+    public function run()
+    {
+        function (): never {
+            throw new Exception('test');
+        };
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/Fixture/skip_has_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/Fixture/skip_has_return.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector\Fixture;
+
+use Exception;
+
+final class SkipHasReturn
+{
+    public function run()
+    {
+        function () {
+            if (rand(0, 1)) {
+                throw new Exception('test');
+            }
+
+            return 1;
+        };
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddClosureNeverReturnTypeRector::class);
+    $rectorConfig->phpVersion(PhpVersionFeature::NEVER_TYPE);
+};

--- a/rules/TypeDeclaration/NodeManipulator/AddNeverReturnType.php
+++ b/rules/TypeDeclaration/NodeManipulator/AddNeverReturnType.php
@@ -1,0 +1,102 @@
+
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeManipulator;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\Throw_;
+use PHPStan\Analyser\Scope;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeNestingScope\ValueObject\ControlStructure;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\Reflection\ClassModifierChecker;
+use Rector\TypeDeclaration\NodeAnalyzer\NeverFuncCallAnalyzer;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+
+final class AddNeverReturnType
+{
+    public function __construct(
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+        private readonly ClassModifierChecker $classModifierChecker,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly NeverFuncCallAnalyzer $neverFuncCallAnalyzer,
+        private readonly NodeNameResolver $nodeNameResolver
+    )
+    {
+    }
+
+    public function add(ClassMethod|Function_|Closure $node, Scope $scope): ClassMethod|Function_|Closure|null
+    {
+        if ($this->shouldSkip($node, $scope)) {
+            return null;
+        }
+
+        $node->returnType = new Identifier('never');
+
+        return $node;
+    }
+
+    private function shouldSkip(ClassMethod | Function_ | Closure $node, Scope $scope): bool
+    {
+        if ($node->returnType instanceof Node && ! $this->nodeNameResolver->isName($node->returnType, 'void')) {
+            return true;
+        }
+
+        if ($this->hasReturnOrYields($node)) {
+            return true;
+        }
+
+        if (! $this->hasNeverNodesOrNeverFuncCalls($node)) {
+            return true;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scope
+        )) {
+            return true;
+        }
+
+        if (! $node->returnType instanceof Node) {
+            return false;
+        }
+
+        // skip as most likely intentional
+        if (! $this->classModifierChecker->isInsideFinalClass($node) && $this->nodeNameResolver->isName($node->returnType, 'void')) {
+            return true;
+        }
+
+        return $this->nodeNameResolver->isName($node->returnType, 'never');
+    }
+
+    private function hasReturnOrYields(ClassMethod|Function_|Closure $node): bool
+    {
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, Return_::class)) {
+            return true;
+        }
+
+        return $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
+            $node,
+            [Yield_::class, YieldFrom::class, ...ControlStructure::CONDITIONAL_NODE_SCOPE_TYPES]
+        );
+    }
+
+    private function hasNeverNodesOrNeverFuncCalls(ClassMethod|Function_|Closure $node): bool
+    {
+        $hasNeverNodes = $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, [Throw_::class]);
+        if ($hasNeverNodes) {
+            return true;
+        }
+
+        return $this->neverFuncCallAnalyzer->hasNeverFuncCall($node);
+    }
+}

--- a/rules/TypeDeclaration/NodeManipulator/AddNeverReturnType.php
+++ b/rules/TypeDeclaration/NodeManipulator/AddNeverReturnType.php
@@ -1,4 +1,3 @@
-
 <?php
 
 declare(strict_types=1);
@@ -22,16 +21,15 @@ use Rector\Reflection\ClassModifierChecker;
 use Rector\TypeDeclaration\NodeAnalyzer\NeverFuncCallAnalyzer;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 
-final class AddNeverReturnType
+final readonly class AddNeverReturnType
 {
     public function __construct(
-        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
-        private readonly ClassModifierChecker $classModifierChecker,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly NeverFuncCallAnalyzer $neverFuncCallAnalyzer,
-        private readonly NodeNameResolver $nodeNameResolver
-    )
-    {
+        private ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+        private ClassModifierChecker $classModifierChecker,
+        private BetterNodeFinder $betterNodeFinder,
+        private NeverFuncCallAnalyzer $neverFuncCallAnalyzer,
+        private NodeNameResolver $nodeNameResolver
+    ) {
     }
 
     public function add(ClassMethod|Function_|Closure $node, Scope $scope): ClassMethod|Function_|Closure|null
@@ -71,7 +69,10 @@ final class AddNeverReturnType
         }
 
         // skip as most likely intentional
-        if (! $this->classModifierChecker->isInsideFinalClass($node) && $this->nodeNameResolver->isName($node->returnType, 'void')) {
+        if (! $this->classModifierChecker->isInsideFinalClass($node) && $this->nodeNameResolver->isName(
+            $node->returnType,
+            'void'
+        )) {
             return true;
         }
 

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\Throw_;
+use PHPStan\Analyser\Scope;
+use Rector\NodeNestingScope\ValueObject\ControlStructure;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\Rector\AbstractScopeAwareRector;
+use Rector\Reflection\ClassModifierChecker;
+use Rector\TypeDeclaration\NodeAnalyzer\NeverFuncCallAnalyzer;
+use Rector\TypeDeclaration\NodeManipulator\AddNeverReturnType;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/noreturn_type
+ *
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddClosureNeverReturnTypeRector\AddClosureNeverReturnTypeRectorTest
+ */
+final class AddClosureNeverReturnTypeRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly AddNeverReturnType $addNeverReturnType
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add "never" return-type for closure that never return anything', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+function () {
+    throw new InvalidException();
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+function (): never {
+    throw new InvalidException();
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Closure::class];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
+    {
+        return $this->addNeverReturnType->add($node, $scope);
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::NEVER_TYPE;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureNeverReturnTypeRector.php
@@ -2,34 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Rector\TypeDeclaration\Rector\ClassMethod;
+namespace Rector\TypeDeclaration\Rector\Closure;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Expr\Yield_;
-use PhpParser\Node\Expr\YieldFrom;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
-use PhpParser\Node\Stmt\Return_;
-use PhpParser\Node\Stmt\Throw_;
 use PHPStan\Analyser\Scope;
-use Rector\NodeNestingScope\ValueObject\ControlStructure;
-use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractScopeAwareRector;
-use Rector\Reflection\ClassModifierChecker;
-use Rector\TypeDeclaration\NodeAnalyzer\NeverFuncCallAnalyzer;
 use Rector\TypeDeclaration\NodeManipulator\AddNeverReturnType;
 use Rector\ValueObject\PhpVersionFeature;
-use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @changelog https://wiki.php.net/rfc/noreturn_type
- *
- * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddClosureNeverReturnTypeRector\AddClosureNeverReturnTypeRectorTest
+ * @see \Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector\AddClosureNeverReturnTypeRectorTest
  */
 final class AddClosureNeverReturnTypeRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -38,6 +38,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromSymfonySerializerRec
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureUnionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
@@ -111,6 +112,7 @@ final class TypeDeclarationLevel
         TypedPropertyFromAssignsRector::class,
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
         ReturnTypeFromStrictFluentReturnRector::class,
+        AddClosureNeverReturnTypeRector::class,
         ReturnNeverTypeRector::class,
         StrictArrayParamDimFetchRector::class,
         StrictStringParamConcatRector::class,


### PR DESCRIPTION
Part of resolve this issue effort:

- https://github.com/rectorphp/rector/issues/8678 

Ref from PR comment:

- https://github.com/rectorphp/rector-src/pull/6029#issuecomment-2188731185

this PR extract `Closure` from `ReturnNeverTypeRector` into separate new rule: `AddClosureNeverReturnTypeRector` special for `Closure` only.