### PR TITLE
[AutoImport] Handle doctrine aliased auto import

### DIFF
--- a/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -22,6 +22,7 @@ use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeVisitor\AbstractPhpDocNodeVisitor;
 use Rector\PostRector\Collector\UseNodesToAddCollector;
 use Rector\StaticTypeMapper\PhpDocParser\IdentifierPhpDocTypeMapper;
+use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\ValueObject\Application\File;
@@ -217,7 +218,11 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
                 return;
             }
 
-            $staticType = new FullyQualifiedObjectType($staticType->getClassName());
+            if ($staticType instanceof AliasedObjectType || $staticType instanceof ShortenedObjectType) {
+                $staticType = new FullyQualifiedObjectType($staticType->getFullyQualifiedName());
+            } else {
+                $staticType = new FullyQualifiedObjectType($staticType->getClassName());
+            }
         }
 
         $file = $this->currentFileProvider->getFile();
@@ -270,7 +275,11 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
                 return null;
             }
 
-            $staticType = new FullyQualifiedObjectType($staticType->getClassName());
+            if ($staticType instanceof AliasedObjectType || $staticType instanceof ShortenedObjectType) {
+                $staticType = new FullyQualifiedObjectType($staticType->getFullyQualifiedName());
+            } else {
+                $staticType = new FullyQualifiedObjectType($staticType->getClassName());
+            }
         }
 
         $file = $this->currentFileProvider->getFile();

--- a/tests/Issues/AutoImport/Fixture/DocBlock/skip_doctrine_aliased.php.inc
+++ b/tests/Issues/AutoImport/Fixture/DocBlock/skip_doctrine_aliased.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * Text comment
+ *
+ * @MongoDB\Document(
+ *     repositoryClass="App\Repository\SomeRepository",
+ *     collection="SomeLog"
+ * )
+ */
+class SkipDoctrineAliased
+{
+}


### PR DESCRIPTION
It produce invalid result:

```diff
- * @MongoDB\Document(
- *     repositoryClass="App\Repository\SomeRepository",
- *     collection="SomeLog"
- * )
+ * @MongoDB(repositoryClass="App\Repository\SomeRepository", collection="SomeLog")
```

This PR fix it.