### PR TITLE
Add rule for converting Enum cases to PascalCase naming

### DIFF
--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/EnumCaseToPascalCaseRectorTest.php
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/EnumCaseToPascalCaseRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EnumCaseToPascalCaseRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/StatusEnum.php
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/StatusEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+enum StatusEnum
+{
+    case PENDING;
+    case published;
+    case IN_REVIEW;
+    case waiting_for_approval;
+}
+
+
+if (StatusEnum::PENDING) {
+    echo 'PENDING';
+}
+?>

--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/enum_usage_in_other_package.php.inc
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/enum_usage_in_other_package.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+class EnumUsageInOtherPackage {
+    public function isValid(StatusEnum $status): bool {
+        return $status === StatusEnum::PENDING;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/enum_used.php.inc
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/enum_used.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+enum Status
+{
+    case PENDING;
+    case published;
+    case IN_REVIEW;
+    case waiting_for_approval;
+}
+
+class EnumUsage {
+    public function isValid(Status $status): bool {
+        return $status === Status::PENDING;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+enum Status
+{
+    case Pending;
+    case Published;
+    case InReview;
+    case WaitingForApproval;
+}
+
+class EnumUsage {
+    public function isValid(Status $status): bool {
+        return $status === Status::Pending;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/enum_used_alias.php.inc
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/enum_used_alias.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture\StatusAlias as Status;
+
+enum StatusAlias
+{
+    case PENDING;
+}
+
+class EnumUsage {
+    public function isValid(Status $status): bool {
+        return $status === Status::PENDING;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture\StatusAlias as Status;
+
+enum StatusAlias
+{
+    case Pending;
+}
+
+class EnumUsage {
+    public function isValid(Status $status): bool {
+        return $status === Status::Pending;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/config/configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([EnumCaseToPascalCaseRector::class]);

--- a/rules/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector.php
+++ b/rules/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\Enum_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\EnumCase;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Rector\AbstractRector;
+use Rector\Util\FilePath;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\EnumCaseToPascalCaseRectorTest
+ */
+final class EnumCaseToPascalCaseRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Convert enum cases to PascalCase and update their usages',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                    enum Status
+                    {
+                        case PENDING;
+                        case published;
+                        case IN_REVIEW;
+                        case waiting_for_approval;
+                    }
+                    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                    enum Status
+                    {
+                        case Pending;
+                        case Published;
+                        case InReview;
+                        case WaitingForApproval;
+                    }
+                    CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Enum_::class, ClassConstFetch::class];
+    }
+
+    /**
+     * @param Enum_|ClassConstFetch $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof Enum_) {
+            return $this->refactorEnum($node);
+        }
+
+        if ($node instanceof ClassConstFetch) {
+            return $this->refactorClassConstFetch($node);
+        }
+
+        return null;
+    }
+
+    public function refactorEnum(Enum_ $enum): Enum_|null
+    {
+        $enumName = $this->getName($enum);
+        if ($enumName === null) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($enum->stmts as $stmt) {
+            if (! $stmt instanceof EnumCase) {
+                continue;
+            }
+
+            $currentName = $stmt->name->toString();
+            $pascalCaseName = $this->convertToPascalCase($currentName);
+
+            if ($currentName === $pascalCaseName) {
+                continue;
+            }
+
+            $stmt->name = new Identifier($pascalCaseName);
+            $hasChanged = true;
+        }
+
+        return $hasChanged ? $enum : null;
+    }
+
+    private function refactorClassConstFetch(ClassConstFetch $classConstFetch): ?Node
+    {
+        if (! $classConstFetch->class instanceof Name) {
+            return null;
+        }
+
+        if (! $classConstFetch->name instanceof Identifier) {
+            return null;
+        }
+
+        if ($this->nodeTypeResolver->getType($classConstFetch->class)->isEnum()->no()) {
+            return null;
+        }
+
+        $constName = $classConstFetch->name->toString();
+
+        // Skip "class" constant
+        if ($constName === 'class') {
+            return null;
+        }
+
+        $enumClassName = $classConstFetch->class->toString();
+        if (! $this->reflectionProvider->hasClass($enumClassName)) {
+            return null;
+        }
+
+        $targetEnumFile = $this->reflectionProvider->getClass($classConstFetch->class->toString())
+            ->getFileName();
+
+        if ($targetEnumFile === null) {
+            return null;
+        }
+
+        if (! FilePath::fileIsInRectorPathOrSource($targetEnumFile)) {
+            return null;
+        }
+
+        $pascalCaseName = $this->convertToPascalCase($constName);
+        if ($constName !== $pascalCaseName) {
+            $classConstFetch->name = new Identifier($pascalCaseName);
+            return $classConstFetch;
+        }
+
+        return null;
+    }
+
+    private function convertToPascalCase(string $name): string
+    {
+        $parts = explode('_', strtolower($name));
+        return implode('', array_map(ucfirst(...), $parts));
+    }
+}

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -143,6 +143,7 @@ final readonly class ConfigurationFactory
 
         // give priority to command line
         if ($commandLinePaths !== []) {
+            SimpleParameterProvider::addParameter(Option::SOURCE, $commandLinePaths);
             $this->setFilesWithoutExtensionParameter($commandLinePaths);
             return $commandLinePaths;
         }

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -286,6 +286,6 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         }
 
         $fixtureBasename = pathinfo($trimmedFixtureFilePath, PATHINFO_BASENAME);
-        return $inputFileDirectory . '/' . $fixtureBasename;
+        return $inputFileDirectory . DIRECTORY_SEPARATOR . $fixtureBasename;
     }
 }

--- a/src/Util/FilePath.php
+++ b/src/Util/FilePath.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Util;
+
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+
+/**
+ * @see \Rector\Tests\Util\FilePathTest
+ */
+final class FilePath
+{
+    public static function fileIsInRectorPathOrSource(string $file): bool
+    {
+        foreach (SimpleParameterProvider::provideArrayParameter(Option::SOURCE) as $source) {
+            if ($source === $file) {
+                return true;
+            }
+        }
+
+        $paths = SimpleParameterProvider::provideArrayParameter(Option::PATHS);
+        $pathToCheck = realpath(dirname($file)) . DIRECTORY_SEPARATOR;
+
+        foreach ($paths as $path) {
+            if (str_starts_with(realpath($path) . DIRECTORY_SEPARATOR, $pathToCheck)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Util/FilePathTest.php
+++ b/tests/Util/FilePathTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Util;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Util\FilePath;
+
+final class FilePathTest extends AbstractLazyTestCase
+{
+    protected function tearDown(): void
+    {
+        SimpleParameterProvider::setParameter(Option::SOURCE, []);
+        SimpleParameterProvider::setParameter(Option::PATHS, []);
+    }
+
+    /**
+     * @param list<string> $source
+     * @param list<string> $paths
+     */
+    #[DataProvider('provideValidDataForFileIsInRectorPathOrSource')]
+    public function testFileIsInRectorPathOrSource(string $file, array $source, array $paths): void
+    {
+        SimpleParameterProvider::setParameter(Option::SOURCE, $source);
+        SimpleParameterProvider::setParameter(Option::PATHS, $paths);
+        $this->assertTrue(FilePath::fileIsInRectorPathOrSource($file));
+    }
+
+    /**
+     * @param list<string> $source
+     * @param list<string> $paths
+     */
+    #[DataProvider('provideInvalidDataForFileIsInRectorPathOrSource')]
+    public function testFileIsNotInRectorPathOrSource(string $file, array $source, array $paths): void
+    {
+        SimpleParameterProvider::setParameter(Option::SOURCE, $source);
+        SimpleParameterProvider::setParameter(Option::PATHS, $paths);
+        $this->assertFalse(FilePath::fileIsInRectorPathOrSource($file));
+    }
+
+    /**
+     * @return iterable<string, array<string|list<string>>>
+     */
+    public static function provideValidDataForFileIsInRectorPathOrSource(): iterable
+    {
+        yield 'file is in source' => [__DIR__ . '/file.php', [__DIR__ . '/file.php'], []];
+        yield 'file directory is in path' => [__DIR__ . '/file.php', [], [__DIR__]];
+    }
+
+    /**
+     * @return iterable<string, array<string|list<string>>>
+     */
+    public static function provideInvalidDataForFileIsInRectorPathOrSource(): iterable
+    {
+        yield 'file is in not in source' => [__DIR__ . '/file.php', [__DIR__ . '/file2.php'], []];
+        yield 'file directory is not in path' => [__DIR__ . '/file.php', [], [__DIR__ . 'WithSuffix']];
+    }
+}


### PR DESCRIPTION
Found the idea yesterday from @boesing and didn't find a rector rule for it. 

In this PR we would rename the cases of a Enum to PascalCase and add a post rector to change the usages of all changed enums. 

I have some open Question about my PR because i'm not very familar with the PostRector stuff.
- Do i really need a e2e test to check, that i do not modify a Enum that was not changed in the run by rector already? 
- How should i optimize the perfomance of the PostRector that this should not run every time and not for every node? 