### PR TITLE
Create doctrine_annotation_with_extra_parenthesis.php.inc

### DIFF
--- a/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/doctrine_annotation_with_extra_parenthesis.php.inc
+++ b/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/doctrine_annotation_with_extra_parenthesis.php.inc
@@ -21,9 +21,9 @@ class ChangeLog
 <?php
 
 namespace Rector\Tests\Php80\Rector\Property\NestedAnnotationToAttributeRector\Fixture;
- 
+
 use Doctrine\ORM\Mapping as ORM;
- 
+
 #[ORM\Table(name: 'changelog')]
 #[ORM\Index(name: 'entity', columns: ['entity_class', 'entity_id'])]
 #[ORM\Entity(repositoryClass: ChangeLogRepository::class)]

--- a/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/doctrine_annotation_with_extra_parenthesis.php.inc
+++ b/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/doctrine_annotation_with_extra_parenthesis.php.inc
@@ -13,7 +13,6 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity(repositoryClass="ChangeLogRepository")
  * @ORM\HasLifecycleCallbacks
  */
-
 class ChangeLog
 {
 }

--- a/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/doctrine_annotation_with_extra_parenthesis.php.inc
+++ b/rules-tests/Php80/Rector/Property/NestedAnnotationToAttributeRector/Fixture/doctrine_annotation_with_extra_parenthesis.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Property\NestedAnnotationToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="changelog",
+ *   indexes={
+ *     @ORM\Index(name="entity", columns={"entity_class", "entity_id"}),
+ *   }
+ * ))
+ * @ORM\Entity(repositoryClass="ChangeLogRepository")
+ * @ORM\HasLifecycleCallbacks
+ */
+
+class ChangeLog
+{
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Property\NestedAnnotationToAttributeRector\Fixture;
+ 
+use Doctrine\ORM\Mapping as ORM;
+ 
+#[ORM\Table(name: 'changelog')]
+#[ORM\Index(name: 'entity', columns: ['entity_class', 'entity_id'])]
+#[ORM\Entity(repositoryClass: ChangeLogRepository::class)]
+#[ORM\HasLifecycleCallbacks]
+class ChangeLog
+{
+}
+?>


### PR DESCRIPTION
Test case for https://github.com/rectorphp/rector/issues/8897.

Note that there are currently two issues:
1. Due to the extra parenthesis, two annotations are silently dropped.
2. (Without the extra parenthesis) The repository class should be resolved relative to the namespace, i.e. not prefixed with `\`.