### PR TITLE
Add `always` config for EncapsedStringsToSprintfRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/AlwaysSprintfTest.php
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/AlwaysSprintfTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AlwaysSprintfTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureAlwaysSprintf');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/always_sprintf.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/encapsed_strings_to_sprintf_should_escape_percent.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/encapsed_strings_to_sprintf_should_escape_percent.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class EncapsedStringsToSprintfShouldEscapePercent
+{
+    public function run(string $value)
+    {
+        return "$value%";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class EncapsedStringsToSprintfShouldEscapePercent
+{
+    public function run(string $value)
+    {
+        return sprintf('%s%%', $value);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/include_numbers.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/include_numbers.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class IncludeNumbers
+{
+    public function run(int $number)
+    {
+        return "value {$number}";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class IncludeNumbers
+{
+    public function run(int $number)
+    {
+        return sprintf('value %d', $number);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/just_value.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/just_value.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class JustValue
+{
+    public function testCommand(): void
+    {
+        $flag = 'hey';
+        $expected = ["--${flag}"];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class JustValue
+{
+    public function testCommand(): void
+    {
+        $flag = 'hey';
+        $expected = [sprintf('--%s', $flag)];
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/newline.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/newline.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class Newline
+{
+    public function run(string $format)
+    {
+        $result = "${format}\n";
+
+        $nextResult = "\n${format}";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class Newline
+{
+    public function run(string $format)
+    {
+        $result = $format . PHP_EOL;
+
+        $nextResult = PHP_EOL . $format;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/numberz.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/numberz.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class Numberz
+{
+    public function run(string $format, int $value, float $money)
+    {
+        return "Format {$format} from {$value} to {$money}";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class Numberz
+{
+    public function run(string $format, int $value, float $money)
+    {
+        return sprintf('Format %s from %d to %s', $format, $value, $money);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/only_three_concat.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/only_three_concat.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class OnlyThreeConcat
+{
+    public function run()
+    {
+        $url = "{$host}{$requestUri}{$more}";
+        return $url;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class OnlyThreeConcat
+{
+    public function run()
+    {
+        $url = $host . $requestUri . $more;
+        return $url;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/prefixed_eol.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/prefixed_eol.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class PrefixedEol
+{
+    public function run(string $format)
+    {
+        return "prefix $format\n";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class PrefixedEol
+{
+    public function run(string $format)
+    {
+        return sprintf('prefix %s%s', $format, PHP_EOL);
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/single_encapsed.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/single_encapsed.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class SingleEncapsed
+{
+    private $format = 'json';
+
+    public function run(string $format)
+    {
+        return "{$this->format}";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class SingleEncapsed
+{
+    private $format = 'json';
+
+    public function run(string $format)
+    {
+        return $this->format;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/skip_in_heredoc.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/skip_in_heredoc.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class SkipInHeredoc
+{
+    public function run(string $data)
+    {
+        $data = 'test';
+        $value = <<<CODE
+                            Some {$data}
+CODE;
+
+        echo $value;
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/skip_prefixed_multi_eol.php.inc
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/FixtureAlwaysSprintf/skip_prefixed_multi_eol.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector\FixtureAlwaysSprintf;
+
+final class SkipPrefixedMultiEol
+{
+    public function run(string $format)
+    {
+        return "prefix {$format}\n\n";
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/config/always_sprintf.php
+++ b/rules-tests/CodingStyle/Rector/Encapsed/EncapsedStringsToSprintfRector/config/always_sprintf.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(EncapsedStringsToSprintfRector::class, [
+            EncapsedStringsToSprintfRector::ALWAYS => true,
+        ]);
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8690

This makes it possible to always convert to sprintf.

@TomasVotruba @samsonasik Please let me know what you think. I need some inspiration for the config key.