### PR TITLE
Remove @docs script from complete check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,6 @@
         "complete-check": [
             "@check-cs",
             "@phpstan",
-            "@docs",
             "phpunit"
         ],
         "check-cs": "vendor/bin/ecs check --ansi",


### PR DESCRIPTION
The `docs` script no longer exists in the composer configuration. This PR removes it from the `complete-check` script