### PR TITLE
Revert "[Scoper] Fix scoper to fix prefixed regex on doctrine inflector"

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -118,6 +118,16 @@ return [
 
         // unprefix string classes, as they're string on purpose - they have to be checked in original form, not prefixed
         static function (string $filePath, string $prefix, string $content): string {
+            // skip vendor, expect rector packages
+            if (\str_contains($filePath, 'vendor/') && ! \str_contains($filePath, 'vendor/rector')) {
+                return $content;
+            }
+
+            // skip bin/rector.php for composer autoload class
+            if (\str_ends_with($filePath, 'bin/rector.php')) {
+                return $content;
+            }
+
             return Unprefixer::unprefixQuoted($content, $prefix);
         },
 


### PR DESCRIPTION
Reverts rectorphp/rector-src#6654

should only change some regex, the previous try seems cause unwanted change

https://github.com/rectorphp/rector/commit/96ec70632fcbbaf9b74080846e312cbd9c65328a