### PR TITLE
Adds AddClosureParamTypeFromObjectRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/AddClosureParamTypeFromObjectRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/AddClosureParamTypeFromObjectRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureParamTypeFromObjectRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/fixture.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+
+SimpleContainer::someCall(true, function ($object) {
+    return $object;
+});
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+
+SimpleContainer::someCall(true, function (\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer $object) {
+    return $object;
+});
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/overrides_previous_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/overrides_previous_type.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SomeType;
+
+SimpleContainer::someCall(SomeType::class, fn(object $var) => $var);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SomeType;
+
+SimpleContainer::someCall(SomeType::class, fn(\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer $var) => $var);
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_calllike_arg_is_named.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_calllike_arg_is_named.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+
+SimpleContainer::someCall(anotherCallback: fn ($var) => $var, callback: fn($var) => $var);

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_functionlike_parameter_missing.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_functionlike_parameter_missing.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+
+SimpleContainer::someCall(fn() => 'test');

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_functionlike_parameters_in_method_call.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_functionlike_parameters_in_method_call.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+
+SimpleContainer::someCall('test');

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_matching_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_matching_class.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\NonTargetedClass;
+
+NonTargetedClass::someCall(function ($name) {
+    return $name;
+});

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_matching_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Fixture/skip_if_non_matching_method.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+
+SimpleContainer::someOtherCall(function ($name) {
+    return $name;
+});

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Source/NonTargetedClass.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Source/NonTargetedClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source;
+
+class NonTargetedClass
+{
+
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Source/SimpleContainer.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/Source/SimpleContainer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source;
+
+final class SimpleContainer
+{
+
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector/config/configured_rule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\Source\SimpleContainer;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector;
+use Rector\TypeDeclaration\ValueObject\AddClosureParamTypeFromObject;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(AddClosureParamTypeFromObjectRector::class, [
+            new AddClosureParamTypeFromObject(SimpleContainer::class, 'someCall', 1, 0),
+        ]);
+
+    $rectorConfig->phpVersion(PhpVersionFeature::MIXED_TYPE);
+};

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromObjectRector.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\ValueObject\AddClosureParamTypeFromObject;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromObjectRector\AddClosureParamTypeFromObjectRectorTest
+ */
+final class AddClosureParamTypeFromObjectRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var int
+     */
+    private const DEFAULT_CLOSURE_ARG_POSITION = 0;
+
+    /**
+     * @var AddClosureParamTypeFromObject[]
+     */
+    private array $addClosureParamTypeFromObjects = [];
+
+    public function __construct(
+        private readonly TypeComparator $typeComparator,
+        private readonly StaticTypeMapper $staticTypeMapper
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add closure param type based on the object of the method call', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+$request = new Request();
+$request->when(true, function ($request) {});
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$request = new Request();
+$request->when(true, function (Request $request) {});
+CODE_SAMPLE
+                ,
+                [new AddClosureParamTypeFromObject('Request', 'when', 1, 0)]
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($this->addClosureParamTypeFromObjects as $addClosureParamTypeFromObject) {
+            if ($node instanceof MethodCall) {
+                $caller = $node->var;
+            } elseif ($node instanceof StaticCall) {
+                $caller = $node->class;
+            } else {
+                continue;
+            }
+
+            if (! $this->isCallMatch($caller, $addClosureParamTypeFromObject, $node)) {
+                continue;
+            }
+
+            $type = $this->getType($caller);
+            if (! $type instanceof ObjectType) {
+                continue;
+            }
+
+            return $this->processCallLike($node, $addClosureParamTypeFromObject, $type);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, AddClosureParamTypeFromObject::class);
+
+        $this->addClosureParamTypeFromObjects = $configuration;
+    }
+
+    private function processCallLike(
+        MethodCall|StaticCall $callLike,
+        AddClosureParamTypeFromObject $addClosureParamTypeFromArg,
+        ObjectType $objectType
+    ): MethodCall|StaticCall|null {
+        if ($callLike->isFirstClassCallable()) {
+            return null;
+        }
+
+        $callLikeArg = $callLike->args[$addClosureParamTypeFromArg->getCallLikePosition()] ?? null;
+        if (! $callLikeArg instanceof Arg) {
+            return null;
+        }
+
+        // int positions shouldn't have names
+        if ($callLikeArg->name instanceof Identifier) {
+            return null;
+        }
+
+        $functionLike = $callLikeArg->value;
+        if (! $functionLike instanceof Closure && ! $functionLike instanceof ArrowFunction) {
+            return null;
+        }
+
+        if (! isset($functionLike->params[$addClosureParamTypeFromArg->getFunctionLikePosition()])) {
+            return null;
+        }
+
+        $callLikeArg = $callLike->getArgs()[self::DEFAULT_CLOSURE_ARG_POSITION] ?? null;
+        if (! $callLikeArg instanceof Arg) {
+            return null;
+        }
+
+        $hasChanged = $this->refactorParameter(
+            $functionLike->params[$addClosureParamTypeFromArg->getFunctionLikePosition()],
+            $objectType,
+        );
+
+        if ($hasChanged) {
+            return $callLike;
+        }
+
+        return null;
+    }
+
+    private function refactorParameter(Param $param, ObjectType $objectType): bool
+    {
+        // already set → no change
+        if ($param->type instanceof Node) {
+            $currentParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+            if ($this->typeComparator->areTypesEqual($currentParamType, $objectType)) {
+                return false;
+            }
+        }
+
+        $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($objectType, TypeKind::PARAM);
+        $param->type = $paramTypeNode;
+
+        return true;
+    }
+
+    private function isCallMatch(
+        Name|Expr $name,
+        AddClosureParamTypeFromObject $addClosureParamTypeFromArg,
+        StaticCall|MethodCall $call
+    ): bool {
+        if (! $this->isObjectType($name, $addClosureParamTypeFromArg->getObjectType())) {
+            return false;
+        }
+
+        return $this->isName($call->name, $addClosureParamTypeFromArg->getMethodName());
+    }
+}

--- a/rules/TypeDeclaration/ValueObject/AddClosureParamTypeFromObject.php
+++ b/rules/TypeDeclaration/ValueObject/AddClosureParamTypeFromObject.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\ValueObject;
+
+use PHPStan\Type\ObjectType;
+use Rector\Validation\RectorAssert;
+
+final readonly class AddClosureParamTypeFromObject
+{
+    /**
+     * @param int<0, max> $callLikePosition
+     * @param int<0, max> $functionLikePosition
+     */
+    public function __construct(
+        private string $className,
+        private string $methodName,
+        private int $callLikePosition,
+        private int $functionLikePosition,
+    ) {
+        RectorAssert::className($className);
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->className);
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public function getCallLikePosition(): int
+    {
+        return $this->callLikePosition;
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public function getFunctionLikePosition(): int
+    {
+        return $this->functionLikePosition;
+    }
+}


### PR DESCRIPTION
# Changes

* Adds a AddClosureParamTypeFromObjectRector
* Adds a AddClosureParamTypeFromObject value object
* Adds tests for the new rule

# Why

Similar to AddClosureParamTypeFromArgRector there's a few times where classes will automatically use the type of the object in a method call to pass to a Closure as an argument. I feel it makes sense to allow Rector to do this with a configurable rule as it's a common pattern.

```diff
$request = new Request();
-$request->when(true, function ($request) {});
+$request->when(true, function (Request $request) {});
```