### PR TITLE
[DeadCode] Skip key variable used in throw stmts in catch on RemoveUnusedForeachKeyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector/Fixture/skip_used_in_throw_stmts_in_catch.php.inc
+++ b/rules-tests/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector/Fixture/skip_used_in_throw_stmts_in_catch.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Foreach_\RemoveUnusedForeachKeyRector\Fixture;
+
+/**
+ * @see https://3v4l.org/i9j78
+ */
+final class SkipUsedInThrowStmtsInCatch
+{
+    public function run(array $data): void
+    {
+        try {
+            foreach ($data as $key =>  $val) {
+                throw new \Exception('test');
+            }
+        } catch (\Throwable) {
+            echo 'Failed at index '.$key;
+        }
+	}
+}

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\TryCatch;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\DeadCode\NodeAnalyzer\ExprUsedInNodeAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -89,6 +90,13 @@ final readonly class StmtsManipulator
             null,
             true
         );
+
+        if ($stmtsAware instanceof TryCatch) {
+            $stmts = array_merge(
+                $stmts,
+                $stmtsAware->catches
+            );
+        }
 
         $variable = new Variable($variableName);
         return (bool) $this->betterNodeFinder->findFirst(

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\TryCatch;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\DeadCode\NodeAnalyzer\ExprUsedInNodeAnalyzer;
@@ -96,6 +97,10 @@ final readonly class StmtsManipulator
                 $stmts,
                 $stmtsAware->catches
             );
+
+            if ($stmtsAware->finally instanceof Finally_) {
+                $stmts = array_merge($stmts, $stmtsAware->finally->stmts);
+            }
         }
 
         $variable = new Variable($variableName);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8940