### PR TITLE
[CodeQuality] Skip Assign Op on ternary on SimplifyUselessVariableRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/Fixture/skip_ternary.php.inc
+++ b/rules-tests/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector/Fixture/skip_ternary.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector\Fixture;
+
+class SkipTernary
+{
+    public function run(?string $maybe, string $part): string
+    {
+       $address = $maybe;
+       $address .= $address ? ' - ' . $part : $part;
+
+       return $address;
+    }
+}

--- a/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector.php
+++ b/rules/CodeQuality/Rector/FunctionLike/SimplifyUselessVariableRector.php
@@ -8,6 +8,7 @@ use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
@@ -190,6 +191,10 @@ CODE_SAMPLE
         }
 
         if ($this->onlyDirectAssign && $previousNode instanceof AssignOp) {
+            return true;
+        }
+
+        if ($previousNode instanceof AssignOp && $previousNode->expr instanceof Ternary) {
             return true;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9179