### PR TITLE
[Kaizen] Remove unneeded clean kaizen cache since all cache already cleared early when there are files to be changed + kaizen enabled

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -96,11 +96,6 @@ final class ApplicationFileProcessor
             $preFileCallback = null;
         }
 
-        // on repetitive runs, the counter of kaizen must start from 0 again
-        if ($configuration->isKaizenEnabled()) {
-            $this->kaizenStepper->start();
-        }
-
         if ($configuration->isParallel()) {
             $processResult = $this->runParallel($filePaths, $input, $postFileCallback);
         } else {

--- a/src/Caching/Detector/KaizenRulesDetector.php
+++ b/src/Caching/Detector/KaizenRulesDetector.php
@@ -23,12 +23,6 @@ final readonly class KaizenRulesDetector
         return CacheKey::KAIZEN_RULES . '_' . $this->fileHasher->hash(getcwd());
     }
 
-
-    public function clean(): void
-    {
-        $this->cache->clean(CacheKey::KAIZEN_RULES);
-    }
-
     public function addRule(string $rectorClass): void
     {
         $cachedValue = $this->loadRules();

--- a/src/Configuration/KaizenStepper.php
+++ b/src/Configuration/KaizenStepper.php
@@ -19,11 +19,6 @@ final class KaizenStepper
     ) {
     }
 
-    public function start(): void
-    {
-        $this->kaizenRulesDetector->clean();
-    }
-
     /**
      * @param positive-int $stepCount
      */


### PR DESCRIPTION
@gharlan @TomasVotruba continue of PR:

- https://github.com/rectorphp/rector-src/pull/7052

this remove unneeded clean kaizen cache since all cache cleared early when there are files to be changed + kaizen enabled