### PR TITLE
[CodeQuality] Handle with other attributes on DynamicDocBlockPropertyToNativePropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/with_other_existing_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/with_other_existing_attribute.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency;
+
+/**
+ * @property SomeDependency $someDependency
+ */
+#[\AllowDynamicProperties]
+#[\OtherAttribute]
+final class WithOtherExistingAttribute
+{
+    public function run(): void
+    {
+        $this->someDependency = new SomeDependency();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency;
+
+#[\OtherAttribute]
+final class WithOtherExistingAttribute
+{
+    private ?\Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency $someDependency;
+    public function run(): void
+    {
+        $this->someDependency = new SomeDependency();
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
@@ -113,8 +113,16 @@ CODE_SAMPLE
         }
 
         // 1. remove dynamic attribute, most likely any
-        $node->attrGroups = [];
+        foreach ($node->attrGroups as $key => $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($attr->name->toString() === 'AllowDynamicProperties') {
+                    unset($node->attrGroups[$key]);
+                    continue 2;
+                }
+            }
+        }
 
+        $node->attrGroups = array_values($node->attrGroups);
         $newProperties = $this->createNewPropertyFromPropertyTagValueNodes($propertyPhpDocTagNodes, $node);
 
         // remove property tags


### PR DESCRIPTION
other existing attribute should be kept as is:

```diff
-#[\AllowDynamicProperties]
#[\OtherAttribute]
```

only remove the `AllowDynamicProperties` one.