### PR TITLE
[BetterPhpDocParser] Use str_starts_with() and str_ends_with() over str_contains() on DoctrineAnnotationDecorator

### DIFF
--- a/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -440,7 +440,9 @@ final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorI
             if ($composedTokenIterator->isCurrentTokenType(
                 Lexer::TOKEN_OPEN_CURLY_BRACKET,
                 Lexer::TOKEN_OPEN_PARENTHESES
-            ) || \str_contains($composedTokenIterator->currentTokenValue(), '(')) {
+            ) || \str_starts_with($composedTokenIterator->currentTokenValue(), '{')
+              || \str_starts_with($composedTokenIterator->currentTokenValue(), '(')
+            ) {
                 ++$openBracketCount;
             }
 
@@ -449,8 +451,8 @@ final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorI
                     Lexer::TOKEN_CLOSE_CURLY_BRACKET,
                     Lexer::TOKEN_CLOSE_PARENTHESES
                     // sometimes it gets mixed int    ")
-                ) || \str_contains($composedTokenIterator->currentTokenValue(), '}')
-                  || \str_contains($composedTokenIterator->currentTokenValue(), ')')) {
+                ) || \str_ends_with($composedTokenIterator->currentTokenValue(), '}')
+                  || \str_ends_with($composedTokenIterator->currentTokenValue(), ')')) {
                 ++$closeBracketCount;
             }
 

--- a/tests/Issues/InlineTags/Fixture/with_description.php.inc
+++ b/tests/Issues/InlineTags/Fixture/with_description.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Example {@link https://example.com} some description
+ * @covers \Tests\BarController
+ */
+class WithDescription extends TestCase
+{
+}
+
+?>
+-----
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright Example {@link https://example.com} some description
+ */
+#[\PHPUnit\Framework\Attributes\CoversClass(\Tests\BarController::class)]
+class WithDescription extends TestCase
+{
+}
+
+?>


### PR DESCRIPTION
@andrewnicols continue of your PR:

- https://github.com/rectorphp/rector-src/pull/6670

I am thinking that `str_ends_with()` and `str_starts_with()` can be used over `str_contains()`, which seems should only cover start and last over the whole token for more precise check, ensuring it not just part of some "string".