### PR TITLE
[TypeDeclaration] Skip already typed param on AddClosureParamTypeForArrayMapRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_already_param_typed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/skip_already_param_typed.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Fixture;
+
+class SkipAlreadyParamTyped
+{
+    /**
+     * @param array<int, string> $array
+     */
+    public function run(array $array)
+    {
+        return array_map(function (string $value, int|string $key) {
+            return $value . $key;
+        }, $array);
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
@@ -172,10 +172,7 @@ CODE_SAMPLE
     {
         // already set → no change
         if ($param->type instanceof Node) {
-            $currentParamType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
-            if ($this->typeComparator->areTypesEqual($currentParamType, $type)) {
-                return false;
-            }
+            return false;
         }
 
         $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($type, TypeKind::PARAM);


### PR DESCRIPTION
@peterfox this ensure if param already typed, docblock based param can't enforce it, since typed param can already typed on purpose, reduce possible issue on already typed param.