### PR TITLE
Clean up #[RunClassInSeparateProcess] on RectorConfigTest

### DIFF
--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -4,22 +4,21 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Config;
 
-use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
-use Rector\Config\RectorConfig;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Symfony\Set\TwigSetList;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 
-#[RunClassInSeparateProcess]
 final class RectorConfigTest extends AbstractLazyTestCase
 {
     public function test(): void
     {
-        RectorConfig::configure()
+        $rectorConfig = $this->getContainer();
+
+        $rectorConfig->configure()
             ->withSets([TwigSetList::TWIG_134])
-            ->withRules([ReturnTypeFromReturnNewRector::class])(new RectorConfig());
+            ->withRules([ReturnTypeFromReturnNewRector::class])($rectorConfig);
 
         // only collect root withRules()
         $this->assertCount(1, SimpleParameterProvider::provideArrayParameter(Option::ROOT_STANDALONE_REGISTERED_RULES));


### PR DESCRIPTION
Remove useless `#[RunClassInSeparateProcess]` by update the test to use `$this->getContainer()` on `RectorConfigTest`