### PR TITLE
[FileProcessor] Remove unnecessary FileDiffFactory::createTempFileDiff() take 2

### DIFF
--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -54,46 +54,46 @@ final readonly class FileProcessor
         $fileHasChanged = false;
         $filePath = $file->getFilePath();
 
-        // 2. change nodes with Rectors
-        $rectorWithLineChanges = null;
-
         do {
             $file->changeHasChanged(false);
 
+            // 1. change nodes with Rector Rules
             $newStmts = $this->rectorNodeTraverser->traverse($file->getNewStmts());
 
-            // apply post rectors
+            // 2. apply post rectors
             $postNewStmts = $this->postFileProcessor->traverse($newStmts, $file);
 
-            // this is needed for new tokens added in "afterTraverse()"
+            // 3. this is needed for new tokens added in "afterTraverse()"
             $file->changeNewStmts($postNewStmts);
 
-            // 3. print to file or string
+            // 4. print to file or string
             // important to detect if file has changed
             $this->printFile($file, $configuration, $filePath);
 
-            $fileHasChangedInCurrentPass = $file->hasChanged();
-
-            if ($fileHasChangedInCurrentPass) {
-                $file->setFileDiff($this->fileDiffFactory->createTempFileDiff($file));
-                $rectorWithLineChanges = $file->getRectorWithLineChanges();
-
-                $fileHasChanged = true;
+            // no change in current iteration, stop
+            if (! $file->hasChanged()) {
+                break;
             }
-        } while ($fileHasChangedInCurrentPass);
+
+            $fileHasChanged = true;
+        } while (true);
 
         // 5. add as cacheable if not changed at all
         if (! $fileHasChanged) {
             $this->changedFilesDetector->addCachableFile($filePath);
-        }
+        } else {
+            // when changed, set final status changed to true
+            // to ensure it make sense to verify in next process when needed
+            $file->changeHasChanged(true);
 
-        if ($configuration->shouldShowDiffs() && $rectorWithLineChanges !== null) {
             $currentFileDiff = $this->fileDiffFactory->createFileDiffWithLineChanges(
+                $configuration->shouldShowDiffs(),
                 $file,
                 $file->getOriginalFileContent(),
                 $file->getFileContent(),
-                $rectorWithLineChanges
+                $file->getRectorWithLineChanges()
             );
+
             $file->setFileDiff($currentFileDiff);
         }
 

--- a/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
+++ b/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
@@ -24,6 +24,7 @@ final readonly class FileDiffFactory
      * @param RectorWithLineChange[] $rectorsWithLineChanges
      */
     public function createFileDiffWithLineChanges(
+        bool $shouldShowDiffs,
         File $file,
         string $oldContent,
         string $newContent,
@@ -34,14 +35,9 @@ final readonly class FileDiffFactory
         // always keep the most recent diff
         return new FileDiff(
             $relativeFilePath,
-            $this->defaultDiffer->diff($oldContent, $newContent),
-            $this->consoleDiffer->diff($oldContent, $newContent),
+            $shouldShowDiffs ? $this->defaultDiffer->diff($oldContent, $newContent) : '',
+            $shouldShowDiffs ? $this->consoleDiffer->diff($oldContent, $newContent) : '',
             $rectorsWithLineChanges
         );
-    }
-
-    public function createTempFileDiff(File $file): FileDiff
-    {
-        return $this->createFileDiffWithLineChanges($file, '', '', $file->getRectorWithLineChanges());
     }
 }

--- a/src/Differ/DefaultDiffer.php
+++ b/src/Differ/DefaultDiffer.php
@@ -22,10 +22,6 @@ final readonly class DefaultDiffer
 
     public function diff(string $old, string $new): string
     {
-        if ($old === $new) {
-            return '';
-        }
-
         return $this->differ->diff($old, $new);
     }
 }


### PR DESCRIPTION
@staabm this is take 2 of original PR:

- https://github.com/rectorphp/rector-src/pull/6526

The `FileDiff` object with empty string diff is still needed, as it used when collecting `changed_files`, just use it after the loop, so it no need to fill in the loop, just after.

The `FileDiffFactory::createFileDiffWithLineChanges()` now passed the `bool $shouldShowDiffs` parameter so it can be verified to just fill empty string or teh diff string.

```diff
    public function createFileDiffWithLineChanges(
+        bool $shouldShowDiffs,
        File $file,
        string $oldContent,
        string $newContent,
        // always keep the most recent diff
        return new FileDiff(
            $relativeFilePath,
            $this->defaultDiffer->diff($oldContent, $newContent),
            $this->consoleDiffer->diff($oldContent, $newContent),
-           $this->defaultDiffer->diff($oldContent, $newContent),
+           $shouldShowDiffs ? $this->defaultDiffer->diff($oldContent, $newContent) : '',
-           $this->consoleDiffer->diff($oldContent, $newContent),
+           $shouldShowDiffs ? $this->consoleDiffer->diff($oldContent, $newContent) : '',
            $rectorsWithLineChanges
        );
    }
```

The output will like as before, but only process after instead of in each iteration, when there is a change:

1. with **--no-diffs**

```
bin/rector process src/ChangesReporting/Output/JsonOutputFormatter.php --dry-run --clear-cache --no-diffs --output-format json

{
    "totals": {
        "changed_files": 1,
        "errors": 0
    },
    "file_diffs": [
        {
            "file": "src/ChangesReporting/Output/JsonOutputFormatter.php",
            "diff": "",
            "applied_rectors": [
                "Rector\\DeadCode\\Rector\\Property\\RemoveUnusedPrivatePropertyRector"
            ]
        }
    ],
    "changed_files": [
        "src/ChangesReporting/Output/JsonOutputFormatter.php"
    ]
}
```

2. normal output json

```
bin/rector process src/ChangesReporting/Output/JsonOutputFormatter.php --dry-run --clear-cache --output-format json

{
    "totals": {
        "changed_files": 1,
        "errors": 0
    },
    "file_diffs": [
        {
            "file": "src/ChangesReporting/Output/JsonOutputFormatter.php",
            "diff": "--- Original\n+++ New\n@@ -18,8 +18,6 @@\n      */\n     public const NAME = 'json';\n \n-    private string $unused;\n-\n     public function getName(): string\n     {\n         return self::NAME;\n",
            "applied_rectors": [
                "Rector\\DeadCode\\Rector\\Property\\RemoveUnusedPrivatePropertyRector"
            ]
        }
    ],
    "changed_files": [
        "src/ChangesReporting/Output/JsonOutputFormatter.php"
    ]
}
````