### PR TITLE
[CodeQuality] Skip no @property doc on DynamicDocBlockPropertyToNativePropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_property_doc.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_property_doc.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency;
+
+/**
+ * @see SomeDependency
+ */
+#[\AllowDynamicProperties]
+final class SkipNoPropertyDoc
+{
+    public function run(): void
+    {
+        $this->someDependency = new SomeDependency();
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
@@ -101,28 +101,33 @@ CODE_SAMPLE
             return null;
         }
 
+        // 2. add defined @property explicitly
+        $classPhpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $classPhpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $propertyPhpDocTagNodes = $classPhpDocInfo->getTagsByName('property');
+        if ($propertyPhpDocTagNodes === []) {
+            return null;
+        }
+
         // 1. remove dynamic attribute, most likely any
         $node->attrGroups = [];
 
-        // 2. add defined @property explicitly
-        $classPhpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
-        if ($classPhpDocInfo instanceof PhpDocInfo) {
-            $propertyPhpDocTagNodes = $classPhpDocInfo->getTagsByName('property');
+        $newProperties = $this->createNewPropertyFromPropertyTagValueNodes($propertyPhpDocTagNodes, $node);
 
-            $newProperties = $this->createNewPropertyFromPropertyTagValueNodes($propertyPhpDocTagNodes, $node);
-
-            // remove property tags
-            foreach ($propertyPhpDocTagNodes as $propertyPhpDocTagNode) {
-                // remove from docblock
-                $this->phpDocTagRemover->removeTagValueFromNode($classPhpDocInfo, $propertyPhpDocTagNode);
-            }
-
-            // merge new properties to start of the file
-            $node->stmts = array_merge($newProperties, $node->stmts);
-
-            // update doc info
-            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+        // remove property tags
+        foreach ($propertyPhpDocTagNodes as $propertyPhpDocTagNode) {
+            // remove from docblock
+            $this->phpDocTagRemover->removeTagValueFromNode($classPhpDocInfo, $propertyPhpDocTagNode);
         }
+
+        // merge new properties to start of the file
+        $node->stmts = array_merge($newProperties, $node->stmts);
+
+        // update doc info
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
         return $node;
     }


### PR DESCRIPTION
When no `@property` doc, it should be skipped, since current behaviour is only remove `[\AllowDynamicProperties]` but no add property, cause error:

```
PHP Deprecated:  Creation of dynamic property A::$x is deprecated in php shell code on line 1
```

because attribute removed, but property not added, see https://3v4l.org/aVOsR



