### PR TITLE
 [Reflection] Clean up unnecessary loop parents on ReflectionResolver 

### DIFF
--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -108,8 +108,6 @@ final readonly class ReflectionResolver
 
             $nativeReflection = $classReflection->getNativeReflection();
             $properties = $nativeReflection->getProperties();
-            // no need to lookup properties on interfaces
-            $ancestors = $classReflection->getParents();
 
             foreach ($properties as $property) {
                 if ($property->getName() !== $propertyName) {
@@ -120,10 +118,8 @@ final readonly class ReflectionResolver
                     return $classReflection;
                 }
 
-                foreach ($ancestors as $ancestor) {
-                    if ($ancestor->hasNativeProperty($propertyName)) {
-                        return $ancestor;
-                    }
+                if ($this->reflectionProvider->hasClass($property->getDeclaringClass()->getName())) {
+                    return $this->reflectionProvider->getClass($property->getDeclaringClass()->getName());
                 }
             }
 
@@ -142,21 +138,14 @@ final readonly class ReflectionResolver
 
         $nativeReflection = $classReflection->getNativeReflection();
         $methods = $nativeReflection->getMethods();
-        $ancestors = [...$classReflection->getParents(), ...$classReflection->getInterfaces()];
 
         foreach ($methods as $method) {
             if ($method->getName() !== $methodName) {
                 continue;
             }
 
-            if ($method->getDeclaringClass()->getName() === $className) {
-                return $classReflection;
-            }
-
-            foreach ($ancestors as $ancestor) {
-                if ($ancestor->hasNativeMethod($methodName)) {
-                    return $ancestor;
-                }
+            if ($this->reflectionProvider->hasClass($method->getDeclaringClass()->getName())) {
+                return $this->reflectionProvider->getClass($method->getDeclaringClass()->getName());
             }
         }
 

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -106,21 +106,8 @@ final readonly class ReflectionResolver
                 return $classReflection;
             }
 
-            $nativeReflection = $classReflection->getNativeReflection();
-            $properties = $nativeReflection->getProperties();
-
-            foreach ($properties as $property) {
-                if ($property->getName() !== $propertyName) {
-                    continue;
-                }
-
-                if ($property->getDeclaringClass()->getName() === $className) {
-                    return $classReflection;
-                }
-
-                if ($this->reflectionProvider->hasClass($property->getDeclaringClass()->getName())) {
-                    return $this->reflectionProvider->getClass($property->getDeclaringClass()->getName());
-                }
+            if ($this->reflectionProvider->hasClass($property->getDeclaringClass()->getName())) {
+                return $this->reflectionProvider->getClass($property->getDeclaringClass()->getName());
             }
 
             return $classReflection;
@@ -136,17 +123,8 @@ final readonly class ReflectionResolver
             return $classReflection;
         }
 
-        $nativeReflection = $classReflection->getNativeReflection();
-        $methods = $nativeReflection->getMethods();
-
-        foreach ($methods as $method) {
-            if ($method->getName() !== $methodName) {
-                continue;
-            }
-
-            if ($this->reflectionProvider->hasClass($method->getDeclaringClass()->getName())) {
-                return $this->reflectionProvider->getClass($method->getDeclaringClass()->getName());
-            }
+        if ($this->reflectionProvider->hasClass($extendedMethodReflection->getDeclaringClass()->getName())) {
+            return $this->reflectionProvider->getClass($extendedMethodReflection->getDeclaringClass()->getName());
         }
 
         return $classReflection;


### PR DESCRIPTION
use `$property->getDeclaringClass()->getName()` or `$method->getDeclaringClass()->getName()` instead that ReflectionProvider can pull.