### PR TITLE
Fix test error when bleedingEdge.neon enabled

### DIFF
--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -1,6 +1,3 @@
-includes:
-    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
-
 parameters:
     # see https://github.com/rectorphp/rector/issues/3490#issue-634342324
     featureToggles:

--- a/config/phpstan/static-reflection.neon
+++ b/config/phpstan/static-reflection.neon
@@ -1,3 +1,6 @@
+includes:
+    - phar://vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon
+
 parameters:
     # see https://github.com/rectorphp/rector/issues/3490#issue-634342324
     featureToggles:

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -16,6 +16,9 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ObjectType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -110,12 +113,12 @@ final readonly class StrictReturnNewAnalyzer
                 }
 
                 $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($subNode);
-                if ($reflection === null) {
-                    return false;
+                if (! $reflection instanceof FunctionReflection && ! $reflection instanceof MethodReflection) {
+                    return null;
                 }
 
                 $scope = $subNode->getAttribute(AttributeKey::SCOPE);
-                if ($scope === null) {
+                if (! $scope instanceof Scope) {
                     return false;
                 }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -114,7 +114,7 @@ final readonly class StrictReturnNewAnalyzer
 
                 $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($subNode);
                 if (! $reflection instanceof FunctionReflection && ! $reflection instanceof MethodReflection) {
-                    return null;
+                    return false;
                 }
 
                 $scope = $subNode->getAttribute(AttributeKey::SCOPE);
@@ -124,7 +124,7 @@ final readonly class StrictReturnNewAnalyzer
 
                 $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($reflection, $subNode, $scope);
                 foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
-                    if ($parameterReflection->passedByReference()) {
+                    if ($parameterReflection->passedByReference()->yes()) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Test enable phpstan bleeding edge cause unit test error:

```diff
There was 1 failure:

1) Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\ReturnTypeFromReturnNewRectorTest::test with data set #19 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "skip_type_modified_between_assign_and_return_by_ref.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 final class SkipTypeModifiedBetweenAssignAndReturnByRef
 {
-    public function action()
+    public function action(): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector\Source\SomeResponse
```

I will check if that resolvable.