### PR TITLE
[deprecation] Add explicit warning to withPhpPolyfill() deprecated method + raise error on ->withPhpSets() miss-use on PHP 7.4- projects

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -542,7 +542,7 @@ final class RectorConfigBuilder
 
         $pickedArguments = array_filter(func_get_args());
         if ($pickedArguments !== []) {
-            Notifier::notifyWithPhpSetsNotSuitableForPHP80();
+            Notifier::errorWithPhpSetsNotSuitableForPHP74AndLower();
         }
 
         if (count($pickedArguments) > 1) {

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -499,15 +499,12 @@ final class RectorConfigBuilder
      * @deprecated Already included in withPhpSets(), no need to repeat
      * make use of polyfill packages in composer.json
      */
-    public function withPhpPolyfill(): self
+    public function withPhpPolyfill(): never
     {
         throw new InvalidConfigurationException(sprintf(
             'Method "%s()" is deprecated and is now part of ->withPhpSets() to avoid duplications and too granular configuration.',
             __METHOD__,
         ));
-
-        $this->sets[] = SetList::PHP_POLYFILLS;
-        return $this;
     }
 
     /**

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -501,6 +501,11 @@ final class RectorConfigBuilder
      */
     public function withPhpPolyfill(): self
     {
+        throw new InvalidConfigurationException(sprintf(
+            'Method "%s()" is deprecated and is now part of ->withPhpSets() to avoid duplications and too granular configuration.',
+            __METHOD__,
+        ));
+
         $this->sets[] = SetList::PHP_POLYFILLS;
         return $this;
     }

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Console;
 
+use Rector\Exception\Configuration\InvalidConfigurationException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -27,17 +28,14 @@ final class Notifier
         sleep(3);
     }
 
-    public static function notifyWithPhpSetsNotSuitableForPHP80(): void
+    public static function errorWithPhpSetsNotSuitableForPHP74AndLower(): void
     {
         if (PHP_VERSION_ID >= 80000) {
             return;
         }
 
-        $message = 'The "withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. Use more explicit "withPhp53Sets()" ... "withPhp74Sets()" in lower PHP versions instead.';
-
-        $symfonyStyle = new SymfonyStyle(new ArgvInput(), new ConsoleOutput());
-        $symfonyStyle->warning($message);
-
-        sleep(3);
+        throw new InvalidConfigurationException(
+            'The "->withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. Use more explicit "->withPhp53Sets()" ... "->withPhp74Sets()" in lower PHP versions instead.'
+        );
     }
 }


### PR DESCRIPTION
These methods have been deprecated for couple months now, one raising warnings. Time to increase warning to exception to remove last couple of miss-use in configs :+1: 

Ref https://github.com/rectorphp/rector/issues/8957