### PR TITLE
Fix ArrayDimFetchToMethodCallRector

### DIFF
--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_property_fetch.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_property_fetch.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
+
+use Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Source\SomeExtendedClass;
+
+class FooBar extends SomeExtendedClass
+{
+    public function someMethod()
+    {
+        $this->something['key'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
+
+use Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Source\SomeExtendedClass;
+
+class FooBar extends SomeExtendedClass
+{
+    public function someMethod()
+    {
+        $this->something->make('key');
+    }
+}
+
+?>

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Source/SomeExtendedClass.php
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Source/SomeExtendedClass.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Source;
 
-final class ChoiceControl
+class SomeExtendedClass
 {
-
+    protected \SomeClass $something;
 }

--- a/rules/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector.php
+++ b/rules/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector.php
@@ -103,7 +103,8 @@ CODE_SAMPLE
                 continue;
             }
 
-            $varTagValues = $phpDocInfo->getPhpDocNode()->getVarTagValues();
+            $varTagValues = $phpDocInfo->getPhpDocNode()
+                ->getVarTagValues();
             foreach ($varTagValues as $varTagValue) {
                 $variableName = $varTagValue->variableName;
                 if ($varTagValue->variableName === '$' . $keyVarName) {

--- a/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ObjectType;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
@@ -54,10 +53,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?MethodCall
     {
-        if (! $node->var instanceof Variable) {
-            return null;
-        }
-
         if (! $node->dim instanceof Node) {
             return null;
         }

--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -273,7 +273,10 @@ final class PhpDocInfo
                     return null;
                 }
 
-                if ($name !== null && $node->value instanceof VarTagValueNode && $node->value->variableName !== '$' . ltrim($name, '$')) {
+                if ($name !== null && $node->value instanceof VarTagValueNode && $node->value->variableName !== '$' . ltrim(
+                    $name,
+                    '$'
+                )) {
                     return null;
                 }
 


### PR DESCRIPTION
# Changes

* Removes a Variable check from the ArrayDimFetchToMethodCallRector rule.
* Adds a test to ArrayDimFetchToMethodCallRector to check PropertyFetch works.

# Why

With that if statement in place things like a PropertyFetch node won't be processed when it should be covered by the rule.