### PR TITLE
[Arguments] Handle parent call with static call on ArgumentAdderRector

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/call_parent_static_call.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/call_parent_static_call.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeParentWithProtectedMethod;
+use stdClass;
+
+class CallParentStaticCall extends SomeParentWithProtectedMethod
+{
+    protected function run(mixed $value, ?stdClass $element): string
+    {
+        $result = parent::run($value, $element);
+        return str_replace('a', 'b', $result);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeParentWithProtectedMethod;
+use stdClass;
+
+class CallParentStaticCall extends SomeParentWithProtectedMethod
+{
+    protected function run(mixed $value, ?stdClass $element, bool $inline = false): string
+    {
+        $result = parent::run($value, $element, $inline);
+        return str_replace('a', 'b', $result);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Source/SomeParentWithProtectedMethod.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Source/SomeParentWithProtectedMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source;
+
+use stdClass;
+
+class SomeParentWithProtectedMethod
+{
+    protected function run(mixed $value, ?stdClass $element, bool $inline): string
+    {
+        return '';
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
@@ -16,6 +17,7 @@ use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeCla
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeContainerBuilder;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeParentClient;
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeParentWithProtectedMethod;
 
 return static function (RectorConfig $rectorConfig): void {
     $arrayType = new ArrayType(new MixedType(), new MixedType());
@@ -33,6 +35,7 @@ return static function (RectorConfig $rectorConfig): void {
             ),
             new ArgumentAdder(SomeContainerBuilder::class, 'compile', 0, 'isCompiled', false),
             new ArgumentAdder(SomeContainerBuilder::class, 'addCompilerPass', 2, 'priority', 0, new IntegerType()),
+            new ArgumentAdder(SomeParentWithProtectedMethod::class, 'run', 2, 'inline', false, new BooleanType()),
             // scoped
             new ArgumentAdder(
                 SomeParentClient::class,


### PR DESCRIPTION
It currently only add parameters but doesn't apply on call.

```diff
There was 1 failure:

1) Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\ArgumentAdderRectorTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "call_parent_static_call.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 {
     protected function run(mixed $value, ?stdClass $element, bool $inline = false): string
     {
-        $result = parent::run($value, $element, $inline);
+        $result = parent::run($value, $element);
```