### PR TITLE
[Renaming] Skip used by trait as property promotion on RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_used_by_trait_as_property_promotion.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_used_by_trait_as_property_promotion.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\EliteManager;
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\UseEliteManagerTrait;
+
+class SkipUsedByTraitAsPropertyPromotion
+{
+    use UseEliteManagerTrait;
+
+    public function __construct(private EliteManager $eventManager)
+    {
+    }
+}

--- a/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
+++ b/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Interface_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\Reflection\ClassReflection;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -26,7 +27,6 @@ use Rector\Php\PhpVersionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
-use PHPStan\Reflection\ClassReflection;
 
 final readonly class PropertyPromotionRenamer
 {

--- a/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
+++ b/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Php81\Rector\New_;
 
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Enum\ObjectReference;

--- a/src/NodeNestingScope/ContextAnalyzer.php
+++ b/src/NodeNestingScope/ContextAnalyzer.php
@@ -28,8 +28,9 @@ final class ContextAnalyzer
         return $node->getAttribute(AttributeKey::IS_IN_IF) === true;
     }
 
-    public function isChangeableContext(PropertyFetch | StaticPropertyFetch | NullsafePropertyFetch $propertyFetch): bool
-    {
+    public function isChangeableContext(
+        PropertyFetch | StaticPropertyFetch | NullsafePropertyFetch $propertyFetch
+    ): bool {
         if ($propertyFetch->getAttribute(AttributeKey::IS_UNSET_VAR, false)) {
             return true;
         }


### PR DESCRIPTION
property in trait is not removed, so it cause undifined property as class property promotion renamed, but trait is not.