### PR TITLE
[Php80] Keep numeric string as is on StringAnnotationToAttributeMapper

### DIFF
--- a/src/PhpAttribute/AnnotationToAttributeMapper/StringAnnotationToAttributeMapper.php
+++ b/src/PhpAttribute/AnnotationToAttributeMapper/StringAnnotationToAttributeMapper.php
@@ -7,7 +7,6 @@ namespace Rector\PhpAttribute\AnnotationToAttributeMapper;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
@@ -37,11 +36,6 @@ final class StringAnnotationToAttributeMapper implements AnnotationToAttributeMa
 
         if (strtolower($value) === 'null') {
             return new ConstFetch(new Name('null'));
-        }
-
-        // number as string to number
-        if (is_numeric($value) && strlen((string) (int) $value) === strlen($value)) {
-            return Int_::fromString($value);
         }
 
         if (str_contains($value, "'") && ! str_contains($value, "\n")) {

--- a/tests/PhpAttribute/AnnotationToAttributeMapper/AnnotationToAttributeMapperTest.php
+++ b/tests/PhpAttribute/AnnotationToAttributeMapper/AnnotationToAttributeMapperTest.php
@@ -44,7 +44,8 @@ final class AnnotationToAttributeMapperTest extends AbstractLazyTestCase
     {
         yield [false, ConstFetch::class];
         yield ['false', ConstFetch::class];
-        yield ['100', Int_::class];
+        yield ['100', String_::class];
+        yield [200, Int_::class];
         yield ['hey', String_::class];
         yield [['hey'], Array_::class];
     }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8941