### PR TITLE
[CodeQuality] Skip first class callable on TernaryImplodeToImplodeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Ternary/TernaryImplodeToImplodeRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/TernaryImplodeToImplodeRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\TernaryImplodeToImplodeRector\Fixture;
+
+class SkipFirstClassCallable
+{
+    public function run(array $values)
+    {
+        return $values === [] ? '' : implode(...);
+    }
+}

--- a/rules/CodeQuality/Rector/Ternary/TernaryImplodeToImplodeRector.php
+++ b/rules/CodeQuality/Rector/Ternary/TernaryImplodeToImplodeRector.php
@@ -92,6 +92,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->else->isFirstClassCallable()) {
+            return null;
+        }
+
         $function = $node->else;
         $secondArg = $function->getArgs()[1] ?? null;
 


### PR DESCRIPTION
Avoid error:

```
There was 1 failure:

1) Rector\Tests\CodeQuality\Rector\Ternary\TernaryImplodeToImplodeRector\TernaryImplodeToImplodeRectorTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:32
```