### PR TITLE
[CodeQuality] Skip used by array callable on LocallyCalledStaticMethodToNonStaticRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_used_by_array_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/LocallyCalledStaticMethodToNonStaticRector/Fixture/skip_used_by_array_callable.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector\Fixture;
+
+class SkipUsedByArrayCallable
+{
+  private static function bar(string $a, string $b): int
+  {
+    return $a <=> $b;
+  }
+
+  public static function foo(): void
+  {
+    $array = [];
+    usort($array, [self::class, 'bar']);
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8905