### PR TITLE
[Transform] MethodCall to New

### DIFF
--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Fixture/fixture.php.inc
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Fixture;
+
+class Fixture
+{
+    public function run(\Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\ResponseFactory $factory)
+    {
+        $response = $factory->createResponse([
+            'a' => 'b'
+        ]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Fixture;
+
+class Fixture
+{
+    public function run(\Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\ResponseFactory $factory)
+    {
+        $response = new \Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\Response([
+            'a' => 'b'
+        ]);
+    }
+}
+
+?>

--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Fixture/skip_non_matching_class.php.inc
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Fixture/skip_non_matching_class.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Fixture;
+
+class SkipNonMatchingClass
+{
+    public function run(Response $factory)
+    {
+        $response = $factory->jsonResponse([
+            'a' => 'b'
+        ]);
+    }
+}
+
+?>

--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Fixture/skip_non_matching_method.php.inc
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Fixture/skip_non_matching_method.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Fixture;
+
+class SkipNonMatchingMethod
+{
+    public function run(\Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\ResponseFactory $factory)
+    {
+        $response = $factory->jsonResponse([
+            'a' => 'b'
+        ]);
+    }
+}
+
+?>

--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/MethodCallToNewRectorTest.php
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/MethodCallToNewRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MethodCallToNewRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Source/Response.php
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Source/Response.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source;
+
+class Response
+{
+    public function __construct(public array $params)
+    {
+
+    }
+}

--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Source/ResponseFactory.php
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/Source/ResponseFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source;
+
+class ResponseFactory
+{
+    public function createResponse(array $params): Response
+    {
+        return new Response($params);
+    }
+}

--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Transform\Rector\MethodCall\MethodCallToNewRector;
+use PHPstan\Type\ObjectType;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(MethodCallToNewRector::class, [
+        new \Rector\Transform\ValueObject\MethodCallToNew(
+            new ObjectType('Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\ResponseFactory'),
+            'createResponse',
+            'Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\Response',
+        ),
+    ]);
+};

--- a/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/MethodCall/MethodCallToNewRector/config/configured_rule.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
+use PHPStan\Type\ObjectType;
 use Rector\Config\RectorConfig;
 use Rector\Transform\Rector\MethodCall\MethodCallToNewRector;
-use PHPstan\Type\ObjectType;
+use Rector\Transform\ValueObject\MethodCallToNew;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(MethodCallToNewRector::class, [
-        new \Rector\Transform\ValueObject\MethodCallToNew(
+        new MethodCallToNew(
             new ObjectType('Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\ResponseFactory'),
             'createResponse',
             'Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\Source\Response',

--- a/rules/Transform/Rector/MethodCall/MethodCallToNewRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToNewRector.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rector\Transform\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Type\ObjectType;
@@ -13,6 +16,9 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
+/**
+ * @see \Rector\Tests\Transform\Rector\MethodCall\MethodCallToNewRector\MethodCallToNewRectorTest
+ */
 class MethodCallToNewRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
@@ -36,28 +42,24 @@ class MethodCallToNewRector extends AbstractRector implements ConfigurableRector
             [new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
 $object->createResponse(['a' => 1]);
-CODE_SAMPLE,
+CODE_SAMPLE
+                ,
                 <<<'CODE_SAMPLE'
 new Response(['a' => 1]);
-CODE_SAMPLE,
-                [
-                    new MethodCallToNew(
-                        new ObjectType('ResponseFactory'),
-                        'createResponse',
-                        'Response',
-                    ),
-                ]
+CODE_SAMPLE
+                ,
+                [new MethodCallToNew(new ObjectType('ResponseFactory'), 'createResponse', 'Response')]
             )]
         );
     }
 
     public function getNodeTypes(): array
     {
-        return [Node\Expr\MethodCall::class];
+        return [MethodCall::class];
     }
 
     /**
-     * @param Node\Expr\MethodCall $node
+     * @param MethodCall $node
      */
     public function refactor(Node $node): ?New_
     {
@@ -65,6 +67,7 @@ CODE_SAMPLE,
             if (! $this->isName($node->name, $methodCallToNew->getMethodName())) {
                 continue;
             }
+
             if (! $this->isObjectType($node->var, $methodCallToNew->getObject())) {
                 continue;
             }

--- a/rules/Transform/Rector/MethodCall/MethodCallToNewRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToNewRector.php
@@ -63,6 +63,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?New_
     {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         foreach ($this->methodCallToNew as $methodCallToNew) {
             if (! $this->isName($node->name, $methodCallToNew->getMethodName())) {
                 continue;

--- a/rules/Transform/Rector/MethodCall/MethodCallToNewRector.php
+++ b/rules/Transform/Rector/MethodCall/MethodCallToNewRector.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Rector\Transform\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Rector\Transform\ValueObject\MethodCallToNew;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+class MethodCallToNewRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var MethodCallToNew[]
+     */
+    private array $methodCallToNew;
+
+    /**
+     * @param MethodCallToNew[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, MethodCallToNew::class);
+        $this->methodCallToNew = $configuration;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change method call to new class',
+            [new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+$object->createResponse(['a' => 1]);
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+new Response(['a' => 1]);
+CODE_SAMPLE,
+                [
+                    new MethodCallToNew(
+                        new ObjectType('ResponseFactory'),
+                        'createResponse',
+                        'Response',
+                    ),
+                ]
+            )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\MethodCall::class];
+    }
+
+    /**
+     * @param Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): ?New_
+    {
+        foreach ($this->methodCallToNew as $methodCallToNew) {
+            if (! $this->isName($node->name, $methodCallToNew->getMethodName())) {
+                continue;
+            }
+            if (! $this->isObjectType($node->var, $methodCallToNew->getObject())) {
+                continue;
+            }
+
+            return new New_(new FullyQualified($methodCallToNew->getNewClassString()), $node->args);
+        }
+
+        return null;
+    }
+}

--- a/rules/Transform/ValueObject/MethodCallToNew.php
+++ b/rules/Transform/ValueObject/MethodCallToNew.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Transform\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final readonly class MethodCallToNew
+{
+    /**
+     * @param class-string $newClassString
+     */
+    public function __construct(private ObjectType $object, private string $methodName, private string $newClassString)
+    {
+    }
+
+    public function getObject(): ObjectType
+    {
+        return $this->object;
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function getNewClassString(): string
+    {
+        return $this->newClassString;
+    }
+}

--- a/rules/Transform/ValueObject/MethodCallToNew.php
+++ b/rules/Transform/ValueObject/MethodCallToNew.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rector\Transform\ValueObject;
 
 use PHPStan\Type\ObjectType;
@@ -9,13 +11,16 @@ final readonly class MethodCallToNew
     /**
      * @param class-string $newClassString
      */
-    public function __construct(private ObjectType $object, private string $methodName, private string $newClassString)
-    {
+    public function __construct(
+        private ObjectType $objectType,
+        private string $methodName,
+        private string $newClassString
+    ) {
     }
 
     public function getObject(): ObjectType
     {
-        return $this->object;
+        return $this->objectType;
     }
 
     public function getMethodName(): string


### PR DESCRIPTION
# Changes

- Adds a new rule for MethodCall to New
- Adds a MethodCallToNew value object
- Adds tests for the new rule

# Why

This can be useful when you have something like a factory class that creates a new instance.

```diff
-$factory->createResponse(['a' => 1]);
+new Response(['a' => 1]);
```