### PR TITLE
Fix UnusedImportRemovingPostRector for different letter case

### DIFF
--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -424,7 +424,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getAnnotationClassNames(): array
     {
@@ -441,7 +441,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getGenericTagClassNames(): array
     {
@@ -463,7 +463,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getConstFetchNodeClassNames(): array
     {
@@ -490,7 +490,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getArrayItemNodeClassNames(): array
     {

--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -424,7 +424,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return list<string>
+     * @return string[]
      */
     public function getAnnotationClassNames(): array
     {
@@ -441,7 +441,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return list<string>
+     * @return string[]
      */
     public function getGenericTagClassNames(): array
     {
@@ -463,7 +463,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return list<string>
+     * @return string[]
      */
     public function getConstFetchNodeClassNames(): array
     {
@@ -490,7 +490,7 @@ final class PhpDocInfo
     }
 
     /**
-     * @return list<string>
+     * @return string[]
      */
     public function getArrayItemNodeClassNames(): array
     {

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -72,7 +72,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     }
 
     /**
-     * @return list<string>
+     * @return string[]
      */
     private function findNonUseImportNames(Namespace_|FileWithoutNamespace $namespace): array
     {
@@ -107,7 +107,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     }
 
     /**
-     * @return list<string>
+     * @return string[]
      */
     private function findNamesInDocBlocks(Namespace_|FileWithoutNamespace $namespace): array
     {
@@ -151,7 +151,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     }
 
     /**
-     * @return list<string>
+     * @return string[]
      */
     private function resolveUsedPhpAndDocNames(Namespace_|FileWithoutNamespace $namespace): array
     {
@@ -163,7 +163,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     }
 
     /**
-     * @param list<string> $names
+     * @param string[] $names
      */
     private function isUseImportUsed(UseUse $useUse, array $names, ?Name $namespaceName): bool
     {

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -72,7 +72,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     private function findNonUseImportNames(Namespace_|FileWithoutNamespace $namespace): array
     {
@@ -107,7 +107,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     private function findNamesInDocBlocks(Namespace_|FileWithoutNamespace $namespace): array
     {
@@ -151,7 +151,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     private function resolveUsedPhpAndDocNames(Namespace_|FileWithoutNamespace $namespace): array
     {
@@ -159,17 +159,17 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
         $docBlockNames = $this->findNamesInDocBlocks($namespace);
 
         $names = [...$phpNames, ...$docBlockNames];
-        return array_unique($names);
+        return array_unique(array_map(strtolower(...), $names));
     }
 
     /**
-     * @param string[]  $names
+     * @param list<string> $names
      */
     private function isUseImportUsed(UseUse $useUse, array $names, ?Name $namespaceName): bool
     {
-        $comparedName = $useUse->alias instanceof Identifier
+        $comparedName = strtolower($useUse->alias instanceof Identifier
             ? $useUse->alias->toString()
-            : $useUse->name->toString();
+            : $useUse->name->toString());
 
         if (in_array($comparedName, $names, true)) {
             return true;
@@ -181,8 +181,8 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
             $namespacedPrefix = $comparedName . '\\';
         }
 
-        $lastName = $useUse->name->getLast();
-        $namespaceName = $namespaceName instanceof Name ? $namespaceName->toString() : null;
+        $lastName = strtolower($useUse->name->getLast());
+        $namespaceName = $namespaceName instanceof Name ? strtolower($namespaceName->toString()) : null;
 
         // match partial import
         foreach ($names as $name) {

--- a/tests/Issues/NamespacedUse/Fixture/skip_conflict_last_name_insensitive.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_conflict_last_name_insensitive.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use Some\CLASS_;
+use PhpParser\node;
+
+final class SkipConflictLastNameUsed
+{
+    /**
+     * @param Node\STMT\Class_ $param
+     */
+    public function run($param): void
+    {
+        new Class_();
+    }
+}

--- a/tests/Issues/NamespacedUse/Fixture/skip_different_letter_case.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/skip_different_letter_case.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use App\Bar\JsoN;
+
+final class Json{}
+
+echo JSON::class;
+
+?>


### PR DESCRIPTION
Fixes the `UnusedImportRemovingPostRector` rule when imported namespace doesn't match the letter case in the code, by comparing all names in lowercase.

Example:
```php
<?php

use Json;


class Json {
}

var_dump(JSON::class);
```
https://getrector.com/demo/f2508805-2d69-4792-908b-3555589439e1