### PR TITLE
Fix LocallyCalledStaticMethodToNonStaticRector when static function is called using the class name

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/fixture.php.inc
@@ -7,6 +7,9 @@ class Fixture
     public function run()
     {
         self::someStatic();
+        static::someStatic();
+        Fixture::someStatic();
+        \Rector\Tests\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture\Fixture::someStatic();
     }
 
     private static function someStatic()
@@ -24,6 +27,9 @@ class Fixture
 {
     public function run()
     {
+        $this->someStatic();
+        $this->someStatic();
+        $this->someStatic();
         $this->someStatic();
     }
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_in_static_closure_using_class_name.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_in_static_closure_using_class_name.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture;
+
+final class SkipInStaticClosureUsingClassName
+{
+    public function run()
+    {
+        return static function () {
+            return SkipInStaticClosureUsingClassName::method("string");
+        };
+    }
+
+    private static function method(?string $value)
+    {
+        return $value;
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector.php
@@ -126,22 +126,25 @@ CODE_SAMPLE
 
         // replace all the calls
         $classMethodName = $this->getName($classMethod);
+        $className = $this->getName($class) ?? '';
         $shouldSkip = false;
 
         $this->traverseNodesWithCallable($class->getMethods(), function (Node $node) use (
             &$shouldSkip,
-            $classMethodName
+            $classMethodName,
+            $className
         ): int|null {
             if (($node instanceof Closure || $node instanceof ArrowFunction) && $node->static) {
                 $this->traverseNodesWithCallable($node->getStmts(), function (Node $subNode) use (
                     &$shouldSkip,
-                    $classMethodName
+                    $classMethodName,
+                    $className
                 ): ?int {
                     if (! $subNode instanceof StaticCall) {
                         return null;
                     }
 
-                    if (! $this->isNames($subNode->class, ['self', 'static'])) {
+                    if (! $this->isNames($subNode->class, ['self', 'static', $className])) {
                         return null;
                     }
 
@@ -168,13 +171,14 @@ CODE_SAMPLE
         }
 
         $this->traverseNodesWithCallable($class->getMethods(), function (Node $node) use (
-            $classMethodName
+            $classMethodName,
+            $className
         ): ?MethodCall {
             if (! $node instanceof StaticCall) {
                 return null;
             }
 
-            if (! $this->isNames($node->class, ['self', 'static'])) {
+            if (! $this->isNames($node->class, ['self', 'static', $className])) {
                 return null;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8827