### PR TITLE
Update incorrect configuration example

### DIFF
--- a/rules/Transform/Rector/MethodCall/MethodCallToPropertyFetchRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToPropertyFetchRector.php
@@ -25,14 +25,14 @@ final class MethodCallToPropertyFetchRector extends AbstractRector implements Co
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Turns method call "$this->something()" to property fetch "$this->something"', [
+        return new RuleDefinition('Turns method call "$this->getFirstname()" to property fetch "$this->firstname"', [
             new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run()
     {
-        $this->someMethod();
+        $this->getFirstname();
     }
 }
 CODE_SAMPLE
@@ -42,13 +42,13 @@ class SomeClass
 {
     public function run()
     {
-        $this->someProperty;
+        $this->firstname;
     }
 }
 CODE_SAMPLE
                 ,
                 [
-                    'someMethod' => 'someProperty',
+                    new MethodCallToPropertyFetch('ExamplePersonClass', 'getFirstname', 'firstname'),
                 ]
             ),
         ]);


### PR DESCRIPTION
Hi! 👋

While working with [MethodCallToPropertyFetchRector](https://getrector.com/rule-detail/method-call-to-property-fetch-rector), I discovered that the documented configuration example is incorrect.

Instead of:
```php
[
    'someMethod' => 'someProperty',
]
```

It is required to give a `MethodCallToPropertyFetch` object with three arguments like this:
```php
[
    new MethodCallToPropertyFetch(Person::class, 'getFirstname', 'firstname'),
]
```

I've therefore updated the example.

The class of the corresponding method is also required, and I therefore used a different naming to better reflect this.

@TomasVotruba & @samsonasik, let me know what you think 🙂