### PR TITLE
Bump to PHPStan ^2.1.8 and change deprecated ClassReflection::isSubClassOf() to ClassReflection::is()

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.7"
+        "phpstan/phpstan": "^2.1.8"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0.2",
-        "phpstan/phpstan": "^2.1.7",
+        "phpstan/phpstan": "^2.1.8",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Source/EnforceExceptionSuffixCallback.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Source/EnforceExceptionSuffixCallback.php
@@ -18,7 +18,7 @@ final class EnforceExceptionSuffixCallback
     ): ?string {
         $fullyQualifiedClassName = (string) $nodeNameResolver->getName($class);
         $classReflection = $reflectionProvider->getClass($fullyQualifiedClassName);
-        if (! $classReflection->isSubclassOf(Exception::class)) {
+        if (! $classReflection->is(Exception::class)) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -147,7 +147,7 @@ CODE_SAMPLE
         Class_ $class,
         array $classMethods
     ): array {
-        if (! $classReflection->isSubClassOf('PHPUnit\Framework\TestCase')) {
+        if (! $classReflection->is('PHPUnit\Framework\TestCase')) {
             return [];
         }
 

--- a/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
         $classReflection = $scope->getClassReflection();
 
         // skip PHPUnit calls, as they accept both self:: and $this-> formats
-        if ($classReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
+        if ($classReflection->is('PHPUnit\Framework\TestCase')) {
             return null;
         }
 

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -169,7 +169,7 @@ CODE_SAMPLE
         }
 
         $reflection = $scope->getClassReflection();
-        if ($reflection instanceof ClassReflection && $reflection->isSubclassOf($className)) {
+        if ($reflection instanceof ClassReflection && $reflection->is($className)) {
             return true;
         }
 

--- a/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
+++ b/rules/Php80/Rector/ClassMethod/AddParamBasedOnParentClassMethodRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
         }
 
         $currentClassReflection = $this->reflectionResolver->resolveClassReflection($node);
-        $isPDO = $currentClassReflection instanceof ClassReflection && $currentClassReflection->isSubclassOf('PDO');
+        $isPDO = $currentClassReflection instanceof ClassReflection && $currentClassReflection->is('PDO');
 
         // It relies on phpstorm stubs that define 2 kind of query method for both php 7.4 and php 8.0
         // @see https://github.com/JetBrains/phpstorm-stubs/blob/e2e898a29929d2f520fe95bdb2109d8fa895ba4a/PDO/PDO.php#L1096-L1126

--- a/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
@@ -81,7 +81,7 @@ CODE_SAMPLE
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        if (! $classReflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
+        if (! $classReflection->is('PHPUnit\Framework\TestCase')) {
             return null;
         }
 

--- a/rules/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector.php
+++ b/rules/Transform/Rector/ClassMethod/ReturnTypeWillChangeRector.php
@@ -100,7 +100,7 @@ CODE_SAMPLE
             }
 
             foreach ($this->returnTypeChangedClassMethodReferences as $returnTypeChangedClassMethodReference) {
-                if (! $classReflection->isSubclassOf($returnTypeChangedClassMethodReference->getClass())) {
+                if (! $classReflection->is($returnTypeChangedClassMethodReference->getClass())) {
                     continue;
                 }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromMockObjectRector.php
@@ -153,6 +153,6 @@ CODE_SAMPLE
         }
 
         // is phpunit test case?
-        return $classReflection->isSubclassOf(ClassName::TEST_CASE_CLASS);
+        return $classReflection->is(ClassName::TEST_CASE_CLASS);
     }
 }

--- a/rules/TypeDeclaration/Rector/Property/AddPropertyTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/Property/AddPropertyTypeDeclarationRector.php
@@ -122,6 +122,6 @@ CODE_SAMPLE
             return true;
         }
 
-        return $classReflection->isSubclassOf($type);
+        return $classReflection->is($type);
     }
 }

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -332,7 +332,7 @@ final class NodeTypeResolver
             return true;
         }
 
-        return $classReflection->isSubclassOf($objectType->getClassName());
+        return $classReflection->is($objectType->getClassName());
     }
 
     /**


### PR DESCRIPTION
`ClassReflection::isSubClassOf()` is deprecated in latest PHPStan 2.1.8

https://github.com/phpstan/phpstan/releases/tag/2.1.8

The allowed string to parameter is now changed to use method `ClassReflection::is(string $className)`