### PR TITLE
[TypeDeclaration] Reduce double traverse on StrictReturnNewAnalyzer ReturnTypeFromStrictNewArrayRector

### DIFF
--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -8,8 +8,6 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Expr\Yield_;
-use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -34,13 +32,6 @@ final readonly class StrictReturnNewAnalyzer
     public function matchAlwaysReturnVariableNew(ClassMethod|Function_ $functionLike): ?string
     {
         if ($functionLike->stmts === null) {
-            return null;
-        }
-
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
-            $functionLike,
-            [Yield_::class, YieldFrom::class]
-        )) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -9,8 +9,6 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Expr\Yield_;
-use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -107,11 +105,6 @@ CODE_SAMPLE
 
         $variables = $this->matchArrayAssignedVariable($stmts);
         if ($variables === []) {
-            return null;
-        }
-
-        // 2. skip yields
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($node, [Yield_::class, YieldFrom::class])) {
             return null;
         }
 


### PR DESCRIPTION
Similar with https://github.com/rectorphp/rector-src/pull/6320  the `findReturnsScoped()` already take care of `Yield_` and `YieldFrom` when used on `ReturnAnalyzer` as passed argument to return false if it exists.