### PR TITLE
Add CRLF test case for EregToPregMatchRector

### DIFF
--- a/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/fixture3.php.inc
+++ b/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/fixture3.php.inc
@@ -9,6 +9,8 @@ function eregToPregMatch3()
     split('hi', 'hi, she said', 0);
 
     spliti('hi', 'hi, she said', 1);
+
+    split("\r\n", "line 1\r\nline 2\r\n");
 }
 
 ?>
@@ -24,6 +26,8 @@ function eregToPregMatch3()
     preg_split('#hi#m', 'hi, she said', 1);
 
     preg_split('#hi#mi', 'hi, she said', 1);
+
+    preg_split("#\r\n#m", "line 1\r\nline 2\r\n");
 }
 
 ?>


### PR DESCRIPTION
`EregToPregMatchRector` (and `EregToPcreTransformer`) convert _ereg_ regular expression strings that contain CR or LF characters (i.e., double-quoted strings with `\r` or `\n`) to _preg_ regular expression strings that are single-quoted but contain the unescaped character (i.e., multi-line string literal with embedded CR or LF characters).

Example:

```php
    $splitLF   = split("\n",   $s);
    $splitCRLF = split("\r\n", $s);
```

... becomes ...

```php
    $splitLF   = preg_split('#
#m',   $s);
    $splitCRLF = preg_split('#
#m', $s);
```

(The CR is invisible in the second statement in the output, so it looks like a duplicate of the first statement.)

This transformation complies with PHP syntax, and the _preg_ functions treat `"#\r#"` as equivalent to `'#\r#'`. The problem occurs when _git_ and its _autocrlf_ behavior removes CR characters without regard to them being embedded in multi-line strings. This results in a platform-dependent regular expression, when the original source code avoided that behavior.

Even though this is clearly a _caveat developer_ situation, it would be nice if the `EregToPregMatchRector` rule could try to preserve the original representation. Converting the double-quoted string to a suitable single-quoted PCRE regular expression would be ideal, but probably too error prone.
