### PR TITLE
Fix phpstan notice symplify.noJustPropertyAssign

### DIFF
--- a/src/BetterPhpDocParser/ValueObject/Type/SpacingAwareCallableTypeNode.php
+++ b/src/BetterPhpDocParser/ValueObject/Type/SpacingAwareCallableTypeNode.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Rector\BetterPhpDocParser\ValueObject\Type;
 
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Stringable;
 
 final class SpacingAwareCallableTypeNode extends CallableTypeNode implements Stringable
@@ -19,12 +17,9 @@ final class SpacingAwareCallableTypeNode extends CallableTypeNode implements Str
 
     private function createExplicitCallable(): string
     {
-        /** @var IdentifierTypeNode|GenericTypeNode $returnType */
-        $returnType = $this->returnType;
-
         $parameterTypeString = $this->createParameterTypeString();
 
-        $returnTypeAsString = (string) $returnType;
+        $returnTypeAsString = (string) $this->returnType;
         if (\str_contains($returnTypeAsString, '|')) {
             $returnTypeAsString = '(' . $returnTypeAsString . ')';
         }


### PR DESCRIPTION
latest composer update got phpstan notice;

```
Note: Using configuration file /home/samsonasik/www/rector-src/phpstan.neon.
 2310/2310 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  src/BetterPhpDocParser/ValueObject/Type/SpacingAwareCallableTypeNode.php:23
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Instead of assigning service property to a variable, use the property directly#'
  🪪 symplify.noJustPropertyAssign
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


                                                                                                                        
 [ERROR] Found 1 errors                                                                                                 
                                                                                                                        
```

this patch fix it.