### PR TITLE
[Performance] Reduce double traverse on StrictNativeFunctionReturnTypeAnalyzer

### DIFF
--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictNativeFunctionReturnTypeAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictNativeFunctionReturnTypeAnalyzer.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer;
 
 use PhpParser\Node\Expr\CallLike;
-use PhpParser\Node\Expr\Yield_;
-use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\PhpParser\Node\BetterNodeFinder;
@@ -28,13 +26,6 @@ final readonly class StrictNativeFunctionReturnTypeAnalyzer
     public function matchAlwaysReturnNativeCallLikes(ClassMethod|Function_ $functionLike): ?array
     {
         if ($functionLike->stmts === null) {
-            return null;
-        }
-
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
-            $functionLike,
-            [Yield_::class, YieldFrom::class]
-        )) {
             return null;
         }
 


### PR DESCRIPTION
The `findReturnsScoped()` already take care of `Yield_` and `YieldFrom` when used on `ReturnAnalyzer` as passed argument to return false if it exists.