### PR TITLE
[TypeDeclaration] Direclty use ArrayDimFetch instance on ArrowFunction->expr on AddArrowFunctionParamArrayWhereDimFetchRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector/Fixture/skip_binary_op.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector/Fixture/skip_binary_op.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrowFunctionParamArrayWhereDimFetchRector\Fixture;
+
+final class SkipBinaryOp
+{
+    public function run()
+    {
+        $array = [['name' => 'John']];
+
+        $result = array_map(fn ($item) => ! is_array($item) || $item['name'] === 'some name', $array);
+    }
+}

--- a/rules/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector.php
@@ -8,12 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\Ternary;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Stmt\Class_;
-use PhpParser\NodeFinder;
-use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -80,12 +75,16 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->shouldSkip($arrowFunction)) {
+        if (! $arrowFunction->expr instanceof ArrayDimFetch) {
             return null;
         }
 
-        $paramName = $this->getName($arrowFunctionParam);
-        if (! $this->isParamArrayDimFetched($arrowFunction, $paramName)) {
+        $var = $arrowFunction->expr;
+        while ($var instanceof ArrayDimFetch) {
+            $var = $var->var;
+        }
+
+        if (! $this->nodeComparator->areNodesEqual($var, $arrowFunctionParam->var)) {
             return null;
         }
 
@@ -97,37 +96,5 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::SCALAR_TYPES;
-    }
-
-    private function isParamArrayDimFetched(ArrowFunction $arrowFunction, string $paramName): bool
-    {
-        $nodeFinder = new NodeFinder();
-
-        $arrayDimFetches = $nodeFinder->findInstanceOf($arrowFunction->expr, ArrayDimFetch::class);
-        foreach ($arrayDimFetches as $arrayDimFetch) {
-            if ($this->isName($arrayDimFetch->var, $paramName)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function shouldSkip(ArrowFunction $arrowFunction): bool
-    {
-        $shouldSkip = false;
-
-        $this->traverseNodesWithCallable(
-            $arrowFunction->expr,
-            function (Node $subNode) use (&$shouldSkip): ?int {
-                if ($subNode instanceof Class_ || $subNode instanceof FunctionLike || $subNode instanceof Ternary) {
-                    $shouldSkip = true;
-                    return NodeVisitor::STOP_TRAVERSAL;
-                }
-
-                return null;
-            });
-
-        return $shouldSkip;
     }
 }


### PR DESCRIPTION
@TomasVotruba this will make less possible error due to condition or binary op usage inside arrow function expr.