### PR TITLE
[fix] class phpdoc generic method

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -74,7 +74,10 @@ return [
         // make external rules easier to write without enforing getRuleDefinition()
         // as they are not designed for open-sourcing
         static function (string $filePath, string $prefix, string $content): string {
-            if (!\str_ends_with($filePath, 'vendor/symplify/rule-doc-generator-contracts/src/Contract/DocumentedRuleInterface.php')) {
+            if (! \str_ends_with(
+                $filePath,
+                'vendor/symplify/rule-doc-generator-contracts/src/Contract/DocumentedRuleInterface.php'
+            )) {
                 return $content;
             }
 

--- a/src/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
+++ b/src/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
@@ -96,7 +96,7 @@ final class BetterTokenIterator extends TokenIterator
      */
     public function partialTokens(int $start, int $end): array
     {
-        return array_slice($this->getTokens(), $start, $end);
+        return array_slice($this->getTokens(), $start, $end - $start + 1);
     }
 
     public function containsTokenType(int $type): bool

--- a/tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/FixtureBasic/generic_method.txt
+++ b/tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/FixtureBasic/generic_method.txt
@@ -1,0 +1,1 @@
+/** @method T foo<T of int>(T $bar) */


### PR DESCRIPTION
Currently generic methods in class phpdoc produces error https://getrector.com/demo/ad70e517-410f-44b4-bd09-e935825e6ff9.
This PR fixes this issue.