### PR TITLE
[TypeDeclaration] Skip else throw on BoolReturnTypeFromBooleanConstReturnsRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanConstReturnsRector/Fixture/skip_else_throw.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanConstReturnsRector/Fixture/skip_else_throw.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanConstReturnsRector\Fixture;
+
+final class SkipElseThrow
+{
+    /**
+     * Reset controller to a given one.
+     *
+     * @param string $controller
+     *
+     * @return no-return
+     */
+    public function reset_controller($controller)
+    {
+        if (!class_exists($controller, true)) {
+            return false;
+        }
+        echo 'ABC';
+        throw new \Exception();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8935