### PR TITLE
 [AutoImport] Allow auto import when first stmt is not InlineHTML 

### DIFF
--- a/src/PhpParser/Parser/ParserErrors.php
+++ b/src/PhpParser/Parser/ParserErrors.php
@@ -6,16 +6,16 @@ namespace Rector\PhpParser\Parser;
 
 use PHPStan\Parser\ParserErrorsException;
 
-final class ParserErrors
+final readonly class ParserErrors
 {
     private string $message;
 
     private int $line;
 
-    public function __construct(ParserErrorsException $exception)
+    public function __construct(ParserErrorsException $parserErrorsException)
     {
-        $this->message = $exception->getMessage();
-        $this->line = $exception->getAttributes()['startLine'] ?? $exception->getLine();
+        $this->message = $parserErrorsException->getMessage();
+        $this->line = $parserErrorsException->getAttributes()['startLine'] ?? $parserErrorsException->getLine();
     }
 
     public function getMessage(): string

--- a/tests/Issues/AutoImport/Fixture/with_html_start_normal_php_code.php.inc
+++ b/tests/Issues/AutoImport/Fixture/with_html_start_normal_php_code.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+$this->headTitle('Transaction Detail');
+
+?>
+
+<div>
+    <?=new \Rector\Tests\Issues\AutoImport\Source\SomeClass()?>
+</div>
+-----
+<?php
+
+use Rector\Tests\Issues\AutoImport\Source\SomeClass;
+$this->headTitle('Transaction Detail');
+
+?>
+
+<div>
+    <?=new SomeClass()?>
+</div>

--- a/tests/Issues/AutoImport/Source/SomeClass.php
+++ b/tests/Issues/AutoImport/Source/SomeClass.php
@@ -6,4 +6,8 @@ namespace Rector\Tests\Issues\AutoImport\Source;
 
 class SomeClass
 {
+    public function __toString()
+    {
+        return 'test';
+    }
 }


### PR DESCRIPTION
When first stmt is not `InlineHTML`, it should allowed to import name, this also improve performance to remove unnecessary double traverse for lookup 2 namespace as on root stmts + and InlineHTML in too deep stmt.