### PR TITLE
fix: replace getKey method for name property

### DIFF
--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_key.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_key.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class UsageOfGetKey
+{
+    public function run($value)
+    {
+        $name = SomeEnum::USED_TO_BE_CONST()->getKey();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class UsageOfGetKey
+{
+    public function run($value)
+    {
+        $name = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST->name;
+    }
+}
+
+?>

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -46,7 +46,7 @@ CODE_SAMPLE
 
                 ,
                 <<<'CODE_SAMPLE'
-$name = SomeEnum::VALUE;
+$name = SomeEnum::VALUE->name;
 CODE_SAMPLE
             ),
         ]);
@@ -110,7 +110,7 @@ CODE_SAMPLE
         return $classReflection->hasConstant($constant);
     }
 
-    private function refactorGetKeyMethodCall(MethodCall $methodCall): ?ClassConstFetch
+    private function refactorGetKeyMethodCall(MethodCall $methodCall): ?PropertyFetch
     {
         if (! $methodCall->var instanceof StaticCall) {
             return null;
@@ -131,7 +131,9 @@ CODE_SAMPLE
             return null;
         }
 
-        return $this->nodeFactory->createClassConstFetch($className, $enumCaseName);
+        $classConstFetch = $this->nodeFactory->createClassConstFetch($className, $enumCaseName);
+
+        return new PropertyFetch($classConstFetch, 'name');
     }
 
     private function refactorGetValueMethodCall(MethodCall $methodCall): ?PropertyFetch
@@ -266,10 +268,8 @@ CODE_SAMPLE
         return $this->nodeFactory->createClassConstFetch($className, $enumCaseName);
     }
 
-    private function refactorMethodCall(
-        MethodCall $methodCall,
-        string $methodName
-    ): null|ClassConstFetch|PropertyFetch|Identical {
+    private function refactorMethodCall(MethodCall $methodCall, string $methodName): null|PropertyFetch|Identical
+    {
         if (! $this->isObjectType($methodCall->var, new ObjectType('MyCLabs\Enum\Enum'))) {
             return null;
         }


### PR DESCRIPTION
The Rector rule for the My C-Labs enum replaces the `getKey` for its instance. This PR change to use the property `name` as indicated on their GitHub page.
[Myclabs Ref](https://github.com/myclabs/php-enum)
![image](https://github.com/user-attachments/assets/169d7af0-dd22-45b6-9c5a-692474fc6775)
