### PR TITLE
[StaticTypeMapper] Add ClassNameFromObjectTypeResolver to cover TypeWithClassName instance checks (take 3)

### DIFF
--- a/src/StaticTypeMapper/Resolver/ClassNameFromObjectTypeResolver.php
+++ b/src/StaticTypeMapper/Resolver/ClassNameFromObjectTypeResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\StaticTypeMapper\Resolver;
+
+use PHPStan\Type\Type;
+
+final class ClassNameFromObjectTypeResolver
+{
+    public static function resolve(Type $type): ?string
+    {
+        $objectClassNames = $type->getObjectClassNames();
+
+        if (count($objectClassNames) !== 1) {
+            return null;
+        }
+
+        return $objectClassNames[0];
+    }
+}

--- a/src/StaticTypeMapper/ValueObject/Type/AliasedObjectType.php
+++ b/src/StaticTypeMapper/ValueObject/Type/AliasedObjectType.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeWithClassName;
+use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 
 /**
  * @api
@@ -55,13 +55,15 @@ final class AliasedObjectType extends ObjectType
 
     public function equals(Type $type): bool
     {
+        $className = ClassNameFromObjectTypeResolver::resolve($type);
+
         // compare with FQN classes
-        if ($type instanceof TypeWithClassName) {
+        if ($className !== null) {
             if ($type instanceof self && $this->fullyQualifiedClass === $type->getFullyQualifiedName()) {
                 return true;
             }
 
-            if ($this->fullyQualifiedClass === $type->getClassName()) {
+            if ($this->fullyQualifiedClass === $className) {
                 return true;
             }
         }


### PR DESCRIPTION
Cherry-pick from https://github.com/rectorphp/rector-src/pull/6415

this special service to cover phpstan notice:

```
  src/StaticTypeMapper/ValueObject/Type/AliasedObjectType.php:59
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Doing instanceof PHPStan\\Type\\TypeWithClassName is error\-prone and deprecated\. Use Type\:\:getObjectClassNames\(\) or Type\:\:getObjectClassReflections\(\) instead#'
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
```

if it approved, I can use in other instanceof check. Use special service to ease replace when there is regression and possibly multiple values usage