### PR TITLE
[DeadCode] Fix: Array Duplicated Key which is dynamic

### DIFF
--- a/rules-tests/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector/Fixture/skip_call_like_keys.php.inc
+++ b/rules-tests/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector/Fixture/skip_call_like_keys.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Array_\RemoveDuplicatedArrayKeyRector\Fixture;
+
+class SkipMethodAndFunctCalls
+{
+    public function lists()
+    {
+        $items = [
+            rand() => 'A',
+            rand() => 'A',
+        ];
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector/Fixture/skip_property_fetch.php.inc
+++ b/rules-tests/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector/Fixture/skip_property_fetch.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Array_\RemoveDuplicatedArrayKeyRector\Fixture;
+
+class SkipMethodAndFunctCalls
+{
+    public function __get(string $name)
+    {
+        return rand();
+    }
+
+    public function lists()
+    {
+        $items = [
+            $this->foo => 'A',
+            $this->foo => 'A',
+        ];
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector.php
+++ b/rules/DeadCode/Rector/Array_/RemoveDuplicatedArrayKeyRector.php
@@ -8,8 +8,10 @@ use PhpParser\Node;
 use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\PreDec;
 use PhpParser\Node\Expr\PreInc;
+use PhpParser\Node\Expr\PropertyFetch;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -91,6 +93,14 @@ CODE_SAMPLE
             }
 
             if (! $arrayItem->key instanceof Expr) {
+                continue;
+            }
+
+            if ($arrayItem->key instanceof CallLike) {
+                continue;
+            }
+
+            if ($arrayItem->key instanceof PropertyFetch) {
                 continue;
             }
 


### PR DESCRIPTION
# Changes

- Adds two test fixtures for RemoveDuplicatedArrayKeyRector
- RemoveDuplicatedArrayKeyRector to ignore keys that use CallLike keys or PropertyFetches

# Why

I found this dead code rule could end up removing array keys if the key was set by a method call, function call or a property fetch that might be dynamic. There might be a way to allow these options back by using PHPStan to look for constant values returned by the dynamic call but for now I think it best to just exclude them so the rule is less likely to remove intended user code.