### PR TITLE
[dx] Allow external rules without getRuleDefinition() to make them easier to write

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -71,6 +71,17 @@ return [
             // comment out
             str_replace('\\' . $prefix . '\trigger_deprecation(', '// \trigger_deprecation(', $content),
 
+        // make external rules easier to write without enforing getRuleDefinition()
+        // as they are not designed for open-sourcing
+        static function (string $filePath, string $prefix, string $content): string {
+            if (!\str_ends_with($filePath, 'vendor/symplify/rule-doc-generator-contracts/src/Contract/DocumentedRuleInterface.php')) {
+                return $content;
+            }
+
+            // comment out
+            return str_replace('public function getRuleDefinition', '// public function getRuleDefinition', $content);
+        },
+
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'src/Application/VersionResolver.php')) {
                 return $content;

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -14,7 +14,6 @@ use PHPStan\Parser\Parser;
 use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\Reflection\BetterReflection\SourceLocator\CachingVisitor;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Application\ChangedNodeScopeRefresher;
 use Rector\Application\FileProcessor;
@@ -318,7 +317,6 @@ final class LazyContainerFactory
         TypeNodeResolver::class,
         NodeScopeResolver::class,
         ReflectionProvider::class,
-        CachingVisitor::class,
     ];
 
     /**


### PR DESCRIPTION
We use `getRuleDefinition()` internally to allow easy search in 400+ rules - https://getrector.com/find-rule 

But for the community/private projects, it's been only burden that is filled with lorem ipsun. 
This patch requires docs for us and our packages, but drops the requirements for community to make writing custom rules easier :+1: 