### PR TITLE
[Naming] Handle used in arrow function param, then used again outer ArrowFunction on RenameParamToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_arrow_function_param.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_arrow_function_param.php.inc
@@ -5,6 +5,9 @@ namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fi
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Expr\Variable;
 
+/**
+ * @see https://3v4l.org/Ba9fQ
+ */
 class UsedInArrowFunctionParam
 {
     public function run(Foreach_ $node)
@@ -27,6 +30,9 @@ namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fi
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Expr\Variable;
 
+/**
+ * @see https://3v4l.org/Ba9fQ
+ */
 class UsedInArrowFunctionParam
 {
     public function run(Foreach_ $foreach)

--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_arrow_function_param.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_arrow_function_param.php.inc
@@ -13,6 +13,8 @@ class UsedInArrowFunctionParam
           fn (Variable $node) => $node,
           []
         );
+
+        var_dump($node);
     }
 }
 
@@ -33,6 +35,8 @@ class UsedInArrowFunctionParam
           fn (Variable $variable) => $variable,
           []
         );
+
+        var_dump($foreach);
     }
 }
 

--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_arrow_function_param.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_arrow_function_param.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Expr\Variable;
+
+class UsedInArrowFunctionParam
+{
+    public function run(Foreach_ $node)
+    {
+        array_map(
+          fn (Variable $node) => $node,
+          []
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Expr\Variable;
+
+class UsedInArrowFunctionParam
+{
+    public function run(Foreach_ $foreach)
+    {
+        array_map(
+          fn (Variable $variable) => $variable,
+          []
+        );
+    }
+}
+
+?>

--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_closure_param.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/used_in_closure_param.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Expr\Variable;
+
+class UsedInClosureParam
+{
+    public function run(Foreach_ $node)
+    {
+        array_map(
+          function (Variable $node) {
+            return $node;
+          },
+          []
+        );
+
+        var_dump($node);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Expr\Variable;
+
+class UsedInClosureParam
+{
+    public function run(Foreach_ $foreach)
+    {
+        array_map(
+          function (Variable $variable) {
+            return $variable;
+          },
+          []
+        );
+
+        var_dump($foreach);
+    }
+}
+
+?>

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Naming;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
@@ -69,7 +70,7 @@ final readonly class VariableRenamer
                     $currentStmt = $node;
                 }
 
-                if ($node instanceof Closure) {
+                if ($node instanceof Closure || $node instanceof ArrowFunction) {
                     $currentClosure = $node;
                 }
 
@@ -98,9 +99,9 @@ final readonly class VariableRenamer
         return $hasRenamed;
     }
 
-    private function isParamInParentFunction(Variable $variable, ?Closure $closure): bool
+    private function isParamInParentFunction(Variable $variable, null|Closure|ArrowFunction $functionLike): bool
     {
-        if (! $closure instanceof Closure) {
+        if (! $functionLike instanceof Closure && ! $functionLike instanceof ArrowFunction) {
             return false;
         }
 
@@ -109,7 +110,7 @@ final readonly class VariableRenamer
             return false;
         }
 
-        foreach ($closure->params as $param) {
+        foreach ($functionLike->params as $param) {
             if ($this->nodeNameResolver->isName($param, $variableName)) {
                 return true;
             }

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -43,7 +43,7 @@ final readonly class VariableRenamer
 
         $hasRenamed = false;
         $currentStmt = null;
-        $currentClosure = null;
+        $currentFunctionLike = null;
 
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             (array) $functionLike->getStmts(),
@@ -54,7 +54,7 @@ final readonly class VariableRenamer
                 &$isRenamingActive,
                 &$hasRenamed,
                 &$currentStmt,
-                &$currentClosure
+                &$currentFunctionLike
             ): int|null|Variable {
                 // skip param names
                 if ($node instanceof Param) {
@@ -70,8 +70,8 @@ final readonly class VariableRenamer
                     $currentStmt = $node;
                 }
 
-                if ($node instanceof Closure || $node instanceof ArrowFunction) {
-                    $currentClosure = $node;
+                if ($node instanceof FunctionLike) {
+                    $currentFunctionLike = $node;
                 }
 
                 if (! $node instanceof Variable) {
@@ -79,7 +79,7 @@ final readonly class VariableRenamer
                 }
 
                 // TODO: Should be implemented in BreakingVariableRenameGuard::shouldSkipParam()
-                if ($this->isParamInParentFunction($node, $currentClosure)) {
+                if ($this->isParamInParentFunction($node, $currentFunctionLike)) {
                     return null;
                 }
 
@@ -99,9 +99,9 @@ final readonly class VariableRenamer
         return $hasRenamed;
     }
 
-    private function isParamInParentFunction(Variable $variable, null|Closure|ArrowFunction $functionLike): bool
+    private function isParamInParentFunction(Variable $variable, ?FunctionLike $functionLike): bool
     {
-        if (! $functionLike instanceof Closure && ! $functionLike instanceof ArrowFunction) {
+        if (! $functionLike instanceof FunctionLike) {
             return false;
         }
 

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -11,10 +11,12 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
+use PHPStan\Analyser\MutatingScope;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Naming\PhpDoc\VarTagValueNodeRenamer;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
 final readonly class VariableRenamer
@@ -105,6 +107,15 @@ final readonly class VariableRenamer
 
         $variableName = $this->nodeNameResolver->getName($variable);
         if ($variableName === null) {
+            return false;
+        }
+
+        $scope = $variable->getAttribute(AttributeKey::SCOPE);
+        $functionLikeScope = $functionLike->getAttribute(AttributeKey::SCOPE);
+
+        if ($scope instanceof MutatingScope && $functionLikeScope instanceof MutatingScope && $scope->equals(
+            $functionLikeScope
+        )) {
             return false;
         }
 

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -108,7 +108,7 @@ final readonly class VariableRenamer
             return false;
         }
 
-        foreach ($functionLike->params as $param) {
+        foreach ($functionLike->getParams() as $param) {
             if ($this->nodeNameResolver->isName($param, $variableName)) {
                 return true;
             }

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Rector\Naming;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8693
Ref rectify error https://github.com/rectorphp/rector-src/pull/6045/commits/33ddf96050a1f96f91df42aca410038d509e53e9
Ref https://3v4l.org/Ba9fQ