### PR TITLE
[TypeDeclaration] Skip already typed param on AddClosureParamTypeForArrayReduceRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Fixture/skip_already_typed_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Fixture/skip_already_typed_param.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector\Fixture;
+
+class SkipAlreadyTypedParam
+{
+    /**
+     * @param list<string> $array
+     */
+    public function run(array $array)
+    {
+        return array_reduce($array, function (string $carry, ?string $value) {
+            return $carry . $value;
+        }, '');
+    }
+}

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector.php
@@ -140,10 +140,7 @@ CODE_SAMPLE
 
         // already set → no change
         if ($param->type instanceof Node) {
-            $currentParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
-            if ($this->typeComparator->areTypesEqual($currentParamType, $type)) {
-                return false;
-            }
+            return false;
         }
 
         $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($type, TypeKind::PARAM);


### PR DESCRIPTION
@peterfox this ensure if param already typed, docblock based param can't enforce it, since typed param can already typed on purpose, reduce possible issue on already typed param.