### PR TITLE
[DeadCode] Allow remove createMock method call on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/create_mock_in_test.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/create_mock_in_test.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CreateMockInTest extends TestCase
+{
+    public function test($params)
+    {
+        $tmp = $this->createMock('SomeClass');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CreateMockInTest extends TestCase
+{
+    public function test($params)
+    {
+    }
+}
+
+?>

--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -99,10 +99,7 @@ final readonly class SideEffectNodeDetector
             return false;
         }
 
-        return $this->nodeNameResolver->isNames(
-            $node->name,
-            ['getMock', 'getMockBuilder', 'createMock', 'getMockForAbstractClass']
-        );
+        return $this->nodeNameResolver->isName($node->name, 'createMock');
     }
 
     private function isPhpParser(New_ $new): bool


### PR DESCRIPTION
`createMock()` on test doesn't have side effect, so can be removed if unused.