### PR TITLE
[CodeQuality] Add ReplaceProductionConstantsWithLiteralsInTestFilesRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/fix_array_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/fix_array_constant.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class FixArrayConstant extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        $foo = SomeDisallowedArrayConstant::FOO;
+    }
+}
+
+final class SomeDisallowedArrayConstant {
+    public const FOO = ['1', 2, false];
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class FixArrayConstant extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        $foo = ['1', 2, false];
+    }
+}
+
+final class SomeDisallowedArrayConstant {
+    public const FOO = ['1', 2, false];
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/fix_int_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/fix_int_constant.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class FixIntConstant extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        echo SomeDisallowedIntConstant::FOO;
+    }
+}
+
+final class SomeDisallowedIntConstant {
+    public const FOO = 1;
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class FixIntConstant extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        echo 1;
+    }
+}
+
+final class SomeDisallowedIntConstant {
+    public const FOO = 1;
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/fix_string_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/fix_string_constant.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class FixStringConstant extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        echo SomeDisallowedStringConstant::FOO;
+    }
+}
+
+final class SomeDisallowedStringConstant {
+    public const FOO = '1';
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class FixStringConstant extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        echo '1';
+    }
+}
+
+final class SomeDisallowedStringConstant {
+    public const FOO = '1';
+}
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_allowed_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_allowed_constant.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class SkipAllowedConstant extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        echo AllowedConstant::FOO;
+    }
+}
+
+final class AllowedConstant {
+    public const FOO = 1;
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_allowed_pattern.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_allowed_pattern.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class SkipAllowedPattern extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        echo SomeConstantWithAllowedConstantPattern::FOO;
+    }
+}
+
+final class SomeConstantWithAllowedConstantPattern {
+    public const FOO = 1;
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class SkipClass
+{
+    public function baz(): void
+    {
+        echo SkipClass::class;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_enum.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_enum.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class SkipAllowedPattern extends \PHPUnit\Framework\TestCase
+{
+    public function baz(): void
+    {
+        echo SomeEnum::FOO->value;
+    }
+}
+
+enum SomeEnum: int {
+    case FOO = 1;
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_non_test_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_non_test_class.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class SkipNonTestClass
+{
+    public function baz(): void
+    {
+        echo ProductionConstant::FOO;
+    }
+}
+
+final class ProductionConstant {
+    public const FOO = 1;
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_self.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/Fixture/skip_self.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture;
+
+final class SkipSelf extends \PHPUnit\Framework\TestCase
+{
+    private const BAR = 1;
+
+    public function baz(): void
+    {
+        echo self::BAR;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/ReplaceProductionConstantsWithLiteralsInTestFilesRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/ReplaceProductionConstantsWithLiteralsInTestFilesRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class ReplaceProductionConstantsWithLiteralsInTestFilesRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/config/config.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector/config/config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector;
+use Rector\Config\RectorConfig;
+use Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\Fixture\AllowedConstant;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(ReplaceProductionConstantsWithLiteralsInTestFilesRector::class, [
+        'allowedPatterns' => ['*_allowed_pattern.php'],
+        'allowedConstants' => [AllowedConstant::class],
+    ]);

--- a/rules/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\ClassConstFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Rector\Skipper\Matcher\FileInfoMatcher;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+use function assert;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector\ReplaceProductionConstantsWithLiteralsInTestFilesRectorTest
+ */
+class ReplaceProductionConstantsWithLiteralsInTestFilesRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    private const string ALLOWED_PATTERNS = 'allowedPatterns';
+
+    private const string ALLOWED_CONSTANTS = 'allowedConstants';
+
+    /**
+     * @var array<string>
+     */
+    private array $allowedPatterns = [];
+
+    /**
+     * @var array<string>
+     */
+    private array $allowedConstants = [];
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly FileInfoMatcher $fileInfoMatcher,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace production constants with literals in test files',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class Foo
+{
+    public function run()
+    {
+        $bar = SomeConstant::BAR;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class Foo
+{
+    public function run()
+    {
+        $bar = 'bar';
+    }
+}
+CODE_SAMPLE
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassConstFetch::class];
+    }
+
+    public function refactor(Node $node)
+    {
+        assert($node instanceof ClassConstFetch);
+
+        if (! $node->class instanceof Name) {
+            return null;
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return null;
+        }
+
+        $scope = $node->getAttribute('scope');
+        if (! $scope instanceof Scope) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $nodeClassReflection = $this->reflectionProvider->getClass($classReflection->getName());
+
+        $className = $this->getName($node->class);
+
+        if (! $nodeClassReflection->is('\PHPUnit\Framework\TestCase')) {
+            return null;
+        }
+
+        if ($className === 'self') {
+            return null;
+        }
+
+        $constantName = $this->getName($node->name);
+
+        if ($constantName === 'class') {
+            return null;
+        }
+
+        if ($constantName === null) {
+            return null;
+        }
+
+        $constantClassReflection = $this->reflectionProvider->getClass($className);
+
+        if (in_array((string) $constantClassReflection->getName(), $this->allowedConstants, true)) {
+            return null;
+        }
+
+        if ($this->fileInfoMatcher->doesFileInfoMatchPatterns(
+            $constantClassReflection->getFileName() ?? '',
+            $this->allowedPatterns
+        )) {
+            return null;
+        }
+
+        if (! $constantClassReflection->hasConstant($constantName)) {
+            return null;
+        }
+
+        if ($constantClassReflection->isEnum()) {
+            return null;
+        }
+
+        return $constantClassReflection->getConstant($constantName)
+            ->getValueExpr();
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        if (isset($configuration[self::ALLOWED_PATTERNS])) {
+            Assert::isArray($configuration[self::ALLOWED_PATTERNS]);
+            Assert::allString($configuration[self::ALLOWED_PATTERNS]);
+            $this->allowedPatterns = $configuration[self::ALLOWED_PATTERNS];
+            unset($configuration[self::ALLOWED_PATTERNS]);
+        }
+
+        if (isset($configuration[self::ALLOWED_CONSTANTS])) {
+            Assert::isArray($configuration[self::ALLOWED_CONSTANTS]);
+            Assert::allString($configuration[self::ALLOWED_CONSTANTS]);
+            $this->allowedConstants = $configuration[self::ALLOWED_CONSTANTS];
+            unset($configuration[self::ALLOWED_CONSTANTS]);
+        }
+    }
+}

--- a/rules/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ReplaceProductionConstantsWithLiteralsInTestFilesRector.php
@@ -23,9 +23,9 @@ use function assert;
  */
 class ReplaceProductionConstantsWithLiteralsInTestFilesRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    private const string ALLOWED_PATTERNS = 'allowedPatterns';
+    private const ALLOWED_PATTERNS = 'allowedPatterns';
 
-    private const string ALLOWED_CONSTANTS = 'allowedConstants';
+    private const ALLOWED_CONSTANTS = 'allowedConstants';
 
     /**
      * @var array<string>

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -14,6 +14,7 @@ use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector;
 use Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
+use Rector\CodeQuality\Rector\ClassConstFetch\ReplaceProductionConstantsWithLiteralsInTestFilesRector;
 use Rector\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
@@ -164,6 +165,7 @@ final class CodeQualityLevel
         CleanupUnneededNullsafeOperatorRector::class,
         DisallowedEmptyRuleFixerRector::class,
         ConvertStaticPrivateConstantToSelfRector::class,
+        ReplaceProductionConstantsWithLiteralsInTestFilesRector::class,
         LocallyCalledStaticMethodToNonStaticRector::class,
         NumberCompareToMaxFuncCallRector::class,
         CompleteMissingIfElseBracketRector::class,


### PR DESCRIPTION
This rule disallows using production (source code) constants in test files. Using them in test code can cause tests to pass when the constant changes without any notification to the user. Here's an article that explains it pretty well: https://dev.to/scottshipp/don-t-use-non-test-constants-in-unit-tests-3ej0.

The rule has configuration for allowed constants and patterns, for example to allow test constants to be used freely, or to allow constants from vendor packages. This is an example from our project:
```php
->withConfiguredRule(
        ReplaceProductionConstantsWithLiteralsInTestFilesRector::class,
        [
            'allowedPatterns' => [
                '/vendor/*',
                '/tests/*',
                '*Tester.php',
                '*Fixture.php',
            ],
            'allowedConstants' => [
                FakeUuidHelper::class,
                HttpMethod::class,
            ],
        ]
    )
```

This is something we've disallowed in our project a long time ago and now that I've written the rule, it seemed like a good idea to try to create a PR to the main code base instead of leaving it in our project. Let me know what you think, thanks! :)

