### PR TITLE
[Testing] Modify autoload on AbstractLazyTestCase to only use vendor/scoper-autoload.php when it exists

### DIFF
--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -63,14 +63,12 @@ abstract class AbstractLazyTestCase extends TestCase
     {
         if (\file_exists(__DIR__ . '/../../../vendor/scoper-autoload.php')) {
             require_once __DIR__ . '/../../../vendor/scoper-autoload.php';
-        } else {
-            if (file_exists(__DIR__ . '/../../../preload.php')) {
-                if (file_exists(__DIR__ . '/../../../vendor')) {
-                    require_once __DIR__ . '/../../../preload.php';
-                    // test case in rector split package
-                } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
-                    require_once __DIR__ . '/../../../preload-split-package.php';
-                }
+        } elseif (file_exists(__DIR__ . '/../../../preload.php')) {
+            if (file_exists(__DIR__ . '/../../../vendor')) {
+                require_once __DIR__ . '/../../../preload.php';
+                // test case in rector split package
+            } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
+                require_once __DIR__ . '/../../../preload-split-package.php';
             }
         }
     }

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -61,17 +61,17 @@ abstract class AbstractLazyTestCase extends TestCase
 
     private function includePreloadFilesAndScoperAutoload(): void
     {
-        if (file_exists(__DIR__ . '/../../../preload.php')) {
-            if (file_exists(__DIR__ . '/../../../vendor')) {
-                require_once __DIR__ . '/../../../preload.php';
-                // test case in rector split package
-            } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
-                require_once __DIR__ . '/../../../preload-split-package.php';
-            }
-        }
-
         if (\file_exists(__DIR__ . '/../../../vendor/scoper-autoload.php')) {
             require_once __DIR__ . '/../../../vendor/scoper-autoload.php';
+        } else {
+            if (file_exists(__DIR__ . '/../../../preload.php')) {
+                if (file_exists(__DIR__ . '/../../../vendor')) {
+                    require_once __DIR__ . '/../../../preload.php';
+                    // test case in rector split package
+                } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
+                    require_once __DIR__ . '/../../../preload-split-package.php';
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9242