### PR TITLE
[DeadCode] Allow remove assign variable with next method call on RemoveDoubleAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/next_reassign_with_call_on_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/next_reassign_with_call_on_variable.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleAssignRector\Fixture;
+
+class NextReassignWithCallOnVariable
+{
+    private $items;
+
+    public function create($input)
+    {
+        $items = $input;
+        $items = $this->getItems();
+    }
+
+    public function getItems()
+    {
+        return sort($this->items);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleAssignRector\Fixture;
+
+class NextReassignWithCallOnVariable
+{
+    private $items;
+
+    public function create($input)
+    {
+        $items = $this->getItems();
+    }
+
+    public function getItems()
+    {
+        return sort($this->items);
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_next_reassign_with_call_on_property_fetch.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_next_reassign_with_call_on_property_fetch.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleAssignRector\Fixture;
+
+class SkipNextReassignWithCallOnPropertyFetch
+{
+    private $items;
+
+    public function create($input)
+    {
+        $this->items = $input;
+
+        $this->items = $this->getItems();
+    }
+
+    public function getItems()
+    {
+        return sort($this->items);
+    }
+}

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
@@ -6,7 +6,6 @@ namespace Rector\DeadCode\Rector\Assign;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
@@ -104,7 +103,10 @@ CODE_SAMPLE
             }
 
             // next stmts can have side effect as well
-            if ($nextAssign->expr instanceof MethodCall) {
+            if (($nextAssign->var instanceof PropertyFetch || $nextAssign->var instanceof StaticPropertyFetch) && $this->sideEffectNodeDetector->detectCallExpr(
+                $nextAssign->expr,
+                $scope
+            )) {
                 continue;
             }
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6442#pullrequestreview-2440567758