### PR TITLE
Bump to phpstan/phpdoc-parser:1.32.0 and run composer preload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^4.19.1",
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
-        "phpstan/phpdoc-parser": "^1.29",
+        "phpstan/phpdoc-parser": "^1.32.0",
         "phpstan/phpstan": "^1.12.4",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -301,6 +301,7 @@ require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/Ph
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PhpDocTagNode.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PhpDocTextNode.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PropertyTagValueNode.php';
+require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PureUnlessCallableIsImpureTagValueNode.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/RequireExtendsTagValueNode.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/RequireImplementsTagValueNode.php';
 require_once __DIR__ . '/../../../vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/ReturnTagValueNode.php';

--- a/preload.php
+++ b/preload.php
@@ -301,6 +301,7 @@ require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PhpDocNode.
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PhpDocTagNode.php';
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PhpDocTextNode.php';
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PropertyTagValueNode.php';
+require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/PureUnlessCallableIsImpureTagValueNode.php';
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/RequireExtendsTagValueNode.php';
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/RequireImplementsTagValueNode.php';
 require_once __DIR__ . '/vendor/phpstan/phpdoc-parser/src/Ast/PhpDoc/ReturnTagValueNode.php';


### PR DESCRIPTION
To have add `PureUnlessCallableIsImpureTagValueNode` into the preload list.