### PR TITLE
[CodeQuality] Add rector: CatchThrowableInsteadOfExceptionRector

### DIFF
--- a/build/target-repository/docs/rector_rules_overview.md
+++ b/build/target-repository/docs/rector_rules_overview.md
@@ -12,7 +12,7 @@ Use https://getrector.com/find-rule instead!
 
 - [Carbon](#carbon) (4)
 
-- [CodeQuality](#codequality) (69)
+- [CodeQuality](#codequality) (70)
 
 - [CodingStyle](#codingstyle) (29)
 
@@ -344,6 +344,23 @@ Refactor `call_user_func()` with arrow function to direct call
 -        $result = \call_user_func(fn () => 100);
 +        $result = 100;
      }
+ }
+```
+
+<br>
+
+### CatchThrowableInsteadOfExceptionRector
+
+Replace last catch Exception with catch Throwable
+
+- class: [`Rector\CodeQuality\Rector\Catch_\CatchThrowableInsteadOfExceptionRector`](../rules/CodeQuality/Rector/Catch_\CatchThrowableInsteadOfExceptionRector.php)
+
+```diff
+ try {
+     $this->doSomething();
+-} catch (Exception $exception) {
++} catch (Throwable $exception) {
+     // do something
  }
 ```
 

--- a/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/CatchThrowableInsteadOfExceptionRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/CatchThrowableInsteadOfExceptionRectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Catch_\CatchThrowableInsteadOfExceptionRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CatchThrowableInsteadOfExceptionRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/escaped_exception.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/escaped_exception.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (\Exception $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \Exception('Some exception');
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+use Throwable;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (Throwable $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \Exception('Some exception');
+	}
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/escaped_exception_with_imported_throwable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/escaped_exception_with_imported_throwable.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+use Throwable;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (\Exception $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \Exception('Some exception');
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+use Throwable;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (Throwable $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \Exception('Some exception');
+	}
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/imported_exception.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/imported_exception.php.inc
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+use Exception;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (Exception $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new Exception('Some exception');
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+use Throwable;
+use Exception;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (Throwable $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new Exception('Some exception');
+	}
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/multiple_types.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/multiple_types.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+use ArithmeticError;
+use Exception;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (ArithmeticError|Exception $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \UnexpectedValueException('Some exception');
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+use Throwable;
+use ArithmeticError;
+use Exception;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (ArithmeticError|Throwable $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \UnexpectedValueException('Some exception');
+	}
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/other_exception.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/Fixture/other_exception.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (\UnexpectedValueException $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \UnexpectedValueException('Some exception');
+	}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Custom\GYG\GeneralExceptionCatchRector\Fixture;
+
+class SomeClass
+{
+	public function run(): void
+	{
+		try {
+			$this->someMethod();
+		} catch (\UnexpectedValueException $e) {
+			print $e;
+		}
+	}
+
+	private function someMethod(): void
+	{
+		throw new \UnexpectedValueException('Some exception');
+	}
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Catch_\CatchThrowableInsteadOfExceptionRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([CatchThrowableInsteadOfExceptionRector::class]);

--- a/rules/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector.php
@@ -35,17 +35,17 @@ final class CatchThrowableInsteadOfExceptionRector extends AbstractRector
             new CodeSample(
                 <<<'CODE_SAMPLE'
 try {
-	$this->doSomething();
+    $this->doSomething();
 } catch (Exception $exception) {
-	// do something
+    // do something
 }
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
 try {
-	$this->doSomething();
+    $this->doSomething();
 } catch (Throwable $exception) {
-	// do something
+    // do something
 }
 CODE_SAMPLE
                 ,

--- a/rules/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/CatchThrowableInsteadOfExceptionRector.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\Catch_;
+
+use Exception;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\TryCatch;
+use Rector\Application\Provider\CurrentFileProvider;
+use Rector\PostRector\Collector\UseNodesToAddCollector;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Throwable;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\Catch_\CatchThrowableInsteadOfExceptionRector\CatchThrowableInsteadOfExceptionRectorTest
+ */
+final class CatchThrowableInsteadOfExceptionRector extends AbstractRector
+{
+    public function __construct(
+        private readonly CurrentFileProvider $currentFileProvider,
+        private readonly UseNodesToAddCollector $useNodesToAddCollector
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace last catch Exception with catch Throwable', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+try {
+	$this->doSomething();
+} catch (Exception $exception) {
+	// do something
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+try {
+	$this->doSomething();
+} catch (Throwable $exception) {
+	// do something
+}
+CODE_SAMPLE
+                ,
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [TryCatch::class];
+    }
+
+    /**
+     * @param TryCatch $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof TryCatch) {
+            return $node;
+        }
+
+        $hasChanged = false;
+        foreach ($node->catches as $key => $catch) {
+            if ($this->isLastCatchCatchingOnlyException($node, $key, $catch)) {
+                $this->replaceCatchExceptionWithThrowable($catch);
+
+                $hasChanged = true;
+            }
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function isLastCatchCatchingOnlyException(TryCatch $node, int $key, Catch_ $catch): bool
+    {
+
+        if ($key !== count($node->catches) - 1) {
+            return false;
+        }
+
+        return $this->array_find($catch->types, fn (Name $type) => $this->isName($type, Exception::class)) !== null
+            && $this->array_find($catch->types, fn (Name $type) => $this->isName($type, Throwable::class)) === null;
+    }
+
+    private function addUseImport(string $class): void
+    {
+        $file = $this->currentFileProvider->getFile();
+        if ($file === null) {
+            return;
+        }
+
+        $fullyQualified = new FullyQualified($class);
+        $fullyQualifiedObjectType = new FullyQualifiedObjectType($class);
+        if (! $this->useNodesToAddCollector->hasImport($file, $fullyQualified, $fullyQualifiedObjectType)) {
+            $this->useNodesToAddCollector->addUseImport($fullyQualifiedObjectType);
+        }
+    }
+
+    private function replaceCatchExceptionWithThrowable(Catch_ $catch): void
+    {
+        $replaceKey = $this->array_find_key($catch->types, fn ($type) => $this->isName($type, Exception::class));
+        if ($replaceKey !== null) {
+            $this->addUseImport(Throwable::class);
+            $catch->types[$replaceKey] = new Name(Throwable::class);
+        }
+    }
+
+    /**
+     * @template T
+     * @param array<int|string, T> $array
+     * @param callable(T): bool $func
+     * @return T|null
+     */
+    private function array_find(array $array, callable $func): mixed
+    {
+        return array_values(array_filter($array, $func))[0] ?? null;
+    }
+
+    /**
+     * @template T
+     * @param array<int|string, T> $array
+     * @param callable(T): bool $func
+     */
+    private function array_find_key(array $array, callable $func): string|int|null
+    {
+        return array_key_first(array_filter($array, $func));
+    }
+}


### PR DESCRIPTION
This adds a rector that in try catch blocks replaces the last `} catch (Exception ...) {` with `} catch (Throwable ...) {`
Reason for this is that Exception doesn't catch all the problems like TypeError which often want to be caught in such try catch blocks.

Example:

```
try {
	$this->doSomething();
} catch (Exception $exception) {
	// do something
}
```

becomes
```
try {
	$this->doSomething();
} catch (Throwable $exception) {
	// do something
}
```