### PR TITLE
[Printer] Remove ltrim() on BetterStandardPrinter

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -125,9 +125,7 @@ final class BetterStandardPrinter extends Standard
      */
     public function pFileWithoutNamespace(FileWithoutNamespace $fileWithoutNamespace): string
     {
-        $content = $this->pStmts($fileWithoutNamespace->stmts, false);
-
-        return ltrim($content);
+        return $this->pStmts($fileWithoutNamespace->stmts, false);
     }
 
     protected function p(Node $node, $parentFormatPreserved = false): string


### PR DESCRIPTION
# first step to migrate to php-parser 5:

on php-parser 4, ltrim is added on print format preserving:

- https://github.com/nikic/PHP-Parser/blob/715f4d25e225bc47b293a8b997fe6ce99bf987d2/lib/PhpParser/PrettyPrinterAbstract.php#L503

on php-parser 5, ltrim is removed on print format preserving:

- https://github.com/nikic/PHP-Parser/blob/8eea230464783aa9671db8eea6f8c6ac5285794b/lib/PhpParser/PrettyPrinterAbstract.php#L581

as space before `<?php` is allowed on no-namespaced code.

so just use parent stmt method.

Next is to remove `ltrim()` on FileProcessor:

https://github.com/rectorphp/rector-src/blob/2c5cd97a3a98ab5af9efb846f6f78738e4a195a6/src/Application/FileProcessor.php#L160

when upgraded to php-parser 5.


part of https://github.com/rectorphp/rector/issues/8815 process.