### PR TITLE
[TypeDeclaration] Add param type to array map closure

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/AddClosureParamTypeForArrayMapRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/AddClosureParamTypeForArrayMapRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureParamTypeForArrayMapRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo;
+
+class Fixture
+{
+    /**
+     * @param array<int, string> $array
+     */
+    public function run(array $array)
+    {
+        return array_map(function ($value, $key) {
+            return $value . $key;
+        }, $array);
+    }
+
+    /**
+     * @param array<int, string> $array
+     * @param array<int, Foo> $arrayTwo
+     */
+    public function runTwo(array $array, array $arrayTwo)
+    {
+        return array_map(function ($value, $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo;
+
+class Fixture
+{
+    /**
+     * @param array<int, string> $array
+     */
+    public function run(array $array)
+    {
+        return array_map(function (string $value, int $key) {
+            return $value . $key;
+        }, $array);
+    }
+
+    /**
+     * @param array<int, string> $array
+     * @param array<int, Foo> $arrayTwo
+     */
+    public function runTwo(array $array, array $arrayTwo)
+    {
+        return array_map(function (string|\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo $value, int $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
@@ -2,6 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture;
 
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Bar;
 use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo;
 
 class Fixture
@@ -26,6 +27,17 @@ class Fixture
             return get_class($value) . $key;
         }, $array, $arrayTwo);
     }
+
+    /**
+     * @param array<int, string> $array
+     * @param array<int, Foo|Bar> $arrayTwo
+     */
+    public function runThree(array $array, array $arrayTwo)
+    {
+        return array_map(function ($value, $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
 }
 
 ?>
@@ -34,6 +46,7 @@ class Fixture
 
 namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture;
 
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Bar;
 use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo;
 
 class Fixture
@@ -54,7 +67,18 @@ class Fixture
      */
     public function runTwo(array $array, array $arrayTwo)
     {
-        return array_map(function (string|\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo $value, int $key) {
+        return array_map(function (\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo|string $value, int $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
+
+    /**
+     * @param array<int, string> $array
+     * @param array<int, Foo|Bar> $arrayTwo
+     */
+    public function runThree(array $array, array $arrayTwo)
+    {
+        return array_map(function (\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Bar|\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo|string $value, int $key) {
             return get_class($value) . $key;
         }, $array, $arrayTwo);
     }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
@@ -38,6 +38,17 @@ class Fixture
             return get_class($value) . $key;
         }, $array, $arrayTwo);
     }
+
+    /**
+     * @param array<int, string> $array
+     * @param array<int> $arrayTwo
+     */
+    public function runFour(array $array, array $arrayTwo)
+    {
+        return array_map(function ($value, $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
 }
 
 ?>
@@ -79,6 +90,17 @@ class Fixture
     public function runThree(array $array, array $arrayTwo)
     {
         return array_map(function (\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Bar|\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo|string $value, int $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
+
+    /**
+     * @param array<int, string> $array
+     * @param array<int> $arrayTwo
+     */
+    public function runFour(array $array, array $arrayTwo)
+    {
+        return array_map(function (string $value, int $key) {
             return get_class($value) . $key;
         }, $array, $arrayTwo);
     }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
@@ -41,9 +41,20 @@ class Fixture
 
     /**
      * @param array<int, string> $array
-     * @param array<int> $arrayTwo
+     * @param array<string> $arrayTwo tested for the missing key
      */
     public function runFour(array $array, array $arrayTwo)
+    {
+        return array_map(function ($value, $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
+
+    /**
+     * @param array<int, string> $array
+     * @param list<string> $arrayTwo tested for the missing key
+     */
+    public function runFive(array $array, array $arrayTwo)
     {
         return array_map(function ($value, $key) {
             return get_class($value) . $key;
@@ -96,9 +107,20 @@ class Fixture
 
     /**
      * @param array<int, string> $array
-     * @param array<int> $arrayTwo
+     * @param array<string> $arrayTwo tested for the missing key
      */
     public function runFour(array $array, array $arrayTwo)
+    {
+        return array_map(function (string $value, int|string $key) {
+            return get_class($value) . $key;
+        }, $array, $arrayTwo);
+    }
+
+    /**
+     * @param array<int, string> $array
+     * @param list<string> $arrayTwo tested for the missing key
+     */
+    public function runFive(array $array, array $arrayTwo)
     {
         return array_map(function (string $value, int $key) {
             return get_class($value) . $key;

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_mixed_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_mixed_type.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture;
+
+class SkipMixedType
+{
+    /**
+     * @param array<int, mixed> $array
+     */
+    public function run(array $array)
+    {
+        return array_map(function ($value) {
+            return $value;
+        }, $array);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_non_array_map_functions.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_non_array_map_functions.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture;
+
+function array_map(callable $func, array $array)
+{
+
+}
+
+class SkipNonArrayMapFunctions
+{
+    /**
+     * @param array<int, string> $array
+     */
+    public function run(array $array)
+    {
+        return \Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture\array_map(function ($value, $key) {
+            return $value . $key;
+        }, $array);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_tuple.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_tuple.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+class SkipTuple
+{
+    /**
+     * @param array{0: list<string>, 1: list<string>} $tuple
+     */
+    public function run(array $tuple)
+    {
+        array_map(function ($first, $second) {
+            return $first . $second;
+        }, ...$tuple);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Source/Bar.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Source/Bar.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source;
+
+use Illuminate\Support\Arr;
+
+final class Bar
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Source/Foo.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Source/Foo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source;
+
+use Illuminate\Support\Arr;
+
+final class Foo
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->rules([AddClosureParamTypeForArrayMapRector::class]);
+
+    $rectorConfig->phpVersion(PhpVersionFeature::INTERSECTION_TYPES);
+};

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/config/configured_rule.php
@@ -10,5 +10,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
         ->rules([AddClosureParamTypeForArrayMapRector::class]);
 
-    $rectorConfig->phpVersion(PhpVersionFeature::INTERSECTION_TYPES);
+    $rectorConfig->phpVersion(PhpVersionFeature::UNION_TYPES);
 };

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
@@ -82,7 +82,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $node->args[0] instanceof Arg || ! $node->args[0]->value instanceof Closure) {
+        $args = $node->getArgs();
+
+        if (! isset($args[0]) || ! $args[0]->value instanceof Closure) {
             return null;
         }
 
@@ -136,7 +138,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->updateClosureWithTypes($node->args[0]->value, $keyType, $valueType)) {
+        if ($this->updateClosureWithTypes($args[0]->value, $keyType, $valueType)) {
             return $node;
         }
 

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Param;
+use PhpParser\Node\VariadicPlaceholder;
+use PHPStan\Reflection\Native\NativeFunctionReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\AddClosureParamTypeForArrayMapRectorTest
+ */
+final class AddClosureParamTypeForArrayMapRector extends AbstractRector
+{
+    public function __construct(
+        private readonly TypeComparator $typeComparator,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly TypeUnwrapper $typeUnwrapper,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Applies type hints to array_map closures',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+array_map(function ($value, $key): string {
+    return $value . $key;
+}, $strings);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+array_map(function (string $value, int $key): bool {
+    return $value . $key;
+}, $strings);
+CODE_SAMPLE
+                    ,
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->isName($node,'array_map')) {
+            return null;
+        }
+
+        $funcReflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+
+        if (! $funcReflection instanceof NativeFunctionReflection) {
+            return null;
+        }
+
+        if (! $node->args[0]->value instanceof Closure) {
+            return null;
+        }
+
+        /** @var ArrayType[] $types */
+        $types = array_filter(array_map(function (Arg $arg): ?ArrayType {
+            $type = $this->getType($arg->value);
+
+            if ($type instanceof ArrayType) {
+                return $type;
+            }
+
+            return null;
+        }, array_slice($node->args, 1)));
+
+        $values = [];
+        $keys = [];
+
+        foreach ($types as $type) {
+           $values[] = $type->getIterableValueType();
+           $keys[] = $type->getIterableKeyType();
+        }
+
+        foreach ($values as $value) {
+            if ($value instanceof MixedType) {
+                $values = [];
+                break;
+            }
+        }
+
+        foreach ($keys as $key) {
+            if ($key instanceof MixedType) {
+                $keys = [];
+                break;
+            }
+        }
+
+        $valueType = $this->combineTypes($values);
+        $keyType = $this->combineTypes($keys);
+
+        if (! $keyType instanceof Type && ! $valueType instanceof Type) {
+            return null;
+        }
+
+        $this->updateClosureWithTypes($node->args[0]->value, $keyType, $valueType);
+
+        return $node;
+    }
+
+    private function updateClosureWithTypes(
+        Closure $closure,
+        ?Type $keyType,
+        ?Type $valueType
+    ): void {
+        if ($closure->params[0] ?? null instanceof Param) {
+            $this->refactorParameter($closure->params[0], $valueType);
+        }
+        if ($closure->params[1] ?? null instanceof Param) {
+            $this->refactorParameter($closure->params[1], $keyType);
+        }
+    }
+
+    private function refactorParameter(Param $param, Type $type): bool
+    {
+        // already set → no change
+        if ($param->type instanceof Node) {
+            $currentParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+            if ($this->typeComparator->areTypesEqual($currentParamType, $type)) {
+                return false;
+            }
+        }
+
+        $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($type, TypeKind::PARAM);
+
+        if (! $paramTypeNode instanceof Node) {
+            return false;
+        }
+
+        $param->type = $paramTypeNode;
+
+        return true;
+    }
+
+    /**
+     * @param Type[] $types
+     * @throws ShouldNotHappenException
+     */
+    private function combineTypes(array $types): Type
+    {
+        $types = array_reduce($types, function(array $types, Type $type): array {
+            foreach ($types as $previousType) {
+                if ($this->typeComparator->areTypesEqual($type, $previousType)) {
+                    return $types;
+                }
+            }
+
+            $types[] = $type;
+            return $types;
+        }, []);
+
+        if (count($types) === 1) {
+            return $types[0];
+        }
+
+        return new UnionType($types);
+    }
+}


### PR DESCRIPTION
# Changes

- Adds a new rule for type hinting closures used with `array_map`.
- Adds tests.

# Why

Another rule from me which will deal with the difficulties of type hinting closures. It takes the key and value types of all the arrays provided and then type hints them. If more than one array is provide and the value/key types are different it will work out the union type.

```diff
-array_map(function ($value, $key): string {
+array_map(function (string $value, int $key): string {
    return $value . $key;
}, $strings);
```