### PR TITLE
[TypeDeclaration] Handle crash on return different over static on AddReturnTypeDeclarationRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/Fixture/return_different_over_static.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/Fixture/return_different_over_static.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture;
+
+final class ReturnDifferentOverStatic
+{
+    public function transform(): string
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture;
+
+final class ReturnDifferentOverStatic
+{
+    public function transform(): static
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector/config/configured_rule.php
@@ -10,6 +10,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
 use Rector\Config\RectorConfig;
 use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture\ReturnDifferentOverStatic;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture\ReturnOfStatic;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture\ReturnTheMixed;
 use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector\Fixture\SkipAlreadyStaticReturn;
@@ -41,6 +42,11 @@ return static function (RectorConfig $rectorConfig): void {
                 SkipAlreadyStaticReturn::class,
                 'transform',
                 new SimpleStaticType(SkipAlreadyStaticReturn::class)
+            ),
+            new AddReturnTypeDeclaration(
+                ReturnDifferentOverStatic::class,
+                'transform',
+                new SimpleStaticType(ReturnDifferentOverStatic::class)
             ),
         ]);
 };


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/6940

this cover if return is diffferent.

Ref https://getrector.com/demo/4cf6551b-e7ff-44ba-9e00-36e53bdfa037