### PR TITLE
[chore] Remove left over config fixture test without test

### DIFF
--- a/rules-tests/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/config/configured_rule.php
+++ b/rules-tests/RemovingStatic/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/config/configured_rule.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
-use Rector\Config\RectorConfig;
-
-return RectorConfig::configure()
-    ->withRules([LocallyCalledStaticMethodToNonStaticRector::class]);


### PR DESCRIPTION
`LocallyCalledStaticMethodToNonStaticRector` was moved from `RemovingStatic` to `CodeQuality` set.

moved to https://github.com/rectorphp/rector-src/tree/main/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector

This config test left over not used and can be removed.