### PR TITLE
[DeadCode] Add ReplaceBlockToItsStmtsRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector\Fixture;
+
+{
+    echo "statement 1";
+    echo PHP_EOL;
+    echo "statement 2";
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector\Fixture;
+
+echo "statement 1";
+echo PHP_EOL;
+echo "statement 2";
+
+?>

--- a/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/Fixture/skip_normal_statements.php.inc
+++ b/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/Fixture/skip_normal_statements.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector\Fixture;
+
+function skipNormalStatements()
+{
+    echo "statement 1";
+    echo PHP_EOL;
+    echo "statement 2";
+}

--- a/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/ReplaceBlockToItsStmtsRectorTest.php
+++ b/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/ReplaceBlockToItsStmtsRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceBlockToItsStmtsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector;
+
+return RectorConfig::configure()
+    ->withRules([ReplaceBlockToItsStmtsRector::class]);

--- a/rules/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector.php
+++ b/rules/DeadCode/Rector/Block/ReplaceBlockToItsStmtsRector.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\Block;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Block;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector\ReplaceBlockToItsStmtsRectorTest
+ * @see https://3v4l.org/ZUfEV
+ */
+final class ReplaceBlockToItsStmtsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace Block Stmt with its stmts',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+{
+    echo "statement 1";
+    echo PHP_EOL;
+    echo "statement 2";
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+echo "statement 1";
+echo PHP_EOL;
+echo "statement 2";
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Block::class];
+    }
+
+    /**
+     * @param Block $node
+     * @return Stmt[]
+     */
+    public function refactor(Node $node): array
+    {
+        return $node->stmts;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -9,6 +9,7 @@ use Rector\Contract\Rector\RectorInterface;
 use Rector\DeadCode\Rector\Array_\RemoveDuplicatedArrayKeyRector;
 use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
 use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
+use Rector\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector;
 use Rector\DeadCode\Rector\BooleanAnd\RemoveAndTrueRector;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassConst\RemoveUnusedPrivateClassConstantRector;
@@ -82,6 +83,7 @@ final class DeadCodeLevel
         RemoveUnusedNonEmptyArrayBeforeForeachRector::class,
         RemoveNullPropertyInitializationRector::class,
         RemoveUselessReturnExprInConstructRector::class,
+        ReplaceBlockToItsStmtsRector::class,
 
         RemoveTypedPropertyDeadInstanceOfRector::class,
         TernaryToBooleanOrFalseToBooleanAndRector::class,


### PR DESCRIPTION
This PR inspired by @tacman use case at:

- https://github.com/rectorphp/rector/issues/8956

that handled at PR:

- https://github.com/rectorphp/rector-src/pull/6640

the block statement should never used imo, as it always executed, direct replace with its stmts instead.

```php
{
    echo "statement 1";
    echo PHP_EOL;
    echo "statement 2";
}
```

see https://3v4l.org/ZUfEV