### PR TITLE
Remove self after exection of add-phpstan-self-replace.php

### DIFF
--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -33,6 +33,10 @@ wget https://github.com/humbug/php-scoper/releases/download/0.18.10/php-scoper.p
 # avoid phpstan/phpstan dependency duplicate
 note "Remove PHPStan to avoid duplicating it"
 php "$BUILD_DIRECTORY/bin/add-phpstan-self-replace.php"
+
+# no longer used
+rm -rf "$BUILD_DIRECTORY/bin/add-phpstan-self-replace.php"
+
 composer remove phpstan/phpstan -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
 composer remove ocramius/package-versions -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
 


### PR DESCRIPTION
It unused on scoped build after execution, so it needs to be removed after it executed