### PR TITLE
[DeadCode] Skip dynamic name on RemoveParentCallWithoutParentRector

### DIFF
--- a/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_dynamic_call.php.inc
+++ b/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_dynamic_call.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Source\SomeParentMethod;
+
+class SkipDynamicCallName extends SomeParentMethod
+{
+    public function innerSearchService(string $function, array $args): mixed
+    {
+        $result = parent::{$function}(...$args);
+    }
+}

--- a/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -129,6 +129,10 @@ CODE_SAMPLE
             return false;
         }
 
+        if ($expr->name instanceof Expr) {
+            return false;
+        }
+
         return $this->isName($expr->class, ObjectReference::PARENT);
     }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8960