### PR TITLE
Temporary pin php-parser to 5.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.0.10",
         "illuminate/container": "^11.35",
         "nette/utils": "^4.0",
-        "nikic/php-parser": "^5.3.1",
+        "nikic/php-parser": "5.3.1",
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0",


### PR DESCRIPTION
nikic/php-parser 5.4.0 just released https://github.com/nikic/PHP-Parser/releases/tag/v5.4.0 , and this cause vendor patches error:

```

   Could not apply patch! Skipping. The error was: Cannot apply patch 
https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-nodetraverser-php.patch

Error: Cannot apply patch 15 (https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-nodetraverser-php.patch)!

```

see https://github.com/rectorphp/rector-src/actions/runs/12545721446/job/34980384434

This patch temporary pin to 5.3.1 to update vendor patches later.