### PR TITLE
Skip symfony response in ReturnTypeFromReturnNewRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/skip_response.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector/Fixture/skip_response.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Fixture;
+
+use Rector\Symfony\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Handled in another rule, @see ResponseReturnTypeControllerActionRector
+ */
+class SkipResponse extends Controller
+{
+    public function create()
+    {
+        return new JsonResponse();
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -29,6 +29,7 @@ use Rector\Rector\AbstractScopeAwareRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\SelfStaticType;
+use Rector\Symfony\CodeQuality\Enum\ResponseClass;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer\StrictReturnNewAnalyzer;
 use Rector\ValueObject\PhpVersionFeature;
@@ -182,6 +183,12 @@ CODE_SAMPLE
         }
 
         $returnType = $this->typeFactory->createMixedPassedOrUnionType($newTypes);
+
+        // skip in case of response, as handled by another rule earlier
+        /** @see ResponseReturnTypeControllerActionRector */
+        if ($returnType instanceof ObjectType && $returnType->isInstanceOf(ResponseClass::BASIC)->yes()) {
+            return null;
+        }
 
         $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
         if (! $returnTypeNode instanceof Node) {

--- a/stubs/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+if (class_exists('Symfony\Bundle\FrameworkBundle\Controller\Controller')) {
+    return;
+}
+
+class Controller
+{
+}

--- a/stubs/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/stubs/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+if (class_exists('Symfony\Component\HttpFoundation\JsonResponse')) {
+    return;
+}
+
+class JsonResponse extends Response
+{
+}

--- a/stubs/Symfony/Component/HttpFoundation/Response.php
+++ b/stubs/Symfony/Component/HttpFoundation/Response.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+if (class_exists('Symfony\Component\HttpFoundation\Response')) {
+    return;
+}
+
+class Response
+{
+}


### PR DESCRIPTION
Symfony Response is already handled exclusively by ResponseReturnTypeControllerActionRector,
to keep each rule more robuts and separated :+1: 

Also easier to review and add type coverage in a project ugprade :) 