### PR TITLE
Clean up skip config on rector.php

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
-use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 
 return RectorConfig::configure()
     ->withPreparedSets(
@@ -47,14 +45,6 @@ return RectorConfig::configure()
         '*/Source/*',
         '*/Source*',
         '*/Expected/*',
-
-        // stmts aware type
-        RenameParamToMatchTypeRector::class => [
-            __DIR__ . '/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php',
-        ],
-        AddMethodCallBasedStrictParamTypeRector::class => [
-            __DIR__ . '/rules/DeadCode/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php',
-        ],
 
         // keep configs untouched, as the classes are just strings
         UseClassKeywordForClassNameResolutionRector::class => [__DIR__ . '/config', '*/config/*'],


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6258#pullrequestreview-2263775128

Tested with:


```
rm -rf vendor && composer update && bin/rector
```

nothing change on rules directory, which skip clean is ok.