### PR TITLE
[test-autoload] Trigger preload only in case of old php-parser to avoid double php-parser crash

### DIFF
--- a/rules-tests/Naming/Naming/PropertyNamingTest.php
+++ b/rules-tests/Naming/Naming/PropertyNamingTest.php
@@ -17,6 +17,8 @@ final class PropertyNamingTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->propertyNaming = $this->make(PropertyNaming::class);
     }
 

--- a/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
+++ b/rules-tests/Naming/Naming/UseImportsResolver/UseImportsResolverTest.php
@@ -26,6 +26,8 @@ final class UseImportsResolverTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->useImportsResolver = $this->make(UseImportsResolver::class);
         $this->testingParser = $this->make(TestingParser::class);
         $this->betterNodeFinder = $this->make(BetterNodeFinder::class);

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -17,7 +17,14 @@ final class ScopeAnalyzer
     /**
      * @var array<class-string<Node>>
      */
-    private const NON_REFRESHABLE_NODES = [Name::class, Identifier::class, Param::class, Arg::class, Variable::class, Attribute::class];
+    private const NON_REFRESHABLE_NODES = [
+        Name::class,
+        Identifier::class,
+        Param::class,
+        Arg::class,
+        Variable::class,
+        Attribute::class,
+    ];
 
     public function isRefreshable(Node $node): bool
     {

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -12,6 +12,11 @@ abstract class AbstractLazyTestCase extends TestCase
 {
     protected static ?RectorConfig $rectorConfig = null;
 
+    protected function setUp(): void
+    {
+        $this->includePreloadFilesAndScoperAutoload();
+    }
+
     /**
      * @api
      * @param string[] $configFiles
@@ -50,5 +55,21 @@ abstract class AbstractLazyTestCase extends TestCase
     protected function isWindows(): bool
     {
         return strncasecmp(PHP_OS, 'WIN', 3) === 0;
+    }
+
+    private function includePreloadFilesAndScoperAutoload(): void
+    {
+        if (file_exists(__DIR__ . '/../../../preload.php')) {
+            if (file_exists(__DIR__ . '/../../../vendor')) {
+                require_once __DIR__ . '/../../../preload.php';
+                // test case in rector split package
+            } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
+                require_once __DIR__ . '/../../../preload-split-package.php';
+            }
+        }
+
+        if (\file_exists(__DIR__ . '/../../../vendor/scoper-autoload.php')) {
+            require_once __DIR__ . '/../../../vendor/scoper-autoload.php';
+        }
     }
 }

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -14,6 +14,8 @@ abstract class AbstractLazyTestCase extends TestCase
 
     protected function setUp(): void
     {
+        // this is needed to have always the same preloaded nikic/php-parser classes
+        // in both bare AbstractLazyTestCase lazy tests and AbstractRectorTestCase tests
         $this->includePreloadFilesAndScoperAutoload();
     }
 

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -63,7 +63,7 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
 
     protected function setUp(): void
     {
-        $this->includePreloadFilesAndScoperAutoload();
+        parent::setUp();
 
         $configFile = $this->provideConfigFilePath();
 
@@ -191,22 +191,6 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
                 return $afterResolvingCallbacks;
             }
         );
-    }
-
-    private function includePreloadFilesAndScoperAutoload(): void
-    {
-        if (file_exists(__DIR__ . '/../../../preload.php')) {
-            if (file_exists(__DIR__ . '/../../../vendor')) {
-                require_once __DIR__ . '/../../../preload.php';
-                // test case in rector split package
-            } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
-                require_once __DIR__ . '/../../../preload-split-package.php';
-            }
-        }
-
-        if (\file_exists(__DIR__ . '/../../../vendor/scoper-autoload.php')) {
-            require_once __DIR__ . '/../../../vendor/scoper-autoload.php';
-        }
     }
 
     private function doTestFileMatchesExpectedContent(

--- a/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
+++ b/tests/BetterPhpDocParser/PhpDoc/ArrayItemNode/ArrayItemNodeTest.php
@@ -29,6 +29,8 @@ final class ArrayItemNodeTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->docBlockUpdater = $this->make(DocBlockUpdater::class);
         $this->phpDocInfoFactory = $this->make(PhpDocInfoFactory::class);
         $this->phpDocInfoPrinter = $this->make(PhpDocInfoPrinter::class);

--- a/tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfo/PhpDocInfoTest.php
+++ b/tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfo/PhpDocInfoTest.php
@@ -26,6 +26,8 @@ final class PhpDocInfoTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         // to avoid reflection parsing previous files
         $dynamicSourceLocatorProvider = $this->make(DynamicSourceLocatorProvider::class);
         $dynamicSourceLocatorProvider->reset();

--- a/tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/AbstractPhpDocInfoPrinterTestCase.php
+++ b/tests/BetterPhpDocParser/PhpDocInfo/PhpDocInfoPrinter/AbstractPhpDocInfoPrinterTestCase.php
@@ -22,6 +22,8 @@ abstract class AbstractPhpDocInfoPrinterTestCase extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->filePathHelper = $this->make(FilePathHelper::class);
         $this->phpDocInfoFactory = $this->make(PhpDocInfoFactory::class);
         $this->phpDocInfoPrinter = $this->make(PhpDocInfoPrinter::class);

--- a/tests/BetterPhpDocParser/PhpDocNodeMapperTest.php
+++ b/tests/BetterPhpDocParser/PhpDocNodeMapperTest.php
@@ -19,6 +19,8 @@ final class PhpDocNodeMapperTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->phpDocNodeMapper = $this->make(PhpDocNodeMapper::class);
     }
 

--- a/tests/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher/ResolveTagToKnownFullyQualifiedNameTest.php
+++ b/tests/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher/ResolveTagToKnownFullyQualifiedNameTest.php
@@ -32,6 +32,8 @@ final class ResolveTagToKnownFullyQualifiedNameTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->classAnnotationMatcher = $this->make(ClassAnnotationMatcher::class);
         $this->testingParser = $this->make(TestingParser::class);
         $this->betterNodeFinder = $this->make(BetterNodeFinder::class);

--- a/tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParserTest.php
+++ b/tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/ArrayParserTest.php
@@ -21,6 +21,8 @@ final class ArrayParserTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->arrayParser = $this->make(ArrayParser::class);
         $this->tokenIteratorFactory = $this->make(TokenIteratorFactory::class);
     }

--- a/tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/StaticDoctrineAnnotationParserTest.php
+++ b/tests/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser/StaticDoctrineAnnotationParserTest.php
@@ -22,6 +22,8 @@ final class StaticDoctrineAnnotationParserTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->tokenIteratorFactory = $this->make(TokenIteratorFactory::class);
         $this->staticDoctrineAnnotationParser = $this->make(StaticDoctrineAnnotationParser::class);
     }

--- a/tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
+++ b/tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
@@ -34,6 +34,8 @@ final class TagValueNodeReprintTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->testingParser = $this->make(TestingParser::class);
         $this->filePathHelper = $this->make(FilePathHelper::class);
         $this->betterNodeFinder = $this->make(BetterNodeFinder::class);

--- a/tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
+++ b/tests/BetterPhpDocParser/PhpDocParser/TagValueNodeReprint/TestModifyReprintTest.php
@@ -33,6 +33,8 @@ final class TestModifyReprintTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->testingParser = $this->make(TestingParser::class);
         $this->betterNodeFinder = $this->make(BetterNodeFinder::class);
         $this->phpDocInfoPrinter = $this->make(PhpDocInfoPrinter::class);

--- a/tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
+++ b/tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
@@ -15,6 +15,8 @@ final class FileHashComputerTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->fileHashComputer = $this->make(FileHashComputer::class);
     }
 

--- a/tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -13,6 +13,8 @@ final class ChangedFilesDetectorTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->changedFilesDetector = $this->make(ChangedFilesDetector::class);
     }
 

--- a/tests/Comments/CommentRemover/CommentRemoverTest.php
+++ b/tests/Comments/CommentRemover/CommentRemoverTest.php
@@ -25,6 +25,8 @@ final class CommentRemoverTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->commentRemover = $this->make(CommentRemover::class);
         $this->testingParser = $this->make(TestingParser::class);
         $this->betterStandardPrinter = $this->make(BetterStandardPrinter::class);

--- a/tests/Configuration/OnlyRuleResolverTest.php
+++ b/tests/Configuration/OnlyRuleResolverTest.php
@@ -18,6 +18,8 @@ final class OnlyRuleResolverTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->bootFromConfigFiles([__DIR__ . '/config/only_rule_resolver_config.php']);
         $rectorConfig = self::getContainer();
 

--- a/tests/FileSystem/FilesFinder/FilesFinderTest.php
+++ b/tests/FileSystem/FilesFinder/FilesFinderTest.php
@@ -17,6 +17,8 @@ final class FilesFinderTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->filesFinder = $this->make(FilesFinder::class);
     }
 

--- a/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
+++ b/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
@@ -15,6 +15,8 @@ final class InflectorSingularResolverTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->inflectorSingularResolver = $this->make(InflectorSingularResolver::class);
     }
 

--- a/tests/NodeManipulator/ClassDependencyManipulatorTest.php
+++ b/tests/NodeManipulator/ClassDependencyManipulatorTest.php
@@ -32,6 +32,8 @@ final class ClassDependencyManipulatorTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->classDependencyManipulator = $this->make(ClassDependencyManipulator::class);
 
         $this->printerStandard = new Standard();

--- a/tests/NodeTypeResolver/PerNodeTypeResolver/AbstractNodeTypeResolverTestCase.php
+++ b/tests/NodeTypeResolver/PerNodeTypeResolver/AbstractNodeTypeResolverTestCase.php
@@ -20,6 +20,8 @@ abstract class AbstractNodeTypeResolverTestCase extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->betterNodeFinder = $this->make(BetterNodeFinder::class);
         $this->testingParser = $this->make(TestingParser::class);
         $this->nodeTypeResolver = $this->make(NodeTypeResolver::class);

--- a/tests/NodeTypeResolver/StaticTypeMapper/StaticTypeMapperTest.php
+++ b/tests/NodeTypeResolver/StaticTypeMapper/StaticTypeMapperTest.php
@@ -26,6 +26,8 @@ final class StaticTypeMapperTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->staticTypeMapper = $this->make(StaticTypeMapper::class);
     }
 

--- a/tests/NodeTypeResolver/TypeComparator/ArrayTypeComparatorTest.php
+++ b/tests/NodeTypeResolver/TypeComparator/ArrayTypeComparatorTest.php
@@ -26,6 +26,8 @@ final class ArrayTypeComparatorTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->arrayTypeComparator = $this->make(ArrayTypeComparator::class);
         $this->reflectionProvider = $this->make(ReflectionProvider::class);
     }

--- a/tests/NodeTypeResolver/TypeComparator/ScalarTypeComparatorTest.php
+++ b/tests/NodeTypeResolver/TypeComparator/ScalarTypeComparatorTest.php
@@ -21,6 +21,8 @@ final class ScalarTypeComparatorTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->scalarTypeComparator = $this->make(ScalarTypeComparator::class);
     }
 

--- a/tests/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapperTest.php
+++ b/tests/PHPStanStaticTypeMapper/TypeMapper/ArrayTypeMapperTest.php
@@ -20,6 +20,8 @@ final class ArrayTypeMapperTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->arrayTypeMapper = $this->make(ArrayTypeMapper::class);
     }
 

--- a/tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -38,6 +38,8 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->workerCommandLineFactory = $this->make(WorkerCommandLineFactory::class);
         $this->processCommand = $this->make(ProcessCommand::class);
     }

--- a/tests/PhpAttribute/AnnotationToAttributeMapper/AnnotationToAttributeMapperTest.php
+++ b/tests/PhpAttribute/AnnotationToAttributeMapper/AnnotationToAttributeMapperTest.php
@@ -21,6 +21,8 @@ final class AnnotationToAttributeMapperTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->annotationToAttributeMapper = $this->make(AnnotationToAttributeMapper::class);
     }
 

--- a/tests/PhpAttribute/Printer/PhpAttributeGroupFactoryTest.php
+++ b/tests/PhpAttribute/Printer/PhpAttributeGroupFactoryTest.php
@@ -17,6 +17,8 @@ final class PhpAttributeGroupFactoryTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->phpAttributeGroupFactory = $this->make(PhpAttributeGroupFactory::class);
     }
 

--- a/tests/PhpAttribute/UseAliasNameMatcherTest.php
+++ b/tests/PhpAttribute/UseAliasNameMatcherTest.php
@@ -25,6 +25,8 @@ final class UseAliasNameMatcherTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->useAliasNameMatcher = $this->make(UseAliasNameMatcher::class);
     }
 

--- a/tests/PhpDocParser/PhpDocParser/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitorTest.php
+++ b/tests/PhpDocParser/PhpDocParser/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitorTest.php
@@ -20,6 +20,8 @@ final class ParentConnectingPhpDocNodeVisitorTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->phpDocNodeTraverser = $this->make(PhpDocNodeTraverser::class);
 
         /** @var ParentConnectingPhpDocNodeVisitor $parentConnectingPhpDocNodeVisitor */

--- a/tests/PhpDocParser/PhpDocParser/SimplePhpDocNodeTraverser/PhpDocNodeTraverserTest.php
+++ b/tests/PhpDocParser/PhpDocParser/SimplePhpDocNodeTraverser/PhpDocNodeTraverserTest.php
@@ -23,6 +23,8 @@ final class PhpDocNodeTraverserTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->phpDocNodeTraverser = $this->make(PhpDocNodeTraverser::class);
     }
 

--- a/tests/PhpParser/Node/BetterNodeFinder/BetterNodeFinderTest.php
+++ b/tests/PhpParser/Node/BetterNodeFinder/BetterNodeFinderTest.php
@@ -22,6 +22,8 @@ final class BetterNodeFinderTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->betterNodeFinder = $this->make(BetterNodeFinder::class);
 
         $simplePhpParser = $this->make(SimplePhpParser::class);

--- a/tests/PhpParser/Node/NodeFactoryTest.php
+++ b/tests/PhpParser/Node/NodeFactoryTest.php
@@ -21,6 +21,8 @@ final class NodeFactoryTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->nodeFactory = $this->make(NodeFactory::class);
     }
 

--- a/tests/PhpParser/Node/Value/ValueResolverTest.php
+++ b/tests/PhpParser/Node/Value/ValueResolverTest.php
@@ -19,6 +19,8 @@ final class ValueResolverTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->valueResolver = $this->make(ValueResolver::class);
     }
 

--- a/tests/PhpParser/NodeTraverser/RectorNodeTraverserTest.php
+++ b/tests/PhpParser/NodeTraverser/RectorNodeTraverserTest.php
@@ -23,6 +23,8 @@ final class RectorNodeTraverserTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->rectorNodeTraverser = $this->make(RectorNodeTraverser::class);
         $this->rectorNodeTraverser->refreshPhpRectors([]);
 

--- a/tests/PhpParser/Printer/BetterStandardPrinterTest.php
+++ b/tests/PhpParser/Printer/BetterStandardPrinterTest.php
@@ -24,6 +24,8 @@ final class BetterStandardPrinterTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->betterStandardPrinter = $this->make(BetterStandardPrinter::class);
     }
 

--- a/tests/Skipper/FileSystem/FnMatchPathNormalizerTest.php
+++ b/tests/Skipper/FileSystem/FnMatchPathNormalizerTest.php
@@ -16,6 +16,8 @@ final class FnMatchPathNormalizerTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->fnMatchPathNormalizer = $this->make(FnMatchPathNormalizer::class);
     }
 

--- a/tests/Skipper/SkipCriteriaResolver/SkippedPathsResolver/SkippedPathsResolverTest.php
+++ b/tests/Skipper/SkipCriteriaResolver/SkippedPathsResolver/SkippedPathsResolverTest.php
@@ -16,6 +16,8 @@ final class SkippedPathsResolverTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         SimpleParameterProvider::setParameter(Option::SKIP, [
             // windows slashes
             __DIR__ . '\non-existing-path',

--- a/tests/Skipper/Skipper/SkipperRectorRuleTest.php
+++ b/tests/Skipper/Skipper/SkipperRectorRuleTest.php
@@ -16,6 +16,8 @@ final class SkipperRectorRuleTest extends AbstractLazyTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         // reset to make skip free and invoke resolving
         self::$rectorConfig = null;
     }

--- a/tests/Skipper/Skipper/SkipperTest.php
+++ b/tests/Skipper/Skipper/SkipperTest.php
@@ -21,6 +21,8 @@ final class SkipperTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         SimpleParameterProvider::setParameter(Option::SKIP, [
             // windows like path
             '*\SomeSkipped\*',

--- a/tests/StaticTypeMapper/PhpDoc/PhpDocTypeMapperTest.php
+++ b/tests/StaticTypeMapper/PhpDoc/PhpDocTypeMapperTest.php
@@ -24,6 +24,8 @@ final class PhpDocTypeMapperTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->phpDocTypeMapper = $this->make(PhpDocTypeMapper::class);
         $this->nameScopeFactory = $this->make(NameScopeFactory::class);
     }

--- a/tests/Util/FileHasherTest.php
+++ b/tests/Util/FileHasherTest.php
@@ -14,6 +14,8 @@ final class FileHasherTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->fileHasher = $this->make(FileHasher::class);
     }
 


### PR DESCRIPTION
cc @peterfox
