### PR TITLE
[TypeDeclaration] Refactor CallerParamMatcher to avoid ambigous returns usage

### DIFF
--- a/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
@@ -42,17 +42,17 @@ final readonly class CallerParamMatcher
         Param $param,
         Param $callParam
     ): null | Identifier | Name | NullableType | UnionType | ComplexType {
+        if (! $callParam->type instanceof Node) {
+            return null;
+        }
+
         if (! $param->default instanceof Expr && ! $callParam->default instanceof Expr) {
             // skip as mixed is not helpful and possibly requires more precise change elsewhere
-            if ($this->isCallParamMixed($callParam)) {
+            if ($this->isCallParamMixed($callParam->type)) {
                 return null;
             }
 
             return $callParam->type;
-        }
-
-        if (! $callParam->type instanceof Node) {
-            return null;
         }
 
         $default = $param->default ?? $callParam->default;
@@ -163,13 +163,9 @@ final readonly class CallerParamMatcher
         return null;
     }
 
-    private function isCallParamMixed(Param $param): bool
+    private function isCallParamMixed(Node $node): bool
     {
-        if (! $param->type instanceof Node) {
-            return false;
-        }
-
-        $callParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+        $callParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node);
         return $callParamType instanceof MixedType;
     }
 }

--- a/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
@@ -39,17 +39,9 @@ final readonly class CallerParamMatcher
     }
 
     public function matchCallParamType(
-        StaticCall | MethodCall | FuncCall $call,
         Param $param,
-        Scope $scope
-    ): null | Identifier | Name | NullableType | UnionType | ComplexType | StaticCall | MethodCall | FuncCall {
-        $callParam = $this->matchCallParam($call, $param, $scope);
-
-        // just return caller, it means the caller is nothing to do with param
-        if (! $callParam instanceof Param) {
-            return $call;
-        }
-
+        Param $callParam
+    ): null | Identifier | Name | NullableType | UnionType | ComplexType {
         if (! $param->default instanceof Expr && ! $callParam->default instanceof Expr) {
             // skip as mixed is not helpful and possibly requires more precise change elsewhere
             if ($this->isCallParamMixed($callParam)) {
@@ -110,7 +102,7 @@ final readonly class CallerParamMatcher
         return $this->resolveParentMethodParam($scope, $methodName, $parentStaticCallArgPosition);
     }
 
-    private function matchCallParam(StaticCall | MethodCall | FuncCall $call, Param $param, Scope $scope): ?Param
+    public function matchCallParam(StaticCall | MethodCall | FuncCall $call, Param $param, Scope $scope): ?Param
     {
         $callArgPosition = $this->matchCallArgPosition($call, $param);
         if ($callArgPosition === null) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -167,13 +167,14 @@ CODE_SAMPLE
 
             $paramTypes = [];
             foreach ($callers as $caller) {
-                $paramType = $this->callerParamMatcher->matchCallParamType($caller, $param, $scope);
+                $matchCallParam = $this->callerParamMatcher->matchCallParam($caller, $param, $scope);
 
                 // nothing to do with param, continue
-                if ($paramType === $caller) {
+                if (! $matchCallParam instanceof Param) {
                     continue;
                 }
 
+                $paramType = $this->callerParamMatcher->matchCallParamType($param, $matchCallParam);
                 if ($paramType === null) {
                     $paramTypes = [];
                     break;

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -175,7 +175,7 @@ CODE_SAMPLE
                 }
 
                 $paramType = $this->callerParamMatcher->matchCallParamType($param, $matchCallParam);
-                if ($paramType === null) {
+                if (! $paramType instanceof Node) {
                     $paramTypes = [];
                     break;
                 }


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/6156

to avoid ambiguous returns of usage.