### PR TITLE
[CodeQuality] Skip late static binding use on CompleteDynamicPropertiesRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/skip_late_static_binding.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/skip_late_static_binding.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+abstract class SkipLateStaticBinding
+{
+    public const PRIMARY_KEY = 'id';
+
+    public function insert(): void
+    {
+        $this->{static::PRIMARY_KEY} = 1;
+    }
+}

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Function_;

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\NodeVisitor;
@@ -135,7 +136,7 @@ final readonly class LocalPropertyAnalyzer
             return true;
         }
 
-        return $propertyFetch->name instanceof Variable;
+        return ! $propertyFetch->name instanceof Identifier;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9195
Closes https://github.com/rectorphp/rector-src/pull/6937
Ref https://getrector.com/demo/42658105-dc72-482a-8985-d438a3957fdf