### PR TITLE
[Transform] Adds the ScalarValueToConstFetchRector rule

### DIFF
--- a/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/Fixture/fixture.php.inc
+++ b/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/Fixture/fixture.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\New_\NewToStaticCallRector\Fixture;
+
+$int = 10;
+$float = 10.1;
+$string = 'ABC';
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\New_\NewToStaticCallRector\Fixture;
+
+$int = \Rector\Tests\Transform\Rector\Scalar\ScalarValueToConstFetchRector\Source\ClassWithConst::FOOBAR_INT;
+$float = \Rector\Tests\Transform\Rector\Scalar\ScalarValueToConstFetchRector\Source\ClassWithConst::FOOBAR_FLOAT;
+$string = \Rector\Tests\Transform\Rector\Scalar\ScalarValueToConstFetchRector\Source\ClassWithConst::FOOBAR_STRING;
+
+?>

--- a/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/Fixture/skip_non_matching_values.php.inc
+++ b/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/Fixture/skip_non_matching_values.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\New_\NewToStaticCallRector\Fixture;
+
+$int = 11;
+$float = 10.2;
+$string = 'abc';
+
+?>

--- a/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/ScalarValueToConstFetchRectorTest.php
+++ b/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/ScalarValueToConstFetchRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\Scalar\ScalarValueToConstFetchRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ScalarValueToConstFetchRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/Source/ClassWithConst.php
+++ b/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/Source/ClassWithConst.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\Scalar\ScalarValueToConstFetchRector\Source;
+
+class ClassWithConst
+{
+    public const FOOBAR_INT = 10;
+
+    public const FOOBAR_STRING = 'ABC';
+
+    public const FOOBAR_FLOAT = 10.1;
+}

--- a/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/Scalar/ScalarValueToConstFetchRector/config/configured_rule.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use Rector\Config\RectorConfig;
+use Rector\Tests\Transform\Rector\Scalar\ScalarValueToConstFetchRector\Source\ClassWithConst;
+use Rector\Transform\Rector\Scalar\ScalarValueToConstFetchRector;
+use Rector\Transform\ValueObject\ScalarValueToConstFetch;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(
+            ScalarValueToConstFetchRector::class,
+            [
+                new ScalarValueToConstFetch(
+                    new LNumber(10),
+                    new ClassConstFetch(new FullyQualified(ClassWithConst::class), new Identifier('FOOBAR_INT'))
+                ),
+                new ScalarValueToConstFetch(
+                    new DNumber(10.1),
+                    new ClassConstFetch(new FullyQualified(ClassWithConst::class), new Identifier('FOOBAR_FLOAT'))
+                ),
+                new ScalarValueToConstFetch(
+                    new String_('ABC'),
+                    new ClassConstFetch(new FullyQualified(ClassWithConst::class), new Identifier('FOOBAR_STRING'))
+                ),
+            ]
+        );
+};

--- a/rules/Transform/Rector/Scalar/ScalarValueToConstFetchRector.php
+++ b/rules/Transform/Rector/Scalar/ScalarValueToConstFetchRector.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Transform\Rector\Scalar;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Rector\Transform\ValueObject\ScalarValueToConstFetch;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see Rector\Tests\Transform\Rector\Scalar\ScalarValueToConstFetchRector\ScalarValueToConstFetchRectorTest
+ */
+class ScalarValueToConstFetchRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ScalarValueToConstFetch[]
+     */
+    private array $scalarValueToConstFetches;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replaces Scalar values with a ConstFetch or ClassConstFetch',
+            [new ConfiguredCodeSample(<<<'SAMPLE'
+$var = 10;
+SAMPLE
+                , <<<'SAMPLE'
+$var = \SomeClass::FOOBAR_INT;
+SAMPLE
+                , [
+                    new ScalarValueToConstFetch(
+                        new LNumber(10),
+                        new ClassConstFetch(new FullyQualified('SomeClass'), new Identifier('FOOBAR_INT')),
+                    ),
+                ])]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [String_::class, DNumber::class, LNumber::class];
+    }
+
+    /**
+     * @param String_|DNumber|LNumber $node
+     */
+    public function refactor(Node $node): ConstFetch|ClassConstFetch|null
+    {
+        foreach ($this->scalarValueToConstFetches as $scalarValueToConstFetch) {
+            if ($node->value === $scalarValueToConstFetch->getScalar()->value) {
+                return $scalarValueToConstFetch->getConstFetch();
+            }
+        }
+
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, ScalarValueToConstFetch::class);
+
+        $this->scalarValueToConstFetches = $configuration;
+    }
+}

--- a/rules/Transform/ValueObject/ScalarValueToConstFetch.php
+++ b/rules/Transform/ValueObject/ScalarValueToConstFetch.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Transform\ValueObject;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+
+final readonly class ScalarValueToConstFetch
+{
+    public function __construct(
+        private DNumber|String_|LNumber $scalar,
+        private ConstFetch|ClassConstFetch $constFetch
+    ) {
+    }
+
+    public function getScalar(): DNumber|String_|LNumber
+    {
+        return $this->scalar;
+    }
+
+    public function getConstFetch(): ConstFetch|ClassConstFetch
+    {
+        return $this->constFetch;
+    }
+}


### PR DESCRIPTION
# Changes

- Adds a new ScalarValueToConstFetchRector rule
- Adds a value object for configuring ScalarValueToConstFetchRector
- Adds tests
- Updates the docs

# Why

Feels like a useful rule for removing certain Scalar values within a codebase with a predefined constant.

```diff
-$var = 10;
+$var = \SomeClass::FOOBAR_INT;
```