### PR TITLE
[Naming] Clean up unnecessary use of NodeTypeResolver on PropertyNaming

### DIFF
--- a/rules/Naming/Naming/PropertyNaming.php
+++ b/rules/Naming/Naming/PropertyNaming.php
@@ -11,13 +11,10 @@ use PHPStan\Type\StaticType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeWithClassName;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\Naming\RectorNamingInflector;
 use Rector\Naming\ValueObject\ExpectedName;
-use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
-use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\SelfObjectType;
 use Rector\Util\StringUtils;
 
@@ -57,7 +54,6 @@ final readonly class PropertyNaming
 
     public function __construct(
         private RectorNamingInflector $rectorNamingInflector,
-        private NodeTypeResolver $nodeTypeResolver,
     ) {
     }
 
@@ -298,11 +294,6 @@ final readonly class PropertyNaming
             return null;
         }
 
-        if ($type instanceof AliasedObjectType) {
-            return $className;
-        }
-
-        /** @var TypeWithClassName $type */
-        return $this->nodeTypeResolver->getFullyQualifiedClassName($type);
+        return $className;
     }
 }


### PR DESCRIPTION
use class name detected from `ClassNameFromObjectTypeResolver::resolve()`