### PR TITLE
[Experiment] [NodeTypeResolver] Allow more rules apply continuity by ensure Scope filled instead of skipped on RectifiedAnalyzer

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -171,6 +171,18 @@ final readonly class PHPStanNodeScopeResolver
                 return;
             }
 
+            if ($node instanceof StmtsAwareInterface && $node->stmts !== null) {
+                foreach ($node->stmts as $stmt) {
+                    // just being added
+                    if ($stmt->getStartTokenPos() < 0 && ! $stmt->hasAttribute(AttributeKey::SCOPE)) {
+                        $this->nodeScopeResolverProcessNodes([$stmt], $mutatingScope, $nodeCallback);
+                    }
+                }
+
+                // don't return early here
+                // other more specific StmtsAwareInterface instance checked below
+            }
+
             if ((
                 $node instanceof Expression ||
                 $node instanceof Return_ ||
@@ -283,15 +295,6 @@ final readonly class PHPStanNodeScopeResolver
             if ($node instanceof CallLike) {
                 $this->processCallike($node, $mutatingScope);
                 return;
-            }
-
-            if ($node instanceof StmtsAwareInterface && $node->stmts !== null) {
-                foreach ($node->stmts as $stmt) {
-                    // just being added
-                    if ($stmt->getStartTokenPos() < 0 && ! $stmt->hasAttribute(AttributeKey::SCOPE)) {
-                        $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-                    }
-                }
             }
         };
 

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -292,11 +292,6 @@ final readonly class PHPStanNodeScopeResolver
 
                 return;
             }
-
-            // ensure nothing left behind
-            if ($node instanceof Stmt) {
-                $this->setJustAddedStmtScope($node, $mutatingScope, $nodeCallback);
-            }
         };
 
         $this->nodeScopeResolverProcessNodes($stmts, $scope, $nodeCallback);

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -293,6 +293,7 @@ final readonly class PHPStanNodeScopeResolver
                 return;
             }
 
+            // ensure nothing left behind
             if ($node instanceof Stmt) {
                 $this->setJustAddedStmtScope($node, $mutatingScope, $nodeCallback);
             }

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -287,11 +287,14 @@ final readonly class PHPStanNodeScopeResolver
 
             if ($node instanceof StmtsAwareInterface && $node->stmts !== null) {
                 foreach ($node->stmts as $stmt) {
-                    // just created and not yet has scope attribute
-                    if ($stmt->getStartTokenPos() < 0 && ! $stmt->hasAttribute(AttributeKey::SCOPE)) {
-                        $this->nodeScopeResolverProcessNodes([$stmt], $mutatingScope, $nodeCallback);
-                    }
+                    $this->setJustAddedStmtScope($stmt, $mutatingScope, $nodeCallback);
                 }
+
+                return;
+            }
+
+            if ($node instanceof Stmt) {
+                $this->setJustAddedStmtScope($node, $mutatingScope, $nodeCallback);
             }
         };
 
@@ -307,6 +310,17 @@ final readonly class PHPStanNodeScopeResolver
         $nodeTraverser->traverse($stmts);
 
         return $stmts;
+    }
+
+    /**
+     * @param callable(Node $node, MutatingScope $scope): void $nodeCallback
+     */
+    private function setJustAddedStmtScope(Stmt $stmt, MutatingScope $mutatingScope, callable $nodeCallback): void
+    {
+        // just created and not yet has scope attribute
+        if ($stmt->getStartTokenPos() < 0 && ! $stmt->hasAttribute(AttributeKey::SCOPE)) {
+            $this->nodeScopeResolverProcessNodes([$stmt], $mutatingScope, $nodeCallback);
+        }
     }
 
     /**

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -37,17 +37,19 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
         $mutatingScope = $this->resolveScope($node->getAttribute(AttributeKey::SCOPE));
 
         foreach ($node->stmts as $stmt) {
-            $hasMutatingScope = $stmt->getAttribute(AttributeKey::SCOPE) instanceof MutatingScope;
-            if (! $hasMutatingScope) {
+            // just being added, set
+            if (! $stmt->hasAttribute(AttributeKey::SCOPE)) {
                 $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
                 $this->phpStanNodeScopeResolver->processNodes([$stmt], $this->filePath, $mutatingScope);
             }
 
+            // has isUnreachable attribute already, continue as scope already set
             if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
                 $isPassedUnreachableStmt = true;
                 continue;
             }
 
+            // is stmt after isUnreachable stmt, needs isUnreachable attribute set
             if ($isPassedUnreachableStmt) {
                 $stmt->setAttribute(AttributeKey::IS_UNREACHABLE, true);
             }

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -37,21 +37,18 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
         $mutatingScope = $this->resolveScope($node->getAttribute(AttributeKey::SCOPE));
 
         foreach ($node->stmts as $stmt) {
-            // just being added, set
-            if (! $stmt->hasAttribute(AttributeKey::SCOPE)) {
-                $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-                $this->phpStanNodeScopeResolver->processNodes([$stmt], $this->filePath, $mutatingScope);
-            }
-
             // has isUnreachable attribute already, continue as scope already set
             if ($stmt->getAttribute(AttributeKey::IS_UNREACHABLE) === true) {
                 $isPassedUnreachableStmt = true;
                 continue;
             }
 
-            // is stmt after isUnreachable stmt, needs isUnreachable attribute set
+            // is stmt after isUnreachable stmt, set isUnreachable attribute and scope
             if ($isPassedUnreachableStmt) {
                 $stmt->setAttribute(AttributeKey::IS_UNREACHABLE, true);
+                $stmt->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+
+                $this->phpStanNodeScopeResolver->processNodes([$stmt], $this->filePath, $mutatingScope);
             }
         }
 

--- a/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
+++ b/src/PHPStan/NodeVisitor/UnreachableStatementNodeVisitor.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Rector\PHPStan\NodeVisitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\Declare_;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
@@ -25,7 +23,7 @@ final class UnreachableStatementNodeVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node): ?Node
     {
-        if (! $node instanceof StmtsAwareInterface && ! $node instanceof ClassLike && ! $node instanceof Declare_) {
+        if (! $node instanceof StmtsAwareInterface) {
             return null;
         }
 

--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\ProcessAnalyzer;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -13,7 +12,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  * This service verify if the Node:
  *
  *      - already applied same Rector rule before current Rector rule on last previous Rector rule.
- *      - Just added as new Stmt
  *      - just re-printed but token start still >= 0
  *      - has above node skipped traverse children on current rule
  */
@@ -30,22 +28,11 @@ final class RectifiedAnalyzer
             return true;
         }
 
-        if ($this->isJustAddedAsNewStmt($node, $originalNode)) {
-            return true;
-        }
-
         if ($this->isJustReprintedOverlappedTokenStart($node, $originalNode)) {
             return true;
         }
 
         return $node->getAttribute(AttributeKey::SKIPPED_BY_RECTOR_RULE) === $rectorClass;
-    }
-
-    private function isJustAddedAsNewStmt(Node $node, ?Node $originalNode): bool
-    {
-        return ! $originalNode instanceof Node
-            && $node instanceof Stmt
-            && array_keys($node->getAttributes()) === [AttributeKey::SCOPE];
     }
 
     /**
@@ -77,14 +64,6 @@ final class RectifiedAnalyzer
          * - Parent Node's original node is null
          */
         $startTokenPos = $node->getStartTokenPos();
-        if ($startTokenPos >= 0) {
-            return true;
-        }
-
-        if ($node instanceof Stmt) {
-            return ! in_array(AttributeKey::SCOPE, array_keys($node->getAttributes()), true);
-        }
-
-        return $node->getAttributes() === [];
+        return $startTokenPos >= 0;
     }
 }


### PR DESCRIPTION
Currently, on multiple rules apply, there are 2 conditions when Scope not yet filled skipped on `RectifiedAnalyzer`:

- On Stmt just being added
- On Expr inside Attribute, eg: Array_ on AttributeGroups which needs to be used on next rules.

This ensure allow more rules apply continuity instead of skipped so less re-run rector :)