### PR TITLE
Skip files with short <?= PHP tag as leads to invalid changes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -300,3 +300,8 @@ parameters:
         -
             message: '#Parameters should have "PhpParser\\Node\\Stmt\\ClassMethod" types as the only types passed to this method#'
             path: src/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+
+        # on purpose to allow checking broken symlinks on windows
+        -
+            message: '#"@file_get_contents\(\$file\)" is forbidden to use#'
+            path: src/FileSystem/FilesFinder.php

--- a/src/Caching/UnchangedFilesFilter.php
+++ b/src/Caching/UnchangedFilesFilter.php
@@ -17,7 +17,7 @@ final readonly class UnchangedFilesFilter
      * @param string[] $filePaths
      * @return string[]
      */
-    public function filterFileInfos(array $filePaths): array
+    public function filterFilePaths(array $filePaths): array
     {
         $changedFileInfos = [];
 

--- a/src/PostRector/Rector/NameImportingPostRector.php
+++ b/src/PostRector/Rector/NameImportingPostRector.php
@@ -92,15 +92,7 @@ final class NameImportingPostRector extends AbstractPostRector
         }
 
         $currentStmt = current($firstStmt->stmts);
-
-        if ($currentStmt instanceof InlineHTML || $currentStmt === false) {
-            return true;
-        }
-
-        $oldTokens = $file->getOldTokens();
-        $tokenStartPos = $currentStmt->getStartTokenPos();
-
-        return isset($oldTokens[$tokenStartPos][1]) && $oldTokens[$tokenStartPos][1] === '<?=';
+        return $currentStmt instanceof InlineHTML || $currentStmt === false;
     }
 
     private function processNodeName(FullyQualified $fullyQualified, File $file): ?Node

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -20,10 +20,13 @@ final class FilesFinderTest extends AbstractLazyTestCase
         $this->filesFinder = $this->make(FilesFinder::class);
     }
 
-    public function testDefault(): void
+    public function test(): void
     {
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithSymlinks'], ['txt']);
         $this->assertCount(1, $foundFiles);
+
+        $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithShortEchoes'], ['php']);
+        $this->assertCount(0, $foundFiles);
     }
 
     public function testWithFollowingBrokenSymlinks(): void

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -31,6 +31,13 @@ final class FilesFinderTest extends AbstractLazyTestCase
 
     public function testWithFollowingBrokenSymlinks(): void
     {
+        // detect Windows
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped(
+                'This test fails on Windows, due to possible bug in symfony/finder. When Finder is applied on broken symlinks and uses ->notContains(). Fix needed.'
+            );
+        }
+
         SimpleParameterProvider::setParameter(Option::SKIP, [__DIR__ . '/../SourceWithBrokenSymlinks/folder1']);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithBrokenSymlinks']);

--- a/tests/FileSystem/FilesFinder/SourceWithShortEchoes/SomeFileWithShortOpen.php
+++ b/tests/FileSystem/FilesFinder/SourceWithShortEchoes/SomeFileWithShortOpen.php
@@ -1,2 +1,2 @@
-hello
 <?= $world ?>
+hello

--- a/tests/FileSystem/FilesFinder/SourceWithShortEchoes/SomeFileWithShortOpen.php
+++ b/tests/FileSystem/FilesFinder/SourceWithShortEchoes/SomeFileWithShortOpen.php
@@ -1,0 +1,2 @@
+hello
+<?= $world ?>

--- a/tests/Issues/AutoImport/Fixture/skip_short_open_tag.php.inc
+++ b/tests/Issues/AutoImport/Fixture/skip_short_open_tag.php.inc
@@ -1,1 +1,0 @@
-<?= ns\Class::method() ?>


### PR DESCRIPTION
Currently, PHP allows to use `<?=` tags intead of typical `<?php ...`: https://www.php.net/manual/en/language.basic-syntax.phptags.php

Yet, such tags would lead to breaking changes like:

```diff
+<?php
+
+declare(strict_types=1);
 <?= $something ?>
```

We currently skip this on importing files, but we should not process such files at all, to avoid breaking code.

<br>

Use php-cs-fixer rule https://cs.symfony.com/doc/rules/php_tag/echo_tag_syntax.html to migrate your short tags. Then use Rector safely :+1: 