### PR TITLE
[Test] Add test for crash after reprint Stmt

### DIFF
--- a/tests/Issues/ChangeSwitchTernary/Source/AnotherExpressionRector.php
+++ b/tests/Issues/ChangeSwitchTernary/Source/AnotherExpressionRector.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\ChangeSwitchTernary\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Expression;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AnotherExpressionRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        // fetch for testing crash no scope after reprint
+        ScopeFetcher::fetch($node);
+
+        return null;
+    }
+}

--- a/tests/Issues/ChangeSwitchTernary/config/configured_rule.php
+++ b/tests/Issues/ChangeSwitchTernary/config/configured_rule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\Expression\TernaryFalseExpressionToIfRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\Tests\Issues\ChangeSwitchTernary\Source\AnotherExpressionRector;
 
 return RectorConfig::configure()
-    ->withRules([ChangeSwitchToMatchRector::class, TernaryFalseExpressionToIfRector::class]);
+    ->withRules([ChangeSwitchToMatchRector::class, TernaryFalseExpressionToIfRector::class, AnotherExpressionRector::class]);


### PR DESCRIPTION
This add test for `RectifiedAnalyzer::isJustReprintedOverlappedTokenStart()` on no scope after re-print due to seems phpstan can't detect reprinted stmt:

https://github.com/rectorphp/rector-src/blob/9f3665ae712294588cb9f1d1001c6efc1ad8683b/src/ProcessAnalyzer/RectifiedAnalyzer.php#L85

if the check removed, the code got error:

```php
There was 1 error:

1) Rector\Tests\Issues\ChangeSwitchTernary\ChangeSwitchTernaryTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Exception\ShouldNotHappenException: Scope not available on "PhpParser\Node\Stmt\Expression" node. Fix scope refresh on changed nodes first
```

This test ensure the code in place tested in place.