### PR TITLE
[TypeDeclaration] Add AddClosureReturnTypeFromStrictNativeCallRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/AddClosureReturnTypeFromStrictNativeCallRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/AddClosureReturnTypeFromStrictNativeCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictNativeCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureReturnTypeFromStrictNativeCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/Fixture/return_date_time_format.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/Fixture/return_date_time_format.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictNativeCallRector\Fixture;
+
+final class ReturnDateTimeFormat
+{
+    public function run()
+    {
+        function () {
+            $dt = new \DateTime('now');
+            return $dt->format('Y-m-d');
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictNativeCallRector\Fixture;
+
+final class ReturnDateTimeFormat
+{
+    public function run()
+    {
+        function (): string {
+            $dt = new \DateTime('now');
+            return $dt->format('Y-m-d');
+        };
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/Fixture/skip_no_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/Fixture/skip_no_return.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictNativeCallRector\Fixture;
+
+final class ReturnDateTimeFormat
+{
+    public function run()
+    {
+        function () {
+            $dt = new \DateTime('now');
+            echo $dt->format('Y-m-d');
+        };
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictNativeCallRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddClosureReturnTypeFromStrictNativeCallRector::class);
+    $rectorConfig->phpVersion(PhpVersionFeature::SCALAR_TYPES);
+};

--- a/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromStrictNativeCall.php
+++ b/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromStrictNativeCall.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeManipulator;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\MixedType;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer\StrictNativeFunctionReturnTypeAnalyzer;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+
+final readonly class AddReturnTypeFromStrictNativeCall
+{
+    public function __construct(
+        private StaticTypeMapper $staticTypeMapper,
+        private StrictNativeFunctionReturnTypeAnalyzer $strictNativeFunctionReturnTypeAnalyzer,
+        private NodeTypeResolver $nodeTypeResolver,
+        private TypeFactory $typeFactory,
+        private ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+    ) {
+    }
+
+    public function add(ClassMethod|Function_|Closure $node, Scope $scope): ClassMethod|Function_|Closure|null
+    {
+        if ($node->returnType !== null) {
+            return null;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scope
+        )) {
+            return null;
+        }
+
+        $nativeCallLikes = $this->strictNativeFunctionReturnTypeAnalyzer->matchAlwaysReturnNativeCallLikes($node);
+        if ($nativeCallLikes === null) {
+            return null;
+        }
+
+        $callLikeTypes = [];
+        foreach ($nativeCallLikes as $nativeCallLike) {
+            $callLikeTypes[] = $this->nodeTypeResolver->getType($nativeCallLike);
+        }
+
+        $returnType = $this->typeFactory->createMixedPassedOrUnionTypeAndKeepConstant($callLikeTypes);
+        if ($returnType instanceof MixedType) {
+            return null;
+        }
+
+        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
+        if (! $returnTypeNode instanceof Node) {
+            return null;
+        }
+
+        $node->returnType = $returnTypeNode;
+        return $node;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromStrictNativeCallRector.php
@@ -2,11 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Rector\TypeDeclaration\Rector\ClassMethod;
+namespace Rector\TypeDeclaration\Rector\Closure;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Expr\Closure;
 use PHPStan\Analyser\Scope;
 use Rector\Rector\AbstractScopeAwareRector;
 use Rector\TypeDeclaration\NodeManipulator\AddReturnTypeFromStrictNativeCall;
@@ -16,9 +15,9 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector\ReturnTypeFromStrictNativeCallRectorTest
+ * @see \Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictNativeCallRector\AddClosureReturnTypeFromStrictNativeCallRectorTest
  */
-final class ReturnTypeFromStrictNativeCallRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
+final class AddClosureReturnTypeFromStrictNativeCallRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly AddReturnTypeFromStrictNativeCall $addReturnTypeFromStrictNativeCall
@@ -27,27 +26,21 @@ final class ReturnTypeFromStrictNativeCallRector extends AbstractScopeAwareRecto
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add strict return type based native function or native method', [
+        return new RuleDefinition('Add closure strict return type based native function or native method', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-final class SomeClass
-{
-    public function run()
-    {
-        return strlen('value');
-    }
-}
+function () {
+    $dt = new DateTime('now');
+    return $dt->format('Y-m-d');
+};
 CODE_SAMPLE
 
                 ,
                 <<<'CODE_SAMPLE'
-final class SomeClass
-{
-    public function run(): int
-    {
-        return strlen('value');
-    }
-}
+function (): string {
+    $dt = new DateTime('now');
+    return $dt->format('Y-m-d');
+};
 CODE_SAMPLE
             ),
         ]);
@@ -58,11 +51,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class, Function_::class];
+        return [Closure::class];
     }
 
     /**
-     * @param ClassMethod|Function_ $node
+     * @param Closure $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -40,6 +40,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictNativeCallRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureUnionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
@@ -94,6 +95,7 @@ final class TypeDeclarationLevel
 
         // php 7.4
         TypedPropertyFromStrictSetUpRector::class,
+        AddClosureReturnTypeFromStrictNativeCallRector::class,
         ReturnTypeFromStrictNativeCallRector::class,
         ReturnTypeFromStrictTypedCallRector::class,
         ChildDoctrineRepositoryClassTypeRector::class,


### PR DESCRIPTION
Part of resolve this issue effort:

- https://github.com/rectorphp/rector/issues/8678 

Ref from PR comment:

- https://github.com/rectorphp/rector-src/pull/6029#issuecomment-2188731185

this PR extract `Closure` from `ReturnTypeFromStrictNativeCallRector` into separate new rule: `AddClosureReturnTypeFromStrictNativeCallRector` special for `Closure` only.