### PR TITLE
Deprecate PublicConstantVisibilityRector, as adds public blindly everywhere; use scope-based approach instead

### DIFF
--- a/config/set/php71.php
+++ b/config/set/php71.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Rector\Php71\Rector\Assign\AssignArrayToStringRector;
 use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
 use Rector\Php71\Rector\BooleanOr\IsIterableRector;
-use Rector\Php71\Rector\ClassConst\PublicConstantVisibilityRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php71\Rector\List_\ListToArrayDestructRector;
 use Rector\Php71\Rector\TryCatch\MultiExceptionCatchRector;
@@ -19,6 +18,5 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveExtraParametersRector::class,
         BinaryOpBetweenNumberAndStringRector::class,
         ListToArrayDestructRector::class,
-        PublicConstantVisibilityRector::class,
     ]);
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -297,5 +297,5 @@ parameters:
             path: src/VendorLocker/ParentClassMethodTypeOverrideGuard.php
 
         # deprecated
-        - '#Property Rector\\TypeDeclaration\\Rector\\ClassMethod\\ReturnTypeFromStrictScalarReturnExprRector\:\:\$hardCodedOnly is never read, only written#'
+        - '#Register "Rector\\Php71\\Rector\\ClassConst\\PublicConstantVisibilityRector" service to "php71\.php" config set#'
         - '#Public method "Rector\\ValueObject\\Error\\SystemError\:\:getFile\(\)" is never used#'

--- a/rules/Php71/Rector/ClassConst/PublicConstantVisibilityRector.php
+++ b/rules/Php71/Rector/ClassConst/PublicConstantVisibilityRector.php
@@ -6,6 +6,7 @@ namespace Rector\Php71\Rector\ClassConst;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassConst;
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
@@ -15,8 +16,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\Tests\Php71\Rector\ClassConst\PublicConstantVisibilityRector\PublicConstantVisibilityRectorTest
+ * @deprecated Since 1.2.4, as adds blindly public to all constants, even local-only ones that should be private. Use scope-based solution instead, e.g. https://tomasvotruba.com/blog/how-to-add-visbility-to-338-class-constants-in-25-seconds
  */
-final class PublicConstantVisibilityRector extends AbstractRector implements MinPhpVersionInterface
+final class PublicConstantVisibilityRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedInterface
 {
     public function __construct(
         private readonly VisibilityManipulator $visibilityManipulator,

--- a/tests/Issues/AutoImport/config/configured_rule.php
+++ b/tests/Issues/AutoImport/config/configured_rule.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\Renaming\Rector\Name\RenameClassRector;
-use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\Symfony\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -20,8 +20,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
         new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity'),
     ]);
-    $rectorConfig->rules([
-        ConsoleExecuteReturnIntRector::class,
-        RemoveUnusedPrivatePropertyRector::class,
-    ]);
+    $rectorConfig->rules([ConsoleExecuteReturnIntRector::class, RemoveUnusedPrivatePropertyRector::class]);
 };


### PR DESCRIPTION
This rule blindly adds `public` visibility to all constants, even if it's used only locally and should be `private`. This makes code upgraded in wrong way.

Solution with scope detection should be used instead, e.g.:
https://tomasvotruba.com/blog/how-to-add-visbility-to-338-class-constants-in-25-seconds