### PR TITLE
[Php80] Fix end slash regex on AttributeValueResolver

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_with_newline_without_another_text.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_with_newline_without_another_text.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class BackslashWitNewlineWithoutAnotherText
+{
+    /**
+     * @Then then :value should \
+     *
+     *
+     *
+     */
+    public function someStep(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class BackslashWitNewlineWithoutAnotherText
+{
+    #[\Behat\Step\Then('then :value should \\')]
+    public function someStep(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_with_newline_without_another_text_with_other_comment.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_with_newline_without_another_text_with_other_comment.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class BackslashWitNewlineWithoutAnotherTextWithOtherComment
+{
+    // some comment
+    /**
+     * @Then then :value should \
+     *
+     *
+     *
+     */
+    public function someStep(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class BackslashWitNewlineWithoutAnotherTextWithOtherComment
+{
+    // some comment
+    #[\Behat\Step\Then('then :value should \\')]
+    public function someStep(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_with_newline_without_another_text_with_other_comment2.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_with_newline_without_another_text_with_other_comment2.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
 
-final class BackslashWitNewlineWithoutAnotherTextWithOtherComment
+final class BackslashWitNewlineWithoutAnotherTextWithOtherComment2
 {
     // some comment
     /**
@@ -11,7 +11,6 @@ final class BackslashWitNewlineWithoutAnotherTextWithOtherComment
      *
      *
      */
-    // some comment 2
     public function someStep(): void
     {
     }
@@ -23,10 +22,9 @@ final class BackslashWitNewlineWithoutAnotherTextWithOtherComment
 
 namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
 
-final class BackslashWitNewlineWithoutAnotherTextWithOtherComment
+final class BackslashWitNewlineWithoutAnotherTextWithOtherComment2
 {
     // some comment
-    // some comment 2
     #[\Behat\Step\Then('then :value should \\')]
     public function someStep(): void
     {

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_without_newline.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_without_newline.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class BackslashWithoutNewline
+{
+    /**
+     * @Then then :value should \
+     *
+     * bar
+     */
+    public function someStep(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class BackslashWithoutNewline
+{
+    #[\Behat\Step\Then('then :value should \\')]
+    public function someStep(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_without_newline.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/backslash_without_newline.php.inc
@@ -6,8 +6,6 @@ final class BackslashWithoutNewline
 {
     /**
      * @Then then :value should \
-     *
-     * bar
      */
     public function someStep(): void
     {

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -177,7 +177,7 @@ CODE_SAMPLE
             }
         }
 
-        $node->setAttribute(AttributeKey::COMMENTS, $comments);
+        $node->setAttribute(AttributeKey::COMMENTS, array_values($comments));
     }
 
     /**

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -170,14 +170,14 @@ CODE_SAMPLE
             return;
         }
 
-        foreach ($node->getComments() as $comment) {
-            if ($comment->getText() !== '') {
-                return;
+        foreach ($comments as $key => $comment) {
+            if ($comment->getText() === '') {
+                unset($comments[$key]);
+                continue;
             }
         }
 
-        $node->setAttribute(AttributeKey::COMMENTS, []);
-        $node->setAttribute(AttributeKey::PHP_DOC_INFO, null);
+        $node->setAttribute(AttributeKey::COMMENTS, $comments);
     }
 
     /**

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -29,6 +29,7 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Exception\Configuration\InvalidConfigurationException;
 use Rector\Naming\Naming\UseImportsResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\Php80\NodeFactory\AttrGroupsFactory;
 use Rector\Php80\NodeManipulator\AttributeGroupNamedArgumentManipulator;
@@ -152,10 +153,31 @@ CODE_SAMPLE
         // 3. Reprint docblock
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
+        // 4. Left over comment removal
+        $this->cleanLeftOverComment($node);
+
         $this->attributeGroupNamedArgumentManipulator->decorate($attributeGroups);
         $node->attrGroups = array_merge($node->attrGroups, $attributeGroups);
 
         return $node;
+    }
+
+    private function cleanLeftOverComment(Node $node): void
+    {
+        $comments = $node->getComments();
+
+        if ($comments === []) {
+            return;
+        }
+
+        foreach ($node->getComments() as $comment) {
+            if ($comment->getText() !== '') {
+                return;
+            }
+        }
+
+        $node->setAttribute(AttributeKey::COMMENTS, []);
+        $node->setAttribute(AttributeKey::PHP_DOC_INFO, null);
     }
 
     /**

--- a/rules/Php80/Rector/Class_/AttributeValueResolver.php
+++ b/rules/Php80/Rector/Class_/AttributeValueResolver.php
@@ -13,7 +13,7 @@ final class AttributeValueResolver
 {
     /**
      * @var string
-     * @see https://regex101.com/r/CL9ktz/2
+     * @see https://regex101.com/r/CL9ktz/4
      */
     private const END_SLASH_REGEX = '#\\\\$#';
 

--- a/rules/Php80/Rector/Class_/AttributeValueResolver.php
+++ b/rules/Php80/Rector/Class_/AttributeValueResolver.php
@@ -8,6 +8,7 @@ use Nette\Utils\Strings;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\Php80\ValueObject\AttributeValueAndDocComment;
+use Rector\Util\NewLineSplitter;
 
 final class AttributeValueResolver
 {
@@ -31,7 +32,7 @@ final class AttributeValueResolver
         // special case for newline
         if (str_contains($docValue, "\n")) {
             $keepJoining = true;
-            $docValueLines = explode("\n", $docValue);
+            $docValueLines = NewLineSplitter::split($docValue);
 
             $joinDocValue = '';
 

--- a/rules/Php80/Rector/Class_/AttributeValueResolver.php
+++ b/rules/Php80/Rector/Class_/AttributeValueResolver.php
@@ -13,9 +13,9 @@ final class AttributeValueResolver
 {
     /**
      * @var string
-     * @see https://regex101.com/r/CL9ktz/1
+     * @see https://regex101.com/r/CL9ktz/2
      */
-    private const END_SLASH_REGEX = '#\\\\\r?$#';
+    private const END_SLASH_REGEX = '#\\\\$#';
 
     public function resolve(
         AnnotationToAttribute $annotationToAttribute,


### PR DESCRIPTION
`\r?` end cause mac os new line detected, it will allow:

```
some with \

```

which should not.