### PR TITLE
[TypeDeclaration] Add AddClosureReturnTypeFromStrictParamRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/AddClosureReturnTypeFromStrictParamRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/AddClosureReturnTypeFromStrictParamRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureReturnTypeFromStrictParamRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/Fixture/skip_no_param_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/Fixture/skip_no_param_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector\Fixture;
+
+class SkipNoParamType
+{
+    public function doFoo() {
+        $c = function ($param) {
+            return $param;
+        };
+        return $c;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/Fixture/with_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/Fixture/with_closure.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector\Fixture;
 
 class WithClosure
 {
@@ -16,7 +16,7 @@ class WithClosure
 -----
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\Fixture;
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector\Fixture;
 
 class WithClosure
 {

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddClosureReturnTypeFromStrictParamRector::class);
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+};

--- a/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromParam.php
+++ b/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromParam.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeManipulator;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeTraverser;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+
+final readonly class AddReturnTypeFromParam
+{
+    public function __construct(
+        private NodeNameResolver $nodeNameResolver,
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
+        private ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+        private ReturnTypeInferer $returnTypeInferer
+    ) {
+    }
+
+    public function add(ClassMethod|Function_|Closure $node, Scope $scope): ClassMethod|Function_|Closure|null
+    {
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        if ($this->shouldSkipNode($node, $scope)) {
+            return null;
+        }
+
+        $return = $this->findCurrentScopeReturn($node->stmts);
+        if (! $return instanceof Return_ || ! $return->expr instanceof Expr) {
+            return null;
+        }
+
+        $returnName = $this->nodeNameResolver->getName($return->expr);
+        $stmts = $node->stmts;
+
+        foreach ($node->getParams() as $param) {
+            if (! $param->type instanceof Node) {
+                continue;
+            }
+
+            if ($this->shouldSkipParam($param, $stmts)) {
+                continue;
+            }
+
+            $paramName = $this->nodeNameResolver->getName($param);
+            if ($returnName !== $paramName) {
+                continue;
+            }
+
+            $node->returnType = $param->type;
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function findCurrentScopeReturn(array $stmts): ?Return_
+    {
+        $return = null;
+
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, static function (Node $node) use (
+            &$return
+        ): ?int {
+            // skip scope nesting
+            if ($node instanceof Class_ || $node instanceof FunctionLike) {
+                $return = null;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            if (! $node instanceof Return_) {
+                return null;
+            }
+
+            if (! $node->expr instanceof Variable) {
+                $return = null;
+                return NodeTraverser::STOP_TRAVERSAL;
+            }
+
+            $return = $node;
+            return null;
+        });
+
+        return $return;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function shouldSkipParam(Param $param, array $stmts): bool
+    {
+        $paramName = $this->nodeNameResolver->getName($param);
+        $isParamModified = false;
+
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($stmts, function (Node $node) use (
+            $paramName,
+            &$isParamModified
+        ): int|null {
+            // skip scope nesting
+            if ($node instanceof Class_ || $node instanceof FunctionLike) {
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            if ($node instanceof AssignRef && $this->nodeNameResolver->isName($node->expr, $paramName)) {
+                $isParamModified = true;
+                return NodeTraverser::STOP_TRAVERSAL;
+            }
+
+            if (! $node instanceof Assign) {
+                return null;
+            }
+
+            if (! $node->var instanceof Variable) {
+                return null;
+            }
+
+            if (! $this->nodeNameResolver->isName($node->var, $paramName)) {
+                return null;
+            }
+
+            $isParamModified = true;
+            return NodeTraverser::STOP_TRAVERSAL;
+        });
+
+        return $isParamModified;
+    }
+
+    private function shouldSkipNode(ClassMethod|Function_|Closure $node, Scope $scope): bool
+    {
+        if ($node->returnType !== null) {
+            return true;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scope
+        )) {
+            return true;
+        }
+
+        $returnType = $this->returnTypeInferer->inferFunctionLike($node);
+        if ($returnType instanceof MixedType) {
+            return true;
+        }
+
+        $returnType = TypeCombinator::removeNull($returnType);
+        return $returnType instanceof UnionType;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictParamRector.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Rector\TypeDeclaration\Rector\ClassMethod;
+namespace Rector\TypeDeclaration\Rector\Closure;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use Rector\Rector\AbstractScopeAwareRector;
 use Rector\TypeDeclaration\NodeManipulator\AddReturnTypeFromParam;
@@ -17,37 +15,31 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector\ReturnTypeFromStrictParamRectorTest
+ * @see \Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector\AddClosureReturnTypeFromStrictParamRectorTest
  */
-final class ReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
+final class AddClosureReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly AddReturnTypeFromParam $addReturnTypeFromParam,
+        private readonly AddReturnTypeFromParam $addReturnTypeFromParam
     ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add return type based on strict parameter type', [
+        return new RuleDefinition('Add closure return type based on strict parameter type', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-class SomeClass
+function(ParamType $item)
 {
-    public function resolve(ParamType $item)
-    {
-        return $item;
-    }
+    return $item;
 }
 CODE_SAMPLE
 
                 ,
                 <<<'CODE_SAMPLE'
-class SomeClass
+function(ParamType $item): ParamType
 {
-    public function resolve(ParamType $item): ParamType
-    {
-        return $item;
-    }
+    return $item;
 }
 CODE_SAMPLE
             ),
@@ -59,7 +51,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class, Function_::class];
+        return [Closure::class];
     }
 
     public function provideMinPhpVersion(): int
@@ -68,7 +60,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param ClassMethod|Function_|Closure $node
+     * @param Closure $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -39,6 +39,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureUnionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
@@ -104,6 +105,7 @@ final class TypeDeclarationLevel
         ReturnUnionTypeRector::class,
 
         // more risky rules
+        AddClosureReturnTypeFromStrictParamRector::class,
         ReturnTypeFromStrictParamRector::class,
         AddParamTypeFromPropertyTypeRector::class,
         MergeDateTimePropertyTypeDeclarationRector::class,


### PR DESCRIPTION
Part of resolve this issue effort:

- https://github.com/rectorphp/rector/issues/8678 

Ref from PR comment:

- https://github.com/rectorphp/rector-src/pull/6029#issuecomment-2188731185

this PR extract `Closure` from `ReturnTypeFromStrictParamRector` into separate new rule: `AddClosureReturnTypeFromStrictParamRector` special for `Closure` only.