### PR TITLE
[naming] Skip public properties in RenamePropertyToMatchTypeRector to avoid external code conflicts

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_public_constructor_property.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_public_constructor_property.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\EliteManager;
+
+final class SkipPublicProperty
+{
+    public function __construct(
+        public EliteManager $entityMessenger
+    ) {
+    }
+}

--- a/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
+++ b/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
@@ -71,6 +71,11 @@ final readonly class PropertyPromotionRenamer
                 continue;
             }
 
+            // skip public properties, as they can be used in external code
+            if ($param->isPublic()) {
+                continue;
+            }
+
             // promoted property
             $desiredPropertyName = $this->matchParamTypeExpectedNameResolver->resolve($param);
             if ($desiredPropertyName === null) {

--- a/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
+++ b/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
@@ -108,6 +108,11 @@ CODE_SAMPLE
     private function refactorClassProperties(ClassLike $classLike): void
     {
         foreach ($classLike->getProperties() as $property) {
+            // skip public properties, as they can be used in external code
+            if ($property->isPublic()) {
+                continue;
+            }
+
             $expectedPropertyName = $this->matchPropertyTypeExpectedNameResolver->resolve($property, $classLike);
             if ($expectedPropertyName === null) {
                 continue;


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/9125