### PR TITLE
Bump to PHPStan ^2.1.7 and update fixture test

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.6"
+        "phpstan/phpstan": "^2.1.7"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0.2",
-        "phpstan/phpstan": "^2.1.6",
+        "phpstan/phpstan": "^2.1.7",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/FixturePhp80/abs_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/FixturePhp80/abs_return.php.inc
@@ -17,7 +17,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTy
 
 final class AbsReturn
 {
-    function aa($param): int|float
+    function aa($param): float|int
     {
         return abs($param);
     }


### PR DESCRIPTION
@TomasVotruba latest PHPStan 2.1.7 cause fixture error that needs update on `abs()` returns

https://github.com/phpstan/phpstan/releases/tag/2.1.7


this PR fix the fixture.