### PR TITLE
[Php81][php82] Add AttributeGroupNewLiner to make new line based on token on ReadOnlyPropertyRector and ReadOnlyClassRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_inline.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_inline.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final class WithAttributeInline
+{
+    #[Serializer\Since(Option::SINCE_20211124)]private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final class WithAttributeInline
+{
+    #[Serializer\Since(Option::SINCE_20211124)]
+    private readonly string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}
+
+?>

--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_with_attribute.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_with_attribute.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
 #[SomeAttribute]
 final class ClassWithAttribute
 {
-   private readonly string $property;
+    private readonly string $property;
 }
 
 ?>

--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_with_attribute_inline.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/class_with_attribute_inline.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+#[SomeAttribute]final class ClassWithAttributeInline
+{
+    private readonly string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+#[SomeAttribute]
+final readonly class ClassWithAttributeInline
+{
+    private string $property;
+}
+
+?>

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -39,10 +39,12 @@ final class AttributeGroupNewLiner
                     break;
                 }
 
-                if (trim($oldTokens[$startTokenPos + $iteration + 1]->text) === '') {
+                if (trim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '') === '') {
                     $space = ltrim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '', "\r\n");
-                } else {
+                } elseif (trim($oldTokens[$startTokenPos - 1]->text ?? '') === '') {
                     $space = ltrim($oldTokens[$startTokenPos - 1]->text ?? '', "\r\n");
+                } else {
+                    $space = '';
                 }
 
                 $oldTokens[$startTokenPos + $iteration]->text = "]\n" . $space;

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -34,7 +34,10 @@ final class AttributeGroupNewLiner
         $lastAttributeTokenPos = $node->attrGroups[$lastKey]->getEndTokenPos();
 
         while (isset($oldTokens[$startTokenPos + $iteration])) {
-            if ($startTokenPos + $iteration === $lastAttributeTokenPos) {
+            if ($startTokenPos + $iteration === $lastAttributeTokenPos
+                && $oldTokens[$startTokenPos + $iteration]->text === ']' &&
+                trim($oldTokens[$startTokenPos + $iteration + 1]->text) === ''
+            ) {
                 $space = ltrim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '', "\r\n");
                 $oldTokens[$startTokenPos + $iteration]->text = "]\n" . $space;
                 break;

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php81\NodeManipulator;
+
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use Rector\ValueObject\Application\File;
+
+final class AttributeGroupNewLiner
+{
+    public function newLine(File $file, Property|Param|Class_ $node): void
+    {
+        $oldTokens = $file->getOldTokens();
+        $startTokenPos = $node->getStartTokenPos();
+
+        if (! isset($oldTokens[$startTokenPos])) {
+            return;
+        }
+
+        if ($oldTokens[$startTokenPos]->text !== '#[') {
+            return;
+        }
+
+        $iteration = 1;
+        $lastKey = array_key_last($node->attrGroups);
+
+        if ($lastKey === null) {
+            return;
+        }
+
+        $lastAttributeTokenPos = $node->attrGroups[$lastKey]->getEndTokenPos();
+
+        while (isset($oldTokens[$startTokenPos + $iteration])) {
+            if ($startTokenPos + $iteration === $lastAttributeTokenPos) {
+                $space = ltrim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '', "\r\n");
+                $oldTokens[$startTokenPos + $iteration]->text = "]\n" . $space;
+                break;
+            }
+
+            ++$iteration;
+        }
+    }
+}

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -34,11 +34,17 @@ final class AttributeGroupNewLiner
         $lastAttributeTokenPos = $node->attrGroups[$lastKey]->getEndTokenPos();
 
         while (isset($oldTokens[$startTokenPos + $iteration])) {
-            if ($startTokenPos + $iteration === $lastAttributeTokenPos
-                && $oldTokens[$startTokenPos + $iteration]->text === ']' &&
-                trim($oldTokens[$startTokenPos + $iteration + 1]->text) === ''
-            ) {
-                $space = ltrim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '', "\r\n");
+            if ($startTokenPos + $iteration === $lastAttributeTokenPos) {
+                if ($oldTokens[$startTokenPos + $iteration]->text !== ']') {
+                    break;
+                }
+
+                if (trim($oldTokens[$startTokenPos + $iteration + 1]->text) === '') {
+                    $space = ltrim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '', "\r\n");
+                } else {
+                    $space = ltrim($oldTokens[$startTokenPos - 1]->text ?? '', "\r\n");
+                }
+
                 $oldTokens[$startTokenPos + $iteration]->text = "]\n" . $space;
                 break;
             }

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -23,7 +23,7 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeAnalyzer\ParamAnalyzer;
 use Rector\NodeManipulator\PropertyFetchAssignManipulator;
 use Rector\NodeManipulator\PropertyManipulator;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Php81\NodeManipulator\AttributeGroupNewLiner;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
@@ -47,7 +47,8 @@ final class ReadOnlyPropertyRector extends AbstractRector implements MinPhpVersi
         private readonly VisibilityManipulator $visibilityManipulator,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly DocBlockUpdater $docBlockUpdater
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly AttributeGroupNewLiner $attributeGroupNewLiner
     ) {
     }
 
@@ -174,7 +175,7 @@ CODE_SAMPLE
 
         $attributeGroups = $property->attrGroups;
         if ($attributeGroups !== []) {
-            $property->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $this->attributeGroupNewLiner->newLine($this->file, $property);
         }
 
         $this->removeReadOnlyDoc($property);
@@ -235,7 +236,7 @@ CODE_SAMPLE
         }
 
         if ($param->attrGroups !== []) {
-            $param->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $this->attributeGroupNewLiner->newLine($this->file, $param);
         }
 
         $this->visibilityManipulator->makeReadonly($param);

--- a/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
+++ b/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
@@ -15,9 +15,9 @@ use PHPStan\BetterReflection\Reflection\Adapter\ReflectionProperty;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeAnalyzer\ClassAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\Php81\Enum\AttributeName;
+use Rector\Php81\NodeManipulator\AttributeGroupNewLiner;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
@@ -37,7 +37,8 @@ final class ReadOnlyClassRector extends AbstractRector implements MinPhpVersionI
         private readonly ClassAnalyzer $classAnalyzer,
         private readonly VisibilityManipulator $visibilityManipulator,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly AttributeGroupNewLiner $attributeGroupNewLiner
     ) {
     }
 
@@ -96,8 +97,7 @@ CODE_SAMPLE
                 $this->visibilityManipulator->removeReadonly($param);
 
                 if ($param->attrGroups !== []) {
-                    // invoke reprint with correct newline
-                    $param->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                    $this->attributeGroupNewLiner->newLine($this->file, $param);
                 }
             }
         }
@@ -106,14 +106,12 @@ CODE_SAMPLE
             $this->visibilityManipulator->removeReadonly($property);
 
             if ($property->attrGroups !== []) {
-                // invoke reprint with correct newline
-                $property->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                $this->attributeGroupNewLiner->newLine($this->file, $property);
             }
         }
 
         if ($node->attrGroups !== []) {
-            // invoke reprint with correct readonly newline
-            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $this->attributeGroupNewLiner->newLine($this->file, $node);
         }
 
         return $node;

--- a/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
@@ -7,7 +7,7 @@ namespace Rector\Privatization\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ReflectionProvider;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Php81\NodeManipulator\AttributeGroupNewLiner;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -21,6 +21,7 @@ final class FinalizeTestCaseClassRector extends AbstractRector
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
         private readonly VisibilityManipulator $visibilityManipulator,
+        private readonly AttributeGroupNewLiner $attributeGroupNewLiner
     ) {
     }
 
@@ -85,7 +86,7 @@ CODE_SAMPLE
         }
 
         if ($node->attrGroups !== []) {
-            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $this->attributeGroupNewLiner->newLine($this->file, $node);
         }
 
         $this->visibilityManipulator->makeFinal($node);


### PR DESCRIPTION
instead of set origiNode to null which cause whole reprint node, add new line based token for AttributeGroups on ReadOnlyPropertyRector and ReadOnlyClassRector