### PR TITLE
[TypeDeclaration] Flip position between bool return and return type from strict constant on TypeDeclarationLevel

### DIFF
--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -69,11 +69,11 @@ final class TypeDeclarationLevel
 
         ReturnTypeFromMockObjectRector::class,
         AddArrowFunctionReturnTypeRector::class,
-        ReturnTypeFromStrictConstantReturnRector::class,
+        BoolReturnTypeFromBooleanConstReturnsRector::class,
         ReturnTypeFromStrictNewArrayRector::class,
 
-        // scalar values
-        BoolReturnTypeFromBooleanConstReturnsRector::class,
+        // scalar and array from constant
+        ReturnTypeFromStrictConstantReturnRector::class,
         StringReturnTypeFromStrictScalarReturnsRector::class,
         NumericReturnTypeFromStrictScalarReturnsRector::class,
 


### PR DESCRIPTION
return bool `true` or `false` also covered on `ReturnTypeFromStrictConstantReturnRector` so it never executed on next level, so flip the position with `BoolReturnTypeFromBooleanConstReturnsRector` instead to be executed early for bool only.