### PR TITLE
[Php81] Skip by ref param on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_by_ref_param.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_by_ref_param.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipByRefParam
+{
+    public function __construct(private  array &$idx)
+    {
+    }
+}

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -222,6 +222,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($param->byRef) {
+            return null;
+        }
+
         if ($this->paramAnalyzer->isParamReassign($classMethod, $param)) {
             return null;
         }


### PR DESCRIPTION
Ref https://3v4l.org/bIRpp#v8.1.31
Fixes https://github.com/rectorphp/rector/issues/8925