### PR TITLE
[TypeDeclaration] Handle crash on generic iterable on TypedPropertyFromJMSSerializerAttributeTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromJMSSerializerAttributeTypeRector/Fixture/skip_generic_iterable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromJMSSerializerAttributeTypeRector/Fixture/skip_generic_iterable.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromJMSSerializerAttributeTypeRector\Fixture;
+
+final class SkipGenericIterable
+{
+    #[\JMS\Serializer\Annotation\Type('iterable<SomeType>')]
+    private $name;
+}

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromJMSSerializerAttributeTypeRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromJMSSerializerAttributeTypeRector.php
@@ -152,6 +152,11 @@ CODE_SAMPLE
                 $typeValue = 'DateTime';
             }
 
+            // skip generic iterable types
+            if (str_starts_with($typeValue, 'iterable<')) {
+                continue;
+            }
+
             $type = $this->scalarStringToTypeMapper->mapScalarStringToType($typeValue);
             if ($type instanceof MixedType) {
                 // fallback to object type


### PR DESCRIPTION
Given the following code:

```php
final class SkipGenericIterable
{
    #[\JMS\Serializer\Annotation\Type('iterable<SomeType>')]
    private $name;
}
```

It cause change:

```diff
-    private $name;
+    private ?\iterable<SomeType> $name = null;
```

which make crash:

```
ParseError: syntax error, unexpected token "<", expecting "," or ";"
```

see https://3v4l.org/3foP0 