### PR TITLE
[CodeQuality] Handle crash on do {} while with first class callable on OptionalParametersAfterRequiredRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_first_class_callable_in_do.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_first_class_callable_in_do.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+final class SkipFirstClassCallableInDo
+{
+    public function getSubscribedEvents()
+    {
+        do {
+
+        } while ($this->textElement(...));
+    }
+
+    public function textElement()
+    {
+         return 1;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_first_class_callable_in_while.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/OptionalParametersAfterRequiredRector/Fixture/skip_first_class_callable_in_while.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\Fixture;
+
+final class SkipFirstClassCallableInWhile
+{
+    public function getSubscribedEvents()
+    {
+        while ($this->textElement(...)) {
+
+        }
+    }
+
+    public function textElement()
+    {
+         return 1;
+    }
+}

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -382,7 +382,7 @@ final readonly class PHPStanNodeScopeResolver
                 throw $e;
             }
 
-            // nothing we can do more precise here as error parsing from deep internal PHPStan service with service injection we cannot reset
+            // nothing we can do more precise here as error printing from deep internal PHPStan Printer service with service injection we cannot reset
             // in the middle of process
             // fallback to fill by found scope
             RectorNodeScopeResolver::processNodes($stmts, $scope);

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
+use Error;
+use PHPStan\Node\Printer\Printer;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ArrayItem;
@@ -377,9 +379,9 @@ final readonly class PHPStanNodeScopeResolver
 
         try {
             $this->nodeScopeResolverProcessNodes($stmts, $scope, $nodeCallback);
-        } catch (\Error $e) {
-            if (! str_starts_with($e->getMessage(), 'Call to undefined method PHPStan\Node\Printer\Printer::pPHPStan_')) {
-                throw $e;
+        } catch (Error $error) {
+            if (! str_starts_with($error->getMessage(), 'Call to undefined method ' . Printer::class . '::pPHPStan_')) {
+                throw $error;
             }
 
             // nothing we can do more precise here as error printing from deep internal PHPStan Printer service with service injection we cannot reset

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -378,15 +378,14 @@ final readonly class PHPStanNodeScopeResolver
         try {
             $this->nodeScopeResolverProcessNodes($stmts, $scope, $nodeCallback);
         } catch (\Error $e) {
+            if (! str_starts_with($e->getMessage(), 'Call to undefined method PHPStan\Node\Printer\Printer::pPHPStan_')) {
+                throw $e;
+            }
+
             // nothing we can do more precise here as error parsing from deep internal PHPStan service with service injection we cannot reset
             // in the middle of process
             // fallback to fill by found scope
-            if (str_starts_with($e->getMessage(), 'Call to undefined method PHPStan\Node\Printer\Printer::pPHPStan_')) {
-                RectorNodeScopeResolver::processNodes($stmts, $scope);
-                return $stmts;
-            }
-
-            throw $e;
+            RectorNodeScopeResolver::processNodes($stmts, $scope);
         }
 
         $nodeTraverser = new NodeTraverser();


### PR DESCRIPTION
PHPStan virtual node seems needs unpack:

```
There was 1 error:

1) Rector\Tests\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector\OptionalParametersAfterRequiredRectorTest::test with data set #12 ('/Users/samsonasik/www/rector-...hp.inc')
Error: Call to undefined method PHPStan\Node\Printer\Printer::pPHPStan_Node_MethodCallableNode()

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:606
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:281
```