### PR TITLE
Fix code example on AddArrowFunctionParamArrayWhereDimFetchRector

### DIFF
--- a/rules/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector.php
@@ -39,7 +39,7 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 $array = [['name' => 'John']];
 
-$result = array_map(fn ($item) => $item['name'], $array);
+$result = array_map(fn (array $item) => $item['name'], $array);
 CODE_SAMPLE
             ),
         ]);


### PR DESCRIPTION
after code should add `array` type param, see error on https://github.com/rectorphp/getrector-com/actions/runs/14242582476/job/39915731879?pr=2944#step:5:14