### PR TITLE
always make paths absolute before processing files

### DIFF
--- a/src/FileSystem/FilePathHelper.php
+++ b/src/FileSystem/FilePathHelper.php
@@ -45,6 +45,15 @@ final readonly class FilePathHelper
         return $this->relativeFilePathFromDirectory($fileRealPath, getcwd());
     }
 
+    public function absolutePath(string $fileRealPath): string
+    {
+        if ($this->filesystem->isAbsolutePath($fileRealPath)) {
+            return $fileRealPath;
+        }
+
+        return realpath($fileRealPath);
+    }
+
     /**
      * Used from
      * https://github.com/phpstan/phpstan-src/blob/02425e61aa48f0668b4efb3e73d52ad544048f65/src/File/FileHelper.php#L40, with custom modifications

--- a/src/FileSystem/FilePathHelper.php
+++ b/src/FileSystem/FilePathHelper.php
@@ -45,15 +45,6 @@ final readonly class FilePathHelper
         return $this->relativeFilePathFromDirectory($fileRealPath, getcwd());
     }
 
-    public function absolutePath(string $fileRealPath): string
-    {
-        if ($this->filesystem->isAbsolutePath($fileRealPath)) {
-            return $fileRealPath;
-        }
-
-        return realpath($fileRealPath);
-    }
-
     /**
      * Used from
      * https://github.com/phpstan/phpstan-src/blob/02425e61aa48f0668b4efb3e73d52ad544048f65/src/File/FileHelper.php#L40, with custom modifications

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -39,6 +39,7 @@ final readonly class FilesFinder
 
         // filtering files in files collection
         $filteredFilePaths = $this->fileAndDirectoryFilter->filterFiles($filesAndDirectories);
+        $filteredFilePaths = array_map($this->filePathHelper->absolutePath(...), $filteredFilePaths);
         $filteredFilePaths = array_filter(
             $filteredFilePaths,
             fn (string $filePath): bool => ! $this->pathSkipper->shouldSkip($filePath)

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -39,7 +39,7 @@ final readonly class FilesFinder
 
         // filtering files in files collection
         $filteredFilePaths = $this->fileAndDirectoryFilter->filterFiles($filesAndDirectories);
-        $filteredFilePaths = array_map(realpath(...), $filteredFilePaths);
+        $filteredFilePaths = array_map(fn (string $filePath): string => realpath($filePath), $filteredFilePaths);
         $filteredFilePaths = array_filter(
             $filteredFilePaths,
             fn (string $filePath): bool => ! $this->pathSkipper->shouldSkip($filePath)

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -39,7 +39,7 @@ final readonly class FilesFinder
 
         // filtering files in files collection
         $filteredFilePaths = $this->fileAndDirectoryFilter->filterFiles($filesAndDirectories);
-        $filteredFilePaths = array_map($this->filePathHelper->absolutePath(...), $filteredFilePaths);
+        $filteredFilePaths = array_map(realpath(...), $filteredFilePaths);
         $filteredFilePaths = array_filter(
             $filteredFilePaths,
             fn (string $filePath): bool => ! $this->pathSkipper->shouldSkip($filePath)

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -29,6 +29,26 @@ final class FilesFinderTest extends AbstractLazyTestCase
         $this->assertCount(0, $foundFiles);
     }
 
+    #[DataProvider('alwaysReturnsAbsolutePathDataProvider')]
+    public function testAlwaysReturnsAbsolutePath(string $relativePath): void
+    {
+        $absolutePath = str_replace('/', DIRECTORY_SEPARATOR, getcwd() . '/' . $relativePath);
+        $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([$absolutePath], ['php']);
+        $this->assertStringStartsWith($absolutePath, $foundFiles[0], 'should return absolute path if absolute is given');
+
+        $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([$relativePath], ['php']);
+        $this->assertStringStartsWith($absolutePath, $foundFiles[0], 'should return absolute path if relative is given');
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public static function alwaysReturnsAbsolutePathDataProvider(): Iterator
+    {
+        yield 'directory given' => ['tests/FileSystem/FilesFinder/Source/'];
+        yield 'file given' => ['tests/FileSystem/FilesFinder/Source/SomeFile.php'];
+    }
+
     public function testWithFollowingBrokenSymlinks(): void
     {
         SimpleParameterProvider::setParameter(Option::SKIP, [__DIR__ . '/../SourceWithBrokenSymlinks/folder1']);


### PR DESCRIPTION
The path is currently only an absolute path if you call rector with a directory like this
`rector process pathToFile/`.
If you call it with a filename instead, the path will be relative. 
`rector process pathToFile/File.php`.
This makes implementing RectorRules with path usage more difficult than necessary.

fixes: https://github.com/sabbelasichon/typo3-rector/issues/4301