### PR TITLE
Bump to PHPStan 1.12.4 and fix test

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "phpstan/phpstan": "^1.12.2"
+        "phpstan/phpstan": "^1.12.4"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^1.29",
-        "phpstan/phpstan": "^1.12.2",
+        "phpstan/phpstan": "^1.12.4",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",

--- a/src/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
+++ b/src/NodeTypeResolver/PHPStan/ParametersAcceptorSelectorVariantsWrapper.php
@@ -28,8 +28,6 @@ final class ParametersAcceptorSelectorVariantsWrapper
             return ParametersAcceptorSelector::selectSingle($variants);
         }
 
-        return count($variants) > 1
-            ? ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $variants)
-            : ParametersAcceptorSelector::selectSingle($variants);
+        return ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $variants);
     }
 }


### PR DESCRIPTION
Bump to PHPStan 1.12.4 seems cause error in tests:

```diff
2) Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Php80Test::test with data set #1 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "abs_return_int.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 final class AbsReturnInt
 {
-    function aa(int $param): int
+    function aa(int $param): float|int
     {
         return abs($param);
     }

/Users/samsonasik/www/rector-src/src/Testing/PHPUnit/AbstractRectorTestCase.php:249
/Users/samsonasik/www/rector-src/src/Testing/PHPUnit/AbstractRectorTestCase.php:165
/Users/samsonasik/www/rector-src/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Php80Test.php:16
```

I will check if it fixable or just follow the change as is.