### PR TITLE
[Php55] Skip parse error on no concat in left in left Concat on PregReplaceEModifierRector

### DIFF
--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/skip_parse_error_no_concat_left.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/skip_parse_error_no_concat_left.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php55\Rector\FuncCall\PregReplaceEModifierRector\Fixture;
+
+class SkipParseErrorNoConcatLeft
+{
+    public function run($contents)
+    {
+        $source_content = preg_replace($search.'e', "'"
+            . $this->_quote_replace($this->left_delimiter) . 'php'
+            . "' . str_repeat(\"\n\", substr_count('\\0', \"\n\")) .'"
+            . $this->_quote_replace($this->right_delimiter)
+            . "'"
+            , $source_content);
+    }
+}

--- a/rules/Php55/RegexMatcher.php
+++ b/rules/Php55/RegexMatcher.php
@@ -84,6 +84,11 @@ final readonly class RegexMatcher
 
     private function matchConcat(Concat $concat): ?Concat
     {
+        // cause parse error
+        if (! $concat->left instanceof Concat) {
+            return null;
+        }
+
         $lastItem = $concat->right;
         if (! $lastItem instanceof String_) {
             return null;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8737
Ref https://getrector.com/demo/dd106a78-dca5-454c-a991-090d76bd1ab7

@wayneh this is the solution I can found right now, skip if not processable that cause crash, if you found a real use case and **the expected output,** please provide a test case PR :)