### PR TITLE
[TypeDeclaration] Unregister AddClosureParamTypeForArrayMapRector and AddClosureParamTypeForArrayReduceRector due to may read from docblock

### DIFF
--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -49,8 +49,6 @@ use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnR
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
 use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
-use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector;
-use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeSplFixedArrayRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
@@ -122,8 +120,6 @@ final class TypeDeclarationLevel
         // closures
         AddClosureNeverReturnTypeRector::class,
         ClosureReturnTypeRector::class,
-        AddClosureParamTypeForArrayReduceRector::class,
-        AddClosureParamTypeForArrayMapRector::class,
 
         // more risky rules
         ReturnTypeFromStrictParamRector::class,

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -26,7 +26,7 @@ final class FilesFinderTest extends AbstractLazyTestCase
         $this->assertCount(1, $foundFiles);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithShortEchoes'], ['php']);
-        $this->assertCount(0, $foundFiles);
+        $this->assertEmpty($foundFiles);
     }
 
     #[DataProvider('alwaysReturnsAbsolutePathDataProvider')]
@@ -66,7 +66,7 @@ final class FilesFinderTest extends AbstractLazyTestCase
         SimpleParameterProvider::setParameter(Option::SKIP, [__DIR__ . '/../SourceWithBrokenSymlinks/folder1']);
 
         $foundFiles = $this->filesFinder->findInDirectoriesAndFiles([__DIR__ . '/SourceWithBrokenSymlinks']);
-        $this->assertCount(0, $foundFiles);
+        $this->assertEmpty($foundFiles);
     }
 
     #[DataProvider('provideData')]


### PR DESCRIPTION
@TomasVotruba @peterfox @staabm this PR unregister 2 rules from type declaration set.

- AddClosureParamTypeForArrayMapRector
- AddClosureParamTypeForArrayReduceRector

due to may read from docblock which unreliable on my tests on a big project. This PR unregister it. To use the rules, manual register is needed.

PR review

- https://github.com/rectorphp/rector-src/pull/6725#issuecomment-2647307286