### PR TITLE
Exclude node modules path

### DIFF
--- a/src/ChangesReporting/Output/GitlabOutputFormatter.php
+++ b/src/ChangesReporting/Output/GitlabOutputFormatter.php
@@ -22,11 +22,15 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
      */
     public const NAME = 'gitlab';
 
-    private const ERROR_TYPE_ISSUE        = 'issue';
+    private const ERROR_TYPE_ISSUE = 'issue';
+
     private const ERROR_CATEGORY_BUG_RISK = 'Bug Risk';
-    private const ERROR_CATEGORY_STYLE    = 'Style';
-    private const ERROR_SEVERITY_BLOCKER  = 'blocker';
-    private const ERROR_SEVERITY_MINOR    = 'minor';
+
+    private const ERROR_CATEGORY_STYLE = 'Style';
+
+    private const ERROR_SEVERITY_BLOCKER = 'blocker';
+
+    private const ERROR_SEVERITY_MINOR = 'minor';
 
     public function __construct(
         private Filehasher $filehasher,

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -37,8 +37,8 @@ use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\PlainV
 use Rector\Caching\Cache;
 use Rector\Caching\CacheFactory;
 use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
-use Rector\ChangesReporting\Output\GitlabOutputFormatter;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
+use Rector\ChangesReporting\Output\GitlabOutputFormatter;
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\AliasClassNameImportSkipVoter;

--- a/src/FileSystem/InitFilePathsResolver.php
+++ b/src/FileSystem/InitFilePathsResolver.php
@@ -50,12 +50,10 @@ final class InitFilePathsResolver
     private function hasDirectoryFileInfoPhpFiles(SplFileInfo $rootDirectoryFileInfo): bool
     {
         // is directory with PHP files?
-        $phpFilesCount = Finder::create()
+        return Finder::create()
             ->files()
             ->in($rootDirectoryFileInfo->getPathname())
             ->name('*.php')
-            ->count();
-
-        return $phpFilesCount !== 0;
+            ->hasResults();
     }
 }

--- a/src/FileSystem/InitFilePathsResolver.php
+++ b/src/FileSystem/InitFilePathsResolver.php
@@ -16,7 +16,7 @@ final class InitFilePathsResolver
      * @var string
      * @see https://regex101.com/r/XkQ6Pe/1
      */
-    private const DO_NOT_INCLUDE_PATHS_REGEX = '#(vendor|var|stubs|temp|templates|tmp|e2e|bin|build|Migrations|data(?:base)?|storage|migrations|writable)#';
+    private const DO_NOT_INCLUDE_PATHS_REGEX = '#(vendor|var|stubs|temp|templates|tmp|e2e|bin|build|Migrations|data(?:base)?|storage|migrations|writable|node_modules)#';
 
     /**
      * @return string[]


### PR DESCRIPTION
@samsonasik to review

Changes:
- exclude root `node_modules` path
- add fixed files resulting from running `composer fix-cs`
- refactor to use `Finder::hasResults()` instead of comparing it's iterator count

Closes https://github.com/rectorphp/rector/issues/8988