### PR TITLE
Temporary pin symfony/service-contracts to 3.5.1

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -17,6 +17,9 @@ return $config
     // ensure use version ^3.2.0
     ->ignoreErrorsOnPackage('composer/pcre', [ErrorType::UNUSED_DEPENDENCY])
 
+    // temporary pin to avoid downgrade error
+    ->ignoreErrorsOnPackage('symfony/service-contracts', [ErrorType::UNUSED_DEPENDENCY])
+
     ->ignoreErrorsOnPaths([
         __DIR__ . '/stubs',
         __DIR__ . '/tests',

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "symfony/process": "^6.4",
         "symplify/easy-parallel": "^11.2.2",
         "symplify/rule-doc-generator-contracts": "^11.2",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.11",
+        "symfony/service-contracts": "3.5.1"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.4",


### PR DESCRIPTION
Latest 3.6.0 https://github.com/symfony/service-contracts/releases/tag/v3.6.0 seems cause downgrade error:

https://github.com/rectorphp/rector-src/actions/runs/15243096830/job/42865604088#step:14:72

