### PR TITLE
[TypeDeclaration] Skip with default value and assigned mixed on TypedPropertyFromAssignsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_default_type_mixed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/skip_default_type_mixed.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture;
+
+final class SkipDefaultTypeMixed
+{
+    private $property = true;
+
+    public function run($prop)
+    {
+        $this->property = $prop;
+    }
+}

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromJMSSerializerAttributeTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromJMSSerializerAttributeTypeRector.php
@@ -25,6 +25,7 @@ use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\Mapper\ScalarStringToTypeMapper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
+use Rector\TypeDeclaration\TypeInferer\AssignToPropertyTypeInferer;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer\AllAssignNodePropertyTypeInferer;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -36,11 +37,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class TypedPropertyFromJMSSerializerAttributeTypeRector extends AbstractRector implements MinPhpVersionInterface
 {
-    /**
-     * @var string
-     */
-    private const JMS_TYPE = 'JMS\Serializer\Annotation\Type';
-
     public function __construct(
         private readonly AllAssignNodePropertyTypeInferer $allAssignNodePropertyTypeInferer,
         private readonly MakePropertyTypedGuard $makePropertyTypedGuard,
@@ -107,7 +103,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $this->phpAttributeAnalyzer->hasPhpAttribute($property, self::JMS_TYPE)) {
+            if (! $this->phpAttributeAnalyzer->hasPhpAttribute($property, AssignToPropertyTypeInferer::JMS_TYPE)) {
                 continue;
             }
 
@@ -140,7 +136,7 @@ CODE_SAMPLE
             $typeValue = null;
             foreach ($property->attrGroups as $attrGroup) {
                 foreach ($attrGroup->attrs as $attr) {
-                    if ($attr->name->toString() === self::JMS_TYPE) {
+                    if ($attr->name->toString() === AssignToPropertyTypeInferer::JMS_TYPE) {
                         $typeValue = $this->valueResolver->getValue($attr->args[0]->value);
                         break;
                     }

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -198,7 +198,7 @@ final readonly class AssignToPropertyTypeInferer
             }
 
             if ($this->exprAnalyzer->isNonTypedFromParam($node->expr)) {
-                $assignedExprTypes = [];
+                $assignedExprTypes[] = new MixedType();
                 return NodeVisitor::STOP_TRAVERSAL;
             }
 

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -22,6 +22,7 @@ use Rector\NodeAnalyzer\ExprAnalyzer;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
@@ -34,6 +35,11 @@ use Rector\TypeDeclaration\Matcher\PropertyAssignMatcher;
  */
 final readonly class AssignToPropertyTypeInferer
 {
+    /**
+     * @var string
+     */
+    public const JMS_TYPE = 'JMS\Serializer\Annotation\Type';
+
     public function __construct(
         private ConstructorAssignDetector $constructorAssignDetector,
         private PropertyAssignMatcher $propertyAssignMatcher,
@@ -45,6 +51,7 @@ final readonly class AssignToPropertyTypeInferer
         private ExprAnalyzer $exprAnalyzer,
         private ValueResolver $valueResolver,
         private PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -54,7 +61,7 @@ final readonly class AssignToPropertyTypeInferer
             return null;
         }
 
-        $assignedExprTypes = $this->getAssignedExprTypes($classLike, $propertyName);
+        $assignedExprTypes = $this->getAssignedExprTypes($classLike, $property, $propertyName);
 
         if ($this->shouldAddNullType($classLike, $propertyName, $assignedExprTypes)) {
             $assignedExprTypes[] = new NullType();
@@ -180,13 +187,15 @@ final readonly class AssignToPropertyTypeInferer
     /**
      * @return array<Type>
      */
-    private function getAssignedExprTypes(ClassLike $classLike, string $propertyName): array
+    private function getAssignedExprTypes(ClassLike $classLike, Property $property, string $propertyName): array
     {
         $assignedExprTypes = [];
 
+        $hasJmsType = $this->phpAttributeAnalyzer->hasPhpAttribute($property, self::JMS_TYPE);
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($classLike->stmts, function (Node $node) use (
             $propertyName,
             &$assignedExprTypes,
+            $hasJmsType
         ): ?int {
             if (! $node instanceof Assign) {
                 return null;
@@ -198,7 +207,10 @@ final readonly class AssignToPropertyTypeInferer
             }
 
             if ($this->exprAnalyzer->isNonTypedFromParam($node->expr)) {
-                $assignedExprTypes[] = new MixedType();
+                $assignedExprTypes = $hasJmsType
+                    ? []
+                    : [new MixedType()];
+
                 return NodeVisitor::STOP_TRAVERSAL;
             }
 


### PR DESCRIPTION
The following code should be skipped, as assign mixed can be anything:

```php
final class SkipDefaultTypeMixed
{
    private $property = true;

    public function run($prop)
    {
        $this->property = $prop;
    }
}
```