### PR TITLE
[TypeDeclaration] Skip nullable callable on TypedPropertyFromAssignsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/union_callable_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/union_callable_return.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class UnionCallableReturn
+{
+    public function run(callable $a)
+    {
+        if (rand(0, 1)) {
+            return $a;
+        }
+
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class UnionCallableReturn
+{
+    public function run(callable $a): callable|array
+    {
+        if (rand(0, 1)) {
+            return $a;
+        }
+
+        return [];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_nullable_callable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_nullable_callable.php.inc
@@ -11,7 +11,7 @@ final class SkipNullableCallable
         $this->prop = $prop;
     }
 
-    private function reset(): void
+    public function reset(): void
     {
         $this->prop = null;
     }

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_nullable_callable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_nullable_callable.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class SkipNullableCallable
+{
+    private $prop;
+
+    public function set(callable $prop): void
+    {
+        $this->prop = $prop;
+    }
+
+    private function reset(): void
+    {
+        $this->prop = null;
+    }
+}

--- a/src/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType as PhpParserUnionType;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\CallableType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
@@ -64,7 +65,7 @@ final class UnionTypeMapper implements TypeMapperInterface
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
     {
-        $phpParserUnionType = $this->matchPhpParserUnionType($type);
+        $phpParserUnionType = $this->matchPhpParserUnionType($type, $typeKind);
         if ($phpParserUnionType instanceof PhpParserUnionType) {
             return $this->resolveUnionTypeNode($phpParserUnionType);
         }
@@ -171,7 +172,7 @@ final class UnionTypeMapper implements TypeMapperInterface
     /**
      * @return Name|FullyQualified|ComplexType|Identifier|null
      */
-    private function matchPhpParserUnionType(UnionType $unionType): ?Node
+    private function matchPhpParserUnionType(UnionType $unionType, string $typeKind): ?Node
     {
         $phpParserUnionedTypes = [];
 
@@ -180,6 +181,11 @@ final class UnionTypeMapper implements TypeMapperInterface
             // void type and mixed type are not allowed in union
             $phpParserNode = $this->phpStanStaticTypeMapper->mapToPhpParserNode($unionedType, TypeKind::UNION);
             if ($phpParserNode === null) {
+                return null;
+            }
+
+            // special callable type only not allowed on property
+            if ($typeKind === TypeKind::PROPERTY && $unionedType instanceof CallableType) {
                 return null;
             }
 


### PR DESCRIPTION
nullable callable got error:

```
Fatal error: Property DemoFile::$prop cannot have type ?callable in /in/bGlmf on line 5
```

Ref https://3v4l.org/bGlmf
Ref https://getrector.com/demo/adc6bb0c-418d-4f89-9d00-9c5202711a93