### PR TITLE
[DX] Deprecate dump-node command, use more advanced https://getrector.com/ast instead

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,7 @@ return RectorConfig::configure()
         naming: true,
         rectorPreset: true,
         // @experimental 2024-06
-        // twig: false,
+        // twig: true,
         phpunitCodeQuality: true
     )
     ->withPhpSets()

--- a/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector.php
+++ b/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector.php
@@ -86,7 +86,7 @@ function () {
 };
 CODE_SAMPLE
                 ,
-                 [
+                [
                     self::ONLY_DIRECT_ASSIGN => false,
                 ]
             ),

--- a/src/Bridge/SetProviderCollector.php
+++ b/src/Bridge/SetProviderCollector.php
@@ -25,9 +25,12 @@ final readonly class SetProviderCollector
      */
     private array $setProviders;
 
-    public function __construct()
+    /**
+     * @param SetProviderInterface[] $extraSetProviders
+     */
+    public function __construct(array $extraSetProviders = [])
     {
-        $this->setProviders = [
+        $setProviders = [
             // register all known set providers here
             new PHPSetProvider(),
             new CoreSetProvider(),
@@ -36,6 +39,8 @@ final readonly class SetProviderCollector
             new DoctrineSetProvider(),
             new TwigSetProvider(),
         ];
+
+        $this->setProviders = array_merge($setProviders, $extraSetProviders);
     }
 
     /**

--- a/src/Console/Command/DetectNodeCommand.php
+++ b/src/Console/Command/DetectNodeCommand.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 
 namespace Rector\Console\Command;
 
-use Rector\PhpParser\Parser\SimplePhpParser;
-use Rector\Util\NodePrinter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Throwable;
 
+/**
+ * @deprecated since 1.1.2 as too sensitive on correct output and unable to click through.
+ * Use dynamic, sharedable online version https://getrector.com/ast instead
+ */
 final class DetectNodeCommand extends Command
 {
     public function __construct(
-        private readonly SimplePhpParser $simplePhpParser,
-        private readonly NodePrinter $nodePrinter,
         private readonly SymfonyStyle $symfonyStyle
     ) {
         parent::__construct();
@@ -31,36 +29,13 @@ final class DetectNodeCommand extends Command
         $this->addOption('loop', null, InputOption::VALUE_NONE, 'Keep open so you can try multiple inputs');
 
         $this->setAliases(['dump-node']);
-
-        // @todo invoke https://github.com/matthiasnoback/php-ast-inspector/
-        // $this->addOption('file');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if ((bool) $input->getOption('loop')) {
-            while (true) {
-                $this->askQuestionAndDumpNode();
-            }
-        }
-
-        $this->askQuestionAndDumpNode();
+        $this->symfonyStyle->warning('This rule is deprecated as too sensitive on correct output and unable to click through.
+ Use dynamic, sharedable online version https://getrector.com/ast instead.');
 
         return self::SUCCESS;
-    }
-
-    private function askQuestionAndDumpNode(): void
-    {
-        $question = new Question('Write short PHP code snippet');
-        $phpContents = $this->symfonyStyle->askQuestion($question);
-
-        try {
-            $nodes = $this->simplePhpParser->parseString($phpContents);
-        } catch (Throwable) {
-            $this->symfonyStyle->warning('Provide valid PHP code');
-            return;
-        }
-
-        $this->nodePrinter->printNodes($nodes);
     }
 }

--- a/src/Console/Command/DetectNodeCommand.php
+++ b/src/Console/Command/DetectNodeCommand.php
@@ -33,8 +33,10 @@ final class DetectNodeCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->symfonyStyle->warning('This rule is deprecated as too sensitive on correct output and unable to click through.
- Use dynamic, sharedable online version https://getrector.com/ast instead.');
+        $this->symfonyStyle->warning(
+            'This rule is deprecated as too sensitive on correct output and unable to click through.
+ Use dynamic, sharedable online version https://getrector.com/ast instead.'
+        );
 
         return self::SUCCESS;
     }

--- a/src/Set/SetManager.php
+++ b/src/Set/SetManager.php
@@ -4,23 +4,18 @@ declare(strict_types=1);
 
 namespace Rector\Set;
 
+use Rector\Bridge\SetProviderCollector;
 use Rector\Composer\InstalledPackageResolver;
-use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\ValueObject\ComposerTriggeredSet;
-use Webmozart\Assert\Assert;
 
 /**
- * @see \Rector\Tests\Set\SetCollector\SetCollectorTest
+ * @see \Rector\Tests\Set\SetManager\SetManagerTest
  */
 final readonly class SetManager
 {
-    /**
-     * @param SetProviderInterface[] $setProviders
-     */
     public function __construct(
-        private array $setProviders
+        private SetProviderCollector $setProviderCollector
     ) {
-        Assert::allIsInstanceOf($setProviders, SetProviderInterface::class);
     }
 
     /**
@@ -30,15 +25,13 @@ final readonly class SetManager
     {
         $matchedSets = [];
 
-        foreach ($this->setProviders as $setProvider) {
-            foreach ($setProvider->provide() as $set) {
-                if (! $set instanceof ComposerTriggeredSet) {
-                    continue;
-                }
+        foreach ($this->setProviderCollector->provideSets() as $set) {
+            if (! $set instanceof ComposerTriggeredSet) {
+                continue;
+            }
 
-                if ($set->getGroupName() === $groupName) {
-                    $matchedSets[] = $set;
-                }
+            if ($set->getGroupName() === $groupName) {
+                $matchedSets[] = $set;
             }
         }
 

--- a/templates/rector.php.dist
+++ b/templates/rector.php.dist
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -11,6 +10,4 @@ __PATHS__
     ])
     // uncomment to reach your current PHP version
     // ->withPhpSets()
-    ->withRules([
-        AddVoidReturnTypeWhereNoReturnRector::class,
-    ]);
+    ->withTypeCoverageLevel(0);

--- a/tests/Set/SetManager/SetManagerTest.php
+++ b/tests/Set/SetManager/SetManagerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rector\Tests\Set\SetManager;
 
 use PHPUnit\Framework\TestCase;
+use Rector\Bridge\SetProviderCollector;
+use Rector\Set\Enum\SetGroup;
 use Rector\Set\SetManager;
 use Rector\Tests\Set\SetManager\Source\SomeSetProvider;
 
@@ -12,9 +14,11 @@ final class SetManagerTest extends TestCase
 {
     public function test(): void
     {
-        $setManager = new SetManager([new SomeSetProvider()]);
+        $setProviderCollector = new SetProviderCollector([new SomeSetProvider()]);
 
-        $twigComposerTriggeredSet = $setManager->matchComposerTriggered('twig');
-        $this->assertCount(1, $twigComposerTriggeredSet);
+        $setManager = new SetManager($setProviderCollector);
+
+        $twigComposerTriggeredSet = $setManager->matchComposerTriggered(SetGroup::TWIG);
+        $this->assertGreaterThan(6, count($twigComposerTriggeredSet));
     }
 }

--- a/tests/Set/SetManager/Source/SomeSetProvider.php
+++ b/tests/Set/SetManager/Source/SomeSetProvider.php
@@ -6,6 +6,7 @@ namespace Rector\Tests\Set\SetManager\Source;
 
 use Rector\Set\Contract\SetInterface;
 use Rector\Set\Contract\SetProviderInterface;
+use Rector\Set\Enum\SetGroup;
 use Rector\Set\ValueObject\ComposerTriggeredSet;
 use Rector\Symfony\Set\TwigSetList;
 
@@ -17,7 +18,7 @@ final class SomeSetProvider implements SetProviderInterface
     public function provide(): array
     {
         return [
-            new ComposerTriggeredSet('twig', 'twig/twig', '1.12', TwigSetList::TWIG_112)
+            new ComposerTriggeredSet(SetGroup::TWIG, 'twig/twig', '1.12', TwigSetList::TWIG_112)
         ];
     }
 }


### PR DESCRIPTION
I've added this command to give a quick feedback on a PHP code <-> node conversion.
This command has some limitations, as it can be run just once, the code has to be parsed as a whole and CLI is not the best GUI for clicking through nodes :)

**Since then we've added a page to solve this :tada:**
https://getrector.com/ast

Use the page instead . We'll soon add more features, thinking of shareable links, maybe even update a books links