### PR TITLE
[PhpParser] Remove SimpleCallableNodeTraverser usage on AstResolver

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -336,7 +336,7 @@ final class AstResolver
             $traits,
             function (Node $node) use ($methodName): bool {
                 if (! $node instanceof ClassMethod) {
-                    return null;
+                    return false;
                 }
 
                 return $this->nodeNameResolver->isName($node, $methodName);

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -383,6 +383,8 @@ final class AstResolver
                         return true;
                     }
                 }
+
+                return false;
             }
         );
 


### PR DESCRIPTION
The `AstResolver` use both `BetterNodeFinder` and `SimpleCallableNodeTraverser`. This PR remove `SimpleCallableNodeTraverser` usage over `BetterNodeFinder`, reduce cycling dependencies.