### PR TITLE
Fix duplicated register ContinueToBreakInSwitchRector in php52.php and php73.php

### DIFF
--- a/config/set/php73.php
+++ b/config/set/php73.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php52\Rector\Switch_\ContinueToBreakInSwitchRector;
 use Rector\Php73\Rector\BooleanOr\IsCountableRector;
 use Rector\Php73\Rector\ConstFetch\SensitiveConstantNameRector;
 use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
@@ -37,7 +36,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         StringifyStrNeedlesRector::class,
         RegexDashEscapeRector::class,
-        ContinueToBreakInSwitchRector::class,
         SetCookieRector::class,
         IsCountableRector::class,
 

--- a/tests/Bridge/SetRectorsResolverTest.php
+++ b/tests/Bridge/SetRectorsResolverTest.php
@@ -53,10 +53,10 @@ final class SetRectorsResolverTest extends TestCase
         $rectorRulesWithConfiguration = $this->setRectorsResolver->resolveFromFilePathIncludingConfiguration(
             SetList::PHP_73
         );
-        $this->assertCount(10, $rectorRulesWithConfiguration);
+        $this->assertCount(9, $rectorRulesWithConfiguration);
 
         $this->assertArrayHasKey(0, $rectorRulesWithConfiguration);
-        $this->assertArrayHasKey(9, $rectorRulesWithConfiguration);
+        $this->assertArrayHasKey(8, $rectorRulesWithConfiguration);
 
         foreach ($rectorRulesWithConfiguration as $rectorRuleWithConfiguration) {
             if (is_string($rectorRuleWithConfiguration)) {

--- a/tests/Bridge/SetRectorsResolverTest.php
+++ b/tests/Bridge/SetRectorsResolverTest.php
@@ -45,7 +45,7 @@ final class SetRectorsResolverTest extends TestCase
         $rectorRulesWithConfiguration = $this->setRectorsResolver->resolveFromFilePathsIncludingConfiguration(
             $configFilePaths
         );
-        $this->assertCount(63, $rectorRulesWithConfiguration);
+        $this->assertCount(62, $rectorRulesWithConfiguration);
     }
 
     public function testResolveWithConfiguration(): void


### PR DESCRIPTION
it exists in php52.php and php73.php

https://github.com/rectorphp/rector-src/blob/7be438b5fc0f91a9dc9b70a0b6a38a6bf1e906b2/config/set/php52.php#L12

https://github.com/rectorphp/rector-src/blob/7be438b5fc0f91a9dc9b70a0b6a38a6bf1e906b2/config/set/php73.php#L40

detected when create experiment PR:

- https://github.com/rectorphp/rector-src/pull/6384

On PHP_INT_MAX level, it show error:

```
cd e2e/with-php-level && composer install
with-php-level git:(experiment-use-composer-json-priority-fallback) ✗ php ../e2eTestRunner.php
    ---------- begin diff ----------
@@ @@
-[ERROR] Following rules are registered twice: Rector\Php52\Rector\Switch_\ContinueToBreakInSwitchRector
```

when using 

```php
->withPhpLevel(PHP_INT_MAX)
```