### PR TITLE
Clean up return in __construct() in nullable checked fixture

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/nullable_if_checked.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/nullable_if_checked.php.inc
@@ -16,7 +16,6 @@ final class NullableIfChecked
         if ($this->connection == null) {
             $this->initConnection();
         }
-        return $this->connection;
     }
 
     private function initConnection(): void
@@ -42,7 +41,6 @@ final class NullableIfChecked
         if ($this->connection == null) {
             $this->initConnection();
         }
-        return $this->connection;
     }
 
     private function initConnection(): void


### PR DESCRIPTION
ref https://github.com/rectorphp/rector-src/pull/6100#pullrequestreview-2152228656

return expression in `__construct()` is dead code, see https://3v4l.org/e3rYX

we already have rule for it :) https://getrector.com/demo/b3f08404-ae65-4447-942b-38ace79c2af3