### PR TITLE
Support more assign cases in  PropertyFetchAssignManipulator

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_assign_op.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_assign_op.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipAssignOp
+{
+    private string $name;
+    private int $count;
+
+    public function __construct(string $name, bool $flag = false)
+    {
+        $this->name = $name;
+
+        if ($flag) {
+            $this->name .= 'changed';
+        }
+
+        $this->count = 0;
+        if ($flag) {
+            ++$this->count;
+        }
+    }
+}

--- a/src/NodeManipulator/PropertyFetchAssignManipulator.php
+++ b/src/NodeManipulator/PropertyFetchAssignManipulator.php
@@ -6,6 +6,7 @@ namespace Rector\NodeManipulator;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -43,7 +44,7 @@ final readonly class PropertyFetchAssignManipulator
                     return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
-                if (! $node instanceof Assign) {
+                if (! $node instanceof Assign && ! $node instanceof AssignOp) {
                     return null;
                 }
 


### PR DESCRIPTION
It was suggesting this rector rule in this case:

```php
final class SomeClass
{
    private string $name;

    public function __construct()
    {
        $this->name = __NAMESPACE__;
        $this->name .= __CLASS__;
    }
}
```