### PR TITLE
 [DeadCode] Skip fluent no return type on RemoveUnusedPrivateMethodRector take 2

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_fluent_no_return_type2.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_fluent_no_return_type2.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+class SkipFluentNoReturnType2
+{
+    public function foo()
+    {
+        return $this
+            ->bar()
+            ->baz();
+    }
+
+    private function bar()
+    {
+        return $this;
+    }
+
+    private function baz()
+    {
+        return $this;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/with_fluent_no_return_never_called.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/with_fluent_no_return_never_called.php.inc
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+class WithFluentNoReturnNeverCalled
+{
+    public function foo()
+    {
+        return $this
+            ->bar()
+            ->bat();
+    }
+
+    private function bar()
+    {
+        return $this;
+    }
+
+    private function baz()
+    {
+        return $this;
+    }
+
+    private function bat()
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+class WithFluentNoReturnNeverCalled
+{
+    public function foo()
+    {
+        return $this
+            ->bar()
+            ->bat();
+    }
+
+    private function bar()
+    {
+        return $this;
+    }
+
+    private function bat()
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
@@ -38,13 +38,14 @@ final readonly class CallCollectionAnalyzer
                 // that methods don't have return type
                 if ($callerType instanceof MixedType && ! $callerType->isExplicitMixed()) {
                     $cloneCallerRoot = clone $callerRoot;
-                    while ($cloneCallerRoot instanceof MethodCall && $cloneCallerRoot->var instanceof MethodCall) {
-                        $callerType = $this->nodeTypeResolver->getType($cloneCallerRoot->var->var);
-                        $cloneCallerRoot = $cloneCallerRoot->var;
+                    while ($cloneCallerRoot instanceof MethodCall) {
+                        $callerType = $this->nodeTypeResolver->getType($cloneCallerRoot->var);
 
                         if ($callerType instanceof ThisType && $callerType->getStaticObjectType()->getClassName() === $className) {
                             return true;
                         }
+
+                        $cloneCallerRoot = $cloneCallerRoot->var;
                     }
                 }
 

--- a/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
@@ -7,10 +7,10 @@ namespace Rector\DeadCode\NodeAnalyzer;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\ThisType;
 use PHPStan\Type\TypeWithClassName;
 use Rector\Enum\ObjectReference;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -38,14 +38,24 @@ final readonly class CallCollectionAnalyzer
                 // that methods don't have return type
                 if ($callerType instanceof MixedType && ! $callerType->isExplicitMixed()) {
                     $cloneCallerRoot = clone $callerRoot;
-                    while ($cloneCallerRoot instanceof MethodCall) {
-                        $callerType = $this->nodeTypeResolver->getType($cloneCallerRoot->var);
+                    $isFluent = false;
+                    // init
+                    $methodCallNames = [];
 
-                        if ($callerType instanceof ThisType && $callerType->getStaticObjectType()->getClassName() === $className) {
-                            return true;
+                    // first append
+                    $methodCallNames[] = (string) $this->nodeNameResolver->getName($call->name);
+                    while ($cloneCallerRoot instanceof MethodCall) {
+                        $methodCallNames[] = (string) $this->nodeNameResolver->getName($cloneCallerRoot->name);
+                        if ($cloneCallerRoot->var instanceof Variable && $cloneCallerRoot->var->name === 'this') {
+                            $isFluent = true;
+                            break;
                         }
 
                         $cloneCallerRoot = $cloneCallerRoot->var;
+                    }
+
+                    if ($isFluent && in_array($classMethodName, $methodCallNames, true)) {
+                        return true;
                     }
                 }
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6108#issuecomment-2208470144

- [x] skip called on last
- [x] allow remove if never called on fluent 