### PR TITLE
Bump php-parser to ^4.19.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.0.10",
         "illuminate/container": "^11.22.0",
         "nette/utils": "^4.0",
-        "nikic/php-parser": "4.19.2",
+        "nikic/php-parser": "^4.19.4",
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^1.32",


### PR DESCRIPTION
Test patch of error in 4.19.3 , ref 

- https://github.com/nikic/PHP-Parser/releases/tag/v4.19.4
- https://github.com/nikic/PHP-Parser/issues/1028
- https://github.com/rectorphp/rector-src/pull/6336#issuecomment-2381380995