### PR TITLE
[CodeQuality] Make CompleteDynamicPropertiesRector to allow use public modifier even defined on __construct/setUp

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixturePublicOnInitialized/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixturePublicOnInitialized/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\FixturePublicOnInitialized;
+
+class Fixture
+{
+    public function __construct()
+    {
+        $this->value = 5;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\FixturePublicOnInitialized;
+
+class Fixture
+{
+    /**
+     * @var int
+     */
+    public $value;
+    public function __construct()
+    {
+        $this->value = 5;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/PublicOnInitializedTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/PublicOnInitializedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PublicOnInitializedTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixturePublicOnInitialized');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_public_on_initialized.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/config/configured_rule_public_on_initialized.php
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/config/configured_rule_public_on_initialized.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(CompleteDynamicPropertiesRector::class, [
+        CompleteDynamicPropertiesRector::PRIVATE_ON_INITIALIZED => false,
+    ]);
+};

--- a/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
+++ b/rules/CodeQuality/NodeFactory/MissingPropertiesFactory.php
@@ -28,11 +28,11 @@ final readonly class MissingPropertiesFactory
      * @param DefinedPropertyWithType[] $definedPropertiesWithType
      * @return Property[]
      */
-    public function create(array $definedPropertiesWithType): array
+    public function create(array $definedPropertiesWithType, bool $privateOnInitialized): array
     {
         $newProperties = [];
         foreach ($definedPropertiesWithType as $definedPropertyWithType) {
-            $visibilityModifier = $this->isFromAlwaysDefinedMethod($definedPropertyWithType)
+            $visibilityModifier = $this->isFromAlwaysDefinedMethod($definedPropertyWithType, $privateOnInitialized)
                 ? Modifiers::PRIVATE
                 : Modifiers::PUBLIC;
 
@@ -41,7 +41,8 @@ final readonly class MissingPropertiesFactory
             ]);
 
             if ($this->isFromAlwaysDefinedMethod(
-                $definedPropertyWithType
+                $definedPropertyWithType,
+                $privateOnInitialized
             ) && $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::TYPED_PROPERTIES)) {
                 $propertyType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
                     $definedPropertyWithType->getType(),
@@ -64,12 +65,12 @@ final readonly class MissingPropertiesFactory
         return $newProperties;
     }
 
-    private function isFromAlwaysDefinedMethod(DefinedPropertyWithType $definedPropertyWithType): bool
+    private function isFromAlwaysDefinedMethod(DefinedPropertyWithType $definedPropertyWithType, bool $privateOnInitialized): bool
     {
         return in_array(
             $definedPropertyWithType->getDefinedInMethodName(),
             [MethodName::CONSTRUCT, MethodName::SET_UP],
             true
-        );
+        ) && $privateOnInitialized;
     }
 }


### PR DESCRIPTION
Per PR:

- https://github.com/rectorphp/rector-src/pull/7036#issuecomment-3024725050

this make it configurable to allow set public when needed.