### PR TITLE
[CodeQuality] Allow transform static to self on final class on ConvertStaticPrivateConstantToSelfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/on_final_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/on_final_class.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Fixture;
+
+final class OnFinalClass
+{
+    protected const BAR = 1;
+
+    public const BAZ = 1;
+
+    public function run(): void
+    {
+        echo static::BAR;
+        echo static::BAZ;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Fixture;
+
+final class OnFinalClass
+{
+    protected const BAR = 1;
+
+    public const BAZ = 1;
+
+    public function run(): void
+    {
+        echo self::BAR;
+        echo self::BAZ;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/skip-other-visibility.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/skip-other-visibility.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Fixture;
 
-final class SkipOtherVisibility
+class SkipOtherVisibility
 {
     protected const BAR = 1;
 

--- a/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
@@ -80,7 +80,11 @@ CODE_SAMPLE
                 return null;
             }
 
-            if ($this->shouldBeSkipped($class, $node)) {
+            if (! $this->isUsingStatic($node)) {
+                return null;
+            }
+
+            if (! $class->isFinal() && ! $this->isPrivateConstant($node, $class)) {
                 return null;
             }
 
@@ -118,15 +122,6 @@ CODE_SAMPLE
         }
 
         return false;
-    }
-
-    private function shouldBeSkipped(Class_ $class, ClassConstFetch $classConstFetch): bool
-    {
-        if (! $this->isUsingStatic($classConstFetch)) {
-            return true;
-        }
-
-        return ! $this->isPrivateConstant($classConstFetch, $class);
     }
 
     private function getConstantName(ClassConstFetch $classConstFetch): ?string


### PR DESCRIPTION
**On non-final class**, it only works on private constant, see

https://3v4l.org/rPYm0 vs https://3v4l.org/80571

This rule currently only works on private constant https://getrector.com/demo/5c3ff3fc-8b61-45d1-acab-2bb3f974f3af

**On Final class**, it can actually should works on private, protected, and public as no child to read:

see https://3v4l.org/7TGlv

so this PR add this ability

Closes https://github.com/rectorphp/rector/issues/8818