### PR TITLE
[TypeDeclaration] Skip possible value resetted on TypedPropertyFromCreateMockAssignRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector/Fixture/skip_value_resetted.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector/Fixture/skip_value_resetted.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector\Source\SomeMockedClass;
+
+class SkipValueResetted extends TestCase
+{
+    public $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = $this->createMock(SomeMockedClass::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->someMock = null;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\IntersectionType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use Rector\NodeManipulator\ClassMethodPropertyFetchManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer\TrustedClassMethodPropertyTypeInferer;
 use Rector\ValueObject\MethodName;
@@ -150,14 +146,5 @@ CODE_SAMPLE
         }
 
         return in_array(self::MOCK_OBJECT_CLASS, $type->getObjectClassNames());
-    }
-
-    private function resolveSingleAssignedExprType(Class_ $class, Property $property, ClassMethod $classMethod): Type
-    {
-        return $this->trustedClassMethodPropertyTypeInferer->inferProperty(
-            $class,
-            $property,
-            $classMethod
-        );
     }
 }


### PR DESCRIPTION
I can see that the mock can be resetted on some use case, so when there is possibility that type resetted, it should be skipped.