### PR TITLE
Revert "Temporary pin symfony/service-contracts to 3.5.1"

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -17,9 +17,6 @@ return $config
     // ensure use version ^3.2.0
     ->ignoreErrorsOnPackage('composer/pcre', [ErrorType::UNUSED_DEPENDENCY])
 
-    // temporary pin to avoid downgrade error
-    ->ignoreErrorsOnPackage('symfony/service-contracts', [ErrorType::UNUSED_DEPENDENCY])
-
     ->ignoreErrorsOnPaths([
         __DIR__ . '/stubs',
         __DIR__ . '/tests',

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
         "symfony/process": "^6.4",
         "symplify/easy-parallel": "^11.2.2",
         "symplify/rule-doc-generator-contracts": "^11.2",
-        "webmozart/assert": "^1.11",
-        "symfony/service-contracts": "3.5.1"
+        "webmozart/assert": "^1.11"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.4",


### PR DESCRIPTION
Reverts rectorphp/rector-src#6930

This should be handled on downgrade process now:

- https://github.com/rectorphp/rector-downgrade-php/pull/282