### PR TITLE
Fix ambiguous variable name

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -103,10 +103,10 @@ final readonly class FilesFinder
         );
 
         $filePaths = [...$filteredFilePaths, ...$filteredFilePathsInDirectories];
-        $changedFiles = $this->unchangedFilesFilter->filterFilePaths($filePaths);
+        $toBeChangedFiles = $this->unchangedFilesFilter->filterFilePaths($filePaths);
 
-        // no files changed, early return empty
-        if ($changedFiles === []) {
+        // no files to be changed, early return empty
+        if ($toBeChangedFiles === []) {
             return [];
         }
 
@@ -118,7 +118,7 @@ final readonly class FilesFinder
             return array_unique($filePaths);
         }
 
-        return $changedFiles;
+        return $toBeChangedFiles;
     }
 
     /**


### PR DESCRIPTION
change variable name `changedFiles` to `toBeChangedFiles` because on first run, it not yet changed.