### PR TITLE
[DeadCode] Allow remove useless @var on typed class constant as well on RemoveUselessVarTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUselessVarTagRector/Fixture/with_constant_type.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUselessVarTagRector/Fixture/with_constant_type.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUselessVarTagRector\Fixture;
+
+final class WithConstantType
+{
+    /**
+     * @var string
+     */
+    public const string NAME = 'value';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUselessVarTagRector\Fixture;
+
+final class WithConstantType
+{
+    public const string NAME = 'value';
+}
+
+?>

--- a/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\PhpDoc;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\Type\IntersectionType;
@@ -24,7 +25,7 @@ final readonly class DeadVarTagValueNodeAnalyzer
     ) {
     }
 
-    public function isDead(VarTagValueNode $varTagValueNode, Property $property): bool
+    public function isDead(VarTagValueNode $varTagValueNode, Property|ClassConst $property): bool
     {
         if (! $property->type instanceof Node) {
             return false;

--- a/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
+++ b/rules/DeadCode/PhpDoc/TagRemover/VarTagRemover.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\PhpDoc\TagRemover;
 
 use PhpParser\Node;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
@@ -31,7 +32,7 @@ final readonly class VarTagRemover
     ) {
     }
 
-    public function removeVarTagIfUseless(PhpDocInfo $phpDocInfo, Property $property): bool
+    public function removeVarTagIfUseless(PhpDocInfo $phpDocInfo, Property|ClassConst $property): bool
     {
         $varTagValueNode = $phpDocInfo->getVarTagValueNode();
         if (! $varTagValueNode instanceof VarTagValueNode) {

--- a/rules/DeadCode/Rector/Property/RemoveUselessVarTagRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUselessVarTagRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\Property;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
@@ -25,7 +26,7 @@ final class RemoveUselessVarTagRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Remove unused @var annotation for properties', [
+        return new RuleDefinition('Remove unused @var annotation for properties and class constant', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass
@@ -53,11 +54,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Property::class];
+        return [Property::class, ClassConst::class];
     }
 
     /**
-     * @param Property $node
+     * @param Property|ClassConst $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/rules/DeadCode/Rector/Property/RemoveUselessVarTagRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUselessVarTagRector.php
@@ -26,7 +26,7 @@ final class RemoveUselessVarTagRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Remove unused @var annotation for properties and class constant', [
+        return new RuleDefinition('Remove unused @var annotation for properties and class constants', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass


### PR DESCRIPTION
to remove useless `@var` on php 8.3 code which class constant can be typed, but stil with `@var` that no longer needed.