### PR TITLE
[DeadCode] Add RemoveArgumentFromDefaultParentCallRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Source\SomeParentClass;
+
+final class Fixture extends SomeParentClass
+{
+    final public function __construct(string $differentParam)
+    {
+        init($differentParam);
+
+        parent::__construct([]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Source\SomeParentClass;
+
+final class Fixture extends SomeParentClass
+{
+    final public function __construct(string $differentParam)
+    {
+        init($differentParam);
+
+        parent::__construct();
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/skip_different_value.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/skip_different_value.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDefaultArgumentFromParentCallRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Source\SomeParentClass;
+
+final class SkipDifferentValue extends SomeParentClass
+{
+    final public function __construct(string $differentParam)
+    {
+        init($differentParam);
+
+        parent::__construct(['some value']);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/skip_dynamic_from_param.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/skip_dynamic_from_param.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDefaultArgumentFromParentCallRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Source\SomeParentClass;
+
+final class SkipDynamicFromParam extends SomeParentClass
+{
+    final public function __construct(string $differentParam, array $params = [])
+    {
+        init($differentParam);
+
+        parent::__construct($params);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/RemoveArgumentFromDefaultParentCallRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/RemoveArgumentFromDefaultParentCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveArgumentFromDefaultParentCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Source/SomeParentClass.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Source/SomeParentClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Source;
+
+class SomeParentClass
+{
+    public function __construct(array $params = [])
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveArgumentFromDefaultParentCallRector::class]);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\ClassMethod;
+
+use PHPStan\Reflection\ClassReflection;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Expression;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\NodeAnalyzer\ExprAnalyzer;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\RemoveArgumentFromDefaultParentCallRectorTest
+ */
+final class RemoveArgumentFromDefaultParentCallRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly ValueResolver $valueResolver,
+        private readonly ExprAnalyzer $exprAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove default argument from parent call',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeParent
+{
+    public function __construct(array $param = [])
+    {
+    }
+}
+
+class ChildClass extends SomeParent
+{
+    public function __construct(string $differentParam)
+    {
+        init($differentParam);
+
+        parent::__construct([]);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeParent
+{
+    public function __construct(array $param = [])
+    {
+    }
+}
+
+class ChildClass extends SomeParent
+{
+    public function __construct(string $differentParam)
+    {
+        init($differentParam);
+
+        parent::__construct();
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+
+        if (!$classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        $ancestors = array_filter(
+            $classReflection->getAncestors(),
+            fn (ClassReflection $ancestorClassReflection): bool => $classReflection->isClass() && $ancestorClassReflection->getName() !== $classReflection->getName()
+        );
+
+        $hasChanged = false;
+        foreach ($node->getMethods() as $classMethod) {
+            if ($classMethod->isPrivate()) {
+                continue;
+            }
+
+            if ($classMethod->isAbstract()) {
+                continue;
+            }
+
+            foreach ((array) $classMethod->stmts as $stmt) {
+                if (! $stmt instanceof Expression) {
+                    continue;
+                }
+
+                if (! $stmt->expr instanceof StaticCall) {
+                    continue;
+                }
+
+                if (! $this->isName($stmt->expr->class, 'parent')) {
+                    continue;
+                }
+
+                if ($stmt->expr->isFirstClassCallable()) {
+                    continue;
+                }
+
+                $args = $stmt->expr->getArgs();
+
+                if ($args === []) {
+                    continue;
+                }
+
+                if ($this->argsAnalyzer->hasNamedArg($args)) {
+                    continue;
+                }
+
+                $methodName = $this->getName($stmt->expr->name);
+                if ($methodName === null) {
+                    continue;
+                }
+
+                foreach ($ancestors as $ancestor) {
+                    $nativeClassReflection = $ancestor->getNativeReflection();
+                    if (! $nativeClassReflection->hasMethod($methodName)) {
+                        continue;
+                    }
+
+                    $method = $nativeClassReflection->getMethod($methodName);
+
+                    $parameters = $method->getParameters();
+                    $totalParameters = count($parameters);
+                    $justChanged = false;
+
+                    for ($index = $totalParameters - 1; $index >= 0; --$index) {
+                        if (! $parameters[$index]->isDefaultValueAvailable()) {
+                            break;
+                        }
+
+                        // already passed
+                        if (! isset($args[$index])) {
+                            break;
+                        }
+
+                        // only literal values
+                        if ($this->exprAnalyzer->isDynamicExpr($args[$index]->value)) {
+                            break;
+                        }
+
+                        $defaultValue = $parameters[$index]->getDefaultValue();
+                        if ($defaultValue === $this->valueResolver->getValue($args[$index]->value)) {
+                            unset($args[$index]);
+                            $hasChanged = true;
+                            $justChanged = true;
+                        }
+                    }
+
+                    if ($justChanged) {
+                        $stmt->expr->args = array_values($args);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -14,6 +14,7 @@ use Rector\DeadCode\Rector\BooleanAnd\RemoveAndTrueRector;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassConst\RemoveUnusedPrivateClassConstantRector;
 use Rector\DeadCode\Rector\ClassLike\RemoveTypedPropertyNonMockDocblockRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
@@ -136,5 +137,7 @@ final class DeadCodeLevel
         RemoveUnusedConstructorParamRector::class,
         RemoveEmptyClassMethodRector::class,
         RemoveDeadReturnRector::class,
+
+        RemoveArgumentFromDefaultParentCallRector::class,
     ];
 }

--- a/src/Exception/ShouldNotHappenException.php
+++ b/src/Exception/ShouldNotHappenException.php
@@ -5,20 +5,19 @@ declare(strict_types=1);
 namespace Rector\Exception;
 
 use Exception;
-use Throwable;
 
 final class ShouldNotHappenException extends Exception
 {
     /**
      * @param int $code
      */
-    public function __construct(string $message = '', $code = 0, ?Throwable $throwable = null)
+    public function __construct(string $message = '', $code = 0)
     {
         if ($message === '') {
             $message = $this->createDefaultMessageWithLocation();
         }
 
-        parent::__construct($message, $code, $throwable);
+        parent::__construct($message, $code);
     }
 
     private function createDefaultMessageWithLocation(): string

--- a/src/Exception/ShouldNotHappenException.php
+++ b/src/Exception/ShouldNotHappenException.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace Rector\Exception;
 
 use Exception;
+use Throwable;
 
 final class ShouldNotHappenException extends Exception
 {
     /**
      * @param int $code
      */
-    public function __construct(string $message = '', $code = 0)
+    public function __construct(string $message = '', $code = 0, ?Throwable $throwable = null)
     {
         if ($message === '') {
             $message = $this->createDefaultMessageWithLocation();
         }
 
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $throwable);
     }
 
     private function createDefaultMessageWithLocation(): string

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -56,7 +56,7 @@ final class BetterStandardPrinter extends Standard
     public function __construct(
         private readonly ExprAnalyzer $exprAnalyzer
     ) {
-        parent::__construct([]);
+        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
This to remove argument from `parent::` call when argument value is equal with parent default value on exactly same position.

```diff
-parent::__construct([]);
+parent::__construct();
```

when parent method is exactly have same value with default:

```php
class SomeParent
{
    public function __construct(array $params = [])
    {
    }
}
```