### PR TITLE
[Scoper] Revert src/functions/node_helper.php from exclude files

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -25,8 +25,6 @@ $excludedFiles = array_map(
     iterator_to_array($polyfillFinder->getIterator()),
 );
 
-$excludedFiles[] = 'src/functions/node_helper.php';
-
 // see https://github.com/humbug/php-scoper/blob/master/docs/configuration.md#configuration
 return [
     'prefix' => 'RectorPrefix' . $timestamp,
@@ -44,8 +42,6 @@ return [
         '#^Symplify\\\\RuleDocGenerator#',
         '#^Symfony\\\\Polyfill#',
     ],
-
-    'exclude-files' => $excludedFiles,
 
     // expose
     'expose-classes' => ['Normalizer'],


### PR DESCRIPTION
@TomasVotruba this revert src/functions/node_helper.php from exclude files as it now cause error:

```
 [ERROR] Could not process "/Users/samsonasik/www/CodeIgniter4/app/Config/Boot/development.php" file, due to:           
         "System error: "Class "Illuminate\Container\Container" not found"                                              
         Run Rector with "--debug" option and post the report here: https://github.com/rectorphp/rector/issues/new". On line: 35
```

because not prefixed, see diff https://github.com/rectorphp/rector/commit/44c8e9ed71d6517463305e449b6bb30c4ab4f0b8