### PR TITLE
[DX] Add default empty definition with add getRuleDefinition() method on AbstractRector

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -71,20 +71,6 @@ return [
             // comment out
             str_replace('\\' . $prefix . '\trigger_deprecation(', '// \trigger_deprecation(', $content),
 
-        // make external rules easier to write without enforing getRuleDefinition()
-        // as they are not designed for open-sourcing
-        static function (string $filePath, string $prefix, string $content): string {
-            if (! \str_ends_with(
-                $filePath,
-                'vendor/symplify/rule-doc-generator-contracts/src/Contract/DocumentedRuleInterface.php'
-            )) {
-                return $content;
-            }
-
-            // comment out
-            return str_replace('public function getRuleDefinition', '// public function getRuleDefinition', $content);
-        },
-
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'src/Application/VersionResolver.php')) {
                 return $content;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -34,6 +34,7 @@ use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\ValueObject\Application\File;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 abstract class AbstractRector extends NodeVisitorAbstract implements RectorInterface
 {
@@ -117,6 +118,11 @@ CODE_SAMPLE;
         $this->file = $file;
 
         return parent::beforeTraverse($nodes);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
     }
 
     final public function enterNode(Node $node): int|Node|null


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6438#pullrequestreview-2440616004

This avoid tricky patch via scoper, allow user to add whenever they want, or not if they don't want to, eg, when updating for laravel package, it required to show on our website.

see, tricky patch on website https://github.com/rectorphp/getrector-com/commit/a4b9deeec52cb95136217b65239e3ec5036ae484

