### PR TITLE
Add back #[RunClassInSeparateProcess] on RectorConfigTest

### DIFF
--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Config;
 
+use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Symfony\Set\TwigSetList;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 
+#[RunClassInSeparateProcess]
 final class RectorConfigTest extends AbstractLazyTestCase
 {
     public function test(): void


### PR DESCRIPTION
It somehow cause invalid assert on latest composer update.