### PR TITLE
Do not try to refresh attributes

### DIFF
--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -16,7 +17,7 @@ final class ScopeAnalyzer
     /**
      * @var array<class-string<Node>>
      */
-    private const NON_REFRESHABLE_NODES = [Name::class, Identifier::class, Param::class, Arg::class, Variable::class];
+    private const NON_REFRESHABLE_NODES = [Name::class, Identifier::class, Param::class, Arg::class, Variable::class, Attribute::class];
 
     public function isRefreshable(Node $node): bool
     {


### PR DESCRIPTION
with the following code and test, it crashed

```php
<?php

namespace App;

use ApiPlatform\Metadata\ApiProperty;
use ApiPlatform\Metadata\HttpOperation;
use ApiPlatform\OpenApi\Model\Operation;
use PhpParser\Node;
use PhpParser\NodeTraverser;
use PhpParser\NodeVisitor;
use PhpParser\Node\Attribute;
use PhpParser\Node\Expr\New_;
use Rector\PhpParser\Node\Value\ValueResolver;
use Rector\Rector\AbstractRector;

final class ApipMigrateOpenApiRector extends AbstractRector
{
    public function __construct(
        private readonly ValueResolver $valueResolver,
    ) {
    }

    public function getNodeTypes(): array
    {
        return [New_::class, Attribute::class];
    }

    public function refactor(Node $node)
    {
        if ($node instanceof New_ && is_a($this->getName($node->class), HttpOperation::class, true)) {
            return $this->convert($node);
        }

        if ($node instanceof Attribute && ApiProperty::class === $this->getName($node->name)) {
            return $this->convert($node);
        }

        return null;
    }

    private function convert(Node $node): ?Node
    {
        $scope = $node->getAttribute('scope');
        $update = false;

        foreach ($node->args as $arg) {
            if ('openapiContext' !== $this->getName($arg)) {
                continue;
            }


            $arg->name->name = 'openapi';

            $argValue = $arg->value;


            if (!$argValue instanceof Node\Expr\Array_) {
                // It should be an array! If it's not, we can't do anything.
                continue;
            }
            $update = true;

            $openApiArgs = [];

            foreach ($argValue->items as $item) {
                $openApiArgs[] = $i = new Node\Arg(
                    $item->value,
                    name: new Node\Identifier($this->valueResolver->getValue($item->key)),
                );
                $i->setAttribute('multiline', true);
                // Should we copy the current scope ? 
                // $i->setAttribute('scope', $scope);
            }

            $arg->value = new New_(
                new Node\Name\FullyQualified(Operation::class),
                $openApiArgs,
                [
                    'scope' => $scope,
                ]
            );

            return $node;
        }
 
        return null;
    }
}
```

```php
<?php

namespace AppBundle\Api\Dto\AuditLog;

use ApiPlatform\Metadata\ApiProperty;
use AppBundle\Entity\Organization as OrganizationEntity;
use Symfony\Component\Serializer\Attribute\Groups;

#[Groups('auditLog/read')]
class Organization
{
    public function __construct(
        public ?OrganizationEntity $organization,
        public string $organizationName,
        public bool $loginPasswordAllowed,
        public bool $twoFactorRequired,
        #[ApiProperty(openapiContext: [
            'type' => 'object',
            'properties' => [
                'allowed' => ['type' => 'boolean'],
                'providers' => ['type' => 'object', 'additionalProperties' => ['type' => 'boolean']],
            ],
        ])]
        public ?array $oAuthRestriction = null,
    ) {
    }
}
-----
<?php

namespace AppBundle\Api\Dto\AuditLog;

use ApiPlatform\OpenApi\Model\Operation;
use ApiPlatform\Metadata\ApiProperty;
use AppBundle\Entity\Organization as OrganizationEntity;
use Symfony\Component\Serializer\Attribute\Groups;

#[Groups('auditLog/read')]
class Organization
{
    public function __construct(
        public ?OrganizationEntity $organization,
        public string $organizationName,
        public bool $loginPasswordAllowed,
        public bool $twoFactorRequired,
        #[ApiProperty(openapi: new Operation(
            type: 'object',
            properties: [
                'allowed' => ['type' => 'boolean'],
                'providers' => ['type' => 'object', 'additionalProperties' => ['type' => 'boolean']],
            ],
        ))]
        public ?array $oAuthRestriction = null,
    ) {
    }
}
```
