### PR TITLE
[PhpParser] Handle read phar:// file on AstResolver to returns empty stmts in case of error

### DIFF
--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -317,6 +317,16 @@ final class AstResolver
                 return [];
             }
 
+            /**
+             * it may cause invalid describe() type
+             *
+             * @see https://github.com/rectorphp/rector/issues/8834
+             * @see https://github.com/rectorphp/rector/issues/8835
+             */
+            if (str_starts_with($fileName, 'phar://')) {
+                return [];
+            }
+
             throw $throwable;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8834
Fixes https://github.com/rectorphp/rector/issues/8835