### PR TITLE
[NodeTypeResolver] Clean up unnecessary scope attribute set on Class_/Interface_/Enum_

### DIFF
--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_in_attribute_class.php.inc
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_in_attribute_class.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+
+#[SomeAttribute(['array-argument'])]
+class SkipInAttributeClass
+{
+}

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -162,12 +162,12 @@ final readonly class PHPStanNodeScopeResolver
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
             }
 
-            $this->decorateNodeAttrGroups($node, $mutatingScope, $nodeCallback);
-
             if ($node instanceof FileWithoutNamespace) {
                 $this->nodeScopeResolverProcessNodes($node->stmts, $mutatingScope, $nodeCallback);
                 return;
             }
+
+            $this->decorateNodeAttrGroups($node, $mutatingScope, $nodeCallback);
 
             if ((
                 $node instanceof Expression ||

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -136,7 +136,6 @@ final readonly class PHPStanNodeScopeResolver
                 /** @var MutatingScope $mutatingScope */
                 $mutatingScope = $this->resolveClassOrInterfaceScope($node, $mutatingScope);
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-                $this->decorateNodeAttrGroups($node, $mutatingScope, $nodeCallback);
 
                 return;
             }


### PR DESCRIPTION
continue of https://github.com/rectorphp/rector-src/pull/6313, under `Class_`, `Interface_`, or `Enum_`, it seems not really needed, as before. Only trait and other nodes.

It needs a use case in case of attribute set is needed.