### PR TITLE
[DeadCode] Covers scenario where func_get_args used in constructor for RemoveUnusedConstructorParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/skip_used_by_get_func_args.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedConstructorParamRector/Fixture/skip_used_by_get_func_args.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector\Fixture;
+
+final class SkipUsedByGetFuncArgs
+{
+    public $data;
+
+    public function __construct($hey, $man)
+    {
+        $this->data = func_get_args();
+    }
+}

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -51,6 +51,10 @@ final readonly class ParamAnalyzer
                 return NodeVisitor::STOP_TRAVERSAL;
             }
 
+            if ($this->isFuncGetArgsCall($node)) {
+                $isParamUsed = true;
+            }
+
             if ($this->isUsedAsArg($node, $param)) {
                 $isParamUsed = true;
             }
@@ -163,5 +167,18 @@ final readonly class ParamAnalyzer
 
         $arguments = $this->funcCallManipulator->extractArgumentsFromCompactFuncCalls([$node]);
         return $this->nodeNameResolver->isNames($param, $arguments);
+    }
+
+    private function isFuncGetArgsCall(Node $node): bool
+    {
+        if (! $node instanceof Node\Expr\FuncCall) {
+            return false;
+        }
+
+        if (! $this->nodeNameResolver->isName($node, 'func_get_args')) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
# Changes

- Adds a new check in ParamAnalyzer to look for the use of `func_get_args` within a method
- Adds a test fixture for RemoveUnusedConstructorParamRector to skip when `func_get_args`

# Why

I found this issue popping up if `func_get_args` was used in a constructor. In theory there's also `func_get_arg(int position)` to consider as well but it's a question of either:

1. refactor the analyzer to consider param position or
2. just outright skip any methods that use `func_get_arg()` as well