### PR TITLE
[Rector Rule] Replace `date`, `strtotime`, and `time` calls with `Carbon` equivalents

### DIFF
--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/date_with_strtotime.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/date_with_strtotime.php.inc
@@ -2,11 +2,11 @@
 
 namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
 
-class StrtotimeExample
+class DateWithStrtotimeExample
 {
     public function run()
     {
-        $timestamp = strtotime('2025-02-20');
+        $formatted = date('d.m.Y', strtotime('2025-02-21'));
     }
 }
 
@@ -15,10 +15,10 @@ class StrtotimeExample
 
 namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
 
-class StrtotimeExample
+class DateWithStrtotimeExample
 {
     public function run()
     {
-        $timestamp = \Carbon\Carbon::parse('2025-02-20')->timestamp;
+        $formatted = \Carbon\Carbon::parse('2025-02-21')->format('d.m.Y');
     }
 }

--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/simple_date.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/simple_date.php.inc
@@ -2,11 +2,11 @@
 
 namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
 
-class StrtotimeExample
+class SimpleDateExample
 {
     public function run()
     {
-        $timestamp = strtotime('2025-02-20');
+        $date = date('Y-m-d');
     }
 }
 
@@ -15,10 +15,10 @@ class StrtotimeExample
 
 namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
 
-class StrtotimeExample
+class SimpleDateExample
 {
     public function run()
     {
-        $timestamp = \Carbon\Carbon::parse('2025-02-20')->timestamp;
+        $date = \Carbon\Carbon::now()->format('Y-m-d');
     }
 }

--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/strtotime.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/strtotime.php.inc
@@ -15,10 +15,12 @@ class StrtotimeExample
 
 namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
 
+use Carbon\Carbon;
+
 class StrtotimeExample
 {
     public function run()
     {
-        $timestamp = \Carbon\Carbon::parse('2025-02-20')->timestamp;
+        $timestamp = Carbon::parse('2025-02-20')->timestamp;
     }
 }

--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/strtotime.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/strtotime.php.inc
@@ -19,6 +19,6 @@ class StrtotimeExample
 {
     public function run()
     {
-        $timestamp = \Carbon\Carbon::parse('2025-02-20')->timestamp;
+        $timestamp = \Carbon\Carbon::parse('2025-02-20')->getTimestamp();
     }
 }

--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/strtotime.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/strtotime.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
+
+class StrtotimeExample
+{
+    public function run()
+    {
+        $timestamp = strtotime('2025-02-20');
+    }
+}
+
+-----
+<?php
+
+namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
+
+class StrtotimeExample
+{
+    public function run()
+    {
+        $timestamp = \Carbon\Carbon::parse('2025-02-20')->timestamp;
+    }
+}

--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/time_calculation.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/time_calculation.php.inc
@@ -23,10 +23,10 @@ class TimeCalculationExample
 {
     public function run()
     {
-        $twoSecondsAgo = \Carbon\Carbon::now()->subSeconds(2)->timestamp;
-        $twoMinutesAgo = \Carbon\Carbon::now()->subMinutes(2)->timestamp;
-        $twoHoursAgo   = \Carbon\Carbon::now()->subHours(2)->timestamp;
-        $twoDaysAgo    = \Carbon\Carbon::now()->subDays(2)->timestamp;
-        $twoWeeksAgo   = \Carbon\Carbon::now()->subWeeks(2)->timestamp;
+        $twoSecondsAgo = \Carbon\Carbon::now()->subSeconds(2)->getTimestamp();
+        $twoMinutesAgo = \Carbon\Carbon::now()->subMinutes(2)->getTimestamp();
+        $twoHoursAgo   = \Carbon\Carbon::now()->subHours(2)->getTimestamp();
+        $twoDaysAgo    = \Carbon\Carbon::now()->subDays(2)->getTimestamp();
+        $twoWeeksAgo   = \Carbon\Carbon::now()->subWeeks(2)->getTimestamp();
     }
 }

--- a/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/time_calculation.php.inc
+++ b/rules-tests/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector/Fixture/time_calculation.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
+
+class TimeCalculationExample
+{
+    public function run()
+    {
+        $twoSecondsAgo = time() - 2;
+        $twoMinutesAgo = time() - (60 * 2);
+        $twoHoursAgo   = time() - (60 * 60 * 2);
+        $twoDaysAgo    = time() - (60 * 60 * 24 * 2);
+        $twoWeeksAgo   = time() - (60 * 60 * 24 * 14);
+    }
+}
+
+-----
+<?php
+
+namespace Rector\Tests\Carbon\Rector\FuncCall\DateFuncCallToCarbonRector\Fixture;
+
+class TimeCalculationExample
+{
+    public function run()
+    {
+        $twoSecondsAgo = \Carbon\Carbon::now()->subSeconds(2)->timestamp;
+        $twoMinutesAgo = \Carbon\Carbon::now()->subMinutes(2)->timestamp;
+        $twoHoursAgo   = \Carbon\Carbon::now()->subHours(2)->timestamp;
+        $twoDaysAgo    = \Carbon\Carbon::now()->subDays(2)->timestamp;
+        $twoWeeksAgo   = \Carbon\Carbon::now()->subWeeks(2)->timestamp;
+    }
+}

--- a/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
@@ -200,7 +200,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function calculateProduct(Expr $node): ?int
+    private function calculateProduct(Expr $node): float|int|null
     {
         if ($node instanceof LNumber) {
             return $node->value;

--- a/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
@@ -6,13 +6,18 @@ namespace Rector\Carbon\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Minus;
+use PhpParser\Node\Expr\BinaryOp\Mul;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Exception\PoorDocumentationException;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,6 +26,17 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DateFuncCallToCarbonRector extends AbstractRector
 {
+    private const TIME_UNITS = [
+        ['weeks', 604800],
+        ['days', 86400],
+        ['hours', 3600],
+        ['minutes', 60],
+        ['seconds', 1],
+    ];
+
+    /**
+     * @throws PoorDocumentationException
+     */
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Convert date() function call to Carbon::now()->format(*)', [
@@ -34,7 +50,6 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-
                 ,
                 <<<'CODE_SAMPLE'
 class SomeClass
@@ -54,41 +69,193 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [FuncCall::class];
+        return [Minus::class, FuncCall::class];
     }
 
     /**
      * @param FuncCall $node
+     * @return Node|null
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isName($node->name, 'date') && ! $this->isName($node->name, 'strtotime')) {
+        if ($node instanceof Minus) {
+            $left = $node->left;
+            if ($left instanceof FuncCall && $this->isName($left->name, 'time')) {
+                $timeUnit = $this->detectTimeUnit($node->right);
+                if ($timeUnit !== null) {
+                    return $this->createCarbonSubtract($timeUnit);
+                }
+            }
+
             return null;
         }
 
-        if ($node->isFirstClassCallable()) {
+        if (! $node instanceof FuncCall) {
             return null;
         }
 
-        if (count($node->getArgs()) !== 1) {
-            return null;
+        if ($this->isName($node->name, 'date') && isset($node->args[1]) && $node->args[1] instanceof Arg) {
+            $format = $this->getArgValue($node, 0);
+            if (! $format instanceof Expr) {
+                return null;
+            }
+
+            $timestamp = $node->args[1]->value;
+            if ($timestamp instanceof FuncCall
+                && $this->isName($timestamp->name, 'strtotime')
+                && isset($timestamp->args[0]) && $timestamp->args[0] instanceof Arg
+            ) {
+                $dateExpr = $timestamp->args[0]->value;
+                return $this->createCarbonParseFormat($dateExpr, $format);
+            }
         }
 
-        $firstArg = $node->getArgs()[0];
-        if (! $firstArg->value instanceof String_) {
-            return null;
+        if ($this->isName($node->name, 'date') && isset($node->args[0])) {
+            $format = $this->getArgValue($node, 0);
+            if ($format instanceof String_) {
+                return $this->createCarbonNowFormat($format);
+            }
         }
 
-        if ($this->isName($node->name, 'date')) {
-            $nowStaticCall = new StaticCall(new FullyQualified('Carbon\\Carbon'), 'now');
-            return new MethodCall($nowStaticCall, 'format', [new Arg($firstArg->value)]);
-        }
-
-        if ($this->isName($node->name, 'strtotime')) {
-            $parseCall = new StaticCall(new FullyQualified('Carbon\\Carbon'), 'parse', [new Arg($firstArg->value)]);
-            return new PropertyFetch($parseCall, 'timestamp');
+        if ($this->isName($node->name, 'strtotime') && isset($node->args[0])) {
+            $dateExpr = $this->getArgValue($node, 0);
+            if ($dateExpr !== null) {
+                return $this->createCarbonParseTimestamp($dateExpr);
+            }
         }
 
         return null;
+    }
+
+    /**
+     * @param FuncCall $node
+     * @param int $index
+     * @return Expr|null
+     */
+    private function getArgValue(FuncCall $node, int $index): ?Expr
+    {
+        if (!isset($node->args[$index]) || !$node->args[$index] instanceof Arg) {
+            return null;
+        }
+
+        return $node->args[$index]->value;
+    }
+
+    private function createCarbonNowFormat(String_ $format): MethodCall
+    {
+        $nowCall = new StaticCall(
+            new FullyQualified('Carbon\\Carbon'),
+            'now'
+        );
+
+        return new MethodCall($nowCall, 'format', [new Arg($format)]);
+    }
+
+    private function createCarbonParseTimestamp(Expr $dateExpr): PropertyFetch
+    {
+        $parseCall = new StaticCall(
+            new FullyQualified('Carbon\\Carbon'),
+            'parse',
+            [new Arg($dateExpr)]
+        );
+
+        return new PropertyFetch($parseCall, 'timestamp');
+    }
+
+    private function createCarbonParseFormat(Expr $dateExpr, Expr $format): MethodCall
+    {
+        $parseCall = new StaticCall(
+            new FullyQualified('Carbon\\Carbon'),
+            'parse',
+            [new Arg($dateExpr)]
+        );
+
+        return new MethodCall($parseCall, 'format', [new Arg($format)]);
+    }
+
+    /**
+     * @param array{unit: string, value: int} $timeUnit
+     * @return PropertyFetch
+     */
+    private function createCarbonSubtract(array $timeUnit): PropertyFetch
+    {
+        $nowCall = new StaticCall(
+            new FullyQualified('Carbon\\Carbon'),
+            'now'
+        );
+        $methodName = 'sub' . ucfirst($timeUnit['unit']);
+        $subtractCall = new MethodCall($nowCall, $methodName, [new Arg(new LNumber($timeUnit['value']))]);
+        return new PropertyFetch($subtractCall, 'timestamp');
+    }
+
+    /**
+     * @param Expr $node
+     * @return array{unit: string, value: int}|null
+     */
+    private function detectTimeUnit(Expr $node): ?array
+    {
+        $product = $this->calculateProduct($node);
+        if ($product === null) {
+            return null;
+        }
+
+        foreach (self::TIME_UNITS as [$unit, $seconds]) {
+            if ($product % $seconds === 0) {
+                return [
+                    'unit' => (string) $unit,
+                    'value' => (int) ($product / $seconds)
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Expr $node
+     * @return int|null
+     */
+    private function calculateProduct(Expr $node): ?int
+    {
+        if ($node instanceof LNumber) {
+            return $node->value;
+        }
+
+        if (!$node instanceof Mul) {
+            return null;
+        }
+
+        $multipliers = $this->extractMultipliers($node);
+        if ($multipliers === []) {
+            return null;
+        }
+
+        return array_product($multipliers);
+    }
+
+    /**
+     * @param Node $node
+     * @return int[]
+     */
+    private function extractMultipliers(Node $node): array
+    {
+        $multipliers = [];
+        if (!$node instanceof Mul) {
+            return $multipliers;
+        }
+
+        if ($node->left instanceof LNumber) {
+            $multipliers[] = $node->left->value;
+        } elseif ($node->left instanceof Mul) {
+            $multipliers = array_merge($multipliers, $this->extractMultipliers($node->left));
+        }
+
+        if ($node->right instanceof LNumber) {
+            $multipliers[] = $node->right->value;
+        } elseif ($node->right instanceof Mul) {
+            $multipliers = array_merge($multipliers, $this->extractMultipliers($node->right));
+        }
+
+        return $multipliers;
     }
 }

--- a/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\Exception\PoorDocumentationException;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -34,9 +33,6 @@ final class DateFuncCallToCarbonRector extends AbstractRector
         ['seconds', 1],
     ];
 
-    /**
-     * @throws PoorDocumentationException
-     */
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Convert date() function call to Carbon::now()->format(*)', [
@@ -74,7 +70,6 @@ CODE_SAMPLE
 
     /**
      * @param FuncCall $node
-     * @return Node|null
      */
     public function refactor(Node $node): ?Node
     {
@@ -127,14 +122,9 @@ CODE_SAMPLE
         return null;
     }
 
-    /**
-     * @param FuncCall $node
-     * @param int $index
-     * @return Expr|null
-     */
     private function getArgValue(FuncCall $node, int $index): ?Expr
     {
-        if (!isset($node->args[$index]) || !$node->args[$index] instanceof Arg) {
+        if (! isset($node->args[$index]) || ! $node->args[$index] instanceof Arg) {
             return null;
         }
 
@@ -175,10 +165,10 @@ CODE_SAMPLE
 
     /**
      * @param array{unit: string, value: int} $timeUnit
-     * @return PropertyFetch
      */
-    private function createCarbonSubtract(array $timeUnit): PropertyFetch
-    {
+    private function createCarbonSubtract(
+        array $timeUnit
+    ): PropertyFetch {
         $nowCall = new StaticCall(
             new FullyQualified('Carbon\\Carbon'),
             'now'
@@ -189,7 +179,6 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Expr $node
      * @return array{unit: string, value: int}|null
      */
     private function detectTimeUnit(Expr $node): ?array
@@ -203,7 +192,7 @@ CODE_SAMPLE
             if ($product % $seconds === 0) {
                 return [
                     'unit' => (string) $unit,
-                    'value' => (int) ($product / $seconds)
+                    'value' => (int) ($product / $seconds),
                 ];
             }
         }
@@ -211,17 +200,13 @@ CODE_SAMPLE
         return null;
     }
 
-    /**
-     * @param Expr $node
-     * @return int|null
-     */
     private function calculateProduct(Expr $node): ?int
     {
         if ($node instanceof LNumber) {
             return $node->value;
         }
 
-        if (!$node instanceof Mul) {
+        if (! $node instanceof Mul) {
             return null;
         }
 
@@ -234,13 +219,12 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Node $node
      * @return int[]
      */
     private function extractMultipliers(Node $node): array
     {
         $multipliers = [];
-        if (!$node instanceof Mul) {
+        if (! $node instanceof Mul) {
             return $multipliers;
         }
 

--- a/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
@@ -89,6 +89,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if ($this->isName($node->name, 'date') && isset($node->args[1]) && $node->args[1] instanceof Arg) {
             $format = $this->getArgValue($node, 0);
             if (! $format instanceof Expr) {

--- a/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\BinaryOp\Minus;
 use PhpParser\Node\Expr\BinaryOp\Mul;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\LNumber;
@@ -145,7 +144,7 @@ CODE_SAMPLE
         return new MethodCall($nowCall, 'format', [new Arg($format)]);
     }
 
-    private function createCarbonParseTimestamp(Expr $dateExpr): PropertyFetch
+    private function createCarbonParseTimestamp(Expr $dateExpr): MethodCall
     {
         $parseCall = new StaticCall(
             new FullyQualified('Carbon\\Carbon'),
@@ -153,7 +152,7 @@ CODE_SAMPLE
             [new Arg($dateExpr)]
         );
 
-        return new PropertyFetch($parseCall, 'timestamp');
+        return new MethodCall($parseCall, 'getTimestamp');
     }
 
     private function createCarbonParseFormat(Expr $dateExpr, Expr $format): MethodCall
@@ -172,14 +171,14 @@ CODE_SAMPLE
      */
     private function createCarbonSubtract(
         array $timeUnit
-    ): PropertyFetch {
+    ): MethodCall {
         $nowCall = new StaticCall(
             new FullyQualified('Carbon\\Carbon'),
             'now'
         );
         $methodName = 'sub' . ucfirst($timeUnit['unit']);
         $subtractCall = new MethodCall($nowCall, $methodName, [new Arg(new LNumber($timeUnit['value']))]);
-        return new PropertyFetch($subtractCall, 'timestamp');
+        return new MethodCall($subtractCall, 'getTimestamp');
     }
 
     /**


### PR DESCRIPTION
## Related issue

Closes [#8695](https://github.com/rectorphp/rector/issues/8695)

## Description

This PR adds a Rector rule to replace certain native PHP date/time function calls with Carbon equivalents. The conversions are based on the examples provided in the original issue

## Implemented changes

- `date('format', strotime(...))` → `Carbon::parse(...)->format('format')`
- `strtotime($date)` → `Carbon::parse($date)->timestamp`
- `time() - (60 * 60 * 24 * 14)` → `Carbon::now()->subWeeks(2)->timestamp`

## Code examples

**Before**
```php
$dateFormatted = date('d.m.Y', strtotime($invoice->getDate()));
$timestamp = strtotime('2025-02-20');
$twoWeeksAgo = time() - (60 * 60 * 24 * 14);
```

**After**
```php
$dateFormatted = \Carbon\Carbon::parse($invoice->getDate())->format('d.m.Y');
$timestamp = \Carbon\Carbon::parse('2025-02-20')->timestamp;
$twoWeeksAgo = \Carbon\Carbon::now()->subWeeks(2)->timestamp;
```

## Tests & validation

- Added unit tests for each transformation, using these fixtures:
   - `strtotime.php.inc`
   - `date_with_strtotime.php.inc`
   - `time_calculation.php.inc`
   - `simple_date.php.inc`
- Validated conversions using PHPUnit
![image](https://github.com/user-attachments/assets/8365caa2-f46b-4a39-af0f-1cd4bb77ea19)

## Notes

- The rule detects **nested calls** (e.g., `date('format', strtotime(...))` and applies the correct Carbon replacement
- Supports **time calculations** that are multiples of common time units (`seconds`, `minutes`, `hours`, `days`, `weeks`)
- The rule ensures **backward compatibility** by strictly replacing only the targeted patterns

##### Looking forward to any suggestions or improvements! Let me know if there's anything else I should adjust 😁 
