### PR TITLE
[PhpParser] Alternative PR for findInstancesOfScoped() to keep existing performance

### DIFF
--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -225,10 +225,10 @@ final readonly class BetterNodeFinder
      *
      * @template T of Node
      * @param Node[] $nodes
-     * @param class-string<T>|array<class-string<T>> $type
+     * @param class-string<T>|array<class-string<T>> $types
      * @return T[]
      */
-    public function findInstancesOfScoped(array $nodes, string|array $type): array
+    public function findInstancesOfScoped(array $nodes, string|array $types): array
     {
         // here verify only pass single nodes as FunctionLike
         if (count($nodes) === 1
@@ -236,7 +236,9 @@ final readonly class BetterNodeFinder
             $nodes = (array) $nodes[0]->stmts;
         }
 
-        $types = is_string($type) ? [$type] : $type;
+        if (is_string($types)) {
+            $types = [$types];
+        }
 
         /** @var T[] $foundNodes */
         $foundNodes = [];


### PR DESCRIPTION
Alternative PR for https://github.com/rectorphp/rector-src/pull/6323 , make it allow `FunctionLike` in array of nodes[0]:

1. Keep `hasInstancesOfInFunctionLikeScoped` as is for performance reason
2. Modify the method to allow single `$nodes`, as `FunctionLike` reuse


```php
    /**
     * @api to be used
     *
     * @template T of Node
     * @param Node[] $nodes
     * @param class-string<T>|array<class-string<T>> $types
     * @return T[]
     */
    public function findInstancesOfScoped(array $nodes, string|array $types): array
    {
        // here verify only pass single nodes as FunctionLike
        if (count($nodes) === 1
            && ($nodes[0] instanceof ClassMethod || $nodes[0] instanceof Function_ || $nodes[0] instanceof Closure)) {
            $nodes = (array) $nodes[0]->stmts;
        }

        if (is_string($types)) {
            $types = [$types];
        }

        /** @var T[] $foundNodes */
        $foundNodes = [];

        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
            $nodes,
            static function (Node $subNode) use ($types, &$foundNodes): ?int {
                if ($subNode instanceof Class_ || $subNode instanceof Function_ || $subNode instanceof Closure) {
                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                }

                foreach ($types as $type) {
                    if ($subNode instanceof $type) {
                        $foundNodes[] = $subNode;
                        return null;
                    }
                }

                return null;
            }
        );

        return $foundNodes;
    }
```

3. Then, in `findInstancesOfInFunctionLikeScoped`, change to just call it:

```php
    public function findInstancesOfInFunctionLikeScoped(
        ClassMethod | Function_ | Closure $functionLike,
        string|array $types
    ): array {
        return $this->findInstancesOfScoped([$functionLike], $types);
    }
```

Closes https://github.com/rectorphp/rector-src/pull/6323