### PR TITLE
fix: Convert DateTime to Carbon properly when hours/minutes/seconds are used

### DIFF
--- a/rules-tests/Carbon/Rector/New_/DateTimeInstanceToCarbonRector/Fixture/datetime_with_today_sub_time.php.inc
+++ b/rules-tests/Carbon/Rector/New_/DateTimeInstanceToCarbonRector/Fixture/datetime_with_today_sub_time.php.inc
@@ -22,7 +22,7 @@ final class DateTimeTodayAddSubTime
 
 namespace Rector\Tests\Carbon\Rector\New_\DateTimeInstanceToCarbonRector\Fixture;
 
-final class DateTimeNow
+final class DateTimeTodayAddSubTime
 {
     public function run()
     {

--- a/rules-tests/Carbon/Rector/New_/DateTimeInstanceToCarbonRector/Fixture/datetime_with_today_sub_time.php.inc
+++ b/rules-tests/Carbon/Rector/New_/DateTimeInstanceToCarbonRector/Fixture/datetime_with_today_sub_time.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Carbon\Rector\New_\DateTimeInstanceToCarbonRector\Fixture;
+
+final class DateTimeTodayAddSubTime
+{
+    public function run()
+    {
+        $addHours = new \DateTime('+ 5 hours');
+        $addMinutes = new \DateTime('+ 5 minutes');
+        $addSeconds = new \DateTime('+ 5 seconds');
+
+        $subHours = new \DateTime('- 5 hours');
+        $subMinuts = new \DateTime('- 5 minutes');
+        $subSeconds = new \DateTime('- 5 seconds');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Carbon\Rector\New_\DateTimeInstanceToCarbonRector\Fixture;
+
+final class DateTimeNow
+{
+    public function run()
+    {
+        $addHours = \Carbon\Carbon::now()->addHours(5);
+        $addMinutes = \Carbon\Carbon::now()->addMinutes(5);
+        $addSeconds = \Carbon\Carbon::now()->addSeconds(5);
+
+        $subHours = \Carbon\Carbon::now()->subHours(5);
+        $subMinuts = \Carbon\Carbon::now()->subMinutes(5);
+        $subSeconds = \Carbon\Carbon::now()->subSeconds(5);
+    }
+}
+
+?>

--- a/rules/Carbon/NodeFactory/CarbonCallFactory.php
+++ b/rules/Carbon/NodeFactory/CarbonCallFactory.php
@@ -33,11 +33,23 @@ final class CarbonCallFactory
      */
     private const PLUS_MONTH_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(month|months)#';
 
+    private const PLUS_HOUR_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(hour|hours)#';
+
+    private const PLUS_MINUTE_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(minute|minuts)#';
+
+    private const PLUS_SECOND_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(second|seconds)#';
+
     /**
      * @var string
      * @see https://regex101.com/r/IvyT7w/1
      */
     private const MINUS_MONTH_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(month|months)#';
+
+    private const MINUS_HOUR_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(hour|hours)#';
+
+    private const MINUS_MINUTE_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(minute|minutes)#';
+
+    private const MINUS_SECOND_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(second|seconds)#';
 
     /**
      * @var array<self::*_REGEX, string>
@@ -47,6 +59,12 @@ final class CarbonCallFactory
         self::MINUS_DAY_COUNT_REGEX => 'subDays',
         self::PLUS_MONTH_COUNT_REGEX => 'addMonths',
         self::MINUS_MONTH_COUNT_REGEX => 'subMonths',
+        self::PLUS_HOUR_COUNT_REGEX => 'addHours',
+        self::MINUS_HOUR_COUNT_REGEX => 'subHours',
+        self::PLUS_MINUTE_COUNT_REGEX => 'addMinutes',
+        self::MINUS_MINUTE_COUNT_REGEX => 'subMinutes',
+        self::PLUS_SECOND_COUNT_REGEX => 'addSeconds',
+        self::MINUS_SECOND_COUNT_REGEX => 'subSeconds',
     ];
 
     public function createFromDateTimeString(

--- a/rules/Carbon/NodeFactory/CarbonCallFactory.php
+++ b/rules/Carbon/NodeFactory/CarbonCallFactory.php
@@ -33,10 +33,22 @@ final class CarbonCallFactory
      */
     private const PLUS_MONTH_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(month|months)#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/dWRjk5/1
+     */
     private const PLUS_HOUR_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(hour|hours)#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/dfK0Ri/1
+     */
     private const PLUS_MINUTE_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(minute|minuts)#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/o7QDYL/1
+     */
     private const PLUS_SECOND_COUNT_REGEX = '#\+(\s+)?(?<count>\d+)(\s+)?(second|seconds)#';
 
     /**
@@ -45,10 +57,22 @@ final class CarbonCallFactory
      */
     private const MINUS_MONTH_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(month|months)#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/bICKg6/1
+     */
     private const MINUS_HOUR_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(hour|hours)#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/WILFvX/1
+     */
     private const MINUS_MINUTE_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(minute|minutes)#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/FwCUup/1
+     */
     private const MINUS_SECOND_COUNT_REGEX = '#-(\s+)?(?<count>\d+)(\s+)?(second|seconds)#';
 
     /**

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -173,7 +173,11 @@ final readonly class PHPStanNodeScopeResolver
                 $this->processAssign($node, $mutatingScope);
 
                 if ($node->var instanceof Variable && $node->var->name instanceof Expr) {
-                    $this->nodeScopeResolverProcessNodes([new Expression($node->var), new Expression($node->expr)], $mutatingScope, $nodeCallback);
+                    $this->nodeScopeResolverProcessNodes(
+                        [new Expression($node->var), new Expression($node->expr)],
+                        $mutatingScope,
+                        $nodeCallback
+                    );
                 }
 
                 return;

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -173,11 +173,7 @@ final readonly class PHPStanNodeScopeResolver
                 $this->processAssign($node, $mutatingScope);
 
                 if ($node->var instanceof Variable && $node->var->name instanceof Expr) {
-                    $this->nodeScopeResolverProcessNodes(
-                        [new Expression($node->var), new Expression($node->expr)],
-                        $mutatingScope,
-                        $nodeCallback
-                    );
+                    $this->nodeScopeResolverProcessNodes([new Expression($node->var), new Expression($node->expr)], $mutatingScope, $nodeCallback);
                 }
 
                 return;


### PR DESCRIPTION
Improve fix for problem in https://github.com/rectorphp/rector/issues/8692

Subtract of months and days was added, but it's still missing hours, minutes & seconds.
This PR adds those changes.