### PR TITLE
[TypeDeclaration] Convert inline @var tag to assert()

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -56,5 +56,5 @@ return RectorConfig::configure()
             __DIR__ . '/src/Console/Notifier.php',
         ],
 
-        RemoveUnusedPrivatePropertyRector::class => [__DIR__ . '/src/Configuration/RectorConfigBuilder.php']
+        RemoveUnusedPrivatePropertyRector::class => [__DIR__ . '/src/Configuration/RectorConfigBuilder.php'],
     ]);

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector;
 
 return RectorConfig::configure()
     ->withPreparedSets(
@@ -57,4 +58,5 @@ return RectorConfig::configure()
         ],
 
         RemoveUnusedPrivatePropertyRector::class => [__DIR__ . '/src/Configuration/RectorConfigBuilder.php'],
+        InlineVarDocTagToAssertRector::class,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -7,7 +7,6 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
-use Rector\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector;
 
 return RectorConfig::configure()
     ->withPreparedSets(
@@ -57,6 +56,5 @@ return RectorConfig::configure()
             __DIR__ . '/src/Console/Notifier.php',
         ],
 
-        RemoveUnusedPrivatePropertyRector::class => [__DIR__ . '/src/Configuration/RectorConfigBuilder.php'],
-        InlineVarDocTagToAssertRector::class,
+        RemoveUnusedPrivatePropertyRector::class => [__DIR__ . '/src/Configuration/RectorConfigBuilder.php']
     ]);

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_all_basic_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_all_basic_types.php.inc
@@ -1,0 +1,73 @@
+<?php
+
+/** @var false $foo */
+$foo = getFalse();
+
+/** @var true $foo */
+$foo = getTrue();
+
+/** @var string $foo */
+$foo = getString();
+
+/** @var float $foo */
+$foo = getFloat();
+
+/** @var int $foo */
+$foo = getInt();
+
+/** @var bool $foo */
+$foo = getBool();
+
+/** @var null $foo */
+$foo = getNull();
+
+/** @var callable $foo */
+$foo = getCallable();
+
+/** @var object $foo */
+$foo = getObject();
+
+/** @var array $foo */
+$foo = getArray();
+
+/** @var iterable $foo */
+$foo = getIterable();
+
+?>
+-----
+<?php
+
+$foo = getFalse();
+assert($foo === false);
+
+$foo = getTrue();
+assert($foo === true);
+
+$foo = getString();
+assert(is_string($foo));
+
+$foo = getFloat();
+assert(is_float($foo));
+
+$foo = getInt();
+assert(is_int($foo));
+
+$foo = getBool();
+assert(is_bool($foo));
+
+$foo = getNull();
+assert($foo === null);
+
+$foo = getCallable();
+assert(is_callable($foo));
+
+$foo = getObject();
+assert(is_object($foo));
+
+$foo = getArray();
+assert(is_array($foo));
+
+$foo = getIterable();
+assert(is_iterable($foo));
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_classes_and_interfaces.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_classes_and_interfaces.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+use Foo\Bar;
+use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\FooInterface;
+use Traversable;
+
+/** @var Bar $foo */
+$foo = getBar();
+
+/** @var \Foo\Bar $foo */
+$foo = getFooBar();
+
+/** @var FooInterface $foo */
+$foo = getFooInterface();
+
+/** @var Traversable $foo */
+$foo = getTraversable();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+use Foo\Bar;
+use Rector\Tests\Renaming\Rector\MethodCall\RenameMethodRector\Source\FooInterface;
+use Traversable;
+
+$foo = getBar();
+assert($foo instanceof Bar);
+
+$foo = getFooBar();
+assert($foo instanceof \Foo\Bar);
+
+$foo = getFooInterface();
+assert($foo instanceof FooInterface);
+
+$foo = getTraversable();
+assert($foo instanceof Traversable);
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_intersection_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_intersection_types.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+/** @var Foo&Bar $foo */
+$foo = getFooAndBar();
+
+/** @var \Foo&\Bar $foo */
+$foo = getFooAndBar();
+
+?>
+-----
+<?php
+
+$foo = getFooAndBar();
+assert($foo instanceof Foo && $foo instanceof Bar);
+
+$foo = getFooAndBar();
+assert($foo instanceof \Foo && $foo instanceof \Bar);
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_nullable_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_nullable_types.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+/** @var ?string $foo */
+$foo = getNullableString();
+
+/** @var ?Foo $foo */
+$foo = getNullableFoo();
+
+?>
+-----
+<?php
+
+$foo = getNullableString();
+assert(is_string($foo) || $foo === null);
+
+$foo = getNullableFoo();
+assert($foo instanceof Foo || $foo === null);
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_self_static_and_parent.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_self_static_and_parent.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+class OtherClass {}
+
+class SomeClass extends OtherClass
+{
+    function test()
+    {
+        /** @var self $foo */
+        $foo = getSelf();
+
+        /** @var static $foo */
+        $foo = getStatic();
+
+        /** @var parent $foo */
+        $foo = getParent();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+class OtherClass {}
+
+class SomeClass extends OtherClass
+{
+    function test()
+    {
+        $foo = getSelf();
+        assert($foo instanceof self);
+
+        $foo = getStatic();
+        assert($foo instanceof static);
+
+        $foo = getParent();
+        assert($foo instanceof parent);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_union_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_union_types.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+/** @var string|false $foo */
+$foo = getStringOrFalse();
+
+/** @var string|int|null $foo */
+$foo = getStringOrFalse();
+
+/** @var int|float|bool|string|array $foo */
+$foo = getMultipleTypes();
+
+/** @var string|Foo $foo */
+$foo = getStringOrFoo();
+
+/** @var Foo|Bar $foo */
+$foo = getFooOrBar();
+
+/** @var \Foo|\Bar $foo */
+$foo = getFooOrBar();
+
+?>
+-----
+<?php
+
+$foo = getStringOrFalse();
+assert(is_string($foo) || $foo === false);
+
+$foo = getStringOrFalse();
+assert(is_string($foo) || is_int($foo) || $foo === null);
+
+$foo = getMultipleTypes();
+assert(is_int($foo) || is_float($foo) || is_bool($foo) || is_string($foo) || is_array($foo));
+
+$foo = getStringOrFoo();
+assert(is_string($foo) || $foo instanceof Foo);
+
+$foo = getFooOrBar();
+assert($foo instanceof Foo || $foo instanceof Bar);
+
+$foo = getFooOrBar();
+assert($foo instanceof \Foo || $foo instanceof \Bar);
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_variable_in_some_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_variable_in_some_function.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+function test() {
+    /** @var string $foo */
+    $foo = getString();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+function test() {
+    $foo = getString();
+    assert(is_string($foo));
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_variable_in_some_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/convert_variable_in_some_method.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+final class SomeClass
+{
+    function test() {
+        /** @var string $foo */
+        $foo = getString();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+final class SomeClass
+{
+    function test() {
+        $foo = getString();
+        assert(is_string($foo));
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/preserve_comments.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/preserve_comments.php.inc
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @var string $foo
+ * This is the string
+ */
+$foo = getString();
+
+/**
+ * We are going to do something
+ * @var string $foo
+ */
+$foo = getString();
+
+/**
+ * @var string $foo
+ * @deprecated
+ */
+$foo = getString();
+
+/**
+ * @var string $foo
+ * @see getStringTest()
+ * Please do not change
+ */
+$foo = getString();
+
+/**
+ * @var string $foo
+ * @var int $bar
+ */
+$foo = getString();
+$bar = getInt();
+
+/** @var string $foo this is the string */
+$foo = getString();
+
+?>
+-----
+<?php
+
+/**
+ * @var string $foo
+ * This is the string
+ */
+$foo = getString();
+
+/**
+ * We are going to do something
+ */
+$foo = getString();
+assert(is_string($foo));
+
+/**
+ * @deprecated
+ */
+$foo = getString();
+assert(is_string($foo));
+
+/**
+ * @see getStringTest()
+ * Please do not change
+ */
+$foo = getString();
+assert(is_string($foo));
+
+/**
+ * @var int $bar
+ */
+$foo = getString();
+assert(is_string($foo));
+$bar = getInt();
+
+/** @var string $foo this is the string */
+$foo = getString();
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/preserve_comments.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/preserve_comments.php.inc
@@ -35,6 +35,14 @@ $bar = getInt();
 /** @var string $foo this is the string */
 $foo = getString();
 
+/* normal comment */
+/** @var string $foo */
+$foo = getString();
+
+/** @var string $foo */
+// normal comment
+$foo = getString();
+
 ?>
 -----
 <?php
@@ -73,5 +81,13 @@ $bar = getInt();
 
 /** @var string $foo this is the string */
 $foo = getString();
+
+/* normal comment */
+$foo = getString();
+assert(is_string($foo));
+
+// normal comment
+$foo = getString();
+assert(is_string($foo));
 
 ?>

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_complex_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_complex_types.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+/** @var array<string> $foo */
+$foo = getArrayOfString();
+
+/** @var string[] $foo */
+$foo = getArrayOfString();
+
+/** @var Collection<Foo> $foo */
+$foo = getCollection();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_incorrect_php_docs.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_incorrect_php_docs.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+/** @var string */
+$foo = getString();
+
+/* @var string $foo */
+$foo = getString();
+
+/** @param string $foo */
+$foo = getString();
+
+/** @var string $bar */
+$foo = getString();
+
+/** @var string $foo */
+$bar = getString();
+$foo = getString();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_intersections_with_complex_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_intersections_with_complex_types.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+/** @var Foo&Collection<Foo> $foo */
+$foo = getFooAndCollection();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_nullable_complex_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_nullable_complex_types.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+/** @var ?array<string> $foo */
+$foo = getArrayOfString();
+
+/** @var ?string[] $foo */
+$foo = getArrayOfString();
+
+/** @var ?Collection<Foo> $foo */
+$foo = getCollection();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_phpstan_and_psalm_tags.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_phpstan_and_psalm_tags.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+/** @phpstan-var string $foo */
+$foo = getString();
+
+/** @psalm-var string $foo */
+$foo = getString();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_some_basic_narrowed_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_some_basic_narrowed_types.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+/** @var non-empty-string $foo */
+$foo = getNonEmptyString();
+
+/** @var class-string $foo */
+$foo = getClassString();
+
+/** @var positive-int $foo */
+$foo = getPositiveInt();
+
+/** @var negative-int $foo */
+$foo = getNegativeInt();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_some_basic_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_some_basic_types.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+/** @var void $foo */
+$foo = getVoid();
+
+/** @var resource $foo */
+$foo = getResource();
+
+/** @var never $foo */
+$foo = getNever();
+
+/** @var mixed $foo */
+$foo = getMixed();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_tag_in_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_tag_in_property.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\Fixture;
+
+final class SomeClass
+{
+    /**
+     * @var string $foo
+     */
+    private string $foo;
+}

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_unions_with_complex_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/Fixture/skip_unions_with_complex_types.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+/** @var array<string>|false $foo */
+$foo = getArrayOfString();
+
+/** @var string[]|null $foo */
+$foo = getArrayOfString();
+
+/** @var string|Collection<Foo> $foo */
+$foo = getCollection();
+
+/** @var array<Foo>|Collection<Foo> $foo */
+$foo = getCollectionOrArray();
+

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/InlineVarDocTagToAssertRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/InlineVarDocTagToAssertRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class InlineVarDocTagToAssertRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<string>
+     */
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->phpVersion(PhpVersionFeature::STRING_IN_ASSERT_ARG);
+    $rectorConfig->rule(InlineVarDocTagToAssertRector::class);
+};

--- a/rules/TypeDeclaration/PhpDocParser/TypeExpressionFromVarTagResolver.php
+++ b/rules/TypeDeclaration/PhpDocParser/TypeExpressionFromVarTagResolver.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\PhpDocParser;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StringType;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareIntersectionTypeNode;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
+use Rector\StaticTypeMapper\Mapper\ScalarStringToTypeMapper;
+
+final readonly class TypeExpressionFromVarTagResolver
+{
+    public function __construct(
+        private ScalarStringToTypeMapper $scalarStringToTypeMapper
+    ) {
+    }
+
+    public function resolveTypeExpressionFromVarTag(TypeNode $typeNode, Variable $variable): Expr|false
+    {
+        if ($typeNode instanceof IdentifierTypeNode) {
+            $scalarType = $this->scalarStringToTypeMapper->mapScalarStringToType($typeNode->name);
+            $scalarTypeFunction = $this->getScalarTypeFunction($scalarType::class);
+            if ($scalarTypeFunction !== null) {
+                $arg = new Arg($variable);
+                return new FuncCall(new Name($scalarTypeFunction), [$arg]);
+            }
+
+            if ($scalarType instanceof NullType) {
+                return new Identical($variable, new ConstFetch(new Name('null')));
+            }
+
+            if ($scalarType instanceof ConstantBooleanType) {
+                return new Identical(
+                    $variable,
+                    new ConstFetch(new Name($scalarType->getValue() ? 'true' : 'false'))
+                );
+            }
+
+            if ($scalarType instanceof MixedType && ! $scalarType->isExplicitMixed()) {
+                return new Instanceof_($variable, new Name($typeNode->name));
+            }
+        } elseif ($typeNode instanceof NullableTypeNode) {
+            $unionExpressions = [];
+            $nullableTypeExpression = $this->resolveTypeExpressionFromVarTag($typeNode->type, $variable);
+            if ($nullableTypeExpression === false) {
+                return false;
+            }
+
+            $unionExpressions[] = $nullableTypeExpression;
+            $nullExpression = $this->resolveTypeExpressionFromVarTag(new IdentifierTypeNode('null'), $variable);
+            assert($nullExpression !== false);
+            $unionExpressions[] = $nullExpression;
+            return $this->generateOrExpression($unionExpressions);
+        } elseif ($typeNode instanceof BracketsAwareUnionTypeNode) {
+            $unionExpressions = [];
+            foreach ($typeNode->types as $typeNode) {
+                $unionExpression = $this->resolveTypeExpressionFromVarTag($typeNode, $variable);
+                if ($unionExpression === false) {
+                    return false;
+                }
+
+                $unionExpressions[] = $unionExpression;
+            }
+
+            return $this->generateOrExpression($unionExpressions);
+        } elseif ($typeNode instanceof BracketsAwareIntersectionTypeNode) {
+            $intersectionExpressions = [];
+            foreach ($typeNode->types as $typeNode) {
+                $intersectionExpression = $this->resolveTypeExpressionFromVarTag($typeNode, $variable);
+                if ($intersectionExpression === false) {
+                    return false;
+                }
+
+                $intersectionExpressions[] = $intersectionExpression;
+            }
+
+            return $this->generateAndExpression($intersectionExpressions);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Expr[] $unionExpressions
+     * @return BooleanOr
+     */
+    private function generateOrExpression(array $unionExpressions)
+    {
+        $booleanOr = new BooleanOr($unionExpressions[0], $unionExpressions[1]);
+        if (count($unionExpressions) == 2) {
+            return $booleanOr;
+        }
+
+        array_splice($unionExpressions, 0, 2, [$booleanOr]);
+        return $this->generateOrExpression($unionExpressions);
+    }
+
+    /**
+     * @param Expr[] $intersectionExpressions
+     * @return BooleanAnd
+     */
+    private function generateAndExpression(array $intersectionExpressions)
+    {
+        $booleanAnd = new BooleanAnd($intersectionExpressions[0], $intersectionExpressions[1]);
+        if (count($intersectionExpressions) == 2) {
+            return $booleanAnd;
+        }
+
+        array_splice($intersectionExpressions, 0, 2, [$booleanAnd]);
+        return $this->generateAndExpression($intersectionExpressions);
+    }
+
+    /**
+     * @param class-string $className
+     */
+    private function getScalarTypeFunction(string $className): ?string
+    {
+        return match ($className) {
+            IntegerType::class => 'is_int',
+            BooleanType::class => 'is_bool',
+            FloatType::class => 'is_float',
+            StringType::class => 'is_string',
+            ArrayType::class => 'is_array',
+            CallableType::class => 'is_callable',
+            ObjectWithoutClassType::class => 'is_object',
+            IterableType::class => 'is_iterable',
+            default => null,
+        };
+    }
+}

--- a/rules/TypeDeclaration/PhpDocParser/TypeExpressionFromVarTagResolver.php
+++ b/rules/TypeDeclaration/PhpDocParser/TypeExpressionFromVarTagResolver.php
@@ -39,7 +39,7 @@ final readonly class TypeExpressionFromVarTagResolver
     ) {
     }
 
-    public function resolveTypeExpressionFromVarTag(TypeNode $typeNode, Variable $variable): Expr|false
+    public function resolveTypeExpressionFromVarTag(TypeNode $typeNode, Variable $variable): ?Expr
     {
         if ($typeNode instanceof IdentifierTypeNode) {
             $scalarType = $this->scalarStringToTypeMapper->mapScalarStringToType($typeNode->name);
@@ -66,21 +66,21 @@ final readonly class TypeExpressionFromVarTagResolver
         } elseif ($typeNode instanceof NullableTypeNode) {
             $unionExpressions = [];
             $nullableTypeExpression = $this->resolveTypeExpressionFromVarTag($typeNode->type, $variable);
-            if ($nullableTypeExpression === false) {
-                return false;
+            if (! $nullableTypeExpression instanceof Expr) {
+                return null;
             }
 
             $unionExpressions[] = $nullableTypeExpression;
             $nullExpression = $this->resolveTypeExpressionFromVarTag(new IdentifierTypeNode('null'), $variable);
-            assert($nullExpression !== false);
+            assert($nullExpression instanceof Expr);
             $unionExpressions[] = $nullExpression;
             return $this->generateOrExpression($unionExpressions);
         } elseif ($typeNode instanceof BracketsAwareUnionTypeNode) {
             $unionExpressions = [];
             foreach ($typeNode->types as $typeNode) {
                 $unionExpression = $this->resolveTypeExpressionFromVarTag($typeNode, $variable);
-                if ($unionExpression === false) {
-                    return false;
+                if (! $unionExpression instanceof Expr) {
+                    return null;
                 }
 
                 $unionExpressions[] = $unionExpression;
@@ -91,8 +91,8 @@ final readonly class TypeExpressionFromVarTagResolver
             $intersectionExpressions = [];
             foreach ($typeNode->types as $typeNode) {
                 $intersectionExpression = $this->resolveTypeExpressionFromVarTag($typeNode, $variable);
-                if ($intersectionExpression === false) {
-                    return false;
+                if (! $intersectionExpression instanceof Expr) {
+                    return null;
                 }
 
                 $intersectionExpressions[] = $intersectionExpression;
@@ -101,7 +101,7 @@ final readonly class TypeExpressionFromVarTagResolver
             return $this->generateAndExpression($intersectionExpressions);
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
+++ b/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
@@ -16,7 +16,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\PhpDocParser\TypeExpressionFromVarTagResolver;
@@ -32,7 +31,6 @@ final class InlineVarDocTagToAssertRector extends AbstractRector implements MinP
 {
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly TypeExpressionFromVarTagResolver $typeExpressionFromVarTagResolver
     ) {
@@ -106,7 +104,7 @@ CODE_SAMPLE
                         new Variable($variableName)
                     );
                     if ($typeExpression !== false) {
-                        $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $tagValueNode);
+                        $phpDocInfo->removeByType(VarTagValueNode::class, $variableName);
                         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
                         $arg = new Arg($typeExpression);

--- a/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
+++ b/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
@@ -7,6 +7,7 @@ namespace Rector\TypeDeclaration\Rector\Expression;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
@@ -95,7 +96,7 @@ CODE_SAMPLE
                     $varTagValueNode->type,
                     new Variable($variableName)
                 );
-                if ($typeExpression !== false) {
+                if ($typeExpression instanceof Expr) {
                     $phpDocInfo->removeByType(VarTagValueNode::class, $variableName);
                     $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 

--- a/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
+++ b/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
@@ -18,7 +18,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\PhpDocParser\TypeExpressionFromVarTagResolver;
 use Rector\ValueObject\PhpVersionFeature;
@@ -109,7 +108,6 @@ CODE_SAMPLE
                     if ($typeExpression !== false) {
                         $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $tagValueNode);
                         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
-                        $node->setAttribute(AttributeKey::DO_NOT_CHANGE, true);
 
                         $arg = new Arg($typeExpression);
                         $funcCall = new FuncCall(new Name('assert'), [$arg]);

--- a/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
+++ b/rules/TypeDeclaration/Rector/Expression/InlineVarDocTagToAssertRector.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Expression;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Rector\TypeDeclaration\PhpDocParser\TypeExpressionFromVarTagResolver;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector\InlineVarDocTagToAssertRectorTest
+ */
+final class InlineVarDocTagToAssertRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpDocTagRemover $phpDocTagRemover,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly TypeExpressionFromVarTagResolver $typeExpressionFromVarTagResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Convert inline @var tags to calls to assert()', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+/** @var Foo $foo */
+$foo = createFoo();
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+$foo = createFoo();
+assert($foo instanceof Foo);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    /**
+     * @param Expression $node
+     * @return Node[]|null
+     */
+    public function refactor(Node $node): ?array
+    {
+        if (! $node->expr instanceof Assign) {
+            return null;
+        }
+
+        if (! $node->expr->var instanceof Variable) {
+            return null;
+        }
+
+        $docComment = $node->getDocComment();
+        if (! $docComment instanceof Doc) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+
+        if (! $phpDocInfo instanceof PhpDocInfo || $phpDocInfo->getPhpDocNode()->children === []) {
+            return null;
+        }
+
+        $expressionVariableName = $node->expr->var->name;
+        foreach ($phpDocInfo->getPhpDocNode()->children as $phpDocChildNode) {
+            if (! $phpDocChildNode instanceof PhpDocTagNode) {
+                continue;
+            }
+
+            $tagValueNode = $phpDocChildNode->value;
+            // handle only basic types, keep phpstan/psalm helper ones
+            if ($tagValueNode instanceof VarTagValueNode && $phpDocChildNode->name === '@var') {
+                //remove $ from variable name
+                $variableName = substr($tagValueNode->variableName, 1);
+                if ($variableName === $expressionVariableName && $tagValueNode->description === '') {
+                    $typeExpression = $this->typeExpressionFromVarTagResolver->resolveTypeExpressionFromVarTag(
+                        $tagValueNode->type,
+                        new Variable($variableName)
+                    );
+                    if ($typeExpression !== false) {
+                        $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $tagValueNode);
+                        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+                        $node->setAttribute(AttributeKey::DO_NOT_CHANGE, true);
+
+                        $arg = new Arg($typeExpression);
+                        $funcCall = new FuncCall(new Name('assert'), [$arg]);
+                        $expression = new Expression($funcCall);
+                        return [$node, $expression];
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::STRING_IN_ASSERT_ARG;
+    }
+}

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -48,6 +48,7 @@ use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
+use Rector\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector;
 use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeSplFixedArrayRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector;
@@ -134,5 +135,6 @@ final class TypeDeclarationLevel
         StrictArrayParamDimFetchRector::class,
         StrictStringParamConcatRector::class,
         TypedPropertyFromJMSSerializerAttributeTypeRector::class,
+        InlineVarDocTagToAssertRector::class,
     ];
 }

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -48,7 +48,6 @@ use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
-use Rector\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector;
 use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeSplFixedArrayRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector;
@@ -135,6 +134,5 @@ final class TypeDeclarationLevel
         StrictArrayParamDimFetchRector::class,
         StrictStringParamConcatRector::class,
         TypedPropertyFromJMSSerializerAttributeTypeRector::class,
-        InlineVarDocTagToAssertRector::class,
     ];
 }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -21,6 +21,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Application\ChangedNodeScopeRefresher;
 use Rector\Application\Provider\CurrentFileProvider;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Exception\ShouldNotHappenException;
@@ -263,11 +264,14 @@ CODE_SAMPLE;
             return;
         }
 
-        if ($newNode->getAttribute(AttributeKey::DO_NOT_CHANGE) === true) {
+        $oldPhpDocInfo = $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $newPhpDocInfo = $newNode->getAttribute(AttributeKey::PHP_DOC_INFO);
+
+        if ($newPhpDocInfo instanceof PhpDocInfo && $oldPhpDocInfo !== $newPhpDocInfo) {
             return;
         }
 
-        $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO));
+        $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
         if (! $newNode instanceof Nop) {
             $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -263,6 +263,10 @@ CODE_SAMPLE;
             return;
         }
 
+        if ($newNode->getAttribute(AttributeKey::DO_NOT_CHANGE) === true) {
+            return;
+        }
+
         $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO));
         if (! $newNode instanceof Nop) {
             $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -267,8 +267,14 @@ CODE_SAMPLE;
         $oldPhpDocInfo = $oldNode->getAttribute(AttributeKey::PHP_DOC_INFO);
         $newPhpDocInfo = $newNode->getAttribute(AttributeKey::PHP_DOC_INFO);
 
-        if ($newPhpDocInfo instanceof PhpDocInfo && $oldPhpDocInfo !== $newPhpDocInfo) {
-            return;
+        if ($newPhpDocInfo instanceof PhpDocInfo) {
+            if (! $oldPhpDocInfo instanceof PhpDocInfo) {
+                return;
+            }
+
+            if ((string) $oldPhpDocInfo->getPhpDocNode() !== (string) $newPhpDocInfo->getPhpDocNode()) {
+                return;
+            }
         }
 
         $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);


### PR DESCRIPTION
PhpStan suggests that using inline `@var` tags should be avoided as much as possible, fixing the information instead in the source or using stubs. But when this is not possible, they suggest to use an `assert()` check instead, see:

https://phpstan.org/writing-php-code/phpdocs-basics#inline-%40var

Using a PHP language construct when possible is always better than using a PhpDoc, this provides better type inference and a well defined meaning provided by the language itself.

This would change a statement like:
```php
/** @var Foo $foo */
$foo = createFoo();
```
into
```php
$foo = createFoo();
assert($foo instanceof Foo);
```

We only update cases where the type declaration can be converted into a set of simple assertions, we don't deal with complex types like array shapes or generics which cannot be easily defined using simple PHP expressions. We also ignore complex subtypes like `positive-int` which need a more complex expression to be implemented.

This will only apply to inline @var declarations which are located just above the assignment where the variable is defined and only to @var declarations which list a variable name that matches the assignment.

We also ignore any @var declaration which includes a comment to preserve this information