### PR TITLE
Remove union type mapper narrower, as no longer needed

### DIFF
--- a/src/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeCommonTypeNarrower.php
+++ b/src/PHPStanStaticTypeMapper/TypeAnalyzer/UnionTypeCommonTypeNarrower.php
@@ -44,25 +44,6 @@ final readonly class UnionTypeCommonTypeNarrower
     ) {
     }
 
-    public function narrowToSharedObjectType(UnionType $unionType): ?ObjectType
-    {
-        $sharedTypes = $this->narrowToSharedTypes($unionType);
-
-        if ($sharedTypes !== []) {
-            foreach (self::PRIORITY_TYPES as $winningType => $groupTypes) {
-                $intersectedGroupTypes = array_intersect($groupTypes, $sharedTypes);
-                if ($intersectedGroupTypes === $groupTypes) {
-                    return new ObjectType($winningType);
-                }
-            }
-
-            $firstSharedType = $sharedTypes[0];
-            return new ObjectType($firstSharedType);
-        }
-
-        return null;
-    }
-
     public function narrowToGenericClassStringType(UnionType $unionType): UnionType | GenericClassStringType
     {
         $availableTypes = [];
@@ -93,35 +74,6 @@ final readonly class UnionTypeCommonTypeNarrower
         }
 
         return $unionType;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function narrowToSharedTypes(UnionType $unionType): array
-    {
-        $availableTypes = [];
-
-        foreach ($unionType->getTypes() as $unionedType) {
-            if (! $unionedType instanceof ObjectType) {
-                return [];
-            }
-
-            $typeClassReflections = $this->resolveClassParentClassesAndInterfaces($unionedType);
-            $typeClassNames = [];
-
-            foreach ($typeClassReflections as $typeClassReflection) {
-                $typeClassNames[] = $typeClassReflection->getName();
-            }
-
-            if ($typeClassNames === []) {
-                continue;
-            }
-
-            $availableTypes[] = $typeClassNames;
-        }
-
-        return $this->narrowAvailableTypes($availableTypes);
     }
 
     /**


### PR DESCRIPTION
Couple of services were used in array shapes to narrow to minimal shared type. Those were buggy and removed in Rector 0.15 - https://getrector.com/blog/new-in-rector-015-complete-safe-and-known-type-declarations

These are leftovers :)