### PR TITLE
[DeadCode] Skip used by get_object_vars() when implements JsonSerializable on RemoveUnusedPromotedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/skip_used_by_get_object_vars_from_jsonserializable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/skip_used_by_get_object_vars_from_jsonserializable.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector\Fixture;
+
+class SkipUsedByGetObjectVarsFromJsonSerializable implements \JsonSerializable
+{
+    public function __construct(private readonly string $foo)
+    {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector.php
@@ -191,6 +191,6 @@ CODE_SAMPLE
             }
         }
 
-        return false;
+        return $this->propertyWriteonlyAnalyzer->hasClassDynamicPropertyNames($class);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8904