### PR TITLE
[CodeQuality] Skip multiple lines on JoinStringConcatRector 

### DIFF
--- a/rules-tests/CodeQuality/Rector/Concat/JoinStringConcatRector/Fixture/skip_multiple_lines.php.inc
+++ b/rules-tests/CodeQuality/Rector/Concat/JoinStringConcatRector/Fixture/skip_multiple_lines.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Concat\JoinStringConcatRector\Fixture;
+
+class SkipMultiplelines
+{
+    public function run()
+    {
+        return 'a' .
+            'b' .
+            'c' .
+            'd';
+    }
+}

--- a/rules/CodeQuality/Rector/Concat/JoinStringConcatRector.php
+++ b/rules/CodeQuality/Rector/Concat/JoinStringConcatRector.php
@@ -81,6 +81,13 @@ CODE_SAMPLE
             return null;
         }
 
+        $leftStartLine = $node->left->getStartLine();
+        $rightStartLine = $node->right->getStartLine();
+
+        if ($leftStartLine > 0 && $rightStartLine > 0 && $rightStartLine > $leftStartLine) {
+            return null;
+        }
+
         return $this->joinConcatIfStrings($node->left, $node->right);
     }
 


### PR DESCRIPTION
I think on multi lines, this rule should be skipped, as it will stop on specific length, which make it half joined on length > 100

https://github.com/rectorphp/rector-src/blob/61ebcc53b5c50f244ce0f7dfb626ded8d371c0a5/rules/CodeQuality/Rector/Concat/JoinStringConcatRector.php#L24

see https://getrector.com/demo/cffc989d-690f-42d6-a938-fda840e2b5f7