### PR TITLE
[TypeDeclaration] Add NativeMethodReflection support on ReturnStrictTypeAnalyzer

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/FixturePhp80/datetime_format_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/FixturePhp80/datetime_format_return.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+use DateTime;
+
+final class DateTimeFormatReturn
+{
+    function aa(DateTime $dateTime)
+    {
+        return $dateTime->format('Y-m-d');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector\Fixture;
+
+use DateTime;
+
+final class DateTimeFormatReturn
+{
+    function aa(DateTime $dateTime): string
+    {
+        return $dateTime->format('Y-m-d');
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/ReturnStrictTypeAnalyzer.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
+use PHPStan\Reflection\Native\NativeMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StaticType;
@@ -122,7 +123,7 @@ final readonly class ReturnStrictTypeAnalyzer
             $scope
         );
 
-        if ($methodReflection instanceof NativeFunctionReflection) {
+        if ($methodReflection instanceof NativeFunctionReflection || $methodReflection instanceof NativeMethodReflection) {
             $returnType = $parametersAcceptorWithPhpDocs->getReturnType();
         } elseif ($parametersAcceptorWithPhpDocs instanceof ParametersAcceptorWithPhpDocs) {
             // native return type is needed, as docblock can be false


### PR DESCRIPTION
For support:

```diff
-   function aa(DateTime $dateTime)
+   function aa(DateTime $dateTime): string
    {
        return $dateTime->format('Y-m-d');
    }
```

Both `NativeFunctionReflection` and `NativeMethodReflection` use `getReturnType()` instead of `getNativeReturnType()`