### PR TITLE
[Alternative 2] Make AddTypeToConstRector configurable to set inline_public config to allow non-final class to have typed constant

### DIFF
--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/FixtureInlinePublic/fixture.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/FixtureInlinePublic/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
+class Fixture
+{
+    public const VALUE = 1;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
+
+class Fixture
+{
+    public const int VALUE = 1;
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/InlinePublicTest.php
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/InlinePublicTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class InlinePublicTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureInlinePublic');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_inline_public.php';
+    }
+}

--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/config/configured_rule_inline_public.php
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/config/configured_rule_inline_public.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AddTypeToConstRector::class, [
+       AddTypeToConstRector::INLINE_PUBLIC => true,
+    ]);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
+};


### PR DESCRIPTION
@TomasVotruba this is the 2nd alternative for 

- https://github.com/rectorphp/rector/issues/9213

The make `AddTypeToConstRector` so user can define `inline_public` theirself when needed to allow non-final class to have typed constant only on the `AddTypeToConstRector`.

**I prefer this option, as this feel less destructive, and more inline with other typed rules:**

- https://getrector.com/rule-detail/class-property-assign-to-constructor-promotion-rector
- https://getrector.com/rule-detail/typed-property-from-assigns-rector

which has `inline_public` config that user can toggle on/off per specific rule.