### PR TITLE
[TypeDeclaration] Handle crash on func call not found on BoolReturnTypeFromBooleanStrictReturnsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/func_call_found.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/func_call_found.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+class FuncCallFound
+{
+    public function run()
+    {
+        return in_array('a', ['a', 'b'], true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+class FuncCallFound
+{
+    public function run(): bool
+    {
+        return in_array('a', ['a', 'b'], true);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/skip_func_call_not_found.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/skip_func_call_not_found.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+class SkipFuncCallNotFound
+{
+    public function run()
+    {
+        return dt('some');
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector.php
@@ -167,7 +167,12 @@ CODE_SAMPLE
             return false;
         }
 
-        $functionReflection = $this->reflectionProvider->getFunction(new Name($functionName), null);
+        $name = new Name($functionName);
+        if (! $this->reflectionProvider->hasFunction($name, null)) {
+            return false;
+        }
+
+        $functionReflection = $this->reflectionProvider->getFunction($name, null);
         if (! $functionReflection->isBuiltin()) {
             return false;
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8842