### PR TITLE
Add sub namespace Groups fixture on AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/same_groups_class_name.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Symfony/same_groups_class_name.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+class Booking
+{
+    /**
+     * @var int
+     *
+     * @Groups({"Booking.id"})
+     */
+    private $id;
+
+    /**
+     * @var int
+     *
+     * @Source\Groups({"Booking.id"})
+     */
+    private $id2;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+
+class Booking
+{
+    /**
+     * @var int
+     */
+    #[Groups(['Booking.id'])]
+    private $id;
+
+    /**
+     * @var int
+     *
+     * @Source\Groups({"Booking.id"})
+     */
+    private $id2;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Groups.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Groups.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source;
+
+class Groups
+{
+    #[ORM\Column(name: 'id', type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private $id;
+}

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -49,6 +49,8 @@ return static function (RectorConfig $rectorConfig): void {
         ),
         new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Security'),
 
+        new AnnotationToAttribute('Symfony\Component\Serializer\Attribute\Groups'),
+
         // special case with following comment becoming a inner value
         new AnnotationToAttribute('When', When::class, useValueAsAttributeArgument: true),
         new AnnotationToAttribute('Then', Then::class, useValueAsAttributeArgument: true),

--- a/stubs/Symfony/Component/Serializer/Attribute/Groups.php
+++ b/stubs/Symfony/Component/Serializer/Attribute/Groups.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @changelog https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Annotation/Route.php */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Attribute;
+
+if (class_exists('Symfony\Component\Serializer\Attribute\Groups')) {
+    return;
+}
+
+class Groups
+{
+}

--- a/tests/NodeTypeResolver/PerNodeTypeResolver/NewTypeResolver/NewTypeResolverTest.php
+++ b/tests/NodeTypeResolver/PerNodeTypeResolver/NewTypeResolver/NewTypeResolverTest.php
@@ -27,7 +27,7 @@ final class NewTypeResolverTest extends AbstractNodeTypeResolverTestCase
         $resolvedType = $this->nodeTypeResolver->getType($newNodes[$nodePosition]);
         $this->assertEquals($expectedType, $resolvedType);
 
-        $this->assertEquals(
+        $this->assertSame(
             $isObjectType,
             $this->nodeTypeResolver->isObjectType(
                 $newNodes[$nodePosition],


### PR DESCRIPTION
@daveharding this fixture test for same namespace `Groups` class per your description

https://github.com/rectorphp/rector-phpunit/issues/297#issuecomment-2557683657

it processed correctly on target `Groups` class, which skip current namespace Groups class, per config definition.