### PR TITLE
Clean PHPStan ignore errors for path that no longer exists

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -290,7 +290,6 @@ parameters:
              paths:
                  - src/CustomRules/SimpleNodeDumper.php
                  - src/PhpDocParser/PhpDocParser/PhpDocNodeTraverser.php
-                 - src/Testing/PHPUnit/AbstractTestCase.php
 
         # known node variables
         -


### PR DESCRIPTION
`src/Testing/PHPUnit/AbstractTestCase.php` is no longer exists so can be removed from ignore errors.