### PR TITLE
fix: replace getKey/getValue methods when enum is a variable

### DIFF
--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_usage_of_get_key.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_usage_of_get_key.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeClass;
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class SkipUsageOfGetKeyForClass
+{
+    public function run($value)
+    {
+        $obj = new SomeClass();
+        $objKey = $obj->getKey();
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_usage_of_get_value.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_usage_of_get_value.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeClass;
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
+
+final class SkipUsageOfGetValueForClass
+{
+    public function run($value)
+    {
+        $obj = new SomeClass();
+        $objName = $obj->getValue();
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_key.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_key.php.inc
@@ -2,6 +2,7 @@
 
 namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
 
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeClass;
 use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
 
 final class UsageOfGetKey
@@ -9,6 +10,8 @@ final class UsageOfGetKey
     public function run($value)
     {
         $name = SomeEnum::USED_TO_BE_CONST()->getKey();
+        $enum = SomeEnum::USED_TO_BE_CONST();
+        $name2 = $enum->getKey();
     }
 }
 
@@ -18,6 +21,7 @@ final class UsageOfGetKey
 
 namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
 
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeClass;
 use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
 
 final class UsageOfGetKey
@@ -25,6 +29,8 @@ final class UsageOfGetKey
     public function run($value)
     {
         $name = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST->name;
+        $enum = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+        $name2 = $enum->name;
     }
 }
 

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_value.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/usage_of_get_value.php.inc
@@ -2,13 +2,16 @@
 
 namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
 
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeClass;
 use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
 
 final class UsageOfGetValue
 {
     public function run($value)
     {
-        $enum = SomeEnum::USED_TO_BE_CONST()->getValue();
+        $value = SomeEnum::USED_TO_BE_CONST()->getValue();
+        $enum = SomeEnum::USED_TO_BE_CONST();
+        $value2 = $enum->getValue();
     }
 }
 
@@ -18,13 +21,16 @@ final class UsageOfGetValue
 
 namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
 
+use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeClass;
 use Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum;
 
 final class UsageOfGetValue
 {
     public function run($value)
     {
-        $enum = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST->value;
+        $value = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST->value;
+        $enum = \Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source\SomeEnum::USED_TO_BE_CONST;
+        $value2 = $enum->value;
     }
 }
 

--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Source/SomeClass.php
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Source/SomeClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Source;
+
+final class SomeClass
+{
+    public function getValue(): string
+    {
+        return 'value';
+    }
+    public function getKey(): string
+    {
+        return 'key';
+    }
+}

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -113,7 +113,7 @@ CODE_SAMPLE
     private function refactorGetKeyMethodCall(MethodCall $methodCall): ?PropertyFetch
     {
         if (! $methodCall->var instanceof StaticCall) {
-            return null;
+            return $this->nodeFactory->createPropertyFetch($methodCall->var, 'name');
         }
 
         $staticCall = $methodCall->var;
@@ -139,7 +139,7 @@ CODE_SAMPLE
     private function refactorGetValueMethodCall(MethodCall $methodCall): ?PropertyFetch
     {
         if (! $methodCall->var instanceof StaticCall) {
-            return null;
+            return $this->nodeFactory->createPropertyFetch($methodCall->var, 'value');
         }
 
         $staticCall = $methodCall->var;


### PR DESCRIPTION
The current My C-Labs rule only replaces the methods `getKey` and `getValue` if they are called from an enum case. It is currently skipping when an enum is previously assigned to a variable. This PR fixes this missing case.