### PR TITLE
[Renaming] Fix space on union docblock during rename on RenameClassRector

### DIFF
--- a/src/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
+++ b/src/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
@@ -36,7 +36,13 @@ final class UnionTypeNodePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor imp
 
         $startAndEnd = $this->resolveStardAndEnd($node);
         if (! $startAndEnd instanceof StartAndEnd) {
-            return null;
+            $firstKey = array_key_first($node->types);
+            $lastKey = array_key_last($node->types);
+
+            $startAndEnd = new StartAndEnd(
+                $node->types[$firstKey]->getAttribute('startIndex'),
+                $node->types[$lastKey]->getAttribute('endIndex')
+            );
         }
 
         $betterTokenProvider = $this->currentTokenIteratorProvider->provide();

--- a/tests/Issues/AutoImport/Fixture/DocBlock/union_docblock_space.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/union_docblock_space.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use DateTime;
+
+class UnionDocblockSpace
+{
+    /**
+     * @param array<(DateTime|null)> $param
+     */
+    public function some($param)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\AutoImport\Fixture\DocBlock;
+
+use DateTimeInterface;
+
+class UnionDocblockSpace
+{
+    /**
+     * @param array<(DateTimeInterface|null)> $param
+     */
+    public function some($param)
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Let see if the reprint from phpdoc-parser is fixable.

```diff
-     * @param array<(DateTimeInterface|null)> $param
+     * @param array<(DateTimeInterface | null)> $param
```