### PR TITLE
[Config] Handle config realpath() actually has asterisk, not pattern

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -230,7 +230,11 @@ final class RectorConfig extends Container
 
     public function import(string $filePath): void
     {
-        if (str_contains($filePath, '*')) {
+        /**
+         * Only stop when filePath realpath is false and contains glob patterns
+         * @see https://github.com/rectorphp/rector/issues/9156#issuecomment-2869130541
+         */
+        if (realpath($filePath) === false && str_contains($filePath, '*')) {
             throw new ShouldNotHappenException(
                 'Matching file paths by using glob-patterns is no longer supported. Use specific file path instead.'
             );


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/9156#issuecomment-2869130541
Fixes https://github.com/rectorphp/rector/issues/9156

with directory structure:

```
➜  ~ tree -L 2 com.example.\* 

com.example.*
└── some-other
    └── projectdir
```

**Before**

```
➜  projectdir vendor/bin/rector
                                                                                                                   
 [ERROR] Matching file paths by using glob-patterns is no longer supported. Use specific file path instead.             
```

**After**

```
➜  projectdir vendor/bin/rector 
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                      
```

Reproduced on macOS