### PR TITLE
[Renaming] [Symfony 7.0] Skip ClassConstFetch that rename its ->class to Interface that constant not exists in new interface

### DIFF
--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/skip_rename_target_interface_class_const_fetch_not_found.php.inc
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/Fixture/skip_rename_target_interface_class_const_fetch_not_found.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\Fixture;
+
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+echo ObjectNormalizer::SKIP_NULL_VALUES;

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/config/configured_rule.php
@@ -58,5 +58,9 @@ return static function (RectorConfig $rectorConfig): void {
              * @see https://github.com/rectorphp/rector-symfony/issues/535
              */
             'Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted' => 'Symfony\Component\Security\Http\Attribute\IsGranted',
+
+            // test skip rename class const fetch when target rename is interface
+            // and interface class const fetch not found
+            'Symfony\Component\Serializer\Normalizer\ObjectNormalizer' => 'Symfony\Component\Serializer\Normalizer\NormalizerInterface',
         ]);
 };

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -22,6 +22,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockClassRenamer;
 use Rector\NodeTypeResolver\ValueObject\OldToNewType;
 use Rector\Renaming\Collector\RenamedNameCollector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\Util\FileHasher;
 
@@ -49,6 +50,10 @@ final class ClassRenamer
      */
     public function renameNode(Node $node, array $oldToNewClasses, ?Scope $scope): ?Node
     {
+        if ($node instanceof FullyQualified && $node->getAttribute(RenameClassRector::SKIPPED_AS_CLASS_CONST_FETCH_CLASS) === true) {
+            return null;
+        }
+
         $oldToNewTypes = $this->createOldToNewTypes($oldToNewClasses);
 
         if ($node instanceof FullyQualified) {

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -29,6 +29,11 @@ use Webmozart\Assert\Assert;
  */
 final class RenameClassRector extends AbstractRector implements ConfigurableRectorInterface
 {
+    /**
+     * @var string
+     */
+    public const SKIPPED_AS_CLASS_CONST_FETCH_CLASS = 'skipped_as_class_const_fetch_class';
+
     public function __construct(
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
         private readonly ClassRenamer $classRenamer,
@@ -107,7 +112,11 @@ CODE_SAMPLE
                         $oldClassReflection = $this->reflectionProvider->getClass($oldClass);
 
                         if ($oldClassReflection->hasConstant($node->name->toString()) && ! $classReflection->hasConstant($node->name->toString())) {
-                            // no constant found on new interface? skip node below ClassConstFetch
+                            // used by ClassRenamer::renameNode()
+                            // that called on ClassRenamingPostRector PostRector
+                            $node->class->setAttribute(self::SKIPPED_AS_CLASS_CONST_FETCH_CLASS, true);
+
+                            // no constant found on new interface? skip node below ClassConstFetch on this rule
                             return NodeVisitor::DONT_TRAVERSE_CHILDREN;
                         }
                     }

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -96,7 +96,7 @@ CODE_SAMPLE
     {
         $oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
         if ($node instanceof ClassConstFetch) {
-            if ($node->class instanceof FullyQualified && $node->name instanceof Identifier) {
+            if ($node->class instanceof FullyQualified && $node->name instanceof Identifier && $this->reflectionProvider->hasClass($node->class->toString())) {
                 foreach ($oldToNewClasses as $oldClass => $newClass) {
                     if ($this->isName($node->class, $oldClass) && $this->reflectionProvider->hasClass($newClass)) {
                         $classReflection = $this->reflectionProvider->getClass($newClass);
@@ -104,7 +104,9 @@ CODE_SAMPLE
                             continue;
                         }
 
-                        if (! $classReflection->hasConstant($node->name->toString())) {
+                        $oldClassReflection = $this->reflectionProvider->getClass($oldClass);
+
+                        if ($oldClassReflection->hasConstant($node->name->toString()) && ! $classReflection->hasConstant($node->name->toString())) {
                             // no constant found on new interface? skip node below ClassConstFetch
                             return NodeVisitor::DONT_TRAVERSE_CHILDREN;
                         }

--- a/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+if (class_exists('Symfony\Component\Serializer\Normalizer\NormalizerInterface')) {
+    return;
+}
+
+interface NormalizerInterface
+{
+}

--- a/stubs/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/stubs/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+if (class_exists('Symfony\Component\Serializer\Normalizer\ObjectNormalizer')) {
+    return;
+}
+
+class ObjectNormalizer
+{
+    public const SKIP_NULL_VALUES = 'skip_null_values';
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-symfony/issues/785