### PR TITLE
[CodeQuality] Handle crash first class callable on InlineArrayReturnAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/with_first_class_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/with_first_class_callable.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Source\SomeAssignedObject;
+
+final class WithFirstClassCallable
+{
+    public function run()
+    {
+        $complexObjects = [];
+
+        $complexObjects[] = new SomeAssignedObject(...);
+
+        return $complexObjects;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Source\SomeAssignedObject;
+
+final class WithFirstClassCallable
+{
+    public function run()
+    {
+        return [new SomeAssignedObject(...)];
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
@@ -190,7 +190,7 @@ CODE_SAMPLE
             $assign = $stmt->expr;
 
             // skip new X instance with args to keep complex assign readable
-            if ($assign->expr instanceof New_ && $assign->expr->getArgs() !== []) {
+            if ($assign->expr instanceof New_ && ! $assign->expr->isFirstClassCallable() && $assign->expr->getArgs() !== []) {
                 return false;
             }
 


### PR DESCRIPTION
@TomasVotruba your PR

- https://github.com/rectorphp/rector-src/pull/6762 

cause crash on first class callable

```
There was 1 failure:

1) Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\InlineArrayReturnAssignRectorTest::test with data set #12 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:32
/Users/samsonasik/www/rector-src/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php:193
```

This PR fix it.
