### PR TITLE
[UnusedImport] Fix removing multiple uses

### DIFF
--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -57,12 +57,13 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
 
             $isCaseSensitive = $namespaceStmt->type === Use_::TYPE_CONSTANT;
 
+            if ($isCaseSensitive) {
+                $names = $namesInOriginalCase;
+            } else {
+                $names = $namesInLowerCase;
+            }
+
             foreach ($namespaceStmt->uses as $useUseKey => $useUse) {
-                if ($isCaseSensitive) {
-                    $names = $namesInOriginalCase;
-                } else {
-                    $names = $namesInLowerCase;
-                }
 
                 if ($this->isUseImportUsed($useUse, $isCaseSensitive, $names, $namespaceName)) {
                     continue;

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -41,7 +41,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
             : null;
 
         $namesInOriginalCase = $this->resolveUsedPhpAndDocNames($node);
-        $namesInLowerCase = null; // Initialized as null, lazy loaded when case in-sensitive names are needed
+        $namesInLowerCase = array_map(strtolower(...), $namesInOriginalCase);
 
         foreach ($node->stmts as $key => $namespaceStmt) {
             if (! $namespaceStmt instanceof Use_) {
@@ -62,10 +62,6 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 if ($isCaseSensitive) {
                     $names = $namesInOriginalCase;
                 } else {
-                    if ($namesInLowerCase === null) {
-                        $namesInLowerCase = array_map(strtolower(...), $namesInOriginalCase);
-                    }
-
                     $names = $namesInLowerCase;
                 }
 

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -57,7 +57,6 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
 
             $isCaseSensitive = $namespaceStmt->type === Use_::TYPE_CONSTANT;
 
-            $useCount = count($namespaceStmt->uses);
             foreach ($namespaceStmt->uses as $useUseKey => $useUse) {
                 if ($isCaseSensitive) {
                     $names = $namesInOriginalCase;
@@ -68,13 +67,14 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 if ($this->isUseImportUsed($useUse, $isCaseSensitive, $names, $namespaceName)) {
                     continue;
                 }
-                if ($useCount > 1) {
-                    unset($namespaceStmt->uses[$useUseKey]);
-                } else {
-                    unset($node->stmts[$key]);
-                }
+
+                unset($namespaceStmt->uses[$useUseKey]);
 
                 $hasChanged = true;
+            }
+
+            if ($namespaceStmt->uses === []) {
+                unset($node->stmts[$key]);
             }
         }
 

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -55,25 +55,31 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 continue;
             }
 
-            $useUse = $namespaceStmt->uses[0];
             $isCaseSensitive = $namespaceStmt->type === Use_::TYPE_CONSTANT;
 
-            if ($isCaseSensitive) {
-                $names = $namesInOriginalCase;
-            } else {
-                if ($namesInLowerCase === null) {
-                    $namesInLowerCase = array_map(strtolower(...), $namesInOriginalCase);
+            $useCount = count($namespaceStmt->uses);
+            foreach ($namespaceStmt->uses as $useUseKey => $useUse) {
+                if ($isCaseSensitive) {
+                    $names = $namesInOriginalCase;
+                } else {
+                    if ($namesInLowerCase === null) {
+                        $namesInLowerCase = array_map(strtolower(...), $namesInOriginalCase);
+                    }
+
+                    $names = $namesInLowerCase;
                 }
 
-                $names = $namesInLowerCase;
-            }
+                if ($this->isUseImportUsed($useUse, $isCaseSensitive, $names, $namespaceName)) {
+                    continue;
+                }
+                if ($useCount > 1) {
+                    unset($namespaceStmt->uses[$useUseKey]);
+                } else {
+                    unset($node->stmts[$key]);
+                }
 
-            if ($this->isUseImportUsed($useUse, $isCaseSensitive, $names, $namespaceName)) {
-                continue;
+                $hasChanged = true;
             }
-
-            unset($node->stmts[$key]);
-            $hasChanged = true;
         }
 
         if ($hasChanged === false) {

--- a/tests/Issues/NamespacedUse/Fixture/multiple_use_const_namespace.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/multiple_use_const_namespace.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Bar;
+
+use const A, B, C;
+use const D, E, F;
+use const G, H, I;
+use const J, K, L;
+use const AA, BB, CC;
+
+use const M, N;
+use const O, P;
+use const Q, R;
+use const X, Y;
+
+var_dump(A);
+var_dump(E);
+var_dump(I);
+var_dump(AA);
+var_dump(BB);
+var_dump(CC);
+
+var_dump(M);
+var_dump(P);
+var_dump(X);
+var_dump(Y);
+
+?>
+-----
+<?php
+
+namespace App\Bar;
+
+use const A;
+use const E;
+use const I;
+use const AA, BB, CC;
+
+use const M;
+use const P;
+use const X, Y;
+
+var_dump(A);
+var_dump(E);
+var_dump(I);
+var_dump(AA);
+var_dump(BB);
+var_dump(CC);
+
+var_dump(M);
+var_dump(P);
+var_dump(X);
+var_dump(Y);
+
+?>

--- a/tests/Issues/NamespacedUse/Fixture/multiple_use_namespace.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/multiple_use_namespace.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Bar;
+
+use A, B, C;
+use D, E, F;
+use G, H, I;
+use J, K, L;
+use AA, BB, CC;
+
+use M, N;
+use O, P;
+use Q, R;
+use X, Y;
+
+var_dump(A::class);
+var_dump(E::class);
+var_dump(I::class);
+var_dump(AA::class);
+var_dump(BB::class);
+var_dump(CC::class);
+
+var_dump(M::class);
+var_dump(P::class);
+var_dump(X::class);
+var_dump(Y::class);
+
+?>
+-----
+<?php
+
+namespace App\Bar;
+
+use A;
+use E;
+use I;
+use AA, BB, CC;
+
+use M;
+use P;
+use X, Y;
+
+var_dump(A::class);
+var_dump(E::class);
+var_dump(I::class);
+var_dump(AA::class);
+var_dump(BB::class);
+var_dump(CC::class);
+
+var_dump(M::class);
+var_dump(P::class);
+var_dump(X::class);
+var_dump(Y::class);
+
+?>


### PR DESCRIPTION
Fixes removal of unused import for multiple uses.

Example of bug reported in another PR https://github.com/rectorphp/rector-src/pull/6362#discussion_r1794880998
 ```
 namespace A;
 
 use B, C;
 
 echo B::class;
 ```

[getrector.com/demo/755f134f-8f83-4bb1-a904-99ab62db0c6b](https://getrector.com/demo/755f134f-8f83-4bb1-a904-99ab62db0c6b)