### PR TITLE
Cleanup ReflectionResolver

### DIFF
--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -268,17 +268,7 @@ final readonly class ReflectionResolver
 
         $classReflection = $this->reflectionProvider->getClass($className);
 
-        if (! $classReflection->hasProperty($propertyName)) {
-            return null;
-        }
-
-        $scope = $propertyFetch->getAttribute(AttributeKey::SCOPE);
-        if ($scope instanceof Scope) {
-            $propertyReflection = $classReflection->getProperty($propertyName, $scope);
-            if ($propertyReflection instanceof PhpPropertyReflection) {
-                return $propertyReflection;
-            }
-
+        if (! $classReflection->hasNativeProperty($propertyName)) {
             return null;
         }
 


### PR DESCRIPTION
`instanceof PhpPropertyReflection` is a PHPStan implementation detail which can change in minor versions. it should not be relied on.