### PR TITLE
[Alternative 1] Add withTreatClassesAsFinal() on RectorConfigBuilder so can be used in typed rules

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -44,4 +44,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     // allow real paths in output formatters
     $rectorConfig->reportingRealPath(false);
+
+    $rectorConfig->treatClassesAsFinal(false);
 };

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/FixtureMarkedAsFinal/normal_class_as_final.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/FixtureMarkedAsFinal/normal_class_as_final.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\FixtureMarkedAsFinal;
+
+class NormalClassAsFinal
+{
+    public const A = 'A';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\FixtureMarkedAsFinal;
+
+class NormalClassAsFinal
+{
+    public const string A = 'A';
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/WithTreatClassesAsFinalTest.php
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/WithTreatClassesAsFinalTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class WithTreatClassesAsFinalTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureMarkedAsFinal');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_marked_classes_as_final.php';
+    }
+}

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/config/configured_rule_marked_classes_as_final.php
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/config/configured_rule_marked_classes_as_final.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddTypeToConstRector::class);
+    $rectorConfig->treatClassesAsFinal(true);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
+};

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -224,7 +224,7 @@ CODE_SAMPLE
     private function canBeInherited(ClassConst $classConst, Class_ $class): bool
     {
         // as classes marked as final just by pass final/private check
-        if (SimpleParameterProvider::provideBoolParameter(Option::TREAT_CLASSES_AS_FINAL) === true) {
+        if (SimpleParameterProvider::provideBoolParameter(Option::TREAT_CLASSES_AS_FINAL)) {
             return false;
         }
 

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -21,6 +21,8 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -221,6 +223,11 @@ CODE_SAMPLE
 
     private function canBeInherited(ClassConst $classConst, Class_ $class): bool
     {
+        // as classes marked as final just by pass final/private check
+        if (SimpleParameterProvider::provideBoolParameter(Option::TREAT_CLASSES_AS_FINAL) === true) {
+            return false;
+        }
+
         return ! $class->isFinal() && ! $classConst->isPrivate() && ! $classConst->isFinal();
     }
 }

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -316,6 +316,11 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::NEW_LINE_ON_FLUENT_CALL, $enabled);
     }
 
+    public function treatClassesAsFinal(bool $treatClassesAsFinal = true): void
+    {
+        SimpleParameterProvider::setParameter(Option::TREAT_CLASSES_AS_FINAL, $treatClassesAsFinal);
+    }
+
     /**
      * @param string[] $extensions
      */

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -281,6 +281,12 @@ final class Option
     public const EDITOR_URL = 'editor_url';
 
     /**
+     * @internal Use @see \Rector\Config\RectorConfig::treatClassesAsFinal() method
+     * @var string
+     */
+    public const TREAT_CLASSES_AS_FINAL = 'treat_classes_as_final';
+
+    /**
      * @internal To report composer based loaded sets
      * @see \Rector\Configuration\RectorConfigBuilder::withComposerBased()
      * @var string

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -151,6 +151,8 @@ final class RectorConfigBuilder
 
     private ?bool $isFluentNewLine = null;
 
+    private ?bool $isTreatClassesAsFinal = null;
+
     /**
      * @var RegisteredService[]
      */
@@ -359,6 +361,10 @@ final class RectorConfigBuilder
 
         if ($this->isFluentNewLine !== null) {
             $rectorConfig->newLineOnFluentCall($this->isFluentNewLine);
+        }
+
+        if ($this->isTreatClassesAsFinal !== null) {
+            $rectorConfig->treatClassesAsFinal($this->isTreatClassesAsFinal);
         }
 
         if ($this->reportingRealPath !== null) {
@@ -1154,6 +1160,12 @@ final class RectorConfigBuilder
     public function withFluentCallNewLine(bool $isFluentNewLine = true): self
     {
         $this->isFluentNewLine = $isFluentNewLine;
+        return $this;
+    }
+
+    public function withTreatClassesAsFinal(bool $isTreatClassesAsFinal = true): self
+    {
+        $this->isTreatClassesAsFinal = $isTreatClassesAsFinal;
         return $this;
     }
 


### PR DESCRIPTION
@TomasVotruba this is the 1st alternative for 

- https://github.com/rectorphp/rector/issues/9213

The option checked direclty on `AddTypeToConstRector`. 

**This is more destructive since config set globally, and can be used anywhere in any rules, which should be on end user that decide on specific rule.**

I will create 2nd PR for define `inline_public` config on the `AddTypeToConstRector` rule itself.