### PR TITLE
[TypeDeclaration] Skip void return on callback docblock on AddArrowFunctionReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/skip_void_return_on_callback_docblock.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/skip_void_return_on_callback_docblock.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+final class SkipVoidReturnOnCallbackDockblock
+{
+    public function doNohing(string $a): void
+    {
+        echo $a;
+    }
+
+    public function run()
+    {
+        fn() => $this->executesCallback(fn() => $this->doNohing('a'));
+    }
+
+    /**
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    public function executesCallback(callable $callback): mixed
+    {
+        return $callback();
+    }
+}

--- a/rules/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector.php
@@ -6,6 +6,8 @@ namespace Rector\TypeDeclaration\Rector\ArrowFunction;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -60,6 +62,11 @@ CODE_SAMPLE
 
         // not valid to add explicit type in PHP
         if ($type->isVoid()->yes()) {
+            return null;
+        }
+
+        $docblockType = $this->getType($node->expr);
+        if ($type instanceof MixedType && $docblockType instanceof NullType) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9065 