### PR TITLE
[DeadCode] Skip used by unpack and named argument on RemoveUnusedPrivateMethodParameterRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_named_argument.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_named_argument.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
+
+class SkipNamedArgument
+{
+    public function run(bool $param): void
+    {
+        $this->isTrue(value: $param, text: 'test');
+    }
+
+    private function isTrue(string $text, bool $value): bool
+    {
+        return $value === true;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_unpack_argument.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_unpack_argument.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
+
+class SkipUnpackArgument
+{
+    public function run(bool $param): void
+    {
+        $this->isTrue(...['test', $param]);
+    }
+
+    private function isTrue(string $text, bool $value): bool
+    {
+        return $value === true;
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector.php
@@ -7,6 +7,7 @@ namespace Rector\DeadCode\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -92,6 +93,11 @@ CODE_SAMPLE
                 continue;
             }
 
+            // early remove callers
+            if (! $this->removeCallerArgs($node, $classMethod, $unusedParameters)) {
+                continue;
+            }
+
             $unusedParameterPositions = array_keys($unusedParameters);
             foreach (array_keys($classMethod->params) as $key) {
                 if (! in_array($key, $unusedParameterPositions, true)) {
@@ -105,7 +111,6 @@ CODE_SAMPLE
             $classMethod->params = array_values($classMethod->params);
 
             $this->clearPhpDocInfo($classMethod, $unusedParameters);
-            $this->removeCallerArgs($node, $classMethod, $unusedParameters);
 
             $hasChanged = true;
         }
@@ -120,28 +125,44 @@ CODE_SAMPLE
     /**
      * @param Param[] $unusedParameters
      */
-    private function removeCallerArgs(Class_ $class, ClassMethod $classMethod, array $unusedParameters): void
+    private function removeCallerArgs(Class_ $class, ClassMethod $classMethod, array $unusedParameters): bool
     {
         $classMethods = $class->getMethods();
         if ($classMethods === []) {
-            return;
+            return false;
         }
 
         $methodName = $this->getName($classMethod);
         $keysArg = array_keys($unusedParameters);
 
         $classObjectType = new ObjectType((string) $this->getName($class));
+        $callers = [];
         foreach ($classMethods as $classMethod) {
             /** @var MethodCall[]|StaticCall[] $callers */
-            $callers = $this->resolveCallers($classMethod, $methodName, $classObjectType);
-            if ($callers === []) {
-                continue;
+            $callers = array_merge($callers, $this->resolveCallers($classMethod, $methodName, $classObjectType));
+        }
+
+        foreach ($callers as $caller) {
+            if ($caller->isFirstClassCallable()) {
+                return false;
             }
 
-            foreach ($callers as $caller) {
-                $this->cleanupArgs($caller, $keysArg);
+            foreach ($caller->getArgs() as $arg) {
+                if ($arg->unpack) {
+                    return false;
+                }
+
+                if ($arg->name instanceof Identifier) {
+                    return false;
+                }
             }
         }
+
+        foreach ($callers as $caller) {
+            $this->cleanupArgs($caller, $keysArg);
+        }
+
+        return true;
     }
 
     /**
@@ -149,10 +170,6 @@ CODE_SAMPLE
      */
     private function cleanupArgs(MethodCall|StaticCall $call, array $keysArg): void
     {
-        if ($call->isFirstClassCallable()) {
-            return;
-        }
-
         $args = $call->getArgs();
         foreach (array_keys($args) as $key) {
             if (in_array($key, $keysArg, true)) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9214