### PR TITLE
[Php70] Handle empty branch crash on unprintable char \x0C on EregToPregMatchRector

### DIFF
--- a/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/empty_branch.php.inc
+++ b/rules-tests/Php70/Rector/FuncCall/EregToPregMatchRector/Fixture/empty_branch.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\FuncCall\EregToPregMatchRector\Fixture;
+
+function emptyBranch()
+{
+	// If there was a font color or size change, change the font tag now.
+	if(@ereg("(\\\cf[0-9])||(\\\fs[0-9][0-9])", $tags)) {
+		$html .= '</font><font size="'.$size.'" color="'.$color.'">';
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\FuncCall\EregToPregMatchRector\Fixture;
+
+function emptyBranch()
+{
+	// If there was a font color or size change, change the font tag now.
+	if(@preg_match("#(\\\\cf[0-9])||(\\\\fs[0-9][0-9])#m", $tags)) {
+		$html .= '</font><font size="'.$size.'" color="'.$color.'">';
+	}
+}
+
+?>

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -104,6 +104,8 @@ final class EregToPcreTransformer
         $r = [''];
         $rr = 0;
         $l = strlen($content);
+        $normalizeUnprintableChar = false;
+
         while ($i < $l) {
             // atom
             $char = $content[$i];
@@ -149,6 +151,10 @@ final class EregToPcreTransformer
                 ++$i;
                 continue;
             } elseif ($char === '|') {
+                if ($r[$rr] === '') {
+                    $normalizeUnprintableChar = true;
+                }
+
                 $r[] = '';
                 ++$rr;
                 ++$i;
@@ -185,12 +191,14 @@ final class EregToPcreTransformer
             throw new InvalidEregException('empty regular expression or branch');
         }
 
-        return [$this->normalize(implode('|', $r)), $i];
+        return [$this->normalize(implode('|', $r), $normalizeUnprintableChar), $i];
     }
 
-    private function normalize(string $content): string
+    private function normalize(string $content, bool $normalizeUnprintableChar): string
     {
-        $content = str_replace("\x0C", '\\\f', $content);
+        if ($normalizeUnprintableChar) {
+            $content = str_replace("\x0C", '\\\f', $content);
+        }
 
         return str_replace($this->pcreDelimiter, '\\' . $this->pcreDelimiter, $content);
     }

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -149,10 +149,6 @@ final class EregToPcreTransformer
                 ++$i;
                 continue;
             } elseif ($char === '|') {
-                if ($r[$rr] === '') {
-                    throw new InvalidEregException('empty branch');
-                }
-
                 $r[] = '';
                 ++$rr;
                 ++$i;
@@ -194,6 +190,8 @@ final class EregToPcreTransformer
 
     private function normalize(string $content): string
     {
+        $content = str_replace("\x0C", '\\\f', $content);
+
         return str_replace($this->pcreDelimiter, '\\' . $this->pcreDelimiter, $content);
     }
 

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -156,6 +156,7 @@ CODE_SAMPLE
                 if ($parentMethod->isPrivate()) {
                     continue;
                 }
+
                 if ($parentClassReflection->isTrait() && !$parentMethod->isAbstract()) {
                     continue;
                 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8854