### PR TITLE
[Performance] Remove SimpleCallableNodeTraverser usage on ByRefReturnNodeVisitor

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
@@ -6,6 +6,7 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitorAbstract;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
@@ -37,7 +37,7 @@ final class ByRefReturnNodeVisitor extends NodeVisitorAbstract implements ScopeR
     /**
      * @param Stmt[] $stmts
      */
-    private function setByRefAttribute(array $stmts)
+    private function setByRefAttribute(array $stmts): void
     {
         foreach ($stmts as $stmt) {
             if ($stmt instanceof FunctionLike) {

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
@@ -6,21 +6,14 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Return_;
-use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
+use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
-use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
 final class ByRefReturnNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
-    public function __construct(
-        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
-    ) {
-    }
-
     public function enterNode(Node $node): ?Node
     {
         if (! $node instanceof FunctionLike) {
@@ -36,22 +29,29 @@ final class ByRefReturnNodeVisitor extends NodeVisitorAbstract implements ScopeR
             return null;
         }
 
-        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
-            $stmts,
-            static function (Node $node): int|null|Node {
-                if ($node instanceof Class_ || $node instanceof FunctionLike) {
-                    return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-                }
-
-                if (! $node instanceof Return_) {
-                    return null;
-                }
-
-                $node->setAttribute(AttributeKey::IS_BYREF_RETURN, true);
-                return $node;
-            }
-        );
+        $this->setByRefAttribute($stmts);
 
         return null;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function setByRefAttribute(array $stmts)
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof FunctionLike) {
+                continue;
+            }
+
+            if ($stmt instanceof StmtsAwareInterface && $stmt->stmts !== null) {
+                $this->setByRefAttribute($stmt->stmts);
+                continue;
+            }
+
+            if ($stmt instanceof Return_) {
+                $stmt->setAttribute(AttributeKey::IS_BYREF_RETURN, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
Using normal recursive method is enough for Stmt lookup.