### PR TITLE
Fix str_getcsv() escape argument on PHP 8.4

### DIFF
--- a/src/PhpParser/NodeTransformer.php
+++ b/src/PhpParser/NodeTransformer.php
@@ -136,7 +136,7 @@ final class NodeTransformer
      */
     private function splitBySpace(string $value): array
     {
-        $value = str_getcsv($value, ' ');
+        $value = str_getcsv($value, ' ', '"', "\\");
 
         return array_filter($value);
     }


### PR DESCRIPTION
The `str_getcsv` is used on rector-symfony, see

https://github.com/rectorphp/rector-symfony/actions/runs/13029243732/job/36344650111#step:5:28

which test show the error.


```
2 tests triggered 1 PHP deprecation:

1) /home/runner/work/rector-symfony/rector-symfony/vendor/rector/rector-src/src/PhpParser/NodeTransformer.php:139
str_getcsv(): the $escape parameter must be provided as its default value will change

Triggered by:

* Rector\Symfony\Tests\Symfony42\Rector\New_\StringToArrayArgumentProcessRector\StringToArrayArgumentProcessRectorTest::test#1 (4 times)
  /home/runner/work/rector-symfony/rector-symfony/rules-tests/Symfony42/Rector/New_/StringToArrayArgumentProcessRector/StringToArrayArgumentProcessRectorTest.php:14

* Rector\Symfony\Tests\Symfony42\Rector\New_\StringToArrayArgumentProcessRector\StringToArrayArgumentProcessRectorTest::test#7
  /home/runner/work/rector-symfony/rector-symfony/rules-tests/Symfony42/Rector/New_/StringToArrayArgumentProcessRector/StringToArrayArgumentProcessRectorTest.php:14
```

on PR: 

- https://github.com/rectorphp/rector-symfony/pull/698