### PR TITLE
[Php80] Handle crash on @testdoc with rector-phpunit AnnotationWithValueToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/test_annotation.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/test_annotation.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+final class TestAnnotation
+{
+    /**
+     * @testdox ::property is true
+     */
+    public function myAwesomeTest(): void
+    {
+    }
+}

--- a/src/PhpAttribute/AnnotationToAttributeMapper/ClassConstFetchAnnotationToAttributeMapper.php
+++ b/src/PhpAttribute/AnnotationToAttributeMapper/ClassConstFetchAnnotationToAttributeMapper.php
@@ -6,6 +6,7 @@ namespace Rector\PhpAttribute\AnnotationToAttributeMapper;
 
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
 use Rector\PhpAttribute\Contract\AnnotationToAttributeMapperInterface;
 
 /**
@@ -30,9 +31,13 @@ final class ClassConstFetchAnnotationToAttributeMapper implements AnnotationToAt
     /**
      * @param string $value
      */
-    public function map($value): ClassConstFetch
+    public function map($value): String_|ClassConstFetch
     {
         [$class, $constant] = explode('::', $value);
+
+        if ($class === '') {
+            return new String_($value);
+        }
 
         return new ClassConstFetch(new Name($class), $constant);
     }

--- a/tests/Issues/TestDocAnnotation/Fixture/fixture.php.inc
+++ b/tests/Issues/TestDocAnnotation/Fixture/fixture.php.inc
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
 
 final class Fixture extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\TestDox('property is true')]
+    #[\PHPUnit\Framework\Attributes\TestDox('::property is true')]
     public function myAwesomeTest(): void
     {
     }

--- a/tests/Issues/TestDocAnnotation/Fixture/fixture.php.inc
+++ b/tests/Issues/TestDocAnnotation/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Issues\TestDocAnnotation\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+    /**
+     * @testdox ::property is true
+     */
+    public function myAwesomeTest(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\TestDocAnnotation\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\TestDox('property is true')]
+    public function myAwesomeTest(): void
+    {
+    }
+}
+
+?>

--- a/tests/Issues/TestDocAnnotation/TestDocAnnotationTest.php
+++ b/tests/Issues/TestDocAnnotation/TestDocAnnotationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\TestDocAnnotation;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TestDocAnnotationTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/TestDocAnnotation/config/configured_rule.php
+++ b/tests/Issues/TestDocAnnotation/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector;
+use Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AnnotationWithValueToAttributeRector::class, [
+        new AnnotationWithValueToAttribute('testdox', 'PHPUnit\Framework\Attributes\TestDox'),
+    ]);
+};


### PR DESCRIPTION
It cause crash:

```
There was 1 error:

1) Rector\Tests\Issues\TestDocAnnotation\TestDocAnnotationTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
InvalidArgumentException: Name cannot be empty

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Name.php:254
/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Name.php:29
/Users/samsonasik/www/rector-src/src/PhpAttribute/AnnotationToAttributeMapper/ClassConstFetchAnnotationToAttributeMapper.php:37
/Users/samsonasik/www/rector-src/src/PhpAttribute/AnnotationToAttributeMapper.php:39
/Users/samsonasik/www/rector-src/src/PhpAttribute/AnnotationToAttributeMapper/ArrayAnnotationToAttributeMapper.php:49

```

Fixes https://github.com/rectorphp/rector/issues/9120

The patch needs to be in rector-src so test is in here.