### PR TITLE
Support * in `ComposerTriggeredSet::packageName` (fixes https://github.com/rectorphp/rector/issues/9107)

### DIFF
--- a/src/Set/ValueObject/ComposerTriggeredSet.php
+++ b/src/Set/ValueObject/ComposerTriggeredSet.php
@@ -46,7 +46,7 @@ final readonly class ComposerTriggeredSet implements SetInterface
     public function matchInstalledPackages(array $installedPackages): bool
     {
         foreach ($installedPackages as $installedPackage) {
-            if ($installedPackage->getName() !== $this->packageName) {
+            if (!fnmatch($this->packageName, $installedPackage->getName())) {
                 continue;
             }
 


### PR DESCRIPTION
`$packageName` may hold the value `symfony/*`, which must be matched appropriately against the actual package names.