### PR TITLE
[PostRector] Clean up rename process on ClassRenamingPostRector

### DIFF
--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -23,7 +23,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockClassRenamer;
 use Rector\NodeTypeResolver\ValueObject\OldToNewType;
 use Rector\Renaming\Collector\RenamedNameCollector;
-use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\Util\FileHasher;
 

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -52,12 +52,12 @@ final class ClassRenamer
     {
         $oldToNewTypes = $this->createOldToNewTypes($oldToNewClasses);
 
-        // place FullyQualified before Name on purpose executed early before the Name as parent
+        // execute FullyQualified before Name on purpose so next Name check is pure Name node
         if ($node instanceof FullyQualified) {
             return $this->refactorName($node, $oldToNewClasses);
         }
 
-        // Name as parent of FullyQualified executed later for fallback annotation to attribute rename to Name
+        // Name as parent of FullyQualified executed for fallback annotation to attribute rename to Name
         if ($node instanceof Name) {
             $phpAttributeName = $node->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
             if (is_string($phpAttributeName)) {

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -6,6 +6,7 @@ namespace Rector\Renaming\NodeManipulator;
 
 use PhpParser\Node;
 use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
@@ -50,14 +51,19 @@ final class ClassRenamer
      */
     public function renameNode(Node $node, array $oldToNewClasses, ?Scope $scope): ?Node
     {
-        if ($node instanceof FullyQualified && $node->getAttribute(RenameClassRector::SKIPPED_AS_CLASS_CONST_FETCH_CLASS) === true) {
-            return null;
-        }
-
         $oldToNewTypes = $this->createOldToNewTypes($oldToNewClasses);
 
         if ($node instanceof FullyQualified) {
             return $this->refactorName($node, $oldToNewClasses);
+        }
+
+        if ($node instanceof Name) {
+            $phpAttributeName = $node->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
+            if (is_string($phpAttributeName)) {
+                return $this->refactorName(new FullyQualified($phpAttributeName), $oldToNewClasses);
+            }
+
+            return null;
         }
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -52,10 +52,12 @@ final class ClassRenamer
     {
         $oldToNewTypes = $this->createOldToNewTypes($oldToNewClasses);
 
+        // place FullyQualified before Name on purpose executed early before the Name as parent
         if ($node instanceof FullyQualified) {
             return $this->refactorName($node, $oldToNewClasses);
         }
 
+        // Name as parent of FullyQualified executed later for fallback annotation to attribute rename to Name
         if ($node instanceof Name) {
             $phpAttributeName = $node->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
             if (is_string($phpAttributeName)) {

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -150,9 +150,8 @@ CODE_SAMPLE
 
             $oldClassReflection = $this->reflectionProvider->getClass($oldClass);
 
-            if ($oldClassReflection->hasConstant($classConstFetch->name->toString()) && ! $classReflection->hasConstant(
-                $classConstFetch->name->toString()
-            )) {
+            if ($oldClassReflection->hasConstant($classConstFetch->name->toString())
+                && ! $classReflection->hasConstant($classConstFetch->name->toString())) {
                 // no constant found on new interface? skip node below ClassConstFetch on this rule
                 return NodeVisitor::DONT_TRAVERSE_CHILDREN;
             }

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -128,9 +128,9 @@ CODE_SAMPLE
      */
     private function processClassConstFetch(ClassConstFetch $classConstFetch, array $oldToNewClasses): int|null
     {
-        if (! $classConstFetch->class instanceof FullyQualified || ! $classConstFetch->name instanceof Identifier || ! $this->reflectionProvider->hasClass(
-            $classConstFetch->class->toString()
-        )) {
+        if (! $classConstFetch->class instanceof FullyQualified
+            || ! $classConstFetch->name instanceof Identifier
+            || ! $this->reflectionProvider->hasClass($classConstFetch->class->toString())) {
             return null;
         }
 

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -92,7 +92,8 @@ final class ExprAnalyzer
         }
 
         $nativeType = $scope->getNativeType($expr);
-        return $nativeType->isBoolean()->yes();
+        return $nativeType->isBoolean()
+            ->yes();
     }
 
     /**

--- a/src/PostRector/Rector/ClassRenamingPostRector.php
+++ b/src/PostRector/Rector/ClassRenamingPostRector.php
@@ -5,31 +5,23 @@ declare(strict_types=1);
 namespace Rector\PostRector\Rector;
 
 use PhpParser\Node;
-use PhpParser\Node\Name;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
-use PHPStan\Analyser\Scope;
 use Rector\CodingStyle\Application\UseImportsRemover;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\RenamedClassesDataCollector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Renaming\Collector\RenamedNameCollector;
-use Rector\Renaming\NodeManipulator\ClassRenamer;
 
 final class ClassRenamingPostRector extends AbstractPostRector
 {
-    private FileWithoutNamespace|Namespace_|null $rootNode = null;
-
     /**
      * @var array<string, string>
      */
     private array $oldToNewClasses = [];
 
     public function __construct(
-        private readonly ClassRenamer $classRenamer,
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
         private readonly UseImportsRemover $useImportsRemover,
         private readonly RenamedNameCollector $renamedNameCollector
@@ -42,40 +34,20 @@ final class ClassRenamingPostRector extends AbstractPostRector
      */
     public function beforeTraverse(array $nodes): array
     {
-        // ensure reset early on every run to avoid reuse existing value
-        $this->rootNode = $this->resolveRootNode($nodes);
+        if (! SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_NAMES)) {
+            return $nodes;
+        }
+
+        foreach ($nodes as $node) {
+            if ($node instanceof FileWithoutNamespace || $node instanceof Namespace_) {
+                $removedUses = $this->renamedClassesDataCollector->getOldClasses();
+                $node->stmts = $this->useImportsRemover->removeImportsFromStmts($node->stmts, $removedUses);
+
+                break;
+            }
+        }
 
         return $nodes;
-    }
-
-    public function enterNode(Node $node): ?Node
-    {
-        // no longer need post rename
-        if (! $node instanceof Name) {
-            return null;
-        }
-
-        /** @var Scope|null $scope */
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-
-        if ($node instanceof FullyQualified) {
-            $result = $this->classRenamer->renameNode($node, $this->oldToNewClasses, $scope);
-        } else {
-            $result = $this->resolveResultWithPhpAttributeName($node, $scope);
-        }
-
-        if (! SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_NAMES)) {
-            return $result;
-        }
-
-        if (! $this->rootNode instanceof FileWithoutNamespace && ! $this->rootNode instanceof Namespace_) {
-            return $result;
-        }
-
-        $removedUses = $this->renamedClassesDataCollector->getOldClasses();
-        $this->rootNode->stmts = $this->useImportsRemover->removeImportsFromStmts($this->rootNode->stmts, $removedUses);
-
-        return $result;
     }
 
     /**
@@ -93,33 +65,5 @@ final class ClassRenamingPostRector extends AbstractPostRector
         $this->oldToNewClasses = $this->renamedClassesDataCollector->getOldToNewClasses();
 
         return $this->oldToNewClasses !== [];
-    }
-
-    private function resolveResultWithPhpAttributeName(Name $name, ?Scope $scope): ?FullyQualified
-    {
-        $phpAttributeName = $name->getAttribute(AttributeKey::PHP_ATTRIBUTE_NAME);
-        if (is_string($phpAttributeName)) {
-            return $this->classRenamer->renameNode(
-                new FullyQualified($phpAttributeName, $name->getAttributes()),
-                $this->oldToNewClasses,
-                $scope
-            );
-        }
-
-        return null;
-    }
-
-    /**
-     * @param Stmt[] $nodes
-     */
-    private function resolveRootNode(array $nodes): FileWithoutNamespace|Namespace_|null
-    {
-        foreach ($nodes as $node) {
-            if ($node instanceof FileWithoutNamespace || $node instanceof Namespace_) {
-                return $node;
-            }
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
- [x] Make rename procces to **only** happen on `RenameClassRector`
- [x] **Remove** rename process on `ClassRenamingPostRector`
- [x] Make `ClassRenamingPostRector` only doing post process remove use statement from renamed code on auto import enabled:

```php
    $removedUses = $this->renamedClassesDataCollector->getOldClasses();
    $node->stmts = $this->useImportsRemover->removeImportsFromStmts($node->stmts, $removedUses);
```