### PR TITLE
Add option to insert use imports in sorted order

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -16,7 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->parallel();
 
     // to avoid autoimporting out of the box
-    $rectorConfig->importNames(false, false);
+    $rectorConfig->importNames(false, false, false);
     $rectorConfig->removeUnusedImports(false);
 
     $rectorConfig->importShortClasses();

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodingStyle\Application;
 
 use Nette\Utils\Strings;
+use PhpParser\Comment;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Declare_;
@@ -14,6 +15,8 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Use_;
 use PHPStan\Type\ObjectType;
 use Rector\CodingStyle\ClassNameImport\UsedImportsResolver;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -31,33 +34,33 @@ final readonly class UseImportsAdder
     /**
      * @param Stmt[] $stmts
      * @param array<FullyQualifiedObjectType|AliasedObjectType> $useImportTypes
-     * @param array<FullyQualifiedObjectType|AliasedObjectType> $constantUseImportTypes
      * @param array<FullyQualifiedObjectType|AliasedObjectType> $functionUseImportTypes
+     * @param array<FullyQualifiedObjectType|AliasedObjectType> $constantUseImportTypes
      * @return Stmt[]
      */
     public function addImportsToStmts(
         FileWithoutNamespace $fileWithoutNamespace,
         array $stmts,
         array $useImportTypes,
-        array $constantUseImportTypes,
-        array $functionUseImportTypes
+        array $functionUseImportTypes,
+        array $constantUseImportTypes
     ): array {
         $usedImports = $this->usedImportsResolver->resolveForStmts($stmts);
         $existingUseImportTypes = $usedImports->getUseImports();
-        $existingConstantUseImports = $usedImports->getConstantImports();
-        $existingFunctionUseImports = $usedImports->getFunctionImports();
+        $existingFunctionUseImportTypes = $usedImports->getFunctionImports();
+        $existingConstantUseImportTypes = $usedImports->getConstantImports();
 
-        $useImportTypes = $this->diffFullyQualifiedObjectTypes($useImportTypes, $existingUseImportTypes);
-        $constantUseImportTypes = $this->diffFullyQualifiedObjectTypes(
-            $constantUseImportTypes,
-            $existingConstantUseImports
-        );
-        $functionUseImportTypes = $this->diffFullyQualifiedObjectTypes(
+        $newUseImportTypes = $this->diffFullyQualifiedObjectTypes($useImportTypes, $existingUseImportTypes);
+        $newFunctionUseImportTypes = $this->diffFullyQualifiedObjectTypes(
             $functionUseImportTypes,
-            $existingFunctionUseImports
+            $existingFunctionUseImportTypes
+        );
+        $newConstantUseImportTypes = $this->diffFullyQualifiedObjectTypes(
+            $constantUseImportTypes,
+            $existingConstantUseImportTypes
         );
 
-        $newUses = $this->createUses($useImportTypes, $constantUseImportTypes, $functionUseImportTypes, null);
+        $newUses = $this->createUses($newUseImportTypes, $newFunctionUseImportTypes, $newConstantUseImportTypes, null);
         if ($newUses === []) {
             return [$fileWithoutNamespace];
         }
@@ -74,42 +77,48 @@ final readonly class UseImportsAdder
                 break;
             }
 
-            $nodesToAdd = array_merge([new Nop()], $newUses);
+            $position = $key + 1;
 
-            $this->mirrorUseComments($stmts, $newUses, $key + 1);
+            $useComments = $this->getAndRemoveExistingUseComments($stmts, $position);
 
             // remove space before next use tweak
-            if (isset($stmts[$key + 1]) && ($stmts[$key + 1] instanceof Use_ || $stmts[$key + 1] instanceof GroupUse)) {
-                $stmts[$key + 1]->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            if (isset($stmts[$position]) && ($stmts[$position] instanceof Use_ || $stmts[$position] instanceof GroupUse)) {
+                $stmts[$position]->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             }
 
-            array_splice($stmts, $key + 1, 0, $nodesToAdd);
+            array_splice($stmts, $position, 0, [new Nop()]);
+            ++$position;
 
-            $fileWithoutNamespace->stmts = $stmts;
-            $fileWithoutNamespace->stmts = array_values($fileWithoutNamespace->stmts);
+            $fileWithoutNamespace->stmts = $this->insertUseNodesInStatements($stmts, $newUses, $position, false);
+
+            if ($useComments !== []) {
+                $this->reapplyUseComments($useComments, $fileWithoutNamespace->stmts, $position);
+            }
 
             return [$fileWithoutNamespace];
         }
 
-        $this->mirrorUseComments($stmts, $newUses);
+        $useComments = $this->getAndRemoveExistingUseComments($stmts);
 
-        // make use stmts first
-        $fileWithoutNamespace->stmts = array_merge($newUses, $this->resolveInsertNop($fileWithoutNamespace), $stmts);
-        $fileWithoutNamespace->stmts = array_values($fileWithoutNamespace->stmts);
+        $fileWithoutNamespace->stmts = $this->insertUseNodesInStatements($fileWithoutNamespace->stmts, $newUses);
+
+        if ($useComments !== []) {
+            $this->reapplyUseComments($useComments, $fileWithoutNamespace->stmts);
+        }
 
         return [$fileWithoutNamespace];
     }
 
     /**
      * @param FullyQualifiedObjectType[] $useImportTypes
-     * @param FullyQualifiedObjectType[] $constantUseImportTypes
      * @param FullyQualifiedObjectType[] $functionUseImportTypes
+     * @param FullyQualifiedObjectType[] $constantUseImportTypes
      */
     public function addImportsToNamespace(
         Namespace_ $namespace,
         array $useImportTypes,
-        array $constantUseImportTypes,
-        array $functionUseImportTypes
+        array $functionUseImportTypes,
+        array $constantUseImportTypes
     ): void {
         $namespaceName = $this->getNamespaceName($namespace);
 
@@ -120,36 +129,45 @@ final readonly class UseImportsAdder
 
         $existingUseImportTypes = $this->typeFactory->uniquateTypes($existingUseImportTypes);
 
-        $useImportTypes = $this->diffFullyQualifiedObjectTypes($useImportTypes, $existingUseImportTypes);
+        $newUseImportTypes = $this->diffFullyQualifiedObjectTypes($useImportTypes, $existingUseImportTypes);
 
-        $constantUseImportTypes = $this->diffFullyQualifiedObjectTypes(
-            $constantUseImportTypes,
-            $existingConstantUseImportTypes
-        );
-
-        $functionUseImportTypes = $this->diffFullyQualifiedObjectTypes(
+        $newFunctionUseImportTypes = $this->diffFullyQualifiedObjectTypes(
             $functionUseImportTypes,
             $existingFunctionUseImportTypes
         );
 
-        $newUses = $this->createUses($useImportTypes, $constantUseImportTypes, $functionUseImportTypes, $namespaceName);
+        $newConstantUseImportTypes = $this->diffFullyQualifiedObjectTypes(
+            $constantUseImportTypes,
+            $existingConstantUseImportTypes
+        );
+
+        $newUses = $this->createUses(
+            $newUseImportTypes,
+            $newFunctionUseImportTypes,
+            $newConstantUseImportTypes,
+            $namespaceName
+        );
 
         if ($newUses === []) {
             return;
         }
 
-        $this->mirrorUseComments($namespace->stmts, $newUses);
+        $useComments = $this->getAndRemoveExistingUseComments($namespace->stmts);
 
-        $namespace->stmts = array_merge($newUses, $this->resolveInsertNop($namespace), $namespace->stmts);
-        $namespace->stmts = array_values($namespace->stmts);
+        $namespace->stmts = $this->insertUseNodesInStatements($namespace->stmts, $newUses);
+
+        if ($useComments !== []) {
+            $this->reapplyUseComments($useComments, $namespace->stmts);
+        }
     }
 
     /**
+     * @param Stmt[] $stmts
      * @return Nop[]
      */
-    private function resolveInsertNop(FileWithoutNamespace|Namespace_ $namespace): array
+    private function resolveInsertNop(array $stmts, int $position): array
     {
-        $currentStmt = $namespace->stmts[0] ?? null;
+        $currentStmt = $stmts[$position] ?? null;
         if (! $currentStmt instanceof Stmt || $currentStmt instanceof Use_ || $currentStmt instanceof GroupUse) {
             return [];
         }
@@ -159,25 +177,34 @@ final readonly class UseImportsAdder
 
     /**
      * @param Stmt[] $stmts
-     * @param Use_[] $newUses
+     * @return Comment[]
      */
-    private function mirrorUseComments(array $stmts, array $newUses, int $indexStmt = 0): void
+    private function getAndRemoveExistingUseComments(array $stmts, int $indexStmt = 0): array
     {
+        $comments = [];
         if ($stmts === []) {
-            return;
+            return $comments;
         }
 
         if (isset($stmts[$indexStmt]) && $stmts[$indexStmt] instanceof Use_) {
             $comments = (array) $stmts[$indexStmt]->getAttribute(AttributeKey::COMMENTS);
 
             if ($comments !== []) {
-                $newUses[0]->setAttribute(
-                    AttributeKey::COMMENTS,
-                    $stmts[$indexStmt]->getAttribute(AttributeKey::COMMENTS)
-                );
-
                 $stmts[$indexStmt]->setAttribute(AttributeKey::COMMENTS, []);
             }
+        }
+
+        return $comments;
+    }
+
+    /**
+     * @param Comment[] $comments
+     * @param Stmt[] $stmts
+     */
+    private function reapplyUseComments(array $comments, array $stmts, int $indexStmt = 0): void
+    {
+        if (isset($stmts[$indexStmt])) {
+            $stmts[$indexStmt]->setAttribute(AttributeKey::COMMENTS, $comments);
         }
     }
 
@@ -201,14 +228,14 @@ final readonly class UseImportsAdder
 
     /**
      * @param array<AliasedObjectType|FullyQualifiedObjectType> $useImportTypes
-     * @param array<FullyQualifiedObjectType|AliasedObjectType> $constantUseImportTypes
      * @param array<FullyQualifiedObjectType|AliasedObjectType> $functionUseImportTypes
+     * @param array<FullyQualifiedObjectType|AliasedObjectType> $constantUseImportTypes
      * @return Use_[]
      */
     private function createUses(
         array $useImportTypes,
-        array $constantUseImportTypes,
         array $functionUseImportTypes,
+        array $constantUseImportTypes,
         ?string $namespaceName
     ): array {
         $newUses = [];
@@ -216,20 +243,31 @@ final readonly class UseImportsAdder
         /** @var array<Use_::TYPE_*, array<AliasedObjectType|FullyQualifiedObjectType>> $importsMapping */
         $importsMapping = [
             Use_::TYPE_NORMAL => $useImportTypes,
-            Use_::TYPE_CONSTANT => $constantUseImportTypes,
             Use_::TYPE_FUNCTION => $functionUseImportTypes,
+            Use_::TYPE_CONSTANT => $constantUseImportTypes,
         ];
 
         foreach ($importsMapping as $type => $importTypes) {
-            /** @var AliasedObjectType|FullyQualifiedObjectType $importType */
+            $newUsesPerType = [];
             foreach ($importTypes as $importType) {
                 if ($namespaceName !== null && $this->isCurrentNamespace($namespaceName, $importType)) {
                     continue;
                 }
 
                 // already imported in previous cycle
-                $newUses[] = $importType->getUseNode($type);
+                $newUsesPerType[] = $importType->getUseNode($type);
             }
+
+            if (SimpleParameterProvider::provideBoolParameter(Option::IMPORT_INSERT_SORTED)) {
+                //sort uses by name in ascending order
+                usort($newUsesPerType, function (Use_ $use1, Use_ $use2): int {
+                    $name1 = $use1->uses[0]->name->toString();
+                    $name2 = $use2->uses[0]->name->toString();
+                    return strcmp($name1, $name2);
+                });
+            }
+
+            $newUses = [...$newUses, ...$newUsesPerType];
         }
 
         return $newUses;
@@ -252,5 +290,77 @@ final readonly class UseImportsAdder
         }
 
         return ! \str_contains($afterCurrentNamespace, '\\');
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     * @param Use_[] $newUses
+     * @return Stmt[]
+     */
+    private function insertUseNodesInStatements(
+        array $stmts,
+        array $newUses,
+        int $position = 0,
+        bool $addSpace = true
+    ): array {
+        $importInsertSorted = SimpleParameterProvider::provideBoolParameter(Option::IMPORT_INSERT_SORTED);
+        if ($importInsertSorted && isset($stmts[$position])
+            && ($stmts[$position] instanceof Use_ || $stmts[$position] instanceof GroupUse)) {
+            foreach ($newUses as $newUse) {
+                do {
+                    $useListPosition = 0;
+                    $prefix = '';
+                    if (! isset($stmts[$position])
+                        || (! $stmts[$position] instanceof Use_ && ! $stmts[$position] instanceof GroupUse)) {
+                        break;
+                    }
+
+                    if ($stmts[$position] instanceof GroupUse) {
+                        $prefix = $stmts[$position]->prefix->toString() . '\\';
+                    }
+
+                    $parentUseType = $stmts[$position]->type;
+                    $newUseType = $newUse->type;
+                    foreach ($stmts[$position]->uses as $use) {
+                        $currentUseType = $parentUseType === Use_::TYPE_UNKNOWN ? $use->type : $parentUseType;
+
+                        if ($newUseType < $currentUseType) {
+                            break 2;
+                        }
+
+                        if ($newUseType === $currentUseType
+                            && $prefix . $use->name->toString() > $newUse->uses[0]->name->toString()) {
+                            break 2;
+                        }
+
+                        ++$useListPosition;
+                    }
+
+                    ++$position;
+                } while (true);
+
+                if ($useListPosition === 0) {
+                    array_splice($stmts, $position, 0, [$newUse]);
+                    ++$position;
+                } else {
+                    assert($stmts[$position] instanceof Use_ || $stmts[$position] instanceof GroupUse);
+                    if ($prefix !== '') {
+                        $newUse->uses[0]->name =
+                            new Name(substr($newUse->uses[0]->name->toString(), strlen($prefix)));
+                        $newUse->uses[0]->type = $newUse->type;
+                    }
+
+                    array_splice($stmts[$position]->uses, $useListPosition, 0, [$newUse->uses[0]]);
+                }
+            }
+        } else {
+            if ($addSpace) {
+                $newUses = [...$newUses, ...$this->resolveInsertNop($stmts, $position)];
+            }
+
+            array_splice($stmts, $position, 0, $newUses);
+        }
+
+        return array_values($stmts);
     }
 }

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -138,10 +138,14 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::REMOVE_UNUSED_IMPORTS, $removeUnusedImports);
     }
 
-    public function importNames(bool $importNames = true, bool $importDocBlockNames = true): void
-    {
+    public function importNames(
+        bool $importNames = true,
+        bool $importDocBlockNames = true,
+        bool $importInsertSorted = false,
+    ): void {
         SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_NAMES, $importNames);
         SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_DOC_BLOCK_NAMES, $importDocBlockNames);
+        SimpleParameterProvider::setParameter(Option::IMPORT_INSERT_SORTED, $importInsertSorted);
     }
 
     public function importShortClasses(bool $importShortClasses = true): void

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -76,6 +76,12 @@ final class Option
     public const IMPORT_SHORT_CLASSES = 'import_short_classes';
 
     /**
+     * @internal Use @see \Rector\Config\RectorConfig::importNames() instead
+     * @var string
+     */
+    public const IMPORT_INSERT_SORTED = 'import_insert_sorted';
+
+    /**
      * @internal Use @see \Rector\Config\RectorConfig::symfonyContainerXml() instead
      * @var string
      */

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -92,6 +92,8 @@ final class RectorConfigBuilder
 
     private bool $removeUnusedImports = false;
 
+    private bool $importInsertSorted = false;
+
     private bool $noDiffs = false;
 
     private ?string $memoryLimit = null;
@@ -246,7 +248,7 @@ final class RectorConfigBuilder
         }
 
         if ($this->importNames || $this->importDocBlockNames) {
-            $rectorConfig->importNames($this->importNames, $this->importDocBlockNames);
+            $rectorConfig->importNames($this->importNames, $this->importDocBlockNames, $this->importInsertSorted);
             $rectorConfig->importShortClasses($this->importShortClasses);
         }
 
@@ -845,12 +847,14 @@ final class RectorConfigBuilder
         bool $importNames = true,
         bool $importDocBlockNames = true,
         bool $importShortClasses = true,
-        bool $removeUnusedImports = false
+        bool $removeUnusedImports = false,
+        bool $importInsertSorted = false,
     ): self {
         $this->importNames = $importNames;
         $this->importDocBlockNames = $importDocBlockNames;
         $this->importShortClasses = $importShortClasses;
         $this->removeUnusedImports = $removeUnusedImports;
+        $this->importInsertSorted = $importInsertSorted;
         return $this;
     }
 

--- a/src/PostRector/Rector/UseAddingPostRector.php
+++ b/src/PostRector/Rector/UseAddingPostRector.php
@@ -103,8 +103,8 @@ final class UseAddingPostRector extends AbstractPostRector
             $this->useImportsAdder->addImportsToNamespace(
                 $namespace,
                 $useImportTypes,
-                $constantUseImportTypes,
-                $functionUseImportTypes
+                $functionUseImportTypes,
+                $constantUseImportTypes
             );
 
             return $nodes;
@@ -118,8 +118,8 @@ final class UseAddingPostRector extends AbstractPostRector
             $namespace,
             $nodes,
             $useImportTypes,
-            $constantUseImportTypes,
-            $functionUseImportTypes
+            $functionUseImportTypes,
+            $constantUseImportTypes
         );
     }
 

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -54,6 +54,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_DOC_BLOCK_NAMES, false);
         SimpleParameterProvider::setParameter(Option::REMOVE_UNUSED_IMPORTS, false);
         SimpleParameterProvider::setParameter(Option::IMPORT_SHORT_CLASSES, true);
+        SimpleParameterProvider::setParameter(Option::IMPORT_INSERT_SORTED, false);
 
         SimpleParameterProvider::setParameter(Option::INDENT_CHAR, ' ');
         SimpleParameterProvider::setParameter(Option::INDENT_SIZE, 4);

--- a/tests/Issues/AutoImport/AutoImportInsertSortedTest.php
+++ b/tests/Issues/AutoImport/AutoImportInsertSortedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\AutoImport;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AutoImportInsertSortedTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/InsertSortedFixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/insert_sorted_configured_rule.php';
+    }
+}

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_const_type.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_const_type.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const FOO;
+
+new B();
+f();
+$b = \Foobar\BAR;
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const FOO;
+use const Foobar\BAR;
+
+new B();
+f();
+$b = BAR;
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_const_type_in_mixed_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_const_type_in_mixed_group_use.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const FOO};
+
+new B();
+f();
+$a = FOO;
+$f = \Foobar\XXX;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const FOO};
+use const Foobar\XXX;
+
+new B();
+f();
+$a = FOO;
+$f = XXX;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_function_type.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_function_type.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const FOO;
+
+\test\A();
+new B();
+f();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use function test\A;
+use const FOO;
+
+A();
+new B();
+f();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_function_type_in_mixed_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_function_type_in_mixed_group_use.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const FOO};
+
+new B();
+f();
+\Foobar\x();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, function x, const FOO};
+
+new B();
+f();
+x();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_group_use.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, C};
+
+new \Test\A();
+new B();
+new C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, C};
+use Test\A;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_group_use_same_prefix.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_group_use_same_prefix.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{A, B};
+
+new A();
+new B();
+new \Foobar\C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{A, B};
+use Foobar\C;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_multiple_uses.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_multiple_uses.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\B;
+
+new A();
+new B();
+new \Foobar\C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\B;
+use Foobar\C;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_normal_type.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_normal_type.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const FOO;
+
+new B();
+new \Foobar\x();
+f();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use Foobar\x;
+use function f;
+use const FOO;
+
+new B();
+new x();
+f();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_after_normal_type_in_mixed_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_after_normal_type_in_mixed_group_use.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const FOO};
+
+new \Foobar\t();
+new B();
+f();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, t, function f, const FOO};
+
+new t();
+new B();
+f();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_at_beginning_of_use_list.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_at_beginning_of_use_list.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use Foobar\C;
+
+new \Foobar\A();
+new B();
+new C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\B;
+use Foobar\C;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_at_the_end_of_use_list.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_at_the_end_of_use_list.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\B;
+
+new A();
+new B();
+new \Foobar\C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\B;
+use Foobar\C;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_const_type.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_const_type.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const FOO;
+
+new B();
+f();
+$b = \Bar\BAR;
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const Bar\BAR;
+use const FOO;
+
+new B();
+f();
+$b = BAR;
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_const_type_in_mixed_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_const_type_in_mixed_group_use.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const FOO};
+
+new B();
+f();
+$f = \Foobar\BAR;
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const BAR, const FOO};
+
+new B();
+f();
+$f = BAR;
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_function_type.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_function_type.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const FOO;
+
+\Foobar\A();
+new B();
+f();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function Foobar\A;
+use function f;
+use const FOO;
+
+A();
+new B();
+f();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_function_type_in_mixed_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_function_type_in_mixed_group_use.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const FOO};
+
+new B();
+\Foobar\A();
+f();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function A, function f, const FOO};
+
+new B();
+A();
+f();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_group_use.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{A, B};
+
+new A();
+new B();
+new \Foo\C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foo\C;
+use Foobar\{A, B};
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_group_use_same_prefix.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_group_use_same_prefix.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, C};
+
+new \Foobar\A();
+new B();
+new C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\{B, C};
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_multiple_uses.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_multiple_uses.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B, Foobar\C;
+
+new \Foobar\A();
+new B();
+new C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\B, Foobar\C;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_normal_type.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_normal_type.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\B;
+use function f;
+use const FOO;
+
+new \Foobar\A();
+new B();
+f();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\B;
+use function f;
+use const FOO;
+
+new A();
+new B();
+f();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_before_normal_type_in_mixed_group_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_before_normal_type_in_mixed_group_use.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{B, function f, const FOO};
+
+new \Foobar\A();
+new B();
+f();
+$a = FOO;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\{B, function f, const FOO};
+
+new A();
+new B();
+f();
+$a = FOO;
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_in_the_middle_of_group_use_same_prefix.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_in_the_middle_of_group_use_same_prefix.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{A, C};
+
+new A();
+new \Foobar\B();
+new C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\{A, B, C};
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_in_the_middle_of_multiple_uses.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_in_the_middle_of_multiple_uses.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\C;
+
+new A();
+new \Foobar\B();
+new C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\B, Foobar\C;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_in_the_middle_of_use_list.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_in_the_middle_of_use_list.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\C;
+
+new A();
+new \Foobar\B();
+new C();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\B;
+use Foobar\C;
+
+new A();
+new B();
+new C();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_separated_multiple_uses_in_the_middle_of_multiple_uses.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_separated_multiple_uses_in_the_middle_of_multiple_uses.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\C, Foobar\E;
+
+new A();
+new \Foobar\B();
+new C();
+new \Foobar\D();
+new E();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\B, Foobar\C, Foobar\D, Foobar\E;
+
+new A();
+new B();
+new C();
+new D();
+new E();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/insert_together_multiple_uses_in_the_middle_of_multiple_uses.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/insert_together_multiple_uses_in_the_middle_of_multiple_uses.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\D;
+
+new A();
+new \Foobar\B();
+new \Foobar\C();
+new D();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A, Foobar\B, Foobar\C, Foobar\D;
+
+new A();
+new B();
+new C();
+new D();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/no_existing_uses_in_namespace.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/no_existing_uses_in_namespace.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+new \Foo\Bar();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foo\Bar;
+
+new Bar();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/no_existing_uses_with_strict_types.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/no_existing_uses_with_strict_types.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+new \Foo\Bar();
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+use Foo\Bar;
+
+new Bar();
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/no_existing_uses_without_namespace.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/no_existing_uses_without_namespace.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+new \Foo\Bar();
+
+?>
+-----
+<?php
+
+use Foo\Bar;
+
+new Bar();

--- a/tests/Issues/AutoImport/InsertSortedFixture/preserve_comments_when_adding_after_existing_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/preserve_comments_when_adding_after_existing_use.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+/**
+ * License
+ */
+
+use Foobar\B;
+
+/**
+ * Docblock
+ */
+final class DemoFile
+{
+    public function run()
+    {
+        new \Foobar\A();
+        new B();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+/**
+ * License
+ */
+use Foobar\A;
+use Foobar\B;
+
+/**
+ * Docblock
+ */
+final class DemoFile
+{
+    public function run()
+    {
+        new A();
+        new B();
+    }
+}
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/preserve_comments_when_adding_before_existing_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/preserve_comments_when_adding_before_existing_use.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * License
+ */
+
+use Foobar\A;
+
+/**
+ * Docblock
+ */
+final class NoNamespaceWithStrictTypes
+{
+    public function run()
+    {
+        new A();
+        new \Foobar\B();
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+/**
+ * License
+ */
+use Foobar\A;
+use Foobar\B;
+
+/**
+ * Docblock
+ */
+final class NoNamespaceWithStrictTypes
+{
+    public function run()
+    {
+        new A();
+        new B();
+    }
+}
+
+?>

--- a/tests/Issues/AutoImport/InsertSortedFixture/preserve_comments_when_adding_without_existing_use.php.inc
+++ b/tests/Issues/AutoImport/InsertSortedFixture/preserve_comments_when_adding_without_existing_use.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+/**
+ * License
+ */
+
+/**
+ * Docblock
+ */
+final class DemoFile
+{
+    public function run()
+    {
+        new \Foobar\A();
+        new \Foobar\B();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\InsertSortedFixture;
+
+use Foobar\A;
+use Foobar\B;
+
+/**
+ * License
+ */
+/**
+ * Docblock
+ */
+final class DemoFile
+{
+    public function run()
+    {
+        new A();
+        new B();
+    }
+}
+
+?>

--- a/tests/Issues/AutoImport/config/insert_sorted_configured_rule.php
+++ b/tests/Issues/AutoImport/config/insert_sorted_configured_rule.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
+use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Symfony\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames(importInsertSorted: true);
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Some\Exception' => 'Some\Target\Exception',
+        'DateTime' => 'DateTimeInterface',
+    ]);
+    $rectorConfig->rule(TernaryToNullCoalescingRector::class);
+    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity'),
+    ]);
+    $rectorConfig->rules([ConsoleExecuteReturnIntRector::class, RemoveUnusedPrivatePropertyRector::class]);
+};


### PR DESCRIPTION
Add a new `importInsertSorted` parameter to the `importNames` config setting.

When this option is set to true, any new `use` import statements will be inserted in sorted order, including sorting within already existing use statements.

Takes into account the different possible use statement types (normal, function and const). Also works for use groups, including mixed use groups.

This PR assumes that the existing use statements are already sorted. If that is not the case, the new use statements will be sorted but it is not guaranteed that they will be sorted within the existing use statements as we do not re-order those.

See the PR comments for more info