### PR TITLE
[Php80] Prevent adding empty return when stringable always throws

### DIFF
--- a/rules-tests/Php80/Rector/Class_/StringableForToStringRector/Fixture/always_throws.php.inc
+++ b/rules-tests/Php80/Rector/Class_/StringableForToStringRector/Fixture/always_throws.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\StringableForToStringRector\Fixture;
+
+final class DemoFile implements \Stringable
+{
+    public function __toString(): string
+    {
+        throw new \Exception('Not implemented');
+    }
+}
+?>

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
@@ -45,7 +46,7 @@ final class TerminatedNodeAnalyzer
      */
     private const ALLOWED_CONTINUE_CURRENT_STMTS = [InlineHTML::class, Nop::class];
 
-    public function isAlwaysTerminated(StmtsAwareInterface $stmtsAware, Stmt $node, Stmt $currentStmt): bool
+    public function isAlwaysTerminated(StmtsAwareInterface|ClassMethod $stmtsAware, Stmt $node, Stmt $currentStmt): bool
     {
         if (in_array($currentStmt::class, self::ALLOWED_CONTINUE_CURRENT_STMTS, true)) {
             return false;


### PR DESCRIPTION
Prevents adding empty return when stringable always throws. Not sure if this is the right way to fix this.

https://getrector.com/demo/c4c2d42d-16f0-454d-af48-da9f06f84bf6