### PR TITLE
[CodeQuality][Renaming] Handle DynamicDocBlockPropertyToNativePropertyRector+RenameClassRector with aliased name

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/aliased_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/aliased_class.php.inc
@@ -26,7 +26,7 @@ use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativeProper
 
 final class AliasedClass
 {
-    private ?SomeSource\SomeDependency $someDependency;
+    private ?\Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency $someDependency;
     public function run(): void
     {
         $this->someDependency = new SomeSource\SomeDependency();

--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/bare_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/bare_class.php.inc
@@ -26,7 +26,7 @@ use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativeProper
 
 final class BareClass
 {
-    private ?SomeDependency $someDependency;
+    private ?\Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency $someDependency;
     public function run(): void
     {
         $this->someDependency = new SomeDependency();

--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/improve_existing_property_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/improve_existing_property_type.php.inc
@@ -31,7 +31,7 @@ use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativeProper
 
 final class ImproveExistingPropertyType extends TestCase
 {
-    private SomeDependency $someDependency;
+    private \Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency $someDependency;
     protected function setUp(): void
     {
         parent::setUp();

--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/include_null.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/include_null.php.inc
@@ -23,7 +23,7 @@ use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativeProper
 
 final class IncludeNull
 {
-    protected ?SomeDependency $someDependency = null;
+    protected ?\Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency $someDependency = null;
 }
 
 ?>

--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/some_test.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/some_test.php.inc
@@ -29,7 +29,7 @@ use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativeProper
 
 final class SomeTest extends TestCase
 {
-    private ?SomeDependency $someDependency;
+    private ?\Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency $someDependency;
     protected function setUp(): void
     {
         parent::setUp();

--- a/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/with_other_existing_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector/Fixture/with_other_existing_attribute.php.inc
@@ -28,7 +28,7 @@ use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativeProper
 #[\OtherAttribute]
 final class WithOtherExistingAttribute
 {
-    private ?SomeDependency $someDependency;
+    private ?\Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency $someDependency;
     public function run(): void
     {
         $this->someDependency = new SomeDependency();

--- a/src/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -13,7 +13,6 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;

--- a/src/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ObjectTypeMapper.php
@@ -72,9 +72,7 @@ final class ObjectTypeMapper implements TypeMapperInterface
         }
 
         if ($type instanceof ShortenedObjectType || $type instanceof AliasedObjectType) {
-            return new Name($type->getClassName(), [
-                AttributeKey::NAMESPACED_NAME => $type->getFullyQualifiedName(),
-            ]);
+            return new FullyQualified($type->getFullyQualifiedName());
         }
 
         if ($type instanceof FullyQualifiedObjectType) {

--- a/tests/Issues/DynamicDocblockRename/DynamicDocblockRenameTest.php
+++ b/tests/Issues/DynamicDocblockRename/DynamicDocblockRenameTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\DynamicDocblockRename;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DynamicDocblockRenameTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DynamicDocblockRename/Fixture/fixture.php.inc
+++ b/tests/Issues/DynamicDocblockRename/Fixture/fixture.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\Issues\DynamicDocblockRename\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source as SomeSource;
+
+/**
+ * @property SomeSource\SomeDependency $someDependency
+ */
+#[\AllowDynamicProperties]
+final class Fixture
+{
+    public function run(): void
+    {
+        $this->someDependency = new SomeSource\SomeDependency();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\DynamicDocblockRename\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source as SomeSource;
+
+final class Fixture
+{
+    private ?\stdClass $someDependency;
+    public function run(): void
+    {
+        $this->someDependency = new \stdClass();
+    }
+}
+
+?>

--- a/tests/Issues/DynamicDocblockRename/config/configured_rule.php
+++ b/tests/Issues/DynamicDocblockRename/config/configured_rule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DynamicDocBlockPropertyToNativePropertyRector::class);
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\Source\SomeDependency'
+                => 'stdClass'
+        ]
+    );
+};


### PR DESCRIPTION
Continue of 

- https://github.com/rectorphp/rector-src/pull/6493

It currently only change assign, but property keep using old before renamed:

```diff
1) Rector\Tests\Issues\DynamicDocblockRename\DynamicDocblockRenameTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "fixture.php.inc"

Applied Rector rules:
 * Rector\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector
 * Rector\Renaming\Rector\Name\RenameClassRector

Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 final class Fixture
 {
-    private ?\stdClass $someDependency;
+    private ?SomeSource\SomeDependency $someDependency;
     public function run(): void
     {
         $this->someDependency = new \stdClass();
```

make always fqcn seems the way to go.