### PR TITLE
[Php71] Handle not identical to Float for empty string should compare to 0.0 on BinaryOpBetweenNumberAndStringRector

### DIFF
--- a/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/fixture.php.inc
@@ -26,7 +26,7 @@ class Fixture
     public function run()
     {
         $value = 5 + 0;
-        $value = 5.0 + 0;
+        $value = 5.0 + 0.0;
         $value = 5 + 0;
 
         $value = 5 * 0;

--- a/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/not_identical_float.php.inc
+++ b/rules-tests/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/not_identical_float.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class NotIdenticalFloat
+{
+    function foo(): ?float
+    {
+        return 0;
+    }
+
+    public function run()
+    {
+        $data = $this->foo();
+        if (! is_null($data)) {
+            var_dump($data !== '');
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class NotIdenticalFloat
+{
+    function foo(): ?float
+    {
+        return 0;
+    }
+
+    public function run()
+    {
+        $data = $this->foo();
+        if (! is_null($data)) {
+            var_dump($data !== 0.0);
+        }
+    }
+}
+
+?>

--- a/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
+++ b/rules/Php71/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar;
+use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\MagicConst\Line;
 use PhpParser\Node\Scalar\String_;
@@ -60,7 +61,7 @@ class SomeClass
     public function run()
     {
         $value = 5 + 0;
-        $value = 5.0 + 0;
+        $value = 5.0 + 0.0;
     }
 }
 CODE_SAMPLE
@@ -101,7 +102,9 @@ CODE_SAMPLE
         if ($this->isStringOrStaticNonNumericString($node->left) && $this->nodeTypeResolver->isNumberType(
             $node->right
         )) {
-            $node->left = new LNumber(0);
+            $node->left = $this->nodeTypeResolver->getNativeType($node->right)->isInteger()->yes()
+                ? new LNumber(0)
+                : new DNumber(0);
 
             return $node;
         }
@@ -109,7 +112,9 @@ CODE_SAMPLE
         if ($this->isStringOrStaticNonNumericString($node->right) && $this->nodeTypeResolver->isNumberType(
             $node->left
         )) {
-            $node->right = new LNumber(0);
+            $node->right = $this->nodeTypeResolver->getNativeType($node->left)->isInteger()->yes()
+                ? new LNumber(0)
+                : new DNumber(0);
 
             return $node;
         }


### PR DESCRIPTION
`not identical` for `(float) 0` vs `0.0` should be `false` as both are identical.

Ref https://3v4l.org/HE1sb
