### PR TITLE
[Printer] Remove AlwaysRememberedExpr check on BetterStandardPrinter

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -264,13 +264,14 @@ final class PHPStanNodeScopeResolver
         $this->nodeScopeResolverProcessNodes($stmts, $scope, $nodeCallback);
 
         $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor(new WrappedNodeRestoringNodeVisitor());
         $nodeTraverser->addVisitor(new ExprScopeFromStmtNodeVisitor($this, $filePath, $scope));
 
         if ($hasUnreachableStatementNode) {
             $nodeTraverser->addVisitor(new UnreachableStatementNodeVisitor($this, $filePath, $scope));
         }
 
+        // wrap node on last to avoid PHPStan Virtual node re-added
+        $nodeTraverser->addVisitor(new WrappedNodeRestoringNodeVisitor());
         $nodeTraverser->traverse($stmts);
 
         return $stmts;

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -27,7 +27,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\PrettyPrinter\Standard;
-use PHPStan\Node\Expr\AlwaysRememberedExpr;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -132,10 +131,6 @@ final class BetterStandardPrinter extends Standard
 
     protected function p(Node $node, $parentFormatPreserved = false): string
     {
-        while ($node instanceof AlwaysRememberedExpr) {
-            $node = $node->getExpr();
-        }
-
         $content = parent::p($node, $parentFormatPreserved);
 
         return $node->getAttribute(AttributeKey::WRAPPED_IN_PARENTHESES) === true


### PR DESCRIPTION
Previously, we have `AlwaysRememberedExpr` check on `BetterStandardPrinter`, which strange, it seems due to it maybe re-added after wrapped due to `WrappedNodeRestoringNodeVisitor` added too early, instead, add on the last.