### PR TITLE
[Php81] Unregister NewInInitializerRector from php81 config set as not safe

### DIFF
--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
-use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
 use Rector\Php81\Rector\MethodCall\SpatieEnumMethodCallToEnumConstRector;
@@ -23,7 +22,6 @@ return static function (RectorConfig $rectorConfig): void {
         ReadOnlyPropertyRector::class,
         SpatieEnumClassToEnumRector::class,
         SpatieEnumMethodCallToEnumConstRector::class,
-        NewInInitializerRector::class,
         NullToStrictStringFuncCallArgRector::class,
         FirstClassCallableRector::class,
     ]);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -216,6 +216,8 @@ parameters:
         # optional as changes behavior, should be used explicitly outside PHP upgrade
         - '#Register "Rector\\Php73\\Rector\\FuncCall\\JsonThrowOnErrorRector" service to "php73\.php" config set#'
 
+        - '#Register "Rector\\Php81\\Rector\\ClassMethod\\NewInInitializerRector" service to "php81\.php" config set#'
+
         # closure detailed
         - '#Method Rector\\Config\\RectorConfig\:\:singleton\(\) has parameter \$concrete with no signature specified for Closure#'
 


### PR DESCRIPTION
@mathieudz @theofidry I talked with @TomasVotruba today, and the best way for it is unregister for php 8.1 set, user can manually register via `withRules()` if needed.

Closes https://github.com/rectorphp/rector/issues/8971