### PR TITLE
[Php81] Handle crash Class parent was not found on MyCLabsMethodCallToEnumConstRector

### DIFF
--- a/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_parent_name.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector/Fixture/skip_parent_name.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector\Fixture;
+
+final class SkipParentName extends \MyCLabs\Enum\Enum
+{
+    public function run($value)
+    {
+        $compare = parent::someCall();
+    }
+}

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -105,6 +105,10 @@ CODE_SAMPLE
 
     private function isEnumConstant(string $className, string $constant): bool
     {
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
         $classReflection = $this->reflectionProvider->getClass($className);
 
         return $classReflection->hasConstant($constant);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9025
Ref https://getrector.com/demo/f1aa061b-74d2-4e1b-a483-7ca34dfb35ba