### PR TITLE
[Command] Fix to make additionalAutoloader->autoloadPaths() works on both parallel and non-parallel proccess

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -96,7 +96,6 @@ EOF
         }
 
         $this->additionalAutoloader->autoloadInput($input);
-        $this->additionalAutoloader->autoloadPaths();
 
         $paths = $configuration->getPaths();
 
@@ -142,6 +141,13 @@ EOF
             );
 
             return ExitCode::FAILURE;
+        }
+
+        // autoload paths is register to DynamicSourceLocatorProvider,
+        // so check after arePathsEmpty() above
+        // check in no parallel since parallel will require register on its own process
+        if (! $configuration->isParallel()) {
+            $this->additionalAutoloader->autoloadPaths();
         }
 
         // show debug info

--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -10,6 +10,7 @@ use React\EventLoop\StreamSelectLoop;
 use React\Socket\ConnectionInterface;
 use React\Socket\TcpConnector;
 use Rector\Application\ApplicationFileProcessor;
+use Rector\Autoloading\AdditionalAutoloader;
 use Rector\Configuration\ConfigurationFactory;
 use Rector\Configuration\ConfigurationRuleFilter;
 use Rector\Console\ProcessConfigureDecorator;
@@ -42,6 +43,7 @@ final class WorkerCommand extends Command
     private const RESULT = 'result';
 
     public function __construct(
+        private readonly AdditionalAutoloader $additionalAutoloader,
         private readonly DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator,
         private readonly ApplicationFileProcessor $applicationFileProcessor,
         private readonly MemoryLimiter $memoryLimiter,
@@ -100,6 +102,7 @@ final class WorkerCommand extends Command
         Configuration $configuration,
         OutputInterface $output
     ): void {
+        $this->additionalAutoloader->autoloadPaths();
         $this->dynamicSourceLocatorDecorator->addPaths($configuration->getPaths());
 
         if ($configuration->isDebug()) {


### PR DESCRIPTION
This patch is variant version of PR for `autoloadPaths()` from config.

- https://github.com/rectorphp/rector-src/pull/6915

Do the followings:

- ensure `additionalAutoloader->autoloadPaths()` called after `$this->dynamicSourceLocatorDecorator->arePathsEmpty()` on `ProcessCommand` 

https://github.com/rectorphp/rector-src/blob/7feb6c8375ec82bafd6640c1385baf8d80d2fe15/src/Console/Command/ProcessCommand.php#L120

since it register to `DynamicSourceLocatorProvider` via

https://github.com/rectorphp/rector-src/blob/7feb6c8375ec82bafd6640c1385baf8d80d2fe15/src/Autoloading/AdditionalAutoloader.php#L40-L44

- make run it on parallel as well, since it different process on its own