### PR TITLE
bump to laravel illuminate/container: ^11.22.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "composer/semver": "^3.4",
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.0.10",
-        "illuminate/container": "11.20.0",
+        "illuminate/container": "^11.22.0",
         "nette/utils": "^4.0",
         "nikic/php-parser": "^4.19.1",
         "ocramius/package-versions": "^2.9",


### PR DESCRIPTION
The `@param` patch was merged at :

- https://github.com/laravel/framework/pull/52541

Let's see if it works now on new release.

Closes https://github.com/rectorphp/rector/issues/8804