### PR TITLE
[PhpAttribute] Ensure count($attributeGroups) !== 1 check before loop to avoid repetitive annotation produce only single AttributeGroup on GenericAnnotationToAttributeConverter

### DIFF
--- a/src/PhpAttribute/GenericAnnotationToAttributeConverter.php
+++ b/src/PhpAttribute/GenericAnnotationToAttributeConverter.php
@@ -87,11 +87,15 @@ final readonly class GenericAnnotationToAttributeConverter
 
         $attributeGroups = $this->attrGroupsFactory->create($doctrineTagAndAnnotationToAttributes, $uses);
 
+        if (count($attributeGroups) !== 1) {
+            return null;
+        }
+
         foreach ($doctrineTagValueNodes as $doctrineTagValueNode) {
             $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $doctrineTagValueNode);
         }
 
-        return $attributeGroups[0] ?? null;
+        return $attributeGroups[0];
     }
 
     private function isExistingAttributeClass(AnnotationToAttribute $annotationToAttribute): bool


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6984#pullrequestreview-2929914935 , single AttributeGrup result, or skip.