### PR TITLE
[Naming] Reduce instanceof ObjectType on ExpectedNameResolver (take 5)

### DIFF
--- a/rules/Naming/Naming/ExpectedNameResolver.php
+++ b/rules/Naming/Naming/ExpectedNameResolver.php
@@ -215,13 +215,13 @@ final readonly class ExpectedNameResolver
     /**
      * Skip date time, as custom naming
      */
-    private function isDateTimeType(ObjectType $type): bool
+    private function isDateTimeType(ObjectType $objectType): bool
     {
-        if ($type->isInstanceOf('DateTimeInterface')->yes()) {
+        if ($objectType->isInstanceOf('DateTimeInterface')->yes()) {
             return true;
         }
 
-        return $type->isInstanceOf('DateTime')
+        return $objectType->isInstanceOf('DateTime')
             ->yes();
     }
 }

--- a/rules/Naming/Naming/ExpectedNameResolver.php
+++ b/rules/Naming/Naming/ExpectedNameResolver.php
@@ -114,7 +114,7 @@ final readonly class ExpectedNameResolver
         }
 
         $returnedType = $this->nodeTypeResolver->getType($expr);
-        if (! $returnedType->isObject()->yes()) {
+        if (! $returnedType instanceof ObjectType) {
             return null;
         }
 
@@ -215,12 +215,8 @@ final readonly class ExpectedNameResolver
     /**
      * Skip date time, as custom naming
      */
-    private function isDateTimeType(Type $type): bool
+    private function isDateTimeType(ObjectType $type): bool
     {
-        if (! $type instanceof ObjectType) {
-            return false;
-        }
-
         if ($type->isInstanceOf('DateTimeInterface')->yes()) {
             return true;
         }


### PR DESCRIPTION
`isObjectType()->yes()` not always working, see https://github.com/rectorphp/rector-src/pull/6422#issuecomment-2470608290 for reasoning, that cause error:

```
2) Rector\Tests\DeadCode\Rector\If_\RemoveDeadInstanceOfRector\RemoveDeadInstanceOfRectorTest::test with data set #21 ('/home/runner/work/rector-src/...hp.inc')
Error: Call to undefined method PHPStan\Type\UnionType::isInstanceOf()
```

see https://github.com/rectorphp/rector-src/actions/runs/11798721617/job/32865546672?pr=6422#step:5:110

use `instanceof ObjectType` but reduce its usage.

Ref https://github.com/rectorphp/rector/issues/8815#issuecomment-2467753857