### PR TITLE
[Performance][AutoImport] Verify already use last name usage on long name on NameImportingPostRector

### DIFF
--- a/src/PostRector/Rector/NameImportingPostRector.php
+++ b/src/PostRector/Rector/NameImportingPostRector.php
@@ -50,6 +50,16 @@ final class NameImportingPostRector extends AbstractPostRector
             return null;
         }
 
+        // verify long name, as short name verify may conflict
+        // see test PR: https://github.com/rectorphp/rector-src/pull/6208
+        // ref https://3v4l.org/21H5j vs https://3v4l.org/GIHSB
+        if (substr_count($node->toCodeString(), '\\') > 1) {
+            $originalName = $node->getAttribute(AttributeKey::ORIGINAL_NAME);
+            if ($originalName instanceof Name && $originalName->getLast() === $originalName->toString()) {
+                return null;
+            }
+        }
+
         if ($this->classNameImportSkipper->shouldSkipName($node, $this->currentUses)) {
             return null;
         }

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -89,17 +89,17 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 return null;
             }
 
-            $names[] = $node->toString();
-
             if ($node instanceof FullyQualified) {
                 $originalName = $node->getAttribute(AttributeKey::ORIGINAL_NAME);
 
                 if ($originalName instanceof Name) {
-                    // collect original Name as well to cover namespaced used
+                    // collect original Name as cover namespaced used
                     $names[] = $originalName->toString();
+                    return $node;
                 }
             }
 
+            $names[] = $node->toString();
             return $node;
         });
 


### PR DESCRIPTION
It got **5 seconds faster** on rector-src itself:

**Before**

```
➜  rector-src git:(main) time bin/rector process --clear-cache
 2269/2269 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        
bin/rector process --clear-cache  243.43s user 13.41s system 700% cpu 36.678 total
```

**After**

```
➜  rector-src git:(performance-early-already-last-name-usage) time bin/rector process --clear-cache                 
 2269/2269 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        
bin/rector process --clear-cache  223.70s user 10.11s system 734% cpu 31.843 total
```