### PR TITLE
[PostRector] Avoid double traverse between on NameImportingPostRector and DocblockNameImportingPostRector

### DIFF
--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -62,7 +62,7 @@ final class PostFileProcessor implements ResetableInterface
                 continue;
             }
 
-            if ($postRector instanceof DocblockNameImportingPostRector && $shouldSkipImport) {
+            if (($postRector instanceof DocblockNameImportingPostRector || $postRector instanceof UseAddingPostRector) && $shouldSkipImport) {
                 continue;
             }
 

--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -52,11 +52,8 @@ final class PostFileProcessor implements ResetableInterface
         $shouldSkipImport = false;
 
         foreach ($this->getPostRectors() as $postRector) {
-            if (! $postRector->shouldTraverse($stmts)) {
-                if ($postRector instanceof NameImportingPostRector) {
-                    $shouldSkipImport = true;
-                }
-
+            if ($postRector instanceof NameImportingPostRector && ! $postRector->shouldTraverse($stmts)) {
+                $shouldSkipImport = true;
                 continue;
             }
 
@@ -64,7 +61,7 @@ final class PostFileProcessor implements ResetableInterface
                 continue;
             }
 
-            if ($this->shouldSkipPostRector($postRector, $file->getFilePath(), $stmts)) {
+            if ($this->shouldSkipPostRector($postRector, $file->getFilePath())) {
                 continue;
             }
 
@@ -78,10 +75,7 @@ final class PostFileProcessor implements ResetableInterface
         return $stmts;
     }
 
-    /**
-     * @param Stmt[] $stmts
-     */
-    private function shouldSkipPostRector(PostRectorInterface $postRector, string $filePath, array $stmts): bool
+    private function shouldSkipPostRector(PostRectorInterface $postRector, string $filePath): bool
     {
         if ($this->skipper->shouldSkipElementAndFilePath($postRector, $filePath)) {
             return true;

--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -49,7 +49,21 @@ final class PostFileProcessor implements ResetableInterface
      */
     public function traverse(array $stmts, File $file): array
     {
+        $shouldSkipImport = false;
+
         foreach ($this->getPostRectors() as $postRector) {
+            if (! $postRector->shouldTraverse($stmts)) {
+                if ($postRector instanceof NameImportingPostRector) {
+                    $shouldSkipImport = true;
+                }
+
+                continue;
+            }
+
+            if ($postRector instanceof DocblockNameImportingPostRector && $shouldSkipImport) {
+                continue;
+            }
+
             if ($this->shouldSkipPostRector($postRector, $file->getFilePath(), $stmts)) {
                 continue;
             }
@@ -69,10 +83,6 @@ final class PostFileProcessor implements ResetableInterface
      */
     private function shouldSkipPostRector(PostRectorInterface $postRector, string $filePath, array $stmts): bool
     {
-        if (! $postRector->shouldTraverse($stmts)) {
-            return true;
-        }
-
         if ($this->skipper->shouldSkipElementAndFilePath($postRector, $filePath)) {
             return true;
         }

--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -52,16 +52,17 @@ final class PostFileProcessor implements ResetableInterface
         $shouldSkipImport = false;
 
         foreach ($this->getPostRectors() as $postRector) {
+            if ($this->shouldSkipPostRector($postRector, $file->getFilePath())) {
+                continue;
+            }
+
+            /** @var Stmt[] $stmts */
             if ($postRector instanceof NameImportingPostRector && ! $postRector->shouldTraverse($stmts)) {
                 $shouldSkipImport = true;
                 continue;
             }
 
             if ($postRector instanceof DocblockNameImportingPostRector && $shouldSkipImport) {
-                continue;
-            }
-
-            if ($this->shouldSkipPostRector($postRector, $file->getFilePath())) {
                 continue;
             }
 

--- a/src/PostRector/Contract/Rector/PostRectorInterface.php
+++ b/src/PostRector/Contract/Rector/PostRectorInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PostRector\Contract\Rector;
 
-use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitor;
 use Rector\ValueObject\Application\File;
 
@@ -13,10 +12,5 @@ use Rector\ValueObject\Application\File;
  */
 interface PostRectorInterface extends NodeVisitor
 {
-    /**
-     * @param Stmt[] $stmts
-     */
-    public function shouldTraverse(array $stmts): bool;
-
     public function setFile(File $file): void;
 }

--- a/src/PostRector/Rector/AbstractPostRector.php
+++ b/src/PostRector/Rector/AbstractPostRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\PostRector\Rector;
 
-use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitorAbstract;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Rector\ValueObject\Application\File;
@@ -13,14 +12,6 @@ use Webmozart\Assert\Assert;
 abstract class AbstractPostRector extends NodeVisitorAbstract implements PostRectorInterface
 {
     private File|null $file = null;
-
-    /**
-     * @param Stmt[] $stmts
-     */
-    public function shouldTraverse(array $stmts): bool
-    {
-        return true;
-    }
 
     public function setFile(File $file): void
     {

--- a/src/PostRector/Rector/DocblockNameImportingPostRector.php
+++ b/src/PostRector/Rector/DocblockNameImportingPostRector.php
@@ -7,7 +7,6 @@ namespace Rector\PostRector\Rector;
 use PhpParser\Node;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\InlineHTML;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -42,13 +41,5 @@ final class DocblockNameImportingPostRector extends AbstractPostRector
 
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
         return $node;
-    }
-
-    /**
-     * @param Stmt[] $stmts
-     */
-    public function shouldTraverse(array $stmts): bool
-    {
-        return ! $this->betterNodeFinder->hasInstancesOf($stmts, [InlineHTML::class]);
     }
 }

--- a/src/PostRector/Rector/DocblockNameImportingPostRector.php
+++ b/src/PostRector/Rector/DocblockNameImportingPostRector.php
@@ -11,7 +11,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockNameImporter;
-use Rector\PhpParser\Node\BetterNodeFinder;
 
 final class DocblockNameImportingPostRector extends AbstractPostRector
 {
@@ -19,7 +18,6 @@ final class DocblockNameImportingPostRector extends AbstractPostRector
         private readonly DocBlockNameImporter $docBlockNameImporter,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 


### PR DESCRIPTION
should traverse logic between `NameImportingPostRector` and `DocblockNameImportingPostRector` should sync, so this PR only make it once, and add flag on loop, the fixture for it already exists on 

https://github.com/rectorphp/rector-src/blob/fa0d8d834d3518168a150bbba8157b2880d66ad6/tests/Issues/AutoImport/Fixture/DocBlock/skip_with_html.php.inc#L1-L8

by this, the `shouldTraverse()` only used once, so I removed from interface.