### PR TITLE
[PostRector] Keep first comment before first Use_ if removed on UnusedImportRemovingPostRector

### DIFF
--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\UseItem;
 use PhpParser\NodeVisitor;
@@ -71,7 +72,14 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
             }
 
             if ($stmt->uses === []) {
-                unset($node->stmts[$key]);
+                $comments = $node->stmts[$key]->getComments();
+
+                if ($key === 0 && $comments !== []) {
+                    $node->stmts[$key] = new Nop();
+                    $node->stmts[$key]->setAttribute(AttributeKey::COMMENTS, $comments);
+                } else {
+                    unset($node->stmts[$key]);
+                }
             }
         }
 

--- a/tests/Issues/NoNamespaced/Fixture/keep_first_comment.php.inc
+++ b/tests/Issues/NoNamespaced/Fixture/keep_first_comment.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @license some license docblock
+ */
+use PhpParser\Node\Scalar\String_ as Foo;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Stmt\Expression as Bar;
+
+new Bar(new Array_([]));
+
+?>
+-----
+<?php
+
+/**
+ * @license some license docblock
+ */
+
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Stmt\Expression as Bar;
+
+new Bar(new Array_([]));
+
+?>


### PR DESCRIPTION
First comment can be a license docblock.

Ref https://getrector.com/demo/474af1c4-c629-46d9-9e8c-37cdfb91ac32

this PR fix it.

Fixes https://github.com/rectorphp/rector/issues/8913 