### PR TITLE
Update developing with docker: Fix php version to 8.2.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,13 +56,16 @@ above commands in a docker container:
 
 ```bash
 # Build the docker image
-docker compose build
+docker compose build --pull
+
+# Install dependencies
+docker compose run --rm php composer install
 
 # Run the entire CI suite
-docker compose run php composer complete-check
+docker compose run --rm php composer complete-check
 
 # Fix the coding standards
-docker compose run php composer fix-cs
+docker compose run --rm php composer fix-cs
 ```
 
 ## TroubleShooting

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-cli-alpine
+FROM php:8.2-cli-alpine
 
 WORKDIR /etc/rector
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   php:
     build: .

--- a/rules/Strict/NodeFactory/ExactCompareFactory.php
+++ b/rules/Strict/NodeFactory/ExactCompareFactory.php
@@ -81,7 +81,7 @@ final readonly class ExactCompareFactory
                 new Arg(new Array_([
                     new ArrayItem($result->left->left->right),
                     new ArrayItem($result->left->right->right),
-                    new ArrayItem($result->right->right)
+                    new ArrayItem($result->right->right),
                 ])),
                 new Arg(new ConstFetch(new Name('true'))),
             ]);
@@ -136,7 +136,7 @@ final readonly class ExactCompareFactory
                 new Arg(new Array_([
                     new ArrayItem($result->left->left->right),
                     new ArrayItem($result->left->right->right),
-                    new ArrayItem($result->right->right)
+                    new ArrayItem($result->right->right),
                 ])),
                 new Arg(new ConstFetch(new Name('true'))),
             ]));

--- a/scoper.php
+++ b/scoper.php
@@ -75,10 +75,7 @@ return [
         // as they are not designed for open-sourcing
         // remove implements is the safest way to avoid error on conflict with real dependency of symplify/rule-doc-generator
         static function (string $filePath, string $prefix, string $content): string {
-            if (! \str_ends_with(
-                $filePath,
-                'src/Contract/Rector/RectorInterface.php'
-            )) {
+            if (! \str_ends_with($filePath, 'src/Contract/Rector/RectorInterface.php')) {
                 return $content;
             }
 

--- a/src/NodeTypeResolver/PHPStan/TypeHasher.php
+++ b/src/NodeTypeResolver/PHPStan/TypeHasher.php
@@ -30,7 +30,9 @@ final class TypeHasher
         }
 
         if ($type instanceof ArrayType) {
-            return $this->createTypeHash($type->getIterableValueType()) . $this->createTypeHash($type->getIterableKeyType()) . '[]';
+            return $this->createTypeHash($type->getIterableValueType()) . $this->createTypeHash(
+                $type->getIterableKeyType()
+            ) . '[]';
         }
 
         if ($type instanceof GenericObjectType) {


### PR DESCRIPTION
- With PHP 8.2 being the development environment, I've set the Dockerfile to reflect that version. Otherwise we'd already get 8.4.
- I've removed the deprecated `version` key from the `docker-compose.yml`
- The other changes came from a run of `docker compose run --rm php composer fix-cs` - curious why the main branch had those dirty bits.