### PR TITLE
[CodeQuality] Handle crash division by zero error on ForeachItemsAssignToEmptyArrayToAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_division_by_zero.php.inc
+++ b/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_division_by_zero.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRector\Fixture;
+
+class SkipDivisionByZero
+{
+    function run($mode)
+    {
+        $x = 1 / 0;
+    }
+}

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PhpParser\Node\Value;
 
-use DivisionByZeroError;
+use ArithmeticError;
 use PhpParser\ConstExprEvaluationException;
 use PhpParser\ConstExprEvaluator;
 use PhpParser\Node\Arg;
@@ -158,7 +158,7 @@ final class ValueResolver
         try {
             $constExprEvaluator = $this->getConstExprEvaluator();
             return $constExprEvaluator->evaluateDirectly($expr);
-        } catch (ConstExprEvaluationException|TypeError|DivisionByZeroError) {
+        } catch (ConstExprEvaluationException|TypeError|ArithmeticError) {
         }
 
         if ($expr instanceof Class_) {

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\PhpParser\Node\Value;
 
+use DivisionByZeroError;
 use PhpParser\ConstExprEvaluationException;
 use PhpParser\ConstExprEvaluator;
 use PhpParser\Node\Arg;
@@ -157,7 +158,7 @@ final class ValueResolver
         try {
             $constExprEvaluator = $this->getConstExprEvaluator();
             return $constExprEvaluator->evaluateDirectly($expr);
-        } catch (ConstExprEvaluationException|TypeError) {
+        } catch (ConstExprEvaluationException|TypeError|DivisionByZeroError) {
         }
 
         if ($expr instanceof Class_) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9026
Ref https://getrector.com/demo/4c21575d-13c5-475d-88bd-391165734f44