### PR TITLE
[Configuration] Fix root standalone registered rules verify on RectorConfigBuilder

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -41,8 +41,18 @@ final class RectorConfig extends Container
      */
     private array $autotagInterfaces = [Command::class, ResetableInterface::class];
 
+    private static ?bool $recreated = null;
+
     public static function configure(): RectorConfigBuilder
     {
+        if (self::$recreated === null) {
+            self::$recreated = false;
+        } elseif (self::$recreated === false) {
+            self::$recreated = true;
+        }
+
+        SimpleParameterProvider::setParameter(Option::IS_RECTORCONFIG_BUILDER_RECREATED, self::$recreated);
+
         return new RectorConfigBuilder();
     }
 

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -249,6 +249,12 @@ final class Option
     public const REGISTERED_RECTOR_SETS = 'registered_rector_sets';
 
     /**
+     * @internal For verify RectorConfigBuilder instance recreated
+     * @var string
+     */
+    public const IS_RECTORCONFIG_BUILDER_RECREATED = 'is_rectorconfig_builder_recreated';
+
+    /**
      * @internal For verify skipped rules exists in registered rules
      * @var string
      */

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -788,13 +788,16 @@ final class RectorConfigBuilder
     {
         $this->rules = array_merge($this->rules, $rules);
 
-        // log all explicitly registered rules
-        // we only check the non-configurable rules, as the configurable ones might override them
-        $nonConfigurableRules = array_filter(
-            $rules,
-            fn (string $rule): bool => ! is_a($rule, ConfigurableRectorInterface::class, true)
-        );
-        SimpleParameterProvider::addParameter(Option::ROOT_STANDALONE_REGISTERED_RULES, $nonConfigurableRules);
+        if (SimpleParameterProvider::provideBoolParameter(Option::IS_RECTORCONFIG_BUILDER_RECREATED) === false) {
+            // log all explicitly registered rules on root rector.php
+            // we only check the non-configurable rules, as the configurable ones might override them
+            $nonConfigurableRules = array_filter(
+                $rules,
+                fn (string $rule): bool => ! is_a($rule, ConfigurableRectorInterface::class, true)
+            );
+
+            SimpleParameterProvider::addParameter(Option::ROOT_STANDALONE_REGISTERED_RULES, $nonConfigurableRules);
+        }
 
         return $this;
     }

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -788,7 +788,7 @@ final class RectorConfigBuilder
     {
         $this->rules = array_merge($this->rules, $rules);
 
-        if (SimpleParameterProvider::provideBoolParameter(Option::IS_RECTORCONFIG_BUILDER_RECREATED) === false) {
+        if (SimpleParameterProvider::provideBoolParameter(Option::IS_RECTORCONFIG_BUILDER_RECREATED, false) === false) {
             // log all explicitly registered rules on root rector.php
             // we only check the non-configurable rules, as the configurable ones might override them
             $nonConfigurableRules = array_filter(

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -15,7 +15,7 @@ final class RectorConfigTest extends AbstractLazyTestCase
 {
     public function test(): void
     {
-        $rectorConfig = RectorConfig::configure()
+        $rectorConfigBuilder = RectorConfig::configure()
             ->withSets([
                 TwigSetList::TWIG_134
             ])
@@ -24,7 +24,7 @@ final class RectorConfigTest extends AbstractLazyTestCase
             ]);
 
         // invoke is needed to get collection of rules
-        $rectorConfig->__invoke(new RectorConfig());
+        $rectorConfigBuilder->__invoke(new RectorConfig());
 
         // only collect root withRules()
         $this->assertCount(1, SimpleParameterProvider::provideArrayParameter(Option::ROOT_STANDALONE_REGISTERED_RULES));

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -15,16 +15,13 @@ final class RectorConfigTest extends AbstractLazyTestCase
 {
     public function test(): void
     {
-        $rectorConfigBuilder = RectorConfig::configure()
+        RectorConfig::configure()
             ->withSets([
                 TwigSetList::TWIG_134
             ])
             ->withRules([
                 ReturnTypeFromReturnNewRector::class
-            ]);
-
-        // invoke is needed to get collection of rules
-        $rectorConfigBuilder->__invoke(new RectorConfig());
+            ])(new RectorConfig());
 
         // only collect root withRules()
         $this->assertCount(1, SimpleParameterProvider::provideArrayParameter(Option::ROOT_STANDALONE_REGISTERED_RULES));

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Config;
+
+use Rector\Config\RectorConfig;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Symfony\Set\TwigSetList;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
+
+final class RectorConfigTest extends AbstractLazyTestCase
+{
+    public function test(): void
+    {
+        RectorConfig::configure()
+            ->withRules([
+                ReturnTypeFromReturnNewRector::class
+            ])
+            ->withSets([
+                TwigSetList::TWIG_134
+            ]);
+
+        // only collect root withRules()
+        $this->assertCount(1, SimpleParameterProvider::provideArrayParameter(Option::ROOT_STANDALONE_REGISTERED_RULES));
+    }
+}

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -15,13 +15,16 @@ final class RectorConfigTest extends AbstractLazyTestCase
 {
     public function test(): void
     {
-        RectorConfig::configure()
-            ->withRules([
-                ReturnTypeFromReturnNewRector::class
-            ])
+        $rectorConfig = RectorConfig::configure()
             ->withSets([
                 TwigSetList::TWIG_134
+            ])
+            ->withRules([
+                ReturnTypeFromReturnNewRector::class
             ]);
+
+        // invoke is needed to get collection of rules
+        $rectorConfig->__invoke(new RectorConfig());
 
         // only collect root withRules()
         $this->assertCount(1, SimpleParameterProvider::provideArrayParameter(Option::ROOT_STANDALONE_REGISTERED_RULES));


### PR DESCRIPTION
@ottsch @TomasVotruba this patch make ensure `ROOT_STANDALONE_REGISTERED_RULES` only sets once to avoid invalid merge when `RectorConfigBuilder` is used in the config that included.

Ref https://github.com/rectorphp/rector-src/pull/6761#issuecomment-2807761266