### PR TITLE
Rollback SimpleCallableNodeTraverser usage on ByRefReturnNodeVisitor

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ByRefReturnNodeVisitor.php
@@ -6,16 +6,21 @@ namespace Rector\NodeTypeResolver\PHPStan\Scope\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Return_;
-use PhpParser\Node\Stmt\Switch_;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
-use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 
 final class ByRefReturnNodeVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
 {
+    public function __construct(
+        private readonly SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+    ) {
+    }
+
     public function enterNode(Node $node): ?Node
     {
         if (! $node instanceof FunctionLike) {
@@ -31,37 +36,21 @@ final class ByRefReturnNodeVisitor extends NodeVisitorAbstract implements ScopeR
             return null;
         }
 
-        $this->setByRefAttribute($stmts);
-
-        return null;
-    }
-
-    /**
-     * @param Stmt[] $stmts
-     */
-    private function setByRefAttribute(array $stmts): void
-    {
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof FunctionLike) {
-                continue;
-            }
-
-            if ($stmt instanceof StmtsAwareInterface && $stmt->stmts !== null) {
-                $this->setByRefAttribute($stmt->stmts);
-                continue;
-            }
-
-            if ($stmt instanceof Switch_) {
-                foreach ($stmt->cases as $case) {
-                    $this->setByRefAttribute($case->stmts);
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+            $stmts,
+            static function (Node $node): int|null|Node {
+                if ($node instanceof Class_ || $node instanceof FunctionLike) {
+                    return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
-                continue;
-            }
+                if (! $node instanceof Return_) {
+                    return null;
+                }
 
-            if ($stmt instanceof Return_) {
-                $stmt->setAttribute(AttributeKey::IS_BYREF_RETURN, true);
-            }
-        }
+                $node->setAttribute(AttributeKey::IS_BYREF_RETURN, true);
+                return $node;
+            });
+
+        return null;
     }
 }


### PR DESCRIPTION
Just loop `StmtsAwareInterface` is not enough, for example, on try catch finally, or if else stmts, it needs to look on its property Else_ first, then loop stmts.