### PR TITLE
[TypeDeclaration] Skip __destruct() from add return type based on parent on AddReturnTypeDeclarationBasedOnParentClassMethodRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_destruct.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Fixture/skip_destruct.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationBasedOnParentClassMethodRector\Source\SomeClassWithoutReturnType;
+
+class SkipDestruct extends SomeClassWithoutReturnType
+{
+    public function __destruct()
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithoutReturnType.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector/Source/SomeClassWithoutReturnType.php
@@ -10,4 +10,8 @@ class SomeClassWithoutReturnType
     {
       return 5;
     }
+
+    public function __destruct()
+    {
+    }
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationBasedOnParentClassMethodRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($node->getMethods() as $classMethod) {
-            if ($this->isName($classMethod, MethodName::CONSTRUCT)) {
+            if ($this->isNames($classMethod, [MethodName::CONSTRUCT, MethodName::DESCTRUCT])) {
                 continue;
             }
 


### PR DESCRIPTION
While wait for PHPStan patch to be merged:

- https://github.com/phpstan/phpstan-src/pull/3979

this patch to ensure `__destruct()` is not add `void`, list of magic method add return type and not allowed return type is here https://3v4l.org/7t7jA

Fixes https://github.com/rectorphp/rector/issues/9144
