### PR TITLE
[AutoImport] Skip early on no \ in identifier name on NameImportingPhpDocNodeVisitor

### DIFF
--- a/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -67,6 +67,11 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
             throw new ShouldNotHappenException();
         }
 
+        // no \, skip early
+        if (! str_contains($node->name, '\\')) {
+            return null;
+        }
+
         $staticType = $this->identifierPhpDocTypeMapper->mapIdentifierTypeNode($node, $this->currentPhpParserNode);
 
         if ($staticType instanceof ShortenedObjectType) {

--- a/src/PhpParser/Parser/ParserErrors.php
+++ b/src/PhpParser/Parser/ParserErrors.php
@@ -6,16 +6,16 @@ namespace Rector\PhpParser\Parser;
 
 use PHPStan\Parser\ParserErrorsException;
 
-final class ParserErrors
+final readonly class ParserErrors
 {
     private string $message;
 
     private int $line;
 
-    public function __construct(ParserErrorsException $exception)
+    public function __construct(ParserErrorsException $parserErrorsException)
     {
-        $this->message = $exception->getMessage();
-        $this->line = $exception->getAttributes()['startLine'] ?? $exception->getLine();
+        $this->message = $parserErrorsException->getMessage();
+        $this->line = $parserErrorsException->getAttributes()['startLine'] ?? $parserErrorsException->getLine();
     }
 
     public function getMessage(): string

--- a/tests/Issues/AutoImport/Fixture/DocBlock/short_name_renamed_imported.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/short_name_renamed_imported.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+class ShortNameRenamedImported
+{
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function some($dateTime)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use DateTimeInterface;
+class ShortNameRenamedImported
+{
+    /**
+     * @param DateTimeInterface $dateTime
+     */
+    public function some($dateTime)
+    {
+    }
+}
+
+?>

--- a/tests/Issues/AutoImport/config/configured_rule.php
+++ b/tests/Issues/AutoImport/config/configured_rule.php
@@ -12,6 +12,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->importNames();
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Some\Exception' => 'Some\Target\Exception',
+        'DateTime' => 'DateTimeInterface',
     ]);
     $rectorConfig->rule(TernaryToNullCoalescingRector::class);
     $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [

--- a/tests/Issues/AutoImportShortName/Fixture/import_docblock_shortname_fqcn.php.inc
+++ b/tests/Issues/AutoImportShortName/Fixture/import_docblock_shortname_fqcn.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
-class InNoNamespaceShortName
+class ImportDocblockShortName
 {
     /**
      * @param \DateTime $dateTime
@@ -19,7 +19,7 @@ class InNoNamespaceShortName
 namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
 
 use DateTime;
-class InNoNamespaceShortName
+class ImportDocblockShortName
 {
     /**
      * @param DateTime $dateTime

--- a/tests/Issues/AutoImportShortName/Fixture/import_docblock_shortname_fqcn.php.inc
+++ b/tests/Issues/AutoImportShortName/Fixture/import_docblock_shortname_fqcn.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
+
+class InNoNamespaceShortName
+{
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function run($dateTime)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
+
+use DateTime;
+class InNoNamespaceShortName
+{
+    /**
+     * @param DateTime $dateTime
+     */
+    public function run($dateTime)
+    {
+    }
+}
+
+?>

--- a/tests/Issues/AutoImportShortName/Fixture/skip_imported_shortname.php.inc
+++ b/tests/Issues/AutoImportShortName/Fixture/skip_imported_shortname.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImportShortName\Fixture;
+
+use DateTime;
+
+class SkipImportedShortName
+{
+    /**
+     * @param DateTime $dateTime
+     */
+    public function run($dateTime)
+    {
+    }
+}

--- a/tests/Issues/ImportFullyQualifiedIdentifierDocblock/Fixture/add_property_var.php.inc
+++ b/tests/Issues/ImportFullyQualifiedIdentifierDocblock/Fixture/add_property_var.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\ImportFullyQualifiedIdentifierDocblock;
+
+final class AddPropertyVar
+{
+    public $property;
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\ImportFullyQualifiedIdentifierDocblock;
+
+use DateTime;
+final class AddPropertyVar
+{
+    /**
+     * @var DateTime
+     */
+    public $property;
+}
+
+?>

--- a/tests/Issues/ImportFullyQualifiedIdentifierDocblock/ImportFullyQualifiedIdentifierDocblockTest.php
+++ b/tests/Issues/ImportFullyQualifiedIdentifierDocblock/ImportFullyQualifiedIdentifierDocblockTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\ImportFullyQualifiedIdentifierDocblock;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ImportFullyQualifiedIdentifierDocblockTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/ImportFullyQualifiedIdentifierDocblock/Source/AddFullyQualifiedIdentifierDocblockRector.php
+++ b/tests/Issues/ImportFullyQualifiedIdentifierDocblock/Source/AddFullyQualifiedIdentifierDocblockRector.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\ImportFullyQualifiedIdentifierDocblock\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AddFullyQualifiedIdentifierDocblockRector extends AbstractRector
+{
+    public function __construct(
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('uff', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Property::class,
+        ];
+    }
+
+    public function refactor(Node $node)
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $varTagValueNode = new VarTagValueNode(new FullyQualifiedIdentifierTypeNode('DateTime'), '', '');
+
+        $phpDocInfo->addTagValueNode($varTagValueNode);
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+}

--- a/tests/Issues/ImportFullyQualifiedIdentifierDocblock/config/configured_rule.php
+++ b/tests/Issues/ImportFullyQualifiedIdentifierDocblock/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Tests\Issues\ImportFullyQualifiedIdentifierDocblock\Source\AddFullyQualifiedIdentifierDocblockRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        AddFullyQualifiedIdentifierDocblockRector::class,
+    ])
+    ->withImportNames();


### PR DESCRIPTION
no need unnecessary import logic on obvious Identifier type when no `\` in the identifier name.