### PR TITLE
Make loading of post rectors conditional, to avoid traversing with disabled features

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -10,6 +10,7 @@ use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\RectorConfigBuilder;
 use Rector\Contract\DependencyInjection\RelatedConfigInterface;
+use Rector\Contract\DependencyInjection\ResetableInterface;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\DependencyInjection\Laravel\ContainerMemento;
@@ -37,7 +38,7 @@ final class RectorConfig extends Container
     /**
      * @var string[]
      */
-    private array $autotagInterfaces = [Command::class];
+    private array $autotagInterfaces = [Command::class, ResetableInterface::class];
 
     public static function configure(): RectorConfigBuilder
     {


### PR DESCRIPTION
Currently, all post rectors run traverse and get into `enterNode()`, even if disabled. Instead, we should avoid traversing with them in the first place :+1:  This PR fixes it

Split of https://github.com/rectorphp/rector-src/pull/6049