### PR TITLE
Output for the code quality widget in GitLab CI

### DIFF
--- a/src/ChangesReporting/Output/GitlabOutputFormatter.php
+++ b/src/ChangesReporting/Output/GitlabOutputFormatter.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * CodeClimate Specification:
+ * - https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md
+ */
+
+declare(strict_types=1);
+
+namespace Rector\ChangesReporting\Output;
+
+use Nette\Utils\Json;
+use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
+use Rector\Util\FileHasher;
+use Rector\ValueObject\Configuration;
+use Rector\ValueObject\ProcessResult;
+
+final readonly class GitlabOutputFormatter implements OutputFormatterInterface
+{
+    /**
+     * @var string
+     */
+    public const NAME = 'gitlab';
+
+    private const ERROR_TYPE_ISSUE        = 'issue';
+    private const ERROR_CATEGORY_BUG_RISK = 'Bug Risk';
+    private const ERROR_CATEGORY_STYLE    = 'Style';
+    private const ERROR_SEVERITY_BLOCKER  = 'blocker';
+    private const ERROR_SEVERITY_MINOR    = 'minor';
+
+    public function __construct(
+        private Filehasher $filehasher,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    public function report(ProcessResult $processResult, Configuration $configuration): void
+    {
+        $errorsJson = [
+            ...$this->appendSystemErrors($processResult, $configuration),
+            ...$this->appendFileDiffs($processResult, $configuration),
+        ];
+
+        $json = Json::encode($errorsJson, true);
+
+        echo $json . PHP_EOL;
+    }
+
+    /**
+     * @return array<array{
+     *      type: 'issue',
+     *      categories: array{'Bug Risk'},
+     *      severity: 'blocker',
+     *      description: string,
+     *      check_name: string,
+     *      location: array{
+     *          path: string,
+     *          lines: array{
+     *              begin: int,
+     *          },
+     *      },
+     *  }>
+     */
+    private function appendSystemErrors(ProcessResult $processResult, Configuration $configuration): array
+    {
+        $errorsJson = [];
+
+        foreach ($processResult->getSystemErrors() as $error) {
+            $filePath = $configuration->isReportingWithRealPath()
+                ? ($error->getAbsoluteFilePath() ?? '')
+                : ($error->getRelativeFilePath() ?? '')
+            ;
+
+            $fingerprint = $this->filehasher->hash($filePath . ';' . $error->getLine() . ';' . $error->getMessage());
+
+            $errorsJson[] = [
+                'fingerprint' => $fingerprint,
+                'type' => self::ERROR_TYPE_ISSUE,
+                'categories' => [self::ERROR_CATEGORY_BUG_RISK],
+                'severity' => self::ERROR_SEVERITY_BLOCKER,
+                'description' => $error->getMessage(),
+                'check_name' => $error->getRectorClass() ?? '',
+                'location' => [
+                    'path' => $filePath,
+                    'lines' => [
+                        'begin' => $error->getLine() ?? 0,
+                    ],
+                ],
+            ];
+        }
+
+        return $errorsJson;
+    }
+
+    /**
+     * @return array<array{
+     *      type: 'issue',
+     *      categories: array{'Style'},
+     *      description: string,
+     *      check_name: string,
+     *      location: array{
+     *          path: string,
+     *          lines: array{
+     *              begin: int,
+     *          },
+     *      },
+     *  }>
+     */
+    private function appendFileDiffs(ProcessResult $processResult, Configuration $configuration): array
+    {
+        $errorsJson = [];
+
+        $fileDiffs = $processResult->getFileDiffs();
+        ksort($fileDiffs);
+
+        foreach ($fileDiffs as $fileDiff) {
+            $filePath = $configuration->isReportingWithRealPath()
+                ? ($fileDiff->getAbsoluteFilePath() ?? '')
+                : ($fileDiff->getRelativeFilePath() ?? '')
+            ;
+
+            $rectorClasses = implode(' / ', $fileDiff->getRectorShortClasses());
+            $fingerprint = $this->filehasher->hash($filePath . ';' . $fileDiff->getDiff());
+
+            $errorsJson[] = [
+                'fingerprint' => $fingerprint,
+                'type' => self::ERROR_TYPE_ISSUE,
+                'categories' => [self::ERROR_CATEGORY_STYLE],
+                'severity' => self::ERROR_SEVERITY_MINOR,
+                'description' => $rectorClasses,
+                'content' => [
+                    'body' => $fileDiff->getDiff(),
+                ],
+                'check_name' => $rectorClasses,
+                'location' => [
+                    'path' => $filePath,
+                    'lines' => [
+                        'begin' => $fileDiff->getFirstLineNumber() ?? 0,
+                    ],
+                ],
+            ];
+        }
+
+        return $errorsJson;
+    }
+}

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -37,6 +37,7 @@ use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\PlainV
 use Rector\Caching\Cache;
 use Rector\Caching\CacheFactory;
 use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
+use Rector\ChangesReporting\Output\GitlabOutputFormatter;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
@@ -329,7 +330,11 @@ final class LazyContainerFactory
     /**
      * @var array<class-string<OutputFormatterInterface>>
      */
-    private const OUTPUT_FORMATTER_CLASSES = [ConsoleOutputFormatter::class, JsonOutputFormatter::class];
+    private const OUTPUT_FORMATTER_CLASSES = [
+        ConsoleOutputFormatter::class,
+        JsonOutputFormatter::class,
+        GitlabOutputFormatter::class,
+    ];
 
     /**
      * @var array<class-string<NodeTypeResolverInterface>>


### PR DESCRIPTION
## Adoption of the CodeClimate format for GitLab CI integration

Specification: https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types

## Example

Run command:
```shell
php bin/rector process bin --output-format=gitlab --dry-run
```

Output:
```json
[
    {
        "fingerprint": "7e5f879fe12ff579e958c9935e9ee034",
        "type": "issue",
        "categories": [
            "Bug Risk"
        ],
        "severity": "blocker",
        "description": "Syntax error, unexpected T_VARIABLE",
        "check_name": "",
        "location": {
            "path": "bin/test-fixture-stats.php",
            "lines": {
                "begin": 17
            }
        }
    },
    {
        "fingerprint": "183de697ac3261bb7f85226e0ef2253a",
        "type": "issue",
        "categories": [
            "Style"
        ],
        "severity": "minor",
        "description": "MultiDirnameRector / AddVoidReturnTypeWhereNoReturnRector",
        "content": {
            "body": "--- Original\n+++ New\n@@ -71,7 +71,7 @@\n         $this->loadIfExistsAndNotLoadedYet('vendor/autoload.php');\n     }\n \n-    public function autoloadFromCommandLine()\n+    public function autoloadFromCommandLine(): void\n     {\n         $cliArgs = $_SERVER['argv'];\n \n"
        },
        "check_name": "MultiDirnameRector / AddVoidReturnTypeWhereNoReturnRector",
        "location": {
            "path": "bin/rector.php",
            "lines": {
                "begin": 70
            }
        }
    }
]
```

Code Quality widget:

![image](https://github.com/user-attachments/assets/6aef5588-a309-4222-a0e0-6d099a8ca446)
