### PR TITLE
fix: NewlineBeforeNewAssignSetRector variable as same name like property

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/objects.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/objects.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Objects
+{
+    private ?Value $foo = null;
+    private ?Value $bar = null;
+    public function run()
+    {
+        $this->foo = new Value;
+        $this->foo->bar = 1;
+        $this->bar = new Value;
+        $this->bar->bar = 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Objects
+{
+    private ?Value $foo = null;
+    private ?Value $bar = null;
+    public function run()
+    {
+        $this->foo = new Value;
+        $this->foo->bar = 1;
+
+        $this->bar = new Value;
+        $this->bar->bar = 1;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/properties.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/properties.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $foo = new Value;
+        $foo->bar = new Value;
+        $foo->bar->bar = 5;
+        $bar = new Value;
+        $bar->foo = 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        $foo = new Value;
+        $foo->bar = new Value;
+        $foo->bar->bar = 5;
+
+        $bar = new Value;
+        $bar->foo = 1;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/properties.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/properties.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
 
-final class Fixture
+final class Properties
 {
     public function run()
     {
@@ -20,7 +20,7 @@ final class Fixture
 
 namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
 
-final class Fixture
+final class Properties
 {
     public function run()
     {

--- a/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/statics.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector/Fixture/statics.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Statics
+{
+    protected static ?Value $fooBar = null;
+    protected static ?Value $barFoo = null;
+    public function run()
+    {
+        self::$fooBar = new Value;
+        self::$fooBar->bar = 1;
+        self::$barFoo = new Value;
+        self::$barFoo->bar = 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector\Fixture;
+
+final class Statics
+{
+    protected static ?Value $fooBar = null;
+    protected static ?Value $barFoo = null;
+    public function run()
+    {
+        self::$fooBar = new Value;
+        self::$fooBar->bar = 1;
+
+        self::$barFoo = new Value;
+        self::$barFoo->bar = 1;
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
@@ -42,6 +42,10 @@ final class SomeClass
         $value->setValue(5);
         $value2 = new Value;
         $value2->setValue(1);
+        $foo = new Value;
+        $foo->bar = 5;
+        $bar = new Value;
+        $bar->foo = 1;
     }
 }
 CODE_SAMPLE
@@ -56,6 +60,12 @@ final class SomeClass
 
         $value2 = new Value;
         $value2->setValue(1);
+
+        $foo = new Value;
+        $foo->bar = 5;
+
+        $bar = new Value;
+        $bar->foo = 1;
     }
 }
 CODE_SAMPLE
@@ -187,5 +197,14 @@ CODE_SAMPLE
         $currentNode = $node->stmts[$key];
 
         return abs($currentNode->getStartLine() - $previousNode->getStartLine()) >= 2;
+    }
+    protected function getName(Node $node): ?string
+    {
+        if ($node instanceof Node\Expr\PropertyFetch) {
+            do {
+                $node = $node->var;
+            } while ($node instanceof Node\Expr\PropertyFetch);
+        }
+        return parent::getName($node);
     }
 }

--- a/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
@@ -136,7 +136,14 @@ CODE_SAMPLE
             }
 
             if (! $stmtExpr->var instanceof MethodCall && ! $stmtExpr->var instanceof StaticCall) {
-                return $this->getName($stmtExpr->var);
+                $node = $stmtExpr->var;
+
+                if ($node instanceof Node\Expr\PropertyFetch) {
+                    do {
+                        $node = $node->var;
+                    } while ($node instanceof Node\Expr\PropertyFetch);
+                }
+                return $this->getName($node);
             }
         }
 
@@ -197,14 +204,5 @@ CODE_SAMPLE
         $currentNode = $node->stmts[$key];
 
         return abs($currentNode->getStartLine() - $previousNode->getStartLine()) >= 2;
-    }
-    protected function getName(Node $node): ?string
-    {
-        if ($node instanceof Node\Expr\PropertyFetch) {
-            do {
-                $node = $node->var;
-            } while ($node instanceof Node\Expr\PropertyFetch);
-        }
-        return parent::getName($node);
     }
 }

--- a/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/NewlineBeforeNewAssignSetRector.php
@@ -136,14 +136,19 @@ CODE_SAMPLE
             }
 
             if (! $stmtExpr->var instanceof MethodCall && ! $stmtExpr->var instanceof StaticCall) {
-                $node = $stmtExpr->var;
+                $nodeVar = $stmtExpr->var;
 
-                if ($node instanceof Node\Expr\PropertyFetch) {
+                if ($nodeVar instanceof Node\Expr\PropertyFetch) {
                     do {
-                        $node = $node->var;
-                    } while ($node instanceof Node\Expr\PropertyFetch);
+                        $previous = $nodeVar;
+                        $nodeVar = $nodeVar->var;
+                    } while ($nodeVar instanceof Node\Expr\PropertyFetch);
+
+                    if ($this->getName($nodeVar) === 'this') {
+                        $nodeVar = $previous;
+                    }
                 }
-                return $this->getName($node);
+                return $this->getName($nodeVar);
             }
         }
 


### PR DESCRIPTION
Hi people,

I open an [issue](https://github.com/rectorphp/rector/issues/8991) and i try to fix.

I'm not sure for a development code :pray: 

Thanks for your feedback.