### PR TITLE
[Performance] Move realpath() collection early on FilesystemTweaker (part 1)

### DIFF
--- a/src/FileSystem/FileAndDirectoryFilter.php
+++ b/src/FileSystem/FileAndDirectoryFilter.php
@@ -17,7 +17,7 @@ final class FileAndDirectoryFilter
     {
         $directories = array_filter(
             $filesAndDirectories,
-            static fn (string $path): bool => is_dir($path) && realpath($path) !== false
+            static fn (string $path): bool => is_dir($path)
         );
 
         return array_values($directories);
@@ -31,7 +31,7 @@ final class FileAndDirectoryFilter
     {
         $files = array_filter(
             $filesAndDirectories,
-            static fn (string $path): bool => is_file($path) && realpath($path) !== false
+            static fn (string $path): bool => is_file($path)
         );
 
         return array_values($files);

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -43,7 +43,6 @@ final readonly class FilesFinder
 
         // filtering files in files collection
         $filteredFilePaths = $this->fileAndDirectoryFilter->filterFiles($filesAndDirectories);
-        $filteredFilePaths = array_map(fn (string $filePath): string => realpath($filePath), $filteredFilePaths);
         $filteredFilePaths = array_filter(
             $filteredFilePaths,
             fn (string $filePath): bool => ! $this->pathSkipper->shouldSkip($filePath)

--- a/src/FileSystem/FilesystemTweaker.php
+++ b/src/FileSystem/FilesystemTweaker.php
@@ -19,10 +19,30 @@ final class FilesystemTweaker
         foreach ($paths as $path) {
             if (\str_contains($path, '*')) {
                 $foundPaths = $this->foundInGlob($path);
-                $absolutePathsFound = [...$absolutePathsFound, ...$foundPaths];
+                $absolutePathsFound = $this->appendPaths($foundPaths, $absolutePathsFound);
             } else {
-                $absolutePathsFound[] = $path;
+                $absolutePathsFound = $this->appendPaths([$path], $absolutePathsFound);
             }
+        }
+
+        return $absolutePathsFound;
+    }
+
+    /**
+     * @param string[] $foundPaths
+     * @param string[] $absolutePathsFound
+     * @return string[]
+     */
+    private function appendPaths(array $foundPaths, array $absolutePathsFound): array
+    {
+        foreach ($foundPaths as $foundPath) {
+            $foundPath = realpath($foundPath);
+
+            if ($foundPath === false) {
+                continue;
+            }
+
+            $absolutePathsFound[] = $foundPath;
         }
 
         return $absolutePathsFound;


### PR DESCRIPTION
@TomasVotruba @staabm this is part of improve performance by moving collect realpath to early on `FilesystemTweaker` to avoid repetitive filter/loop to get/collect it.

There is another part to improve (`PathSkipper` and maybe `cache`,but will be in separate PR to ease for review :)