### PR TITLE
[Scoper] Fix exclude files

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -43,6 +43,8 @@ return [
         '#^Symfony\\\\Polyfill#',
     ],
 
+    'exclude-files' => $excludedFiles,
+
     // expose
     'expose-classes' => ['Normalizer'],
     'expose-functions' => [


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/6699 

that `'exclude-files'` accidentally removed.