### PR TITLE
fix(ValueObject): FileDiff first line number is below as expected

### DIFF
--- a/e2e/applied-polyfill-php80/expected-output.diff
+++ b/e2e/applied-polyfill-php80/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) src/SomeStartWith.php:3
+1) src/SomeStartWith.php:4
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/applied-rule-change-docblock/expected-output.diff
+++ b/e2e/applied-rule-change-docblock/expected-output.diff
@@ -1,7 +1,7 @@
 2 files with changes
 ====================
 
-1) src/RenameDocblock.php:0
+1) src/RenameDocblock.php:1
 
     ---------- begin diff ----------
 @@ @@
@@ -19,7 +19,7 @@ Applied rules:
  * RenameClassRector
 
 
-2) src/UselessVarTag.php:1
+2) src/UselessVarTag.php:2
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/applied-rule-removed-node-with-cache/expected-output.diff
+++ b/e2e/applied-rule-removed-node-with-cache/expected-output.diff
@@ -1,7 +1,7 @@
 2 files with changes
 ====================
 
-1) src/AlwaysTrue.php:3
+1) src/AlwaysTrue.php:4
 
     ---------- begin diff ----------
 @@ @@
@@ -20,7 +20,7 @@ Applied rules:
  * RemoveAlwaysTrueIfConditionRector
 
 
-2) src/DeadConstructor.php:1
+2) src/DeadConstructor.php:2
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/applied-rule-removed-node/expected-output.diff
+++ b/e2e/applied-rule-removed-node/expected-output.diff
@@ -1,7 +1,7 @@
 2 files with changes
 ====================
 
-1) src/AlwaysTrue.php:3
+1) src/AlwaysTrue.php:4
 
     ---------- begin diff ----------
 @@ @@
@@ -20,7 +20,7 @@ Applied rules:
  * RemoveAlwaysTrueIfConditionRector
 
 
-2) src/DeadConstructor.php:1
+2) src/DeadConstructor.php:2
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/applied-rule-return-array-nodes/expected-output.diff
+++ b/e2e/applied-rule-return-array-nodes/expected-output.diff
@@ -1,7 +1,7 @@
 2 files with changes
 ====================
 
-1) src/MultiRules.php:5
+1) src/MultiRules.php:6
 
     ---------- begin diff ----------
 @@ @@
@@ -25,7 +25,7 @@ Applied rules:
  * RemoveAlwaysElseRector
 
 
-2) src/RemoveAlwaysElse.php:5
+2) src/RemoveAlwaysElse.php:6
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/different-path-over-skip-config/expected-output.diff
+++ b/e2e/different-path-over-skip-config/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) src/models/DeadConstructor.php:3
+1) src/models/DeadConstructor.php:4
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/no-parallel-reflection-resolver/expected-output.diff
+++ b/e2e/no-parallel-reflection-resolver/expected-output.diff
@@ -1,7 +1,7 @@
 2 files with changes
 ====================
 
-1) src/NamespacedSomeClassFound.php:5
+1) src/NamespacedSomeClassFound.php:6
 
     ---------- begin diff ----------
 @@ @@
@@ -16,7 +16,7 @@ Applied rules:
  * RemoveUnusedPrivatePropertyRector
 
 
-2) src/SomeClassNotFound.php:3
+2) src/SomeClassNotFound.php:4
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/only-option-quote-double-equalnone/expected-output.diff
+++ b/e2e/only-option-quote-double-equalnone/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) ../only-option/src/MultiRules.php:9
+1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/only-option-quote-single-bsdouble/expected-output.diff
+++ b/e2e/only-option-quote-single-bsdouble/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) ../only-option/src/MultiRules.php:9
+1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/only-option-quote-single-equalnone/expected-output.diff
+++ b/e2e/only-option-quote-single-equalnone/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) ../only-option/src/MultiRules.php:9
+1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/only-option-quote-single/expected-output.diff
+++ b/e2e/only-option-quote-single/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) ../only-option/src/MultiRules.php:9
+1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/only-option/expected-output.diff
+++ b/e2e/only-option/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) src/MultiRules.php:9
+1) src/MultiRules.php:10
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/parallel-custom-config/expected-output.diff
+++ b/e2e/parallel-custom-config/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) src/SomeClass.php:6
+1) src/SomeClass.php:7
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/parallel-reflection-resolver/expected-output.diff
+++ b/e2e/parallel-reflection-resolver/expected-output.diff
@@ -1,7 +1,7 @@
 2 files with changes
 ====================
 
-1) src/NamespacedSomeClassFound.php:5
+1) src/NamespacedSomeClassFound.php:6
 
     ---------- begin diff ----------
 @@ @@
@@ -16,7 +16,7 @@ Applied rules:
  * RemoveUnusedPrivatePropertyRector
 
 
-2) src/SomeClassNotFound.php:3
+2) src/SomeClassNotFound.php:4
 
     ---------- begin diff ----------
 @@ @@

--- a/e2e/print-new-node/expected-output.diff
+++ b/e2e/print-new-node/expected-output.diff
@@ -1,7 +1,7 @@
 1 file with changes
 ===================
 
-1) src/ExtendingTestClass.php:0
+1) src/ExtendingTestClass.php:1
 
     ---------- begin diff ----------
 @@ @@

--- a/rules/Php53/Rector/Ternary/TernaryToElvisRector.php
+++ b/rules/Php53/Rector/Ternary/TernaryToElvisRector.php
@@ -70,6 +70,11 @@ CODE_SAMPLE
         return $node;
     }
 
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ELVIS_OPERATOR;
+    }
+
     private function isParenthesized(Expr $ifExpr, Expr $elseExpr): bool
     {
         $tokens = $this->file->getOldTokens();
@@ -94,10 +99,5 @@ CODE_SAMPLE
         }
 
         return false;
-    }
-
-    public function provideMinPhpVersion(): int
-    {
-        return PhpVersionFeature::ELVIS_OPERATOR;
     }
 }

--- a/src/ValueObject/Reporting/FileDiff.php
+++ b/src/ValueObject/Reporting/FileDiff.php
@@ -15,9 +15,10 @@ final readonly class FileDiff implements SerializableInterface
 {
     /**
      * @var string
-     * @se https://regex101.com/r/AUPIX4/1
+     * @see https://en.wikipedia.org/wiki/Diff#Unified_format
+     * @see https://regex101.com/r/AUPIX4/1
      */
-    private const FIRST_LINE_REGEX = '#@@(.*?)(?<' . self::FIRST_LINE_KEY . '>\d+)(.*?)@@#';
+    private const DIFF_HUNK_HEADER_REGEX = '#@@(.*?)(?<' . self::FIRST_LINE_KEY . '>\d+)(.*?)@@#';
 
     /**
      * @var string
@@ -93,14 +94,14 @@ final readonly class FileDiff implements SerializableInterface
 
     public function getFirstLineNumber(): ?int
     {
-        $match = Strings::match($this->diff, self::FIRST_LINE_REGEX);
+        $match = Strings::match($this->diff, self::DIFF_HUNK_HEADER_REGEX);
 
         // probably some error in diff
         if (! isset($match[self::FIRST_LINE_KEY])) {
             return null;
         }
 
-        return (int) $match[self::FIRST_LINE_KEY] - 1;
+        return (int) $match[self::FIRST_LINE_KEY];
     }
 
     /**

--- a/tests/ValueObject/Reporting/FileDiffTest.php
+++ b/tests/ValueObject/Reporting/FileDiffTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\ValueObject\Reporting;
+
+use PHPUnit\Framework\TestCase;
+use Rector\ValueObject\Reporting\FileDiff;
+
+final class FileDiffTest extends TestCase
+{
+    public function testGetFirstLineNumberShouldReturnFirstLineNumberRegardingHunk(): void
+    {
+        $fileDiff = new FileDiff(
+            'some/file.php',
+            '--- Original\n+++ New\n@@ -38,5 +39,6 @@\nreturn true;\n}\n',
+            'diff console formatted'
+        );
+        $this->assertSame(38, $fileDiff->getFirstLineNumber());
+    }
+
+    public function testGetFirstLineNumberShouldBeNullWhenHunkIsInvalid(): void
+    {
+        $fileDiff = new FileDiff(
+            'some/file.php',
+            '--- Original\n+++ New\n@@@@\nreturn true;\n}\n',
+            'diff console formatted'
+        );
+        $this->assertNull($fileDiff->getFirstLineNumber());
+    }
+}


### PR DESCRIPTION
/This PR fixes an issue with printed line number in report:

The line number of file is below than expected (1 less than the line in file).

## Example:

**Console output:**

```sh
> tools/vendor/bin/rector process src '--dry-run'
 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
2 files with changes
====================

1) src/CssLint/CliArgs.php:41

    ---------- begin diff ----------
@@ @@

         foreach ($arguments as $sArgument) {
             // --foo --bar=baz
-            if (substr($sArgument, 0, 2) == '--') {
```


> [!NOTE]
> The console outputs says that a change diff is starting at line **41**

**File `src/CssLint/CliArgs.php`:**

![image](https://github.com/user-attachments/assets/5bb89554-030c-4807-b268-adb42075843d)
 
> [!WARNING]
> We can see that the diff change starts at line **42**, not 41 