### PR TITLE
[CodeQuality] Use existing PhpAttributeAnalyzer service instead of AttributeFinder from Doctrine package on DynamicDocBlockPropertyToNativePropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_allow_dynamic_properties_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_allow_dynamic_properties_attribute.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency;
+
+final class SkipNoAllowDynamicPropertiesAttribute
+{
+    public function run(): void
+    {
+        $this->someDependency = new SomeDependency();
+    }
+
+    public function __get($name)
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_allow_dynamic_properties_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_allow_dynamic_properties_attribute.php.inc
@@ -4,6 +4,9 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNative
 
 use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency;
 
+/**
+ * @property SomeDependency $someDependency
+ */
 final class SkipNoAllowDynamicPropertiesAttribute
 {
     public function run(): void

--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_allow_dynamic_properties_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/skip_no_allow_dynamic_properties_attribute.php.inc
@@ -13,8 +13,4 @@ final class SkipNoAllowDynamicPropertiesAttribute
     {
         $this->someDependency = new SomeDependency();
     }
-
-    public function __get($name)
-    {
-    }
 }

--- a/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -17,7 +16,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\CodeQuality\NodeFactory\TypedPropertyFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
-use Rector\Doctrine\NodeAnalyzer\AttributeFinder;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -33,7 +32,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DynamicDocBlockPropertyToNativePropertyRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly AttributeFinder $attributeFinder,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
@@ -89,11 +88,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $allowDynamicPropertiesAttribute = $this->attributeFinder->findAttributeByClass(
-            $node,
-            'AllowDynamicProperties'
-        );
-        if (! $allowDynamicPropertiesAttribute instanceof Attribute) {
+        if (! $this->phpAttributeAnalyzer->hasPhpAttribute($node, 'AllowDynamicProperties')) {
             return null;
         }
 


### PR DESCRIPTION
we already have `PhpAttributeAnalyzer` service on rector-src code base itself, no need to use from rector-doctrine.