### PR TITLE
[Transform] Follow empty parent construct parameters on StaticCallToMethodCallRector

### DIFF
--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/follow_parent_empty_construct.php.inc
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/follow_parent_empty_construct.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Fixture;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\XmlResource;
+
+class FollowParentEmptyConstruct extends XmlResource
+{
+    public function toArray(
+        Request $request,
+    ): array {
+        return [
+            'user_id' => $this->user_id ?? App::get(MissingValue::class),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Fixture;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\XmlResource;
+
+class FollowParentEmptyConstruct extends XmlResource
+{
+    public function __construct(private \Illuminate\Foundation\Application $application)
+    {
+        parent::__construct();
+    }
+    public function toArray(
+        Request $request,
+    ): array {
+        return [
+            'user_id' => $this->user_id ?? $this->application->get(MissingValue::class),
+        ];
+    }
+}
+
+?>

--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/FixturePhp74/follow_parent_empty_construct_on_php74.php.inc
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/FixturePhp74/follow_parent_empty_construct_on_php74.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\FixturePhp74;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\XmlResource2;
+
+class FollowParentEmptyConstructOnPhp74 extends XmlResource2
+{
+    public function toArray(
+        Request $request,
+    ): array {
+        return [
+            'user_id' => $this->user_id ?? App::get(MissingValue::class),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\FixturePhp74;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\XmlResource2;
+
+class FollowParentEmptyConstructOnPhp74 extends XmlResource2
+{
+    private \Illuminate\Foundation\Application $application;
+    public function __construct(\Illuminate\Foundation\Application $application)
+    {
+        parent::__construct();
+        $this->application = $application;
+    }
+    public function toArray(
+        Request $request,
+    ): array {
+        return [
+            'user_id' => $this->user_id ?? $this->application->get(MissingValue::class),
+        ];
+    }
+}
+
+?>

--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/XmlResource.php
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/XmlResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source;
+
+// for testing under php 8.0 to avoid flip flop ClassReflection cache
+class XmlResource
+{
+    public $resource;
+
+    public function __construct()
+    {
+        $this->resource = new \SimpleXMLElement('<root/>');
+    }
+}

--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/XmlResource2.php
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/XmlResource2.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source;
+
+// for testing under php 8.0 to avoid flip flop ClassReflection cache
+class XmlResource2
+{
+    public $resource;
+
+    public function __construct()
+    {
+        $this->resource = new \SimpleXMLElement('<root/>');
+    }
+}

--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -85,12 +85,6 @@ final readonly class ClassDependencyManipulator
                 continue;
             }
 
-            // only if it has parameters to check
-            // early returns as nearest parent construct
-            if ($parentConstructorMethod->params === []) {
-                return null;
-            }
-
             // reprint parent method node to avoid invalid tokens
             $this->nodeFactory->createReprintedNode($parentConstructorMethod);
 


### PR DESCRIPTION
continue of:

- https://github.com/rectorphp/rector-src/pull/6854

with add `parent::__construct()` to not change existing behaviour.