### PR TITLE
[Php83] Skip add #[\Override] on non-empty method from trait on AddOverrideAttributeToOverriddenMethodsRector

### DIFF
--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_override_non_empty_method_from_trait.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_override_non_empty_method_from_trait.php.inc
@@ -4,11 +4,11 @@ namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverridden
 
 use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromTrait;
 
-final class SkipAbstractTraitMethod
+class SkipOverrideNonEmptyMethodFromTrait
 {
     use ExampleFromTrait;
 
-    public function foo()
+    public function bar()
     {
     }
 }

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/with_abstract_trait_method.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/with_abstract_trait_method.php.inc
@@ -4,11 +4,11 @@ namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverridden
 
 use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromTrait;
 
-class ApplyAttributeToOverrideMethodFromTrait
+final class WithAbstractTraitMethod
 {
     use ExampleFromTrait;
 
-    public function bar()
+    public function foo()
     {
     }
 }
@@ -21,12 +21,12 @@ namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverridden
 
 use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromTrait;
 
-class ApplyAttributeToOverrideMethodFromTrait
+final class WithAbstractTraitMethod
 {
     use ExampleFromTrait;
 
     #[\Override]
-    public function bar()
+    public function foo()
     {
     }
 }

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -207,8 +207,12 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($parentClassMethod->isAbstract()) {
+        if ($parentClassReflection->isTrait() && ! $parentClassMethod->isAbstract()) {
             return true;
+        }
+
+        if ($parentClassMethod->isAbstract()) {
+            return ! $parentClassReflection->isTrait();
         }
 
         // has any stmts?

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -155,6 +155,7 @@ CODE_SAMPLE
         $classMethodName = $this->getName($classMethod->name);
 
         // Private methods should be ignored
+        $shouldAddOverride = false;
         foreach ($parentClassReflections as $parentClassReflection) {
             if (! $parentClassReflection->hasNativeMethod($classMethod->name->toString())) {
                 continue;
@@ -167,16 +168,23 @@ CODE_SAMPLE
 
             $parentMethod = $parentClassReflection->getNativeMethod($classMethodName);
             if ($parentMethod->isPrivate()) {
-                continue;
+                // early stop as already private
+                $shouldAddOverride = false;
+                return;
             }
 
             if ($this->shouldSkipParentClassMethod($parentClassReflection, $classMethod)) {
-                continue;
+                // early stop as already skipped
+                $shouldAddOverride = false;
+                return;
             }
 
+            $shouldAddOverride = true;
+        }
+
+        if ($shouldAddOverride) {
             $classMethod->attrGroups[] = new AttributeGroup([new Attribute(new FullyQualified(self::OVERRIDE_CLASS))]);
             $this->hasChanged = true;
-            return;
         }
     }
 


### PR DESCRIPTION
The PR:

- https://github.com/rectorphp/rector-src/pull/6447

cause regression which non-empty method override add `#[\Override]` attribute, which cause error, see

```
Fatal error: ApplyAttributeToOverrideMethodFromTrait::bar() has #[\Override] attribute, but no matching parent method exists in /in/O2TdJ on line 16
```

https://3v4l.org/O2TdJ

this patch try to fix it.