### PR TITLE
[DeadCode] Skip union docblock param with is_object() native type check on RemoveAlwaysTrueIfConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_union_docblock_param_is_object.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_union_docblock_param_is_object.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+use DateTime;
+use stdClass;
+
+class SkipUnionDocblockParamIsObject
+{
+    /**
+     * @param DateTime|stdClass|null $param
+     */
+    function bar($param)
+    {
+        if (! is_object($param)) {
+            return '-';
+        }
+
+        if ($param instanceof Datetime) {
+            return 'a';
+        }
+
+        if ($param instanceof stdClass) {
+            return 'b';
+        }
+
+        return 'c';
+    }
+}

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\UnionType;
 use Rector\Enum\ObjectReference;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -44,6 +45,11 @@ final class ExprAnalyzer
         }
 
         $type = $scope->getType($expr);
+
+        if ($nativeType instanceof ObjectWithoutClassType && ! $type instanceof ObjectWithoutClassType) {
+            return true;
+        }
+
         if ($nativeType instanceof UnionType) {
             return ! $nativeType->equals($type);
         }

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -237,9 +237,10 @@ final class NodeTypeResolver
             }
         }
 
-        $type = $this->resolveNativeTypeWithBuiltinMethodCallFallback($expr, $scope);
         if ($expr instanceof ArrayDimFetch) {
             $type = $this->resolveArrayDimFetchType($expr, $scope, $type);
+        } else {
+            $type = $this->resolveNativeTypeWithBuiltinMethodCallFallback($expr, $scope);
         }
 
         if (! $type instanceof UnionType) {

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -237,10 +237,9 @@ final class NodeTypeResolver
             }
         }
 
+        $type = $this->resolveNativeTypeWithBuiltinMethodCallFallback($expr, $scope);
         if ($expr instanceof ArrayDimFetch) {
             $type = $this->resolveArrayDimFetchType($expr, $scope, $type);
-        } else {
-            $type = $this->resolveNativeTypeWithBuiltinMethodCallFallback($expr, $scope);
         }
 
         if (! $type instanceof UnionType) {


### PR DESCRIPTION
Ref https://getrector.com/demo/f8777179-b03c-4f75-b7f2-9934bdd9a1fc
see example usage https://3v4l.org/GNuh3