### PR TITLE
[Privatization] Skip with parameter on PrivatizeLocalGetterToPropertyRector

### DIFF
--- a/rules-tests/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector/Fixture/skip_with_parameter.php.inc
+++ b/rules-tests/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector/Fixture/skip_with_parameter.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector\Fixture;
+
+class SkipWithParameter
+{
+    public $a = 'value';
+
+    public function run()
+    {
+        $var = 'a';
+        return $this->getSome($var);
+    }
+
+    private function getSome(string $parameter)
+    {
+        return (new SkipWithParameter())->$parameter;
+    }
+}

--- a/rules/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector.php
+++ b/rules/Privatization/Rector/MethodCall/PrivatizeLocalGetterToPropertyRector.php
@@ -134,6 +134,10 @@ CODE_SAMPLE
 
     private function matchLocalPropertyFetchInGetterMethod(ClassMethod $classMethod): ?PropertyFetch
     {
+        if ($classMethod->params !== []) {
+            return null;
+        }
+
         $stmts = (array) $classMethod->stmts;
         if (count($stmts) !== 1) {
             return null;


### PR DESCRIPTION
Ref https://3v4l.org/sPe0c (work)
Ref https://3v4l.org/Pu2Eb  (error)
Ref https://getrector.com/demo/032bff1f-4445-4b88-a090-7d1ed7d29864

that cause error:

```
Warning: Undefined variable $parameter in /in/Pu2Eb on line 10

Warning: Undefined property: SkipWithParameter::$ in /in/Pu2Eb on line 10
```