### PR TITLE
[Php83] Remove get traits class as ancestors collection on AddOverrideAttributeToOverriddenMethodsRector

### DIFF
--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -124,8 +124,8 @@ CODE_SAMPLE
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
+        $parentClassReflections = $classReflection->getParents();
 
-        $parentClassReflections = array_merge($classReflection->getParents(), $classReflection->getTraits());
         if ($parentClassReflections === []) {
             return null;
         }
@@ -213,11 +213,6 @@ CODE_SAMPLE
 
         $parentClassMethod = $parentClass->getMethod($classMethod->name->toString());
         if (! $parentClassMethod instanceof ClassMethod) {
-            return true;
-        }
-
-        // non-abstract trait can't have #[\Override]
-        if ($parentClassReflection->isTrait() && ! $parentClassMethod->isAbstract()) {
             return true;
         }
 


### PR DESCRIPTION
continue of PR:

- https://github.com/rectorphp/rector-src/pull/6512

since we skip override only trait anyway, we can just remove it from ancestors collection, so only parent classes.

```diff
-$parentClassReflections = array_merge($classReflection->getParents(), $classReflection->getTraits());
+$parentClassReflections = $classReflection->getParents();
```

as add `#[\Override]` on non-empty trait is not-allowed, which must rely on parent class method which not empty first to allow add it.