### PR TITLE
[AutoImport] Skip conflict short name import docblock on no namespace

### DIFF
--- a/tests/Issues/AutoImport/Fixture/DocBlock/skip_no_namespace_conflict_docblock_shortname.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/skip_no_namespace_conflict_docblock_shortname.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+class SkipNoNamespaceConflictDocblockShortname
+{
+    /**
+     * @param Rector\Tests\Issues\AutoImport\Source\stdClass
+     */
+    public function some($param)
+    {
+    }
+
+    /**
+     * @param stdClass
+     */
+    public function some2($param)
+    {
+    }
+}

--- a/tests/Issues/AutoImport/Fixture/DocBlock/skip_no_namespace_conflict_docblock_shortname.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/skip_no_namespace_conflict_docblock_shortname.php.inc
@@ -3,14 +3,14 @@
 class SkipNoNamespaceConflictDocblockShortname
 {
     /**
-     * @param Rector\Tests\Issues\AutoImport\Source\stdClass
+     * @param Rector\Tests\Issues\AutoImport\Source\stdClass $param
      */
     public function some($param)
     {
     }
 
     /**
-     * @param stdClass
+     * @param stdClass $param
      */
     public function some2($param)
     {


### PR DESCRIPTION
this is more test for skip import docblock on no `\` on :

- https://github.com/rectorphp/rector-src/pull/6189