### PR TITLE
[Php74] Skip property hook on RestoreDefaultNullToNullableTypePropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_property_hook.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_property_hook.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+final class SkipPropertyHook
+{
+    public ?string $bar {
+        get => 'bar';
+    }
+}

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -115,6 +115,10 @@ CODE_SAMPLE
             return true;
         }
 
+        if ($property->hooks !== []) {
+            return true;
+        }
+
         // is variable assigned in constructor
         $propertyName = $this->getName($property);
         return $this->constructorAssignDetector->isPropertyAssignedConditionally($class, $propertyName);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9021