### PR TITLE
[PHPStan 2.1.14] Fix resolve __toString() parent non builtin method without return type

### DIFF
--- a/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\FamilyTree\NodeAnalyzer;
 
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\PhpMethodReflection;
@@ -80,7 +81,7 @@ final readonly class ClassChildAnalyzer
 
         if ($class instanceof ClassLike) {
             $classMethod = $class->getMethod($phpMethodReflection->getName());
-            if ($classMethod->returnType === null) {
+            if ($classMethod instanceof ClassMethod && $classMethod->returnType === null) {
                 return new MixedType();
             }
         }

--- a/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace Rector\FamilyTree\NodeAnalyzer;
 
+use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use Rector\PhpParser\AstResolver;
 
 final readonly class ClassChildAnalyzer
 {
+    public function __construct(
+        private AstResolver $astResolver
+    ) {
+    }
+
     /**
      * Look both parent class and interface, yes, all PHP interface methods are abstract
      */
@@ -42,8 +50,14 @@ final readonly class ClassChildAnalyzer
         }
 
         foreach ($parentClassMethods as $parentClassMethod) {
-            $parametersAcceptor = ParametersAcceptorSelector::combineAcceptors($parentClassMethod->getVariants());
-            $nativeReturnType = $parametersAcceptor->getNativeReturnType();
+            // for downgrade purpose on __toString
+            // @see https://3v4l.org/kdcEh#v7.4.33
+            // @see https://github.com/phpstan/phpstan-src/commit/3854cbc5748a7cb51ee0b86ceffe29bd0564bc98
+            if ($parentClassMethod->getDeclaringClass()->isBuiltIn() || $methodName !== '__toString') {
+                $nativeReturnType = $this->resolveNativeType($parentClassMethod);
+            } else {
+                $nativeReturnType = $this->resolveToStringNativeTypeFromAstResolver($parentClassMethod);
+            }
 
             if (! $nativeReturnType instanceof MixedType) {
                 return $nativeReturnType;
@@ -51,6 +65,27 @@ final readonly class ClassChildAnalyzer
         }
 
         return new MixedType();
+    }
+
+    private function resolveNativeType(PhpMethodReflection $phpMethodReflection): Type
+    {
+        $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors($phpMethodReflection->getVariants());
+        return $extendedParametersAcceptor->getNativeReturnType();
+    }
+
+    private function resolveToStringNativeTypeFromAstResolver(PhpMethodReflection $phpMethodReflection): Type
+    {
+        $classReflection = $phpMethodReflection->getDeclaringClass();
+        $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
+
+        if ($class instanceof ClassLike) {
+            $classMethod = $class->getMethod($phpMethodReflection->getName());
+            if ($classMethod->returnType === null) {
+                return new MixedType();
+            }
+        }
+
+        return new StringType();
     }
 
     /**

--- a/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\FamilyTree\NodeAnalyzer;
 
+use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
@@ -81,7 +82,7 @@ final readonly class ClassChildAnalyzer
 
         if ($class instanceof ClassLike) {
             $classMethod = $class->getMethod($phpMethodReflection->getName());
-            if ($classMethod instanceof ClassMethod && $classMethod->returnType === null) {
+            if ($classMethod instanceof ClassMethod && !$classMethod->returnType instanceof Node) {
                 return new MixedType();
             }
         }


### PR DESCRIPTION
@TomasVotruba this is the real patch for resolve `__toString` from non builtin parent method.

This require revert of PR:

-  https://github.com/rectorphp/rector-downgrade-php/pull/272