### PR TITLE
Bump to PHPStan ^2.1.15 and revert tweak __toString() native type on ClassChildAnalyzer

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.14"
+        "phpstan/phpstan": "^2.1.15"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0.2",
-        "phpstan/phpstan": "^2.1.14",
+        "phpstan/phpstan": "^2.1.15",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",

--- a/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -4,24 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\FamilyTree\NodeAnalyzer;
 
-use PhpParser\Node;
-use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
-use Rector\PhpParser\AstResolver;
 
 final readonly class ClassChildAnalyzer
 {
-    public function __construct(
-        private AstResolver $astResolver
-    ) {
-    }
-
     /**
      * Look both parent class and interface, yes, all PHP interface methods are abstract
      */
@@ -52,14 +42,8 @@ final readonly class ClassChildAnalyzer
         }
 
         foreach ($parentClassMethods as $parentClassMethod) {
-            // for downgrade purpose on __toString
-            // @see https://3v4l.org/kdcEh#v7.4.33
-            // @see https://github.com/phpstan/phpstan-src/commit/3854cbc5748a7cb51ee0b86ceffe29bd0564bc98
-            if ($parentClassMethod->getDeclaringClass()->isBuiltIn() || $methodName !== '__toString') {
-                $nativeReturnType = $this->resolveNativeType($parentClassMethod);
-            } else {
-                $nativeReturnType = $this->resolveToStringNativeTypeFromAstResolver($parentClassMethod);
-            }
+            $parametersAcceptor = ParametersAcceptorSelector::combineAcceptors($parentClassMethod->getVariants());
+            $nativeReturnType = $parametersAcceptor->getNativeReturnType();
 
             if (! $nativeReturnType instanceof MixedType) {
                 return $nativeReturnType;
@@ -67,27 +51,6 @@ final readonly class ClassChildAnalyzer
         }
 
         return new MixedType();
-    }
-
-    private function resolveNativeType(PhpMethodReflection $phpMethodReflection): Type
-    {
-        $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors($phpMethodReflection->getVariants());
-        return $extendedParametersAcceptor->getNativeReturnType();
-    }
-
-    private function resolveToStringNativeTypeFromAstResolver(PhpMethodReflection $phpMethodReflection): Type
-    {
-        $classReflection = $phpMethodReflection->getDeclaringClass();
-        $class = $this->astResolver->resolveClassFromClassReflection($classReflection);
-
-        if ($class instanceof ClassLike) {
-            $classMethod = $class->getMethod($phpMethodReflection->getName());
-            if ($classMethod instanceof ClassMethod && ! $classMethod->returnType instanceof Node) {
-                return new MixedType();
-            }
-        }
-
-        return new StringType();
     }
 
     /**


### PR DESCRIPTION
Previous **PHPStan 2.1.14** introduce regression that needs tweak on PR on previous PR:

- https://github.com/rectorphp/rector-src/pull/6879

On **PHPStan 2.1.15**, the patch for it sent there:

- https://github.com/phpstan/phpstan-src/pull/3979

so this tweak no longer needed.