### PR TITLE
Remove unneeded bin/add-phpstan-self-replace.php and bin/test-fixture-stats.php on target remote-repository on build after execution

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -95,6 +95,8 @@ jobs:
 
             -   run: cp -a rector-prefixed-downgraded/. remote-repository
 
+            -   run: rm -rf remote-repository/bin/add-phpstan-self-replace.php remote-repository/bin/test-fixture-stats.php
+
             # 7. setup git
             -
                 working-directory: remote-repository

--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -34,9 +34,6 @@ wget https://github.com/humbug/php-scoper/releases/download/0.18.10/php-scoper.p
 note "Remove PHPStan to avoid duplicating it"
 php "$BUILD_DIRECTORY/bin/add-phpstan-self-replace.php"
 
-# no longer used
-rm -rf "$BUILD_DIRECTORY/bin/add-phpstan-self-replace.php"
-
 composer remove phpstan/phpstan -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
 composer remove ocramius/package-versions -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
 


### PR DESCRIPTION
The 2 files on bin/ are not needed on build scoped:

- https://github.com/rectorphp/rector/blob/85a76abf27fd77334bc75192f1191f7d4f3b0338/bin/add-phpstan-self-replace.php
- https://github.com/rectorphp/rector/blob/85a76abf27fd77334bc75192f1191f7d4f3b0338/bin/test-fixture-stats.php
