### PR TITLE
[PhpParser] Remove regex check single line spaces before <?php on FileProcessor

### DIFF
--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Application;
 
 use Nette\Utils\FileSystem;
-use Nette\Utils\Strings;
 use PHPStan\AnalysedCodeException;
 use PHPStan\Parser\ParserErrorsException;
 use Rector\Caching\Detector\ChangedFilesDetector;
@@ -30,12 +29,6 @@ use Throwable;
 
 final readonly class FileProcessor
 {
-    /**
-     * @var string
-     * @see https://regex101.com/r/llm7XZ/1
-     */
-    private const OPEN_TAG_SPACED_REGEX = '#^[ \t]+<\?php#m';
-
     public function __construct(
         private BetterStandardPrinter $betterStandardPrinter,
         private RectorNodeTraverser $rectorNodeTraverser,
@@ -150,32 +143,6 @@ final readonly class FileProcessor
             $file->getOldStmts(),
             $file->getOldTokens()
         );
-
-        /**
-         * When no diff applied, the PostRector may still change the content, that's why printing still needed
-         * On printing, the space may be wiped, these below check compare with original file content used to verify
-         * that no change actually needed
-         */
-        if (! $file->getFileDiff() instanceof FileDiff) {
-            /**
-             * exact compare with original file content
-             */
-            $originalFileContent = $file->getOriginalFileContent();
-            if ($originalFileContent === $newContent) {
-                return;
-            }
-
-            // handle space before <?php
-            $strippedNewContent = Strings::replace($newContent, self::OPEN_TAG_SPACED_REGEX, '<?php');
-            $strippedOriginalFileContent = Strings::replace(
-                $originalFileContent,
-                self::OPEN_TAG_SPACED_REGEX,
-                '<?php'
-            );
-            if ($strippedOriginalFileContent === $strippedNewContent) {
-                return;
-            }
-        }
 
         // change file content early to make $file->hasChanged() based on new content
         $file->changeFileContent($newContent);

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -23,7 +23,6 @@ use Rector\ValueObject\Application\File;
 use Rector\ValueObject\Configuration;
 use Rector\ValueObject\Error\SystemError;
 use Rector\ValueObject\FileProcessResult;
-use Rector\ValueObject\Reporting\FileDiff;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
 

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -23,6 +23,7 @@ use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Node\Expr\AlwaysRememberedExpr;
@@ -459,13 +460,20 @@ final class BetterStandardPrinter extends Standard
      */
     private function containsNop(array $nodes): bool
     {
+        $hasNop = false;
         foreach ($nodes as $node) {
+            // early false when visited Node is InlineHTML
+            if ($node instanceof InlineHTML) {
+                return false;
+            }
+
+            // use flag to avoid next is InlineHTML that returns early
             if ($node instanceof Nop) {
-                return true;
+                $hasNop = true;
             }
         }
 
-        return false;
+        return $hasNop;
     }
 
     private function wrapValueWith(String_ $string, string $wrap): string


### PR DESCRIPTION
Move the check on `BetterStandardPrinter::containsNop()` which verify the nodes collection is consist of `InlineHTML` to not necessary clear extra space before `Nop` as on `InlineHTML`, space before `<?php` can be on purpose to not changed.

The fixture already at 

https://github.com/rectorphp/rector-src/blob/1b68ff48b80d81bd4295ef304196fd97d74e0032/tests/Issues/NoNamespaced/Fixture/open_tag_spaced_with_comment.php.inc#L1-L5

/cc @stilliard this may need to verify on a project you used