### PR TITLE
[Kaizen] Add CLI note on kaizen run on parallel, which rule collection start from 0 on different process

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -89,7 +89,12 @@ EOF
         $configuration = $this->configurationFactory->createFromInput($input);
         if ($configuration->isKaizenEnabled()) {
             $this->symfonyStyle->writeln(sprintf(
-                '<fg=yellow>[EXPERIMENTAL] Running Kaizen mode. Only first %d rule%s will be applied</>',
+                <<<'TXT'
+                <fg=yellow>[EXPERIMENTAL] Running Kaizen mode. Only first %d rule%s will be applied</>
+
+                <fg=yellow>Note: When running in parallel, each process starts from step 0. This can lead to different rule collections per process, up to the defined maximum Kaizen step count.</>
+                TXT
+                ,
                 $configuration->getKaizenStepCount(),
                 $configuration->getKaizenStepCount() > 1 ? 's' : ''
             ));


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/9231

![Screenshot 2025-07-06 at 15 17 36](https://github.com/user-attachments/assets/8c8c73a1-7920-4f46-88fe-0a898aa99b23)