### PR TITLE
[dx] Prepend command name automatically if only paths are passed

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -30,6 +30,12 @@ jobs:
                         run: vendor/bin/phpstan analyse --ansi
 
                     -
+                        name: 'Help and Version'
+                        run:
+                            bin/rector --help
+                            bin/rector --version
+
+                    -
                         name: 'Commented Code'
                         run: vendor/bin/swiss-knife check-commented-code src rules tests rules-tests --line-limit 5 --ansi
 

--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -60,13 +60,13 @@ return RectorConfig::configure()
 Then dry run Rector:
 
 ```bash
-vendor/bin/rector process src --dry-run
+vendor/bin/rector src --dry-run
 ```
 
 Rector will show you diff of files that it *would* change. To *make* the changes, drop `--dry-run`:
 
 ```bash
-vendor/bin/rector process src
+vendor/bin/rector src
 ```
 
 ## Documentation
@@ -124,7 +124,7 @@ See [the contribution guide](/CONTRIBUTING.md) or go to development repository [
 You can use `--debug` option, that will print nested exceptions output:
 
 ```bash
-vendor/bin/rector process src/Controller --dry-run --debug
+vendor/bin/rector src/Controller --dry-run --debug
 ```
 
 Or with Xdebug:
@@ -133,7 +133,7 @@ Or with Xdebug:
 2. Add `--xdebug` option when running Rector
 
 ```bash
-vendor/bin/rector process src/Controller --dry-run --xdebug
+vendor/bin/rector src/Controller --dry-run --xdebug
 ```
 
 To assist with simple debugging Rector provides 2 helpers to pretty-print AST-nodes:

--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,10 @@
         "rector/swiss-knife": "^2.0",
         "rector/type-perfect": "^2.0",
         "shipmonk/composer-dependency-analyser": "^1.8",
-        "symplify/easy-coding-standard": "^12.5",
+        "phpecs/phpecs": "^2.1",
         "symplify/phpstan-extensions": "^12.0",
-        "symplify/phpstan-rules": "^14.0",
-        "symplify/vendor-patches": "^11.3",
+        "symplify/phpstan-rules": "^14.5",
+        "symplify/vendor-patches": "^11.4",
         "tomasvotruba/class-leak": "^2.0",
         "tracy/tracy": "^2.10"
     },

--- a/ecs.php
+++ b/ecs.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\Casing\LowercaseKeywordsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
+use Rector\DeadCode\Rector\Foreach_\RemoveUnusedForeachKeyRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 
 return RectorConfig::configure()
@@ -24,6 +25,10 @@ return RectorConfig::configure()
     ->withAttributesSets()
     ->withComposerBased(phpunit: true)
     ->withPhpSets()
+    ->withRules([
+        // @todo this should be reported as registered twice
+        RemoveUnusedForeachKeyRector::class,
+    ])
     ->withPaths([
         __DIR__ . '/bin',
         __DIR__ . '/src',

--- a/rector.php
+++ b/rector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
-use Rector\DeadCode\Rector\Foreach_\RemoveUnusedForeachKeyRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 
 return RectorConfig::configure()
@@ -25,10 +24,6 @@ return RectorConfig::configure()
     ->withAttributesSets()
     ->withComposerBased(phpunit: true)
     ->withPhpSets()
-    ->withRules([
-        // @todo this should be reported as registered twice
-        RemoveUnusedForeachKeyRector::class,
-    ])
     ->withPaths([
         __DIR__ . '/bin',
         __DIR__ . '/src',

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -102,7 +102,6 @@ EOF
 
         // 0. warn about too high levels
         foreach ($configuration->getLevelOverflows() as $levelOverflow) {
-<<<<<<< HEAD
             $this->reportLevelOverflow($levelOverflow);
         }
 
@@ -114,9 +113,8 @@ EOF
                 PHP_EOL . PHP_EOL,
                 implode(' * ', $setAndRulesDuplicatedRegistrations) . PHP_EOL
             ));
-=======
+
             $this->warnAboutLevelOverflow($levelOverflow);
->>>>>>> 9f563287fb ([dx] prepare command name if nothing passed)
         }
 
         // 1. add files and directories to static locator
@@ -229,11 +227,7 @@ EOF
         $this->symfonyStyle->listing($composerBasedSets);
     }
 
-<<<<<<< HEAD
-    private function reportLevelOverflow(LevelOverflow $levelOverflow): void
-=======
     private function warnAboutLevelOverflow(LevelOverflow $levelOverflow): void
->>>>>>> 9f563287fb ([dx] prepare command name if nothing passed)
     {
         $suggestedSetMethod = PHP_VERSION_ID >= 80000 ? sprintf(
             '->withPreparedSets(%s: true)',

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -115,7 +115,7 @@ EOF
             ));
         }
 
-        // 1. add files and directories to static locator
+        // 2. add files and directories to static locator
         $this->dynamicSourceLocatorDecorator->addPaths($paths);
         if ($this->dynamicSourceLocatorDecorator->isPathsEmpty()) {
             // read from rector.php, no paths definition needs withPaths() config

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -105,7 +105,7 @@ EOF
             $this->reportLevelOverflow($levelOverflow);
         }
 
-        // 0. warn about rules registered in both withRules() and sets to avoid bloated rector.php configs
+        // 1. warn about rules registered in both withRules() and sets to avoid bloated rector.php configs
         $setAndRulesDuplicatedRegistrations = $configuration->getBothSetAndRulesDuplicatedRegistrations();
         if ($setAndRulesDuplicatedRegistrations !== []) {
             $this->symfonyStyle->warning(sprintf(
@@ -113,8 +113,6 @@ EOF
                 PHP_EOL . PHP_EOL,
                 implode(' * ', $setAndRulesDuplicatedRegistrations) . PHP_EOL
             ));
-
-            $this->warnAboutLevelOverflow($levelOverflow);
         }
 
         // 1. add files and directories to static locator
@@ -227,7 +225,7 @@ EOF
         $this->symfonyStyle->listing($composerBasedSets);
     }
 
-    private function warnAboutLevelOverflow(LevelOverflow $levelOverflow): void
+    private function reportLevelOverflow(LevelOverflow $levelOverflow): void
     {
         $suggestedSetMethod = PHP_VERSION_ID >= 80000 ? sprintf(
             '->withPreparedSets(%s: true)',

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -102,6 +102,7 @@ EOF
 
         // 0. warn about too high levels
         foreach ($configuration->getLevelOverflows() as $levelOverflow) {
+<<<<<<< HEAD
             $this->reportLevelOverflow($levelOverflow);
         }
 
@@ -113,6 +114,9 @@ EOF
                 PHP_EOL . PHP_EOL,
                 implode(' * ', $setAndRulesDuplicatedRegistrations) . PHP_EOL
             ));
+=======
+            $this->warnAboutLevelOverflow($levelOverflow);
+>>>>>>> 9f563287fb ([dx] prepare command name if nothing passed)
         }
 
         // 1. add files and directories to static locator
@@ -225,7 +229,11 @@ EOF
         $this->symfonyStyle->listing($composerBasedSets);
     }
 
+<<<<<<< HEAD
     private function reportLevelOverflow(LevelOverflow $levelOverflow): void
+=======
+    private function warnAboutLevelOverflow(LevelOverflow $levelOverflow): void
+>>>>>>> 9f563287fb ([dx] prepare command name if nothing passed)
     {
         $suggestedSetMethod = PHP_VERSION_ID >= 80000 ? sprintf(
             '->withPreparedSets(%s: true)',

--- a/src/Console/ConsoleApplication.php
+++ b/src/Console/ConsoleApplication.php
@@ -8,6 +8,7 @@ use Composer\XdebugHandler\XdebugHandler;
 use Rector\Application\VersionResolver;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\Configuration\Option;
+use Rector\Util\Reflection\PrivatesAccessor;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -59,6 +60,18 @@ final class ConsoleApplication extends Application
 
         if ($shouldFollowByNewline) {
             $output->write(PHP_EOL);
+        }
+
+        $commandName = $input->getFirstArgument();
+
+        // if paths exist
+        if (is_string($commandName) && file_exists($commandName)) {
+            // prepend command name if implicit
+            $privatesAccessor = new PrivatesAccessor();
+            $tokens = $privatesAccessor->getPrivateProperty($input, 'tokens');
+            $tokens = array_merge(['process'], $tokens);
+
+            $privatesAccessor->setPrivateProperty($input, 'tokens', $tokens);
         }
 
         return parent::doRun($input, $output);

--- a/src/Parallel/Command/WorkerCommandLineFactory.php
+++ b/src/Parallel/Command/WorkerCommandLineFactory.php
@@ -41,8 +41,15 @@ final readonly class WorkerCommandLineFactory
         int $port
     ): string {
         $commandArguments = array_slice($_SERVER['argv'], 1);
-        $args = [PHP_BINARY, $mainScript, ...$commandArguments];
 
+        // add implicit "process" command name if missing
+        if ($commandArguments !== [] && ($commandArguments[0] !== 'process' && $commandArguments[0] !== 'p') && ! defined(
+            'PHPUNIT_COMPOSER_INSTALL'
+        )) {
+            $commandArguments = array_merge(['process'], $commandArguments);
+        }
+
+        $args = [PHP_BINARY, $mainScript, ...$commandArguments];
         $workerCommandArray = [];
 
         $mainCommand = $this->commandFromReflectionFactory->create($mainCommandClass);


### PR DESCRIPTION
By default, Symfony Console requires explicit command name, if args/options are passed.

That's not very practical, because 99.99 % cases we want to run  the `process` command. E.g. for unit tests, we can run PHPUnit like:

```bash
vendor/bin/phpunit
vendor/bin/phpunit path/to/test
```

No extra `vendor/bin/phpunit test path/to/test`  is needed.

<br>

If it's not provided explicitly, and no other command is used, the process command should be run automatically.


![image](https://github.com/user-attachments/assets/bf0ee672-ac81-4c27-b1b2-bf92e4f42dee)
