### PR TITLE
[TypeDeclaration] Skip union intersection types on php 8.1, allow on php 8.2+

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixturePhp81/skip_union_intersection.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixturePhp81/skip_union_intersection.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\FixturePhp81;
+
+final class SkipUnionIntersection
+{
+    public function run(\Iterator&\Countable $obj)
+    {
+        if (rand(0, 1)) {
+            return $obj;
+        }
+
+        return '10';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureUnionIntersection/union_intersection.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureUnionIntersection/union_intersection.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\FixtureUnionIntersection;
+
+/**
+ * union intersection works on php 8.2+
+ */
+final class UnionIntersection
+{
+    public function run(\Iterator&\Countable $obj)
+    {
+        if (rand(0, 1)) {
+            return $obj;
+        }
+
+        return '10';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\FixtureUnionIntersection;
+
+/**
+ * union intersection works on php 8.2+
+ */
+final class UnionIntersection
+{
+    public function run(\Iterator&\Countable $obj): (\Iterator&\Countable)|string
+    {
+        if (rand(0, 1)) {
+            return $obj;
+        }
+
+        return '10';
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/UnionIntersectionTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/UnionIntersectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class UnionIntersectionTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureUnionIntersection');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_union_intersection.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule_union_intersection.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/config/configured_rule_union_intersection.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReturnUnionTypeRector::class);
+    $rectorConfig->phpVersion(PhpVersionFeature::UNION_INTERSECTION_TYPES);
+};

--- a/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeRector/config/configured_rule.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
+use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ClosureReturnTypeRector::class);
+    $rectorConfig->phpVersion(PhpVersion::PHP_82);
 };

--- a/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -95,10 +95,6 @@ final readonly class IntersectionTypeMapper implements TypeMapperInterface
             return null;
         }
 
-        if ($typeKind === TypeKind::UNION && ! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_INTERSECTION_TYPES)) {
-            return null;
-        }
-
         $intersectionedTypeNodes = [];
         foreach ($type->getTypes() as $type) {
             if ($type instanceof ObjectWithoutClassType) {
@@ -124,6 +120,10 @@ final readonly class IntersectionTypeMapper implements TypeMapperInterface
 
         if (count($intersectionedTypeNodes) === 1) {
             return current($intersectionedTypeNodes);
+        }
+
+        if ($typeKind === TypeKind::UNION && ! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_INTERSECTION_TYPES)) {
+            return null;
         }
 
         return new Node\IntersectionType($intersectionedTypeNodes);

--- a/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -19,6 +19,7 @@ use PHPStan\Type\Type;
 use Rector\Php\PhpVersionProvider;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\StaticTypeMapper\Mapper\ScalarStringToTypeMapper;
 use Rector\ValueObject\PhpVersionFeature;
 
@@ -91,6 +92,10 @@ final readonly class IntersectionTypeMapper implements TypeMapperInterface
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
     {
         if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::INTERSECTION_TYPES)) {
+            return null;
+        }
+
+        if ($typeKind === TypeKind::UNION && ! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_INTERSECTION_TYPES)) {
             return null;
         }
 

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -594,6 +594,12 @@ final class PhpVersionFeature
     public const INTERSECTION_TYPES = PhpVersion::PHP_81;
 
     /**
+     * @see https://php.watch/versions/8.2/dnf-types
+     * @var int
+     */
+    public const UNION_INTERSECTION_TYPES = PhpVersion::PHP_82;
+
+    /**
      * @see https://wiki.php.net/rfc/array_unpacking_string_keys
      * @var int
      */


### PR DESCRIPTION
On php 8.1, union intersection is not allowed, only php 8.2+ that allowed, see https://3v4l.org/fiMkq