### PR TITLE
Fix method name in `StaticCallToMethodCallRector`, in case of method is static

### DIFF
--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/instant_make_in_static_method.php.inc
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/instant_make_in_static_method.php.inc
@@ -2,12 +2,15 @@
 
 namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Fixture;
 
+use Illuminate\Support\Facades\Response;
 use Nette\Utils\FileSystem;
 
 class InstantMakeInStaticMethod
 {
     public static function run()
     {
+        Response::view('example', ['new_example' => 123])->render();
+
         return FileSystem::write('file', 'content');
     }
 }
@@ -18,12 +21,15 @@ class InstantMakeInStaticMethod
 
 namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Fixture;
 
+use Illuminate\Support\Facades\Response;
 use Nette\Utils\FileSystem;
 
 class InstantMakeInStaticMethod
 {
     public static function run()
     {
+        (new \Illuminate\Contracts\Routing\ResponseFactory())->view('example', ['new_example' => 123])->render();
+
         return (new \Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\TargetFileSystem())->dumpFile('file', 'content');
     }
 }

--- a/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
@@ -125,15 +125,7 @@ CODE_SAMPLE
                         $staticCallToMethodCall->getClassObjectType(),
                     );
 
-                    if ($staticCallToMethodCall->getMethodName() === '*') {
-                        $methodName = $this->getName($node->name);
-                    } else {
-                        $methodName = $staticCallToMethodCall->getMethodName();
-                    }
-
-                    if (! is_string($methodName)) {
-                        throw new ShouldNotHappenException();
-                    }
+                    $methodName = $this->getMethodName($node, $staticCallToMethodCall);
 
                     $hasChanged = true;
 
@@ -161,12 +153,31 @@ CODE_SAMPLE
         $this->staticCallsToMethodCalls = $configuration;
     }
 
+    private function getMethodName(
+        StaticCall $staticCall,
+        StaticCallToMethodCall $staticCallToMethodCall
+    ): string {
+        if ($staticCallToMethodCall->getMethodName() === '*') {
+            $methodName = $this->getName($staticCall->name);
+        } else {
+            $methodName = $staticCallToMethodCall->getMethodName();
+        }
+
+        if (! is_string($methodName)) {
+            throw new ShouldNotHappenException();
+        }
+
+        return $methodName;
+    }
+
     private function refactorToInstanceCall(
         StaticCall $staticCall,
         StaticCallToMethodCall $staticCallToMethodCall
     ): MethodCall {
         $new = new New_(new FullyQualified($staticCallToMethodCall->getClassType()));
 
-        return new MethodCall($new, $staticCallToMethodCall->getMethodName(), $staticCall->args);
+        $methodName = $this->getMethodName($staticCall, $staticCallToMethodCall);
+
+        return new MethodCall($new, $methodName, $staticCall->args);
     }
 }


### PR DESCRIPTION
This PR fixes method name in `StaticCallToMethodCallRector`, while method is static and wildcard is used. At the moment method name is been replaced by the `*`.

Config

    $rectorConfig
        ->ruleWithConfiguration(StaticCallToMethodCallRector::class, [
            new StaticCallToMethodCall(
                'Illuminate\Support\Facades\App',
                '*',
                'Illuminate\Foundation\Application',
                '*'
            ),
        ]);

Before

    use Illuminate\Support\Facades\App;

    class ModelSeeder
    {
        public static function seed() {
            App::get(ClassName::class)
                ->handle();
        }
    }

After

    use Illuminate\Support\Facades\App;

    class ModelSeeder
    {
        public static function seed() {
            (new \Illuminate\Foundation\Application())->*(SomeClass::class)
                 ->handle();
        }
    }

Expected

    use Illuminate\Support\Facades\App;

    class ModelSeeder
    {
        public static function seed() {
            (new \Illuminate\Foundation\Application())->get(SomeClass::class)
                 ->handle();
        }
    }