### PR TITLE
[Scoper] Remove implements DocumentedRuleInterface on RectorInterface on scoper process

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -73,7 +73,7 @@ return [
 
         // make external rules easier to write without enforing getRuleDefinition()
         // as they are not designed for open-sourcing
-        // remove is the safest way to avoid error on conflict with real dependency of symplify/rule-doc-generator
+        // remove implements is the safest way to avoid error on conflict with real dependency of symplify/rule-doc-generator
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with(
                 $filePath,

--- a/scoper.php
+++ b/scoper.php
@@ -85,7 +85,7 @@ return [
             return str_replace('public function getRuleDefinition', '// public function getRuleDefinition', $content);
         },
 
-        // avoid error to on conflict with real dependency of symplify/rule-doc-generator
+        // avoid error on conflict with real dependency of symplify/rule-doc-generator
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with(
                 $filePath,

--- a/scoper.php
+++ b/scoper.php
@@ -73,19 +73,7 @@ return [
 
         // make external rules easier to write without enforing getRuleDefinition()
         // as they are not designed for open-sourcing
-        static function (string $filePath, string $prefix, string $content): string {
-            if (! \str_ends_with(
-                $filePath,
-                'vendor/symplify/rule-doc-generator-contracts/src/Contract/DocumentedRuleInterface.php'
-            )) {
-                return $content;
-            }
-
-            // comment out
-            return str_replace('public function getRuleDefinition', '// public function getRuleDefinition', $content);
-        },
-
-        // avoid error on conflict with real dependency of symplify/rule-doc-generator
+        // remove is the safest way to avoid error on conflict with real dependency of symplify/rule-doc-generator
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with(
                 $filePath,

--- a/scoper.php
+++ b/scoper.php
@@ -85,6 +85,23 @@ return [
             return str_replace('public function getRuleDefinition', '// public function getRuleDefinition', $content);
         },
 
+        // avoid error to on conflict with real dependency of symplify/rule-doc-generator
+        static function (string $filePath, string $prefix, string $content): string {
+            if (! \str_ends_with(
+                $filePath,
+                'src/Contract/Rector/RectorInterface.php'
+            )) {
+                return $content;
+            }
+
+            // remove DocumentedRuleInterface implements
+            return str_replace(
+                'interface RectorInterface extends NodeVisitor, DocumentedRuleInterface',
+                'interface RectorInterface extends NodeVisitor',
+                $content
+            );
+        },
+
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'src/Application/VersionResolver.php')) {
                 return $content;


### PR DESCRIPTION
@TomasVotruba per discussion with @ruudk  at https://github.com/rectorphp/rector-src/pull/6476#issuecomment-2495398218

this PR remove `DocumentedRuleInterface` to avoid conflict with implementing for real dependency of `symplify/rule-doc-generator`