### PR TITLE
[PostRector] Allow remove unused use on conflict short name aliased on UnusedmportRemovingPostRector

### DIFF
--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -174,7 +174,10 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
      */
     private function isUseImportUsed(UseUse $useUse, array $names, ?Name $namespaceName): bool
     {
-        $comparedName = $useUse->name->toString();
+        $comparedName = $useUse->alias instanceof Identifier
+            ? $useUse->alias->toString()
+            : $useUse->name->toString();
+
         if (in_array($comparedName, $names, true)) {
             return true;
         }

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/conflict_last_name_aliased2.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/conflict_last_name_aliased2.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use Class_ as ClassOrig;
+use PhpParser\Node;
+
+final class ConflictLastNameAliased2
+{
+    /**
+     * @param Node\Stmt\Class_ $param
+     */
+    public function run($param): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use PhpParser\Node\Stmt\Class_;
+final class ConflictLastNameAliased2
+{
+    /**
+     * @param Class_ $param
+     */
+    public function run($param): void
+    {
+    }
+}
+
+?>

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/conflict_last_name_aliased_used.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/conflict_last_name_aliased_used.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use Class_ as ClassOrig;
+use PhpParser\Node;
+
+final class ConflictLastNameAliasedUsed
+{
+    /**
+     * @param Node\Stmt\Class_ $param
+     */
+    public function run($param): void
+    {
+        new ClassOrig();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use PhpParser\Node\Stmt\Class_;
+use Class_ as ClassOrig;
+
+final class ConflictLastNameAliasedUsed
+{
+    /**
+     * @param Class_ $param
+     */
+    public function run($param): void
+    {
+        new ClassOrig();
+    }
+}
+
+?>


### PR DESCRIPTION
On alias use, the used one is the alias one, ref https://3v4l.org/aVi6V