### PR TITLE
Remove deprecated-level-set warning as no longer exists

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -21,9 +21,6 @@ use Rector\ValueObject\Configuration\LevelOverflow;
 use Rector\ValueObject\PhpVersion;
 use Rector\ValueObject\PolyfillPackage;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Webmozart\Assert\Assert;
 
 /**
@@ -85,25 +82,6 @@ final class RectorConfig extends Container
         foreach ($sets as $set) {
             Assert::fileExists($set);
             $this->import($set);
-        }
-
-        // notify about deprecated sets
-        foreach ($sets as $set) {
-            if (! str_contains($set, 'deprecated-level-set')) {
-                continue;
-            }
-
-            // display only on main command run, skip spamming in workers
-            $commandArguments = $_SERVER['argv'];
-            if (! in_array('worker', $commandArguments, true)) {
-                // show warning, to avoid confusion
-                $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
-                $symfonyStyle->warning(
-                    "The Symfony/Twig/PHPUnit level sets have been deprecated since Rector 0.19.2 due to heavy performance loads and conflicting overrides. Instead, please use the latest major set.\n\nFor more information, visit https://getrector.com/blog/5-common-mistakes-in-rector-config-and-how-to-avoid-them"
-                );
-
-                break;
-            }
         }
 
         // for cache invalidation in case of sets change


### PR DESCRIPTION
The warning was used to give user information to not using level set for Symfony/Twig/PHPUnit, ref PR:

-  https://github.com/rectorphp/rector-symfony/pull/572/files#diff-4d22a27b56e5eb7c6ceeb64bcc7ff103fd42b0e73e91313fcec2e7e81d8da7a3
- https://github.com/rectorphp/rector-src/pull/5477

Now, the `deprecated-level-set.php` no longer exists, so it can be removed.