### PR TITLE
Bump to PHPStan 2.1.9

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.8"
+        "phpstan/phpstan": "^2.1.9"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0.2",
-        "phpstan/phpstan": "^2.1.8",
+        "phpstan/phpstan": "^2.1.9",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",

--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -108,15 +108,15 @@ final readonly class ArgumentDefaultValueReplacer
         }
 
         $argValue = $this->valueResolver->getValue($particularArg->value);
-
         if (is_scalar(
             $replaceArgumentDefaultValue->getValueBefore()
         ) && $argValue === $replaceArgumentDefaultValue->getValueBefore()) {
             $expr->args[$position] = $this->normalizeValueToArgument($replaceArgumentDefaultValue->getValueAfter());
             return $expr;
-        } elseif (is_array($replaceArgumentDefaultValue->getValueBefore())) {
-            $newArgs = $this->processArrayReplacement($expr->getArgs(), $replaceArgumentDefaultValue);
+        }
 
+        if (is_array($replaceArgumentDefaultValue->getValueBefore())) {
+            $newArgs = $this->processArrayReplacement($expr->getArgs(), $replaceArgumentDefaultValue);
             if (is_array($newArgs)) {
                 $expr->args = $newArgs;
                 return $expr;

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -459,7 +459,7 @@ final readonly class PHPStanNodeScopeResolver
     ): void {
         try {
             $this->nodeScopeResolver->processNodes($stmts, $mutatingScope, $nodeCallback);
-        } catch (ParserErrorsException|ParserException|ShouldNotHappenException) {
+        } catch (ParserErrorsException|ParserException|ShouldNotHappenException|\PHPStan\Analyser\UndefinedVariableException) {
             // nothing we can do more precise here as error parsing from deep internal PHPStan service with service injection we cannot reset
             // in the middle of process
             // fallback to fill by found scope

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
+use PHPStan\Analyser\UndefinedVariableException;
 use Error;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
@@ -459,7 +460,7 @@ final readonly class PHPStanNodeScopeResolver
     ): void {
         try {
             $this->nodeScopeResolver->processNodes($stmts, $mutatingScope, $nodeCallback);
-        } catch (ParserErrorsException|ParserException|ShouldNotHappenException|\PHPStan\Analyser\UndefinedVariableException) {
+        } catch (ParserErrorsException|ParserException|ShouldNotHappenException|UndefinedVariableException) {
             // nothing we can do more precise here as error parsing from deep internal PHPStan service with service injection we cannot reset
             // in the middle of process
             // fallback to fill by found scope


### PR DESCRIPTION
Bump to latest PHPStan 2.1.9 seems cause error in tests:

```
There were 2 errors:

1) Rector\Tests\Php55\Rector\String_\StringClassNameToClassConstantRector\StringClassNameToClassConstantRectorTest::test with data set #4 ('/Users/samsonasik/www/rector-...hp.inc')
PHPStan\Analyser\UndefinedVariableException: Undefined variable: $field1

phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:427
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1487
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1487
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:554
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:1845
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:727
phar:///Users/samsonasik/www/rector-src/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:404
/Users/samsonasik/www/rector-src/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:461
/Users/samsonasik/www/rector-src/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php:247
```

This PR try to resolve it.