### PR TITLE
use vendor-patches main branch that already include php-parser 5.4.0 patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-case-php.patch",
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-elseif-php.patch",
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-node-stmt-namespace-php.patch",
-                "https://raw.githubusercontent.com/rectorphp/vendor-patches/fix-patch-php-parser-54/patches/nikic-php-parser-lib-phpparser-nodetraverser-php.patch"
+                "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/nikic-php-parser-lib-phpparser-nodetraverser-php.patch"
             ]
         },
         "composer-exit-on-patch-failure": true,


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/6637
- https://github.com/rectorphp/vendor-patches/pull/10

this update to use vendor-patches main branch that already include php-parser 5.4.0 patch

