### PR TITLE
[Configuration] Allow define max level > possible level on LevelRulesResolver

### DIFF
--- a/src/Configuration/Levels/LevelRulesResolver.php
+++ b/src/Configuration/Levels/LevelRulesResolver.php
@@ -26,7 +26,7 @@ final class LevelRulesResolver
         }
 
         // level < 0 is not allowed
-        Assert::natural($level, 'Level must be > 0');
+        Assert::natural($level, sprintf('Level must be > 0 on %s', $methodName));
 
         // start with 0
         $maxLevel = $rulesCount - 1;

--- a/src/Configuration/Levels/LevelRulesResolver.php
+++ b/src/Configuration/Levels/LevelRulesResolver.php
@@ -14,16 +14,19 @@ final class LevelRulesResolver
      * @param array<class-string<RectorInterface>> $availableRules
      * @return array<class-string<RectorInterface>>
      */
-    public static function resolve(int $level, array $availableRules): array
+    public static function resolve(int $level, array $availableRules, string $methodName): array
     {
         $rulesCount = count($availableRules);
 
         if ($availableRules === []) {
-            throw new ShouldNotHappenException('There is no available rules, define the available rules first');
+            throw new ShouldNotHappenException(sprintf(
+                'There is no available rules in %s, define the available rules first',
+                $methodName
+            ));
         }
 
         // level < 0 is not allowed
-        Assert::natural($level);
+        Assert::natural($level, 'Level must be > 0');
 
         // start with 0
         $maxLevel = $rulesCount - 1;

--- a/src/Configuration/Levels/LevelRulesResolver.php
+++ b/src/Configuration/Levels/LevelRulesResolver.php
@@ -6,6 +6,7 @@ namespace Rector\Configuration\Levels;
 
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Exception\ShouldNotHappenException;
+use Webmozart\Assert\Assert;
 
 final class LevelRulesResolver
 {
@@ -20,6 +21,9 @@ final class LevelRulesResolver
         if ($availableRules === []) {
             throw new ShouldNotHappenException('There is no available rules, define the available rules first');
         }
+
+        // level < 0 is not allowed
+        Assert::natural($level);
 
         // start with 0
         $maxLevel = $rulesCount - 1;

--- a/src/Configuration/Levels/LevelRulesResolver.php
+++ b/src/Configuration/Levels/LevelRulesResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\Configuration\Levels;
 
 use Rector\Contract\Rector\RectorInterface;
-use Webmozart\Assert\Assert;
+use Rector\Exception\ShouldNotHappenException;
 
 final class LevelRulesResolver
 {
@@ -13,16 +13,19 @@ final class LevelRulesResolver
      * @param array<class-string<RectorInterface>> $availableRules
      * @return array<class-string<RectorInterface>>
      */
-    public static function resolve(int $level, array $availableRules, string $methodName): array
+    public static function resolve(int $level, array $availableRules): array
     {
         $rulesCount = count($availableRules);
 
-        Assert::range(
-            $level,
-            0,
-            $rulesCount - 1,
-            'Level %s is not available "' . $methodName . '" method. Pick one between %2$s (lowest) and %3$s (highest).'
-        );
+        if ($availableRules === []) {
+            throw new ShouldNotHappenException('There is no available rules, define the available rules first');
+        }
+
+        // start with 0
+        $maxLevel = $rulesCount - 1;
+        if ($level > $maxLevel) {
+            $level = $maxLevel;
+        }
 
         $levelRules = [];
 

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -870,8 +870,7 @@ final class RectorConfigBuilder
 
         $levelRules = LevelRulesResolver::resolve(
             $level,
-            DeadCodeLevel::RULES,
-            'RectorConfig::withDeadCodeLevel()'
+            DeadCodeLevel::RULES
         );
 
         $this->rules = array_merge($this->rules, $levelRules);
@@ -889,8 +888,7 @@ final class RectorConfigBuilder
 
         $levelRules = LevelRulesResolver::resolve(
             $level,
-            TypeDeclarationLevel::RULES,
-            'RectorConfig::withTypeCoverageLevel()'
+            TypeDeclarationLevel::RULES
         );
 
         $this->rules = array_merge($this->rules, $levelRules);
@@ -908,8 +906,7 @@ final class RectorConfigBuilder
 
         $levelRules = LevelRulesResolver::resolve(
             $level,
-            CodeQualityLevel::RULES,
-            'RectorConfig::withCodeQualityLevel()'
+            CodeQualityLevel::RULES
         );
 
         $this->rules = array_merge($this->rules, $levelRules);

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -870,7 +870,8 @@ final class RectorConfigBuilder
 
         $levelRules = LevelRulesResolver::resolve(
             $level,
-            DeadCodeLevel::RULES
+            DeadCodeLevel::RULES,
+            'RectorConfig::withDeadCodeLevel()'
         );
 
         $this->rules = array_merge($this->rules, $levelRules);
@@ -888,7 +889,8 @@ final class RectorConfigBuilder
 
         $levelRules = LevelRulesResolver::resolve(
             $level,
-            TypeDeclarationLevel::RULES
+            TypeDeclarationLevel::RULES,
+            'RectorConfig::withTypeCoverageLevel()'
         );
 
         $this->rules = array_merge($this->rules, $levelRules);
@@ -906,7 +908,8 @@ final class RectorConfigBuilder
 
         $levelRules = LevelRulesResolver::resolve(
             $level,
-            CodeQualityLevel::RULES
+            CodeQualityLevel::RULES,
+            'RectorConfig::withCodeQualityLevel()'
         );
 
         $this->rules = array_merge($this->rules, $levelRules);


### PR DESCRIPTION
List of rules come and go, so I think it should be better to allow define max level > possible level to avoid error after composer update.