### PR TITLE
[Php70] More delimiter case in the middle fix on EregToPregMatchRector

### DIFF
--- a/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/with_delimiter_char_in_middle2.php.inc
+++ b/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/with_delimiter_char_in_middle2.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\FuncCall\EregToPregMatchRector\Fixture;
+
+function withDelimiterInMiddle2($text)
+{
+    return (bool) ereg('A# (minor|major)', $text);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\FuncCall\EregToPregMatchRector\Fixture;
+
+function withDelimiterInMiddle2($text)
+{
+    return (bool) preg_match('#A\# (minor|major)#m', $text);
+}
+
+?>

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -71,19 +71,7 @@ final class EregToPcreTransformer
     ) {
     }
 
-    public function transform(string $ereg, bool $isCaseInsensitive): string
-    {
-        if (! \str_contains($ereg, $this->pcreDelimiter)) {
-            return $this->ere2pcre($ereg, $isCaseInsensitive);
-        }
-
-        // fallback
-        $quotedEreg = preg_quote($ereg, $this->pcreDelimiter);
-        return $this->ere2pcre($quotedEreg, $isCaseInsensitive);
-    }
-
-    // converts the ERE $s into the PCRE $r. triggers error on any invalid input.
-    private function ere2pcre(string $content, bool $ignorecase): string
+    public function transform(string $content, bool $ignorecase): string
     {
         if ($ignorecase) {
             if (isset($this->icache[$content])) {
@@ -201,9 +189,14 @@ final class EregToPcreTransformer
         }
 
         return [
-            str_replace($this->pcreDelimiter, '\\' . $this->pcreDelimiter, implode('|', $r)),
+            $this->normalize(implode('|', $r)),
             $i
         ];
+    }
+
+    private function normalize(string $content): string
+    {
+        return str_replace($this->pcreDelimiter, '\\' . $this->pcreDelimiter, $content);
     }
 
     /**

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -71,6 +71,7 @@ final class EregToPcreTransformer
     ) {
     }
 
+    // converts the ERE $s into the PCRE $r. triggers error on any invalid input.
     public function transform(string $content, bool $ignorecase): string
     {
         if ($ignorecase) {


### PR DESCRIPTION
continue of PR:

- https://github.com/rectorphp/rector-src/pull/6356

@corentin-larose this is more fix for https://github.com/rectorphp/rector/issues/8850