### PR TITLE
 [DX] Move isWindows() method from AbstractRectorTestCase to AbstractLazyTestCase

### DIFF
--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -46,4 +46,9 @@ abstract class AbstractLazyTestCase extends TestCase
 
         return self::$rectorConfig;
     }
+
+    protected function isWindows(): bool
+    {
+        return strncasecmp(PHP_OS, 'WIN', 3) === 0;
+    }
 }

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -130,11 +130,6 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         return FixtureFileFinder::yieldDirectory($directory, $suffix);
     }
 
-    protected function isWindows(): bool
-    {
-        return strncasecmp(PHP_OS, 'WIN', 3) === 0;
-    }
-
     protected function doTestFile(string $fixtureFilePath): void
     {
         // prepare input file contents and expected file output contents

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -59,6 +59,10 @@ final class FilesFinderTest extends AbstractLazyTestCase
 
     public function testWithFollowingBrokenSymlinks(): void
     {
+        if ($this->isWindows()) {
+            $this->markTestSkipped('This test is not reliable on Windows');
+        }
+
         SimpleParameterProvider::setParameter(Option::SKIP, [__DIR__ . '/../SourceWithBrokenSymlinks/folder1']);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithBrokenSymlinks']);

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -60,7 +60,7 @@ final class FilesFinderTest extends AbstractLazyTestCase
     public function testWithFollowingBrokenSymlinks(): void
     {
         if ($this->isWindows()) {
-            $this->markTestSkipped('This test is not reliable on Windows');
+            $this->markTestSkipped('Symlinks test is not reliable on Windows');
         }
 
         SimpleParameterProvider::setParameter(Option::SKIP, [__DIR__ . '/../SourceWithBrokenSymlinks/folder1']);

--- a/tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -196,7 +196,7 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
 
     private function cleanUpEmptyQuoteExpectedCommandOutput(string $result): string
     {
-        if (strncasecmp(PHP_OS, 'WIN', 3) === 0) {
+        if ($this->isWindows()) {
             return str_replace(' "" ', ' ', $result);
         }
 
@@ -205,7 +205,7 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
 
     private function normalizeExpectedCommandOutput(string $command): string
     {
-        if (strncasecmp(PHP_OS, 'WIN', 3) === 0) {
+        if ($this->isWindows()) {
             return str_replace("'", '"', $command);
         }
 


### PR DESCRIPTION
- [x] Move isWindows() method from AbstractRectorTestCase to AbstractLazyTestCase
- [x] Make use of this repetitive usage.
- [x] Skip symlink tested locally on windows 11 which unreliable with use the `isWindows()` method