### PR TITLE
[code-quality] Make ctor defined dynamic properties private, as most probably case

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/constructor_private.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/constructor_private.php.inc
@@ -18,7 +18,7 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 
 class ConstructorPrivate
 {
-    private $value;
+    private string $value;
     public function __construct()
     {
         $this->value = 'classStringCaseInSensitive';

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/constructor_private.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/constructor_private.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+class ConstructorPrivate
+{
+    public function __construct()
+    {
+        $this->value = 'classStringCaseInSensitive';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+class ConstructorPrivate
+{
+    private $value;
+    public function __construct()
+    {
+        $this->value = 'classStringCaseInSensitive';
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/setup_private.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/setup_private.php.inc
@@ -18,6 +18,7 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 
 final class SetupPrivate
 {
+    private int $initialValue;
     public function setUp()
     {
         $this->initialValue = 123;

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/setup_private.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/setup_private.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+final class SetupPrivate
+{
+    public function setUp()
+    {
+        $this->initialValue = 123;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+final class SetupPrivate
+{
+    public function setUp()
+    {
+        $this->initialValue = 123;
+    }
+}
+
+?>

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -166,7 +166,7 @@ final readonly class LocalPropertyAnalyzer
     {
         $definedPropertiesWithTypesByPropertyName = [];
         foreach ($definedPropertiesWithTypes as $definedPropertyWithType) {
-            $definedPropertiesWithTypesByPropertyName[$definedPropertyWithType->getPropertyName()][] = $definedPropertyWithType;
+            $definedPropertiesWithTypesByPropertyName[$definedPropertyWithType->getName()][] = $definedPropertyWithType;
         }
 
         $normalizedDefinedPropertiesWithTypes = [];

--- a/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
+++ b/rules/CodeQuality/NodeAnalyzer/LocalPropertyAnalyzer.php
@@ -17,8 +17,8 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\NodeVisitor;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\Type;
 use Rector\CodeQuality\TypeResolver\ArrayDimFetchTypeResolver;
+use Rector\CodeQuality\ValueObject\DefinedPropertyWithType;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -44,53 +44,73 @@ final readonly class LocalPropertyAnalyzer
     }
 
     /**
-     * @return array<string, Type>
+     * @return DefinedPropertyWithType[]
      */
     public function resolveFetchedPropertiesToTypesFromClass(Class_ $class): array
     {
-        $fetchedLocalPropertyNameToTypes = [];
+        $definedPropertiesWithTypes = [];
 
-        $this->simpleCallableNodeTraverser->traverseNodesWithCallable($class->getMethods(), function (Node $node) use (
-            &$fetchedLocalPropertyNameToTypes
-        ): ?int {
-            if ($this->shouldSkip($node)) {
-                return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-            }
+        foreach ($class->getMethods() as $classMethod) {
+            $methodName = $this->nodeNameResolver->getName($classMethod);
 
-            if ($node instanceof Assign && ($node->var instanceof PropertyFetch || $node->var instanceof ArrayDimFetch)) {
-                $propertyFetch = $node->var;
+            $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+                $classMethod->getStmts(),
+                function (Node $node) use (&$definedPropertiesWithTypes, $methodName): ?int {
+                    if ($this->shouldSkip($node)) {
+                        return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                    }
 
-                $propertyName = $this->resolvePropertyName(
-                    $propertyFetch instanceof ArrayDimFetch ? $propertyFetch->var : $propertyFetch
-                );
+                    if ($node instanceof Assign && ($node->var instanceof PropertyFetch || $node->var instanceof ArrayDimFetch)) {
+                        $propertyFetch = $node->var;
 
-                if ($propertyName === null) {
-                    return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-                }
+                        $propertyName = $this->resolvePropertyName(
+                            $propertyFetch instanceof ArrayDimFetch ? $propertyFetch->var : $propertyFetch
+                        );
 
-                if ($propertyFetch instanceof ArrayDimFetch) {
-                    $fetchedLocalPropertyNameToTypes[$propertyName][] = $this->arrayDimFetchTypeResolver->resolve(
-                        $propertyFetch,
-                        $node
+                        if ($propertyName === null) {
+                            return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                        }
+
+                        if ($propertyFetch instanceof ArrayDimFetch) {
+                            $propertyType = $this->arrayDimFetchTypeResolver->resolve($propertyFetch, $node);
+
+                            $definedPropertiesWithTypes[] = new DefinedPropertyWithType(
+                                $propertyName,
+                                $propertyType,
+                                $methodName
+                            );
+
+                            return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                        }
+
+                        $propertyType = $this->nodeTypeResolver->getType($node->expr);
+
+                        $definedPropertiesWithTypes[] = new DefinedPropertyWithType(
+                            $propertyName,
+                            $propertyType,
+                            $methodName
+                        );
+
+                        return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                    }
+
+                    $propertyName = $this->resolvePropertyName($node);
+                    if ($propertyName === null) {
+                        return null;
+                    }
+
+                    $definedPropertiesWithTypes[] = new DefinedPropertyWithType(
+                        $propertyName,
+                        new MixedType(),
+                        $methodName
                     );
-                    return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+
+                    return null;
                 }
+            );
+        }
 
-                $fetchedLocalPropertyNameToTypes[$propertyName][] = $this->nodeTypeResolver->getType($node->expr);
-                return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-            }
-
-            $propertyName = $this->resolvePropertyName($node);
-            if ($propertyName === null) {
-                return null;
-            }
-
-            $fetchedLocalPropertyNameToTypes[$propertyName][] = new MixedType();
-
-            return null;
-        });
-
-        return $this->normalizeToSingleType($fetchedLocalPropertyNameToTypes);
+        return $this->normalizeToSingleType($definedPropertiesWithTypes);
     }
 
     private function shouldSkip(Node $node): bool
@@ -139,18 +159,40 @@ final readonly class LocalPropertyAnalyzer
     }
 
     /**
-     * @param array<string, Type[]> $propertyNameToTypes
-     * @return array<string, Type>
+     * @param DefinedPropertyWithType[] $definedPropertiesWithTypes
+     * @return DefinedPropertyWithType[]
      */
-    private function normalizeToSingleType(array $propertyNameToTypes): array
+    private function normalizeToSingleType(array $definedPropertiesWithTypes): array
     {
-        // normalize types to union
-        $propertyNameToType = [];
-        foreach ($propertyNameToTypes as $name => $types) {
-            $propertyNameToType[$name] = $this->typeFactory->createMixedPassedOrUnionType($types);
+        $definedPropertiesWithTypesByPropertyName = [];
+        foreach ($definedPropertiesWithTypes as $definedPropertyWithType) {
+            $definedPropertiesWithTypesByPropertyName[$definedPropertyWithType->getPropertyName()][] = $definedPropertyWithType;
         }
 
-        return $propertyNameToType;
+        $normalizedDefinedPropertiesWithTypes = [];
+
+        foreach ($definedPropertiesWithTypesByPropertyName as $propertyName => $definedPropertiesWithTypes) {
+            if (count($definedPropertiesWithTypes) === 1) {
+                $normalizedDefinedPropertiesWithTypes[] = $definedPropertiesWithTypes[0];
+                continue;
+            }
+
+            $propertyTypes = [];
+            foreach ($definedPropertiesWithTypes as $definedPropertyWithType) {
+                /** @var DefinedPropertyWithType $definedPropertyWithType */
+                $propertyTypes[] = $definedPropertyWithType->getType();
+            }
+
+            $normalizePropertyType = $this->typeFactory->createMixedPassedOrUnionType($propertyTypes);
+            $normalizedDefinedPropertiesWithTypes[] = new DefinedPropertyWithType(
+                $propertyName,
+                $normalizePropertyType,
+                // skip as multiple places can define the same property
+                null
+            );
+        }
+
+        return $normalizedDefinedPropertiesWithTypes;
     }
 
     /**

--- a/rules/CodeQuality/NodeAnalyzer/MissingPropertiesResolver.php
+++ b/rules/CodeQuality/NodeAnalyzer/MissingPropertiesResolver.php
@@ -9,11 +9,11 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\CodeQuality\ValueObject\DefinedPropertyWithType;
 use Rector\NodeAnalyzer\PropertyPresenceChecker;
 
-final class MissingPropertiesResolver
+final readonly class MissingPropertiesResolver
 {
     public function __construct(
-        private readonly ClassLikeAnalyzer $classLikeAnalyzer,
-        private readonly PropertyPresenceChecker $propertyPresenceChecker,
+        private ClassLikeAnalyzer $classLikeAnalyzer,
+        private PropertyPresenceChecker $propertyPresenceChecker,
     ) {
     }
 
@@ -29,12 +29,12 @@ final class MissingPropertiesResolver
 
         foreach ($definedPropertiesWithTypes as $definedPropertyWithType) {
             // 1. property already exists, skip it
-            if (in_array($definedPropertyWithType->getPropertyName(), $existingPropertyNames, true)) {
+            if (in_array($definedPropertyWithType->getName(), $existingPropertyNames, true)) {
                 continue;
             }
 
             // 2. is part of class docblock or another magic, skip it
-            if ($classReflection->hasProperty($definedPropertyWithType->getPropertyName())) {
+            if ($classReflection->hasProperty($definedPropertyWithType->getName())) {
                 continue;
             }
 

--- a/rules/CodeQuality/NodeAnalyzer/MissingPropertiesResolver.php
+++ b/rules/CodeQuality/NodeAnalyzer/MissingPropertiesResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\NodeAnalyzer;
+
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Reflection\ClassReflection;
+use Rector\CodeQuality\ValueObject\DefinedPropertyWithType;
+use Rector\NodeAnalyzer\PropertyPresenceChecker;
+
+final class MissingPropertiesResolver
+{
+    public function __construct(
+        private readonly ClassLikeAnalyzer $classLikeAnalyzer,
+        private readonly PropertyPresenceChecker $propertyPresenceChecker,
+    ) {
+    }
+
+    /**
+     * @param DefinedPropertyWithType[] $definedPropertiesWithTypes
+     * @return DefinedPropertyWithType[]
+     */
+    public function resolve(Class_ $class, ClassReflection $classReflection, array $definedPropertiesWithTypes): array
+    {
+        $existingPropertyNames = $this->classLikeAnalyzer->resolvePropertyNames($class);
+
+        $missingPropertiesWithTypes = [];
+
+        foreach ($definedPropertiesWithTypes as $definedPropertyWithType) {
+            // 1. property already exists, skip it
+            if (in_array($definedPropertyWithType->getPropertyName(), $existingPropertyNames, true)) {
+                continue;
+            }
+
+            // 2. is part of class docblock or another magic, skip it
+            if ($classReflection->hasProperty($definedPropertyWithType->getPropertyName())) {
+                continue;
+            }
+
+            // 3. is fetched by parent class on non-private property etc., skip it
+            $hasClassContextProperty = $this->propertyPresenceChecker->hasClassContextProperty(
+                $class,
+                $definedPropertyWithType
+            );
+
+            if ($hasClassContextProperty) {
+                continue;
+            }
+
+            // it's most likely missing!
+            $missingPropertiesWithTypes[] = $definedPropertyWithType;
+        }
+
+        return $missingPropertiesWithTypes;
+    }
+}

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -41,9 +41,7 @@ final readonly class MissingPropertiesFactory
 
             if ($this->isFromAlwaysDefinedMethod(
                 $definedPropertyWithType
-            ) && $this->phpVersionProvider->isAtLeastPhpVersion(
-                PhpVersionFeature::TYPED_PROPERTIES
-            )) {
+            ) && $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
                 $propertyType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
                     $definedPropertyWithType->getType(),
                     TypeKind::PROPERTY

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\NodeFactory;
 
 use PhpParser\Modifiers;
+use PhpParser\Node;
 use PhpParser\Node\PropertyItem;
 use PhpParser\Node\Stmt\Property;
 use Rector\CodeQuality\ValueObject\DefinedPropertyWithType;
@@ -36,7 +37,7 @@ final readonly class MissingPropertiesFactory
                 : Modifiers::PUBLIC;
 
             $property = new Property($visibilityModifier, [
-                new PropertyItem($definedPropertyWithType->getPropertyName()),
+                new PropertyItem($definedPropertyWithType->getName()),
             ]);
 
             if ($this->isFromAlwaysDefinedMethod(
@@ -46,7 +47,7 @@ final readonly class MissingPropertiesFactory
                     $definedPropertyWithType->getType(),
                     TypeKind::PROPERTY
                 );
-                if ($propertyType instanceof \PhpParser\Node) {
+                if ($propertyType instanceof Node) {
                     $property->type = $propertyType;
                     $newProperties[] = $property;
 

--- a/rules/CodeQuality/ValueObject/DefinedPropertyWithType.php
+++ b/rules/CodeQuality/ValueObject/DefinedPropertyWithType.php
@@ -4,21 +4,23 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\ValueObject;
 
+use PHPStan\Type\Type;
+
 final readonly class DefinedPropertyWithType
 {
     public function __construct(
         private string $propertyName,
-        private \PHPStan\Type\Type $type,
+        private Type $type,
         private ?string $definedInMethodName
     ) {
     }
 
-    public function getPropertyName(): string
+    public function getName(): string
     {
         return $this->propertyName;
     }
 
-    public function getType(): \PHPStan\Type\Type
+    public function getType(): Type
     {
         return $this->type;
     }

--- a/rules/CodeQuality/ValueObject/DefinedPropertyWithType.php
+++ b/rules/CodeQuality/ValueObject/DefinedPropertyWithType.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\ValueObject;
+
+final readonly class DefinedPropertyWithType
+{
+    public function __construct(
+        private string $propertyName,
+        private \PHPStan\Type\Type $type,
+        private ?string $definedInMethodName
+    ) {
+    }
+
+    public function getPropertyName(): string
+    {
+        return $this->propertyName;
+    }
+
+    public function getType(): \PHPStan\Type\Type
+    {
+        return $this->type;
+    }
+
+    public function getDefinedInMethodName(): ?string
+    {
+        return $this->definedInMethodName;
+    }
+}

--- a/src/NodeAnalyzer/PropertyPresenceChecker.php
+++ b/src/NodeAnalyzer/PropertyPresenceChecker.php
@@ -7,15 +7,10 @@ namespace Rector\NodeAnalyzer;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\Php\PhpPropertyReflection;
-use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\Type;
 use Rector\CodeQuality\ValueObject\DefinedPropertyWithType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Php80\NodeAnalyzer\PromotedPropertyResolver;
-use Rector\PhpParser\AstResolver;
-use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
+use Rector\PostRector\ValueObject\PropertyMetadata;
 
 /**
  * Can be local property, parent property etc.
@@ -25,8 +20,6 @@ final readonly class PropertyPresenceChecker
     public function __construct(
         private PromotedPropertyResolver $promotedPropertyResolver,
         private NodeNameResolver $nodeNameResolver,
-        private ReflectionProvider $reflectionProvider,
-        private AstResolver $astResolver,
     ) {
     }
 
@@ -41,122 +34,26 @@ final readonly class PropertyPresenceChecker
 
     public function getClassContextProperty(
         Class_ $class,
-        DefinedPropertyWithType $definedPropertyWithType
+        DefinedPropertyWithType|PropertyMetadata $definedPropertyWithType
     ): Property | Param | null {
         $className = $this->nodeNameResolver->getName($class);
         if ($className === null) {
             return null;
         }
 
-        $property = $class->getProperty($definedPropertyWithType->getPropertyName());
+        $property = $class->getProperty($definedPropertyWithType->getName());
         if ($property instanceof Property) {
-            return $property;
-        }
-
-        $property = $this->matchPropertyByParentNonPrivateProperties($className, $definedPropertyWithType);
-        if ($property instanceof Property || $property instanceof Param) {
             return $property;
         }
 
         $promotedPropertyParams = $this->promotedPropertyResolver->resolveFromClass($class);
 
         foreach ($promotedPropertyParams as $promotedPropertyParam) {
-            if ($this->nodeNameResolver->isName($promotedPropertyParam, $definedPropertyWithType->getPropertyName())) {
+            if ($this->nodeNameResolver->isName($promotedPropertyParam, $definedPropertyWithType->getName())) {
                 return $promotedPropertyParam;
             }
         }
 
         return null;
-    }
-
-    /**
-     * @return PhpPropertyReflection[]
-     */
-    private function getParentClassNonPrivatePropertyReflections(string $className): array
-    {
-        if (! $this->reflectionProvider->hasClass($className)) {
-            return [];
-        }
-
-        $classReflection = $this->reflectionProvider->getClass($className);
-
-        $propertyReflections = [];
-
-        foreach ($classReflection->getParents() as $parentClassReflection) {
-            $propertyNames = $this->resolveNonPrivatePropertyNames($parentClassReflection);
-
-            foreach ($propertyNames as $propertyName) {
-                $propertyReflections[] = $parentClassReflection->getNativeProperty($propertyName);
-            }
-        }
-
-        return $propertyReflections;
-    }
-
-    private function matchPropertyByType(
-        DefinedPropertyWithType $definedPropertyWithType,
-        PhpPropertyReflection $phpPropertyReflection
-    ): Property | Param | null {
-        if (! $definedPropertyWithType->getType() instanceof Type) {
-            return null;
-        }
-
-        if (ClassNameFromObjectTypeResolver::resolve($definedPropertyWithType->getType()) === null) {
-            return null;
-        }
-
-        if (ClassNameFromObjectTypeResolver::resolve($phpPropertyReflection->getWritableType()) === null) {
-            return null;
-        }
-
-        $type = $definedPropertyWithType->getType();
-        if (! $type->equals($phpPropertyReflection->getWritableType())) {
-            return null;
-        }
-
-        return $this->astResolver->resolvePropertyFromPropertyReflection($phpPropertyReflection);
-    }
-
-    private function matchPropertyByParentNonPrivateProperties(
-        string $className,
-        DefinedPropertyWithType $definedPropertyWithType,
-    ): Property | Param | null {
-        $availablePropertyReflections = $this->getParentClassNonPrivatePropertyReflections($className);
-
-        foreach ($availablePropertyReflections as $availablePropertyReflection) {
-            // 1. match type by priority
-            $property = $this->matchPropertyByType($definedPropertyWithType, $availablePropertyReflection);
-            if ($property instanceof Property || $property instanceof Param) {
-                return $property;
-            }
-
-            $nativePropertyReflection = $availablePropertyReflection->getNativeReflection();
-
-            // 2. match by name
-            if ($nativePropertyReflection->getName() === $propertyMetadata->getName()) {
-                return $this->astResolver->resolvePropertyFromPropertyReflection($availablePropertyReflection);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function resolveNonPrivatePropertyNames(ClassReflection $classReflection): array
-    {
-        $propertyNames = [];
-
-        $nativeReflection = $classReflection->getNativeReflection();
-        foreach ($nativeReflection->getProperties() as $reflectionProperty) {
-            if ($reflectionProperty->isPrivate()) {
-                continue;
-            }
-
-            $propertyNames[] = $reflectionProperty->getName();
-        }
-
-        return $propertyNames;
     }
 }


### PR DESCRIPTION
I've just run this rule on a legacy codebase and it's missing features:

* when a property is defined in constructor, it should be `private` by default, as its only missing
* if it uses PHP 7.4 and type is scalar, it should be added instead of no typed or mixed