### PR TITLE
Simplify NodeTypeResolver

### DIFF
--- a/src/NodeTypeResolver/NodeTypeCorrector/AccessoryNonEmptyStringTypeCorrector.php
+++ b/src/NodeTypeResolver/NodeTypeCorrector/AccessoryNonEmptyStringTypeCorrector.php
@@ -10,7 +10,7 @@ use PHPStan\Type\Type;
 
 final class AccessoryNonEmptyStringTypeCorrector
 {
-    public function correct(Type $mainType): Type | IntersectionType
+    public function correct(Type $mainType): Type
     {
         if (! $mainType instanceof IntersectionType) {
             return $mainType;

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -404,10 +404,10 @@ final class NodeTypeResolver
         }
 
         if ($hasChanged) {
-            return $this->accessoryNonEmptyStringTypeCorrector->correct(new UnionType($types));
+            return new UnionType($types);
         }
 
-        return $this->accessoryNonEmptyStringTypeCorrector->correct($unionType);
+        return $unionType;
     }
 
     private function isMatchObjectWithoutClassType(


### PR DESCRIPTION
since `AccessoryNonEmptyStringTypeCorrector` only works on `IntersectionType`, it does not make sense to call into it when a `UnionType` is provided