### PR TITLE
Use createFromNode() from PhpDocInfoFactory on RemoveUnusedPrivateMethodRector

### DIFF
--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -155,7 +155,6 @@ CODE_SAMPLE
                     $dataProviderMethod = $class->getMethod($dataProvider->value->value);
                     if ($dataProviderMethod instanceof ClassMethod && $dataProviderMethod->isPrivate()) {
                         $privateMethods[] = $dataProvider->value->value;
-                        continue;
                     }
                 }
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\DeadCode\NodeAnalyzer\IsClassMethodUsedAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -147,13 +148,14 @@ CODE_SAMPLE
                 continue;
             }
 
-            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-            if ($phpDocInfo->hasByName('dataProvider')) {
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNode($classMethod);
+            if ($phpDocInfo instanceof PhpDocInfo && $phpDocInfo->hasByName('dataProvider')) {
                 $dataProvider = $phpDocInfo->getByName('dataProvider');
                 if ($dataProvider instanceof PhpDocTagNode && $dataProvider->value instanceof GenericTagValueNode) {
                     $dataProviderMethod = $class->getMethod($dataProvider->value->value);
                     if ($dataProviderMethod instanceof ClassMethod && $dataProviderMethod->isPrivate()) {
                         $privateMethods[] = $dataProvider->value->value;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
avoid set empty php doc info node attribute when not needed.