### PR TITLE
[CodeQuality] Skip non-nullable typed with default null on OptionalParametersAfterRequiredRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/no_typed_default_null.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/no_typed_default_null.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+/**
+ * @see https://3v4l.org/5Ek8A#v8.0.30
+ */
+final class NoTypedDefaultNull
+{
+    public function run($a = null, $required)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+/**
+ * @see https://3v4l.org/5Ek8A#v8.0.30
+ */
+final class NoTypedDefaultNull
+{
+    public function run($required, $a = null)
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/nullable_typed_default_null.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/nullable_typed_default_null.php.inc
@@ -2,6 +2,9 @@
 
 namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
 
+/**
+ * @see https://3v4l.org/leYmD#v8.1.19
+ */
 final class NullableTypedDefaultNull
 {
     public function run(?string $a = null, $required)
@@ -15,6 +18,9 @@ final class NullableTypedDefaultNull
 
 namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
 
+/**
+ * @see https://3v4l.org/leYmD#v8.1.19
+ */
 final class NullableTypedDefaultNull
 {
     public function run($required, ?string $a = null)

--- a/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/nullable_typed_default_null.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/nullable_typed_default_null.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+final class NullableTypedDefaultNull
+{
+    public function run(?string $a = null, $required)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+final class NullableTypedDefaultNull
+{
+    public function run($required, ?string $a = null)
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_typed_default_null.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_typed_default_null.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+final class SkipTypedDefaultNull
+{
+    public function run(string $a = null, $required)
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_typed_default_null.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_typed_default_null.php.inc
@@ -2,6 +2,9 @@
 
 namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
 
+/**
+ * @see https://3v4l.org/leYmD#v8.0.28
+ */
 final class SkipTypedDefaultNull
 {
     public function run(string $a = null, $required)


### PR DESCRIPTION
non-nullable typed with default null is allowed to have position before required, see

- https://3v4l.org/leYmD#v8.0.28 vs https://3v4l.org/leYmD#v8.1.19
- https://php.watch/versions/8.0/deprecate-required-param-after-optional