### PR TITLE
Use ocramius/package-versions to get output phpstan version installed to replace on build

### DIFF
--- a/bin/add-phpstan-self-replace.php
+++ b/bin/add-phpstan-self-replace.php
@@ -4,6 +4,7 @@
 
 declare(strict_types=1);
 
+use PackageVersions\Versions;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
 
@@ -12,7 +13,9 @@ require __DIR__ . '/../vendor/autoload.php';
 $composerJsonFileContents = FileSystem::read(__DIR__ . '/../composer.json');
 
 $composerJson = Json::decode($composerJsonFileContents, forceArrays: true);
-$composerJson['replace']['phpstan/phpstan'] = $composerJson['require']['phpstan/phpstan'];
+// result output is like: // 1.0.0@0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33
+[$phpstanVersion, ] = explode('@', Versions::getVersion('phpstan/phpstan'));
+$composerJson['replace']['phpstan/phpstan'] = $phpstanVersion;
 
 $modifiedComposerJsonFileContents = Json::encode($composerJson, pretty: true);
 FileSystem::write(__DIR__ . '/../composer.json', $modifiedComposerJsonFileContents, null);

--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -34,6 +34,7 @@ wget https://github.com/humbug/php-scoper/releases/download/0.18.10/php-scoper.p
 note "Remove PHPStan to avoid duplicating it"
 php "$BUILD_DIRECTORY/bin/add-phpstan-self-replace.php"
 composer remove phpstan/phpstan -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
+composer remove ocramius/package-versions -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
 
 # Work around possible PHP memory limits
 note "Running php-scoper on /bin, /config, /src, /rules and /vendor"

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -9,6 +9,7 @@ $config = new Configuration();
 
 return $config
     ->addPathToScan(__DIR__ . '/build/config', false)
+    ->addPathToScan('bin', false)
     // prepared test tooling
     ->ignoreErrorsOnPackage('phpunit/phpunit', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     // pinned v3.x version

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "illuminate/container": "^11.0",
         "nette/utils": "^4.0",
         "nikic/php-parser": "^4.19.1",
+        "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^1.29",
         "phpstan/phpstan": "^1.11.11",


### PR DESCRIPTION
This is to avoid overlap installed version which may cause conflict with pcre as it was only read composer.json which still not yet updated per latest version

https://github.com/rectorphp/rector-src/actions/runs/10427416553/job/29000192250#step:11:30

running the command will output:

```diff
diff --git a/composer.json b/composer.json
index 31dba81806..fece69b0dd 100644
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
         "rector/rector": "self.version",
         "symfony/string": "*",
         "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-intl-grapheme": "*"
+        "symfony/polyfill-intl-grapheme": "*",
+        "phpstan/phpstan": "1.11.11"
```

phpstan version installed.