### PR TITLE
[Php80] Keep numeric string, string "true", "false" as is on StringAnnotationToAttributeMapper

### DIFF
--- a/src/PhpAttribute/AnnotationToAttributeMapper/StringAnnotationToAttributeMapper.php
+++ b/src/PhpAttribute/AnnotationToAttributeMapper/StringAnnotationToAttributeMapper.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Rector\PhpAttribute\AnnotationToAttributeMapper;
 
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ConstFetch;
-use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
@@ -27,23 +24,6 @@ final class StringAnnotationToAttributeMapper implements AnnotationToAttributeMa
      */
     public function map($value): Expr
     {
-        if (strtolower($value) === 'true') {
-            return new ConstFetch(new Name('true'));
-        }
-
-        if (strtolower($value) === 'false') {
-            return new ConstFetch(new Name('false'));
-        }
-
-        if (strtolower($value) === 'null') {
-            return new ConstFetch(new Name('null'));
-        }
-
-        // number as string to number
-        if (is_numeric($value) && strlen((string) (int) $value) === strlen($value)) {
-            return Int_::fromString($value);
-        }
-
         if (str_contains($value, "'") && ! str_contains($value, "\n")) {
             $kind = String_::KIND_DOUBLE_QUOTED;
         } else {

--- a/tests/Issues/TestWithAttribute/Fixture/keep_string_as_is.php.inc
+++ b/tests/Issues/TestWithAttribute/Fixture/keep_string_as_is.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Issues\DoubleRun\TestWithAttribute;
+
+class KeepStringAsIs extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @testWith ["2", 2, "null", "true", "false", true, false]
+     *           ["benjamin.sisko@ds9.example.com"]
+     */
+    public function testSomething(string $userId): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\DoubleRun\TestWithAttribute;
+
+class KeepStringAsIs extends \PHPUnit\Framework\TestCase
+{
+    #[\PHPUnit\Framework\Attributes\TestWith(['2', 2, 'null', 'true', 'false', true, false])]
+    #[\PHPUnit\Framework\Attributes\TestWith(['benjamin.sisko@ds9.example.com'])]
+    public function testSomething(string $userId): void
+    {
+    }
+}
+
+?>

--- a/tests/Issues/TestWithAttribute/TestWithAttributeTest.php
+++ b/tests/Issues/TestWithAttribute/TestWithAttributeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\TestWithAttribute;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TestWithAttributeTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/TestWithAttribute/config/configured_rule.php
+++ b/tests/Issues/TestWithAttribute/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\TestWithAnnotationToAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TestWithAnnotationToAttributeRector::class);
+};

--- a/tests/PhpAttribute/AnnotationToAttributeMapper/AnnotationToAttributeMapperTest.php
+++ b/tests/PhpAttribute/AnnotationToAttributeMapper/AnnotationToAttributeMapperTest.php
@@ -43,9 +43,10 @@ final class AnnotationToAttributeMapperTest extends AbstractLazyTestCase
     public static function provideData(): Iterator
     {
         yield [false, ConstFetch::class];
-        yield ['false', ConstFetch::class];
-        yield ['100', Int_::class];
+        yield ['false', String_::class];
+        yield ['100', String_::class];
         yield ['hey', String_::class];
         yield [['hey'], Array_::class];
+        yield [100, Int_::class];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8941