### PR TITLE
Fix ArrayItem scope refresh

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\Application;
 
 use PhpParser\Node;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
@@ -94,6 +96,10 @@ final readonly class ChangedNodeScopeRefresher
 
         if ($node instanceof Expr) {
             return [new Expression($node)];
+        }
+
+        if ($node instanceof ArrayItem) {
+            return [new Expression(new Array_([$node]))];
         }
 
         $errorMessage = sprintf('Complete parent node of "%s" be a stmt.', $node::class);


### PR DESCRIPTION
Since ArrayItem directly under node, it no longer resolvable under `Expr`, so it needs this patch to avoid error:

```
There was 1 error:

1) Ssch\TYPO3Rector\Tests\Rector\v10\v4\RemoveFormatConstantsEmailFinisherRector\RemoveFormatConstantsEmailFinisherRectorTest::test with data set #0 ('/Users/samsonasik/www/typo3-r...hp.inc')
Rector\Exception\ShouldNotHappenException: Complete parent node of "PhpParser\Node\ArrayItem" be a stmt.
```