### PR TITLE
Add "--only" option to process only a single rule

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,6 +35,11 @@ jobs:
                     - 'e2e/invalid-paths'
                     - 'e2e/applied-polyfill-php80'
                     - 'e2e/print-new-node'
+                    - 'e2e/only-option'
+                    - 'e2e/only-option-quote-double-equalnone'
+                    - 'e2e/only-option-quote-single'
+                    - 'e2e/only-option-quote-single-bsdouble'
+                    - 'e2e/only-option-quote-single-equalnone'
 
         name: End to end test - ${{ matrix.directory }}
 

--- a/e2e/e2eTestRunner.php
+++ b/e2e/e2eTestRunner.php
@@ -31,6 +31,12 @@ if (isset($argv[1]) && $argv[1] === '-a') {
     $e2eCommand .= ' -a ' . $argv[2];
 }
 
+$cliOptions = 'cli-options.txt';
+if (file_exists($cliOptions)) {
+    $e2eCommand .= ' ' . trim(file_get_contents($cliOptions));
+}
+
+
 exec($e2eCommand, $output, $exitCode);
 $output = trim(implode("\n", $output));
 $output = str_replace(__DIR__, '.', $output);

--- a/e2e/only-option-quote-double-equalnone/cli-options.txt
+++ b/e2e/only-option-quote-double-equalnone/cli-options.txt
@@ -1,0 +1,1 @@
+--only "Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector"

--- a/e2e/only-option-quote-double-equalnone/composer.json
+++ b/e2e/only-option-quote-double-equalnone/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "php": "^8.1"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/e2e/only-option-quote-double-equalnone/expected-output.diff
+++ b/e2e/only-option-quote-double-equalnone/expected-output.diff
@@ -1,0 +1,22 @@
+1 file with changes
+===================
+
+1) ../only-option/src/MultiRules.php:9
+
+    ---------- begin diff ----------
+@@ @@
+             echo 'a statement';
+         }
+     }
+-
+-    private function notUsed()
+-    {
+-    }
+ }
+    ----------- end diff -----------
+
+Applied rules:
+ * RemoveUnusedPrivateMethodRector
+
+
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/only-option-quote-double-equalnone/rector.php
+++ b/e2e/only-option-quote-double-equalnone/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/../only-option/src',
+    ]);
+
+    $rectorConfig->rules([
+        RemoveAlwaysElseRector::class,
+        RemoveUnusedPrivateMethodRector::class,
+    ]);
+};

--- a/e2e/only-option-quote-single-bsdouble/cli-options.txt
+++ b/e2e/only-option-quote-single-bsdouble/cli-options.txt
@@ -1,0 +1,1 @@
+--only='Rector\\DeadCode\\Rector\\ClassMethod\\RemoveUnusedPrivateMethodRector'

--- a/e2e/only-option-quote-single-bsdouble/composer.json
+++ b/e2e/only-option-quote-single-bsdouble/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "php": "^8.1"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/e2e/only-option-quote-single-bsdouble/expected-output.diff
+++ b/e2e/only-option-quote-single-bsdouble/expected-output.diff
@@ -1,0 +1,22 @@
+1 file with changes
+===================
+
+1) ../only-option/src/MultiRules.php:9
+
+    ---------- begin diff ----------
+@@ @@
+             echo 'a statement';
+         }
+     }
+-
+-    private function notUsed()
+-    {
+-    }
+ }
+    ----------- end diff -----------
+
+Applied rules:
+ * RemoveUnusedPrivateMethodRector
+
+
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/only-option-quote-single-bsdouble/rector.php
+++ b/e2e/only-option-quote-single-bsdouble/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/../only-option/src',
+    ]);
+
+    $rectorConfig->rules([
+        RemoveAlwaysElseRector::class,
+        RemoveUnusedPrivateMethodRector::class,
+    ]);
+};

--- a/e2e/only-option-quote-single-equalnone/cli-options.txt
+++ b/e2e/only-option-quote-single-equalnone/cli-options.txt
@@ -1,0 +1,1 @@
+--only 'Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector'

--- a/e2e/only-option-quote-single-equalnone/composer.json
+++ b/e2e/only-option-quote-single-equalnone/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "php": "^8.1"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/e2e/only-option-quote-single-equalnone/expected-output.diff
+++ b/e2e/only-option-quote-single-equalnone/expected-output.diff
@@ -1,0 +1,22 @@
+1 file with changes
+===================
+
+1) ../only-option/src/MultiRules.php:9
+
+    ---------- begin diff ----------
+@@ @@
+             echo 'a statement';
+         }
+     }
+-
+-    private function notUsed()
+-    {
+-    }
+ }
+    ----------- end diff -----------
+
+Applied rules:
+ * RemoveUnusedPrivateMethodRector
+
+
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/only-option-quote-single-equalnone/rector.php
+++ b/e2e/only-option-quote-single-equalnone/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/../only-option/src',
+    ]);
+
+    $rectorConfig->rules([
+        RemoveAlwaysElseRector::class,
+        RemoveUnusedPrivateMethodRector::class,
+    ]);
+};

--- a/e2e/only-option-quote-single/cli-options.txt
+++ b/e2e/only-option-quote-single/cli-options.txt
@@ -1,0 +1,1 @@
+--only='Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector'

--- a/e2e/only-option-quote-single/composer.json
+++ b/e2e/only-option-quote-single/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "php": "^8.1"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/e2e/only-option-quote-single/expected-output.diff
+++ b/e2e/only-option-quote-single/expected-output.diff
@@ -1,0 +1,22 @@
+1 file with changes
+===================
+
+1) ../only-option/src/MultiRules.php:9
+
+    ---------- begin diff ----------
+@@ @@
+             echo 'a statement';
+         }
+     }
+-
+-    private function notUsed()
+-    {
+-    }
+ }
+    ----------- end diff -----------
+
+Applied rules:
+ * RemoveUnusedPrivateMethodRector
+
+
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/only-option-quote-single/rector.php
+++ b/e2e/only-option-quote-single/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/../only-option/src',
+    ]);
+
+    $rectorConfig->rules([
+        RemoveAlwaysElseRector::class,
+        RemoveUnusedPrivateMethodRector::class,
+    ]);
+};

--- a/e2e/only-option/cli-options.txt
+++ b/e2e/only-option/cli-options.txt
@@ -1,0 +1,1 @@
+--only="Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector"

--- a/e2e/only-option/composer.json
+++ b/e2e/only-option/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "php": "^8.1"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/e2e/only-option/expected-output.diff
+++ b/e2e/only-option/expected-output.diff
@@ -1,0 +1,22 @@
+1 file with changes
+===================
+
+1) src/MultiRules.php:9
+
+    ---------- begin diff ----------
+@@ @@
+             echo 'a statement';
+         }
+     }
+-
+-    private function notUsed()
+-    {
+-    }
+ }
+    ----------- end diff -----------
+
+Applied rules:
+ * RemoveUnusedPrivateMethodRector
+
+
+ [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/only-option/rector.php
+++ b/e2e/only-option/rector.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+    ]);
+
+    $rectorConfig->rules([
+        RemoveAlwaysElseRector::class,
+        RemoveUnusedPrivateMethodRector::class,
+    ]);
+};
+

--- a/e2e/only-option/src/MultiRules.php
+++ b/e2e/only-option/src/MultiRules.php
@@ -1,0 +1,17 @@
+<?php
+
+final class MultiRules
+{
+    public function doSomething()
+    {
+        if (true === false) {
+            return -1;
+        } else {
+            echo 'a statement';
+        }
+    }
+
+    private function notUsed()
+    {
+    }
+}

--- a/e2e/only-option/src/RemoveAlwaysElse.php
+++ b/e2e/only-option/src/RemoveAlwaysElse.php
@@ -1,0 +1,13 @@
+<?php
+
+class RemoveAlwaysElse
+{
+    public function run($value)
+    {
+        if ($value) {
+            throw new \InvalidStateException;
+        } else {
+            return 10;
+        }
+    }
+}

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -16,7 +16,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final readonly class ConfigurationFactory
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle
+        private SymfonyStyle $symfonyStyle,
+        private readonly OnlyRuleResolver $onlyRuleResolver,
     ) {
     }
 
@@ -41,7 +42,8 @@ final readonly class ConfigurationFactory
             false,
             null,
             false,
-            false
+            false,
+            null
         );
     }
 
@@ -61,6 +63,11 @@ final readonly class ConfigurationFactory
         $paths = $this->resolvePaths($input);
 
         $fileExtensions = SimpleParameterProvider::provideArrayParameter(Option::FILE_EXTENSIONS);
+
+        $onlyRule = $input->getOption(Option::ONLY);
+        if ($onlyRule !== null) {
+            $onlyRule = $this->onlyRuleResolver->resolve($onlyRule);
+        }
 
         $isParallel = SimpleParameterProvider::provideBoolParameter(Option::PARALLEL);
         $parallelPort = (string) $input->getOption(Option::PARALLEL_PORT);
@@ -90,6 +97,7 @@ final readonly class ConfigurationFactory
             $memoryLimit,
             $isDebug,
             $isReportingWithRealPath,
+            $onlyRule,
         );
     }
 

--- a/src/Configuration/ConfigurationRuleFilter.php
+++ b/src/Configuration/ConfigurationRuleFilter.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Configuration;
+
+use Rector\Contract\Rector\RectorInterface;
+use Rector\ValueObject\Configuration;
+
+/**
+ * Modify available rector rules based on the configuration options
+ */
+final class ConfigurationRuleFilter
+{
+    private ?Configuration $configuration = null;
+
+    public function setConfiguration(Configuration $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @param array<RectorInterface> $rectors
+     * @return array<RectorInterface>
+     */
+    public function filter(array $rectors): array
+    {
+        if ($this->configuration === null) {
+            return $rectors;
+        }
+
+        $onlyRule = $this->configuration->getOnlyRule();
+        if ($onlyRule !== null) {
+            $rectors = $this->filterOnlyRule($rectors, $onlyRule);
+            return $rectors;
+        }
+
+        return $rectors;
+    }
+
+    /**
+     * @param array<RectorInterface> $rectors
+     * @return array<RectorInterface>
+     */
+    public function filterOnlyRule(array $rectors, string $onlyRule): array
+    {
+        $activeRectors = [];
+        foreach ($rectors as $rector) {
+            if (is_a($rector, $onlyRule)) {
+                $activeRectors[] = $rector;
+            }
+        }
+
+        return $activeRectors;
+    }
+}

--- a/src/Configuration/OnlyRuleResolver.php
+++ b/src/Configuration/OnlyRuleResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Configuration;
+
+use Rector\Contract\Rector\RectorInterface;
+use Rector\Exception\Configuration\RectorRuleNotFoundException;
+
+/**
+ * @see \Rector\Tests\Configuration\OnlyRuleResolverTest
+ */
+final class OnlyRuleResolver
+{
+    /**
+     * @param RectorInterface[] $rectors
+     */
+    public function __construct(
+        private readonly array $rectors
+    ) {
+    }
+
+    public function resolve(string $rule): string
+    {
+        //fix wrongly double escaped backslashes
+        $rule = str_replace('\\\\', '\\', $rule);
+
+        //remove single quotes appearing when single-quoting arguments on windows
+        if (str_starts_with($rule, "'") && str_ends_with($rule, "'")) {
+            $rule = substr($rule, 1, -1);
+        }
+
+        $rule = ltrim($rule, '\\');
+
+        foreach ($this->rectors as $rector) {
+            if ($rector::class === $rule) {
+                return $rule;
+            }
+        }
+
+        if (strpos($rule, '\\') === false) {
+            $message = sprintf(
+                'Rule "%s" was not found.%sThe rule has no namespace. Make sure to escape the backslashes, and add quotes around the rule name: --only="My\\Rector\\Rule"',
+                $rule,
+                PHP_EOL
+            );
+        } else {
+            $message = sprintf(
+                'Rule "%s" was not found.%sMake sure it is registered in your config or in one of the sets',
+                $rule,
+                PHP_EOL
+            );
+        }
+        throw new RectorRuleNotFoundException($message);
+    }
+}

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -99,6 +99,11 @@ final class Option
     public const CLEAR_CACHE = 'clear-cache';
 
     /**
+     * @var string
+     */
+    public const ONLY = 'only';
+
+    /**
      * @internal Use @see \Rector\Config\RectorConfig::parallel() instead
      * @var string
      */

--- a/src/Console/Command/ListRulesCommand.php
+++ b/src/Console/Command/ListRulesCommand.php
@@ -6,6 +6,8 @@ namespace Rector\Console\Command;
 
 use Nette\Utils\Json;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
+use Rector\Configuration\ConfigurationRuleFilter;
+use Rector\Configuration\OnlyRuleResolver;
 use Rector\Configuration\Option;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
@@ -24,6 +26,8 @@ final class ListRulesCommand extends Command
     public function __construct(
         private readonly SymfonyStyle $symfonyStyle,
         private readonly SkippedClassResolver $skippedClassResolver,
+        private readonly OnlyRuleResolver $onlyRuleResolver,
+        private readonly ConfigurationRuleFilter $configurationRuleFilter,
         private readonly array $rectors
     ) {
         parent::__construct();
@@ -43,11 +47,17 @@ final class ListRulesCommand extends Command
             'Select output format',
             ConsoleOutputFormatter::NAME
         );
+
+        $this->addOption(Option::ONLY, null, InputOption::VALUE_REQUIRED, 'Fully qualified rule class name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $rectorClasses = $this->resolveRectorClasses();
+        $onlyRule = $input->getOption(Option::ONLY);
+        if ($onlyRule !== null) {
+            $onlyRule = $this->onlyRuleResolver->resolve($onlyRule);
+        }
+        $rectorClasses = $this->resolveRectorClasses($onlyRule);
 
         $skippedClasses = $this->getSkippedCheckers();
 
@@ -79,12 +89,16 @@ final class ListRulesCommand extends Command
     /**
      * @return array<class-string<RectorInterface>>
      */
-    private function resolveRectorClasses(): array
+    private function resolveRectorClasses(?string $onlyRule): array
     {
         $customRectors = array_filter(
             $this->rectors,
             static fn (RectorInterface $rector): bool => ! $rector instanceof PostRectorInterface
         );
+
+        if ($onlyRule !== null) {
+            $customRectors = $this->configurationRuleFilter->filterOnlyRule($customRectors, $onlyRule);
+        }
 
         $rectorClasses = array_map(static fn (RectorInterface $rector): string => $rector::class, $customRectors);
         sort($rectorClasses);

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -10,6 +10,7 @@ use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
 use Rector\Configuration\ConfigInitializer;
 use Rector\Configuration\ConfigurationFactory;
+use Rector\Configuration\ConfigurationRuleFilter;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Console\ExitCode;
@@ -42,6 +43,7 @@ final class ProcessCommand extends Command
         private readonly ConfigurationFactory $configurationFactory,
         private readonly DeprecatedRulesReporter $deprecatedRulesReporter,
         private readonly MissConfigurationReporter $missConfigurationReporter,
+        private ConfigurationRuleFilter $configurationRuleFilter,
     ) {
         parent::__construct();
     }
@@ -85,6 +87,7 @@ EOF
 
         $configuration = $this->configurationFactory->createFromInput($input);
         $this->memoryLimiter->adjust($configuration);
+        $this->configurationRuleFilter->setConfiguration($configuration);
 
         // disable console output in case of json output formatter
         if ($configuration->getOutputFormat() === JsonOutputFormatter::NAME) {

--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -11,6 +11,7 @@ use React\Socket\ConnectionInterface;
 use React\Socket\TcpConnector;
 use Rector\Application\ApplicationFileProcessor;
 use Rector\Configuration\ConfigurationFactory;
+use Rector\Configuration\ConfigurationRuleFilter;
 use Rector\Console\ProcessConfigureDecorator;
 use Rector\Parallel\ValueObject\Bridge;
 use Rector\StaticReflection\DynamicSourceLocatorDecorator;
@@ -44,7 +45,8 @@ final class WorkerCommand extends Command
         private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator,
         private readonly ApplicationFileProcessor $applicationFileProcessor,
         private readonly MemoryLimiter $memoryLimiter,
-        private readonly ConfigurationFactory $configurationFactory
+        private readonly ConfigurationFactory $configurationFactory,
+        private readonly ConfigurationRuleFilter $configurationRuleFilter,
     ) {
         parent::__construct();
     }
@@ -63,6 +65,7 @@ final class WorkerCommand extends Command
     {
         $configuration = $this->configurationFactory->createFromInput($input);
         $this->memoryLimiter->adjust($configuration);
+        $this->configurationRuleFilter->setConfiguration($configuration);
 
         $streamSelectLoop = new StreamSelectLoop();
         $parallelIdentifier = $configuration->getParallelIdentifier();

--- a/src/Console/ProcessConfigureDecorator.php
+++ b/src/Console/ProcessConfigureDecorator.php
@@ -56,6 +56,8 @@ final class ProcessConfigureDecorator
             ConsoleOutputFormatter::NAME
         );
 
+        $command->addOption(Option::ONLY, null, InputOption::VALUE_REQUIRED, 'Fully qualified rule class name');
+
         $command->addOption(Option::DEBUG, null, InputOption::VALUE_NONE, 'Display debug output.');
         $command->addOption(Option::MEMORY_LIMIT, null, InputOption::VALUE_REQUIRED, 'Memory limit for process');
         $command->addOption(Option::CLEAR_CACHE, null, InputOption::VALUE_NONE, 'Clear unchanged files cache');

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -47,6 +47,8 @@ use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\UsesClassNameImp
 use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
 use Rector\Config\RectorConfig;
 use Rector\Configuration\ConfigInitializer;
+use Rector\Configuration\ConfigurationRuleFilter;
+use Rector\Configuration\OnlyRuleResolver;
 use Rector\Configuration\RenamedClassesDataCollector;
 use Rector\Console\Command\CustomRuleCommand;
 use Rector\Console\Command\ListRulesCommand;
@@ -399,6 +401,8 @@ final class LazyContainerFactory
             return $inflectorFactory->build();
         });
 
+        $rectorConfig->singleton(ConfigurationRuleFilter::class);
+
         $rectorConfig->singleton(ProcessCommand::class);
         $rectorConfig->singleton(WorkerCommand::class);
         $rectorConfig->singleton(SetupCICommand::class);
@@ -406,6 +410,10 @@ final class LazyContainerFactory
         $rectorConfig->singleton(CustomRuleCommand::class);
 
         $rectorConfig->when(ListRulesCommand::class)
+            ->needs('$rectors')
+            ->giveTagged(RectorInterface::class);
+
+        $rectorConfig->when(OnlyRuleResolver::class)
             ->needs('$rectors')
             ->giveTagged(RectorInterface::class);
 

--- a/src/Exception/Configuration/RectorRuleNameAmbigiousException.php
+++ b/src/Exception/Configuration/RectorRuleNameAmbigiousException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Exception\Configuration;
+
+use Exception;
+
+final class RectorRuleNameAmbigiousException extends Exception
+{
+}

--- a/src/Exception/Configuration/RectorRuleNotFoundException.php
+++ b/src/Exception/Configuration/RectorRuleNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Exception\Configuration;
+
+use Exception;
+
+final class RectorRuleNotFoundException extends Exception
+{
+}

--- a/src/Parallel/Command/WorkerCommandLineFactory.php
+++ b/src/Parallel/Command/WorkerCommandLineFactory.php
@@ -114,6 +114,11 @@ final readonly class WorkerCommandLineFactory
             $workerCommandArray[] = escapeshellarg($this->filePathHelper->relativePath($config));
         }
 
+        if ($input->getOption(Option::ONLY) !== null) {
+            $workerCommandArray[] = self::OPTION_DASHES . Option::ONLY;
+            $workerCommandArray[] = escapeshellarg($input->getOption(Option::ONLY));
+        }
+
         return implode(' ', $workerCommandArray);
     }
 

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
+use Rector\Configuration\ConfigurationRuleFilter;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\VersionBonding\PhpVersionedFilter;
 
@@ -25,7 +26,8 @@ final class RectorNodeTraverser extends NodeTraverser
      */
     public function __construct(
         private array $rectors,
-        private readonly PhpVersionedFilter $phpVersionedFilter
+        private readonly PhpVersionedFilter $phpVersionedFilter,
+        private readonly ConfigurationRuleFilter $configurationRuleFilter,
     ) {
         parent::__construct();
     }
@@ -93,6 +95,9 @@ final class RectorNodeTraverser extends NodeTraverser
 
         // filer out by version
         $this->visitors = $this->phpVersionedFilter->filter($this->rectors);
+        // filter by configuration
+        $this->visitors = $this->configurationRuleFilter->filter($this->visitors);
+
         $this->areNodeVisitorsPrepared = true;
     }
 }

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -26,7 +26,8 @@ final readonly class Configuration
         private bool $isParallel = false,
         private string|null $memoryLimit = null,
         private bool $isDebug = false,
-        private bool $reportingWithRealPath = false
+        private bool $reportingWithRealPath = false,
+        private ?string $onlyRule = null
     ) {
     }
 
@@ -52,6 +53,11 @@ final readonly class Configuration
     {
         Assert::notEmpty($this->fileExtensions);
         return $this->fileExtensions;
+    }
+
+    public function getOnlyRule(): ?string
+    {
+        return $this->onlyRule;
     }
 
     /**

--- a/tests/Configuration/OnlyRuleResolverTest.php
+++ b/tests/Configuration/OnlyRuleResolverTest.php
@@ -6,6 +6,7 @@ namespace Rector\Tests\Configuration;
 
 use Rector\Configuration\OnlyRuleResolver;
 use Rector\Contract\Rector\RectorInterface;
+use Rector\Exception\Configuration\RectorRuleNameAmbigiousException;
 use Rector\Exception\Configuration\RectorRuleNotFoundException;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 
@@ -75,5 +76,33 @@ final class OnlyRuleResolverTest extends AbstractLazyTestCase
         $this->expectException(RectorRuleNotFoundException::class);
 
         $this->resolver->resolve('This\\Rule\\Does\\Not\\Exist');
+    }
+
+    public function testResolveShortOk(): void
+    {
+        $this->assertEquals(
+            \Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector::class,
+            $this->resolver->resolve('RemoveUnusedPrivateMethodRector'),
+        );
+    }
+
+    public function testResolveShortOkTwoLevels(): void
+    {
+        $this->assertEquals(
+            \Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector::class,
+            $this->resolver->resolve('Assign\\RemoveDoubleAssignRector'),
+        );
+    }
+
+    public function testResolveShortAmbiguous(): void
+    {
+        $this->expectExceptionMessage(
+            'Short rule name "RemoveDoubleAssignRector" is ambiguous. Specify the full rule name:' . PHP_EOL
+                . '- Rector\\DeadCode\\Rector\\Assign\\RemoveDoubleAssignRector' . PHP_EOL
+                . '- Rector\\Tests\\Configuration\\Source\\RemoveDoubleAssignRector'
+        );
+        $this->expectException(RectorRuleNameAmbigiousException::class);
+
+        $this->resolver->resolve('RemoveDoubleAssignRector');
     }
 }

--- a/tests/Configuration/OnlyRuleResolverTest.php
+++ b/tests/Configuration/OnlyRuleResolverTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Configuration;
+
+use Rector\Configuration\OnlyRuleResolver;
+use Rector\Contract\Rector\RectorInterface;
+use Rector\Exception\Configuration\RectorRuleNotFoundException;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+
+final class OnlyRuleResolverTest extends AbstractLazyTestCase
+{
+    protected OnlyRuleResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->bootFromConfigFiles([__DIR__ . '/config/only_rule_resolver_config.php']);
+        $rectorConfig = self::getContainer();
+
+        $this->resolver = new OnlyRuleResolver(iterator_to_array($rectorConfig->tagged(RectorInterface::class)));
+    }
+
+    public function testResolveOk(): void
+    {
+        $this->assertEquals(
+            \Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector::class,
+            $this->resolver->resolve('Rector\\DeadCode\\Rector\\Assign\\RemoveDoubleAssignRector')
+        );
+    }
+
+    public function testResolveOkLeadingBackslash(): void
+    {
+        $this->assertEquals(
+            \Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector::class,
+            $this->resolver->resolve('\\Rector\\DeadCode\\Rector\\Assign\\RemoveDoubleAssignRector')
+        );
+    }
+
+    public function testResolveOkDoubleBackslashes(): void
+    {
+        $this->assertEquals(
+            \Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector::class,
+            $this->resolver->resolve('\\\\Rector\\\\DeadCode\\\\Rector\\\\Assign\\\\RemoveDoubleAssignRector'),
+            'We want to fix wrongly double-quoted backslashes automatically'
+        );
+    }
+
+    public function testResolveOkSingleQuotes(): void
+    {
+        $this->assertEquals(
+            \Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector::class,
+            $this->resolver->resolve("'Rector\\DeadCode\\Rector\\Assign\\RemoveDoubleAssignRector'"),
+            'Remove stray single quotes on Windows systems'
+        );
+    }
+
+    public function testResolveMissingBackslash(): void
+    {
+        $this->expectExceptionMessage(
+            'Rule "RectorDeadCodeRectorAssignRemoveDoubleAssignRector" was not found.' . PHP_EOL
+                . 'The rule has no namespace. Make sure to escape the backslashes, and add quotes around the rule name: --only="My\\Rector\\Rule"'
+        );
+        $this->expectException(RectorRuleNotFoundException::class);
+
+        $this->resolver->resolve('RectorDeadCodeRectorAssignRemoveDoubleAssignRector');
+    }
+
+    public function testResolveNotFound(): void
+    {
+        $this->expectExceptionMessage(
+            'Rule "This\Rule\Does\Not\Exist" was not found.' . PHP_EOL
+                . 'Make sure it is registered in your config or in one of the sets'
+        );
+        $this->expectException(RectorRuleNotFoundException::class);
+
+        $this->resolver->resolve('This\\Rule\\Does\\Not\\Exist');
+    }
+}

--- a/tests/Configuration/Source/RemoveDoubleAssignRector.php
+++ b/tests/Configuration/Source/RemoveDoubleAssignRector.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Configuration\Source;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Dummy rector with same class name as an official one
+ */
+class RemoveDoubleAssignRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test short rule name conflicts', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return $node;
+    }
+}

--- a/tests/Configuration/config/only_rule_resolver_config.php
+++ b/tests/Configuration/config/only_rule_resolver_config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\Tests\Configuration\Source\RemoveDoubleAssignRector as RemoveDoubleAssignRectorTest;
 
 return RectorConfig::configure()
-    ->withRules([RemoveDoubleAssignRector::class, RemoveUnusedPrivateMethodRector::class]);
+    ->withRules([RemoveDoubleAssignRector::class, RemoveDoubleAssignRectorTest::class, RemoveUnusedPrivateMethodRector::class]);

--- a/tests/Configuration/config/only_rule_resolver_config.php
+++ b/tests/Configuration/config/only_rule_resolver_config.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveDoubleAssignRector::class, RemoveUnusedPrivateMethodRector::class]);


### PR DESCRIPTION
The option for the "process" and "list-rules" commands applies the single given rule only, without needing to modify the configuration file.

The option value must be a fully classified class name:
```
  --only="Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector"
```
A hint is given when the user forgot to escape the backslashes.

----

It is impossible to modify the injected "$rectors" after the command line configuration is parsed, so I had to introduce the ConfigurationRuleFilter singleton.

Since both ListRulesCommand and ProcessCommand make use of the ConfigurationRuleFilter - but list-rules does not have a Configuration - I had to make the filterOnlyRule() method public to prevent code duplication.

Resolves https://github.com/rectorphp/rector/issues/8899

---

Test it:
```
./bin/rector process --config=e2e/applied-rule-return-array-nodes/rector.php --dry-run --only="Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector"

./bin/rector list-rules --config=e2e/applied-rule-return-array-nodes/rector.php --only="Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector"
```