### PR TITLE
[DeadCode] Skip value variable used in throw stmts in catch on UnusedForeachValueToArrayKeysRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector/Fixture/skip_used_in_throw_stmts_in_catch.php.inc
+++ b/rules-tests/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector/Fixture/skip_used_in_throw_stmts_in_catch.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector\Fixture;
+
+/**
+ * @see https://3v4l.org/DHPd4a
+ */
+final class SkipUsedInThrowStmtsInCatch
+{
+    public function run(array $data): void
+    {
+        try {
+            foreach ($data as $key =>  $val) {
+                throw new \Exception('test');
+            }
+        } catch (\Throwable) {
+            echo 'Failed at value '.$val;
+        }
+	}
+}

--- a/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
@@ -127,7 +127,7 @@ CODE_SAMPLE
             }
 
             if ($this->stmtsManipulator->isVariableUsedInNextStmt(
-                $stmts,
+                $node,
                 $key + 1,
                 (string) $this->getName($stmt->valueVar)
             )) {


### PR DESCRIPTION
Ref https://3v4l.org/DHPd4