### PR TITLE
[TypeDeclaration] Add missing isAbstract() check on FeatureFlags::treatClassesAsFinal() on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
@@ -131,7 +131,7 @@ CODE_SAMPLE
             return true;
         }
 
-        $isClassFinal = $class->isFinal() || FeatureFlags::treatClassesAsFinal();
+        $isClassFinal = $class->isFinal() || (FeatureFlags::treatClassesAsFinal() && ! $class->isAbstract());
 
         return $isClassFinal && ! $class->extends instanceof Name && $class->implements === [] && $classMethod->isProtected();
     }


### PR DESCRIPTION
continue of PR:

- https://github.com/rectorphp/rector-src/pull/7003

abstract class never can be treated as final.