### PR TITLE
Remove abandoned require-dev symplify/rule-doc-generator

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -34,10 +34,6 @@ jobs:
                         run: vendor/bin/swiss-knife check-commented-code src rules tests rules-tests --line-limit 5 --ansi
 
                     -
-                        name: "Validate docs"
-                        run: vendor/bin/rule-doc-generator validate rules
-
-                    -
                         name: 'Active Classes'
                         run: |
                             vendor/bin/class-leak check bin config src rules utils --skip-suffix "Rector" --skip-type="Rector\\Utils\\Compiler\\Unprefixer" --skip-type="Rector\\NodeCollector\\BinaryOpConditionsCollector" --skip-type="Rector\\Set\\Contract\\SetListInterface"

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -28,11 +28,6 @@ jobs:
                         run: "composer preload"
                         branch: 'automated-regenerated-preload'
 
-                    -
-                        name: "Re-Generate Nodes/Rectors Documentation"
-                        run: "composer docs"
-                        branch: 'automated-regenerated-nodes-rectors-documentation'
-
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
         "symplify/easy-coding-standard": "^12.5",
         "symplify/phpstan-extensions": "^12.0",
         "symplify/phpstan-rules": "^14.0",
-        "symplify/rule-doc-generator": "^12.2.5",
         "symplify/vendor-patches": "^11.3",
         "tomasvotruba/class-leak": "^2.0",
         "tracy/tracy": "^2.10"

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,6 @@
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "vendor/bin/phpstan analyse --ansi --memory-limit=512M",
-        "docs": "vendor/bin/rule-doc-generator validate rules",
         "rector": "bin/rector process --ansi",
         "preload": "php build/build-preload.php .",
         "release": "vendor/bin/rng --from-commit X --to-commit Y --remote-repository rectorphp/rector-symfony --remote-repository rectorphp/rector-doctrine --remote-repository rectorphp/rector-phpunit"


### PR DESCRIPTION
We use `symplify/rule-doc-generator-contracts` in require instead.

https://github.com/rectorphp/rector-src/blob/a26bfd9d12ee70f47ed522356d4fcad248a548a0/composer.json#L42
