### PR TITLE
Fix incorrect result after using RemoveByType in PhpDocInfo

### DIFF
--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -277,7 +277,7 @@ final class PhpDocInfo
                     $name,
                     '$'
                 )) {
-                    return null;
+                    return PhpDocNodeTraverser::DONT_TRAVERSE_CHILDREN;
                 }
 
                 $hasChanged = true;


### PR DESCRIPTION
In the new `InlineVarDocTagToAssertRector` Rector rule we call the function `RemoveByType()` in the `PhpDocInfo` class like this:

```php
                    $phpDocInfo->removeByType(VarTagValueNode::class, $variableName);
```

If we apply this to this example code:

```php
            /**
             * @var Expression $stmt
             * @var FuncCall $expr
             */
            $expr = $stmt->expr;
```
We will call it with `$variableName` = "expr"

In the node visitor defined in line 266 of the `PhpDocInfo` class we would start by processing a node instance of `PhpDocTagNode` and its value would be an instance of `VarTagValueNode` so the first check would be true but the check in line 276 would be false because the variable name does not match the one we passed. Previously we would have returned null and the processing would have continued. We would then process the children of this node and one of them would be the `VarTagValueNode`. Since it matches the type of node that we want to remove it would be removed, but then we would be left with an invalid parent `PhpDocTagNode` node with value `null` and this can create issues if another rule tries to process this same node later on.
If the node value is a `VarTagValueNode` but the variable name does not match, the right solution is to stop processing the children of this node and this is what this PR implements

Hope this makes sense 😅 