### PR TITLE
[chore] Set disableExtensionsAnalysis() on composer dependency analyser due to composer-dependency-analyser:^1.8

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -21,4 +21,6 @@ return $config
         __DIR__ . '/stubs',
         __DIR__ . '/tests',
         __DIR__ . '/rules-tests',
-    ], [ErrorType::UNKNOWN_CLASS]);
+    ], [ErrorType::UNKNOWN_CLASS])
+
+    ->disableExtensionsAnalysis();

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "rector/release-notes-generator": "^0.3.0",
         "rector/swiss-knife": "^0.2.16",
         "rector/type-perfect": "^1.0",
-        "shipmonk/composer-dependency-analyser": "^1.7",
+        "shipmonk/composer-dependency-analyser": "^1.8",
         "symplify/easy-coding-standard": "^12.3",
         "symplify/phpstan-extensions": "^11.4",
         "symplify/phpstan-rules": "^13.0",


### PR DESCRIPTION
Ref new release of `shipmonk-rnd/composer-dependency-analyser`:

https://github.com/shipmonk-rnd/composer-dependency-analyser/releases/tag/1.8.0

**Before**

```
➜  rector-src git:(main) vendor/bin/composer-dependency-analyser
Using config /Users/samsonasik/www/rector-src/composer-dependency-analyser.php

Found 3 shadow dependencies!
(those are used, but not listed as dependency in composer.json)

  • ext-ctype
      e.g. ctype_digit in rules/Naming/Naming/PropertyNaming.php:262 (+ 5 more)

  • ext-dom
      e.g. DOMDocument in src/Console/Command/CustomRuleCommand.php:166 (+ 9 more)

  • ext-filter
      e.g. FILTER_VALIDATE_BOOLEAN in stubs/Symfony/Component/Routing/Annotation/Route.php:65 (+ 1 more)
```

**After**

```
➜  rector-src git:(set-disable-extension-analysis) vendor/bin/composer-dependency-analyser                                           
Using config /Users/samsonasik/www/rector-src/composer-dependency-analyser.php

No composer issues found
(scanned 2773 files in 0.664 s)
```

we can revisit later for it :)