### PR TITLE
Apply AddOverrideAttributeToOverriddenMethodsRector to traits

### DIFF
--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/apply_attribute_to_override_method_from_trait.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/apply_attribute_to_override_method_from_trait.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromTrait;
+
+class ApplyAttributeToOverrideMethodFromTrait
+{
+    use ExampleFromTrait;
+
+    public function foo()
+    {
+    }
+
+    public function bar()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromTrait;
+
+class ApplyAttributeToOverrideMethodFromTrait
+{
+    use ExampleFromTrait;
+
+    #[\Override]
+    public function foo()
+    {
+    }
+
+    public function bar()
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/ExampleFromTrait.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/ExampleFromTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source;
+
+trait ExampleFromTrait
+{
+    public abstract function foo();
+
+    public function bar() {
+
+    }
+}

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -102,7 +102,11 @@ CODE_SAMPLE
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        $parentClassReflections = [...$classReflection->getParents(), ...$classReflection->getInterfaces()];
+        $parentClassReflections = [
+            ...$classReflection->getParents(),
+            ...$classReflection->getInterfaces(),
+            ...$classReflection->getTraits(),
+        ];
 
         $this->processAddOverrideAttribute($node, $parentClassReflections);
 
@@ -150,6 +154,9 @@ CODE_SAMPLE
                 // ignore if it is a private method on the parent
                 $parentMethod = $parentClassReflection->getNativeMethod($classMethod->name->toString());
                 if ($parentMethod->isPrivate()) {
+                    continue;
+                }
+                if ($parentClassReflection->isTrait() && !$parentMethod->isAbstract()) {
                     continue;
                 }
 


### PR DESCRIPTION
Apply the Override Attribute to methods inherited from abstract methods in a trait.

Re-opens #6366 with the change restricted to only abstract methods in a trait.

Example of this in action:
https://3v4l.org/qUg3R