### PR TITLE
[Php80] Returns null on no change on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -159,6 +159,7 @@ CODE_SAMPLE
             return null;
         }
 
+        $hasChanged = false;
         foreach ($promotionCandidates as $promotionCandidate) {
             $param = $promotionCandidate->getParam();
 
@@ -185,6 +186,8 @@ CODE_SAMPLE
             if (! $this->renameProperty && $paramName !== $propertyName) {
                 continue;
             }
+
+            $hasChanged = true;
 
             // remove property from class
             $propertyStmtKey = $property->getAttribute(AttributeKey::STMT_KEY);
@@ -247,6 +250,10 @@ CODE_SAMPLE
 
                 return new PropertyFetch(new Variable('this'), $propertyName);
             });
+        }
+
+        if (! $hasChanged) {
+            return null;
         }
 
         return $node;


### PR DESCRIPTION
Add `$hasChanged` flag on loop to verify it to avoid show applied rules on multi rules apply:

```diff
➜  CodeIgniter4 git:(develop) ✗ vendor/bin/rector 
 956/956 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) system/Database/Forge.php:572

    ---------- begin diff ----------
@@ @@
             }

             // Most databases don't support creating indexes from within the CREATE TABLE statement
-            if (! empty($this->keys)) {
+            if ($this->keys !== []) {
                 for ($i = 0, $sqls = $this->_processIndexes($table), $c = count($sqls); $i < $c; $i++) {
                     $this->db->query($sqls[$i]);
                 }
    ----------- end diff -----------

Applied rules:
 * SimplifyEmptyCheckOnEmptyArrayRector
 * ClassPropertyAssignToConstructorPromotionRector
```