### PR TITLE
[Php83] Ensure class->isAbstract() on FeatureFlags::treatClassesAsFinal() check

### DIFF
--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -71,6 +71,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Class_
     {
+        if ($node->isAbstract()) {
+            return null;
+        }
+
         if (! $node->isFinal() && FeatureFlags::treatClassesAsFinal() === false) {
             return null;
         }

--- a/rules/CodeQuality/Rector/New_/NewStaticToNewSelfRector.php
+++ b/rules/CodeQuality/Rector/New_/NewStaticToNewSelfRector.php
@@ -60,6 +60,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->isAbstract()) {
+            return null;
+        }
+
         if (! $node->isFinal() && FeatureFlags::treatClassesAsFinal() === false) {
             return null;
         }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
     private function shouldSkipNonFinalNonPrivateClassMethod(Class_ $class, ClassMethod $classMethod): bool
     {
         if ($class->isFinal() || FeatureFlags::treatClassesAsFinal()) {
-            return false;
+            return $class->isAbstract();
         }
 
         if ($classMethod->isMagic()) {

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -223,7 +223,7 @@ CODE_SAMPLE
     private function canBeInherited(ClassConst $classConst, Class_ $class): bool
     {
         if (FeatureFlags::treatClassesAsFinal()) {
-            return false;
+            return $class->isAbstract();
         }
 
         return ! $class->isFinal() && ! $classConst->isPrivate() && ! $classConst->isFinal();


### PR DESCRIPTION
`abstract` class never can be marked as "final", so this check will always needed.

Ref https://github.com/rectorphp/rector-src/pull/7002#pullrequestreview-2942549135