### PR TITLE
[DeadCode] Handle multiple default on RemoveArgumentFromDefaultParentCallRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/multiple_default.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector/Fixture/multiple_default.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Fixture;
+
+use Exception;
+
+final class MultipleDefault extends Exception
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 0, null);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector\Fixture;
+
+use Exception;
+
+final class MultipleDefault extends Exception
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
@@ -176,7 +176,7 @@ CODE_SAMPLE
                             break;
                         }
 
-                        // next is not removed, then current can't be removed
+                        // on decrement loop, when next arg is not removed, then current can't be removed
                         if (isset($args[$index + 1])) {
                             break;
                         }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
@@ -176,6 +176,11 @@ CODE_SAMPLE
                             break;
                         }
 
+                        // next is not removed, then current can't be removed
+                        if (isset($args[$index + 1])) {
+                            break;
+                        }
+
                         $defaultValue = $parameters[$index]->getDefaultValue();
                         if ($defaultValue === $this->valueResolver->getValue($args[$index]->value)) {
                             unset($args[$index]);

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -92,6 +92,18 @@ final class ValueResolver
         }
 
         if ($expr instanceof ConstFetch) {
+            if ($this->isNull($expr)) {
+                return null;
+            }
+
+            if ($this->isTrue($expr)) {
+                return true;
+            }
+
+            if ($this->isFalse($expr)) {
+                return false;
+            }
+
             return $this->nodeNameResolver->getName($expr);
         }
 


### PR DESCRIPTION
On this code:

```php
final class MultipleDefault extends Exception
{
    public function __construct(string $message)
    {
        parent::__construct($message, 0, null);
    }
}
```


`0` and `null` are default parameters, so both needs to be removed.

```diff
-        parent::__construct($message, 0, null);
+        parent::__construct($message);
```