### PR TITLE
[EarlyReturn] Skip re-assign in loop on PreparedValueToEarlyReturnRector

### DIFF
--- a/rules-tests/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector/Fixture/foreach_flip.php.inc
+++ b/rules-tests/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector/Fixture/foreach_flip.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector\Fixture;
+
+final class DemoFile {
+    public function preparedValueForeach(): bool {
+        $test = true;
+        foreach([true, false] as $item) {
+        	if(!$item) $test = false;
+        }
+        
+        if(rand(0, 1)) $test = false;
+        
+        return $test;
+    }
+}
+?>

--- a/rules-tests/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector/Fixture/skip_reassign_in_foreach.php.inc
+++ b/rules-tests/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector/Fixture/skip_reassign_in_foreach.php.inc
@@ -2,16 +2,15 @@
 
 namespace Rector\Tests\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector\Fixture;
 
-final class DemoFile {
+final class SkipReassignInForeach {
     public function preparedValueForeach(): bool {
         $test = true;
         foreach([true, false] as $item) {
         	if(!$item) $test = false;
         }
-        
+
         if(rand(0, 1)) $test = false;
-        
+
         return $test;
     }
 }
-?>

--- a/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
+++ b/rules/EarlyReturn/Rector/Return_/PreparedValueToEarlyReturnRector.php
@@ -10,9 +10,13 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\While_;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\EarlyReturn\ValueObject\BareSingleAssignIf;
 use Rector\NodeManipulator\IfManipulator;
@@ -104,6 +108,20 @@ CODE_SAMPLE
         foreach ($node->stmts as $key => $stmt) {
             if ($stmt instanceof Expression && $stmt->expr instanceof AssignOp) {
                 return null;
+            }
+
+            if ($stmt instanceof For_ || $stmt instanceof Foreach_ || $stmt instanceof While_ || $stmt instanceof Do_) {
+                $isReassignInLoop = (bool) $this->betterNodeFinder->findFirst(
+                    $stmt,
+                    fn (Node $node): bool => $node instanceof Assign && $this->nodeComparator->areNodesEqual(
+                        $node->var,
+                        $initialAssign?->var
+                    )
+                );
+
+                if ($isReassignInLoop) {
+                    return null;
+                }
             }
 
             if ($stmt instanceof If_) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9112