### PR TITLE
[DeadCode] Skip fluent no return type on RemoveUnusedPrivateMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_fluent_no_return_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_fluent_no_return_type.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+class SkipFluentNoReturnType
+{
+    public function foo()
+    {
+        return $this
+            ->bar()
+            ->baz()
+            ->qux();
+    }
+
+    private function bar()
+    {
+        return $this;
+    }
+
+    private function baz()
+    {
+        return $this;
+    }
+
+    public function qux()
+    {
+        return $this;
+    }
+}

--- a/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
@@ -35,6 +35,7 @@ final readonly class CallCollectionAnalyzer
 
             if (! $callerType instanceof TypeWithClassName) {
                 // handle fluent by $this->bar()->baz()->qux()
+                // that methods don't have return type
                 if ($callerType instanceof MixedType && ! $callerType->isExplicitMixed()) {
                     $cloneCallerRoot = clone $callerRoot;
                     while ($cloneCallerRoot instanceof MethodCall && $cloneCallerRoot->var instanceof MethodCall) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8711