### PR TITLE
[CodeQuality] Handle crash previous duplicated on ThrowWithPreviousExceptionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/named_argument_previous.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/named_argument_previous.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector\Fixture;
+
+class NamedArgumentPrevious
+{
+    public function run()
+    {
+		try {
+        	throw new \Exception('foo');
+        } catch (\Throwable $e) {
+        	throw new \RuntimeException(previous: $e);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector\Fixture;
+
+class NamedArgumentPrevious
+{
+    public function run()
+    {
+		try {
+        	throw new \Exception('foo');
+        } catch (\Throwable $e) {
+        	throw new \RuntimeException(message: $e->getMessage(), code: $e->getCode(), previous: $e);
+        }
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -142,19 +142,15 @@ CODE_SAMPLE
 
         /** @var Arg|null $messageArgument */
         $messageArgument = $new->args[0] ?? null;
-        $shouldUseNamedArguments = $messageArgument instanceof Arg
-            ? $messageArgument->name !== null
-            : false;
+        $shouldUseNamedArguments = $messageArgument instanceof Arg && $messageArgument->name instanceof Identifier;
 
         if (! isset($new->args[0])) {
             // get previous message
             $getMessageMethodCall = new MethodCall($catchedThrowableVariable, 'getMessage');
             $new->args[0] = new Arg($getMessageMethodCall);
-        } else {
-            if ($new->args[0] instanceof Arg && $new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual($new->args[0]->value, $catchedThrowableVariable)) {
-                $new->args[0]->name->name = 'message';
-                $new->args[0]->value = new MethodCall($catchedThrowableVariable, 'getMessage');
-            }
+        } elseif ($new->args[0] instanceof Arg && $new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual($new->args[0]->value, $catchedThrowableVariable)) {
+            $new->args[0]->name->name = 'message';
+            $new->args[0]->value = new MethodCall($catchedThrowableVariable, 'getMessage');
         }
 
         if (! isset($new->getArgs()[1])) {

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -140,18 +140,18 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var Arg $messageArgument */
-        $messageArgument = $new->getArgs()[0] ?? null;
+        /** @var Arg|null $messageArgument */
+        $messageArgument = $new->args[0] ?? null;
         $shouldUseNamedArguments = $messageArgument instanceof Arg
             ? $messageArgument->name !== null
             : false;
 
-        if (! isset($new->getArgs()[0])) {
+        if (! isset($new->args[0])) {
             // get previous message
             $getMessageMethodCall = new MethodCall($catchedThrowableVariable, 'getMessage');
             $new->args[0] = new Arg($getMessageMethodCall);
         } else {
-            if ($new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual($new->args[0]->value, $catchedThrowableVariable)) {
+            if ($new->args[0] instanceof Arg && $new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual($new->args[0]->value, $catchedThrowableVariable)) {
                 $new->args[0]->name->name = 'message';
                 $new->args[0]->value = new MethodCall($catchedThrowableVariable, 'getMessage');
             }

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -140,15 +140,22 @@ CODE_SAMPLE
             return null;
         }
 
+        /** @var Arg $messageArgument */
+        $messageArgument = $new->getArgs()[0] ?? null;
+        $shouldUseNamedArguments = $messageArgument instanceof Arg
+            ? $messageArgument->name !== null
+            : false;
+
         if (! isset($new->getArgs()[0])) {
             // get previous message
             $getMessageMethodCall = new MethodCall($catchedThrowableVariable, 'getMessage');
             $new->args[0] = new Arg($getMessageMethodCall);
+        } else {
+            if ($new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual($new->args[0]->value, $catchedThrowableVariable)) {
+                $new->args[0]->name->name = 'message';
+                $new->args[0]->value = new MethodCall($catchedThrowableVariable, 'getMessage');
+            }
         }
-
-        /** @var Arg $messageArgument */
-        $messageArgument = $new->getArgs()[0];
-        $shouldUseNamedArguments = $messageArgument->name !== null;
 
         if (! isset($new->getArgs()[1])) {
             // get previous code


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9051
Ref https://getrector.com/demo/139451a2-c64b-4bbd-95f9-61a068b37a6a

in execution, it cause crash duplicated named argument 

https://3v4l.org/XAUSV