### PR TITLE
[PHPStanStaticTypeMapper] Ensure namespaced_name attribute set on Name node when create from ShortenedObjectType or AliasedObjectType

### DIFF
--- a/src/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -71,7 +72,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
         }
 
         if ($type instanceof ShortenedObjectType || $type instanceof AliasedObjectType) {
-            return new Name($type->getClassName());
+            return new Name($type->getClassName(), [AttributeKey::NAMESPACED_NAME => $type->getFullyQualifiedName()]);
         }
 
         if ($type instanceof FullyQualifiedObjectType) {


### PR DESCRIPTION
type by name is used by type detection from Name node, see PRs with include test there:

- https://github.com/rectorphp/rector-src/pull/6237
- https://github.com/rectorphp/rector-src/pull/6284

from Name node, so the namespaced_name attribute needs exists for Name node that created from `ShortenedObjectType` or `AliasedObjectType`