### PR TITLE
 [DX] Filter on files as well with --only-suffix 

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -87,7 +87,7 @@ final readonly class FilesFinder
 
         // filtering files in directories collection
         $directories = $this->fileAndDirectoryFilter->filterDirectories($filesAndDirectories);
-        $filteredFilePathsInDirectories = $this->findInDirectories($directories, $suffixes, $sortByName, $onlySuffix);
+        $filteredFilePathsInDirectories = $this->findInDirectories($directories, $suffixes, $hasOnlySuffix, $onlySuffix, $sortByName);
 
         $filePaths = [...$filteredFilePaths, ...$filteredFilePathsInDirectories];
         return $this->unchangedFilesFilter->filterFilePaths($filePaths);
@@ -127,8 +127,9 @@ final readonly class FilesFinder
     private function findInDirectories(
         array $directories,
         array $suffixes,
+        bool $hasOnlySuffix,
+        ?string $onlySuffix = null,
         bool $sortByName = true,
-        ?string $onlySuffix = null
     ): array {
         if ($directories === []) {
             return [];
@@ -140,20 +141,16 @@ final readonly class FilesFinder
             ->size('> 0')
             ->in($directories);
 
-        if ($sortByName) {
-            $finder->sortByName();
-        }
-
         // filter files by specific suffix
-        if ($onlySuffix !== null && $onlySuffix !== '') {
-            if (! str_ends_with($onlySuffix, '.php')) {
-                $onlySuffix .= '.php';
-            }
-
+        if ($hasOnlySuffix) {
             $finder->name('*' . $onlySuffix);
         } elseif ($suffixes !== []) {
             $suffixesPattern = $this->normalizeSuffixesToPattern($suffixes);
             $finder->name($suffixesPattern);
+        }
+
+        if ($sortByName) {
+            $finder->sortByName();
         }
 
         $filePaths = [];

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -52,17 +52,13 @@ final readonly class FilesFinder
         // fallback append `.php` to be used for both $filteredFilePaths and $filteredFilePathsInDirectories
         $hasOnlySuffix = $onlySuffix !== null && $onlySuffix !== '';
 
-        if ($hasOnlySuffix) {
-            if (! str_ends_with($onlySuffix, '.php')) {
-                $onlySuffix .= '.php';
-            }
+        if ($hasOnlySuffix && ! str_ends_with($onlySuffix, '.php')) {
+            $onlySuffix .= '.php';
         }
 
         // filter files by specific suffix
         if ($hasOnlySuffix) {
-            $fileWithSuffixFilter = static function (string $filePath) use ($onlySuffix): bool {
-                return str_ends_with($filePath, $onlySuffix);
-            };
+            $fileWithSuffixFilter = (static fn(string $filePath): bool => str_ends_with($filePath, $onlySuffix));
         } elseif ($suffixes !== []) {
             $fileWithSuffixFilter = static function (string $filePath) use ($suffixes): bool {
                 $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -58,7 +58,7 @@ final readonly class FilesFinder
 
         // filter files by specific suffix
         if ($hasOnlySuffix) {
-            $fileWithSuffixFilter = (static fn(string $filePath): bool => str_ends_with($filePath, $onlySuffix));
+            $fileWithSuffixFilter = (static fn(string $filePath): bool => str_ends_with($filePath, (string) $onlySuffix));
         } elseif ($suffixes !== []) {
             $fileWithSuffixFilter = static function (string $filePath) use ($suffixes): bool {
                 $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -58,7 +58,8 @@ final readonly class FilesFinder
 
         // filter files by specific suffix
         if ($hasOnlySuffix) {
-            $fileWithSuffixFilter = (static fn(string $filePath): bool => str_ends_with($filePath, (string) $onlySuffix));
+            /** @var string $onlySuffix */
+            $fileWithSuffixFilter = (static fn(string $filePath): bool => str_ends_with($filePath, $onlySuffix));
         } elseif ($suffixes !== []) {
             $fileWithSuffixFilter = static function (string $filePath) use ($suffixes): bool {
                 $filePathExtension = pathinfo($filePath, PATHINFO_EXTENSION);

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -130,7 +130,10 @@ final class FilesFinderTest extends AbstractLazyTestCase
         $this->assertCount(2, $foundNoFilterFiles);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles(
-            [__DIR__ . '/SourceWithSuffix'],
+            [
+                __DIR__ . '/SourceWithSuffix',
+                __DIR__ . '/other_unrelated_file.php',
+            ],
             ['php'],
             true,
             'Controller'

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -127,12 +127,12 @@ final class FilesFinderTest extends AbstractLazyTestCase
     {
         // no suffix filter
         $foundNoFilterFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithSuffix']);
-        $this->assertCount(2, $foundNoFilterFiles);
+        $this->assertCount(3, $foundNoFilterFiles);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles(
             [
                 __DIR__ . '/SourceWithSuffix',
-                __DIR__ . '/other_unrelated_file.php',
+                __DIR__ . '/SourceWithSuffix/other_unrelated_file.php',
             ],
             ['php'],
             true,

--- a/tests/FileSystem/FilesFinder/SourceWithSuffix/other_unrelated_file.php
+++ b/tests/FileSystem/FilesFinder/SourceWithSuffix/other_unrelated_file.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace FileSystem\FilesFinder\SourceWithSuffix;
+
+class OtherUnrelatedFile
+{
+}


### PR DESCRIPTION
@TomasVotruba here also filter `files` in the list of `withPaths()`, provided other unrelated files with different suffix in config, it cause error:

```
There was 1 failure:

1) Rector\Tests\FileSystem\FilesFinder\FilesFinderTest::testFilterBySuffix
Failed asserting that actual size 2 matches expected size 1.
```

Ref https://github.com/rectorphp/rector-src/pull/6647#pullrequestreview-2530853588