### PR TITLE
[Php81] Exclude Doctrine ODM MongoDB Document and EmbeddedDocument from ReadOnlyPropertyRector.

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_doctrine_odm_mongodb_document.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_doctrine_odm_mongodb_document.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+
+#[Document]
+class SkipDoctrineOdmMongodbDocument
+{
+    private int $amount;
+}

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_doctrine_odm_mongodb_embedded_document.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_doctrine_odm_mongodb_embedded_document.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\EmbeddedDocument;
+
+#[EmbeddedDocument]
+class SkipDoctrineOdmMongodbEmbeddedDocument
+{
+    private int $amount;
+}

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -47,6 +47,8 @@ final readonly class PropertyManipulator
         'Doctrine\ORM\Mapping\Table',
         'Doctrine\ORM\Mapping\MappedSuperclass',
         'Doctrine\ORM\Mapping\Embeddable',
+        'Doctrine\ODM\MongoDB\Mapping\Annotations\Document',
+        'Doctrine\ODM\MongoDB\Mapping\Annotations\EmbeddedDocument',
     ];
 
     public function __construct(


### PR DESCRIPTION
The following configuration has been in our codebase for quite some time, so I figured it's about time to patch it directly into Rector. I based my changes on a similar issue: https://github.com/rectorphp/rector-src/pull/6531.

```php
->withSkip([
    ReadOnlyPropertyRector::class => [
        __DIR__ . '/src/Document/*.php',
    ],
])
```