### PR TITLE
[CodeQuality] Skip fopen() or die() on LogicalToBooleanRector on assign

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.0.10",
         "illuminate/container": "^11.35",
         "nette/utils": "^4.0",
-        "nikic/php-parser": "^5.3.1",
+        "nikic/php-parser": "5.3.1",
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0",

--- a/rules-tests/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector/Fixture/skip_fopen_or_die_in_assign.php.inc
+++ b/rules-tests/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector/Fixture/skip_fopen_or_die_in_assign.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\LogicalAnd\LogicalToBooleanRector\Fixture;
+
+final class SkipFopenOrDieInAssign
+{
+    public function run(string $fileLocation)
+    {
+        $file = fopen($fileLocation, 'w') or die('Unable to open file!');
+        fwrite($file, "John Doe\nJane Doe\n");
+        fclose($file);
+    }
+}

--- a/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
+++ b/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
@@ -51,8 +51,14 @@ CODE_SAMPLE
     /**
      * @param LogicalOr|LogicalAnd $node
      */
-    public function refactor(Node $node): BooleanAnd|BooleanOr
+    public function refactor(Node $node): BooleanAnd|BooleanOr|null
     {
+        $type = $this->nodeTypeResolver->getType($node->left);
+
+        if (! $type->isBoolean()->yes()) {
+            return null;
+        }
+
         return $this->refactorLogicalToBoolean($node);
     }
 

--- a/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
+++ b/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\LogicalAnd;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
@@ -55,7 +56,7 @@ CODE_SAMPLE
     {
         $type = $this->nodeTypeResolver->getNativeType($node->left);
 
-        if (! $type->isBoolean()->yes()) {
+        if ($node->left instanceof Assign && ! $type->isBoolean()->yes()) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
+++ b/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
@@ -53,7 +53,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): BooleanAnd|BooleanOr|null
     {
-        $type = $this->nodeTypeResolver->getType($node->left);
+        $type = $this->nodeTypeResolver->getNativeType($node->left);
 
         if (! $type->isBoolean()->yes()) {
             return null;


### PR DESCRIPTION
Hi @lvanstrijland 

I finally found a real use case when `or` should be kept, on `fopen() or die()` when assigned:

```php
        $file = fopen($fileLocation, 'w') or die('Unable to open file!');
        fwrite($file, "John Doe\nJane Doe\n");
        fclose($file);
```

with `||`, `$file` become `bool` instead of `resource` when file opened. 

Ref https://github.com/rectorphp/rector/issues/7604