### PR TITLE
Around PHPStan 1.12.4+ handling on ParametersAcceptors with non-native return type (by docblock)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,6 +53,10 @@ parameters:
             message: '#Function "var_dump\(\)" cannot be used/left in the code#'
             path: src/functions/node_helper.php
 
+        -
+            message: '#Function "method_exists\(\)" cannot be used/left in the code#'
+            path: rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+
         # lack of generic array in nikic/php-parser
         - '#Method (.*?) should return array<PhpParser\\Node\\(.*?)\> but returns array<PhpParser\\Node\>#'
 

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_external_caller_return_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Fixture/skip_external_caller_return_doc.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Source\SomeExternalCaller;
+
+final class SkipExternalCallerReturnDoc
+{
+    public function getData(SomeExternalCaller $someExternalCaller, $x)
+    {
+        return $someExternalCaller->getData($x);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Source/SomeExternalCaller.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/Source/SomeExternalCaller.php
@@ -10,4 +10,12 @@ final class SomeExternalCaller
     {
         return 'Yesman';
     }
+
+    /**
+     * @return string
+     */
+    public function getData($data)
+    {
+        return $data;
+    }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -125,6 +125,14 @@ final readonly class ReturnStrictTypeAnalyzer
             $returnType = $parametersAcceptorWithPhpDocs->getNativeReturnType();
         } else {
             $returnType = $parametersAcceptorWithPhpDocs->getReturnType();
+
+            // around PHPStan 1.12.4+ handling
+            if (method_exists($parametersAcceptorWithPhpDocs, 'getNativeReturnType')) {
+                $nativeReturnType = $parametersAcceptorWithPhpDocs->getNativeReturnType();
+                if ($nativeReturnType instanceof MixedType && ! $nativeReturnType->isExplicitMixed()) {
+                    $returnType = $nativeReturnType;
+                }
+            }
         }
 
         if ($returnType instanceof MixedType) {


### PR DESCRIPTION
@TomasVotruba continue of patch with phpstan around 1.12.4+ handling with docblock:

- https://github.com/rectorphp/rector-src/pull/6318

I tested in our project, and PHPStan seems has new type of ParametersAcceptors which can read on docblock. This PR ensure it check to use native return type when possible.

It is hard to really provide exact same fixture with our project, but I added fixture with docblock return to ensure it safe to apply.