### PR TITLE
[dx] Drop start with short open tag handling on FilesFinder

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -59,7 +59,6 @@ final class ApplicationFileProcessor
     {
         $filePaths = $this->filesFinder->findFilesInPaths($configuration->getPaths(), $configuration);
         $this->missConfigurationReporter->reportVendorInPaths($filePaths);
-        $this->missConfigurationReporter->reportStartWithShortOpenTag();
 
         // no files found
         if ($filePaths === []) {

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -250,12 +250,6 @@ final class Option
     public const SKIPPED_RECTOR_RULES = 'skipped_rector_rules';
 
     /**
-     * @internal For collect skipped start with short open tag files to be reported
-     * @var string
-     */
-    public const SKIPPED_START_WITH_SHORT_OPEN_TAG_FILES = 'skipped_start_with_short_open_tag_files';
-
-    /**
      * @internal For reporting with absolute paths instead of relative paths (default behaviour)
      * @see \Rector\Config\RectorConfig::reportingRealPath()
      * @var string

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -20,7 +20,6 @@ final readonly class FilesFinder
         private UnchangedFilesFilter $unchangedFilesFilter,
         private FileAndDirectoryFilter $fileAndDirectoryFilter,
         private PathSkipper $pathSkipper,
-        private FilePathHelper $filePathHelper,
         private ChangedFilesDetector $changedFilesDetector,
     ) {
     }

--- a/src/Reporting/MissConfigurationReporter.php
+++ b/src/Reporting/MissConfigurationReporter.php
@@ -54,24 +54,4 @@ final readonly class MissConfigurationReporter
 
         sleep(3);
     }
-
-    public function reportStartWithShortOpenTag(): void
-    {
-        $files = SimpleParameterProvider::provideArrayParameter(Option::SKIPPED_START_WITH_SHORT_OPEN_TAG_FILES);
-        if ($files === []) {
-            return;
-        }
-
-        $suffix = count($files) > 1 ? 's were' : ' was';
-        $fileList = implode(PHP_EOL, $files);
-
-        $this->symfonyStyle->warning(sprintf(
-            'The following file%s skipped as starting with short open tag. Migrate to long open PHP tag first: %s%s',
-            $suffix,
-            PHP_EOL . PHP_EOL,
-            $fileList
-        ));
-
-        sleep(3);
-    }
 }

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -26,7 +26,7 @@ final class FilesFinderTest extends AbstractLazyTestCase
         $this->assertCount(1, $foundFiles);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithShortEchoes'], ['php']);
-        $this->assertCount(0, $foundFiles);
+        $this->assertCount(1, $foundFiles);
     }
 
     #[DataProvider('alwaysReturnsAbsolutePathDataProvider')]


### PR DESCRIPTION
Start with short open tag handling was used for auto import on php+html case, and currently already covered by check it first by `AddUseStatementGuard` service that verify has html

- https://github.com/rectorphp/rector-src/blob/e562253268ac3c2b37c3b267d1208148a0a313b5/src/PostRector/Guard/AddUseStatementGuard.php#L12

also, on rules that mixed php + html cover, with added HTMLAverseRectorInterface, that can cover it:

- https://github.com/rectorphp/rector-src/pull/6445

in case of rules that need html handling.