### PR TITLE
[DeadCode] Skip non FullyQualified property type on RemoveTypedPropertyNonMockDocblockRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector/Fixture/skip_array_doc.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector/Fixture/skip_array_doc.php.inc
@@ -7,26 +7,23 @@ use PHPUnit\Framework\TestCase;
 final class SkipArrayDoc extends TestCase
 {
     /**
-     * @var array<string, array<string, list<mixed>>>|array<string, array<string, string>>|array<string, list<mixed>>|array<string, mixed>|array<string, string>|mixed
+     * @var string[]|mixed
      */
-    private array $structure;
+    private mixed $structure;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->structure = [
-            'foo' => [
-                'bar' => 'Once upon a midnight dreary',
-                'baz' => 'While I pondered weak and weary',
-            ],
-            'boo' => [
-                'far' => 'Upon a tome of long-forgotten lore',
-                'faz' => 'There came a tapping up on the door',
-            ],
-            'AnEmptyFolder' => [],
-            'simpleFile'    => 'A tap-tap-tapping upon my door',
-            '.hidden'       => 'There is no spoon',
-        ];
+        if (rand(0, 1)) {
+            $this->structure = ['test'];
+        } else {
+            $this->structure = $this->some_mixed_function();
+        }
     }
+
+	private function some_mixed_function(): mixed
+	{
+		return null;
+	}
 }

--- a/rules-tests/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector/Fixture/skip_array_doc.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector/Fixture/skip_array_doc.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassLike\RemoveTypedPropertyNonMockDocblockRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipArrayDoc extends TestCase
+{
+    /**
+     * @var array<string, array<string, list<mixed>>>|array<string, array<string, string>>|array<string, list<mixed>>|array<string, mixed>|array<string, string>|mixed
+     */
+    private array $structure;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->structure = [
+            'foo' => [
+                'bar' => 'Once upon a midnight dreary',
+                'baz' => 'While I pondered weak and weary',
+            ],
+            'boo' => [
+                'far' => 'Upon a tome of long-forgotten lore',
+                'faz' => 'There came a tapping up on the door',
+            ],
+            'AnEmptyFolder' => [],
+            'simpleFile'    => 'A tap-tap-tapping upon my door',
+            '.hidden'       => 'There is no spoon',
+        ];
+    }
+}

--- a/rules/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector.php
+++ b/rules/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector.php
@@ -142,6 +142,10 @@ CODE_SAMPLE
             return false;
         }
 
+        if ($varTagType->isArray()->maybe()) {
+            return false;
+        }
+
         foreach ($varTagType->getTypes() as $unionedType) {
             if ($unionedType->isSuperTypeOf(new ObjectType(self::MOCK_OBJECT_CLASS))->yes()) {
                 return true;

--- a/rules/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector.php
+++ b/rules/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\ClassLike;
 
 use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
@@ -98,6 +99,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if (! $property->type instanceof FullyQualified) {
+                continue;
+            }
+
             if ($this->isObjectType($property->type, new ObjectType(self::MOCK_OBJECT_CLASS))) {
                 continue;
             }
@@ -139,10 +144,6 @@ CODE_SAMPLE
 
         $varTagType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($varTagValueNode->type, $property);
         if (! $varTagType instanceof UnionType) {
-            return false;
-        }
-
-        if ($varTagType->isArray()->maybe()) {
             return false;
         }
 


### PR DESCRIPTION
see valid usage doc that need to be kept https://phpstan.org/r/6be6bdda-2523-4c39-8dab-f27bfda59ab5