### PR TITLE
Bump to PHPStan 2.1.17 and handle unknown class "PHPStan\\Broker\\ClassAutoloadingException"

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.15"
+        "phpstan/phpstan": "^2.1.17"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^2.9",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.0.2",
-        "phpstan/phpstan": "^2.1.15",
+        "phpstan/phpstan": "^2.1.17",
         "react/event-loop": "^1.5",
         "react/promise": "^3.2",
         "react/socket": "^1.15",

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -129,15 +129,11 @@ final class VisibilityManipulator
         return $this->hasVisibility($node, Visibility::READONLY);
     }
 
-    public function removeReadonly(Class_ | Property | Param | New_ $node): void
+    public function removeReadonly(Class_ | Property | Param $node): void
     {
         $isConstructorPromotionBefore = $node instanceof Param && $node->isPromoted();
 
-        if (! $node instanceof New_) {
-            $node->flags &= ~Modifiers::READONLY;
-        } elseif ($node->class instanceof Class_) {
-            $node->class->flags &= ~Modifiers::READONLY;
-        }
+        $node->flags &= ~Modifiers::READONLY;
 
         $isConstructorPromotionAfter = $node instanceof Param && $node->isPromoted();
 

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Privatization\NodeManipulator;
 
 use PhpParser\Modifiers;
-use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -24,7 +24,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\UnionType as NodeUnionType;
 use PHPStan\Analyser\Scope;
-use PHPStan\Broker\ClassAutoloadingException;
+use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -130,7 +130,7 @@ final class NodeTypeResolver
         if ($resolvedType instanceof ObjectType) {
             try {
                 return $this->resolveObjectType($resolvedType, $requiredObjectType);
-            } catch (ClassAutoloadingException) {
+            } catch (ClassNotFoundException) {
                 // in some type checks, the provided type in rector.php configuration does not have to exists
                 return false;
             }


### PR DESCRIPTION
Latest new PHPStan cause error:

```

  src/NodeTypeResolver/NodeTypeResolver.php:133
 ------------------------------------------------------------------------
  - '#Caught class PHPStan\\Broker\\ClassAutoloadingException not found#'
  🪪 class.notFound
 ------------------------------------------------------------------------
```

This PR try to fix it.

Also Closes https://github.com/rectorphp/rector-src/pull/6917 which the issue detected.