### PR TITLE
[Php80] Skip case after default empty on ChangeSwitchToMatchRector

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_case_after_default_empty.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_case_after_default_empty.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class SkipCaseAfterDefaultEmpty
+{
+    public function run(string $type)
+    {
+        switch ($type) {
+            case 'day':
+                $format = '%Y-%m-%d';
+                break;
+            default:
+            case 'hour':
+                $format = '%Y-%m-%d %H';
+                break;
+        }
+
+        return $format;
+    }
+}

--- a/rules/Php80/NodeResolver/SwitchExprsResolver.php
+++ b/rules/Php80/NodeResolver/SwitchExprsResolver.php
@@ -39,6 +39,10 @@ final class SwitchExprsResolver
             }
 
             if (! $case->cond instanceof Expr) {
+                if ($case->stmts === []) {
+                    return [];
+                }
+
                 continue;
             }
 

--- a/rules/Php80/NodeResolver/SwitchExprsResolver.php
+++ b/rules/Php80/NodeResolver/SwitchExprsResolver.php
@@ -39,11 +39,7 @@ final class SwitchExprsResolver
             }
 
             if (! $case->cond instanceof Expr) {
-                if ($case->stmts === []) {
-                    return [];
-                }
-
-                continue;
+                return [];
             }
 
             $collectionEmptyCasesCond[$key] = $case->cond;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9073


Ref    https://getrector.com/demo/5b6504ba-609a-4fe9-ae2b-48687e14974e
Ref    https://3v4l.org/PWF2s
