### PR TITLE
[NodeTypeResolver] Clean up unreachableStatementNode flag flip-flop check on NodeScopeAndMetadataDecorator

### DIFF
--- a/src/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/src/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -8,9 +8,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
-use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 use Rector\PhpParser\NodeTraverser\FileWithoutNamespaceNodeTraverser;
-use Rector\PHPStan\NodeVisitor\UnreachableStatementNodeVisitor;
 
 final class NodeScopeAndMetadataDecorator
 {
@@ -19,7 +17,6 @@ final class NodeScopeAndMetadataDecorator
     public function __construct(
         CloningVisitor $cloningVisitor,
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
-        private readonly ScopeFactory $scopeFactory,
         private readonly FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser
     ) {
         $this->nodeTraverser = new NodeTraverser();
@@ -36,28 +33,6 @@ final class NodeScopeAndMetadataDecorator
     {
         $stmts = $this->fileWithoutNamespaceNodeTraverser->traverse($stmts);
         $stmts = $this->phpStanNodeScopeResolver->processNodes($stmts, $filePath);
-
-        if ($this->phpStanNodeScopeResolver->hasUnreachableStatementNode()) {
-            $unreachableStatementNodeVisitor = new UnreachableStatementNodeVisitor(
-                $this->phpStanNodeScopeResolver,
-                $filePath,
-                $this->scopeFactory
-            );
-            $this->nodeTraverser->addVisitor($unreachableStatementNodeVisitor);
-
-            $stmts = $this->nodeTraverser->traverse($stmts);
-
-            /**
-             * immediate remove UnreachableStatementNodeVisitor after traverse to avoid
-             * re-used in nodeTraverser property in next file
-             */
-            $this->nodeTraverser->removeVisitor($unreachableStatementNodeVisitor);
-
-            // next file must be init hasUnreachableStatementNode to be false again
-            $this->phpStanNodeScopeResolver->resetHasUnreachableStatementNode();
-
-            return $stmts;
-        }
 
         return $this->nodeTraverser->traverse($stmts);
     }

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -13,14 +13,13 @@ use PHPStan\Analyser\Scope;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
-use Rector\NodeTypeResolver\PHPStan\Scope\ScopeFactory;
 
 final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 {
     public function __construct(
         private readonly PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         private readonly string $filePath,
-        private readonly ScopeFactory $scopeFactory
+        private readonly MutatingScope $mutatingScope
     ) {
     }
 
@@ -59,8 +58,6 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 
     private function resolveScope(?Scope $mutatingScope): MutatingScope
     {
-        return $mutatingScope instanceof MutatingScope ? $mutatingScope : $this->scopeFactory->createFromFile(
-            $this->filePath
-        );
+        return $mutatingScope instanceof MutatingScope ? $mutatingScope : $this->mutatingScope;
     }
 }


### PR DESCRIPTION
instead of flip-flop flag property, use local variable by reference instead to verify it.