### PR TITLE
Update the CustomRuleCommand to accept options

### DIFF
--- a/templates/custom-rule/utils/rector/src/Rector/__Name__.php
+++ b/templates/custom-rule/utils/rector/src/Rector/__Name__.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Utils\Rector\Rector;
+namespace __Namespace__;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
 
 /**
- * @see \Rector\Tests\TypeDeclaration\Rector\__Name__\__Name__Test
+ * @see \__Tests_Namespace__\__Name__\__Name__Test
  */
 final class __Name__ extends AbstractRector
 {

--- a/templates/custom-rule/utils/rector/tests/Rector/__Name__/Fixture/some_class.php.inc
+++ b/templates/custom-rule/utils/rector/tests/Rector/__Name__/Fixture/some_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\__Name__\Fixture;
+namespace __Tests_Namespace__\__Name__\Fixture;
 
 // @todo fill code before
 
@@ -8,7 +8,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\__Name__\Fixture;
 -----
 <?php
 
-namespace Rector\Tests\TypeDeclaration\Rector\__Name__\Fixture;
+namespace __Tests_Namespace__\__Name__\Fixture;
 
 // @todo fill code after
 

--- a/templates/custom-rule/utils/rector/tests/Rector/__Name__/__Name__Test.php
+++ b/templates/custom-rule/utils/rector/tests/Rector/__Name__/__Name__Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\TypeDeclaration\Rector\__Name__;
+namespace __Tests_Namespace__\__Name__;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/templates/custom-rule/utils/rector/tests/Rector/__Name__/config/configured_rule.php
+++ b/templates/custom-rule/utils/rector/tests/Rector/__Name__/config/configured_rule.php
@@ -3,7 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use __Namespace__\__Name__;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(\Utils\Rector\Rector\__Name__::class);
+    $rectorConfig->rule(__Name__::class);
 };

--- a/templates/custom-rules-annotations/utils/rector/tests/Rector/__Name__/__Name__Test.php
+++ b/templates/custom-rules-annotations/utils/rector/tests/Rector/__Name__/__Name__Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\TypeDeclaration\Rector\__Name__;
+namespace __Tests_Namespace__\__Name__;
 
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 

--- a/tests/Console/Command/CustomRuleCommandTest.php
+++ b/tests/Console/Command/CustomRuleCommandTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Rector\Tests\Console\Command;
+
+use Nette\Utils\FileSystem;
+use Rector\Console\Command\CustomRuleCommand;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class CustomRuleCommandTest extends AbstractLazyTestCase
+{
+    private const TEST_OUTPUT_DIRECTORY = 'tests/Console/Command/CustomRuleCommand';
+
+    private CustomRuleCommand $customRuleCommand;
+
+    protected function setUp(): void
+    {
+        $this->customRuleCommand = $this->make(CustomRuleCommand::class);
+    }
+
+    public function test(): void
+    {
+        $ruleName = 'SomeCustomRuleRector';
+        $rulesDirectory = self::TEST_OUTPUT_DIRECTORY . '/src/Rector/Test';
+        $testsDirectory = self::TEST_OUTPUT_DIRECTORY . '/src/Rector';
+
+        $commandTester = new CommandTester($this->customRuleCommand);
+        $commandTester->execute([
+            '--name' => $ruleName,
+            '--with-composer-changes' => false,
+            '--with-phpunit-changes' => false,
+            '--with-rules-dir' => $rulesDirectory,
+            '--with-tests-dir' => $testsDirectory,
+        ]);
+
+        $currentDirectory = getcwd();
+        $this->assertNotEmpty(FileSystem::read(sprintf(
+            '%s/%s/%s.php',
+            $currentDirectory,
+            $rulesDirectory,
+            $ruleName
+        )));
+        $this->assertNotEmpty(
+            FileSystem::read(sprintf(
+                '%s/%s/%s/Fixture/some_class.php.inc',
+                $currentDirectory,
+                $testsDirectory,
+                $ruleName
+            ))
+        );
+        $this->assertNotEmpty(
+            FileSystem::read(sprintf(
+                '%s/%s/%s/config/configured_rule.php',
+                $currentDirectory,
+                $testsDirectory,
+                $ruleName
+            ))
+        );
+        $this->assertNotEmpty(
+            FileSystem::read(sprintf(
+                '%s/%s/%s/%sTest.php',
+                $currentDirectory,
+                $testsDirectory,
+                $ruleName,
+                $ruleName
+            ))
+        );
+
+        $this->cleanup($currentDirectory);
+    }
+
+    public function testWithRulesAndTestsNamespace(): void
+    {
+        $ruleName = 'SomeCustomRuleRector';
+        $ruleDirectory = self::TEST_OUTPUT_DIRECTORY . '/utils/Rector/src/Rector';
+        $testsDirectory = self::TEST_OUTPUT_DIRECTORY . '/utils/Rector/tests/Rector';
+        $rulesNamespace = 'RectorLaravel\Custom';
+        $testsNamespace = 'RectorLaravel\Tests\Custom';
+
+        $commandTester = new CommandTester($this->customRuleCommand);
+        $commandTester->execute([
+            '--name' => $ruleName,
+            '--with-composer-changes' => false,
+            '--with-phpunit-changes' => false,
+            '--with-rules-dir' => $ruleDirectory,
+            '--with-tests-dir' => $testsDirectory,
+            '--with-rules-namespace' => $rulesNamespace,
+            '--with-tests-namespace' => $testsNamespace,
+        ]);
+
+        $currentDirectory = getcwd();
+        $this->assertStringContainsString(
+            sprintf('namespace %s;', $rulesNamespace),
+            FileSystem::read(sprintf('%s/%s/%s.php', $currentDirectory, $ruleDirectory, $ruleName)),
+        );
+        $this->assertStringContainsString(
+            sprintf('@see \\%s\\%s\\%sTest', $testsNamespace, $ruleName, $ruleName),
+            FileSystem::read(sprintf('%s/%s/%s.php', $currentDirectory, $ruleDirectory, $ruleName)),
+        );
+        $this->assertStringContainsString(
+            sprintf('namespace %s\\%s;', $testsNamespace, $ruleName),
+            FileSystem::read(sprintf('%s/%s/%s/%sTest.php', $currentDirectory, $testsDirectory, $ruleName, $ruleName)),
+        );
+
+        $configFile = FileSystem::read(
+            sprintf('%s/%s/%s/config/configured_rule.php', $currentDirectory, $testsDirectory, $ruleName)
+        );
+        $this->assertStringContainsString(sprintf('$rectorConfig->rule(%s::class);', $ruleName), $configFile);
+        $this->assertStringContainsString(sprintf('use %s\\%s;', $rulesNamespace, $ruleName), $configFile);
+
+        $this->assertStringContainsString(
+            sprintf('namespace %s\\%s\\Fixture;', $testsNamespace, $ruleName),
+            FileSystem::read(
+                sprintf('%s/%s/%s/Fixture/some_class.php.inc', $currentDirectory, $testsDirectory, $ruleName)
+            ),
+        );
+
+        $this->cleanup($currentDirectory);
+    }
+
+    private function cleanup(false|string $currentDirectory): void
+    {
+        FileSystem::delete($currentDirectory . '/' . self::TEST_OUTPUT_DIRECTORY);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8976.

The new options available, with the same defaults, are:
- `--name=SomeRector` (if not provided, the user will be prompted for the name)
- `--with-composer-changes=true`
- `--with-phpunit-changes=true`
- `--with-rules-dir=utils/rector/src/Rector`
- `--with-tests-dir=utils/rector/tests/Rector`
- `--with-rules-namespace=Utils\\Rector\\Rector`
- `--with-tests-namespace=Utils\\Rector\\Tests\\Rector`

I've added a new test `CustomRuleCommandTest` that runs the command, and cleans up the files that it generates.

Let me know if this is an acceptable solution, or I need to change anything.

For my use-cases, I can simply vendor-patch this command :).
Thank you.