### PR TITLE
[Performance] Use exactly equal or append / file path check on RealpathMatcher

### DIFF
--- a/src/Skipper/RealpathMatcher.php
+++ b/src/Skipper/RealpathMatcher.php
@@ -23,16 +23,13 @@ final class RealpathMatcher
         $normalizedMatchingPath = PathNormalizer::normalize($realPathMatchingPath);
         $normalizedFilePath = PathNormalizer::normalize($realpathFilePath);
 
-        // skip define direct path
-        if (is_file($normalizedMatchingPath)) {
-            return $normalizedMatchingPath === $normalizedFilePath;
+        // skip define direct path exactly equal
+        if ($normalizedMatchingPath === $normalizedFilePath) {
+            return true;
         }
 
         // ensure add / suffix to ensure no same prefix directory
-        if (is_dir($normalizedMatchingPath)) {
-            $normalizedMatchingPath = rtrim($normalizedMatchingPath, '/') . '/';
-        }
-
-        return str_starts_with($normalizedFilePath, $normalizedMatchingPath);
+        $suffixedMatchingPath = rtrim($normalizedMatchingPath, '/') . '/';
+        return str_starts_with($normalizedFilePath, $suffixedMatchingPath);
     }
 }


### PR DESCRIPTION
Remove unnecessary IO for `is_file()` and `is_dir()`, as `realpath()` already validated before,

https://github.com/rectorphp/rector-src/blob/4f54239565b838f5fcfb8bc4a3fef6e883080dc7/src/Skipper/RealpathMatcher.php#L13-L21

so just compare string equal or append with `/` suffix to file path.