### PR TITLE
Remove direct Name support from getType(), as name is never a type

### DIFF
--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -14,8 +14,6 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Ternary;
-use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\UnionType as NodeUnionType;
@@ -127,10 +125,6 @@ final class NodeTypeResolver
 
     public function getType(Node $node): Type
     {
-        if ($node instanceof Name && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
-            return $this->getType(new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME)));
-        }
-
         if ($node instanceof NullableType) {
             $type = $this->getType($node->type);
 


### PR DESCRIPTION
The https://github.com/rectorphp/rector-src/pull/5947 introduced a direct `Name` to type conversion in `getType()`. The `Name` is not a type, but only a class-string.

Using `Name` as a type leads to bugs: https://github.com/rectorphp/rector-src/pull/6087

We should resolve only exprs or type nodes.