### PR TITLE
[Php55] Avoid $scope = ScopeFetcher::fetch($node); when not needed on GetCalledClassToStaticClassRector

### DIFF
--- a/rules/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector.php
+++ b/rules/Php55/Rector/FuncCall/GetCalledClassToStaticClassRector.php
@@ -59,11 +59,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $scope = ScopeFetcher::fetch($node);
         if (! $this->isName($node, 'get_called_class')) {
             return null;
         }
 
+        $scope = ScopeFetcher::fetch($node);
         if (! $scope->isInClass()) {
             return null;
         }


### PR DESCRIPTION
This is quick fix for:

- Fixes https://github.com/rectorphp/rector/issues/9235