### PR TITLE
[TypeDeclaration] Handle default value with contant type on TypedPropertyFromAssignsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg.php.inc
@@ -20,7 +20,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsR
 
 final class ParseUrlWithSecondArg
 {
-    private string|false|null $host = null;
+    private string|bool|null $host = null;
 
     public function __construct(string $url)
     {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+
+final class ParseUrlWithSecondArg2
+{
+    private $host = true;
+
+    public function __construct(string $url)
+    {
+        $this->host = parse_url($url, \PHP_URL_HOST);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\FixtureComplexTypes;
+
+final class ParseUrlWithSecondArg2
+{
+    private string|bool|null $host = true;
+
+    public function __construct(string $url)
+    {
+        $this->host = parse_url($url, \PHP_URL_HOST);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg2.php.inc
@@ -20,7 +20,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsR
 
 final class ParseUrlWithSecondArg2
 {
-    private string|null|bool $host = true;
+    private string|bool|null $host = true;
 
     public function __construct(string $url)
     {

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg2.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/FixtureComplexTypes/parse_url_with_second_arg2.php.inc
@@ -20,7 +20,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsR
 
 final class ParseUrlWithSecondArg2
 {
-    private string|bool|null $host = true;
+    private string|null|bool $host = true;
 
     public function __construct(string $url)
     {

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -92,7 +92,13 @@ final readonly class AssignToPropertyTypeInferer
             return null;
         }
 
+        if (! $defaultPropertyValue instanceof Expr) {
+            // returns with constant as final result
+            return $this->typeFactory->createMixedPassedOrUnionType($assignedExprTypes, true);
+        }
+
         // returns with constant as final result
+        $assignedExprTypes[] = $this->nodeTypeResolver->getNativeType($defaultPropertyValue);
         return $this->typeFactory->createMixedPassedOrUnionType($assignedExprTypes, true);
     }
 

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -98,7 +98,7 @@ final readonly class AssignToPropertyTypeInferer
         }
 
         // returns with constant as final result
-        // merge type with default value to ensure false and true merged as bool
+        // but merge type with default value to ensure false and true merged as bool
         $assignedExprTypes[] = $this->nodeTypeResolver->getNativeType($defaultPropertyValue);
         return $this->typeFactory->createMixedPassedOrUnionType($assignedExprTypes, true);
     }

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -86,21 +86,11 @@ final readonly class AssignToPropertyTypeInferer
         }
 
         $inferredType = $this->typeFactory->createMixedPassedOrUnionType($assignedExprTypes);
-        // to compare with default value, constant type must not be kept
-        // eg, use more general bool over false or true
         if ($this->shouldSkipWithDifferentDefaultValueType($defaultPropertyValue, $inferredType)) {
             return null;
         }
 
-        if (! $defaultPropertyValue instanceof Expr) {
-            // returns with constant as final result
-            return $this->typeFactory->createMixedPassedOrUnionType($assignedExprTypes, true);
-        }
-
-        // returns with constant as final result
-        // but merge type with default value to ensure false and true merged as bool
-        $assignedExprTypes[] = $this->nodeTypeResolver->getNativeType($defaultPropertyValue);
-        return $this->typeFactory->createMixedPassedOrUnionType($assignedExprTypes, true);
+        return $inferredType;
     }
 
     private function shouldSkipWithDifferentDefaultValueType(?Expr $expr, Type $inferredType): bool

--- a/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/AssignToPropertyTypeInferer.php
@@ -98,6 +98,7 @@ final readonly class AssignToPropertyTypeInferer
         }
 
         // returns with constant as final result
+        // merge type with default value to ensure false and true merged as bool
         $assignedExprTypes[] = $this->nodeTypeResolver->getNativeType($defaultPropertyValue);
         return $this->typeFactory->createMixedPassedOrUnionType($assignedExprTypes, true);
     }


### PR DESCRIPTION
continue of PR:

- https://github.com/rectorphp/rector-src/pull/6562

this PR handle default value with constant type, `false` type can't match with `true`, so it needs to be `bool` as final type.