### PR TITLE
Fix crash on LevelOverflow on SimpleParameterProvider

### DIFF
--- a/src/Configuration/Parameter/SimpleParameterProvider.php
+++ b/src/Configuration/Parameter/SimpleParameterProvider.php
@@ -50,7 +50,7 @@ final class SimpleParameterProvider
 
         if (array_is_list($parameter)) {
             // remove duplicates
-            $uniqueParameters = array_unique($parameter);
+            $uniqueParameters = array_unique($parameter, SORT_REGULAR);
             return array_values($uniqueParameters);
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9044

**Before**

```
➜  rector-src git:(main) ✗ bin/rector process tests/Issues/LevelOverflow --config tests/Issues/LevelOverflow/config/configured_rule.php --dry-run
PHP Fatal error:  Uncaught Error: Object of class Rector\ValueObject\Configuration\LevelOverflow could not be converted to string in /Users/samsonasik/www/rector-src/src/Configuration/Parameter/SimpleParameterProvider.php:53
```

**After**

```
➜  rector-src git:(main) ✗ bin/rector process tests/Issues/LevelOverflow --config tests/Issues/LevelOverflow/config/configured_rule.php --dry-run

                                                                                                                        
 [WARNING] The "->withTypeCoverageLevel()" level contains only 49 rules, but you set level to 999.                      
           You are using the full set now! Time to switch to more efficient "->withPreparedSets(typeCoverage: true)".   
                                                                                                                        

                                                                                                                        
 [WARNING] The "->withDeadCodeLevel()" level contains only 48 rules, but you set level to 999.                          
           You are using the full set now! Time to switch to more efficient "->withPreparedSets(deadCode: true)".       
                                                                                                                        

 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [OK] Rector is done!                                                                                                   
                                                                                                                        
```