### PR TITLE
[TypeDeclaration] Skip possible void and return by docblock on ReturnTypeFromMockObjectRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector/Fixture/skip_possible_void.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector/Fixture/skip_possible_void.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromMockObjectRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipPossibleVoid extends TestCase
+{
+    public function test()
+    {
+        if (rand(0, 1)) {
+            return $this->createMock('SomeType');
+        }
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector/Fixture/skip_return_by_docblock.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector/Fixture/skip_return_by_docblock.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromMockObjectRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SkipReturnByDocblock extends TestCase
+{
+    public function test()
+    {
+        /** @var MockObject $x */
+        return $x;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
@@ -106,7 +107,10 @@ CODE_SAMPLE
             return null;
         }
 
-        $returnType = $this->nodeTypeResolver->getNativeType($returns[0]->expr);
+        /** @var Expr $expr */
+        $expr = $returns[0]->expr;
+        $returnType = $this->nodeTypeResolver->getNativeType($expr);
+
         if (! $this->isMockObjectType($returnType)) {
             return null;
         }


### PR DESCRIPTION
- Use `ReturnAnalyzer` to verify possible void
- Use `getNativeType()` to ensure it returns native type