### PR TITLE
[Windows] Fix windows filter files with `<?=` start content on FilesFinder

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -301,7 +301,3 @@ parameters:
             message: '#Parameters should have "PhpParser\\Node\\Stmt\\ClassMethod" types as the only types passed to this method#'
             path: src/VendorLocker/ParentClassMethodTypeOverrideGuard.php
 
-        # on purpose to allow checking broken symlinks on windows
-        -
-            message: '#"@file_get_contents\(\$file\)" is forbidden to use#'
-            path: src/FileSystem/FilesFinder.php

--- a/src/FileSystem/FileAndDirectoryFilter.php
+++ b/src/FileSystem/FileAndDirectoryFilter.php
@@ -15,7 +15,7 @@ final class FileAndDirectoryFilter
      */
     public function filterDirectories(array $filesAndDirectories): array
     {
-        $directories = array_filter($filesAndDirectories, static fn (string $path): bool => is_dir($path));
+        $directories = array_filter($filesAndDirectories, static fn (string $path): bool => is_dir($path) && realpath($path) !== false);
 
         return array_values($directories);
     }
@@ -26,7 +26,7 @@ final class FileAndDirectoryFilter
      */
     public function filterFiles(array $filesAndDirectories): array
     {
-        $files = array_filter($filesAndDirectories, static fn (string $path): bool => is_file($path));
+        $files = array_filter($filesAndDirectories, static fn (string $path): bool => is_file($path) && realpath($path) !== false);
 
         return array_values($files);
     }

--- a/src/FileSystem/FileAndDirectoryFilter.php
+++ b/src/FileSystem/FileAndDirectoryFilter.php
@@ -15,7 +15,10 @@ final class FileAndDirectoryFilter
      */
     public function filterDirectories(array $filesAndDirectories): array
     {
-        $directories = array_filter($filesAndDirectories, static fn (string $path): bool => is_dir($path) && realpath($path) !== false);
+        $directories = array_filter(
+            $filesAndDirectories,
+            static fn (string $path): bool => is_dir($path) && realpath($path) !== false
+        );
 
         return array_values($directories);
     }
@@ -26,7 +29,10 @@ final class FileAndDirectoryFilter
      */
     public function filterFiles(array $filesAndDirectories): array
     {
-        $files = array_filter($filesAndDirectories, static fn (string $path): bool => is_file($path) && realpath($path) !== false);
+        $files = array_filter(
+            $filesAndDirectories,
+            static fn (string $path): bool => is_file($path) && realpath($path) !== false
+        );
 
         return array_values($files);
     }

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\FileSystem;
 
+use Nette\Utils\FileSystem;
 use Rector\Caching\UnchangedFilesFilter;
 use Rector\Skipper\Skipper\PathSkipper;
 use Symfony\Component\Finder\Finder;
@@ -40,12 +41,7 @@ final readonly class FilesFinder
 
         // exclude short "<?=" tags as lead to invalid changes
         $files = array_filter($files, static function (string $file): bool {
-            // @ on purpose to deal with broken symlinks
-            $fileContents = @file_get_contents($file);
-            if (! is_string($fileContents)) {
-                return true;
-            }
-
+            $fileContents = FileSystem::read($file);
             return ! str_starts_with($fileContents, '<?=');
         });
 

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -31,13 +31,6 @@ final class FilesFinderTest extends AbstractLazyTestCase
 
     public function testWithFollowingBrokenSymlinks(): void
     {
-        // detect Windows
-        if (DIRECTORY_SEPARATOR === '\\') {
-            $this->markTestSkipped(
-                'This test fails on Windows, due to possible bug in symfony/finder. When Finder is applied on broken symlinks and uses ->notContains(). Fix needed.'
-            );
-        }
-
         SimpleParameterProvider::setParameter(Option::SKIP, [__DIR__ . '/../SourceWithBrokenSymlinks/folder1']);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithBrokenSymlinks']);


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6068#issuecomment-2197141269