### PR TITLE
[Scoped] Exclude DateRangeError on Scoper for prefixing

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -34,6 +34,9 @@ return [
         'PHPUnit\Framework\Constraint\IsEqual',
         'PHPUnit\Framework\TestCase',
         'PHPUnit\Framework\ExpectationFailedException',
+
+        // native class on php 8.3+
+        'DateRangeError',
     ],
     'exclude-namespaces' => [
         '#^Rector#',


### PR DESCRIPTION
`DateRangeError` is exists since php 8.3 https://www.php.net/manual/en/class.daterangeerror.php

and on try catch, it prefixed on scoper

https://github.com/rectorphp/rector/commit/f2731d9bf9de8ddefc7703a3a91fc515531ca7b7#diff-cdf34bc65c6dda223722cef24654b7b4e8da5ce72c11ec9451e5c2af12c95557

this should be excluded so it can be cached on match php version.