### PR TITLE
Allow the ExplicitNullableParamTypeRector from PHP 7.1 onwards

### DIFF
--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -18,7 +18,7 @@ use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
-use Rector\ValueObject\PhpVersionFeature;
+use Rector\ValueObject\PhpVersion;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -102,6 +102,7 @@ CODE_SAMPLE
 
     public function provideMinPhpVersion(): int
     {
-        return PhpVersionFeature::DEPRECATE_IMPLICIT_NULLABLE_PARAM_TYPE;
+        // works with PHP 7.1 and higher, ref https://3v4l.org/IhRki
+        return PhpVersion::PHP_71;
     }
 }


### PR DESCRIPTION
ExplicitNullableParamTypeRector works with PHP 7.1 and higher,
ref https://3v4l.org/IhRki

![grafik](https://github.com/user-attachments/assets/332f2947-58d0-405c-a168-bff00cae97e0)
