### PR TITLE
[Php74] Handle crash curly based array on trait on CurlyToSquareBracketArrayStringRector

### DIFF
--- a/rules-tests/Php74/Rector/ArrayDimFetch/CurlyToSquareBracketArrayStringRector/Fixture/OnTrait.php.inc
+++ b/rules-tests/Php74/Rector/ArrayDimFetch/CurlyToSquareBracketArrayStringRector/Fixture/OnTrait.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\ArrayDimFetch\CurlyToSquareBracketArrayStringRector\Fixture;
+
+trait OnTrait
+{
+    public function runString(string $string)
+    {
+        return $string{0};
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\ArrayDimFetch\CurlyToSquareBracketArrayStringRector\Fixture;
+
+trait OnTrait
+{
+    public function runString(string $string)
+    {
+        return $string[0];
+    }
+}
+
+?>

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -455,13 +455,11 @@ final readonly class PHPStanNodeScopeResolver
     ): void {
         try {
             $this->nodeScopeResolver->processNodes($stmts, $mutatingScope, $nodeCallback);
-        } catch (ParserErrorsException|ParserException) {
+        } catch (ParserErrorsException|ParserException|ShouldNotHappenException) {
             // nothing we can do more precise here as error parsing from deep internal PHPStan service with service injection we cannot reset
             // in the middle of process
             // fallback to fill by found scope
             RectorNodeScopeResolver::processNodes($stmts, $mutatingScope);
-        } catch (ShouldNotHappenException) {
-            // internal PHPStan error
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8993

it cause error:

```
There was 1 error:

1) Rector\Tests\Php74\Rector\ArrayDimFetch\CurlyToSquareBracketArrayStringRector\CurlyToSquareBracketArrayStringRectorTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Exception\ShouldNotHappenException: Node "PhpParser\Node\Expr\ArrayDimFetch" with is missing scope required for scope refresh

/Users/samsonasik/www/rector-src/src/Application/ChangedNodeScopeRefresher.php:50
```