### PR TITLE
[Php70] Do not replace if method call if method exists in current class on call same method with parent on Php4ConstructorRector

### DIFF
--- a/rules-tests/Php70/Rector/ClassMethod/Php4ConstructorRector/Fixture/method_call_method_exists.php.inc
+++ b/rules-tests/Php70/Rector/ClassMethod/Php4ConstructorRector/Fixture/method_call_method_exists.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+class SomeParentA2
+{
+	public function SomeParentA2()
+    {
+    }
+}
+
+final class SomeChildB2 extends SomeParentA2
+{
+    public function SomeChildB2() {
+        $this->SomeParentA2();
+    }
+
+    public function SomeParentA2()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+class SomeParentA2
+{
+	public function __construct()
+    {
+    }
+}
+
+final class SomeChildB2 extends SomeParentA2
+{
+    public function __construct() {
+        $this->SomeParentA2();
+    }
+
+    public function SomeParentA2()
+    {
+    }
+}
+
+?>

--- a/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
+++ b/rules/Php70/Rector/ClassMethod/Php4ConstructorRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
                 unset($node->stmts[$stmtKey]);
             }
 
-            if ($this->isLocalMethodCallNamed($classMethodStmt->expr, $parentClassName)) {
+            if ($this->isLocalMethodCallNamed($classMethodStmt->expr, $parentClassName) && ! $node->getMethod($parentClassName) instanceof ClassMethod) {
                 /** @var MethodCall $expr */
                 $expr = $classMethodStmt->expr;
                 $classMethodStmt->expr = new StaticCall(new FullyQualified($parentClassName), new Identifier(MethodName::CONSTRUCT), $expr->args);


### PR DESCRIPTION
@afilina continue of PR:

- https://github.com/rectorphp/rector-src/pull/6519

this PR ensure method exists check in current class before replace `$this->call()` with `\Parent::__construct()`