### PR TITLE
[DX] Use Param->isPromoted() over param->flags !== 0 check on promotion property check

### DIFF
--- a/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
@@ -217,7 +217,7 @@ CODE_SAMPLE
         $constructClassMethod = $class->getMethod(MethodName::CONSTRUCT);
         if ($constructClassMethod instanceof ClassMethod) {
             foreach ($constructClassMethod->params as $param) {
-                if (! $param->flags) {
+                if (! $param->isPromoted()) {
                     continue;
                 }
 

--- a/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
+++ b/rules/DeadCode/NodeCollector/UnusedParameterResolver.php
@@ -26,7 +26,7 @@ final readonly class UnusedParameterResolver
         foreach ($classMethod->params as $i => $param) {
             // skip property promotion
             /** @var Param $param */
-            if ($param->flags !== 0) {
+            if ($param->isPromoted()) {
                 continue;
             }
 

--- a/rules/DeadCode/Rector/Property/RemoveUselessReadOnlyTagRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUselessReadOnlyTagRector.php
@@ -80,7 +80,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         // for param, only on property promotion
-        if ($node instanceof Param && $node->flags === 0) {
+        if ($node instanceof Param && ! $node->isPromoted()) {
             return null;
         }
 

--- a/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
+++ b/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
@@ -57,7 +57,7 @@ final readonly class PropertyPromotionRenamer
         $blockingParamNames = $this->resolveBlockingParamNames($constructClassMethod);
 
         foreach ($constructClassMethod->params as $param) {
-            if ($param->flags === 0) {
+            if (! $param->isPromoted()) {
                 continue;
             }
 

--- a/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
+++ b/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
@@ -131,6 +131,6 @@ CODE_SAMPLE
             return false;
         }
 
-        return $param->flags !== 0;
+        return $param->isPromoted();
     }
 }

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
@@ -175,7 +175,7 @@ final readonly class PromotedPropertyCandidateResolver
         array $firstParamAsVariable
     ): bool {
         // already promoted
-        if ($matchedParam->flags !== 0) {
+        if ($matchedParam->isPromoted()) {
             return true;
         }
 

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyResolver.php
@@ -23,7 +23,7 @@ final class PromotedPropertyResolver
 
         $promotedPropertyParams = [];
         foreach ($constructClassMethod->getParams() as $param) {
-            if ($param->flags === 0) {
+            if (! $param->isPromoted()) {
                 continue;
             }
 

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -215,7 +215,7 @@ CODE_SAMPLE
         }
 
         // early check not property promotion and already readonly
-        if ($param->flags === 0 || $this->visibilityManipulator->isReadonly($param)) {
+        if (! $param->isPromoted() || $this->visibilityManipulator->isReadonly($param)) {
             return null;
         }
 
@@ -253,7 +253,7 @@ CODE_SAMPLE
             return false;
         }
 
-        if ($param->flags === 0) {
+        if (! $param->isPromoted()) {
             return false;
         }
 

--- a/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
+++ b/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
@@ -293,7 +293,7 @@ CODE_SAMPLE
     {
         foreach ($params as $param) {
             // has non-readonly property promotion
-            if (! $this->visibilityManipulator->hasVisibility($param, Visibility::READONLY) && $param->flags !== 0) {
+            if (! $this->visibilityManipulator->hasVisibility($param, Visibility::READONLY) && $param->isPromoted()) {
                 return true;
             }
 

--- a/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
+++ b/rules/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
         $construct = $node->getMethod(MethodName::CONSTRUCT);
         if ($construct instanceof ClassMethod) {
             foreach ($construct->params as $param) {
-                if ($param->flags === 0) {
+                if (! $param->isPromoted()) {
                     continue;
                 }
 

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -84,7 +84,7 @@ final readonly class ParamAnalyzer
     public function hasPropertyPromotion(array $params): bool
     {
         foreach ($params as $param) {
-            if ($param->flags !== 0) {
+            if ($param->isPromoted()) {
                 return true;
             }
         }

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -376,7 +376,7 @@ final class AstResolver
                 }
 
                 foreach ($constructClassMethod->getParams() as $param) {
-                    if ($param->flags === 0) {
+                    if (! $param->isPromoted()) {
                         continue;
                     }
 


### PR DESCRIPTION
Using `->isPromoted()` cover `!==0` and property hook on php 8.4, also easier to verify instead of remember what `!==0` means.

see https://github.com/nikic/PHP-Parser/blob/7d3039c37823003d576247868fe755f3d7ec70b8/lib/PhpParser/Node/Param.php#L67-L73