### PR TITLE
Replace object type hinting

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReplaceReturnObjectTypeHintRector;
+
+class Fixture
+{
+    public function call(): \Carbon\Carbon
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReplaceReturnObjectTypeHintRector;
+
+class Fixture
+{
+    public function call(): \Carbon\CarbonInterface
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReplaceReturnObjectTypeHintRector;
+
+class SkipNonMatchingType
+{
+    public function call(\Carbon\CarbonImmutable $carbon)
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/ReplaceReturnObjectTypeHintRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/ReplaceReturnObjectTypeHintRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\ReplaceReturnObjectTypeHintRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceReturnObjectTypeHintRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ObjectType;
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FunctionLike\ReplaceReturnObjectTypeHintRector;
+use Rector\TypeDeclaration\ValueObject\ReplaceObjectTypeHint;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ReplaceReturnObjectTypeHintRector::class, [
+            new ReplaceObjectTypeHint(new ObjectType('Carbon\Carbon'), new ObjectType('Carbon\CarbonInterface')),
+        ]);
+};

--- a/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector;
+
+class Fixture
+{
+    public function call(\Carbon\Carbon $carbon)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector;
+
+class Fixture
+{
+    public function call(\Carbon\CarbonInterface $carbon)
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector;
+
+class Fixture
+{
+    public function call(\Carbon\CarbonImmutable $carbon)
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector;
 
-class Fixture
+class SkipNonMatchingType
 {
     public function call(\Carbon\CarbonImmutable $carbon)
     {

--- a/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/ReplaceParamObjectTypeHintRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/ReplaceParamObjectTypeHintRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceParamObjectTypeHintRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ObjectType;
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector;
+use Rector\TypeDeclaration\ValueObject\ReplaceObjectTypeHint;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ReplaceParamObjectTypeHintRector::class, [
+            new ReplaceObjectTypeHint(new ObjectType('Carbon\Carbon'), new ObjectType('Carbon\CarbonInterface')),
+        ]);
+};

--- a/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\ReplacePropertyObjectTypeHintRector;
+
+class Fixture
+{
+    protected \Carbon\Carbon $carbon;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\ReplacePropertyObjectTypeHintRector;
+
+class Fixture
+{
+    protected \Carbon\CarbonInterface $carbon;
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\Property\ReplacePropertyObjectTypeHintRector;
 
-class Fixture
+class SkipNonMatchingType
 {
     protected \Carbon\CarbonImmutable $carbon;
 }

--- a/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/Fixture/skip_non_matching_type.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\ReplacePropertyObjectTypeHintRector;
+
+class Fixture
+{
+    protected \Carbon\CarbonImmutable $carbon;
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/ReplacePropertyObjectTypeHintRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/ReplacePropertyObjectTypeHintRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\ReplacePropertyObjectTypeHintRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplacePropertyObjectTypeHintRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ObjectType;
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Property\ReplacePropertyObjectTypeHintRector;
+use Rector\TypeDeclaration\ValueObject\ReplaceObjectTypeHint;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(ReplacePropertyObjectTypeHintRector::class, [
+            new ReplaceObjectTypeHint(new ObjectType('Carbon\Carbon'), new ObjectType('Carbon\CarbonInterface')),
+        ]);
+};

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
@@ -44,34 +44,6 @@ final readonly class ClassNameImportSkipper
         return false;
     }
 
-    private function shouldSkipShortName(FullyQualified $fullyQualified): bool
-    {
-        // is scalar name?
-        if (in_array($fullyQualified->toLowerString(), ['true', 'false', 'bool'], true)) {
-            return true;
-        }
-
-        if ($fullyQualified->isSpecialClassName()) {
-            return true;
-        }
-
-        if ($this->isFunctionOrConstantImport($fullyQualified)) {
-            return true;
-        }
-
-        // Importing root namespace classes (like \DateTime) is optional
-        return ! SimpleParameterProvider::provideBoolParameter(Option::IMPORT_SHORT_CLASSES);
-    }
-
-    private function isFunctionOrConstantImport(FullyQualified $fullyQualified): bool
-    {
-        if ($fullyQualified->getAttribute(AttributeKey::IS_CONSTFETCH_NAME) === true) {
-            return true;
-        }
-
-        return $fullyQualified->getAttribute(AttributeKey::IS_FUNCCALL_NAME) === true;
-    }
-
     /**
      * @param array<Use_|GroupUse> $uses
      */
@@ -113,6 +85,34 @@ final readonly class ClassNameImportSkipper
         }
 
         return false;
+    }
+
+    private function shouldSkipShortName(FullyQualified $fullyQualified): bool
+    {
+        // is scalar name?
+        if (in_array($fullyQualified->toLowerString(), ['true', 'false', 'bool'], true)) {
+            return true;
+        }
+
+        if ($fullyQualified->isSpecialClassName()) {
+            return true;
+        }
+
+        if ($this->isFunctionOrConstantImport($fullyQualified)) {
+            return true;
+        }
+
+        // Importing root namespace classes (like \DateTime) is optional
+        return ! SimpleParameterProvider::provideBoolParameter(Option::IMPORT_SHORT_CLASSES);
+    }
+
+    private function isFunctionOrConstantImport(FullyQualified $fullyQualified): bool
+    {
+        if ($fullyQualified->getAttribute(AttributeKey::IS_CONSTFETCH_NAME) === true) {
+            return true;
+        }
+
+        return $fullyQualified->getAttribute(AttributeKey::IS_FUNCCALL_NAME) === true;
     }
 
     private function isConflictedShortNameInUse(

--- a/rules/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/ReplaceReturnObjectTypeHintRector.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\ValueObject\ReplaceObjectTypeHint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector\ReplaceParamObjectTypeHintRectorTest
+ */
+class ReplaceReturnObjectTypeHintRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ReplaceObjectTypeHint[]
+     */
+    private array $replaceObjectTypeHints;
+
+    public function __construct(
+        private readonly StaticTypeMapper $staticTypeMapper
+    ) {
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, ReplaceObjectTypeHint::class);
+        $this->replaceObjectTypeHints = $configuration;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace object type hints on Parameters with object type hints',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+function foo(): \Carbon\Carbon {}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+function foo(): \Carbon\CarbonInterface {}
+CODE_SAMPLE
+                    ,
+                    [
+                        new ReplaceObjectTypeHint(
+                            new ObjectType('Carbon\Carbon'),
+                            new ObjectType('\Carbon\CarbonInterface')
+                        ),
+                    ],
+                )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Function_::class, ClassMethod::class, Closure::class];
+    }
+
+    /**
+     * @param Function_|ClassMethod|Closure $node
+     */
+    public function refactor(Node $node): Function_|ClassMethod|Closure|null
+    {
+        foreach ($this->replaceObjectTypeHints as $replaceObjectTypeHint) {
+            if (! $node->returnType instanceof Identifier && ! $node->returnType instanceof Name) {
+                continue;
+            }
+
+            if ($this->isObjectType($node->returnType, $replaceObjectTypeHint->getOriginalObjectType())) {
+
+                $node->returnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+                    $replaceObjectTypeHint->getReplacingObjectType(),
+                    TypeKind::PROPERTY
+                );
+
+                return $node;
+            }
+        }
+
+        return null;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector.php
+++ b/rules/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Param;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\ValueObject\ReplaceObjectTypeHint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Param\ReplaceParamObjectTypeHintRector\ReplaceParamObjectTypeHintRectorTest
+ */
+class ReplaceParamObjectTypeHintRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ReplaceObjectTypeHint[]
+     */
+    private array $replaceObjectTypeHints;
+
+    public function __construct(
+        private readonly StaticTypeMapper $staticTypeMapper
+    ) {
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, ReplaceObjectTypeHint::class);
+        $this->replaceObjectTypeHints = $configuration;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace object type hints on Parameters with object type hints',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+function (\Carbon\Carbon $carbon) {}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+function (\Carbon\CarbonInterface $carbon) {}
+CODE_SAMPLE
+                    ,
+                    [
+                        new ReplaceObjectTypeHint(
+                            new ObjectType('Carbon\Carbon'),
+                            new ObjectType('\Carbon\CarbonInterface')
+                        ),
+                    ],
+                )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Param::class];
+    }
+
+    /**
+     * @param Param $node
+     */
+    public function refactor(Node $node): ?Param
+    {
+        $changed = false;
+        foreach ($this->replaceObjectTypeHints as $replaceObjectTypeHint) {
+            if (! $node->type instanceof Identifier && ! $node->type instanceof Name) {
+                continue;
+            }
+
+            if ($this->isObjectType($node->type, $replaceObjectTypeHint->getOriginalObjectType())) {
+
+                $node->type = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+                    $replaceObjectTypeHint->getReplacingObjectType(),
+                    TypeKind::PROPERTY
+                );
+
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector.php
+++ b/rules/TypeDeclaration/Rector/Param/ReplaceParamObjectTypeHintRector.php
@@ -73,7 +73,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Param
     {
-        $changed = false;
         foreach ($this->replaceObjectTypeHints as $replaceObjectTypeHint) {
             if (! $node->type instanceof Identifier && ! $node->type instanceof Name) {
                 continue;
@@ -86,12 +85,8 @@ CODE_SAMPLE
                     TypeKind::PROPERTY
                 );
 
-                $changed = true;
+                return $node;
             }
-        }
-
-        if ($changed) {
-            return $node;
         }
 
         return null;

--- a/rules/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector.php
+++ b/rules/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\ValueObject\ReplaceObjectTypeHint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Property\ReplacePropertyObjectTypeHintRector\ReplacePropertyObjectTypeHintRectorTest
+ */
+final class ReplacePropertyObjectTypeHintRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var ReplaceObjectTypeHint[]
+     */
+    private array $replaceObjectTypeHints;
+
+    public function __construct(
+        private readonly StaticTypeMapper $staticTypeMapper
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace property object type hints with new object type hint',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    property \Carbon\Carbon $carbon;
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    property \Carbon\CarbonInterface $carbon;
+}
+CODE_SAMPLE
+                    ,
+                    [
+                        new ReplaceObjectTypeHint(new ObjectType('\Carbon\Carbon'), new ObjectType(
+                            '\Carbon\CarbonInterface'
+                        )),
+                    ]
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(Node $node): ?Property
+    {
+        $changed = false;
+
+        foreach ($this->replaceObjectTypeHints as $replaceObjectTypeHint) {
+            if (! $node->type instanceof Identifier && ! $node->type instanceof Name) {
+                continue;
+            }
+
+            if ($this->isObjectType($node->type, $replaceObjectTypeHint->getOriginalObjectType())) {
+                $node->type = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+                    $replaceObjectTypeHint->getReplacingObjectType(),
+                    TypeKind::PROPERTY
+                );
+
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, ReplaceObjectTypeHint::class);
+        $this->replaceObjectTypeHints = $configuration;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector.php
+++ b/rules/TypeDeclaration/Rector/Property/ReplacePropertyObjectTypeHintRector.php
@@ -73,8 +73,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Property
     {
-        $changed = false;
-
         foreach ($this->replaceObjectTypeHints as $replaceObjectTypeHint) {
             if (! $node->type instanceof Identifier && ! $node->type instanceof Name) {
                 continue;
@@ -86,12 +84,8 @@ CODE_SAMPLE
                     TypeKind::PROPERTY
                 );
 
-                $changed = true;
+                return $node;
             }
-        }
-
-        if ($changed) {
-            return $node;
         }
 
         return null;

--- a/rules/TypeDeclaration/ValueObject/ReplaceObjectTypeHint.php
+++ b/rules/TypeDeclaration/ValueObject/ReplaceObjectTypeHint.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final readonly class ReplaceObjectTypeHint
+{
+    public function __construct(
+        private ObjectType $originalType,
+        private ObjectType $replaceType,
+    ) {
+    }
+
+    public function getOriginalObjectType(): ObjectType
+    {
+        return $this->originalType;
+    }
+
+    public function getReplacingObjectType(): ObjectType
+    {
+        return $this->replaceType;
+    }
+}


### PR DESCRIPTION
# Changes

* Adds the ReplaceObjectTypeHint as a value object
* Adds the ReplaceParamObjectTypeHintRector rule
* Adds the ReplacePropertyObjectTypeHintRector rule
* Adds the ReplaceReturnObjectTypeHintRector rule
* includes tests for all 3 rules

# Why

This set of rules is meant to make it easier to do quick find and replacements of type hints. The example use case is when someone has type hinted `\Carbon\Carbon` but would have been better off type hinting with the interface `\Carbon\CarbonInterface`.

Three rules were created as the main places you'd likely want to produce such a change, Properties, Parameters and Return type hints.

Example changes:

```diff
class Foo
{
-    private \Carbon\Carbon $carbon;
+    private \Carbon\CarbonInterface $carbon;

-    public function setCarbon(\Carbon\Carbon $carbon)
+    public function setCarbon(\Carbon\CarbonInterface $carbon)
    {
        $this->carbon = $carbon;
    }

-    public function getCarbon(): \Carbon\Carbon
+    public function getCarbon(): \Carbon\CarbonInterface
    {
        return $this->carbon;
    }
}
```

# Notes

This doesn't currently affection union types. I've debated how that would look as it might become quite complicated.

There's also a question of making this work for PHPDoc tags to be able to replace those as well in the same matter. I thought this would be the best start.

I feel these rules will be useful for improving type hinting quality in applications a great deal and will be invaluable to Laravel projects where you just want to swap out lots of type hints quickly within a project.
