### PR TITLE
[CodeQuality] Clean up else check on SimplifyIfReturnBoolRector

### DIFF
--- a/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
@@ -127,10 +127,6 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->isElseSeparatedThenIf($if)) {
-            return true;
-        }
-
         /** @var Return_ $ifInnerNode */
         $ifInnerNode = $if->stmts[0];
 
@@ -198,40 +194,13 @@ CODE_SAMPLE
         return new Return_($this->exprBoolCaster->boolCastOrNullCompareIfNeeded(new BooleanNot($if->cond)));
     }
 
-    /**
-     * Matches: "else if"
-     */
-    private function isElseSeparatedThenIf(If_ $if): bool
-    {
-        if (! $if->else instanceof Else_) {
-            return false;
-        }
-
-        if (count($if->else->stmts) !== 1) {
-            return true;
-        }
-
-        $onlyStmt = $if->else->stmts[0];
-        if (! $onlyStmt instanceof Return_ || ! $onlyStmt->expr instanceof Expr) {
-            return true;
-        }
-
-        if ($this->valueResolver->isTrueOrFalse($onlyStmt->expr)) {
-            /** @var Return_ $ifReturn */
-            $ifReturn = $if->stmts[0];
-            return $this->nodeComparator->areNodesEqual($onlyStmt->expr, $ifReturn->expr);
-        }
-
-        return true;
-    }
-
     private function isIfWithSingleReturnExpr(If_ $if): bool
     {
         if (count($if->stmts) !== 1) {
             return false;
         }
 
-        if ($if->elseifs !== []) {
+        if ($if->else instanceof Else_ || $if->elseifs !== []) {
             return false;
         }
 


### PR DESCRIPTION
direct skip else can be checked for https://github.com/rectorphp/rector-src/pull/6371 with existing fixtures. when there is else or elseif, it can directly be skipped.