### PR TITLE
Fix VersionResolverTest when latest commit just tagged

### DIFF
--- a/tests/Application/VersionResolverTest.php
+++ b/tests/Application/VersionResolverTest.php
@@ -13,6 +13,12 @@ final class VersionResolverTest extends TestCase
     {
         $packageVersion = VersionResolver::resolvePackageVersion();
 
+        // latest commit is tagged
+        if (str_contains($packageVersion, '.')) {
+            $this->assertSame(2, substr_count($packageVersion, '.'));
+            return;
+        }
+
         // should be a commit hash size, as we're in untagged test
         $stringLength = strlen($packageVersion);
         $this->assertSame(40, $stringLength);


### PR DESCRIPTION
When latest commit just tagged, latest main branch got error:

```
There was 1 failure:

1) Rector\Tests\Application\VersionResolverTest::test
Failed asserting that 5 is identical to 40.
```

this patch fix it.