### PR TITLE
[Php80] Skip @template T as mixed on MixedTypeRector

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_from_template.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_from_template.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\Php80\Rector\FunctionLike\MixedTypeRector\Fixture;
 /**
  * @template T as mixed
  */
-class NoMixedParamDoc
+class SkipFromTemplate
 {
     /**
      * @param T $param

--- a/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_from_template.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/MixedTypeRector/Fixture/skip_from_template.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FunctionLike\MixedTypeRector\Fixture;
+
+/**
+ * @template T as mixed
+ */
+class NoMixedParamDoc
+{
+    /**
+     * @param T $param
+     */
+    public function run($param)
+    {
+    }
+}

--- a/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
+++ b/rules/Php80/Rector/FunctionLike/MixedTypeRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\MixedType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -140,6 +141,10 @@ CODE_SAMPLE
             $paramType = $phpDocInfo->getParamType($paramName);
 
             if (! $paramType instanceof MixedType) {
+                continue;
+            }
+
+            if ($paramType instanceof TemplateType) {
                 continue;
             }
 

--- a/src/PhpAttribute/Contract/AnnotationToAttributeMapperInterface.php
+++ b/src/PhpAttribute/Contract/AnnotationToAttributeMapperInterface.php
@@ -16,5 +16,5 @@ interface AnnotationToAttributeMapperInterface
     /**
      * @param T $value
      */
-    public function map(mixed $value): Expr;
+    public function map($value): Expr;
 }


### PR DESCRIPTION
The skip remove `@template` PR:

- https://github.com/rectorphp/rector-src/pull/6396

cause rectify https://github.com/rectorphp/rector-src/pull/6396/commits/d61c756120d9766ca2a4b81a9970a099cb973a3c

while working, can be on purpose, this patch ensure it doesn't change on TemplateType