### PR TITLE
[CodeQuality] Skip compare nullable object on UseIdenticalOverEqualWithSameTypeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/skip_compare_nullable_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/skip_compare_nullable_object.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector\Fixture;
+
+final class SkipCompareNullableObject
+{
+    public function equal(?\DateTime $d, ?\DateTime $d2)
+    {
+    	return $d == $d2;
+    }
+}

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotEqual;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -69,7 +69,7 @@ CODE_SAMPLE
         $rightStaticType = $this->nodeTypeResolver->getNativeType($node->right);
 
         // objects can be different by content
-        if ($leftStaticType instanceof ObjectType || $rightStaticType instanceof ObjectType) {
+        if (! $leftStaticType->isObject()->no() || ! $rightStaticType->isObject()->no()) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8906
Ref equal vs identical on nullable object https://3v4l.org/JDGRQ
