### PR TITLE
feature: replace MyCLabs Enum constructor call

### DIFF
--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -10,6 +10,7 @@ use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
 use Rector\Php81\Rector\MethodCall\SpatieEnumMethodCallToEnumConstRector;
+use Rector\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 
@@ -18,6 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
         ReturnNeverTypeRector::class,
         MyCLabsClassToEnumRector::class,
         MyCLabsMethodCallToEnumConstRector::class,
+        MyCLabsConstructorCallToEnumFromRector::class,
         ReadOnlyPropertyRector::class,
         SpatieEnumClassToEnumRector::class,
         SpatieEnumMethodCallToEnumConstRector::class,

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/constructor_self_call.php.inc
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/constructor_self_call.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture;
+
+use MyCLabs\Enum\Enum;
+
+class EnumWithSelfCreation extends Enum
+{
+    private const VALUE = 'value';
+
+    public static function newSelf(): self
+    {
+        return new self('value');
+    }
+
+    public static function newStatic(): static
+    {
+        return new static('value');
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture;
+
+use MyCLabs\Enum\Enum;
+
+class EnumWithSelfCreation extends Enum
+{
+    private const VALUE = 'value';
+
+    public static function newSelf(): self
+    {
+        return \Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture\EnumWithSelfCreation::from('value');
+    }
+
+    public static function newStatic(): static
+    {
+        return \Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture\EnumWithSelfCreation::from('value');
+    }
+}
+?>

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/default_constructor_call.php.inc
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/default_constructor_call.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture;
+
+use Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source\SomeEnum;
+
+class RefactorDefaultConstructorCall
+{
+    public function someMethod(): SomeEnum
+    {
+        return new SomeEnum('value');
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture;
+
+use Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source\SomeEnum;
+
+class RefactorDefaultConstructorCall
+{
+    public function someMethod(): SomeEnum
+    {
+        return \Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source\SomeEnum::from('value');
+    }
+}
+?>

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/skip_constructor_call_for_custom_constructor.php.inc
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/skip_constructor_call_for_custom_constructor.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture;
+
+use Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source\SomeEnumWithConstructor;
+
+class SkipConstructorCallForCustomConstructor
+{
+    public function someMethod(): SomeEnumWithConstructor
+    {
+        return new SomeEnumWithConstructor('value');
+    }
+}
+?>

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/skip_constructor_call_for_non_enum.php.inc
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Fixture/skip_constructor_call_for_non_enum.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Fixture;
+
+use Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source\SomeClass;
+
+class SkipConstructorCallForNonEnum
+{
+    public function someMethod(): SomeClass
+    {
+        return new SomeClass();
+    }
+}
+?>

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/MyCLabsConstructorCallToEnumFromRectorTest.php
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/MyCLabsConstructorCallToEnumFromRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MyCLabsConstructorCallToEnumFromRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Source/SomeClass.php
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Source/SomeClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source;
+
+final class SomeClass
+{
+}

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Source/SomeEnum.php
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Source/SomeEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method SomeEnum VALUE()
+ */
+final class SomeEnum extends Enum
+{
+    const VALUE = 'value';
+}

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Source/SomeEnumWithConstructor.php
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/Source/SomeEnumWithConstructor.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\Source;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method SomeEnumWithConstructor VALUE()
+ */
+final class SomeEnumWithConstructor extends Enum
+{
+    const VALUE = 'value';
+
+    public function __construct($value)
+    {
+        //some logic
+        parent::__construct($value);
+    }
+}

--- a/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/config/configured_rule.php
+++ b/rules-tests/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector;
+
+return RectorConfig::configure()
+    ->withRules([MyCLabsConstructorCallToEnumFromRector::class]);

--- a/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
+++ b/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
@@ -88,7 +88,7 @@ CODE_SAMPLE
             return null;
         }
 
-        return new StaticCall(new Name\FullyQualified($classname), self::DEFAULT_ENUM_CONSTRUCTOR, $node->getArgs());
+        return new StaticCall(new Name\FullyQualified($classname), self::DEFAULT_ENUM_CONSTRUCTOR, $node->args);
     }
 
     private function isMyCLabsConstructor(New_ $node, string $classname): bool

--- a/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
+++ b/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
@@ -77,7 +77,7 @@ CODE_SAMPLE
 
         $classname = $this->getName($node->class);
         if (in_array($classname, [ObjectReference::SELF, ObjectReference::STATIC], true)) {
-            $classname = ScopeFetcher::fetch($node) ->getClassReflection()?->getDisplayName();
+            $classname = ScopeFetcher::fetch($node)->getClassReflection()?->getName();
         }
 
         if ($classname === null) {

--- a/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
+++ b/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
@@ -93,12 +93,12 @@ CODE_SAMPLE
 
     private function isMyCLabsConstructor(New_ $node, string $classname): bool
     {
-        $class_reflection = $this->reflectionProvider->getClass($classname);
-        if (! $class_reflection->hasMethod(MethodName::CONSTRUCT)) {
+        $classReflection = $this->reflectionProvider->getClass($classname);
+        if (! $classReflection->hasMethod(MethodName::CONSTRUCT)) {
             return true;
         }
 
-        return $class_reflection
+        return $classReflection
             ->getMethod(MethodName::CONSTRUCT, ScopeFetcher::fetch($node))
             ->getDeclaringClass()
             ->getName() === self::MY_C_LABS_CLASS;

--- a/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
+++ b/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Rector\Php81\Rector\New_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use Rector\Enum\ObjectReference;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\MethodName;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector\MyCLabsConstructorCallToEnumFromRectorTest
+ */
+final class MyCLabsConstructorCallToEnumFromRector extends AbstractRector implements MinPhpVersionInterface
+{
+    private const MY_C_LABS_CLASS = 'MyCLabs\Enum\Enum';
+
+    private const DEFAULT_ENUM_CONSTRUCTOR = 'from';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    /**
+     * @param New_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        return $this->refactorConstructorCallToStaticFromCall($node);
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ENUM;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Refactor MyCLabs Enum using constructor for instantiation',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$enum = new Enum($args);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$enum = Enum::from($args);
+CODE_SAMPLE
+                )]
+        );
+    }
+
+    private function refactorConstructorCallToStaticFromCall(New_ $node): ?StaticCall
+    {
+        if (! $this->isObjectType($node->class, new ObjectType(self::MY_C_LABS_CLASS))) {
+            return null;
+        }
+
+        $classname = $this->getName($node->class);
+        if (in_array($classname, [ObjectReference::SELF, ObjectReference::STATIC], true)) {
+            $classname = ScopeFetcher::fetch($node) ->getClassReflection()?->getDisplayName();
+        }
+
+        if ($classname === null) {
+            return null;
+        }
+
+        if (! $this->isMyCLabsConstructor($node, $classname)) {
+            return null;
+        }
+
+        return new StaticCall(new Name\FullyQualified($classname), self::DEFAULT_ENUM_CONSTRUCTOR, $node->getArgs());
+    }
+
+    private function isMyCLabsConstructor(New_ $node, string $classname): bool
+    {
+        $class_reflection = $this->reflectionProvider->getClass($classname);
+        if (! $class_reflection->hasMethod(MethodName::CONSTRUCT)) {
+            return true;
+        }
+
+        return $class_reflection
+            ->getMethod(MethodName::CONSTRUCT, ScopeFetcher::fetch($node))
+            ->getDeclaringClass()
+            ->getName() === self::MY_C_LABS_CLASS;
+    }
+}


### PR DESCRIPTION
The **My C-Labs enum** allows instantiation as a class using `new` instead of the static method `from`. ([ref](https://github.com/myclabs/php-enum)).
![image](https://github.com/user-attachments/assets/6935a31d-7676-4b62-8a77-cbca2e25d12b)

As it is not applicable for native enums, this PR allows the enum instantiations that use the `new` statement to be replaced by the static method `from`.

Enums that override the default My C-Labs enum constructor are skipped.