### PR TITLE
[Kaizen] No need filter unchanged files when --kaizen is used

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -37,7 +37,8 @@ final readonly class FilesFinder
         array $source,
         array $suffixes = [],
         bool $sortByName = true,
-        ?string $onlySuffix = null
+        ?string $onlySuffix = null,
+        bool $isKaizenEnabled = false
     ): array {
         $filesAndDirectories = $this->filesystemTweaker->resolveWithFnmatch($source);
 
@@ -102,6 +103,11 @@ final readonly class FilesFinder
         );
 
         $filePaths = [...$filteredFilePaths, ...$filteredFilePathsInDirectories];
+
+        if ($isKaizenEnabled) {
+            return array_unique($filePaths);
+        }
+
         return $this->unchangedFilesFilter->filterFilePaths($filePaths);
     }
 
@@ -120,6 +126,7 @@ final readonly class FilesFinder
             $configuration->getFileExtensions(),
             true,
             $configuration->getOnlySuffix(),
+            $configuration->isKaizenEnabled()
         );
     }
 


### PR DESCRIPTION
@gharlan @TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/7046

per discussion https://github.com/rectorphp/rector-src/pull/7046#issuecomment-3046057413 , this ensure to not filter unchanged files when `--kaizen` is used.

to ensure when run on multple times, it runs on all files, not just already changed files, because next rule(s) may apply to the unchanged files.