### PR TITLE
[Printer] Use NewLineSplitter on BetterStandardPrinter for heredoc/nowdoc removal space

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -325,7 +325,7 @@ final class BetterStandardPrinter extends Standard
             $lines = NewLineSplitter::split($content);
             $trimmedLines = array_map('ltrim', $lines);
 
-            return implode(PHP_EOL, $trimmedLines);
+            return implode("\n", $trimmedLines);
         }
 
         $isRegularPattern = (bool) $string->getAttribute(AttributeKey::IS_REGULAR_PATTERN, false);
@@ -371,7 +371,7 @@ final class BetterStandardPrinter extends Standard
         $content = parent::pScalar_InterpolatedString($interpolatedString);
 
         if ($interpolatedString->getAttribute(AttributeKey::DOC_INDENTATION) === '__REMOVED__') {
-            $lines = explode("\n", $content);
+            $lines = NewLineSplitter::split($content);
             $trimmedLines = array_map('ltrim', $lines);
 
             return implode("\n", $trimmedLines);

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -29,6 +29,7 @@ use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\Util\NewLineSplitter;
 
 /**
  * @see \Rector\Tests\PhpParser\Printer\BetterStandardPrinterTest
@@ -321,10 +322,10 @@ final class BetterStandardPrinter extends Standard
         if ($string->getAttribute(AttributeKey::DOC_INDENTATION) === '__REMOVED__') {
             $content = parent::pScalar_String($string);
 
-            $lines = explode("\n", $content);
+            $lines = NewLineSplitter::split($content);
             $trimmedLines = array_map('ltrim', $lines);
 
-            return implode("\n", $trimmedLines);
+            return implode(PHP_EOL, $trimmedLines);
         }
 
         $isRegularPattern = (bool) $string->getAttribute(AttributeKey::IS_REGULAR_PATTERN, false);


### PR DESCRIPTION
Using `"\n"` vs allow "\r\n" depends on exists have different result:

```
hp > $content = "foo \r\n Bar \r\n Baz"; var_dump(explode("\n", $content));
array(3) {
  [0]=>
" string(5) "foo 
  [1]=>
" string(6) " Bar 
  [2]=>
  string(4) " Baz"
}
php > $content = "foo \r\n Bar \r\n Baz"; var_dump(explode("\r\n", $content));
array(3) {
  [0]=>
  string(4) "foo "
  [1]=>
  string(5) " Bar "
  [2]=>
  string(4) " Baz"
}
```

The `NewLineSplitter` cover it for windows usage.