### PR TITLE
[NodeAnalyzer] Remove ClassAnalyzer::isAnonymousClassName()

### DIFF
--- a/src/NodeAnalyzer/ClassAnalyzer.php
+++ b/src/NodeAnalyzer/ClassAnalyzer.php
@@ -7,42 +7,17 @@ namespace Rector\NodeAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\Class_;
-use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ClassReflection;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Util\StringUtils;
 
 final class ClassAnalyzer
 {
-    /**
-     * @var string
-     * @see https://regex101.com/r/FQH6RT/2
-     */
-    private const ANONYMOUS_CLASS_REGEX = '#^AnonymousClass\w+$#';
-
-    public function isAnonymousClassName(string $className): bool
-    {
-        return StringUtils::isMatch($className, self::ANONYMOUS_CLASS_REGEX);
-    }
-
     public function isAnonymousClass(Node $node): bool
     {
-        if (! $node instanceof Class_) {
-            return $node instanceof New_ && $this->isAnonymousClass($node->class);
+        if ($node instanceof New_) {
+            return $this->isAnonymousClass($node->class);
         }
 
-        if ($node->isAnonymous()) {
-            return true;
-        }
-
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-        if (! $scope instanceof Scope) {
-            return false;
-        }
-
-        $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection) {
-            return $classReflection->isAnonymous();
+        if ($node instanceof Class_) {
+            return $node->isAnonymous();
         }
 
         return false;

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -417,7 +417,16 @@ final class NodeTypeResolver
 
     private function isAnonymousObjectType(Type $type): bool
     {
-        return $type instanceof ObjectType && $this->classAnalyzer->isAnonymousClassName($type->getClassName());
+        if (! $type instanceof ObjectType) {
+            return false;
+        }
+
+        $classReflection = $type->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->isAnonymous();
     }
 
     private function isUnionTypeable(Type $first, Type $second): bool


### PR DESCRIPTION
Utilize php-parser Node or phpstan ClassReflection instead of verify class name with `AnonymousClass` prefix.