### PR TITLE
[DX] Show paths not match any file/directory on ProcessCommand when given path not exists

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -98,7 +98,19 @@ EOF
         // 1. add files and directories to static locator
         $this->dynamicSourceLocatorDecorator->addPaths($paths);
         if ($this->dynamicSourceLocatorDecorator->isPathsEmpty()) {
-            $this->symfonyStyle->error('The given paths do not match any files');
+            $isSingular = count($paths) === 1;
+            $this->symfonyStyle->error(
+                sprintf(
+                    'The following given path%s do%s not match any file%s or director%s: %s%s',
+                    $isSingular ? '' : 's',
+                    $isSingular ? 'es' : '',
+                    $isSingular ? '' : 's',
+                    $isSingular ? 'y' : 'ies',
+                    PHP_EOL . PHP_EOL . ' - ',
+                    implode(PHP_EOL . ' - ', $paths)
+                )
+            );
+
             return ExitCode::FAILURE;
         }
 

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -101,7 +101,7 @@ EOF
             // read from rector.php, no paths definition needs withPaths() config
             if ($paths === []) {
                 $this->symfonyStyle->error(
-                    sprintf('No given paths in rector configuration, define paths: https://getrector.com/documentation/define-paths')
+                    'No given paths in rector configuration, define paths: https://getrector.com/documentation/define-paths'
                 );
 
                 return ExitCode::FAILURE;

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -107,6 +107,7 @@ EOF
                 return ExitCode::FAILURE;
             }
 
+            // read from cli paths arguments, eg: vendor/bin/rector process A B C which A, B, and C not exists
             $isSingular = count($paths) === 1;
             $this->symfonyStyle->error(
                 sprintf(

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -101,7 +101,7 @@ EOF
             // read from rector.php, no paths definition needs withPaths() config
             if ($paths === []) {
                 $this->symfonyStyle->error(
-                    'No given paths in rector configuration, define paths: https://getrector.com/documentation/define-paths'
+                    'No paths definition in rector configuration, define paths: https://getrector.com/documentation/define-paths'
                 );
 
                 return ExitCode::FAILURE;

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -101,7 +101,7 @@ EOF
             // read from rector.php, no paths definition needs withPaths() config
             if ($paths === []) {
                 $this->symfonyStyle->error(
-                    sprintf('The given paths do not match any files, define paths: https://getrector.com/documentation/define-paths')
+                    sprintf('No given paths in rector configuration, define paths: https://getrector.com/documentation/define-paths')
                 );
 
                 return ExitCode::FAILURE;

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -98,6 +98,15 @@ EOF
         // 1. add files and directories to static locator
         $this->dynamicSourceLocatorDecorator->addPaths($paths);
         if ($this->dynamicSourceLocatorDecorator->isPathsEmpty()) {
+            // read from rector.php, no paths definition needs withPaths() config
+            if ($paths === []) {
+                $this->symfonyStyle->error(
+                    sprintf('The given paths do not match any files, define paths: https://getrector.com/documentation/define-paths')
+                );
+
+                return ExitCode::FAILURE;
+            }
+
             $isSingular = count($paths) === 1;
             $this->symfonyStyle->error(
                 sprintf(


### PR DESCRIPTION
**Before**

```
➜  rector-src git:(main) bin/rector process app foo.php                                                                              
                                                                                           
 [ERROR] The given paths do not match any files                                         
```

**After**

```
➜  rector-src git:(main) ✗ bin/rector process app foo.php
                                                                                                                        
 [ERROR] The following given paths do not match any files or directories:                                               
                                                                                                                        
          - app                                                                                                         
          - foo.php                                                                                               
```