### PR TITLE
[CodeQuality] Skip ArrayDimFetch on IssetOnPropertyObjectToPropertyExistsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/collection.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/collection.php.inc
@@ -1,4 +1,7 @@
 <?php
+
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
+
 /**
  * @template TKey of array-key
  *
@@ -6,16 +9,11 @@
  *
  * @implements \ArrayAccess<TKey, TValue>
  */
-namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
-
 class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerable {}
-namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
 
 class VariableValue {
     public function __construct(public string $name, public mixed $value, public ?string $expression, public ?AnswerType $type) {}
 }
-
-namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
 
 final class DemoFile
 {

--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/collection.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/collection.php.inc
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @template TKey of array-key
+ *
+ * @template-covariant TValue
+ *
+ * @implements \ArrayAccess<TKey, TValue>
+ */
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
+
+class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerable {}
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
+
+class VariableValue {
+    public function __construct(public string $name, public mixed $value, public ?string $expression, public ?AnswerType $type) {}
+}
+
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @param  Collection<string, VariableValue>  $values
+     */
+    private function setBlockTitle(Collection $values): void
+    {
+        if (! isset($values['_identity']->value)) {
+            return;
+        }
+
+        echo $values['_identity']->value;
+    }
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_property_on_array_access.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_property_on_array_access.php.inc
@@ -3,12 +3,12 @@
 namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
 
 use Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Source\Collection;
-use Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Source\SomeClass;
+use Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Source\SomeOtherClass;
 
 final class SkipPropertyOnArrayAccess
 {
     /**
-     * @param  Collection<string, SomeClass>  $values
+     * @param  Collection<string, SomeOtherClass>  $values
      */
     private function run(Collection $values): void
     {

--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_property_on_array_access.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_property_on_array_access.php.inc
@@ -2,25 +2,28 @@
 
 namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
 
+use ArrayAccess;
+use Enumerable;
+
 /**
  * @template TKey of array-key
  *
  * @template-covariant TValue
  *
- * @implements \ArrayAccess<TKey, TValue>
+ * @implements ArrayAccess<TKey, TValue>
  */
-class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerable {}
+class Collection implements ArrayAccess, Enumerable {}
 
 class VariableValue {
-    public function __construct(public string $name, public mixed $value, public ?string $expression, public ?AnswerType $type) {}
+    public function __construct(public mixed $value) {}
 }
 
-final class DemoFile
+final class SkipPropertyOnArrayAccess
 {
     /**
      * @param  Collection<string, VariableValue>  $values
      */
-    private function setBlockTitle(Collection $values): void
+    private function run(Collection $values): void
     {
         if (! isset($values['_identity']->value)) {
             return;
@@ -29,4 +32,3 @@ final class DemoFile
         echo $values['_identity']->value;
     }
 }
-?>

--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_property_on_array_access.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_property_on_array_access.php.inc
@@ -2,26 +2,13 @@
 
 namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
 
-use ArrayAccess;
-use Enumerable;
-
-/**
- * @template TKey of array-key
- *
- * @template-covariant TValue
- *
- * @implements ArrayAccess<TKey, TValue>
- */
-class Collection implements ArrayAccess, Enumerable {}
-
-class VariableValue {
-    public function __construct(public mixed $value) {}
-}
+use Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Source\Collection;
+use Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Source\SomeClass;
 
 final class SkipPropertyOnArrayAccess
 {
     /**
-     * @param  Collection<string, VariableValue>  $values
+     * @param  Collection<string, SomeClass>  $values
      */
     private function run(Collection $values): void
     {

--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Source/Collection.php
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Source/Collection.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Source;
+
+use ArrayAccess;
+
+/**
+ * @template TKey of array-key
+ *
+ * @template-covariant TValue
+ *
+ * @implements ArrayAccess<TKey, TValue>
+ */
+class Collection implements ArrayAccess {}

--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Source/SomeOtherClass.php
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Source/SomeOtherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Source;
+
+class SomeOtherClass
+{
+    public function __construct(public mixed $value) {}
+}

--- a/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
+++ b/rules/Carbon/Rector/FuncCall/DateFuncCallToCarbonRector.php
@@ -124,7 +124,7 @@ CODE_SAMPLE
             $dateExpr = $this->getArgValue($node, 0);
             $baseTimestamp = $this->getArgValue($node, 1);
 
-            if ($dateExpr instanceof Expr && $baseTimestamp === null) {
+            if ($dateExpr instanceof Expr && !$baseTimestamp instanceof Expr) {
                 return $this->createCarbonParseTimestamp($dateExpr);
             }
 

--- a/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -7,6 +7,7 @@ namespace Rector\CodeQuality\Rector\Isset_;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
@@ -117,6 +118,11 @@ CODE_SAMPLE
 
             $classReflection = $this->matchPropertyTypeClassReflection($issetExpr);
             if (! $classReflection instanceof ClassReflection) {
+                continue;
+            }
+
+            // possibly by docblock
+            if ($issetExpr->var instanceof ArrayDimFetch) {
                 continue;
             }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/6861
Fixes https://github.com/rectorphp/rector/issues/9128