### PR TITLE
[TypeDeclaration] Prevent uncaught exception in ReturnTypeFromReturnNewRector

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -157,6 +157,10 @@ CODE_SAMPLE
             return new StaticType($classReflection);
         }
 
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+        
         $classReflection = $this->reflectionProvider->getClass($className);
         return new ObjectType($className, null, $classReflection);
     }


### PR DESCRIPTION
calling `reflectionProvider->getClass(..)` without a previous `reflectionProvider->hasClass(..)` call can throw.

fixes https://github.com/rectorphp/rector/issues/8748