### PR TITLE
[PHPStan 1.11.x] [AttributeKey] Drop statementDepth attribute

### DIFF
--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -189,11 +189,6 @@ final class AttributeKey
     /**
      * @var string
      */
-    public const STATEMENT_DEPTH = 'statementDepth';
-
-    /**
-     * @var string
-     */
     public const IS_IN_LOOP = 'is_in_loop';
 
     /**

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -7,7 +7,6 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Declare_;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -15,38 +14,6 @@ use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNode
 
 final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
-    /**
-     * @param Node[] $nodes
-     */
-    public function beforeTraverse(array $nodes): ?array
-    {
-        if ($nodes === []) {
-            return null;
-        }
-
-        if (! $nodes[0] instanceof Declare_ && ! $nodes[0] instanceof Namespace_) {
-            return null;
-        }
-
-        // on target node or no other root stmt, eg: only namespace without declare, no need to index
-        if (count($nodes) === 1) {
-            return null;
-        }
-
-        // ensure statement depth is 0 to avoid declare in deep statements
-        // eg: declare(ticks=1) @see https://www.php.net/manual/en/control-structures.declare.php#123674
-        $statementDepth = $nodes[0]->getAttribute(AttributeKey::STATEMENT_DEPTH);
-        if ($statementDepth > 0 || $statementDepth === null) {
-            return null;
-        }
-
-        foreach ($nodes as $key => $node) {
-            $node->setAttribute(AttributeKey::STMT_KEY, $key);
-        }
-
-        return $nodes;
-    }
-
     public function enterNode(Node $node): ?Node
     {
         if (! $node instanceof StmtsAwareInterface && ! $node instanceof ClassLike && ! $node instanceof Declare_) {


### PR DESCRIPTION
In PHPStan 1.10.x, there was `StatementOrderVisitor` which calculate statement depth and produce `statementDepth`

https://github.com/phpstan/phpstan-src/blob/c7e624414b93355d5cec2d7737043b099f71132a/src/NodeVisitor/StatementOrderVisitor.php#L42

previously, we check early on our `StmtKeyNodeVisitor`, since it no longer exists in 1.11.x, the check on `beforeTraverse()` is no longer make sense as it always result `null` now.