### PR TITLE
[feat] Add the possibility to add additional post rectors

### DIFF
--- a/rules-tests/PostRector/AdditionalPostRector/AdditionalPostRectorTest.php
+++ b/rules-tests/PostRector/AdditionalPostRector/AdditionalPostRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PostRector\AdditionalPostRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AdditionalPostRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/additional_post_rector.php';
+    }
+}

--- a/rules-tests/PostRector/AdditionalPostRector/Fixture/remove_comments.php.inc
+++ b/rules-tests/PostRector/AdditionalPostRector/Fixture/remove_comments.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\PostRector\AdditionalPostRector\Fixture;
+
+class RemoveComments
+{
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function runA($dateTime)
+    {
+    }
+
+    /**
+     * @param \DateTimeInterface $dateTime
+     */
+    public function runB(\DateTimeInterface $dateTime)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\PostRector\AdditionalPostRector\Fixture;
+
+use DateTimeInterface;
+
+class RemoveComments
+{
+    public function runA($dateTime)
+    {
+    }
+
+    public function runB(DateTimeInterface $dateTime)
+    {
+    }
+}
+
+?>

--- a/rules-tests/PostRector/AdditionalPostRector/Fixture/skip_if_no_namespace.php.inc
+++ b/rules-tests/PostRector/AdditionalPostRector/Fixture/skip_if_no_namespace.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+class SkipIfNoNamespace
+{
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function runA($dateTime)
+    {
+    }
+
+    /**
+     * @param \DateTimeInterface $dateTime
+     */
+    public function runB(\DateTimeInterface $dateTime)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+class SkipIfNoNamespace
+{
+    /**
+     * @param DateTime $dateTime
+     */
+    public function runA($dateTime)
+    {
+    }
+
+    /**
+     * @param DateTimeInterface $dateTime
+     */
+    public function runB(DateTimeInterface $dateTime)
+    {
+    }
+}
+
+?>

--- a/rules-tests/PostRector/AdditionalPostRector/Source/CommentRemoverPostRector.php
+++ b/rules-tests/PostRector/AdditionalPostRector/Source/CommentRemoverPostRector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\PostRector\AdditionalPostRector\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use Rector\PostRector\Rector\AbstractPostRector;
+
+final class CommentRemoverPostRector extends AbstractPostRector
+{
+    public function enterNode(Node $node): Node|null
+    {
+        if (! $node instanceof Stmt ) {
+            return null;
+        }
+
+        if ($node->getComments() === []) {
+            return null;
+        }
+        $node->setAttribute('comments', []);
+        return $node;
+    }
+
+    public function shouldTraverse(array $stmts): bool
+    {
+        //Only remove comments if we have a namespace
+         return $stmts !== [] && $stmts[0] instanceof Stmt\Namespace_;
+    }
+
+    public function getPriority(): int
+    {
+        return 450;
+    }
+}

--- a/rules-tests/PostRector/AdditionalPostRector/config/additional_post_rector.php
+++ b/rules-tests/PostRector/AdditionalPostRector/config/additional_post_rector.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Tests\PostRector\AdditionalPostRector\Source\CommentRemoverPostRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+    $rectorConfig->removeUnusedImports();
+
+    $rectorConfig
+        ->postRector(CommentRemoverPostRector::class);
+};

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -312,4 +312,9 @@ final class Option
      * @internal to allow process file without extension if explicitly registered
      */
     public const FILES_WITHOUT_EXTENSION = 'files_without_extension';
+
+    /**
+     * @internal Additional PostRectorRules to run after all Rector rules have been processed
+     */
+    public const REGISTERED_POST_RECTOR_RULES = 'registered_post_rector_rules';
 }

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -23,6 +23,7 @@ use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Exception\Configuration\InvalidConfigurationException;
 use Rector\Php\PhpVersionResolver\ComposerJsonPhpVersionResolver;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
 use Rector\Set\SetManager;
@@ -71,6 +72,11 @@ final class RectorConfigBuilder
      * @var array<class-string<ConfigurableRectorInterface>, mixed[]>
      */
     private array $rulesWithConfigurations = [];
+
+    /**
+     * @var array<class-string<PostRectorInterface>>
+     */
+    private array $postRectors = [];
 
     /**
      * @var string[]
@@ -279,6 +285,10 @@ final class RectorConfigBuilder
             foreach ($configurations as $configuration) {
                 $rectorConfig->ruleWithConfiguration($rectorClass, $configuration);
             }
+        }
+
+        if ($this->postRectors !== []) {
+            $rectorConfig->postRectors($this->postRectors);
         }
 
         if ($this->fileExtensions !== []) {
@@ -798,6 +808,26 @@ final class RectorConfigBuilder
 
             SimpleParameterProvider::addParameter(Option::ROOT_STANDALONE_REGISTERED_RULES, $nonConfigurableRules);
         }
+
+        return $this;
+    }
+
+    /**
+     * @param class-string<PostRectorInterface> $postRector
+     */
+    public function withPostRector(string $postRector): self
+    {
+        $this->postRectors[] = $postRector;
+
+        return $this;
+    }
+
+    /**
+     * @param array<class-string<PostRectorInterface>> $postRectors
+     */
+    public function withPostRectors(array $postRectors): self
+    {
+        $this->postRectors = array_merge($this->postRectors, $postRectors);
 
         return $this;
     }

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -161,6 +161,7 @@ use Rector\PHPStanStaticTypeMapper\TypeMapper\TypeWithClassNameTypeMapper;
 use Rector\PHPStanStaticTypeMapper\TypeMapper\UnionTypeMapper;
 use Rector\PHPStanStaticTypeMapper\TypeMapper\VoidTypeMapper;
 use Rector\PostRector\Application\PostFileProcessor;
+use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Rector\Rector\AbstractRector;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
@@ -424,6 +425,10 @@ final class LazyContainerFactory
 
         $rectorConfig->singleton(FileProcessor::class);
         $rectorConfig->singleton(PostFileProcessor::class);
+
+        $rectorConfig->when(PostFileProcessor::class)
+            ->needs('$additionalPostRectors')
+            ->giveTagged(PostRectorInterface::class);
 
         $rectorConfig->when(RectorNodeTraverser::class)
             ->needs('$rectors')

--- a/src/PostRector/Contract/Rector/PostRectorInterface.php
+++ b/src/PostRector/Contract/Rector/PostRectorInterface.php
@@ -19,4 +19,10 @@ interface PostRectorInterface extends NodeVisitor
     public function shouldTraverse(array $stmts): bool;
 
     public function setFile(File $file): void;
+
+    /**
+     * Used to sort PostRectors in the order in which they should run
+     * A smaller number means higher priority (should run first)
+     */
+    public function getPriority(): int;
 }

--- a/src/PostRector/Rector/ClassRenamingPostRector.php
+++ b/src/PostRector/Rector/ClassRenamingPostRector.php
@@ -95,6 +95,11 @@ final class ClassRenamingPostRector extends AbstractPostRector
         return $this->oldToNewClasses !== [];
     }
 
+    public function getPriority(): int
+    {
+        return 100;
+    }
+
     private function resolveResultWithPhpAttributeName(Name $name, ?Scope $scope): ?FullyQualified
     {
         $phpAttributeName = $name->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);

--- a/src/PostRector/Rector/DocblockNameImportingPostRector.php
+++ b/src/PostRector/Rector/DocblockNameImportingPostRector.php
@@ -50,4 +50,9 @@ final class DocblockNameImportingPostRector extends AbstractPostRector
     {
         return $this->addUseStatementGuard->shouldTraverse($stmts, $this->getFile()->getFilePath());
     }
+
+    public function getPriority(): int
+    {
+        return 300;
+    }
 }

--- a/src/PostRector/Rector/NameImportingPostRector.php
+++ b/src/PostRector/Rector/NameImportingPostRector.php
@@ -52,4 +52,9 @@ final class NameImportingPostRector extends AbstractPostRector
     {
         return $this->addUseStatementGuard->shouldTraverse($stmts, $this->getFile()->getFilePath());
     }
+
+    public function getPriority(): int
+    {
+        return 200;
+    }
 }

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -91,6 +91,11 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
         return $node;
     }
 
+    public function getPriority(): int
+    {
+        return 500;
+    }
+
     /**
      * @return string[]
      */

--- a/src/PostRector/Rector/UseAddingPostRector.php
+++ b/src/PostRector/Rector/UseAddingPostRector.php
@@ -83,6 +83,11 @@ final class UseAddingPostRector extends AbstractPostRector
         return NodeVisitor::STOP_TRAVERSAL;
     }
 
+    public function getPriority(): int
+    {
+        return 400;
+    }
+
     /**
      * @param Stmt[] $nodes
      * @param FullyQualifiedObjectType[] $useImportTypes


### PR DESCRIPTION
Currently you can easily add custom new rules to Rector but there is no way to add Post Rectors (rules which are applied globally after all rector rules have been applied). This PR adds this capability. It also adds a priority to the post rector rules so that your custom post rectors can run in the appropriate order