### PR TITLE
Bump to use PHPStan ^2.1.6 that uses phpdoc-parser ^2.0.2

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.3"
+        "phpstan/phpstan": "^2.1.6"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0.2",
-        "phpstan/phpstan": "^2.1.3",
+        "phpstan/phpstan": "^2.1.6",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",


### PR DESCRIPTION
Continue of PR;

- https://github.com/rectorphp/rector-src/pull/6744

that introduce `Comment` class, this bump to use PHPStan 2.1.6 to ensure nothing left behind when user use different version.