### PR TITLE
[FileProcessor] Remove unnecessary FileDiffFactory::createTempFileDiff()

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -169,7 +169,7 @@ final class ApplicationFileProcessor
 
         if ($fileProcessResult->getSystemErrors() !== []) {
             $this->changedFilesDetector->invalidateFile($file->getFilePath());
-        } elseif (! $configuration->isDryRun() || ! $fileProcessResult->getFileDiff() instanceof FileDiff) {
+        } elseif (! $configuration->isDryRun() || ! $fileProcessResult->getFileHasChanged()) {
             $this->changedFilesDetector->cacheFile($file->getFilePath());
         }
 

--- a/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
+++ b/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
@@ -39,9 +39,4 @@ final readonly class FileDiffFactory
             $rectorsWithLineChanges
         );
     }
-
-    public function createTempFileDiff(File $file): FileDiff
-    {
-        return $this->createFileDiffWithLineChanges($file, '', '', $file->getRectorWithLineChanges());
-    }
 }

--- a/src/ValueObject/FileProcessResult.php
+++ b/src/ValueObject/FileProcessResult.php
@@ -15,7 +15,8 @@ final readonly class FileProcessResult
      */
     public function __construct(
         private array $systemErrors,
-        private ?FileDiff $fileDiff
+        private ?FileDiff $fileDiff,
+        private bool $fileHasChanged = false
     ) {
         Assert::allIsInstanceOf($systemErrors, SystemError::class);
     }
@@ -31,5 +32,10 @@ final readonly class FileProcessResult
     public function getFileDiff(): ?FileDiff
     {
         return $this->fileDiff;
+    }
+
+    public function getFileHasChanged(): bool
+    {
+        return $this->fileHasChanged;
     }
 }


### PR DESCRIPTION
@staabm The `FileDiffFactory::createTempFileDiff()` was introduced by your PR:

- https://github.com/rectorphp/rector-src/pull/3711

After some check, I think it is not really needed, as it fill empty diff in the loop, so can be removed.

The diff actually filled after the loop on `FileProcessor`.