### PR TITLE
[Php84] Do not reprint node type on ExplicitNullableParamTypeRector

### DIFF
--- a/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/do_not_reprint_node_type.php.inc
+++ b/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/do_not_reprint_node_type.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\Fixture;
+
+use stdClass;
+
+class DoNotReprintNodeType
+{
+    public function run(stdClass $a = null)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\Fixture;
+
+use stdClass;
+
+class DoNotReprintNodeType
+{
+    public function run(?stdClass $a = null)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/do_not_reprint_node_type2.php.inc
+++ b/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/do_not_reprint_node_type2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+class DoNotReprintNodeType2
+{
+    public function run(stdClass|DateTime $a = null)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+class DoNotReprintNodeType2
+{
+    public function run(stdClass|DateTime|null $a = null)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/do_not_reprint_node_type3.php.inc
+++ b/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/do_not_reprint_node_type3.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use stdClass;
+
+class DoNotReprintNodeType3
+{
+    public function run(MockObject&stdClass $a = null)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use stdClass;
+
+class DoNotReprintNodeType3
+{
+    public function run((MockObject&stdClass)|null $a = null)
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/skip_mixed.php.inc
+++ b/rules-tests/Php84/Rector/Param/ExplicitNullableParamTypeRector/Fixture/skip_mixed.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\Fixture;
+
+class SkipMixed
+{
+    public function run(mixed $a = null)
+    {
+    }
+}

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Php84\Rector\Param;
 
 use PhpParser\Node;
+use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
@@ -80,7 +81,9 @@ CODE_SAMPLE
 
         // re-use existing node instead of reprint Node that may cause unnecessary FQCN
         if ($node->type instanceof UnionType) {
-            $node->type->types[] = new ConstFetch(new Name('null'));
+            $node->type->types[] = new Name('null');
+        } elseif ($node->type instanceof ComplexType) {
+            $node->type = new UnionType([$node->type, new Name('null')]);
         } else {
             $node->type = new NullableType($node->type);
         }

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -6,7 +6,10 @@ namespace Rector\Php84\Rector\Param;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
+use PhpParser\Node\UnionType;
 use PHPStan\Type\TypeCombinator;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -67,8 +70,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $newNodeType = TypeCombinator::addNull($nodeType);
-        $node->type = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($newNodeType, TypeKind::PARAM);
+        if ($node->type instanceof UnionType) {
+            $node->type->types[] = new ConstFetch(new Name('null'));
+        } else {
+            $node->type = new NullableType($node->type);
+        }
 
         return $node;
     }

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -74,7 +74,7 @@ CODE_SAMPLE
         $paramType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($newNodeType, TypeKind::PARAM);
 
         // ensure it process valid Node, otherwise, just return null
-        if ($paramType === null) {
+        if (! $paramType instanceof Node) {
             return null;
         }
 

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -7,6 +7,7 @@ namespace Rector\Php84\Rector\Param;
 use PhpParser\Node;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
@@ -83,7 +84,9 @@ CODE_SAMPLE
         if ($node->type instanceof UnionType) {
             $node->type->types[] = new Name('null');
         } elseif ($node->type instanceof ComplexType) {
-            $node->type = new UnionType([$node->type, new Name('null')]);
+            /** @var IntersectionType $nodeType */
+            $nodeType = $node->type;
+            $node->type = new UnionType([$nodeType, new Name('null')]);
         } else {
             $node->type = new NullableType($node->type);
         }

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -70,6 +70,15 @@ CODE_SAMPLE
             return null;
         }
 
+        $newNodeType = TypeCombinator::addNull($nodeType);
+        $paramType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($newNodeType, TypeKind::PARAM);
+
+        // ensure it process valid Node, otherwise, just return null
+        if ($paramType === null) {
+            return null;
+        }
+
+        // re-use existing node instead of reprint Node that may cause unnecessary FQCN
         if ($node->type instanceof UnionType) {
             $node->type->types[] = new ConstFetch(new Name('null'));
         } else {

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php84\Rector\Param;
 
+use PHPStan\Type\MixedType;
 use PhpParser\Node;
 use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr\ConstFetch;
@@ -73,7 +74,7 @@ CODE_SAMPLE
         }
 
         // mixed can't be nullable, ref https://3v4l.org/YUkhH/rfc#vgit.master
-        if ($nodeType instanceof \PHPStan\Type\MixedType) {
+        if ($nodeType instanceof MixedType) {
             return null;
         }
 

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -72,6 +72,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // mixed can't be nullable, ref https://3v4l.org/YUkhH/rfc#vgit.master
+        if ($nodeType instanceof \PHPStan\Type\MixedType) {
+            return null;
+        }
+
         $newNodeType = TypeCombinator::addNull($nodeType);
         $paramType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($newNodeType, TypeKind::PARAM);
 


### PR DESCRIPTION
It currently reprint valid `stdClass` to `\stdClass` with `?` prefix, it should keep as is, just add nullable in front, ref https://getrector.com/demo/a25f4467-9346-4a2a-93e5-e2ebe397f122

@jreklund that's should solve https://github.com/rectorphp/rector/issues/8777 