### PR TITLE
[Naming] Skip protected property on non-final class on RenamePropertyToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_protected_property_on_non_final_class.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_protected_property_on_non_final_class.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper;
+
+class SkipProtectedPropertyOnNonFinalClass
+{
+    /**
+     * @var \Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper
+     */
+    protected $wrapper;
+
+    public function __construct(GitWrapper $wrapper)
+    {
+        $this->wrapper = $wrapper;
+    }
+}

--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_protected_property_promotion.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_protected_property_promotion.php.inc
@@ -8,6 +8,5 @@ class SkipProtectedPropertyPromotionOnNonFinalClass
 {
     public function __construct(protected GitWrapper $wrapper)
     {
-        $this->wrapper = $wrapper;
     }
 }

--- a/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_protected_property_promotion.php.inc
+++ b/rules-tests/Naming/Rector/Class_/RenamePropertyToMatchTypeRector/Fixture/skip_protected_property_promotion.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Class_\RenamePropertyToMatchTypeRector\Source\GitWrapper;
+
+class SkipProtectedPropertyPromotionOnNonFinalClass
+{
+    public function __construct(protected GitWrapper $wrapper)
+    {
+        $this->wrapper = $wrapper;
+    }
+}

--- a/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
+++ b/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
@@ -45,7 +45,7 @@ final readonly class PropertyPromotionRenamer
     ) {
     }
 
-    public function renamePropertyPromotion(Class_|Interface_ $classLike): bool
+    public function renamePropertyPromotion(Class_ $classLike): bool
     {
         $hasChanged = false;
 
@@ -73,6 +73,10 @@ final readonly class PropertyPromotionRenamer
 
             // skip public properties, as they can be used in external code
             if ($param->isPublic()) {
+                continue;
+            }
+
+            if (! $classLike->isFinal() && $param->isProtected()) {
                 continue;
             }
 

--- a/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
+++ b/rules/Naming/PropertyRenamer/PropertyPromotionRenamer.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Interface_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\Reflection\ClassReflection;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -45,7 +44,7 @@ final readonly class PropertyPromotionRenamer
     ) {
     }
 
-    public function renamePropertyPromotion(Class_ $classLike): bool
+    public function renamePropertyPromotion(Class_ $class): bool
     {
         $hasChanged = false;
 
@@ -53,12 +52,12 @@ final readonly class PropertyPromotionRenamer
             return false;
         }
 
-        $constructClassMethod = $classLike->getMethod(MethodName::CONSTRUCT);
+        $constructClassMethod = $class->getMethod(MethodName::CONSTRUCT);
         if (! $constructClassMethod instanceof ClassMethod) {
             return false;
         }
 
-        $classReflection = $this->reflectionResolver->resolveClassReflection($classLike);
+        $classReflection = $this->reflectionResolver->resolveClassReflection($class);
         if (! $classReflection instanceof ClassReflection) {
             return false;
         }
@@ -76,7 +75,7 @@ final readonly class PropertyPromotionRenamer
                 continue;
             }
 
-            if (! $classLike->isFinal() && $param->isProtected()) {
+            if (! $class->isFinal() && $param->isProtected()) {
                 continue;
             }
 
@@ -99,7 +98,7 @@ final readonly class PropertyPromotionRenamer
                 continue;
             }
 
-            $this->renameParamVarNameAndVariableUsage($classLike, $constructClassMethod, $desiredPropertyName, $param);
+            $this->renameParamVarNameAndVariableUsage($class, $constructClassMethod, $desiredPropertyName, $param);
             $hasChanged = true;
         }
 

--- a/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
+++ b/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
@@ -81,11 +81,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Class_::class, Interface_::class];
+        return [Class_::class];
     }
 
     /**
-     * @param Class_|Interface_ $node
+     * @param Class_ $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -105,11 +105,15 @@ CODE_SAMPLE
         return null;
     }
 
-    private function refactorClassProperties(ClassLike $classLike): void
+    private function refactorClassProperties(Class_ $classLike): void
     {
         foreach ($classLike->getProperties() as $property) {
             // skip public properties, as they can be used in external code
             if ($property->isPublic()) {
+                continue;
+            }
+
+            if (!$classLike->isFinal() && $property->isProtected()) {
                 continue;
             }
 

--- a/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
+++ b/rules/Naming/Rector/Class_/RenamePropertyToMatchTypeRector.php
@@ -7,8 +7,6 @@ namespace Rector\Naming\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\ObjectType;
 use Rector\Enum\ClassName;
@@ -105,25 +103,25 @@ CODE_SAMPLE
         return null;
     }
 
-    private function refactorClassProperties(Class_ $classLike): void
+    private function refactorClassProperties(Class_ $class): void
     {
-        foreach ($classLike->getProperties() as $property) {
+        foreach ($class->getProperties() as $property) {
             // skip public properties, as they can be used in external code
             if ($property->isPublic()) {
                 continue;
             }
 
-            if (!$classLike->isFinal() && $property->isProtected()) {
+            if (!$class->isFinal() && $property->isProtected()) {
                 continue;
             }
 
-            $expectedPropertyName = $this->matchPropertyTypeExpectedNameResolver->resolve($property, $classLike);
+            $expectedPropertyName = $this->matchPropertyTypeExpectedNameResolver->resolve($property, $class);
             if ($expectedPropertyName === null) {
                 continue;
             }
 
             $propertyRename = $this->propertyRenameFactory->createFromExpectedName(
-                $classLike,
+                $class,
                 $property,
                 $expectedPropertyName
             );

--- a/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
+++ b/rules/Naming/ValueObjectFactory/PropertyRenameFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Naming\ValueObjectFactory;
 
-use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use Rector\Naming\ValueObject\PropertyRename;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -18,19 +18,19 @@ final readonly class PropertyRenameFactory
     }
 
     public function createFromExpectedName(
-        ClassLike $classLike,
+        Class_ $class,
         Property $property,
         string $expectedName
     ): ?PropertyRename {
         $currentName = $this->nodeNameResolver->getName($property);
-        $className = (string) $this->nodeNameResolver->getName($classLike);
+        $className = (string) $this->nodeNameResolver->getName($class);
 
         try {
             return new PropertyRename(
                 $property,
                 $expectedName,
                 $currentName,
-                $classLike,
+                $class,
                 $className,
                 $property->props[0]
             );


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9125