### PR TITLE
[Php71] Skip already array destruct on ListToArrayDestructRector

### DIFF
--- a/rules-tests/Php71/Rector/List_/ListToArrayDestructRector/Fixture/skip_already_array_destruct.php.inc
+++ b/rules-tests/Php71/Rector/List_/ListToArrayDestructRector/Fixture/skip_already_array_destruct.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\List_\ListToArrayDestructRector\Fixture;
+
+final class SkipAlreadyArrayDestruct
+{
+    public function run($line, $file, $trace)
+    {
+        [
+            'line' => $line,
+            'file' => $file,
+        ] = $trace;
+    }
+}

--- a/rules/Php71/Rector/List_/ListToArrayDestructRector.php
+++ b/rules/Php71/Rector/List_/ListToArrayDestructRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Stmt\Foreach_;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -71,6 +72,10 @@ CODE_SAMPLE
                 return null;
             }
 
+            if ($node->var->getAttribute(AttributeKey::KIND) === List_::KIND_ARRAY) {
+                return null;
+            }
+
             $list = $node->var;
 
             $node->var = new Array_($list->items);
@@ -78,6 +83,10 @@ CODE_SAMPLE
         }
 
         if (! $node->valueVar instanceof List_) {
+            return null;
+        }
+
+        if ($node->valueVar->getAttribute(AttributeKey::KIND) === List_::KIND_ARRAY) {
             return null;
         }
 


### PR DESCRIPTION
Given the following code:

```php
<?php

namespace Rector\Tests\Php71\Rector\List_\ListToArrayDestructRector\Fixture;

final class SkipAlreadyArrayDestruct
{
    public function run($line, $file, $trace)
    {
        [
            'line' => $line,
            'file' => $file,
        ] = $trace;
    }
}

```

It somehow reprinted:

```diff
There was 1 failure:

1) Rector\Tests\Php71\Rector\List_\ListToArrayDestructRector\ListToArrayDestructRectorTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "skip_already_array_destruct.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 {
     public function run($line, $file, $trace)
     {
-        [
-            'line' => $line,
-            'file' => $file,
-        ] = $trace;
+        ['line' => $line, 'file' => $file] = $trace;
```

which should be skipped. This PR try to fix it.