### PR TITLE
[Php82] Handle implicit public readonly on ReadOnlyClassRector

### DIFF
--- a/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/implicit_public_readonly_property.php.inc
+++ b/rules-tests/Php82/Rector/Class_/ReadOnlyClassRector/Fixture/implicit_public_readonly_property.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final class ImplicitPublicReadonlyProperty
+{
+    readonly string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'bar';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
+
+final readonly class ImplicitPublicReadonlyProperty
+{
+    public string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'bar';
+    }
+}
+
+?>

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -139,9 +139,13 @@ final class VisibilityManipulator
         if ($node instanceof Param && $isConstructorPromotionBefore && ! $isConstructorPromotionAfter) {
             $this->makePublic($node);
         }
+
+        if ($node instanceof Property) {
+            $this->publicize($node);
+        }
     }
 
-    public function publicize(ClassConst|ClassMethod $node): ClassConst|ClassMethod|null
+    public function publicize(ClassConst|ClassMethod|Property $node): ClassConst|ClassMethod|Property|null
     {
         // already non-public
         if (! $node->isPublic()) {


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/6895

this handle on property, that cause crash:

```
Parse error: syntax error, unexpected identifier "string", expecting "function"
```

Ref https://3v4l.org/JTelr
Ref https://getrector.com/demo/61b8bb24-c87f-4e92-97f2-b326d3051e55