### PR TITLE
[TypeDeclaration] Add isset(), empty(), and negation support on BoolReturnTypeFromBooleanStrictReturnsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_empty.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_empty.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+final class WithEmpty
+{
+    public function resolve($a)
+    {
+        return empty($a['test']);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+final class WithIsset
+{
+    public function resolve($a): bool
+    {
+        return empty($a['test']);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_empty.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_empty.php.inc
@@ -16,7 +16,7 @@ final class WithEmpty
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
 
-final class WithIsset
+final class WithEmpty
 {
     public function resolve($a): bool
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_isset.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_isset.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+final class WithIsset
+{
+    public function resolve($a)
+    {
+        return isset($a['test']);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+final class WithIsset
+{
+    public function resolve($a): bool
+    {
+        return isset($a['test']);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_negation.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector/Fixture/with_negation.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+final class WithNegation
+{
+    public function resolve($a)
+    {
+        return ! $a;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector\Fixture;
+
+final class WithNegation
+{
+    public function resolve($a): bool
+    {
+        return ! $a;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector.php
@@ -16,9 +16,12 @@ use PhpParser\Node\Expr\BinaryOp\NotEqual;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\BinaryOp\Smaller;
 use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
+use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -145,7 +148,7 @@ CODE_SAMPLE
                 return false;
             }
 
-            if ($this->isBooleanBinaryOp($return->expr)) {
+            if ($this->isBooleanOp($return->expr)) {
                 continue;
             }
 
@@ -184,7 +187,7 @@ CODE_SAMPLE
         return false;
     }
 
-    private function isBooleanBinaryOp(Expr $expr): bool
+    private function isBooleanOp(Expr $expr): bool
     {
         if ($expr instanceof Smaller) {
             return true;
@@ -222,7 +225,19 @@ CODE_SAMPLE
             return true;
         }
 
-        return $expr instanceof NotEqual;
+        if ($expr instanceof NotEqual) {
+            return true;
+        }
+
+        if ($expr instanceof Empty_) {
+            return true;
+        }
+
+        if ($expr instanceof Isset_) {
+            return true;
+        }
+
+        return $expr instanceof BooleanNot;
     }
 
     /**


### PR DESCRIPTION
It not exists yet in any type declaration set

https://getrector.com/demo/47045075-aa6d-4fc0-bd68-86cfbd048677

I add it to `BoolReturnTypeFromBooleanStrictReturnsRector` for this PR.