### PR TITLE
Bump to PHPStan ^2.1.1 and remove usage of PropertyHookNameVisitor on SimpleParser

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.0"
+        "phpstan/phpstan": "^2.1.1"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0",
-        "phpstan/phpstan": "^2.1.0",
+        "phpstan/phpstan": "^2.1.1",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",

--- a/src/PhpDocParser/PhpParser/SmartPhpParserFactory.php
+++ b/src/PhpDocParser/PhpParser/SmartPhpParserFactory.php
@@ -8,7 +8,6 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PHPStan\Parser\CachedParser;
-use PHPStan\Parser\PropertyHookNameVisitor;
 use PHPStan\Parser\SimpleParser;
 use PHPStan\Parser\VariadicFunctionsVisitor;
 use PHPStan\Parser\VariadicMethodsVisitor;
@@ -43,14 +42,12 @@ final class SmartPhpParserFactory
         $nameResolver = new NameResolver();
         $variadicMethodsVisitor = new VariadicMethodsVisitor();
         $variadicFunctionsVisitor = new VariadicFunctionsVisitor();
-        $propertyHookNameVisitor = new PropertyHookNameVisitor();
 
         $simpleParser = new SimpleParser(
             $parser,
             $nameResolver,
             $variadicMethodsVisitor,
             $variadicFunctionsVisitor,
-            $propertyHookNameVisitor
         );
 
         return new CachedParser($simpleParser, 1024);


### PR DESCRIPTION
On PHPStan 2.1.0, `PropertyHookNameVisitor` is required on PHPStan SimpleParser, see PR:

- https://github.com/rectorphp/rector-src/pull/6639

But on PHPStan 2.1.1, `PropertyHookNameVisitor` removed, this PR provide an immediate patch for it, cause error:

```
class PHPStan\\Parser\\PropertyHookNameVisitor not found
```

error, see 

- https://github.com/rectorphp/rector-src/actions/runs/12621308562/job/35168012924#step:5:20