### PR TITLE
[Php54] Use token base replace on LongArrayToShortArrayRector

### DIFF
--- a/rules-tests/Php54/Rector/Array_/LongArrayToShortArrayRector/Fixture/multi_nested.php.inc
+++ b/rules-tests/Php54/Rector/Array_/LongArrayToShortArrayRector/Fixture/multi_nested.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\LongArrayToShortArrayTest\Fixture;
+
+final class MultiNested
+{
+    public function run()
+    {
+        return array(
+            array(
+                array(
+                    'abc' => true,
+                ),
+            ),
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\LongArrayToShortArrayTest\Fixture;
+
+final class MultiNested
+{
+    public function run()
+    {
+        return [
+            [
+                [
+                    'abc' => true,
+                ],
+            ],
+        ];
+    }
+}
+
+?>

--- a/rules-tests/Php54/Rector/Array_/LongArrayToShortArrayRector/Fixture/spaced_array.php.inc
+++ b/rules-tests/Php54/Rector/Array_/LongArrayToShortArrayRector/Fixture/spaced_array.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\LongArrayToShortArrayTest\Fixture;
+
+final class SpacedArray
+{
+    public function run()
+    {
+        return array (
+            array (
+                array (
+                    'abc' => true,
+                ),
+            ),
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php54\Rector\Array_\LongArrayToShortArrayTest\Fixture;
+
+final class SpacedArray
+{
+    public function run()
+    {
+        return  [
+             [
+                 [
+                    'abc' => true,
+                ],
+            ],
+        ];
+    }
+}
+
+?>

--- a/rules/Php54/Rector/Array_/LongArrayToShortArrayRector.php
+++ b/rules/Php54/Rector/Array_/LongArrayToShortArrayRector.php
@@ -76,8 +76,39 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         $node->setAttribute(AttributeKey::KIND, Array_::KIND_SHORT);
+
+        $tokens = $this->file->getOldTokens();
+
+        $startTokenPos = $node->getStartTokenPos();
+        $endTokenPos = $node->getEndTokenPos();
+
+        if (! isset($tokens[$startTokenPos], $tokens[$endTokenPos])) {
+            return null;
+        }
+
+        // replace array opening
+        $tokens[$startTokenPos]->text = '';
+
+        $iteration = 1;
+        while (isset($tokens[$startTokenPos + $iteration])) {
+            if (trim($tokens[$startTokenPos + $iteration]->text) === '') {
+                ++$iteration;
+                continue;
+            }
+
+            if (trim($tokens[$startTokenPos + $iteration]->text) !== '(') {
+                break;
+            }
+
+            // replace ( parentheses opening
+            $tokens[$startTokenPos + $iteration]->text = '[';
+            // replace ) parentheses closing
+            $tokens[$endTokenPos]->text = ']';
+
+            break;
+        }
+
         return $node;
     }
 }


### PR DESCRIPTION
This make array print for short array have same structure:

```diff
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     'abc' => true,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
```

instead of make single line due to reprint.