### PR TITLE
[Php54] No need reprint when array is just created on LongArrayToShortArrayRector

### DIFF
--- a/rules/Php54/Rector/Array_/LongArrayToShortArrayRector.php
+++ b/rules/Php54/Rector/Array_/LongArrayToShortArrayRector.php
@@ -66,6 +66,12 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        // no kind attribute yet, it means just created
+        // no need to reprint, it already will be short array by default
+        if ($node->getAttribute(AttributeKey::KIND) === null) {
+            return null;
+        }
+
         if ($node->getAttribute(AttributeKey::KIND) === Array_::KIND_SHORT) {
             return null;
         }

--- a/rules/Php54/Rector/Array_/LongArrayToShortArrayRector.php
+++ b/rules/Php54/Rector/Array_/LongArrayToShortArrayRector.php
@@ -68,7 +68,7 @@ CODE_SAMPLE
     {
         // no kind attribute yet, it means just created
         // no need to reprint, it already will be short array by default
-        if ($node->getAttribute(AttributeKey::KIND) === null) {
+        if (! $node->hasAttribute(AttributeKey::KIND)) {
             return null;
         }
 

--- a/tests/Issues/CountArrayLongToShort/CountArrayLongToShortTest.php
+++ b/tests/Issues/CountArrayLongToShort/CountArrayLongToShortTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\CountArrayLongToShort;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CountArrayLongToShortTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/CountArrayLongToShort/Fixture/count_to_empty_array_compare.php.inc
+++ b/tests/Issues/CountArrayLongToShort/Fixture/count_to_empty_array_compare.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Issues\CountArrayLongToShort\Fixture;
+
+final class CountToEmptyArrayCompare
+{
+    public function run()
+    {
+        $data = [];
+
+        if (count($data) === 0) {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\CountArrayLongToShort\Fixture;
+
+final class CountToEmptyArrayCompare
+{
+    public function run()
+    {
+        $data = [];
+
+        if ($data === []) {
+        }
+    }
+}
+
+?>

--- a/tests/Issues/CountArrayLongToShort/config/configured_rule.php
+++ b/tests/Issues/CountArrayLongToShort/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
+use Rector\Config\RectorConfig;
+use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        CountArrayToEmptyArrayComparisonRector::class,
+        LongArrayToShortArrayRector::class,
+    ]);


### PR DESCRIPTION
see https://getrector.com/demo/22e9930f-5a0a-47fc-bf98-a744715b6501 that show 2 rules:

```
Applied Rules:
    CountArrayToEmptyArrayComparisonRector
    LongArrayToShortArrayRector
```

while only add array, no need to reprint, as it default to use short array on `BetterStandardPrinter` already

https://github.com/rectorphp/rector-src/blob/ad36316e98182d42006195f66b2f3942639b97b9/src/PhpParser/Printer/BetterStandardPrinter.php#L64-L66
