### PR TITLE
Add `withSetProviders` method

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -23,6 +23,7 @@ use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Exception\Configuration\InvalidConfigurationException;
 use Rector\Php\PhpVersionResolver\ComposerJsonPhpVersionResolver;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
 use Rector\Set\SetManager;
 use Rector\Set\ValueObject\DowngradeLevelSetList;
@@ -165,10 +166,22 @@ final class RectorConfigBuilder
 
     private ?bool $isWithPhpLevelUsed = null;
 
+    /**
+     * @var array<class-string<SetProviderInterface>>
+     */
+    private array $setProviders = [];
+
     public function __invoke(RectorConfig $rectorConfig): void
     {
-        if ($this->setGroups !== []) {
-            $setManager = new SetManager(new SetProviderCollector(), new InstalledPackageResolver(getcwd()));
+        if ($this->setGroups !== [] || $this->setProviders !== []) {
+            $setProviderCollector = new SetProviderCollector(array_map(
+                static fn (string $setProvider): SetProviderInterface =>
+                $rectorConfig->make($setProvider),
+                $this->setProviders
+            ));
+
+            $setManager = new SetManager($setProviderCollector, new InstalledPackageResolver(getcwd()));
+
             $this->groupLoadedSets = $setManager->matchBySetGroups($this->setGroups);
 
             SimpleParameterProvider::addParameter(Option::COMPOSER_BASED_SETS, $this->groupLoadedSets);
@@ -1093,6 +1106,26 @@ final class RectorConfigBuilder
     public function withEditorUrl(string $editorUrl): self
     {
         $this->editorUrl = $editorUrl;
+
+        return $this;
+    }
+
+    /**
+     * @param class-string<SetProviderInterface> ...$setProviders
+     */
+    public function withSetProviders(string ...$setProviders): self
+    {
+        foreach ($setProviders as $setProvider) {
+            if (! is_a($setProvider, SetProviderInterface::class, true)) {
+                throw new InvalidConfigurationException(sprintf(
+                    'Set provider "%s" must implement "%s"',
+                    $setProvider,
+                    SetProviderInterface::class
+                ));
+            }
+
+            $this->setProviders[] = $setProvider;
+        }
 
         return $this;
     }

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -167,7 +167,7 @@ final class RectorConfigBuilder
     private ?bool $isWithPhpLevelUsed = null;
 
     /**
-     * @var array<class-string<SetProviderInterface>>
+     * @var array<class-string<SetProviderInterface>,bool>
      */
     private array $setProviders = [];
 
@@ -177,7 +177,7 @@ final class RectorConfigBuilder
             $setProviderCollector = new SetProviderCollector(array_map(
                 static fn (string $setProvider): SetProviderInterface =>
                 $rectorConfig->make($setProvider),
-                $this->setProviders
+                \array_keys($this->setProviders)
             ));
 
             $setManager = new SetManager($setProviderCollector, new InstalledPackageResolver(getcwd()));
@@ -1116,6 +1116,10 @@ final class RectorConfigBuilder
     public function withSetProviders(string ...$setProviders): self
     {
         foreach ($setProviders as $setProvider) {
+            if (\array_key_exists($setProvider, $this->setProviders)) {
+                continue;
+            }
+
             if (! is_a($setProvider, SetProviderInterface::class, true)) {
                 throw new InvalidConfigurationException(sprintf(
                     'Set provider "%s" must implement "%s"',
@@ -1124,7 +1128,7 @@ final class RectorConfigBuilder
                 ));
             }
 
-            $this->setProviders[] = $setProvider;
+            $this->setProviders[$setProvider] = true;
         }
 
         return $this;


### PR DESCRIPTION
This patch resolves https://github.com/rectorphp/rector/issues/8720#issuecomment-2211808609, via the following changes:

- Add a new `withSetProviders` method, to add set provider class names to the `setProviders` array, including validation to ensure they implement the `SetProviderInterface`.

- Modified the `__invoke` method to handle both `setGroups` and `setProviders` when creating a `SetManager` instance.

```php
<?php

declare(strict_types=1);

use Vendor\Package\RectorSetProvider;
use Vendor\Package\ComposerSetProvider;
use Rector\Config\RectorConfig;

return RectorConfig::configure()
           ->withSetProviders(
               RectorSetProvider::class,
               ComposerSetProvider::class
           );
```

Note: I haven't added tests, but this can serve as a starting point, if you like the idea.