### PR TITLE
[Performance] Cache should traverse for AddUseStatementGuard

### DIFF
--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -50,7 +50,7 @@ final class PostFileProcessor implements ResetableInterface
     public function traverse(array $stmts, File $file): array
     {
         foreach ($this->getPostRectors() as $postRector) {
-            // file must be set into PostRector class to ensure its usage
+            // file must be set early into PostRector class to ensure its usage
             // always match on skipping process
             $postRector->setFile($file);
 

--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -50,11 +50,13 @@ final class PostFileProcessor implements ResetableInterface
     public function traverse(array $stmts, File $file): array
     {
         foreach ($this->getPostRectors() as $postRector) {
+            // file must be set into PostRector class to ensure it usage
+            // always match on skipping process
+            $postRector->setFile($file);
+
             if ($this->shouldSkipPostRector($postRector, $file->getFilePath(), $stmts)) {
                 continue;
             }
-
-            $postRector->setFile($file);
 
             $nodeTraverser = new NodeTraverser();
             $nodeTraverser->addVisitor($postRector);

--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -50,7 +50,7 @@ final class PostFileProcessor implements ResetableInterface
     public function traverse(array $stmts, File $file): array
     {
         foreach ($this->getPostRectors() as $postRector) {
-            // file must be set into PostRector class to ensure it usage
+            // file must be set into PostRector class to ensure its usage
             // always match on skipping process
             $postRector->setFile($file);
 

--- a/src/PostRector/Guard/AddUseStatementGuard.php
+++ b/src/PostRector/Guard/AddUseStatementGuard.php
@@ -11,6 +11,11 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 
 class AddUseStatementGuard
 {
+    /**
+     * @var array<string, bool>
+     */
+    private array $shouldTraverseOnFiles = [];
+
     public function __construct(
         private readonly BetterNodeFinder $betterNodeFinder
     ) {
@@ -19,8 +24,12 @@ class AddUseStatementGuard
     /**
      * @param Stmt[] $stmts
      */
-    public function shouldTraverse(array $stmts): bool
+    public function shouldTraverse(array $stmts, string $filePath): bool
     {
+        if (isset($this->shouldTraverseOnFiles[$filePath])) {
+            return $this->shouldTraverseOnFiles[$filePath];
+        }
+
         $totalNamespaces = 0;
 
         // just loop the first level stmts to locate namespace to improve performance
@@ -32,10 +41,10 @@ class AddUseStatementGuard
 
             // skip if 2 namespaces are present
             if ($totalNamespaces === 2) {
-                return false;
+                return $this->shouldTraverseOnFiles[$filePath] = false;
             }
         }
 
-        return ! $this->betterNodeFinder->hasInstancesOf($stmts, [InlineHTML::class]);
+        return $this->shouldTraverseOnFiles[$filePath] = ! $this->betterNodeFinder->hasInstancesOf($stmts, [InlineHTML::class]);
     }
 }

--- a/src/PostRector/Rector/DocblockNameImportingPostRector.php
+++ b/src/PostRector/Rector/DocblockNameImportingPostRector.php
@@ -48,6 +48,6 @@ final class DocblockNameImportingPostRector extends AbstractPostRector
      */
     public function shouldTraverse(array $stmts): bool
     {
-        return $this->addUseStatementGuard->shouldTraverse($stmts);
+        return $this->addUseStatementGuard->shouldTraverse($stmts, $this->getFile()->getFilePath());
     }
 }

--- a/src/PostRector/Rector/NameImportingPostRector.php
+++ b/src/PostRector/Rector/NameImportingPostRector.php
@@ -57,7 +57,7 @@ final class NameImportingPostRector extends AbstractPostRector
      */
     public function shouldTraverse(array $stmts): bool
     {
-        return $this->addUseStatementGuard->shouldTraverse($stmts);
+        return $this->addUseStatementGuard->shouldTraverse($stmts, $this->getFile()->getFilePath());
     }
 
     /**


### PR DESCRIPTION
`AddUseStatementGuard` is used in both classes:

- NameImportingPostRector
- DocblockNameImportingPostRector

if it already checked, no need to double check, this cache to improve the performance to avoid double traverse to verify double namespace or has InlineHTML on `AddUseStatementGuard`