### PR TITLE
[Printer] Remove no longer needed pSingleQuotedString method on BetterStandardPrinter

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -39,12 +39,6 @@ use Rector\Util\NewLineSplitter;
 final class BetterStandardPrinter extends Standard
 {
     /**
-     * @var string
-     * @see https://regex101.com/r/DrsMY4/1
-     */
-    private const QUOTED_SLASH_REGEX = "#'|\\\\(?=[\\\\']|$)#";
-
-    /**
      * Remove extra spaces before new Nop_ nodes
      * @see https://regex101.com/r/iSvroO/1
      * @var string
@@ -244,20 +238,6 @@ final class BetterStandardPrinter extends Standard
         }
 
         return Strings::replace($content, self::EXTRA_SPACE_BEFORE_NOP_REGEX);
-    }
-
-    /**
-     * Do not preslash all slashes (parent behavior), but only those:
-     *
-     * - followed by "\"
-     * - by "'"
-     * - or the end of the string
-     *
-     * Prevents `Vendor\Class` => `Vendor\\Class`.
-     */
-    protected function pSingleQuotedString(string $string): string
-    {
-        return "'" . Strings::replace($string, self::QUOTED_SLASH_REGEX, '\\\\$0') . "'";
     }
 
     /**


### PR DESCRIPTION
The method is no longer needed, the test for it already exists at 

https://github.com/rectorphp/rector-src/blob/ef191b00b29ed33a35d83758f3a6a4f728cdc368/tests/PhpParser/Printer/BetterStandardPrinterTest.php#L57-L72