### PR TITLE
[Php80] Handle comment multi line on AttributeValueResolver

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/disjoint_newline_multi.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/disjoint_newline_multi.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class DisjointNewlineMulti
+{
+    /**
+     * @Then then :value should
+     *
+     * Unrelated comment
+     * with multi line
+     */
+    public function someStep(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class DisjointNewlineMulti
+{
+    /**
+     * Unrelated comment
+     * with multi line
+     */
+    #[\Behat\Step\Then('then :value should')]
+    public function someStep(): void
+    {
+    }
+}
+
+?>

--- a/rules/Php80/Rector/Class_/AttributeValueResolver.php
+++ b/rules/Php80/Rector/Class_/AttributeValueResolver.php
@@ -44,14 +44,18 @@ final class AttributeValueResolver
 
             $hasPreviousEndSlash = false;
 
-            foreach ($docValueLines as $docValueLine) {
+            foreach ($docValueLines as $key => $docValueLine) {
                 if ($keepJoining) {
                     $joinDocValue .= rtrim($docValueLine, '\\\\');
                 }
 
                 if (Strings::match($docValueLine, self::END_SLASH_REGEX) === null) {
-                    if ($hasPreviousEndSlash === false) {
-                        $docComment = $docValueLine;
+                    if ($hasPreviousEndSlash === false && $key > 0) {
+                        if ($key === 1) {
+                            $docComment .= $docValueLine;
+                        } else {
+                            $docComment .= "\n * " . $docValueLine;
+                        }
                     }
 
                     $keepJoining = false;


### PR DESCRIPTION
Currenlty, multi line comment is removed due to replace instead of append on the loop.

https://github.com/rectorphp/rector-src/blob/15fcd52e45357bf2c244f29b86ab0d3ab77b15b4/rules/Php80/Rector/Class_/AttributeValueResolver.php#L54