### PR TITLE
[CodeQuality] Skip used in static Closure/ArrowFunction on LocallyCalledStaticMethodToNonStaticRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_in_static_closure.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_in_static_closure.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture;
+
+final class SkipInStaticClosure
+{
+    public function run()
+    {
+        return static function () {
+            return self::method("string");
+        };
+    }
+
+    private static function method(?string $value)
+    {
+        return $value;
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
@@ -128,9 +128,9 @@ CODE_SAMPLE
         $classMethodName = $this->getName($classMethod);
         $shouldSkip = false;
 
-        $this->traverseNodesWithCallable($class->getMethods(), function (Node $node) use (&$shouldSkip, $classMethodName): int|null|MethodCall {
+        $this->traverseNodesWithCallable($class->getMethods(), function (Node $node) use (&$shouldSkip, $classMethodName): int|null {
             if (($node instanceof Closure || $node instanceof ArrowFunction) && $node->static) {
-                $this->traverseNodesWithCallable($node->stmts, function (Node $subNode) use (&$shouldSkip, $classMethodName): ?int {
+                $this->traverseNodesWithCallable($node->getStmts(), function (Node $subNode) use (&$shouldSkip, $classMethodName): ?int {
                     if (! $subNode instanceof StaticCall) {
                         return null;
                     }

--- a/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
@@ -124,7 +126,42 @@ CODE_SAMPLE
 
         // replace all the calls
         $classMethodName = $this->getName($classMethod);
-        $this->traverseNodesWithCallable($class, function (Node $node) use ($classMethodName): ?MethodCall {
+        $shouldSkip = false;
+
+        $this->traverseNodesWithCallable($class->getMethods(), function (Node $node) use (&$shouldSkip, $classMethodName): int|null|MethodCall {
+            if (($node instanceof Closure || $node instanceof ArrowFunction) && $node->static) {
+                $this->traverseNodesWithCallable($node->stmts, function (Node $subNode) use (&$shouldSkip, $classMethodName): ?int {
+                    if (! $subNode instanceof StaticCall) {
+                        return null;
+                    }
+
+                    if (! $this->isNames($subNode->class, ['self', 'static'])) {
+                        return null;
+                    }
+
+                    if (! $this->isName($subNode->name, $classMethodName)) {
+                        return null;
+                    }
+
+                    $shouldSkip = true;
+                    return NodeTraverser::STOP_TRAVERSAL;
+                });
+
+                if ($shouldSkip) {
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+
+                return null;
+            }
+
+            return null;
+        });
+
+        if ($shouldSkip) {
+            return null;
+        }
+
+        $this->traverseNodesWithCallable($class->getMethods(), function (Node $node) use ($classMethodName): ?MethodCall {
             if (! $node instanceof StaticCall) {
                 return null;
             }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8733