### PR TITLE
[CodeQuality] Handle crash on return array constant on ExplicitReturnNullRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/array_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/array_constant.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector\Fixture;
+
+class SkipReturnArrayConstant
+{
+    public static function provideClearSession()
+    {
+        return [
+            ['Default', ['Foo' => ['foo' => 'fooValue']]],
+            [null, []],
+        ];
+    }
+}

--- a/rules/TypeDeclaration/TypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeNormalizer.php
@@ -84,9 +84,9 @@ final class TypeNormalizer
                 assert($traversedType instanceof ConstantArrayType);
 
                 // not sure why, but with direct new node everything gets nulled to MixedType
-                $this->privatesAccessor->setPrivateProperty($traversedType, 'keyType', new MixedType());
+                $this->privatesAccessor->setPrivateProperty($traversedType, 'keyTypes', [new MixedType()]);
 
-                $this->privatesAccessor->setPrivateProperty($traversedType, 'itemType', new MixedType());
+                $this->privatesAccessor->setPrivateProperty($traversedType, 'valueTypes', [new MixedType()]);
 
                 return $traversedType;
             }


### PR DESCRIPTION
Given the following code:

```php
class SkipReturnArrayConstant
{
    public static function provideClearSession()
    {
        return [
            ['Default', ['Foo' => ['foo' => 'fooValue']]],
            [null, []],
        ];
    }
}
```

got crash:

```
There was 1 error:

1) Rector\Tests\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector\ExplicitReturnNullRectorTest::test with data set #1 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Exception\Reflection\MissingPrivatePropertyException: Property "$keyType" was not found in "PHPStan\Type\Constant\ConstantArrayType" class
```

This PR fix it.