### PR TITLE
Test for the fix to RemoveByType in PhpDocInfo

### DIFF
--- a/tests/Issues/PhpDocInfoRemoveByType/Fixture/fixture.php.inc
+++ b/tests/Issues/PhpDocInfoRemoveByType/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Stmt\Expression;
+
+/**
+ * @var Expression $stmt
+ * @var FuncCall $expr
+ */
+$expr = $stmt->expr;
+
+?>
+-----
+<?php
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Stmt\Expression;
+
+/**
+ * @var Expression $stmt
+ */
+$expr = $stmt->expr;
+assert($expr instanceof FuncCall);
+
+?>

--- a/tests/Issues/PhpDocInfoRemoveByType/PhpDocInfoRemoveByTypeTest.php
+++ b/tests/Issues/PhpDocInfoRemoveByType/PhpDocInfoRemoveByTypeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\PhpDocInfoRemoveByType;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PhpDocInfoRemoveByTypeTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/PhpDocInfoRemoveByType/config/configured_rule.php
+++ b/tests/Issues/PhpDocInfoRemoveByType/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
+use Rector\TypeDeclaration\Rector\Expression\InlineVarDocTagToAssertRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        InlineVarDocTagToAssertRector::class,
+        RemoveNonExistingVarAnnotationRector::class,
+    ]);


### PR DESCRIPTION
This test previously would have thrown an error when the second rule found a PhpDoc node with a null value property