### PR TITLE
[BetterPhpDocParser] Check for closing brace in text content (#8977)

### DIFF
--- a/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -449,7 +449,8 @@ final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorI
                     Lexer::TOKEN_CLOSE_CURLY_BRACKET,
                     Lexer::TOKEN_CLOSE_PARENTHESES
                     // sometimes it gets mixed int    ")
-                ) || \str_contains($composedTokenIterator->currentTokenValue(), ')')) {
+                ) || \str_contains($composedTokenIterator->currentTokenValue(), '}')
+                  || \str_contains($composedTokenIterator->currentTokenValue(), ')')) {
                 ++$closeBracketCount;
             }
 

--- a/tests/Issues/InlineTags/Fixture/fixture.php.inc
+++ b/tests/Issues/InlineTags/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Example {@link https://example.com}
+ * @covers \Tests\BarController
+ */
+class BarController extends TestCase
+{
+}
+
+?>
+-----
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Example {@link https://example.com}
+ */
+#[\PHPUnit\Framework\Attributes\CoversClass(\Tests\BarController::class)]
+class BarController extends TestCase
+{
+}
+
+?>

--- a/tests/Issues/InlineTags/InlineTagsTest.php
+++ b/tests/Issues/InlineTags/InlineTagsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\InlineTagsTest;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class InlineTagsTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/InlineTags/config/configured_rule.php
+++ b/tests/Issues/InlineTags/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
+
+return RectorConfig::configure()
+    ->withRules([CoversAnnotationWithValueToAttributeRector::class]);


### PR DESCRIPTION
This is a possibel fix for #8977, but it may not be the correct fix.

I feel that the bug is probably the phpstan Lexer as I would expect the closing brace to be picked up as its own token.

Dumping the regex used by the Lexer into regex101 shows that the lexer only tokenises the closing brace if there is whitespace before it, which is not necessarily the case for inline doc tags:
https://regex101.com/r/4TPY7V/2


Closes https://github.com/rectorphp/rector/issues/8977