### PR TITLE
[Strict] Using in_array() on CallLike instead of multiple calls on Strict Rules (part 2)

### DIFF
--- a/rules/Strict/NodeFactory/ExactCompareFactory.php
+++ b/rules/Strict/NodeFactory/ExactCompareFactory.php
@@ -70,6 +70,23 @@ final readonly class ExactCompareFactory
             ]);
         }
 
+        if ($result instanceof BooleanOr
+            && $expr instanceof CallLike
+            && $result->left instanceof BooleanOr
+            && $result->left->left instanceof Identical
+            && $result->left->right instanceof Identical
+            && $result->right instanceof Identical) {
+            return new FuncCall(new Name('in_array'), [
+                new Arg($expr),
+                new Arg(new Array_([
+                    new ArrayItem($result->left->left->right),
+                    new ArrayItem($result->left->right->right),
+                    new ArrayItem($result->right->right)
+                ])),
+                new Arg(new ConstFetch(new Name('true'))),
+            ]);
+        }
+
         return $result;
     }
 
@@ -104,6 +121,23 @@ final readonly class ExactCompareFactory
             return new BooleanNot(new FuncCall(new Name('in_array'), [
                 new Arg($expr),
                 new Arg(new Array_([new ArrayItem($result->left->right), new ArrayItem($result->right->right)])),
+                new Arg(new ConstFetch(new Name('true'))),
+            ]));
+        }
+
+        if ($result instanceof BooleanAnd
+            && $expr instanceof CallLike
+            && $result->left instanceof BooleanAnd
+            && $result->left->left instanceof NotIdentical
+            && $result->left->right instanceof NotIdentical
+            && $result->right instanceof NotIdentical) {
+            return new BooleanNot(new FuncCall(new Name('in_array'), [
+                new Arg($expr),
+                new Arg(new Array_([
+                    new ArrayItem($result->left->left->right),
+                    new ArrayItem($result->left->right->right),
+                    new ArrayItem($result->right->right)
+                ])),
                 new Arg(new ConstFetch(new Name('true'))),
             ]));
         }

--- a/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
+++ b/tests/Issues/SimplifyEmpty/Fixture/fixture.php.inc
@@ -54,7 +54,7 @@ class Fixture {
 
     public function check(): bool
     {
-        return $this->getString() !== null && $this->getString() !== '' && $this->getString() !== '0' && !(($this->getString2() === null || $this->getString2() === '' || $this->getString2() === '0') && !is_numeric($this->getString2()));
+        return !in_array($this->getString(), [null, '', '0'], true) && !(in_array($this->getString2(), [null, '', '0'], true) && !is_numeric($this->getString2()));
     }
 }
 


### PR DESCRIPTION
@etshy @rtm-ctrlz this is continuation of PR:

- https://github.com/rectorphp/rector-src/pull/6388

which previously only handle 2 condition, this PR handle 3 condition which mostly cover on strictly rules on empty condition, eg: `null`, `''`, and `'0'` for using `empty()` on `?string`.

to avoid double call on apply strict comparison on call like to avoid calling function/method more than once during compare.

On this PR, on multiple conditions.