### PR TITLE
Apply AddOverrideAttributeToOverriddenMethodsRector to traits

### DIFF
--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/apply_attribute_to_override_method_from_trait.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/apply_attribute_to_override_method_from_trait.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromTrait;
+
+class ApplyAttributeToOverrideMethodFromTrait
+{
+    use ExampleFromTrait;
+
+    public function foo()
+    {
+    }
+
+    public function bar()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromTrait;
+
+class ApplyAttributeToOverrideMethodFromTrait
+{
+    use ExampleFromTrait;
+
+    #[\Override]
+    public function foo()
+    {
+    }
+
+    #[\Override]
+    public function bar()
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/ExampleFromTrait.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/ExampleFromTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source;
+
+trait ExampleFromTrait
+{
+    public abstract function foo();
+
+    public function bar() {
+
+    }
+}

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -102,7 +102,11 @@ CODE_SAMPLE
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        $parentClassReflections = [...$classReflection->getParents(), ...$classReflection->getInterfaces()];
+        $parentClassReflections = [
+            ...$classReflection->getParents(),
+            ...$classReflection->getInterfaces(),
+            ...$classReflection->getTraits(),
+        ];
 
         $this->processAddOverrideAttribute($node, $parentClassReflections);
 


### PR DESCRIPTION
This aligns with PHPStan's expectation and seems logically correct to me, when this transform is run it should also cover methods inherited from a trait.