### PR TITLE
feat: add the option to use the annotation value as an argument to the attribute

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/with_value_as_argument.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/with_value_as_argument.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+final class WithValueAsArgument
+{
+    /**
+     * @When this is a simple annotation with a value
+     * @When
+     * @When "this value is within quotes"
+     * @When this value has a ' character
+     * @When(key="value") this annotation has parameters so won't use this option
+     */
+    public function someStep(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+final class WithValueAsArgument
+{
+    #[\Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\Behat\When('this is a simple annotation with a value')]
+    #[\Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\Behat\When]
+    #[\Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\Behat\When('"this value is within quotes"')]
+    #[\Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\Behat\When('this value has a \' character')]
+    #[\Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\Behat\When(key: 'value')] // this annotation has parameters so won't use this option
+    public function someStep(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Attribute/Behat/When.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Attribute/Behat/When.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\Behat;
+
+final class When
+{
+}

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -7,6 +7,7 @@ use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Annotation\OpenApi\Annotation\NestedPastAnnotation;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Annotation\OpenApi\PastAnnotation;
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\Behat\When;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute\NestedFutureAttribute;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\FutureAttribute;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\GenericAnnotation;
@@ -47,5 +48,6 @@ return static function (RectorConfig $rectorConfig): void {
                 'Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\UseAlias\TestOther'
             ),
             new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Security'),
+            new AnnotationToAttribute('When', When::class, useValueAsAttributeArgument: true),
         ]);
 };

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -204,7 +204,10 @@ CODE_SAMPLE
                     continue;
                 }
 
-                $attributeGroups[] = $this->phpAttributeGroupFactory->createFromSimpleTag($annotationToAttribute);
+                $attributeGroups[] = $this->phpAttributeGroupFactory->createFromSimpleTag(
+                    $annotationToAttribute,
+                    $annotationToAttribute->getUseValueAsAttributeArgument() ? (string) $docNode->value : null
+                );
                 return PhpDocNodeTraverser::NODE_REMOVE;
             }
 

--- a/rules/Php80/ValueObject/AnnotationToAttribute.php
+++ b/rules/Php80/ValueObject/AnnotationToAttribute.php
@@ -16,7 +16,8 @@ final readonly class AnnotationToAttribute implements AnnotationToAttributeInter
     public function __construct(
         private string $tag,
         private ?string $attributeClass = null,
-        private array $classReferenceFields = []
+        private array $classReferenceFields = [],
+        private bool $useValueAsAttributeArgument = false,
     ) {
         RectorAssert::className($tag);
 
@@ -47,5 +48,10 @@ final readonly class AnnotationToAttribute implements AnnotationToAttributeInter
     public function getClassReferenceFields(): array
     {
         return $this->classReferenceFields;
+    }
+
+    public function getUseValueAsAttributeArgument(): bool
+    {
+        return $this->useValueAsAttributeArgument;
     }
 }

--- a/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -36,18 +36,25 @@ final readonly class PhpAttributeGroupFactory
     ) {
     }
 
-    public function createFromSimpleTag(AnnotationToAttribute $annotationToAttribute): AttributeGroup
-    {
-        return $this->createFromClass($annotationToAttribute->getAttributeClass());
+    public function createFromSimpleTag(
+        AnnotationToAttribute $annotationToAttribute,
+        ?string $value = null
+    ): AttributeGroup {
+        return $this->createFromClass($annotationToAttribute->getAttributeClass(), $value);
     }
 
     /**
      * @param AttributeName::*|string $attributeClass
      */
-    public function createFromClass(string $attributeClass): AttributeGroup
+    public function createFromClass(string $attributeClass, ?string $value = null): AttributeGroup
     {
         $fullyQualified = new FullyQualified($attributeClass);
         $attribute = new Attribute($fullyQualified);
+        if ($value !== null && $value !== '') {
+            $arg = new Arg(new String_($value));
+            $attribute->args = [$arg];
+        }
+
         return new AttributeGroup([$attribute]);
     }
 


### PR DESCRIPTION
Currently if you have an annotation like the ones Behat uses:
```
    /**
     * @Given the user does not exist in the database
     */
```
When you use the `AnnotationToAttributeRector` rule configured like this:
```
    ->withConfiguredRule(AnnotationToAttributeRector::class, [
        new AnnotationToAttribute('Given', Given::class),
    ])
```
The value of the annotation ("the user does not exist in the database") is discarded and the end result is:
```
#[Given]
```

This PR adds a new `useValueAsAttributeArgument` option to the `AnnotationToAttribute` class. If this option is set to true, the value of the annotation will be used as an argument for the attribute, resulting in the correct result of:
```
#[Given('the user does not exist in the database')]
```
This option only applies to "generic" annotations. If Rector considers an annotation to be a "doctrine" annotation (for example if the annotation has parameters) then this won't apply
