### PR TITLE
[DeadCode] Handle crash on valid conditional type on RemoveUselessReturnTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_valid_conditional_return.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_valid_conditional_return.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final readonly class SkipValidConditionalReturn
+{
+    /**
+     * Groups an array by a key returned by a callback.
+     *
+     * Example:
+     *
+     * return SkipValidConditionalReturn::groupBy(
+     *     $results,
+     *     fn ($ticket) => (string) $ticket->getFile()->getId(),
+     * );
+     *
+     * @template TValue of mixed
+     * @template TCallbackValue of mixed
+     * @template TKey of array-key
+     * @param array<TValue> $input
+     * @param callable(TValue): TKey $keyCallback
+     * @param null|callable(TValue): TCallbackValue $valueCallback
+     *
+     * @return ($valueCallback is null ? array<TKey, non-empty-list<TValue>> : array<TKey, non-empty-list<TCallbackValue>>)
+     */
+    public static function groupBy(array $input, callable $keyCallback, ?callable $valueCallback = null) : array
+    {
+        $output = [];
+        foreach ($input as $result) {
+            $output[$keyCallback($result)][] = $valueCallback !== null ? $valueCallback($result) : $result;
+        }
+
+        return $output;
+    }
+}

--- a/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
         }
 
         $arrayStaticType = $this->getType($expr);
-        if (! $arrayStaticType->isArray()->yes()) {
+        if (! $arrayStaticType instanceof ArrayType && ! $arrayStaticType instanceof ConstantArrayType) {
             return true;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
@@ -148,7 +147,7 @@ CODE_SAMPLE
         ClassMethod|Function_|Closure $node,
         Type $returnType
     ): ClassMethod|Function_|Closure|null {
-        if (! $returnType instanceof ArrayType && ! $returnType instanceof ConstantScalarType) {
+        if (! $returnType instanceof ArrayType && ! $returnType instanceof ConstantArrayType) {
             return null;
         }
 
@@ -177,7 +176,7 @@ CODE_SAMPLE
 
     private function changeReturnType(
         ClassMethod|Function_|Closure $node,
-        ArrayType|ConstantScalarType $arrayType
+        ArrayType|ConstantArrayType $arrayType
     ): void {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
@@ -266,7 +265,7 @@ CODE_SAMPLE
         return $variables;
     }
 
-    private function shouldAddReturnArrayDocType(ArrayType|ConstantScalarType $arrayType): bool
+    private function shouldAddReturnArrayDocType(ArrayType|ConstantArrayType $arrayType): bool
     {
         if ($arrayType instanceof ConstantArrayType) {
             if ($arrayType->getItemType() instanceof NeverType) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
@@ -147,7 +148,7 @@ CODE_SAMPLE
         ClassMethod|Function_|Closure $node,
         Type $returnType
     ): ClassMethod|Function_|Closure|null {
-        if (! $returnType->isArray()->yes()) {
+        if (! $returnType instanceof ArrayType && ! $returnType instanceof ConstantScalarType) {
             return null;
         }
 
@@ -174,8 +175,10 @@ CODE_SAMPLE
         );
     }
 
-    private function changeReturnType(ClassMethod|Function_|Closure $node, ArrayType|ConstantArrayType $arrayType): void
-    {
+    private function changeReturnType(
+        ClassMethod|Function_|Closure $node,
+        ArrayType|ConstantScalarType $arrayType
+    ): void {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         // skip already filled type, on purpose
@@ -263,7 +266,7 @@ CODE_SAMPLE
         return $variables;
     }
 
-    private function shouldAddReturnArrayDocType(ArrayType|ConstantArrayType $arrayType): bool
+    private function shouldAddReturnArrayDocType(ArrayType|ConstantScalarType $arrayType): bool
     {
         if ($arrayType instanceof ConstantArrayType) {
             if ($arrayType->getItemType() instanceof NeverType) {

--- a/rules/TypeDeclaration/TypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeNormalizer.php
@@ -6,7 +6,6 @@ namespace Rector\TypeDeclaration;
 
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
@@ -44,11 +43,10 @@ final class TypeNormalizer
             return $type;
         }
 
-        if ($type instanceof UnionType || $type instanceof IntersectionType) {
+        if (! $type instanceof ArrayType && ! $type instanceof ConstantArrayType) {
             return $type;
         }
 
-        /** @var ArrayType|ConstantArrayType $type */
         if ($type instanceof ConstantArrayType && $arrayNesting === 1) {
             return $type;
         }

--- a/rules/TypeDeclaration/TypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeNormalizer.php
@@ -39,10 +39,6 @@ final class TypeNormalizer
      */
     public function normalizeArrayOfUnionToUnionArray(Type $type, int $arrayNesting = 1): Type
     {
-        if (! $type->isArray()->yes()) {
-            return $type;
-        }
-
         if (! $type instanceof ArrayType && ! $type instanceof ConstantArrayType) {
             return $type;
         }


### PR DESCRIPTION
Fix crash:

```
There was 1 error:

1) Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\RemoveUselessReturnTagRectorTest::test with data set #34 ('/Users/samsonasik/www/rector-...hp.inc')
Error: Call to undefined method PHPStan\Type\ConditionalTypeForParameter::getItemType()

/Users/samsonasik/www/rector-src/rules/TypeDeclaration/TypeNormalizer.php:61
/Users/samsonasik/www/rector-src/src/NodeTypeResolver/TypeComparator/TypeComparator.php:60
```

Fixes https://github.com/rectorphp/rector/issues/8907