### PR TITLE
[TypeDeclaration] Remove only void type on ReturnedNodesReturnTypeInfererTypeInferer

### DIFF
--- a/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromCast.php
+++ b/rules/TypeDeclaration/NodeManipulator/AddReturnTypeFromCast.php
@@ -50,7 +50,7 @@ final readonly class AddReturnTypeFromCast
         }
 
         $returnType = $this->returnTypeInferer->inferFunctionLike($functionLike);
-        if ($returnType instanceof UnionType || $returnType->isVoid()->yes()) {
+        if ($returnType instanceof UnionType) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictConstantReturnRector.php
@@ -7,10 +7,7 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
-use PhpParser\Node\Expr\Yield_;
-use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Type;
@@ -88,10 +85,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->hasYield($node)) {
-            return null;
-        }
-
         $returns = $this->betterNodeFinder->findReturnsScoped($node);
         if (! $this->returnAnalyzer->hasOnlyReturnWithExpr($node, $returns)) {
             return null;
@@ -140,13 +133,5 @@ CODE_SAMPLE
         }
 
         return $this->typeFactory->createMixedPassedOrUnionType($classConstFetchTypes);
-    }
-
-    private function hasYield(ClassMethod|Function_ $functionLike): bool
-    {
-        return $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped(
-            $functionLike,
-            [Yield_::class, YieldFrom::class]
-        );
     }
 }

--- a/rules/TypeDeclaration/Rector/Closure/ClosureReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/ClosureReturnTypeRector.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclaration\Rector\Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
 use PHPStan\Type\NeverType;
-use PHPStan\Type\VoidType;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -68,7 +67,7 @@ CODE_SAMPLE
         $closureReturnType = $this->returnTypeInferer->inferFunctionLike($node);
 
         // handled by other rules
-        if ($closureReturnType instanceof VoidType || $closureReturnType instanceof NeverType) {
+        if ($closureReturnType instanceof NeverType) {
             return null;
         }
 

--- a/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInfererTypeInferer.php
@@ -6,7 +6,6 @@ namespace Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Reflection\ClassReflection;
@@ -44,52 +43,36 @@ final readonly class ReturnedNodesReturnTypeInfererTypeInferer
 
         $types = [];
 
+        // empty returns can have yield, use MixedType() instead
         $localReturnNodes = $this->betterNodeFinder->findReturnsScoped($functionLike);
         if ($localReturnNodes === []) {
-            return $this->resolveNoLocalReturnNodes($functionLike, $classReflection);
+            return new MixedType();
         }
 
+        $hasVoid = false;
         foreach ($localReturnNodes as $localReturnNode) {
-            $returnedExprType = $localReturnNode->expr instanceof Expr
-                ? $this->nodeTypeResolver->getNativeType($localReturnNode->expr)
-                : new VoidType();
+            if (! $localReturnNode->expr instanceof Expr) {
+                $hasVoid = true;
+                $types[] = new VoidType();
 
+                continue;
+            }
+
+            $returnedExprType = $this->nodeTypeResolver->getNativeType($localReturnNode->expr);
             $types[] = $this->splArrayFixedTypeNarrower->narrow($returnedExprType);
         }
 
-        if ($this->silentVoidResolver->hasSilentVoid($functionLike)) {
+        if (! $hasVoid && $this->silentVoidResolver->hasSilentVoid($functionLike)) {
             $types[] = new VoidType();
         }
 
-        return $this->typeFactory->createMixedPassedOrUnionTypeAndKeepConstant($types);
-    }
+        $returnType = $this->typeFactory->createMixedPassedOrUnionTypeAndKeepConstant($types);
 
-    private function resolveNoLocalReturnNodes(
-        FunctionLike $functionLike,
-        ?ClassReflection $classReflection,
-    ): VoidType | MixedType {
-        // void type
-        if (! $this->isAbstractMethod($functionLike, $classReflection)) {
-            return new VoidType();
+        // only void?
+        if ($returnType->isVoid()->yes()) {
+            return new MixedType();
         }
 
-        return new MixedType();
-    }
-
-    private function isAbstractMethod(FunctionLike $functionLike, ?ClassReflection $classReflection): bool
-    {
-        if ($functionLike instanceof ClassMethod && $functionLike->isAbstract()) {
-            return true;
-        }
-
-        if (! $classReflection instanceof ClassReflection) {
-            return false;
-        }
-
-        if (! $classReflection->isClass()) {
-            return false;
-        }
-
-        return $classReflection->isAbstract();
+        return $returnType;
     }
 }


### PR DESCRIPTION
The service verify `Return_` statement expr, which utilize collection of local return nodes via:

```php
$localReturnNodes = $this->betterNodeFinder->findReturnsScoped($functionLike);
```

which if it found a `Yield_`, it stopped and returns `[]` array, which it is not a `void` type. 

On the other hand, for `Void` addition usage, the `Yield_` already checked on `SilentVoidResolver` which verify if it always a `Void` return as no `Return_` nor `Yield` on `AddVoidReturnTypeWhereNoReturnRector` rule.

This ensure consistency of usage and verify VoidType only return.