### PR TITLE
Grammar fix

### DIFF
--- a/e2e/applied-polyfill-php80/expected-output.diff
+++ b/e2e/applied-polyfill-php80/expected-output.diff
@@ -18,4 +18,4 @@ Applied rules:
  * StrStartsWithRector
 
 
- [OK] 1 file would have changed (dry-run) by Rector
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/applied-rule-change-docblock/expected-output.diff
+++ b/e2e/applied-rule-change-docblock/expected-output.diff
@@ -37,4 +37,4 @@ Applied rules:
  * RemoveUselessVarTagRector
 
 
- [OK] 2 files would have changed (dry-run) by Rector
+ [OK] 2 files would have been changed (dry-run) by Rector

--- a/e2e/applied-rule-removed-node-with-cache/expected-output.diff
+++ b/e2e/applied-rule-removed-node-with-cache/expected-output.diff
@@ -37,4 +37,4 @@ Applied rules:
  * RemoveEmptyClassMethodRector
 
 
- [OK] 2 files would have changed (dry-run) by Rector
+ [OK] 2 files would have been changed (dry-run) by Rector

--- a/e2e/applied-rule-removed-node/expected-output.diff
+++ b/e2e/applied-rule-removed-node/expected-output.diff
@@ -37,4 +37,4 @@ Applied rules:
  * RemoveEmptyClassMethodRector
 
 
- [OK] 2 files would have changed (dry-run) by Rector
+ [OK] 2 files would have been changed (dry-run) by Rector

--- a/e2e/applied-rule-return-array-nodes/expected-output.diff
+++ b/e2e/applied-rule-return-array-nodes/expected-output.diff
@@ -44,4 +44,4 @@ Applied rules:
  * RemoveAlwaysElseRector
 
 
- [OK] 2 files would have changed (dry-run) by Rector
+ [OK] 2 files would have been changed (dry-run) by Rector

--- a/e2e/different-path-over-skip-config/expected-output.diff
+++ b/e2e/different-path-over-skip-config/expected-output.diff
@@ -18,4 +18,4 @@ Applied rules:
  * RemoveEmptyClassMethodRector
 
 
- [OK] 1 file would have changed (dry-run) by Rector
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/no-parallel-reflection-resolver/expected-output.diff
+++ b/e2e/no-parallel-reflection-resolver/expected-output.diff
@@ -31,4 +31,4 @@ Applied rules:
  * RemoveUnusedPrivatePropertyRector
 
 
- [OK] 2 files would have changed (dry-run) by Rector
+ [OK] 2 files would have been changed (dry-run) by Rector

--- a/e2e/parallel-custom-config/expected-output.diff
+++ b/e2e/parallel-custom-config/expected-output.diff
@@ -19,4 +19,4 @@ Applied rules:
  * DowngradeReadonlyPropertyRector
 
 
- [OK] 1 file would have changed (dry-run) by Rector
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/parallel-reflection-resolver/expected-output.diff
+++ b/e2e/parallel-reflection-resolver/expected-output.diff
@@ -31,4 +31,4 @@ Applied rules:
  * RemoveUnusedPrivatePropertyRector
 
 
- [OK] 2 files would have changed (dry-run) by Rector
+ [OK] 2 files would have been changed (dry-run) by Rector

--- a/src/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/src/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -139,7 +139,7 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
             '%d file%s %s by Rector',
             $changeCount,
             $changeCount > 1 ? 's' : '',
-            $configuration->isDryRun() ? 'would have changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed'
+            $configuration->isDryRun() ? 'would have been changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed'
         );
     }
 }


### PR DESCRIPTION
Just a small grammar fix. 

Before:
```
 [OK] XX files would have changed (dry-run) by Rector 
```

After:
```
 [OK] XX files would have been changed (dry-run) by Rector 
```
