### PR TITLE
[Php80] Do not change to match(true) on variable from param on case cond on ChangeSwitchToMatchRector

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/defined_case4.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/defined_case4.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+final class FromVariable
+{
+    public static function run($filter, bool $variable = true, bool $variable2 = false)
+    {
+        switch ($filter) {
+            case $variable:
+                $result = 'a';
+                break;
+            case $variable2:
+                $result = 'b';
+                break;
+            default:
+                throw new \InvalidArgumentException();
+        }
+
+        var_dump($result);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+final class FromVariable
+{
+    public static function run($filter, bool $variable = true, bool $variable2 = false)
+    {
+        $result = match ($filter) {
+            $variable => 'a',
+            $variable2 => 'b',
+            default => throw new \InvalidArgumentException(),
+        };
+
+        var_dump($result);
+    }
+}
+
+?>

--- a/rules/Php80/Rector/Switch_/ChangeSwitchToMatchRector.php
+++ b/rules/Php80/Rector/Switch_/ChangeSwitchToMatchRector.php
@@ -18,7 +18,6 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
 use PHPStan\Type\ObjectType;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
-use Rector\NodeAnalyzer\ExprAnalyzer;
 use Rector\Php80\NodeAnalyzer\MatchSwitchAnalyzer;
 use Rector\Php80\NodeFactory\MatchFactory;
 use Rector\Php80\NodeResolver\SwitchExprsResolver;
@@ -40,8 +39,7 @@ final class ChangeSwitchToMatchRector extends AbstractRector implements MinPhpVe
         private readonly SwitchExprsResolver $switchExprsResolver,
         private readonly MatchSwitchAnalyzer $matchSwitchAnalyzer,
         private readonly MatchFactory $matchFactory,
-        private readonly ValueResolver $valueResolver,
-        private readonly ExprAnalyzer $exprAnalyzer
+        private readonly ValueResolver $valueResolver
     ) {
     }
 


### PR DESCRIPTION
Continue of:

- https://github.com/rectorphp/rector-src/pull/6962

the variable definition seems no need to change to match(true), as cause different result, ref

https://3v4l.org/jBE1q vs https://3v4l.org/I4IF9

The exact `Node`: - instanceof or CallLike seems need to be used on this case.