### PR TITLE
Multiline annotation value to attribute failing test case

### DIFF
--- a/tests/Issues/PlainValueParser/Fixture/custom_annotation_with_name.php.inc
+++ b/tests/Issues/PlainValueParser/Fixture/custom_annotation_with_name.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\Issues\PlainValueParser\Fixture;
+
+use Rector\Tests\Issues\PlainValueParser\Source\CustomAnnotationWithName;
+
+final class SomeFixture
+{
+    /**
+     * @CustomAnnotationWithName(
+     *     description="Multiline
+     * description",
+     *     name="Possible values"
+     * )
+     */
+    public function test()
+    {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\PlainValueParser\Fixture;
+
+use Rector\Tests\Issues\PlainValueParser\Source\CustomAnnotationWithName;
+
+final class SomeFixture
+{
+    #[CustomAnnotationWithName(description: 'Multiline
+description', name: 'Possible values')]
+    public function test()
+    {}
+}
+
+?>

--- a/tests/Issues/PlainValueParser/Source/CustomAnnotationWithName.php
+++ b/tests/Issues/PlainValueParser/Source/CustomAnnotationWithName.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Rector\Tests\Issues\PlainValueParser\Source;
+
+class CustomAnnotationWithName
+{
+    public function __construct(public string $description, public string $name)
+    {
+    }
+}

--- a/tests/Issues/PlainValueParser/config/configured_rule.php
+++ b/tests/Issues/PlainValueParser/config/configured_rule.php
@@ -6,9 +6,11 @@ use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector as AnnotationToAttributeRectorAlias;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\Tests\Issues\PlainValueParser\Source\CustomAnnotation;
+use Rector\Tests\Issues\PlainValueParser\Source\CustomAnnotationWithName;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRectorAlias::class, [
         new AnnotationToAttribute(CustomAnnotation::class),
+        new AnnotationToAttribute(CustomAnnotationWithName::class),
     ]);
 };


### PR DESCRIPTION
AnnotationToAttributeRector does not work correctly if the annotation value follows a multi-line value.

Last token of multiline value is `",` and comma is skipped, so problem could be in lexer.