### PR TITLE
Fix str_contains() never returns 0 on OnlyRuleResolver

### DIFF
--- a/src/Configuration/OnlyRuleResolver.php
+++ b/src/Configuration/OnlyRuleResolver.php
@@ -62,7 +62,7 @@ final readonly class OnlyRuleResolver
             throw new RectorRuleNameAmbigiousException($message);
         }
 
-        if (in_array(str_contains($rule, '\\'), [0, false], true)) {
+        if (! str_contains($rule, '\\')) {
             $message = sprintf(
                 'Rule "%s" was not found.%sThe rule has no namespace. Make sure to escape the backslashes, and add quotes around the rule name: --only="My\\Rector\\Rule"',
                 $rule,


### PR DESCRIPTION
PHPStan somehow detect `str_contains()` as union 

```
 0/1 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
PHPStan\Type\UnionType #22767
   types: array (2)
   |  0 => PHPStan\Type\IntegerRangeType #20331
   |  |  min: 0
   |  |  max: null
   |  1 => PHPStan\Type\Constant\ConstantBooleanType #22757
   |  |  value: false
   normalized: true
   sortedTypes: true
   cachedDescriptions: array (1)
   |  4 => 'int<0, max>|false'
```

Ref https://github.com/rectorphp/rector-src/pull/6545#pullrequestreview-2495213555