### PR TITLE
Add a hint how to upgrade custom SetListInterface to Rector 2.0

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -93,3 +93,14 @@ This is no longer needed. Now The `getRuleDefinition()` method has been removed:
 
 If you need description yourself to understand rule after many months, use the common place for documentation - docblock above class.
 
+
+### 3. `SetListInterface` was removed
+
+The deprecated `SetListInterface` was removed, if you created your own list just remove the Interface from it:
+
+```diff
+-use Rector\Set\Contract\SetListInterface;
+
+-final class YourSetList implements SetListInterface
++final class YourSetList
+```


### PR DESCRIPTION
based on https://github.com/sulu/sulu-rector/pull/29

I was confused if I need migrate to a `SetProviderInterface` but seems like the way to upgrade is just remove the interface?

Think the hint here with `@see ServiceProviderInterface` is missleading for this upgrade path: https://github.com/rectorphp/rector/blob/40f9cf38c05296bd32f444121336a521a293fa61/src/Set/Contract/SetListInterface.php#L8C9-L8C29