### PR TITLE
[NodeTypeResolver] Move namespaced name check into specific NameTypeResolver

### DIFF
--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;

--- a/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadInstanceOfRector.php
@@ -158,10 +158,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $instanceof->class instanceof FullyQualified) {
-            return null;
-        }
-
         $exprType = $this->nodeTypeResolver->getNativeType($instanceof->expr);
         if (! $exprType instanceof ObjectType) {
             return null;

--- a/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
@@ -37,7 +37,7 @@ final class NameTypeResolver implements NodeTypeResolverInterface
      */
     public function resolve(Node $node): Type
     {
-        if ($node instanceof Name && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
+        if (! $node instanceof FullyQualified && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
             return $this->resolve(new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME)));
         }
 

--- a/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
@@ -37,7 +37,7 @@ final class NameTypeResolver implements NodeTypeResolverInterface
      */
     public function resolve(Node $node): Type
     {
-        // not instanceof FullyQualified it is a Name
+        // not instanceof FullyQualified means it is a Name
         if (! $node instanceof FullyQualified && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
             return $this->resolve(new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME)));
         }

--- a/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
@@ -37,6 +37,10 @@ final class NameTypeResolver implements NodeTypeResolverInterface
      */
     public function resolve(Node $node): Type
     {
+        if ($node instanceof Name && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
+            return $this->resolve(new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME)));
+        }
+
         if ($node->toString() === ObjectReference::PARENT) {
             return $this->resolveParent($node);
         }

--- a/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php
@@ -37,6 +37,7 @@ final class NameTypeResolver implements NodeTypeResolverInterface
      */
     public function resolve(Node $node): Type
     {
+        // not instanceof FullyQualified it is a Name
         if (! $node instanceof FullyQualified && $node->hasAttribute(AttributeKey::NAMESPACED_NAME)) {
             return $this->resolve(new FullyQualified($node->getAttribute(AttributeKey::NAMESPACED_NAME)));
         }

--- a/tests/NodeTypeResolver/PerNodeTypeResolver/NameTypeResolver/NameTypeResolverTest.php
+++ b/tests/NodeTypeResolver/PerNodeTypeResolver/NameTypeResolver/NameTypeResolverTest.php
@@ -37,4 +37,15 @@ final class NameTypeResolverTest extends AbstractNodeTypeResolverTestCase
         # test new
         yield [__DIR__ . '/Source/ParentCall.php', 2, $expectedFullyQualifiedObjectType];
     }
+
+    public function testShortNameNode(): void
+    {
+        $objectType = new FullyQualifiedObjectType(AnotherClass::class);
+        $nameNode = $objectType->getShortNameNode();
+
+        $resolvedType = $this->nodeTypeResolver->getType($nameNode);
+        $expectedFullyQualifiedObjectType = new FullyQualifiedObjectType(AnotherClass::class);
+
+        $this->assertEquals($expectedFullyQualifiedObjectType, $resolvedType);
+    }
 }


### PR DESCRIPTION
Ref review comment https://github.com/rectorphp/rector-src/pull/6089#issuecomment-2199362950

`Name` can be a type, and we have `NameTypeResolver`

https://github.com/rectorphp/rector-src/blob/ef333502fb722ef471049b492a257781d02d0d62/src/NodeTypeResolver/NodeTypeResolver/NameTypeResolver.php#L25-L33

The `namespaced_name` attribute was only working on `NullableType` type, thats why PR https://github.com/rectorphp/rector-src/pull/5947 added to work recursively to get short name support, eg: alias name, which never be FullyQualified.

The `getType()` method works on recursive way in nodes:

https://github.com/rectorphp/rector-src/blob/ef333502fb722ef471049b492a257781d02d0d62/src/NodeTypeResolver/NodeTypeResolver.php#L126-L129

For `Expr` only, there is `getNativeType()` for `Expr` only, but for `getType()`, there is list supported type resolvers:

https://github.com/rectorphp/rector-src/tree/main/src/NodeTypeResolver/NodeTypeResolver