### PR TITLE
Use Type->getIterableValueType() over ArrayType->getItemType()

### DIFF
--- a/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/CompactToVariablesRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($firstValueStaticType->getItemType() instanceof MixedType) {
+        if ($firstValueStaticType->getIterableValueType() instanceof MixedType) {
             return null;
         }
 

--- a/rules/Naming/Naming/ExpectedNameResolver.php
+++ b/rules/Naming/Naming/ExpectedNameResolver.php
@@ -205,11 +205,11 @@ final readonly class ExpectedNameResolver
 
     private function resolveReturnTypeFromArrayType(ArrayType $arrayType): ?Type
     {
-        if (! $arrayType->getItemType() instanceof ObjectType) {
+        if (! $arrayType->getIterableValueType() instanceof ObjectType) {
             return null;
         }
 
-        return $arrayType->getItemType();
+        return $arrayType->getIterableValueType();
     }
 
     /**

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -190,7 +190,7 @@ CODE_SAMPLE
             return;
         }
 
-        $itemType = $arrayType->getItemType();
+        $itemType = $arrayType->getIterableValueType();
         if ($itemType instanceof IntersectionType) {
             $narrowArrayType = $arrayType;
         } else {
@@ -268,7 +268,7 @@ CODE_SAMPLE
     private function shouldAddReturnArrayDocType(ArrayType|ConstantArrayType $arrayType): bool
     {
         if ($arrayType instanceof ConstantArrayType) {
-            if ($arrayType->getItemType() instanceof NeverType) {
+            if ($arrayType->getIterableValueType() instanceof NeverType) {
                 return false;
             }
 

--- a/rules/TypeDeclaration/TypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeNormalizer.php
@@ -52,14 +52,14 @@ final class TypeNormalizer
             $this->collectedNestedArrayTypes = [];
         }
 
-        if ($type->getItemType() instanceof ArrayType) {
+        if ($type->getIterableValueType() instanceof ArrayType) {
             ++$arrayNesting;
-            $this->normalizeArrayOfUnionToUnionArray($type->getItemType(), $arrayNesting);
-        } elseif ($type->getItemType() instanceof UnionType) {
-            $this->collectNestedArrayTypeFromUnionType($type->getItemType(), $arrayNesting);
+            $this->normalizeArrayOfUnionToUnionArray($type->getIterableValueType(), $arrayNesting);
+        } elseif ($type->getIterableValueType() instanceof UnionType) {
+            $this->collectNestedArrayTypeFromUnionType($type->getIterableValueType(), $arrayNesting);
         } else {
             $this->collectedNestedArrayTypes[] = new NestedArrayType(
-                $type->getItemType(),
+                $type->getIterableValueType(),
                 $arrayNesting,
                 $type->getKeyType()
             );
@@ -95,7 +95,7 @@ final class TypeNormalizer
 
     private function isConstantArrayNever(Type $type): bool
     {
-        return $type instanceof ConstantArrayType && $type->getKeyType() instanceof NeverType && $type->getItemType() instanceof NeverType;
+        return $type instanceof ConstantArrayType && $type->getKeyType() instanceof NeverType && $type->getIterableValueType() instanceof NeverType;
     }
 
     private function collectNestedArrayTypeFromUnionType(UnionType $unionType, int $arrayNesting): void

--- a/src/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/src/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -71,7 +71,7 @@ final readonly class PhpDocTypeChanger
         }
 
         // prevent existing type override by mixed
-        if (! $phpDocInfo->getVarType() instanceof MixedType && $newType instanceof ConstantArrayType && $newType->getItemType() instanceof NeverType) {
+        if (! $phpDocInfo->getVarType() instanceof MixedType && $newType instanceof ConstantArrayType && $newType->getIterableValueType() instanceof NeverType) {
             return;
         }
 

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -347,7 +347,7 @@ final class NodeTypeResolver
         Type $originalNativeType
     ): Type {
         $nativeVariableType = $scope->getNativeType($arrayDimFetch->var);
-        if ($nativeVariableType instanceof MixedType || ($nativeVariableType instanceof ArrayType && $nativeVariableType->getItemType() instanceof MixedType)) {
+        if ($nativeVariableType instanceof MixedType || ($nativeVariableType instanceof ArrayType && $nativeVariableType->getIterableValueType() instanceof MixedType)) {
             return $originalNativeType;
         }
 

--- a/src/NodeTypeResolver/PHPStan/Type/StaticTypeAnalyzer.php
+++ b/src/NodeTypeResolver/PHPStan/Type/StaticTypeAnalyzer.php
@@ -71,7 +71,7 @@ final readonly class StaticTypeAnalyzer
 
     private function isAlwaysTruableArrayType(ArrayType $arrayType): bool
     {
-        $itemType = $arrayType->getItemType();
+        $itemType = $arrayType->getIterableValueType();
         if (! $itemType instanceof ConstantScalarType) {
             return false;
         }

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -211,7 +211,7 @@ final readonly class TypeFactory
         $unwrappedTypes = [];
 
         $flattenKeyTypes = TypeUtils::flattenTypes($constantArrayType->getKeyType());
-        $flattenItemTypes = TypeUtils::flattenTypes($constantArrayType->getItemType());
+        $flattenItemTypes = TypeUtils::flattenTypes($constantArrayType->getIterableValueType());
 
         foreach ($flattenItemTypes as $position => $nestedFlattenItemType) {
             $nestedFlattenKeyType = $flattenKeyTypes[$position] ?? null;

--- a/src/NodeTypeResolver/PHPStan/TypeHasher.php
+++ b/src/NodeTypeResolver/PHPStan/TypeHasher.php
@@ -30,7 +30,7 @@ final class TypeHasher
         }
 
         if ($type instanceof ArrayType) {
-            return $this->createTypeHash($type->getItemType()) . $this->createTypeHash($type->getKeyType()) . '[]';
+            return $this->createTypeHash($type->getIterableValueType()) . $this->createTypeHash($type->getKeyType()) . '[]';
         }
 
         if ($type instanceof GenericObjectType) {

--- a/src/NodeTypeResolver/TypeComparator/ArrayTypeComparator.php
+++ b/src/NodeTypeResolver/TypeComparator/ArrayTypeComparator.php
@@ -27,8 +27,8 @@ final readonly class ArrayTypeComparator
             return true;
         }
 
-        $checkedItemType = $checkedType->getItemType();
-        $mainItemType = $mainType->getItemType();
+        $checkedItemType = $checkedType->getIterableValueType();
+        $mainItemType = $mainType->getIterableValueType();
 
         return $checkedItemType->isSuperTypeOf($mainItemType)
             ->yes();

--- a/src/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/src/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -169,8 +169,8 @@ final readonly class TypeComparator
             return false;
         }
 
-        $firstArrayItemType = $firstType->getItemType();
-        $secondArrayItemType = $secondType->getItemType();
+        $firstArrayItemType = $firstType->getIterableValueType();
+        $secondArrayItemType = $secondType->getIterableValueType();
 
         return $this->isMutualObjectSubtypes($firstArrayItemType, $secondArrayItemType);
     }

--- a/src/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapper.php
@@ -64,7 +64,7 @@ final class ArrayTypeMapper implements TypeMapperInterface
     {
         // this cannot be handled by PHPStan $type->toPhpDocNode() as requires space removal around "|" in union type
         // then e.g. "int" instead of explicit number, and nice arrays
-        $itemType = $type->getItemType();
+        $itemType = $type->getIterableValueType();
 
         $isGenericArray = $this->isGenericArrayCandidate($type);
 
@@ -152,7 +152,7 @@ final class ArrayTypeMapper implements TypeMapperInterface
 
     private function createGenericArrayType(ArrayType $arrayType, bool $withKey = false): GenericTypeNode
     {
-        $itemType = $arrayType->getItemType();
+        $itemType = $arrayType->getIterableValueType();
         $itemTypeNode = $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($itemType);
         $identifierTypeNode = new IdentifierTypeNode('array');
 
@@ -205,7 +205,7 @@ final class ArrayTypeMapper implements TypeMapperInterface
             return false;
         }
 
-        return ! $arrayType->getItemType()
+        return ! $arrayType->getIterableValueType()
             ->isArray()
             ->yes();
     }
@@ -213,11 +213,11 @@ final class ArrayTypeMapper implements TypeMapperInterface
     private function isClassStringArrayType(ArrayType $arrayType): bool
     {
         if ($arrayType->getKeyType() instanceof MixedType) {
-            return $arrayType->getItemType() instanceof GenericClassStringType;
+            return $arrayType->getIterableValueType() instanceof GenericClassStringType;
         }
 
         if ($arrayType->getKeyType() instanceof ConstantIntegerType) {
-            return $arrayType->getItemType() instanceof GenericClassStringType;
+            return $arrayType->getIterableValueType() instanceof GenericClassStringType;
         }
 
         return false;


### PR DESCRIPTION
less risky first step which does not involve changing `instanceof *Type` checks.

relying on `Type`-interface will ease using `Type` instead of deprecated `instanceof *Type` conditions