### PR TITLE
[TypeDeclaration] Better approach for native type check ParametersAcceptors on ReturnStrictTypeAnalyzer

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,10 +53,6 @@ parameters:
             message: '#Function "var_dump\(\)" cannot be used/left in the code#'
             path: src/functions/node_helper.php
 
-        -
-            message: '#Function "method_exists\(\)" cannot be used/left in the code#'
-            path: rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
-
         # lack of generic array in nikic/php-parser
         - '#Method (.*?) should return array<PhpParser\\Node\\(.*?)\> but returns array<PhpParser\\Node\>#'
 

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -21,7 +21,8 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\FunctionVariantWithPhpDocs;
+use PHPStan\Reflection\Native\NativeFunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
@@ -120,19 +121,14 @@ final readonly class ReturnStrictTypeAnalyzer
             $call,
             $scope
         );
-        if ($parametersAcceptorWithPhpDocs instanceof FunctionVariantWithPhpDocs) {
+
+        if ($methodReflection instanceof NativeFunctionReflection) {
+            $returnType = $parametersAcceptorWithPhpDocs->getReturnType();
+        } elseif ($parametersAcceptorWithPhpDocs instanceof ParametersAcceptorWithPhpDocs) {
             // native return type is needed, as docblock can be false
             $returnType = $parametersAcceptorWithPhpDocs->getNativeReturnType();
         } else {
             $returnType = $parametersAcceptorWithPhpDocs->getReturnType();
-
-            // around PHPStan 1.12.4+ handling
-            if (method_exists($parametersAcceptorWithPhpDocs, 'getNativeReturnType')) {
-                $nativeReturnType = $parametersAcceptorWithPhpDocs->getNativeReturnType();
-                if ($nativeReturnType instanceof MixedType && ! $nativeReturnType->isExplicitMixed()) {
-                    $returnType = $nativeReturnType;
-                }
-            }
         }
 
         if ($returnType instanceof MixedType) {


### PR DESCRIPTION
@TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/6341

I found that this is better approach to check on `NativeFunctionReflection` early.