### PR TITLE
[DeadCode] Skip private dataProvider method on RemoveUnusedPrivateMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_data_provider_method.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_data_provider_method.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SkipDataProviderMethod extends TestCase
+{
+    /**
+     * @dataProvider fooDataProvider
+     */
+    public function testFoo(): void
+    {
+    }
+
+    private function fooDataProvider(): array
+    {
+        return [
+            [],
+        ];
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_data_provider_method2.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/skip_data_provider_method2.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SkipDataProviderMethod2 extends TestCase
+{
+    #[DataProvider('fooDataProvider')]
+    public function testFoo(): void
+    {
+    }
+
+    private function fooDataProvider(): array
+    {
+        return [
+            [],
+        ];
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -10,9 +10,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\DeadCode\NodeAnalyzer\IsClassMethodUsedAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -148,7 +146,7 @@ CODE_SAMPLE
             }
 
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-            if ($phpDocInfo instanceof PhpDocInfo && $phpDocInfo->hasByName('dataProvider')) {
+            if ($phpDocInfo->hasByName('dataProvider')) {
                 $dataProvider = $phpDocInfo->getByName('dataProvider');
                 if ($dataProvider->value instanceof GenericTagValueNode && is_string($dataProvider->value->value)) {
                     $dataProviderMethod = $class->getMethod($dataProvider->value->value);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\DeadCode\NodeAnalyzer\IsClassMethodUsedAnalyzer;
@@ -129,6 +130,7 @@ CODE_SAMPLE
     }
 
     /**
+     * @param ClassMethod[] $classMethods
      * @return string[]
      */
     private function collectTestMethodsUsesPrivateDataProvider(ClassReflection $classReflection, Class_ $class, array $classMethods): array
@@ -148,7 +150,7 @@ CODE_SAMPLE
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
             if ($phpDocInfo->hasByName('dataProvider')) {
                 $dataProvider = $phpDocInfo->getByName('dataProvider');
-                if ($dataProvider->value instanceof GenericTagValueNode && is_string($dataProvider->value->value)) {
+                if ($dataProvider instanceof PhpDocTagNode && $dataProvider->value instanceof GenericTagValueNode) {
                     $dataProviderMethod = $class->getMethod($dataProvider->value->value);
                     if ($dataProviderMethod instanceof ClassMethod && $dataProviderMethod->isPrivate()) {
                         $privateMethods[] = $dataProvider->value->value;

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
         $privateMethods = [];
         foreach ($classMethods as $classMethod) {
             // test method only public, but may use private data provider
-            // so search public methods
+            // so verify @dataProvider and #[\PHPUnit\Framework\Attributes\DataProvider] only on public methods
             if (! $classMethod->isPublic()) {
                 continue;
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -9,9 +9,14 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\DeadCode\NodeAnalyzer\IsClassMethodUsedAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
@@ -28,7 +33,9 @@ final class RemoveUnusedPrivateMethodRector extends AbstractRector
     public function __construct(
         private readonly IsClassMethodUsedAnalyzer $isClassMethodUsedAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -97,6 +104,7 @@ CODE_SAMPLE
 
         $hasChanged = false;
         $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        $collectionTestMethodsUsesPrivateProvider = $this->collectTestMethodsUsesPrivateDataProvider($classReflection, $node, $classMethods);
 
         foreach ($privateMethods as $privateMethod) {
             if ($this->shouldSkip($privateMethod, $classReflection)) {
@@ -104,6 +112,10 @@ CODE_SAMPLE
             }
 
             if ($this->isClassMethodUsedAnalyzer->isClassMethodUsed($node, $privateMethod, $scope)) {
+                continue;
+            }
+
+            if (in_array($this->getName($privateMethod), $collectionTestMethodsUsesPrivateProvider, true)) {
                 continue;
             }
 
@@ -116,6 +128,54 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectTestMethodsUsesPrivateDataProvider(ClassReflection $classReflection, Class_ $class, array $classMethods): array
+    {
+        if (! $classReflection->isSubClassOf('PHPUnit\Framework\TestCase')) {
+            return [];
+        }
+
+        $privateMethods = [];
+        foreach ($classMethods as $classMethod) {
+            // test method only public, but may use private data provider
+            // so search public methods
+            if (! $classMethod->isPublic()) {
+                continue;
+            }
+
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
+            if ($phpDocInfo instanceof PhpDocInfo && $phpDocInfo->hasByName('dataProvider')) {
+                $dataProvider = $phpDocInfo->getByName('dataProvider');
+                if ($dataProvider->value instanceof GenericTagValueNode && is_string($dataProvider->value->value)) {
+                    $dataProviderMethod = $class->getMethod($dataProvider->value->value);
+                    if ($dataProviderMethod instanceof ClassMethod && $dataProviderMethod->isPrivate()) {
+                        $privateMethods[] = $dataProvider->value->value;
+                    }
+                }
+            }
+
+            if ($this->phpAttributeAnalyzer->hasPhpAttribute($classMethod, 'PHPUnit\Framework\Attributes\DataProvider')) {
+                foreach ($classMethod->attrGroups as $attrGroup) {
+                    foreach ($attrGroup->attrs as $attr) {
+                        if ($attr->name->toString() === 'PHPUnit\Framework\Attributes\DataProvider') {
+                            $argValue = $attr->args[0]->value->value ?? '';
+                            if (is_string($argValue)) {
+                                $dataProviderMethod = $class->getMethod($argValue);
+                                if ($dataProviderMethod instanceof ClassMethod && $dataProviderMethod->isPrivate()) {
+                                    $privateMethods[] = $argValue;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $privateMethods;
     }
 
     private function shouldSkip(ClassMethod $classMethod, ?ClassReflection $classReflection): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8910