### PR TITLE
[CodeQuality] Fix aliased object type on FlipTypeControlToUseExclusiveTypeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector/Fixture/nullable_type_aliased.php.inc
+++ b/rules-tests/CodeQuality/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector/Fixture/nullable_type_aliased.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector\Fixture;
+
+use PhpParser\Node\Scalar\Int_ as SomeInt;
+
+class NullableTypeAliased
+{
+    public function run()
+    {
+        $intNode = $this->getIntNode();
+        if ($intNode === null) {
+            return;
+        }
+    }
+
+    private function getIntNode(): ?SomeInt
+    {
+        if (rand(0, 1)) {
+            return new SomeInt(1);
+        }
+
+        return null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector\Fixture;
+
+use PhpParser\Node\Scalar\Int_ as SomeInt;
+
+class NullableTypeAliased
+{
+    public function run()
+    {
+        $intNode = $this->getIntNode();
+        if (!$intNode instanceof \PhpParser\Node\Scalar\Int_) {
+            return;
+        }
+    }
+
+    private function getIntNode(): ?SomeInt
+    {
+        if (rand(0, 1)) {
+            return new SomeInt(1);
+        }
+
+        return null;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
+++ b/rules/CodeQuality/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Type\ObjectType;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\TypeDeclaration\TypeAnalyzer\NullableTypeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -86,7 +87,9 @@ CODE_SAMPLE
         Expr $expr,
         Identical|NotIdentical $binaryOp
     ): BooleanNot|Instanceof_ {
-        $fullyQualifiedType = $objectType instanceof ShortenedObjectType ? $objectType->getFullyQualifiedName() : $objectType->getClassName();
+        $fullyQualifiedType = $objectType instanceof ShortenedObjectType || $objectType instanceof AliasedObjectType
+            ? $objectType->getFullyQualifiedName()
+            : $objectType->getClassName();
 
         $instanceof = new Instanceof_($expr, new FullyQualified($fullyQualifiedType));
         if ($binaryOp instanceof NotIdentical) {

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -31,6 +31,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
+use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 use Rector\ValueObject\MethodName;
 
@@ -142,7 +143,7 @@ final readonly class ReflectionResolver
     {
         $objectType = $this->nodeTypeResolver->getType($staticCall->class);
 
-        if ($objectType instanceof ShortenedObjectType) {
+        if ($objectType instanceof ShortenedObjectType || $objectType instanceof AliasedObjectType) {
             /** @var array<class-string> $classNames */
             $classNames = [$objectType->getFullyQualifiedName()];
         } else {


### PR DESCRIPTION
make consistent with ShortenedObjectType, with usage of `new FullyQualified()`, it should pass its fully qualified name.