### PR TITLE
[TypeDeclaration] Fix configuration example on AddReturnTypeDeclarationRector

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
@@ -44,8 +44,6 @@ final class AddReturnTypeDeclarationRector extends AbstractRector implements Con
 
     public function getRuleDefinition(): RuleDefinition
     {
-        $arrayType = new ArrayType(new MixedType(), new MixedType());
-
         return new RuleDefinition('Changes defined return typehint of method and class.', [
             new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
@@ -66,7 +64,7 @@ class SomeClass
 }
 CODE_SAMPLE
                 ,
-                [new AddReturnTypeDeclaration('SomeClass', 'getData', $arrayType)]
+                [new AddReturnTypeDeclaration('SomeClass', 'getData', new ArrayType(new MixedType(), new MixedType()))]
             ),
         ]);
     }

--- a/rules/TypeDeclaration/Rector/Property/AddPropertyTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/Property/AddPropertyTypeDeclarationRector.php
@@ -36,8 +36,6 @@ final class AddPropertyTypeDeclarationRector extends AbstractScopeAwareRector im
 
     public function getRuleDefinition(): RuleDefinition
     {
-        $configuration = [new AddPropertyTypeDeclaration('ParentClass', 'name', new StringType())];
-
         return new RuleDefinition('Add type to property by added rules, mostly public/property by parent type', [
             new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
@@ -55,7 +53,7 @@ class SomeClass extends ParentClass
 }
 CODE_SAMPLE
                 ,
-                $configuration
+                [new AddPropertyTypeDeclaration('ParentClass', 'name', new StringType())]
             ),
         ]);
     }


### PR DESCRIPTION
To get correct definition of undefined `$arrayType` variable on generated rule-detail page on https://getrector.com/rule-detail/add-return-type-declaration-rector

![Screenshot 2024-07-16 at 22 52 06](https://github.com/user-attachments/assets/4e6222f9-d723-4e7b-bbbf-468222fc5103)
