### PR TITLE
[DeadCode] Clean up useless union StmtsAwareInterface|ClassMethod on TerminatedNodeAnalyzer

### DIFF
--- a/rules/Php80/Rector/Class_/StringableForToStringRector.php
+++ b/rules/Php80/Rector/Class_/StringableForToStringRector.php
@@ -11,9 +11,9 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
@@ -151,7 +151,7 @@ CODE_SAMPLE
 
             $lastStmt = $toStringClassMethod->stmts[count($toStringClassMethod->stmts) - 1] ?? null;
 
-            if ($lastStmt instanceof Expression && $this->terminatedNodeAnalyzer->isAlwaysTerminated($toStringClassMethod, $lastStmt, $emptyStringReturn)) {
+            if ($lastStmt instanceof Stmt && $this->terminatedNodeAnalyzer->isAlwaysTerminated($toStringClassMethod, $lastStmt, $emptyStringReturn)) {
                 return;
             }
 

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
@@ -46,7 +45,7 @@ final class TerminatedNodeAnalyzer
      */
     private const ALLOWED_CONTINUE_CURRENT_STMTS = [InlineHTML::class, Nop::class];
 
-    public function isAlwaysTerminated(StmtsAwareInterface|ClassMethod $stmtsAware, Stmt $node, Stmt $currentStmt): bool
+    public function isAlwaysTerminated(StmtsAwareInterface $stmtsAware, Stmt $node, Stmt $currentStmt): bool
     {
         if (in_array($currentStmt::class, self::ALLOWED_CONTINUE_CURRENT_STMTS, true)) {
             return false;


### PR DESCRIPTION
`ClassMethod` already instanceof `StmtsAwareInterface`, ref https://github.com/rectorphp/rector-src/pull/6968#pullrequestreview-2911707876