### PR TITLE
 [Php80] Make configurable to allow skip on model based classes on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/DisallowModelBasedClassesTest.php
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/DisallowModelBasedClassesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DisallowModelBasedClassesTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureDisallowModelBasedClasses');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_disallow_model_based_classes.php';
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_jms_type_annotation.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_jms_type_annotation.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\FixtureDisallowModelBasedClasses\Fixture;
+
+use JMS\Serializer\Annotation as JMS;
+
+final class SkipJmsTypeAnnotation
+{
+    /**
+     * @JMS\Type('string)
+     */
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_jms_type_attribute.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_jms_type_attribute.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\FixtureDisallowModelBasedClasses\Fixture;
+
+use JMS\Serializer\Annotation as JMS;
+
+final class SkipJmsTypeAttribute
+{
+    #[JMS\Type('string')]
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_with_doctrine_entity_annotations.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_with_doctrine_entity_annotations.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\FixtureDisallowModelBasedClasses\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class SkipWithDoctrineAnnotation
+{
+    /**
+     * @ORM\Column(type="text")
+     */
+    private string $content;
+
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_with_doctrine_entity_attribute.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/FixtureDisallowModelBasedClasses/skip_with_doctrine_entity_attribute.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\FixtureDisallowModelBasedClasses\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class SkipWithDoctrineEntityAnnotation
+{
+    #[ORM\Column(type: 'text')]
+    private string $content;
+
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/config/configured_rule_disallow_model_based_classes.php
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/config/configured_rule_disallow_model_based_classes.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ClassPropertyAssignToConstructorPromotionRector::class, [
+        ClassPropertyAssignToConstructorPromotionRector::ALLOW_MODEL_BASED_CLASSES => false,
+    ]);
+};

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Enum\ClassName;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Php80\ValueObject\PropertyPromotionCandidate;
@@ -41,7 +42,7 @@ final readonly class PromotedPropertyCandidateResolver
         ClassMethod $constructClassMethod,
         bool $allowModelBasedClasses
     ): array {
-        if (! $allowModelBasedClasses && $this->hasModelTypeCheck($class, 'Doctrine\ORM\Mapping\Entity')) {
+        if (! $allowModelBasedClasses && $this->hasModelTypeCheck($class, ClassName::DOCTRINE_ENTITY)) {
             return [];
         }
 
@@ -57,7 +58,7 @@ final readonly class PromotedPropertyCandidateResolver
                 continue;
             }
 
-            if (! $allowModelBasedClasses && $this->hasModelTypeCheck($property, 'JMS\Serializer\Annotation\Type')) {
+            if (! $allowModelBasedClasses && $this->hasModelTypeCheck($property, ClassName::JMS_TYPE)) {
                 continue;
             }
 

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
@@ -33,21 +33,14 @@ final readonly class PromotedPropertyCandidateResolver
     ) {
     }
 
-    private function hasModelTypeCheck(Class_|Property $node, string $modelType): bool
-    {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
-        if ($phpDocInfo instanceof PhpDocInfo && $phpDocInfo->hasByAnnotationClass($modelType)) {
-            return true;
-        }
-
-        return $this->phpAttributeAnalyzer->hasPhpAttribute($node, $modelType);
-    }
-
     /**
      * @return PropertyPromotionCandidate[]
      */
-    public function resolveFromClass(Class_ $class, ClassMethod $constructClassMethod, bool $allowModelBasedClasses): array
-    {
+    public function resolveFromClass(
+        Class_ $class,
+        ClassMethod $constructClassMethod,
+        bool $allowModelBasedClasses
+    ): array {
         if (! $allowModelBasedClasses && $this->hasModelTypeCheck($class, 'Doctrine\ORM\Mapping\Entity')) {
             return [];
         }
@@ -72,6 +65,16 @@ final readonly class PromotedPropertyCandidateResolver
         }
 
         return $propertyPromotionCandidates;
+    }
+
+    private function hasModelTypeCheck(Class_|Property $node, string $modelType): bool
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if ($phpDocInfo instanceof PhpDocInfo && $phpDocInfo->hasByAnnotationClass($modelType)) {
+            return true;
+        }
+
+        return $this->phpAttributeAnalyzer->hasPhpAttribute($node, $modelType);
     }
 
     private function matchPropertyPromotionCandidate(

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -59,6 +59,12 @@ final class ClassPropertyAssignToConstructorPromotionRector extends AbstractRect
     public const RENAME_PROPERTY = 'rename_property';
 
     /**
+     * @api
+     * @var string
+     */
+    public const ALLOW_MODEL_BASED_CLASSES = 'allow_model_based_classes';
+
+    /**
      * Default to false, which only apply changes:
      *
      *  – private modifier property
@@ -72,6 +78,11 @@ final class ClassPropertyAssignToConstructorPromotionRector extends AbstractRect
      * Set to false will skip property promotion when parameter and property have different names.
      */
     private bool $renameProperty = true;
+
+    /**
+     * Set to false will skip property promotion on model based classes
+     */
+    private bool $allowModelBasedClasses = true;
 
     public function __construct(
         private readonly PromotedPropertyCandidateResolver $promotedPropertyCandidateResolver,
@@ -119,6 +130,7 @@ CODE_SAMPLE
                     [
                         self::INLINE_PUBLIC => false,
                         self::RENAME_PROPERTY => true,
+                        self::ALLOW_MODEL_BASED_CLASSES => true,
                     ]
                 ),
             ]
@@ -129,6 +141,7 @@ CODE_SAMPLE
     {
         $this->inlinePublic = $configuration[self::INLINE_PUBLIC] ?? false;
         $this->renameProperty = $configuration[self::RENAME_PROPERTY] ?? true;
+        $this->allowModelBasedClasses = $configuration[self::ALLOW_MODEL_BASED_CLASSES] ?? true;
     }
 
     /**
@@ -149,7 +162,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $promotionCandidates = $this->promotedPropertyCandidateResolver->resolveFromClass($node, $constructClassMethod);
+        $promotionCandidates = $this->promotedPropertyCandidateResolver->resolveFromClass($node, $constructClassMethod, $this->allowModelBasedClasses);
         if ($promotionCandidates === []) {
             return null;
         }

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -162,7 +162,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $promotionCandidates = $this->promotedPropertyCandidateResolver->resolveFromClass($node, $constructClassMethod, $this->allowModelBasedClasses);
+        $promotionCandidates = $this->promotedPropertyCandidateResolver->resolveFromClass(
+            $node,
+            $constructClassMethod,
+            $this->allowModelBasedClasses
+        );
         if ($promotionCandidates === []) {
             return null;
         }

--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -227,9 +227,6 @@ final class PhpDocInfo
         return $doctrineAnnotationTagValueNodes[0] ?? null;
     }
 
-    /**
-     * @api used in tests, doctrine
-     */
     public function hasByAnnotationClass(string $class): bool
     {
         return $this->findByAnnotationClass($class) !== [];

--- a/src/Enum/ClassName.php
+++ b/src/Enum/ClassName.php
@@ -25,4 +25,9 @@ final class ClassName
      * @var string
      */
     public const JMS_TYPE = 'JMS\Serializer\Annotation\Type';
+
+    /**
+     * @var string
+     */
+    public const DOCTRINE_ENTITY = 'Doctrine\ORM\Mapping\Entity';
 }

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -46,7 +46,7 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
         $firstStmtKey = 0;
         foreach ($node->stmts as $key => $stmt) {
             if ($stmt instanceof Declare_ && $key === 0) {
-                $firstStmtKey += 1;
+                ++$firstStmtKey;
             }
 
             if (! $stmt instanceof Use_) {


### PR DESCRIPTION
To allow configure like this:

```php
    $rectorConfig->ruleWithConfiguration(ClassPropertyAssignToConstructorPromotionRector::class, [
        ClassPropertyAssignToConstructorPromotionRector::ALLOW_MODEL_BASED_CLASSES => false,
    ]);
```

default to true.

Closes https://github.com/rectorphp/rector/issues/9243