### PR TITLE
[TypeDeclaration] Skip already typed with PHPUnit\Framework\MockObject\MockObject on TypedPropertyFromCreateMockAssignRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector/Fixture/skip_already_mockobject_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector/Fixture/skip_already_mockobject_type.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector\Source\SomeMockedClass;
+
+class SkipAlreadyMockObjectType extends TestCase
+{
+    public \PHPUnit\Framework\MockObject\MockObject $someMock;
+
+    protected function setUp(): void
+    {
+        $this->someMock = $this->createMock(SomeMockedClass::class);
+    }
+}

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromCreateMockAssignRector.php
@@ -84,6 +84,11 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($node->getProperties() as $property) {
+            // already use PHPUnit\Framework\MockObject\MockObject type
+            if ($property->type instanceof Node && $this->isObjectType($property->type, new ObjectType(ClassName::MOCK_OBJECT))){
+                continue;
+            }
+
             if (count($property->props) !== 1) {
                 continue;
             }


### PR DESCRIPTION
Avoid repetitive apply if the property type already typed `PHPUnit\Framework\MockObject\MockObject`

Ref https://github.com/rectorphp/rector-src/pull/6826#pullrequestreview-2755947274