### PR TITLE
[TypeDeclaration] Add AddClosureReturnTypeFromReturnCastRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/AddClosureReturnTypeFromReturnCastRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/AddClosureReturnTypeFromReturnCastRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureReturnTypeFromReturnCastRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/Fixture/cast_string_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/Fixture/cast_string_return.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector\Fixture;
+
+final class CastStringReturn
+{
+    public function run()
+    {
+        function ($param) {
+            return (string) $param;
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector\Fixture;
+
+final class CastStringReturn
+{
+    public function run()
+    {
+        function ($param): string {
+            return (string) $param;
+        };
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/Fixture/skip_no_cast_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/Fixture/skip_no_cast_return.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector\Fixture;
+
+final class SkipNoCastReturn
+{
+    public function run()
+    {
+        function ($param) {
+            return $param;
+        };
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddClosureReturnTypeFromReturnCastRector::class);
+    $rectorConfig->phpVersion(PhpVersionFeature::SCALAR_TYPES);
+};

--- a/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromCast.php
+++ b/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromCast.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeManipulator;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\UnionType;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+
+final readonly class AddReturnTypeFromCast
+{
+    public function __construct(
+        private BetterNodeFinder $betterNodeFinder,
+        private ReturnTypeInferer $returnTypeInferer,
+        private StaticTypeMapper $staticTypeMapper,
+        private ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+    ) {
+    }
+
+    public function add(ClassMethod|Function_|Closure $node, Scope $scope): ClassMethod|Function_|Closure|null
+    {
+        if ($node->returnType !== null) {
+            return null;
+        }
+
+        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
+            $node,
+            $scope
+        )) {
+            return null;
+        }
+
+        $hasNonCastReturn = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+            $node,
+            static fn (Node $subNode): bool => $subNode instanceof Return_ && ! $subNode->expr instanceof Cast
+        );
+
+        if ($hasNonCastReturn) {
+            return null;
+        }
+
+        $returnType = $this->returnTypeInferer->inferFunctionLike($node);
+        if ($returnType instanceof UnionType || $returnType->isVoid()->yes()) {
+            return null;
+        }
+
+        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
+        if (! $returnTypeNode instanceof Node) {
+            return null;
+        }
+
+        $node->returnType = $returnTypeNode;
+        return $node;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnCastRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnCastRector.php
@@ -5,20 +5,12 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Cast;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
-use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\UnionType;
-use Rector\PhpParser\Node\BetterNodeFinder;
-use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractScopeAwareRector;
-use Rector\StaticTypeMapper\StaticTypeMapper;
-use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\TypeDeclaration\NodeManipulator\AddReturnTypeFromCast;
 use Rector\ValueObject\PhpVersionFeature;
-use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -29,10 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnTypeFromReturnCastRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
-        private readonly ReturnTypeInferer $returnTypeInferer,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly StaticTypeMapper $staticTypeMapper
+        private readonly AddReturnTypeFromCast $addReturnTypeFromCast
     ) {
     }
 
@@ -78,46 +67,15 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class, Function_::class, Closure::class];
+        return [ClassMethod::class, Function_::class];
     }
 
     /**
-     * @param ClassMethod|Function_|Closure $node
+     * @param ClassMethod|Function_ $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
-        if ($node->returnType !== null) {
-            return null;
-        }
-
-        if ($node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
-            $node,
-            $scope
-        )) {
-            return null;
-        }
-
-        $hasNonCastReturn = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
-            $node,
-            static fn (Node $subNode): bool => $subNode instanceof Return_ && ! $subNode->expr instanceof Cast
-        );
-
-        if ($hasNonCastReturn) {
-            return null;
-        }
-
-        $returnType = $this->returnTypeInferer->inferFunctionLike($node);
-        if ($returnType instanceof UnionType || $returnType->isVoid()->yes()) {
-            return null;
-        }
-
-        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
-        if (! $returnTypeNode instanceof Node) {
-            return null;
-        }
-
-        $node->returnType = $returnTypeNode;
-        return $node;
+        return $this->addReturnTypeFromCast->add($node, $scope);
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector.php
@@ -8,38 +8,35 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PHPStan\Analyser\Scope;
 use Rector\Rector\AbstractScopeAwareRector;
-use Rector\TypeDeclaration\NodeManipulator\AddReturnTypeFromParam;
+use Rector\TypeDeclaration\NodeManipulator\AddReturnTypeFromCast;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector\AddClosureReturnTypeFromStrictParamRectorTest
+ * @see \Rector\Tests\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector\AddClosureReturnTypeFromReturnCastRectorTest
  */
-final class AddClosureReturnTypeFromStrictParamRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
+final class AddClosureReturnTypeFromReturnCastRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly AddReturnTypeFromParam $addReturnTypeFromParam
+        private readonly AddReturnTypeFromCast $addReturnTypeFromCast
     ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add closure return type based on strict parameter type', [
+        return new RuleDefinition('Add return type to closure like with return cast', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-function(ParamType $item)
-{
-    return $item;
+function ($param) {
+    return (string) $param;
 };
 CODE_SAMPLE
-
                 ,
                 <<<'CODE_SAMPLE'
-function(ParamType $item): ParamType
-{
-    return $item;
+function ($param): string {
+    return (string) $param;
 };
 CODE_SAMPLE
             ),
@@ -54,16 +51,16 @@ CODE_SAMPLE
         return [Closure::class];
     }
 
-    public function provideMinPhpVersion(): int
-    {
-        return PhpVersionFeature::NULLABLE_TYPE;
-    }
-
     /**
      * @param Closure $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
-        return $this->addReturnTypeFromParam->add($node, $scope);
+        return $this->addReturnTypeFromCast->add($node, $scope);
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::SCALAR_TYPES;
     }
 }

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureReturnTypeFromReturnCastRector.php
@@ -26,7 +26,7 @@ final class AddClosureReturnTypeFromReturnCastRector extends AbstractScopeAwareR
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add return type to closure like with return cast', [
+        return new RuleDefinition('Add return type to closure with return cast', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 function ($param) {

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureUnionReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureUnionReturnTypeRector.php
@@ -35,7 +35,7 @@ function () {
     }
 
     return 'one';
-}
+};
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
@@ -45,7 +45,7 @@ function (): int|string {
     }
 
     return 'one';
-}
+};
 CODE_SAMPLE
             ),
         ]);

--- a/rules/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/AddClosureVoidReturnTypeWhereNoReturnRector.php
@@ -30,13 +30,13 @@ final class AddClosureVoidReturnTypeWhereNoReturnRector extends AbstractRector i
             new CodeSample(
                 <<<'CODE_SAMPLE'
 function () {
-}
+};
 CODE_SAMPLE
 
                 ,
                 <<<'CODE_SAMPLE'
 function (): void {
-}
+};
 CODE_SAMPLE
             ),
         ]);

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -39,6 +39,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
+use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromReturnCastRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeFromStrictParamRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureUnionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
@@ -75,6 +76,7 @@ final class TypeDeclarationLevel
         ReturnTypeFromStrictScalarReturnExprRector::class,
         ReturnTypeFromReturnDirectArrayRector::class,
         ReturnTypeFromReturnNewRector::class,
+        AddClosureReturnTypeFromReturnCastRector::class,
         ReturnTypeFromReturnCastRector::class,
         ReturnTypeFromSymfonySerializerRector::class,
 


### PR DESCRIPTION
Part of resolve this issue effort:

- https://github.com/rectorphp/rector/issues/8678 

Ref from PR comment:

- https://github.com/rectorphp/rector-src/pull/6029#issuecomment-2188731185

this PR extract `Closure` from `ReturnTypeFromReturnCastRector` into separate new rule: `AddClosureReturnTypeFromReturnCastRector` special for `Closure` only.