### PR TITLE
[NodeTraverser] Clean up call ->addVisitor() after NodeTraverser creation

### DIFF
--- a/rules/Renaming/Rector/FunctionLike/RenameFunctionLikeParamWithinCallLikeArgRector.php
+++ b/rules/Renaming/Rector/FunctionLike/RenameFunctionLikeParamWithinCallLikeArgRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (($node->name ?? null) === null) {
+            if (!$node->name ?? null instanceof Node) {
                 continue;
             }
 

--- a/src/Comments/NodeTraverser/CommentRemovingNodeTraverser.php
+++ b/src/Comments/NodeTraverser/CommentRemovingNodeTraverser.php
@@ -11,8 +11,6 @@ final class CommentRemovingNodeTraverser extends NodeTraverser
 {
     public function __construct(CommentRemovingNodeVisitor $commentRemovingNodeVisitor)
     {
-        parent::__construct();
-
-        $this->addVisitor($commentRemovingNodeVisitor);
+        parent::__construct($commentRemovingNodeVisitor);
     }
 }

--- a/src/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
+++ b/src/NodeTypeResolver/NodeScopeAndMetadataDecorator.php
@@ -19,10 +19,8 @@ final readonly class NodeScopeAndMetadataDecorator
         private PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         private FileWithoutNamespaceNodeTraverser $fileWithoutNamespaceNodeTraverser
     ) {
-        $this->nodeTraverser = new NodeTraverser();
-
         // needed for format preserving printing
-        $this->nodeTraverser->addVisitor($cloningVisitor);
+        $this->nodeTraverser = new NodeTraverser($cloningVisitor);
     }
 
     /**

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -133,11 +133,7 @@ final readonly class PHPStanNodeScopeResolver
         private NodeNameResolver $nodeNameResolver,
         private ClassAnalyzer $classAnalyzer
     ) {
-        $this->nodeTraverser = new NodeTraverser();
-
-        foreach ($nodeVisitors as $nodeVisitor) {
-            $this->nodeTraverser->addVisitor($nodeVisitor);
-        }
+        $this->nodeTraverser = new NodeTraverser(...$nodeVisitors);
     }
 
     /**

--- a/src/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/src/PhpDocParser/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -23,10 +23,8 @@ final class SimpleCallableNodeTraverser
             return;
         }
 
-        $nodeTraverser = new NodeTraverser();
-
         $callableNodeVisitor = new CallableNodeVisitor($callable);
-        $nodeTraverser->addVisitor($callableNodeVisitor);
+        $nodeTraverser = new NodeTraverser($callableNodeVisitor);
 
         $nodes = $node instanceof Node ? [$node] : $node;
         $nodeTraverser->traverse($nodes);

--- a/src/PhpParser/Parser/SimplePhpParser.php
+++ b/src/PhpParser/Parser/SimplePhpParser.php
@@ -24,8 +24,7 @@ final readonly class SimplePhpParser
         $parserFactory = new ParserFactory();
         $this->phpParser = $parserFactory->createForNewestSupportedVersion();
 
-        $this->nodeTraverser = new NodeTraverser();
-        $this->nodeTraverser->addVisitor(new AssignedToNodeVisitor());
+        $this->nodeTraverser = new NodeTraverser(new AssignedToNodeVisitor());
     }
 
     /**

--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -58,8 +58,7 @@ final class PostFileProcessor implements ResetableInterface
                 continue;
             }
 
-            $nodeTraverser = new NodeTraverser();
-            $nodeTraverser->addVisitor($postRector);
+            $nodeTraverser = new NodeTraverser($postRector);
             $stmts = $nodeTraverser->traverse($stmts);
         }
 

--- a/tests/NodeManipulator/ClassDependencyManipulatorTest.php
+++ b/tests/NodeManipulator/ClassDependencyManipulatorTest.php
@@ -108,9 +108,8 @@ final class ClassDependencyManipulatorTest extends AbstractLazyTestCase
     private function setNamespacedName(Class_ $class): void
     {
         $nameResolver = new NameResolver();
-        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser = new NodeTraverser($nameResolver);
 
-        $nodeTraverser->addVisitor($nameResolver);
         $nodeTraverser->traverse([$class]);
     }
 


### PR DESCRIPTION
Pass directly on `__construct()` when possible.