### PR TITLE
[Performance] [TypeDeclaration] Reduce double traverse on SilentVoidResolver::hasExclusiveVoid()

### DIFF
--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -56,7 +56,7 @@ final readonly class SilentVoidResolver
             return false;
         }
 
-        $hasYieldOrReturnWithExpr = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+        return ! (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
             $functionLike,
             function (Node $subNode): bool {
                 if ($subNode instanceof Yield_ || $subNode instanceof YieldFrom) {
@@ -66,8 +66,6 @@ final readonly class SilentVoidResolver
                 return $subNode instanceof Return_ && $subNode->expr instanceof Expr;
             }
         );
-
-        return ! $hasYieldOrReturnWithExpr instanceof Node;
     }
 
     public function hasSilentVoid(FunctionLike $functionLike): bool

--- a/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
+++ b/rules/TypeDeclaration/TypeInferer/SilentVoidResolver.php
@@ -56,18 +56,18 @@ final readonly class SilentVoidResolver
             return false;
         }
 
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
+        $hasYieldOrReturnWithExpr = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
             $functionLike,
-            [Yield_::class, YieldFrom::class]
-        )) {
-            return false;
-        }
+            function (Node $subNode): bool {
+                if ($subNode instanceof Yield_ || $subNode instanceof YieldFrom) {
+                    return true;
+                }
 
-        $return = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
-            $functionLike,
-            static fn (Node $node): bool => $node instanceof Return_ && $node->expr instanceof Expr
+                return $subNode instanceof Return_ && $subNode->expr instanceof Expr;
+            }
         );
-        return ! $return instanceof Return_;
+
+        return ! $hasYieldOrReturnWithExpr instanceof Node;
     }
 
     public function hasSilentVoid(FunctionLike $functionLike): bool


### PR DESCRIPTION
Merge 2 traverse locate node into 1 to improve performance.