### PR TITLE
Optimise post rectors

### DIFF
--- a/src/PostRector/Rector/ClassRenamingPostRector.php
+++ b/src/PostRector/Rector/ClassRenamingPostRector.php
@@ -23,6 +23,11 @@ final class ClassRenamingPostRector extends AbstractPostRector
 {
     private FileWithoutNamespace|Namespace_|null $rootNode = null;
 
+    /**
+     * @var array<string, string>
+     */
+    private array $oldToNewClasses;
+
     public function __construct(
         private readonly ClassRenamer $classRenamer,
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
@@ -43,15 +48,10 @@ final class ClassRenamingPostRector extends AbstractPostRector
         return $nodes;
     }
 
-    public function enterNode(Node $node): ?Node
+    public function enterNode(Node $node): Node|int|null
     {
         // no longer need post rename
         if (! $node instanceof Name) {
-            return null;
-        }
-
-        $oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
-        if ($oldToNewClasses === []) {
             return null;
         }
 
@@ -59,9 +59,9 @@ final class ClassRenamingPostRector extends AbstractPostRector
         $scope = $node->getAttribute(AttributeKey::SCOPE);
 
         if ($node instanceof FullyQualified) {
-            $result = $this->classRenamer->renameNode($node, $oldToNewClasses, $scope);
+            $result = $this->classRenamer->renameNode($node, $this->oldToNewClasses, $scope);
         } else {
-            $result = $this->resolveResultWithPhpAttributeName($node, $oldToNewClasses, $scope);
+            $result = $this->resolveResultWithPhpAttributeName($node, $scope);
         }
 
         if (! SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_NAMES)) {
@@ -88,19 +88,20 @@ final class ClassRenamingPostRector extends AbstractPostRector
         return $nodes;
     }
 
-    /**
-     * @param array<string, string> $oldToNewClasses
-     */
-    private function resolveResultWithPhpAttributeName(
-        Name $name,
-        array $oldToNewClasses,
-        ?Scope $scope
-    ): ?FullyQualified {
+    public function shouldTraverse(array $stmts): bool
+    {
+        $this->oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
+
+        return $this->oldToNewClasses !== [];
+    }
+
+    private function resolveResultWithPhpAttributeName(Name $name, ?Scope $scope): ?FullyQualified
+    {
         $phpAttributeName = $name->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
         if (is_string($phpAttributeName)) {
             return $this->classRenamer->renameNode(
                 new FullyQualified($phpAttributeName, $name->getAttributes()),
-                $oldToNewClasses,
+                $this->oldToNewClasses,
                 $scope
             );
         }

--- a/src/PostRector/Rector/ClassRenamingPostRector.php
+++ b/src/PostRector/Rector/ClassRenamingPostRector.php
@@ -26,7 +26,7 @@ final class ClassRenamingPostRector extends AbstractPostRector
     /**
      * @var array<string, string>
      */
-    private array $oldToNewClasses;
+    private array $oldToNewClasses = [];
 
     public function __construct(
         private readonly ClassRenamer $classRenamer,
@@ -48,7 +48,7 @@ final class ClassRenamingPostRector extends AbstractPostRector
         return $nodes;
     }
 
-    public function enterNode(Node $node): Node|int|null
+    public function enterNode(Node $node): ?Node
     {
         // no longer need post rename
         if (! $node instanceof Name) {

--- a/src/PostRector/Rector/NameImportingPostRector.php
+++ b/src/PostRector/Rector/NameImportingPostRector.php
@@ -23,7 +23,7 @@ final class NameImportingPostRector extends AbstractPostRector
     /**
      * @var array<Use_|GroupUse>
      */
-    private array $currentUses;
+    private array $currentUses = [];
 
     public function __construct(
         private readonly NameImporter $nameImporter,

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -16,8 +16,6 @@ use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
 use PhpParser\NodeTraverser;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\Configuration\Option;
-use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -33,10 +31,6 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     public function enterNode(Node $node): ?Node
     {
         if (! $node instanceof Namespace_ && ! $node instanceof FileWithoutNamespace) {
-            return null;
-        }
-
-        if (! SimpleParameterProvider::provideBoolParameter(Option::REMOVE_UNUSED_IMPORTS)) {
             return null;
         }
 

--- a/src/PostRector/Rector/UseAddingPostRector.php
+++ b/src/PostRector/Rector/UseAddingPostRector.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\PostRector\Rector;
 
+use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeTraverser;
 use Rector\CodingStyle\Application\UseImportsAdder;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -66,6 +68,11 @@ final class UseAddingPostRector extends AbstractPostRector
             $functionUseImportTypes,
             $rootNode
         );
+    }
+
+    public function enterNode(Node $node): int
+    {
+        return NodeTraverser::STOP_TRAVERSAL;
     }
 
     /**

--- a/src/PostRector/Rector/UseAddingPostRector.php
+++ b/src/PostRector/Rector/UseAddingPostRector.php
@@ -72,6 +72,14 @@ final class UseAddingPostRector extends AbstractPostRector
 
     public function enterNode(Node $node): int
     {
+        /**
+         * We stop the traversal because all the work has already been done in the beforeTraverse() function
+         *
+         * Using STOP_TRAVERSAL is usually dangerous as it will stop the processing of all your nodes for all visitors
+         * but since the PostFileProcessor is using direct new NodeTraverser() and traverse() for only a single
+         * visitor per execution, using stop traversal here is safe,
+         * ref https://github.com/rectorphp/rector-src/blob/fc1e742fa4d9861ccdc5933f3b53613b8223438d/src/PostRector/Application/PostFileProcessor.php#L59-L61
+         */
         return NodeTraverser::STOP_TRAVERSAL;
     }
 


### PR DESCRIPTION
When I was investigating https://github.com/rectorphp/rector/issues/8793 yesterday I noticed that the `NameImportingPostRector` post rector could be optimised because it was unnecessarily calculating the use statements for every node so I decided to add a fix. I took the opportunity to look at the other post rectors and found some other possible optimisations. They are small optimisations, nothing really very noticeable, but, as they say, every little helps!

See the PR comments for more info