### PR TITLE
clean up array_values() on StmtKeyNodeVisitor

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -24,8 +24,6 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
             return null;
         }
 
-        $node->stmts = array_values($node->stmts);
-
         // re-index stmt key under current node
         foreach ($node->stmts as $key => $childStmt) {
             $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);


### PR DESCRIPTION
Already covered previously on indexer

https://github.com/rectorphp/rector-src/blob/3e414f34039da79932322ed6e1f906454ab8c366/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php#L162-L168

On refresh process.

On early scan, index always start from 0.