### PR TITLE
[Scoper] Add CommunityNodeVisitorAbstract to be used for community that include getRuleDefinition() empty method

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -40,7 +40,7 @@ jobs:
                     -
                         name: 'Active Classes'
                         run: |
-                            vendor/bin/class-leak check bin config src rules utils --skip-suffix "Rector" --skip-type="Rector\\Utils\\Compiler\\Unprefixer" --skip-type="Rector\\PhpDocParser\\PhpParser\\SmartPhpParserFactory" --skip-type="Rector\\NodeCollector\\BinaryOpConditionsCollector" --skip-type="Rector\\Set\\Contract\\SetListInterface"
+                            vendor/bin/class-leak check bin config src rules utils --skip-suffix "Rector" --skip-type="Rector\\Utils\\Compiler\\Unprefixer" --skip-type="Rector\\PhpDocParser\\PhpParser\\SmartPhpParserFactory" --skip-type="Rector\\NodeCollector\\BinaryOpConditionsCollector" --skip-type="Rector\\Set\\Contract\\SetListInterface" --skip-type="Rector\\Rector\\CommunityNodeVisitorAbstract"
 
                     -
                         name: 'Compatible PHPStan versions'

--- a/scoper.php
+++ b/scoper.php
@@ -85,6 +85,25 @@ return [
             return str_replace('public function getRuleDefinition', '// public function getRuleDefinition', $content);
         },
 
+        // Add empty getRuleDefinition() method on AbstractRector to avoid error on #[Override]
+        // which method getRuleDefinition() no longer exists
+        // @see https://github.com/rectorphp/rector/issues/8815#issuecomment-2495378045
+        static function (string $filePath, string $prefix, string $content): string {
+            if (! \str_ends_with(
+                $filePath,
+                'src/Rector/AbstractRector.php'
+            )) {
+                return $content;
+            }
+
+            // comment out
+            return str_replace(
+                'abstract class AbstractRector extends NodeVisitorAbstract implements RectorInterface',
+                'abstract class AbstractRector extends \Rector\Rector\CommunityNodeVisitorAbstract implements RectorInterface',
+                $content
+            );
+        },
+
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'src/Application/VersionResolver.php')) {
                 return $content;

--- a/scoper.php
+++ b/scoper.php
@@ -87,6 +87,7 @@ return [
 
         // Add empty getRuleDefinition() method on AbstractRector to avoid error on #[Override]
         // which method getRuleDefinition() no longer exists
+        // via replace to extends \Rector\Rector\CommunityNodeVisitorAbstract
         // @see https://github.com/rectorphp/rector/issues/8815#issuecomment-2495378045
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with(
@@ -96,7 +97,7 @@ return [
                 return $content;
             }
 
-            // comment out
+
             return str_replace(
                 'abstract class AbstractRector extends NodeVisitorAbstract implements RectorInterface',
                 'abstract class AbstractRector extends \Rector\Rector\CommunityNodeVisitorAbstract implements RectorInterface',

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -102,8 +102,6 @@ CODE_SAMPLE;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
     }
 
-
-
     /**
      * @return Node[]|null
      */

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -102,6 +102,8 @@ CODE_SAMPLE;
         $this->changedNodeScopeRefresher = $changedNodeScopeRefresher;
     }
 
+
+
     /**
      * @return Node[]|null
      */

--- a/src/Rector/CommunityNodeVisitorAbstract.php
+++ b/src/Rector/CommunityNodeVisitorAbstract.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Rector;
+
+use PhpParser\NodeVisitorAbstract;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+// used for inject to community rule
+// to avoid error when using #[\Override]
+abstract class CommunityNodeVisitorAbstract extends NodeVisitorAbstract
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
+    }
+}


### PR DESCRIPTION
@TomasVotruba this is what I mean.

On rector-src code base, the `AbstractRector` still enforce to have `getRuleDefinition()` method, but not for community, but still have empty method for it.

This PR add `CommunityNodeVisitorAbstract` to be extended from `AbstractRector` on scoping process, to avoid issue like what @ruudk have at https://github.com/rectorphp/rector/issues/8815#issuecomment-2495378045