### PR TITLE
[Transform] Do not call parent::construct() when parent __construct() is private on StaticCallToMethodCallRector

### DIFF
--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/extends_parent_with_private_construct.php.inc
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/extends_parent_with_private_construct.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Fixture;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\SomeResource;
+
+class ExtendsParentWithPrivateConstruct extends SomeResource
+{
+    public function toArray(
+        Request $request,
+    ): array {
+        return [
+            'user_id' => $this->user_id ?? App::get(MissingValue::class),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Fixture;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\SomeResource;
+
+class ExtendsParentWithPrivateConstruct extends SomeResource
+{
+    public function __construct(private \Illuminate\Foundation\Application $application)
+    {
+    }
+    public function toArray(
+        Request $request,
+    ): array {
+        return [
+            'user_id' => $this->user_id ?? $this->application->get(MissingValue::class),
+        ];
+    }
+}
+
+?>

--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/SomeResource.php
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/SomeResource.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source;
+
+class SomeResource
+{
+    private function __construct()
+    {
+    }
+}

--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -225,6 +225,12 @@ final readonly class ClassDependencyManipulator
                 continue;
             }
 
+            if ($parentConstructorMethod->isPrivate()) {
+                // stop, nearest __construct() uses private visibility
+                // which parent::__construct() will cause error
+                break;
+            }
+
             // reprint parent method node to avoid invalid tokens
             $this->nodeFactory->createReprintedNode($parentConstructorMethod);
 


### PR DESCRIPTION
Ref https://3v4l.org/QGk3B