### PR TITLE
[NodeTypeResolver Ensure reindex stmt_key on NodeAttributeReIndexer

### DIFF
--- a/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/fixture.php.inc
@@ -13,7 +13,7 @@ class Fixture
         if ($someObject->run()) {
         }
 
-        $values = [];
+        $values = ['a', 'b', 'c'];
         foreach ($values as $value) {
         }
 
@@ -42,7 +42,9 @@ class Fixture
         if ($someObject->run()) {
         }
 
-        $values = [];
+        $values = ['a', 'b', 'c'];
+        foreach ($values as $value) {
+        }
 
         return $value;
     }

--- a/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/unused_value.php.inc
+++ b/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/unused_value.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\For_\RemoveDeadIfForeachForRector\Fixture;
+
+class UnusedValue
+{
+    public function run()
+    {
+        $value = 5;
+        $values = ['a', 'b', 'c'];
+
+        foreach ($values as $value) {
+
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\For_\RemoveDeadIfForeachForRector\Fixture;
+
+class UnusedValue
+{
+    public function run()
+    {
+        $value = 5;
+        $values = ['a', 'b', 'c'];
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/with_used_value.php.inc
+++ b/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/with_used_value.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DeadCode\Rector\For_\RemoveDeadIfForeachForRector\Fixture;
 
-class Fixture
+class WithUsedValue
 {
     public function run($someObject, $differentValue)
     {
@@ -17,13 +17,7 @@ class Fixture
         foreach ($values as $value) {
         }
 
-        return $differentValue;
-    }
-
-    public function forMe()
-    {
-        for ($i = 0; $i < 5; ++$i) {
-        }
+        return $value;
     }
 }
 
@@ -33,7 +27,7 @@ class Fixture
 
 namespace Rector\Tests\DeadCode\Rector\For_\RemoveDeadIfForeachForRector\Fixture;
 
-class Fixture
+class WithUsedValue
 {
     public function run($someObject, $differentValue)
     {
@@ -43,12 +37,10 @@ class Fixture
         }
 
         $values = ['a', 'b', 'c'];
+        foreach ($values as $value) {
+        }
 
-        return $differentValue;
-    }
-
-    public function forMe()
-    {
+        return $value;
     }
 }
 

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($assignedVariableNamesByStmtPosition as $stmtPosition => $variableName) {
-            if ($this->stmtsManipulator->isVariableUsedInNextStmt($stmts, $stmtPosition + 1, $variableName)) {
+            if ($this->stmtsManipulator->isVariableUsedInNextStmt($node, $stmtPosition + 1, $variableName)) {
                 continue;
             }
 

--- a/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
+++ b/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
@@ -139,7 +139,6 @@ CODE_SAMPLE
 
     private function processForForeach(For_|Foreach_ $for, int $key, StmtsAwareInterface $stmtsAware): void
     {
-        $stmts = (array) $stmtsAware->stmts;
         if ($for instanceof For_) {
             $variables = $this->betterNodeFinder->findInstanceOf(
                 [...$for->init, ...$for->cond, ...$for->loop],
@@ -147,7 +146,7 @@ CODE_SAMPLE
             );
             foreach ($variables as $variable) {
                 if ($this->stmtsManipulator->isVariableUsedInNextStmt(
-                    $stmts,
+                    $stmtsAware,
                     $key + 1,
                     (string) $this->getName($variable)
                 )) {
@@ -165,7 +164,7 @@ CODE_SAMPLE
         $variables = $this->betterNodeFinder->findInstanceOf($exprs, Variable::class);
         foreach ($variables as $variable) {
             if ($this->stmtsManipulator->isVariableUsedInNextStmt(
-                $stmts,
+                $stmtsAware,
                 $key + 1,
                 (string) $this->getName($variable)
             )) {

--- a/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
+++ b/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
@@ -51,8 +51,6 @@ class SomeClass
 
         foreach ($values as $value) {
         }
-
-        return $value;
     }
 }
 CODE_SAMPLE
@@ -62,7 +60,6 @@ class SomeClass
 {
     public function run($value)
     {
-        return $value;
     }
 }
 CODE_SAMPLE

--- a/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
+++ b/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
@@ -44,13 +44,15 @@ final class RemoveDeadIfForeachForRector extends AbstractRector
                     <<<'CODE_SAMPLE'
 class SomeClass
 {
-    public function run($value)
+    public function run($value, $differrentValue)
     {
         if ($value) {
         }
 
         foreach ($values as $value) {
         }
+
+        return $differentValue;
     }
 }
 CODE_SAMPLE
@@ -58,8 +60,9 @@ CODE_SAMPLE
                     <<<'CODE_SAMPLE'
 class SomeClass
 {
-    public function run($value)
+    public function run($value, $differrentValue)
     {
+        return $differentValue;
     }
 }
 CODE_SAMPLE

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -100,12 +100,6 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
-
-        // stmts variable defined to avoid unset overlap when used via array_slice() on
-        // StmtsManipulator::isVariableUsedInNextStmt()
-        // @see https://github.com/rectorphp/rector-src/pull/5968
-        // @see https://3v4l.org/eojhk
-        $stmts = (array) $constructClassMethod->stmts;
         foreach ((array) $constructClassMethod->stmts as $key => $stmt) {
             foreach ($params as $param) {
                 $paramName = $this->getName($param);
@@ -118,7 +112,7 @@ CODE_SAMPLE
                     continue;
                 }
 
-                if ($this->stmtsManipulator->isVariableUsedInNextStmt($stmts, $key + 1, $paramName)) {
+                if ($this->stmtsManipulator->isVariableUsedInNextStmt($constructClassMethod, $key + 1, $paramName)) {
                     continue;
                 }
 

--- a/src/Application/NodeAttributeReIndexer.php
+++ b/src/Application/NodeAttributeReIndexer.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class NodeAttributeReIndexer
 {
@@ -29,6 +30,11 @@ final class NodeAttributeReIndexer
     {
         if (($node instanceof StmtsAwareInterface || $node instanceof ClassLike || $node instanceof Declare_) && $node->stmts !== null) {
             $node->stmts = array_values($node->stmts);
+
+            // re-index stmt key under current node
+            foreach ($node->stmts as $key => $childStmt) {
+                $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
+            }
 
             if ($node instanceof If_) {
                 $node->elseifs = array_values($node->elseifs);

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -73,9 +73,6 @@ final readonly class StmtsManipulator
         return $stmts;
     }
 
-    /**
-     * @param StmtsAwareInterface $stmtsAware
-     */
     public function isVariableUsedInNextStmt(
         StmtsAwareInterface $stmtsAware,
         int $jumpToKey,

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -74,23 +74,27 @@ final readonly class StmtsManipulator
     }
 
     /**
-     * @param StmtsAwareInterface|Stmt[] $stmtsAware
+     * @param StmtsAwareInterface $stmtsAware
      */
     public function isVariableUsedInNextStmt(
-        StmtsAwareInterface|array $stmtsAware,
+        StmtsAwareInterface $stmtsAware,
         int $jumpToKey,
         string $variableName
     ): bool {
-        if ($stmtsAware instanceof StmtsAwareInterface && $stmtsAware->stmts === null) {
+        if ($stmtsAware->stmts === null) {
             return false;
         }
 
-        $stmts = array_slice(
-            $stmtsAware instanceof StmtsAwareInterface ? $stmtsAware->stmts : $stmtsAware,
-            $jumpToKey,
-            null,
-            true
-        );
+        $lastKey = array_key_last($stmtsAware->stmts);
+        $stmts = [];
+
+        for ($key = $jumpToKey; $lastKey <= $lastKey; ++$key) {
+            if (! isset($stmtsAware->stmts[$key])) {
+                break;
+            }
+
+            $stmts[] = $stmtsAware->stmts[$key];
+        }
 
         if ($stmtsAware instanceof TryCatch) {
             $stmts = array_merge(

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -85,7 +85,7 @@ final readonly class StmtsManipulator
         $lastKey = array_key_last($stmtsAware->stmts);
         $stmts = [];
 
-        for ($key = $jumpToKey; $lastKey <= $lastKey; ++$key) {
+        for ($key = $jumpToKey; $key <= $lastKey; ++$key) {
             if (! isset($stmtsAware->stmts[$key])) {
                 break;
             }

--- a/src/NodeManipulator/StmtsManipulator.php
+++ b/src/NodeManipulator/StmtsManipulator.php
@@ -87,7 +87,8 @@ final readonly class StmtsManipulator
 
         for ($key = $jumpToKey; $key <= $lastKey; ++$key) {
             if (! isset($stmtsAware->stmts[$key])) {
-                break;
+                // can be just removed
+                continue;
             }
 
             $stmts[] = $stmtsAware->stmts[$key];

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -24,6 +24,8 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return null;
         }
 
+        $node->stmts = array_values($node->stmts);
+
         // re-index stmt key under current node
         foreach ($node->stmts as $key => $childStmt) {
             $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);


### PR DESCRIPTION
avoid just removed stmt lose the key, which can happen due to call `NodeVisitor::REMOVE_NODE`

Fixes https://github.com/rectorphp/rector/issues/8944