### PR TITLE
[Application] Move autoload and paths setup to ApplicationFileProcessor

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -129,7 +129,7 @@ final class ApplicationFileProcessor
         /** @var FileDiff[] $fileDiffs */
         $fileDiffs = [];
 
-        // avoid registered autoload input, paths, and config paths here gone on parallel
+        // avoid registered autoload input setup gone on parallel
         if ($input instanceof InputInterface) {
             $this->additionalAutoloader->autoloadInput($input);
         }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Console\Command;
 
 use Rector\Application\ApplicationFileProcessor;
-use Rector\Autoloading\AdditionalAutoloader;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
 use Rector\Configuration\ConfigInitializer;
@@ -33,7 +32,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class ProcessCommand extends Command
 {
     public function __construct(
-        private readonly AdditionalAutoloader $additionalAutoloader,
         private readonly ChangedFilesDetector $changedFilesDetector,
         private readonly ConfigInitializer $configInitializer,
         private readonly ApplicationFileProcessor $applicationFileProcessor,
@@ -94,9 +92,6 @@ EOF
         if ($configuration->getOutputFormat() === JsonOutputFormatter::NAME) {
             $this->symfonyStyle->setVerbosity(OutputInterface::VERBOSITY_QUIET);
         }
-
-        $this->additionalAutoloader->autoloadInput($input);
-        $this->additionalAutoloader->autoloadPaths();
 
         $paths = $configuration->getPaths();
 

--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -45,7 +45,7 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
      */
     public function addFiles(array $files): void
     {
-        $this->filePaths = array_merge($this->filePaths, $files);
+        $this->filePaths = array_unique(array_merge($this->filePaths, $files));
     }
 
     /**
@@ -53,7 +53,7 @@ final class DynamicSourceLocatorProvider implements ResetableInterface
      */
     public function addDirectories(array $directories): void
     {
-        $this->directories = array_merge($this->directories, $directories);
+        $this->directories = array_unique(array_merge($this->directories, $directories));
     }
 
     public function provide(): SourceLocator


### PR DESCRIPTION
@marcelthole @boesing while working on alternative PR for EnumCaseToPascalCaseRector:

- https://github.com/rectorphp/rector-src/pull/6899

I realized that when autoload provided, on parallel, the registered autoload input setup gone on parallel. This PR ensure it always included, as on parallel, that means it separate process.

- [x] to avoid setup autoload via `-a` gone on parallel because of separate process.
- [x] ensure the check of 

https://github.com/rectorphp/rector-src/blob/b29132bd65fd8b5adb7226daedc9d22e5214595b/src/Console/Command/ProcessCommand.php#L120

only check registered paths via `withPaths()` or path provided by command, not include `autoloadPaths()` because of no paths defined, but defined withPaths() is empty, it never empty:

```php
->withPaths([]) // empty, should STOP, but because we have autoload paths defined
->withAutoloadPaths([__DIR__  . '/../some/file.php']);
```

and below added too early:

⇓

https://github.com/rectorphp/rector-src/blob/b29132bd65fd8b5adb7226daedc9d22e5214595b/src/Console/Command/ProcessCommand.php#L99

it make never empty.

------

**Last but not least:**

I am thinking of discussing the usage of `autoloadPaths()` more properly, since it currently mix between "autoload" or "include files provided to be analyzed".

https://github.com/rectorphp/rector-src/blob/b29132bd65fd8b5adb7226daedc9d22e5214595b/src/Autoloading/AdditionalAutoloader.php#L40-L44

but that's **different PR** to discuss to keep match with current documentation

https://getrector.com/documentation/static-reflection-and-autoload#content-register