### PR TITLE
[nette/utils] [4.0] Add upgrade set to handle named args in Json class 

### DIFF
--- a/config/set/nette-utils/nette-utils4.php
+++ b/config/set/nette-utils/nette-utils4.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([UtilsJsonStaticCallNamedArgRector::class]);
+};

--- a/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/Fixture/fixture.php.inc
+++ b/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector\Fixture;
+
+use Nette\Utils\Json;
+
+final class SomeStaticCalls
+{
+    public function run($data, $json)
+    {
+        $encodedJson = Json::encode($data, true);
+        $decodedJson = Json::decode($json, true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector\Fixture;
+
+use Nette\Utils\Json;
+
+final class SomeStaticCalls
+{
+    public function run($data, $json)
+    {
+        $encodedJson = Json::encode($data, pretty: true);
+        $decodedJson = Json::decode($json, forceArrays: true);
+    }
+}
+
+?>

--- a/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/Fixture/skip_already_filled.php.inc
+++ b/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/Fixture/skip_already_filled.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector\Fixture;
+
+use Nette\Utils\Json;
+
+final class SkipAlreadyFilled
+{
+    public function run($data, $json)
+    {
+        $encodedJson = Json::encode($data, pretty: true);
+        $decodedJson = Json::decode($json, forceArrays: true);
+    }
+}

--- a/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/Fixture/skip_no_second_arg.php.inc
+++ b/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/Fixture/skip_no_second_arg.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector\Fixture;
+
+use Nette\Utils\Json;
+
+final class SkipNoSecondArg
+{
+    public function run($data, $json)
+    {
+        $encodedJson = Json::encode($data);
+        $decodedJson = Json::decode($json);
+    }
+}

--- a/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/UtilsJsonStaticCallNamedArgRectorTest.php
+++ b/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/UtilsJsonStaticCallNamedArgRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class UtilsJsonStaticCallNamedArgRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/config/configured_rule.php
+++ b/rules-tests/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector;
+
+return RectorConfig::configure()
+    ->withRules([UtilsJsonStaticCallNamedArgRector::class]);

--- a/rules/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector.php
+++ b/rules/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NetteUtils\Rector\StaticCall;
+
+use Nette\Utils\Json;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class UtilsJsonStaticCallNamedArgRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change ' . Json::class . '::encode() and decode() to named args', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Nette\Utils\Json;
+
+$encodedJson = Json::encode($data, true);
+$decodedJson = Json::decode($json, true);
+
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Nette\Utils\Json;
+
+$encodedJson = Json::encode($data, pretty: true);
+$decodedJson = Json::decode($json, forceArrays: true);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node->class, 'Nette\Utils\Json')) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (count($node->getArgs()) < 2) {
+            return null;
+        }
+
+        if (! $this->isNames($node->name, ['encode', 'decode'])) {
+            return null;
+        }
+
+        // flip 2nd arg from true/false to named arg
+        // check if 2nd arg is named arg already
+        $secondArg = $node->getArgs()[1];
+
+        // already set → skip
+        if ($secondArg->name instanceof Identifier) {
+            return null;
+        }
+
+        if ($this->isName($node->name, 'encode')) {
+            $secondArg->name = new Identifier('pretty');
+            return $node;
+        }
+
+        $secondArg->name = new Identifier('forceArrays');
+        return $node;
+    }
+}

--- a/rules/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector.php
+++ b/rules/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector.php
@@ -12,6 +12,9 @@ use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @see \Rector\Tests\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector\UtilsJsonStaticCallNamedArgRectorTest
+ */
 final class UtilsJsonStaticCallNamedArgRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition

--- a/src/Bridge/SetProviderCollector.php
+++ b/src/Bridge/SetProviderCollector.php
@@ -11,6 +11,11 @@ use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\SetProvider\CoreSetProvider;
 use Rector\Set\SetProvider\PHPSetProvider;
 use Rector\Set\ValueObject\ComposerTriggeredSet;
+use Rector\Symfony\Set\SetProvider\Symfony3SetProvider;
+use Rector\Symfony\Set\SetProvider\Symfony4SetProvider;
+use Rector\Symfony\Set\SetProvider\Symfony5SetProvider;
+use Rector\Symfony\Set\SetProvider\Symfony6SetProvider;
+use Rector\Symfony\Set\SetProvider\Symfony7SetProvider;
 use Rector\Symfony\Set\SetProvider\SymfonySetProvider;
 use Rector\Symfony\Set\SetProvider\TwigSetProvider;
 
@@ -37,6 +42,11 @@ final readonly class SetProviderCollector
             new CoreSetProvider(),
             new PHPUnitSetProvider(),
             new SymfonySetProvider(),
+            new Symfony3SetProvider(),
+            new Symfony4SetProvider(),
+            new Symfony5SetProvider(),
+            new Symfony6SetProvider(),
+            new Symfony7SetProvider(),
             new DoctrineSetProvider(),
             new TwigSetProvider(),
         ];

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -791,13 +791,15 @@ final class RectorConfigBuilder
         bool $twig = false,
         bool $doctrine = false,
         bool $phpunit = false,
-        bool $symfony = \false
+        bool $symfony = false,
+        bool $netteUtils = false,
     ): self {
         $setMap = [
             SetGroup::TWIG => $twig,
             SetGroup::DOCTRINE => $doctrine,
             SetGroup::PHPUNIT => $phpunit,
             SetGroup::SYMFONY => $symfony,
+            SetGroup::NETTE_UTILS => $netteUtils,
         ];
 
         foreach ($setMap as $setPath => $isEnabled) {

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -468,7 +468,9 @@ final class RectorConfigBuilder
         // dx for more granular upgrade
         if ($symfonyRoute) {
             if ($symfony) {
-                throw new InvalidConfigurationException('$symfonyRoute is already included in $symfony. Use $symfony only');
+                throw new InvalidConfigurationException(
+                    '$symfonyRoute is already included in $symfony. Use $symfony only'
+                );
             }
 
             $this->withConfiguredRule(AnnotationToAttributeRector::class, [
@@ -478,7 +480,9 @@ final class RectorConfigBuilder
 
         if ($symfonyValidator) {
             if ($symfony) {
-                throw new InvalidConfigurationException('$symfonyValidator is already included in $symfony. Use $symfony only');
+                throw new InvalidConfigurationException(
+                    '$symfonyValidator is already included in $symfony. Use $symfony only'
+                );
             }
 
             $this->sets[] = SymfonySetList::SYMFONY_52_VALIDATOR_ATTRIBUTES;

--- a/src/Set/Enum/SetGroup.php
+++ b/src/Set/Enum/SetGroup.php
@@ -47,6 +47,12 @@ final class SetGroup
      * Version-based set provider
      * @var string
      */
+    public const NETTE_UTILS = 'nette-utils';
+
+    /**
+     * Version-based set provider
+     * @var string
+     */
     public const LARAVEL = 'laravel';
 
     /**

--- a/src/Set/SetProvider/CoreSetProvider.php
+++ b/src/Set/SetProvider/CoreSetProvider.php
@@ -31,7 +31,7 @@ final class CoreSetProvider implements SetProviderInterface
             new Set(SetGroup::CORE, 'Type Declarations', __DIR__ . '/../../../config/set/type-declaration.php'),
 
             new ComposerTriggeredSet(
-                SetGroup::CORE,
+                SetGroup::NETTE_UTILS,
                 'nette/utils',
                 '4.0',
                 __DIR__ . '/../../../config/set/nette-utils/nette-utils4.php',

--- a/src/Set/SetProvider/CoreSetProvider.php
+++ b/src/Set/SetProvider/CoreSetProvider.php
@@ -7,6 +7,7 @@ namespace Rector\Set\SetProvider;
 use Rector\Set\Contract\SetInterface;
 use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
+use Rector\Set\ValueObject\ComposerTriggeredSet;
 use Rector\Set\ValueObject\Set;
 
 final class CoreSetProvider implements SetProviderInterface
@@ -28,6 +29,13 @@ final class CoreSetProvider implements SetProviderInterface
             new Set(SetGroup::CORE, 'Privatization', __DIR__ . '/../../../config/set/privatization.php'),
             new Set(SetGroup::CORE, 'Strict Booleans', __DIR__ . '/../../../config/set/strict-booleans.php'),
             new Set(SetGroup::CORE, 'Type Declarations', __DIR__ . '/../../../config/set/type-declaration.php'),
+
+            new ComposerTriggeredSet(
+                SetGroup::CORE,
+                'nette/utils',
+                '4.0',
+                __DIR__ . '/../../../config/set/nette-utils/nette-utils4.php',
+            ),
         ];
     }
 }


### PR DESCRIPTION

```diff
use Nette\Utils\Json;

final class SomeStaticCalls
{
    public function run($data, $json)
    {
-        $encodedJson = Json::encode($data, true);
+	     $encodedJson = Json::encode($data, pretty: true);


-        $decodedJson = Json::decode($json, true);
+        $decodedJson = Json::decode($json, forceArrays: true);
    }
}
```