### PR TITLE
remove arg positoin from AddClosureParamTypeFromArg, to ease configuration

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ includes:
 parameters:
     level: 8
 
-    reportUnmatchedIgnoredErrors: false
+    # reportUnmatchedIgnoredErrors: false
 
     # requires exact closure types
     checkMissingCallableSignature: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ includes:
 parameters:
     level: 8
 
-    # reportUnmatchedIgnoredErrors: false
+    reportUnmatchedIgnoredErrors: false
 
     # requires exact closure types
     checkMissingCallableSignature: true

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromArgRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromArgRector/config/configured_rule.php
@@ -11,7 +11,7 @@ use Rector\ValueObject\PhpVersionFeature;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
         ->ruleWithConfiguration(AddClosureParamTypeFromArgRector::class, [
-            new AddClosureParamTypeFromArg(SimpleContainer::class, 'someCall', 1, 0, 0),
+            new AddClosureParamTypeFromArg(SimpleContainer::class, 'someCall', 1, 0),
         ]);
 
     $rectorConfig->phpVersion(PhpVersionFeature::MIXED_TYPE);

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromArgRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromArgRector.php
@@ -36,6 +36,11 @@ use Webmozart\Assert\Assert;
 final class AddClosureParamTypeFromArgRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
+     * @var int
+     */
+    private const DEFAULT_CLOSURE_ARG_POSITION = 0;
+
+    /**
      * @var AddClosureParamTypeFromArg[]
      */
     private array $addClosureParamTypeFromArgs = [];
@@ -61,7 +66,7 @@ $app = new Container();
 $app->extend(SomeClass::class, function (SomeClass $parameter) {});
 CODE_SAMPLE
                 ,
-                [new AddClosureParamTypeFromArg('Container', 'extend', 1, 0, 0)]
+                [new AddClosureParamTypeFromArg('Container', 'extend', 1, 0)]
             ),
         ]);
     }
@@ -135,7 +140,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $callLikeArg = $callLike->getArgs()[$addClosureParamTypeFromArg->getFromArgPosition()] ?? null;
+        $callLikeArg = $callLike->getArgs()[self::DEFAULT_CLOSURE_ARG_POSITION] ?? null;
         if (! $callLikeArg instanceof Arg) {
             return null;
         }

--- a/rules/TypeDeclaration/ValueObject/AddClosureParamTypeFromArg.php
+++ b/rules/TypeDeclaration/ValueObject/AddClosureParamTypeFromArg.php
@@ -12,14 +12,12 @@ final readonly class AddClosureParamTypeFromArg
     /**
      * @param int<0, max> $callLikePosition
      * @param int<0, max> $functionLikePosition
-     * @param int<0, max> $fromArgPosition
      */
     public function __construct(
         private string $className,
         private string $methodName,
         private int $callLikePosition,
         private int $functionLikePosition,
-        private int $fromArgPosition,
     ) {
         RectorAssert::className($className);
     }
@@ -48,13 +46,5 @@ final readonly class AddClosureParamTypeFromArg
     public function getFunctionLikePosition(): int
     {
         return $this->functionLikePosition;
-    }
-
-    /**
-     * @return int<0, max>
-     */
-    public function getFromArgPosition(): int
-    {
-        return $this->fromArgPosition;
     }
 }


### PR DESCRIPTION
The closure arg position will be most likely always 1st arg, so there is no need for config. To make the configuration easier :+1: 

If that's not the case, we can restore this