### PR TITLE
[AutoImport] Do not add cast on valid Integer type on aliased Name Node on auto import enabled

### DIFF
--- a/src/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
@@ -75,7 +75,7 @@ final class StaticCallMethodCallTypeResolver implements NodeTypeResolverInterfac
         }
 
         if ($callerType instanceof AliasedObjectType) {
-            $callerType = new FullyQualifiedObjectType ($callerType->getFullyQualifiedName());
+            $callerType = new FullyQualifiedObjectType($callerType->getFullyQualifiedName());
         }
 
         foreach ($callerType->getObjectClassReflections() as $objectClassReflection) {

--- a/src/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/StaticCallMethodCallTypeResolver.php
@@ -18,6 +18,8 @@ use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
+use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
 /**
  * @implements NodeTypeResolverInterface<StaticCall|MethodCall>
@@ -70,6 +72,10 @@ final class StaticCallMethodCallTypeResolver implements NodeTypeResolverInterfac
             $callerType = $this->nodeTypeResolver->getType($node->var);
         } else {
             $callerType = $this->nodeTypeResolver->getType($node->class);
+        }
+
+        if ($callerType instanceof AliasedObjectType) {
+            $callerType = new FullyQualifiedObjectType ($callerType->getFullyQualifiedName());
         }
 
         foreach ($callerType->getObjectClassReflections() as $objectClassReflection) {

--- a/src/PostRector/Rector/NameImportingPostRector.php
+++ b/src/PostRector/Rector/NameImportingPostRector.php
@@ -15,6 +15,7 @@ use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\CodingStyle\Node\NameImporter;
 use Rector\Naming\Naming\AliasNameResolver;
 use Rector\Naming\Naming\UseImportsResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\Guard\AddUseStatementGuard;
 
 final class NameImportingPostRector extends AbstractPostRector
@@ -46,6 +47,7 @@ final class NameImportingPostRector extends AbstractPostRector
         // make use of existing use import
         $nameInUse = $this->resolveNameInUse($node, $currentUses);
         if ($nameInUse instanceof Name) {
+            $nameInUse->setAttribute(AttributeKey::NAMESPACED_NAME, $node->toString());
             return $nameInUse;
         }
 

--- a/tests/Issues/AutoImport/Fixture/do_not_add_cast_valid_int_type_from_name_aliased.php.inc
+++ b/tests/Issues/AutoImport/Fixture/do_not_add_cast_valid_int_type_from_name_aliased.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Rector\Tests\Issues\AutoImport\Source\SomeClass as SomeClass1;
+use Fixture\SomeClass;
+
+class DoNotAddCastValidIntTypeFromNameAliased extends Command
+{
+    private ?OutputInterface $outputInterface = null;
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return \Rector\Tests\Issues\AutoImport\Source\SomeClass::zero();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Rector\Tests\Issues\AutoImport\Source\SomeClass as SomeClass1;
+use Fixture\SomeClass;
+
+class DoNotAddCastValidIntTypeFromNameAliased extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return SomeClass1::zero();
+    }
+}
+
+?>


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/6236

this handle to not cast valid integer from Name from aliased name on Static call.