### PR TITLE
feat(ChangesReporting): add GitHub output formatter

### DIFF
--- a/src/ChangesReporting/Output/GitHubOutputFormatter.php
+++ b/src/ChangesReporting/Output/GitHubOutputFormatter.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Reports errors in pull-requests diff when run in a GitHub Action
+ * @see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+ * @see https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+ *
+ * @todo: print endLine property. For now in GitHub’s PR display (specifically in GitHub Actions annotations), the "endLine" property is known to be bugged.
+ * @see https://github.com/orgs/community/discussions/129899
+ */
+
+declare(strict_types=1);
+
+namespace Rector\ChangesReporting\Output;
+
+use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
+use Rector\ValueObject\Configuration;
+use Rector\ValueObject\ProcessResult;
+
+/**
+ * @phpstan-type AnnotationProperties array{title?: string|null, file?: string|null, col?: int|null, endColumn?: int|null, line?: int|null, endLine?: int|null}
+ */
+final readonly class GitHubOutputFormatter implements OutputFormatterInterface
+{
+    /**
+     * @var string
+     */
+    public const NAME = 'github';
+
+    private const GROUP_NAME = 'Rector report';
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    public function report(ProcessResult $processResult, Configuration $configuration): void
+    {
+        $this->startGroup();
+
+        $this->reportSystemErrors($processResult, $configuration);
+        $this->reportFileDiffs($processResult, $configuration);
+
+        $this->endGroup();
+    }
+
+    private function startGroup(): void
+    {
+        echo sprintf('::group::%s', self::GROUP_NAME) . PHP_EOL;
+    }
+
+    private function endGroup(): void
+    {
+        echo '::endgroup::' . PHP_EOL;
+    }
+
+    private function reportSystemErrors(ProcessResult $processResult, Configuration $configuration): void
+    {
+        foreach ($processResult->getSystemErrors() as $systemError) {
+            $filePath = $configuration->isReportingWithRealPath()
+                ? $systemError->getAbsoluteFilePath()
+                : $systemError->getRelativeFilePath();
+
+            $line = $systemError->getLine();
+            $message = trim($systemError->getRectorShortClass() . PHP_EOL . $systemError->getMessage());
+
+            $this->reportErrorAnnotation($message, [
+                'file' => $filePath,
+                'line' => $line,
+            ]);
+        }
+    }
+
+    private function reportFileDiffs(ProcessResult $processResult, Configuration $configuration): void
+    {
+
+        $fileDiffs = $processResult->getFileDiffs();
+        ksort($fileDiffs);
+
+        foreach ($fileDiffs as $fileDiff) {
+            $filePath = $configuration->isReportingWithRealPath()
+                ? $fileDiff->getAbsoluteFilePath()
+                : $fileDiff->getRelativeFilePath();
+
+            $line = $fileDiff->getFirstLineNumber();
+            $endLine = $fileDiff->getLastLineNumber();
+
+            $message = trim(
+                implode(' / ', $fileDiff->getRectorShortClasses())
+            ) . PHP_EOL . PHP_EOL . $fileDiff->getDiff();
+
+            $this->reportErrorAnnotation($message, [
+                'file' => $filePath,
+                'line' => $line,
+                'endLine' => $endLine,
+            ]);
+        }
+    }
+
+    /**
+     * @param AnnotationProperties $annotationProperties
+     */
+    private function reportErrorAnnotation(string $message, array $annotationProperties): void
+    {
+        $properties = $this->sanitizeAnnotationProperties($annotationProperties);
+
+        $command = sprintf('::error %s::%s', $properties, $message);
+
+        // Sanitize command
+        $command = str_replace(['%', "\r", "\n"], ['%25', '%0D', '%0A'], $command);
+
+        echo $command . PHP_EOL;
+    }
+
+    /**
+     * @param AnnotationProperties $annotationProperties
+     */
+    private function sanitizeAnnotationProperties(array $annotationProperties): string
+    {
+        if (! isset($annotationProperties['line']) || ! $annotationProperties['line']) {
+            $annotationProperties['line'] = 0;
+        }
+
+        // This is a workaround for buggy endLine. See https://github.com/orgs/community/discussions/129899
+        // TODO: Should be removed once github will have fixed it issue.
+        unset($annotationProperties['endLine']);
+
+        $nonNullProperties = array_filter($annotationProperties, static fn ($value) => $value !== null);
+
+        $sanitizedProperties = array_map(
+            fn ($key, $value) => sprintf('%s=%s', $key, $this->sanitizeAnnotationProperty($value)),
+            array_keys($nonNullProperties),
+            $nonNullProperties
+        );
+
+        return implode(',', $sanitizedProperties);
+    }
+
+    private function sanitizeAnnotationProperty(string|int|null $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        $value = (string) $value;
+
+        $value = str_replace(['%', "\r", "\n", ':', ','], ['%25', '%0D', '%0A', '%3A', '%2C'], $value);
+
+        return $value;
+    }
+}

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -36,6 +36,7 @@ use Rector\Caching\Cache;
 use Rector\Caching\CacheFactory;
 use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
+use Rector\ChangesReporting\Output\GitHubOutputFormatter;
 use Rector\ChangesReporting\Output\GitlabOutputFormatter;
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
@@ -330,6 +331,7 @@ final class LazyContainerFactory
         ConsoleOutputFormatter::class,
         JsonOutputFormatter::class,
         GitlabOutputFormatter::class,
+        GitHubOutputFormatter::class,
     ];
 
     /**

--- a/src/ValueObject/Error/SystemError.php
+++ b/src/ValueObject/Error/SystemError.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\ValueObject\Error;
 
+use Nette\Utils\Strings;
 use Rector\Parallel\ValueObject\BridgeItem;
 use Symplify\EasyParallel\Contract\SerializableInterface;
 
@@ -77,5 +78,15 @@ final readonly class SystemError implements SerializableInterface
     public function getRectorClass(): ?string
     {
         return $this->rectorClass;
+    }
+
+    public function getRectorShortClass(): ?string
+    {
+        $rectorClass = $this->getRectorClass();
+        if ($rectorClass) {
+            return (string) Strings::after($rectorClass, '\\', -1);
+        }
+
+        return null;
     }
 }

--- a/src/ValueObject/Reporting/FileDiff.php
+++ b/src/ValueObject/Reporting/FileDiff.php
@@ -16,14 +16,16 @@ final readonly class FileDiff implements SerializableInterface
     /**
      * @var string
      * @see https://en.wikipedia.org/wiki/Diff#Unified_format
-     * @see https://regex101.com/r/AUPIX4/1
+     * @see https://regex101.com/r/AUPIX4/2
      */
-    private const DIFF_HUNK_HEADER_REGEX = '#@@(.*?)(?<' . self::FIRST_LINE_KEY . '>\d+)(.*?)@@#';
+    private const DIFF_HUNK_HEADER_REGEX = '#@@(.*?)(?<' . self::FIRST_LINE_KEY . '>\d+)(,(?<' . self::LINE_RANGE_KEY . '>\d+))?(.*?)@@#';
 
     /**
      * @var string
      */
     private const FIRST_LINE_KEY = 'first_line';
+
+    private const LINE_RANGE_KEY = 'line_range';
 
     /**
      * @param RectorWithLineChange[] $rectorsWithLineChanges
@@ -102,6 +104,27 @@ final readonly class FileDiff implements SerializableInterface
         }
 
         return (int) $match[self::FIRST_LINE_KEY];
+    }
+
+    public function getLastLineNumber(): ?int
+    {
+        $match = Strings::match($this->diff, self::DIFF_HUNK_HEADER_REGEX);
+
+        $firstLine = $this->getFirstLineNumber();
+
+        // probably some error in diff
+        if (! isset($match[self::LINE_RANGE_KEY])) {
+            return $firstLine;
+        }
+
+        // line range is not mandatory
+        if ($match[self::LINE_RANGE_KEY] === '') {
+            return $firstLine;
+        }
+
+        $lineRange = (int) $match[self::LINE_RANGE_KEY];
+
+        return $firstLine + $lineRange;
     }
 
     /**

--- a/tests/ChangesReporting/Output/GitHubOutputFormatterTest.php
+++ b/tests/ChangesReporting/Output/GitHubOutputFormatterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\ChangesReporting\Output;
+
+use PHPUnit\Framework\TestCase;
+use Rector\ChangesReporting\Output\GitHubOutputFormatter;
+use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
+use Rector\Php80\Rector\Identical\StrStartsWithRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\ValueObject\Configuration;
+use Rector\ValueObject\Error\SystemError;
+use Rector\ValueObject\ProcessResult;
+use Rector\ValueObject\Reporting\FileDiff;
+
+final class GitHubOutputFormatterTest extends TestCase
+{
+    private readonly GitHubOutputFormatter $gitHubOutputFormatter;
+
+    protected function setUp(): void
+    {
+        $this->gitHubOutputFormatter = new GitHubOutputFormatter();
+
+        parent::setUp();
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertSame('github', $this->gitHubOutputFormatter->getName());
+    }
+
+    public function testReportShouldOutputErrorMessagesGrouped(): void
+    {
+
+        $this->expectOsOutputString(
+            '::group::Rector report' . PHP_EOL .
+                '::error file=some/file.php,line=1::Some error message' . PHP_EOL .
+                '::error file=some/file.php,line=38::StrStartsWithRector%0A%0A--- Original%0A+++ New%0A@@ -38,5 +39,6 @@%0Areturn true;%0A}%0A' . PHP_EOL .
+                '::endgroup::' . PHP_EOL
+        );
+
+        $this->gitHubOutputFormatter->report(
+            new ProcessResult(
+                [new SystemError('Some error message', 'some/file.php', 1)],
+                [
+                    new FileDiff(
+                        'some/file.php',
+                        '--- Original' . PHP_EOL . '+++ New' . PHP_EOL .
+                            '@@ -38,5 +39,6 @@' . PHP_EOL .
+                            'return true;' . PHP_EOL . '}' . PHP_EOL,
+                        'diff console formatted',
+                        [new RectorWithLineChange(StrStartsWithRector::class, 38)]
+                    ),
+                ],
+            ),
+            new Configuration()
+        );
+    }
+
+    public function testReportShouldOutputErrorMessagesGroupedWithNoErrors(): void
+    {
+        $this->expectOsOutputString('::group::Rector report' . PHP_EOL . '::endgroup::' . PHP_EOL);
+
+        $this->gitHubOutputFormatter->report(new ProcessResult([], []), new Configuration());
+    }
+
+    public function testReportShouldOutputErrorMessagesGroupedWithMultipleDiffs(): void
+    {
+        $this->expectOsOutputString(
+            '::group::Rector report' . PHP_EOL .
+                '::error file=some/file.php,line=38::StrStartsWithRector / NullToStrictStringFuncCallArgRector%0A%0A--- Original%0A+++ New%0A@@ -38,5 +39,6 @@%0Areturn true;%0A}%0A' . PHP_EOL .
+                '::error file=some/another-file.php,line=54::StrStartsWithRector%0A%0A--- Original%0A+++ New%0A@@ -54,10 +54,10 @@%0Areturn true;%0A}%0A' . PHP_EOL .
+                '::endgroup::' . PHP_EOL
+        );
+
+        $this->gitHubOutputFormatter->report(
+            new ProcessResult([], [
+                new FileDiff(
+                    'some/file.php',
+                    '--- Original' . PHP_EOL . '+++ New' . PHP_EOL .
+                        '@@ -38,5 +39,6 @@' . PHP_EOL .
+                        'return true;' . PHP_EOL . '}' . PHP_EOL,
+                    'diff console formatted',
+                    [
+                        new RectorWithLineChange(StrStartsWithRector::class, 38),
+                        new RectorWithLineChange(NullToStrictStringFuncCallArgRector::class, 38),
+                    ]
+                ),
+                new FileDiff(
+                    'some/another-file.php',
+                    '--- Original' . PHP_EOL . '+++ New' . PHP_EOL .
+                        '@@ -54,10 +54,10 @@' . PHP_EOL .
+                        'return true;' . PHP_EOL . '}' . PHP_EOL,
+                    'diff console formatted',
+                    [new RectorWithLineChange(StrStartsWithRector::class, 54)]
+                ),
+            ], ),
+            new Configuration()
+        );
+    }
+
+    protected function expectOsOutputString(string $expectedOutput): void
+    {
+        $isWindows = strncasecmp(PHP_OS, 'WIN', 3) === 0;
+        if ($isWindows) {
+            $expectedOutput = str_replace('%0A', '%0D%0A', $expectedOutput);
+        }
+
+        parent::expectOutputString($expectedOutput);
+    }
+}

--- a/tests/ValueObject/Error/SystemErrorTest.php
+++ b/tests/ValueObject/Error/SystemErrorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\ValueObject\Error;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Php80\Rector\Identical\StrStartsWithRector;
+use Rector\ValueObject\Error\SystemError;
+
+final class SystemErrorTest extends TestCase
+{
+    public function testGetAbsoluteFilePath(): void
+    {
+        $systemError = new SystemError('Some error message', __DIR__ . '/SystemErrorTest.php');
+        $this->assertSame(realpath(__DIR__ . '/SystemErrorTest.php'), $systemError->getAbsoluteFilePath());
+    }
+
+    public function testGetAbsoluteFilePathShouldReturnNullWhenRelativeFilePathIsNull(): void
+    {
+        $systemError = new SystemError('Some error message');
+        $this->assertNull($systemError->getAbsoluteFilePath());
+    }
+
+    public function testGetRectorShortClass(): void
+    {
+        $systemError = new SystemError('Some error message', null, 1, StrStartsWithRector::class);
+        $this->assertSame('StrStartsWithRector', $systemError->getRectorShortClass());
+    }
+
+    public function testGetRectorShortClassShouldReturnNullWhenRectorClassIsNull(): void
+    {
+        $systemError = new SystemError('Some error message');
+        $this->assertNull($systemError->getRectorShortClass());
+    }
+}

--- a/tests/ValueObject/Reporting/FileDiffTest.php
+++ b/tests/ValueObject/Reporting/FileDiffTest.php
@@ -28,4 +28,34 @@ final class FileDiffTest extends TestCase
         );
         $this->assertNull($fileDiff->getFirstLineNumber());
     }
+
+    public function testGetLastLineNumberShouldReturnLastLineNumberRegardingHunk(): void
+    {
+        $fileDiff = new FileDiff(
+            'some/file.php',
+            '--- Original\n+++ New\n@@ -38,5 +39,6 @@\nreturn true;\n}\n',
+            'diff console formatted'
+        );
+        $this->assertSame(43, $fileDiff->getLastLineNumber());
+    }
+
+    public function testGetLastLineNumberShouldBeNullWhenHunkIsInvalid(): void
+    {
+        $fileDiff = new FileDiff(
+            'some/file.php',
+            '--- Original\n+++ New\n@@@@\nreturn true;\n}\n',
+            'diff console formatted'
+        );
+        $this->assertNull($fileDiff->getLastLineNumber());
+    }
+
+    public function testGetLastLineNumberShouldReturnFirstLineWhenUndefinedInHunk(): void
+    {
+        $fileDiff = new FileDiff(
+            'some/file.php',
+            '--- Original\n+++ New\n@@ -38 +39 @@\nreturn true;\n}\n',
+            'diff console formatted'
+        );
+        $this->assertSame(38, $fileDiff->getLastLineNumber());
+    }
 }


### PR DESCRIPTION
Add a new reporting output formatter for GitHub:

- Print errors as error messages  (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message)
- It create proper annotation in summary and Pull request  "Files changed" view.

**Example:**

### Summary annotations

![image](https://github.com/user-attachments/assets/e8808d1b-1d44-4d13-a3a2-020671f0cf18)

### PR view

![image](https://github.com/user-attachments/assets/f8358a7b-24e1-438f-80c0-c9770b0a5cba)

