### PR TITLE
Simple grammar typo

### DIFF
--- a/src/Validation/RectorConfigValidator.php
+++ b/src/Validation/RectorConfigValidator.php
@@ -69,7 +69,7 @@ final class RectorConfigValidator
         }
 
         throw new ShouldNotHappenException(
-            'These rules from "$rectorConfig->skip()" does not exist - remove them or fix their names:' . PHP_EOL . $nonExistingRulesString
+            'These rules from "$rectorConfig->skip()" do not exist - remove them or fix their names:' . PHP_EOL . $nonExistingRulesString
         );
     }
 


### PR DESCRIPTION
s/does/do

![CleanShot 2025-05-15 at 06 33 01@2x](https://github.com/user-attachments/assets/59556f67-d9c5-443e-bed9-9a1909a1f5b9)

(Note, I checked #6898 and this does not overlap/conflict with that) 
