### PR TITLE
Temporary Pin nikic/php-parser to 4.19.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.0.10",
         "illuminate/container": "^11.22.0",
         "nette/utils": "^4.0",
-        "nikic/php-parser": "^4.19.1",
+        "nikic/php-parser": "4.19.2",
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^1.32",


### PR DESCRIPTION
Latest new nikic/php-parser 4.19.3 cause error:

```
PHP Fatal error:  Type of PhpParser\Parser\Php8::$tokenToSymbolMapSize must not be defined (as in class PhpParser\ParserAbstract) in /home/runner/work/rector-src/rector-src/vendor/nikic/php-parser/lib/PhpParser/Parser/Php8.php on line 19
```

see https://github.com/rectorphp/rector-src/pull/6336#issuecomment-2381380995