### PR TITLE
[Kaizen] When no files changed, early return empty on FilesFinder, even on kaizen

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -103,12 +103,16 @@ final readonly class FilesFinder
         );
 
         $filePaths = [...$filteredFilePaths, ...$filteredFilePathsInDirectories];
+        $changedFiles = $this->unchangedFilesFilter->filterFilePaths($filePaths);
 
-        if ($isKaizenEnabled) {
-            return array_unique($filePaths);
+        // no files changed, early return empty
+        if ($changedFiles === []) {
+            return [];
         }
 
-        return $this->unchangedFilesFilter->filterFilePaths($filePaths);
+        return $isKaizenEnabled
+            ? array_unique($filePaths)
+            : $changedFiles;
     }
 
     /**


### PR DESCRIPTION
@gharlan @TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/7050

When no files changed, early return empty on FilesFinder, even on kaizen, because nothing to process anymore, if there is change, then on kaizen, it probably other change as well.

![Screenshot 2025-07-08 at 04 01 34](https://github.com/user-attachments/assets/3e7e88fd-3536-472b-bf7f-202aea49729e)
