### PR TITLE
[DeadCode] Add RemoveUselessAssignFromPropertyPromotionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/simple.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/simple.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
 class Simple
 {
@@ -14,7 +14,7 @@ class Simple
 -----
 <?php
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
 class Simple
 {

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/simple.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/simple.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromProper
 
 class Simple
 {
-    public function __construct(private readonly \stdClass $std)
+    public function __construct(private \stdClass $std)
     {
     	$this->std = $std;
     }
@@ -18,7 +18,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromProper
 
 class Simple
 {
-    public function __construct(private readonly \stdClass $std)
+    public function __construct(private \stdClass $std)
     {
     }
 }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/simple.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/simple.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+
+class Simple
+{
+    public function __construct(private readonly \stdClass $std)
+    {
+    	$this->std = $std;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+
+class Simple
+{
+    public function __construct(private readonly \stdClass $std)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_complex_statement.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_complex_statement.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromProper
 
 class SkipComplexStatement
 {
-    public function __construct(private readonly \stdClass $std)
+    public function __construct(private \stdClass $std)
     {
         if (rand(0, 1)) {
             $this->std = '';

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_complex_statement.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_complex_statement.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+
+class SkipComplexStatement
+{
+    public function __construct(private readonly \stdClass $std)
+    {
+        if (rand(0, 1)) {
+            $this->std = '';
+        }
+    }
+}
+

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_complex_statement.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_complex_statement.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
 class SkipComplexStatement
 {

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
 class SkipDifferentVariable
 {

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
@@ -2,12 +2,13 @@
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
+use stdClass;
+
 class SkipDifferentVariable
 {
-    public function __construct(private \stdClass $std)
+    public function __construct(private \stdClass $std, stdClass $std2)
     {
-        $differentVariable = new \stdClass();
-        $this->std = $differentVariable;
+        $this->std = $std2;
     }
 }
 

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+
+class SkipDifferentVariable
+{
+    public function __construct(private readonly \stdClass $std)
+    {
+        $differentVariable = new \stdClass();
+        $this->std = $differentVariable;
+    }
+}
+

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_different_variable.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromProper
 
 class SkipDifferentVariable
 {
-    public function __construct(private readonly \stdClass $std)
+    public function __construct(private \stdClass $std)
     {
         $differentVariable = new \stdClass();
         $this->std = $differentVariable;

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_normal_param.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_normal_param.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+
+class SkipNormalParam
+{
+    private \stdClass $std;
+
+    public function __construct(\stdClass $std)
+    {
+        $this->std = $std;
+    }
+}
+

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_normal_param.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_normal_param.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotion\Fixture;
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
 class SkipNormalParam
 {

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
@@ -8,7 +8,7 @@ namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromProper
  */
 class SkipReadonlyPromotion
 {
-    public function __construct(private \stdClass $std)
+    public function __construct(private readonly \stdClass $std)
     {
     }
 }

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
@@ -3,7 +3,7 @@
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
 /**
- * Re-assign already error on the first place, no need to check
+ * Re-assign readonly promotion already error on the first place, no need to check
  * see https://3v4l.org/HGulh#v8.4.2
  */
 class SkipReadonlyPromotion

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
@@ -2,7 +2,10 @@
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
 
-/** Re-assign already error on the first place, no need to check */
+/**
+ * Re-assign already error on the first place, no need to check
+ * see https://3v4l.org/HGulh#v8.4.2
+ */
 class SkipReadonlyPromotion
 {
     public function __construct(private \stdClass $std)

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/Fixture/skip_readonly_promotion.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector\Fixture;
+
+/** Re-assign already error on the first place, no need to check */
+class SkipReadonlyPromotion
+{
+    public function __construct(private \stdClass $std)
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/RemoveUselessAssignFromPropertyPromotionRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/RemoveUselessAssignFromPropertyPromotionRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveUselessAssignFromPropertyPromotionRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveUselessAssignFromPropertyPromotionRector::class]);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -99,8 +99,8 @@ CODE_SAMPLE
                 return null;
             }
 
-            // collect first, ensure not stop too early on non property fetch
-            // and already removed
+            // collect first, ensure not removed too early on next non property fetch assignment
+            // which may have side effect
             if ($assign->var->var instanceof Variable && $this->isName($assign->var->var, 'this') && $this->isNames(
                 $assign->var->name,
                 $variableNames

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -30,7 +30,7 @@ final class RemoveUselessAssignFromPropertyPromotionRector extends AbstractRecto
                     <<<'CODE_SAMPLE'
 class SomeClass
 {
-    public function __construct(private readonly \stdClass $std)
+    public function __construct(private \stdClass $std)
     {
     	$this->std = $std;
     }
@@ -40,7 +40,7 @@ CODE_SAMPLE
                     <<<'CODE_SAMPLE'
 class SomeClass
 {
-    public function __construct(private readonly \stdClass $std)
+    public function __construct(private \stdClass $std)
     {
     }
 }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -78,6 +78,7 @@ CODE_SAMPLE
             }
 
             // re-assign will cause error on the first place, no need to collect names
+            // on readonly property promotion
             if ($param->isReadonly()) {
                 continue;
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -80,6 +80,10 @@ CODE_SAMPLE
             $variableNames[] = (string) $this->getName($param->var);
         }
 
+        if ($variableNames === []) {
+            return null;
+        }
+
         /** @var Stmt[] $stmts */
         $stmts = $node->stmts;
         $removeStmtKeys = [];

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -107,7 +107,7 @@ CODE_SAMPLE
             if ($assign->var->var instanceof Variable && $this->isName($assign->var->var, 'this') && $this->isNames(
                 $assign->var->name,
                 $variableNames
-            ) && $assign->expr instanceof Variable && $this->isName($assign->expr, $this->getName($assign->var->name))) {
+            ) && $assign->expr instanceof Variable && $this->isName($assign->expr, (string) $this->getName($assign->var->name))) {
                 $removeStmtKeys[] = $key;
                 continue;
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
         $removeStmtKeys = [];
 
         foreach ($stmts as $key => $stmt) {
-            // skip complex statements
+            // has complex statements, skip
             if (! $stmt instanceof Expression || ! $stmt->expr instanceof Assign) {
                 return null;
             }
@@ -94,7 +94,7 @@ CODE_SAMPLE
             /** @var Assign $assign */
             $assign = $stmt->expr;
 
-            // skip non property fetches assignments
+            // has non property fetches assignments, skip
             if (! $assign->var instanceof PropertyFetch) {
                 return null;
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -83,26 +83,24 @@ CODE_SAMPLE
 
         /** @var Stmt[] $stmts */
         $stmts = $node->stmts;
+        $removeStmtKeys = [];
 
-        // skip complex statements
-        foreach ($stmts as $stmt) {
+        foreach ($stmts as $key => $stmt) {
+            // skip complex statements
             if (! $stmt instanceof Expression || ! $stmt->expr instanceof Assign) {
                 return null;
             }
-        }
 
-        $removeStmtKeys = [];
-
-        /** @var Expression[] $stmts */
-        foreach ($stmts as $key => $stmt) {
             /** @var Assign $assign */
             $assign = $stmt->expr;
 
+            // skip non property fetches assignments
             if (! $assign->var instanceof PropertyFetch) {
                 return null;
             }
 
             // collect first, ensure not stop too early on non property fetch
+            // and already removed
             if ($assign->var->var instanceof Variable && $this->isName($assign->var->var, 'this') && $this->isNames(
                 $assign->var->name,
                 $variableNames

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Rector\AbstractRector;
@@ -67,7 +66,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->isAbstract()) {
+        if ($node->stmts === null || $node->stmts == []) {
             return null;
         }
 
@@ -90,11 +89,9 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var Stmt[] $stmts */
-        $stmts = $node->stmts;
         $removeStmtKeys = [];
 
-        foreach ($stmts as $key => $stmt) {
+        foreach ($node->stmts as $key => $stmt) {
             // has non direct expression with assign, skip
             if (! $stmt instanceof Expression || ! $stmt->expr instanceof Assign) {
                 return null;
@@ -113,7 +110,10 @@ CODE_SAMPLE
             if ($assign->var->var instanceof Variable && $this->isName($assign->var->var, 'this') && $this->isNames(
                 $assign->var->name,
                 $variableNames
-            ) && $assign->expr instanceof Variable && $this->isName($assign->expr, (string) $this->getName($assign->var->name))) {
+            ) && $assign->expr instanceof Variable && $this->isName(
+                $assign->expr,
+                (string) $this->getName($assign->var->name)
+            )) {
                 $removeStmtKeys[] = $key;
                 continue;
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -77,7 +77,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            // re-assign will cause error too early, no need to collect names
+            // re-assign will cause error on the first place, no need to collect names
             if ($param->isReadonly()) {
                 continue;
             }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -77,6 +77,11 @@ CODE_SAMPLE
                 continue;
             }
 
+            // re-assign will cause error too early, no need to collect names
+            if ($param->isReadonly()) {
+                continue;
+            }
+
             $variableNames[] = (string) $this->getName($param->var);
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -42,7 +42,6 @@ class SomeClass
 {
     public function __construct(private readonly \stdClass $std)
     {
-    	$this->std = $std;
     }
 }
 CODE_SAMPLE

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessAssignFromPropertyPromotionRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
         $removeStmtKeys = [];
 
         foreach ($stmts as $key => $stmt) {
-            // has complex statements, skip
+            // has non direct expression with assign, skip
             if (! $stmt instanceof Expression || ! $stmt->expr instanceof Assign) {
                 return null;
             }

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -21,6 +21,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnExprInConstructRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
@@ -88,6 +89,7 @@ final class DeadCodeLevel
         RemoveTypedPropertyDeadInstanceOfRector::class,
         TernaryToBooleanOrFalseToBooleanAndRector::class,
         RemoveDoubleAssignRector::class,
+        RemoveUselessAssignFromPropertyPromotionRector::class,
         RemoveConcatAutocastRector::class,
         SimplifyIfElseWithSameContentRector::class,
         SimplifyUselessVariableRector::class,


### PR DESCRIPTION
This new rule to remove useless assign when match with promoted property.