### PR TITLE
[BetterPhpDocParser] Use str_contains() for DoctrineAnnotationDecorator

### DIFF
--- a/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/DoctrineAnnotationDecorator.php
@@ -440,8 +440,8 @@ final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorI
             if ($composedTokenIterator->isCurrentTokenType(
                 Lexer::TOKEN_OPEN_CURLY_BRACKET,
                 Lexer::TOKEN_OPEN_PARENTHESES
-            ) || \str_starts_with($composedTokenIterator->currentTokenValue(), '{')
-              || \str_starts_with($composedTokenIterator->currentTokenValue(), '(')
+            ) || \str_contains($composedTokenIterator->currentTokenValue(), '{')
+              || \str_contains($composedTokenIterator->currentTokenValue(), '(')
             ) {
                 ++$openBracketCount;
             }
@@ -451,8 +451,8 @@ final readonly class DoctrineAnnotationDecorator implements PhpDocNodeDecoratorI
                     Lexer::TOKEN_CLOSE_CURLY_BRACKET,
                     Lexer::TOKEN_CLOSE_PARENTHESES
                     // sometimes it gets mixed int    ")
-                ) || \str_ends_with($composedTokenIterator->currentTokenValue(), '}')
-                  || \str_ends_with($composedTokenIterator->currentTokenValue(), ')')) {
+                ) || \str_contains($composedTokenIterator->currentTokenValue(), '}')
+                  || \str_contains($composedTokenIterator->currentTokenValue(), ')')) {
                 ++$closeBracketCount;
             }
 

--- a/tests/Issues/InlineTags/Fixture/with_punctuation.inc
+++ b/tests/Issues/InlineTags/Fixture/with_punctuation.inc
@@ -3,8 +3,7 @@
 use PHPUnit\Framework\TestCase;
 
 /**
- * @copyright Example {@link https://example.com}. Additional description.
- * @todo Do this.{@link https://example.com}.
+ * @copyright Some Value. Something.({@link https://example.com}).
  * @covers \Tests\BarController
  */
 class WithDescription extends TestCase
@@ -18,8 +17,7 @@ class WithDescription extends TestCase
 use PHPUnit\Framework\TestCase;
 
 /**
- * @copyright Example {@link https://example.com}. Additional description.
- * @todo Do this.{@link https://example.com}.
+ * @copyright Some Value. {@link https://example.com}.
  */
 #[\PHPUnit\Framework\Attributes\CoversClass(\Tests\BarController::class)]
 class WithDescription extends TestCase


### PR DESCRIPTION

The Lexer tokenizes at whitespace and certain other characters such as `.`, and `(`, If none of these tokens are present then the tokens are not split. For example in the string here:

```
@copyright Some Value. Something.({@link https://example.com}).
```

This is tokenised into:
```
'@copyright'
' '
'Some'
' '
'Value'
'.'
' '
'Something'
.({@link'
' '
'https'
':'
'//example.com}).'
```

Both the open, and close, curly braces may be in the middle of a string and therefore the `str_contains` must be used for these cases.