### PR TITLE
[DeadCode] Skip @return positive-int|0 on RemoveUselessReturnTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_positive_int_or_zero.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_positive_int_or_zero.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+class SkipPositiveIntOrZero
+{
+    /**
+     * @return positive-int|0
+     */
+    function foo(): int
+    {
+        return rand(0, 1) ? 10 : 0;
+    }
+}

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -164,21 +164,7 @@ final readonly class TypeFactory
             return $types[0];
         }
 
-        $unionType = new UnionType($types);
-
-        if ($unionType->isFloat()->yes()) {
-            return new IntegerType();
-        }
-
-        if ($unionType->isString()->yes()) {
-            return new StringType();
-        }
-
-        if ($unionType->isInteger()->yes()) {
-            return new IntegerType();
-        }
-
-        return $unionType;
+        return new UnionType($types);
     }
 
     private function removeValueFromConstantType(Type $type): Type


### PR DESCRIPTION
Ref https://phpstan.org/r/e268f67c-ddd5-4e30-8c2b-9b2137064a93