### PR TITLE
[Arguments] Handle crash on first class callable on ArgumentAdderRector

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeContainerBuilder;
+
+class SkipFirstClassCallable
+{
+    public function create()
+    {
+        $containerBuilder = new SomeContainerBuilder();
+        $containerBuilder->addCompilerPass(...);
+    }
+}

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -341,6 +341,10 @@ CODE_SAMPLE
 
     private function refactorCall(StaticCall|MethodCall $call): void
     {
+        if ($call->isFirstClassCallable()) {
+            return;
+        }
+
         $callName = $this->getName($call->name);
         if ($callName === null) {
             return;

--- a/tests/Bridge/SetRectorsResolverTest.php
+++ b/tests/Bridge/SetRectorsResolverTest.php
@@ -25,7 +25,7 @@ final class SetRectorsResolverTest extends TestCase
     {
         $configFilePaths = PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_70);
         $this->assertCount(6, $configFilePaths);
-        $this->assertContainsOnly('string', $configFilePaths);
+        $this->assertContainsOnlyString($configFilePaths);
 
         foreach ($configFilePaths as $configFilePath) {
             $this->assertFileExists($configFilePath);


### PR DESCRIPTION
it cause error:

```
There was 1 failure:

1) Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\ArgumentAdderRectorTest::test with data set #10 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())
```