### PR TITLE
[TypeDeclaration] Add ConstFetch support on ReturnTypeFromStrictConstantReturnRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector/Fixture/with_constant.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector/Fixture/with_constant.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictConstantReturnRector\Fixture;
+
+const A = [];
+
+class WithConstant
+{
+    public function run()
+    {
+        return A;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictConstantReturnRector\Fixture;
+
+const A = [];
+
+class WithConstant
+{
+    public function run(): array
+    {
+        return A;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -131,7 +132,7 @@ CODE_SAMPLE
         $classConstFetchTypes = [];
 
         foreach ($returns as $return) {
-            if (! $return->expr instanceof ClassConstFetch) {
+            if (! $return->expr instanceof ClassConstFetch && ! $return->expr instanceof ConstFetch) {
                 return null;
             }
 


### PR DESCRIPTION
it currently skipped with set `typeDeclaration` config https://getrector.com/demo/fb17ead9-aebe-4238-a3c9-c0fc723c6219

this PR make apply on it.