### PR TITLE
[DeadCode] Skip RemoveUnusedPrivatePropertyRector in middle assign

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_in_middle_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_in_middle_assign.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+final class SkipInMiddleAssign
+{
+    private int $a = 0;
+    
+    public function run(int $b)
+    {
+        $b = $this->a = 0;
+        return $b;
+    }
+}

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/AssignedToNodeVisitor.php
@@ -39,6 +39,7 @@ final class AssignedToNodeVisitor extends NodeVisitorAbstract implements ScopeRe
         if ($node->expr instanceof Assign) {
             $node->var->setAttribute(AttributeKey::IS_MULTI_ASSIGN, true);
             $node->expr->setAttribute(AttributeKey::IS_MULTI_ASSIGN, true);
+            $node->expr->var->setAttribute(AttributeKey::IS_ASSIGNED_TO, true);
         }
 
         return null;


### PR DESCRIPTION
Ref https://getrector.com/demo/8e9ee5de-d2c6-4d6b-b190-cb761a90615e
Ref https://phpstan.org/r/aad6d764-93f1-4f56-839f-348e587f5e8f that cause access to undefined property error.