### PR TITLE
[AutoImport] Skip early when no \ in FullyQualified node on NameImportingPostRector

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Bar\Foo;
 use Acme\Bar\DoNotUpdateExistingTargetNamespace;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -45,7 +46,7 @@ return static function (RectorConfig $rectorConfig): void {
             'Doctrine\DBAL\DBALException' => 'Doctrine\DBAL\Exception',
             'NotExistsClass' => 'NewClass',
 
-            foo::class => Bar\Foo::class,
+            foo::class => Foo::class,
 
             /**
              * This test never renamed as it is annotation @IsGranted

--- a/src/PostRector/Rector/NameImportingPostRector.php
+++ b/src/PostRector/Rector/NameImportingPostRector.php
@@ -17,6 +17,7 @@ use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\CodingStyle\Node\NameImporter;
 use Rector\Naming\Naming\AliasNameResolver;
 use Rector\Naming\Naming\UseImportsResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
 final class NameImportingPostRector extends AbstractPostRector
@@ -38,6 +39,16 @@ final class NameImportingPostRector extends AbstractPostRector
 
         if ($node->isSpecialClassName()) {
             return null;
+        }
+
+        // no \, skip early
+        // verify with toCodeString() which always prepend \
+        // then check its original name is a Name but not FullyQualified
+        if (substr_count($node->toCodeString(), '\\') === 1) {
+            $originalName = $node->getAttribute(AttributeKey::ORIGINAL_NAME);
+            if ($originalName instanceof Name && ! $originalName instanceof FullyQualified) {
+                return null;
+            }
         }
 
         $currentUses = $this->useImportsResolver->resolve();


### PR DESCRIPTION
similar with PR:

- https://github.com/rectorphp/rector-src/pull/6189

skip on no `\` in `FullyQualified` node, because we use nikic/php-parser `NameResolver`, which name can became `FullyQualified`, this early verify no `\`, and its original name is a `Name`, but not `FullyQualified`.