### PR TITLE
[Experiment] Add apcu support as native cache engine on MemoryCacheStorage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,6 +51,7 @@ jobs:
                 with:
                     php-version: ${{ matrix.php_version }}
                     coverage: none
+                    extensions: apcu
 
             # run in root rector-src
             -   run: composer install --ansi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -71,7 +71,7 @@ jobs:
                 working-directory: ${{ matrix.directory }}
                 if: ${{ matrix.directory == 'e2e/parallel-custom-config' }}
 
-            -   run: php ../e2eTestRunner.php --kaizen 1
+            -   run: php -d apc.enable_cli=1 ../e2eTestRunner.php --kaizen 1
                 working-directory: ${{ matrix.directory }}
                 if: ${{ matrix.directory == 'e2e/parallel-kaizen-applied-rules' }}
 

--- a/e2e/parallel-kaizen-applied-rules/rector.php
+++ b/e2e/parallel-kaizen-applied-rules/rector.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->parallel(maxNumberOfProcess: 2, jobSize: 1);
-    $rectorConfig->cacheClass(FileCacheStorage::class);
-    $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/rector');
 
     $rectorConfig->paths([
         __DIR__ . '/src/',

--- a/e2e/parallel-kaizen-applied-rules/rector.php
+++ b/e2e/parallel-kaizen-applied-rules/rector.php
@@ -2,12 +2,16 @@
 
 declare(strict_types=1);
 
+use Rector\Caching\ValueObject\Storage\MemoryCacheStorage;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->parallel(maxNumberOfProcess: 2, jobSize: 1);
+
+    // this to make reliable result with local (that default to use FileCacheStorage) vs CI (that default to use MemoryCacheStorage)
+    $rectorConfig->cacheClass(MemoryCacheStorage::class);
 
     $rectorConfig->paths([
         __DIR__ . '/src/',

--- a/src/Caching/ValueObject/Storage/MemoryCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/MemoryCacheStorage.php
@@ -31,7 +31,7 @@ final class MemoryCacheStorage implements CacheStorageInterface
      */
     public function load(string $key, string $variableKey): mixed
     {
-        if (!isset($this->storage[$key]) && ($this->hasNativeCacheEngine && apcu_exists($key))) {
+        if (!isset($this->storage[$key]) && $this->hasNativeCacheEngine && apcu_exists($key)) {
             $this->storage[$key] = new CacheItem($variableKey, apcu_fetch($key));
         }
 

--- a/src/Caching/ValueObject/Storage/MemoryCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/MemoryCacheStorage.php
@@ -23,7 +23,7 @@ final class MemoryCacheStorage implements CacheStorageInterface
 
     public function __construct()
     {
-        $this->hasNativeCacheEngine = extension_loaded('apcu');
+        $this->hasNativeCacheEngine = extension_loaded('apcu') && ini_get('apc.enable_cli');
     }
 
     /**
@@ -31,8 +31,13 @@ final class MemoryCacheStorage implements CacheStorageInterface
      */
     public function load(string $key, string $variableKey): mixed
     {
-        if (!isset($this->storage[$key]) && $this->hasNativeCacheEngine && apcu_exists($key)) {
-            $this->storage[$key] = new CacheItem($variableKey, apcu_fetch($key));
+        if (!isset($this->storage[$key]) && $this->hasNativeCacheEngine) {
+            $success = false;
+            $data = apcu_fetch($key, $success);
+
+            if ($success) {
+                $this->storage[$key] = new CacheItem($variableKey, $data);
+            }
         }
 
         if (! isset($this->storage[$key])) {

--- a/src/Caching/ValueObject/Storage/MemoryCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/MemoryCacheStorage.php
@@ -31,10 +31,8 @@ final class MemoryCacheStorage implements CacheStorageInterface
      */
     public function load(string $key, string $variableKey): mixed
     {
-        if (! isset($this->storage[$key])) {
-            if ($this->hasNativeCacheEngine && apcu_exists($key)) {
-                $this->storage[$key] = new CacheItem($variableKey, apcu_fetch($key));
-            }
+        if (!isset($this->storage[$key]) && ($this->hasNativeCacheEngine && apcu_exists($key))) {
+            $this->storage[$key] = new CacheItem($variableKey, apcu_fetch($key));
         }
 
         if (! isset($this->storage[$key])) {


### PR DESCRIPTION
Currently, `MemoryCacheStorage` has its own life when running under parallel, because it rely on property, that's why when add cache test on kaizen with default `MemoryCacheStorage` on CI, it was failed, because it is a default on CI:

https://github.com/rectorphp/rector-src/blob/417d068e942d23b6b32412adcdbde3afdddd8dc9/config/config.php#L30-L34

---------
that cause result:
----------

with `MemoryCacheStorage`, **failure**: https://github.com/rectorphp/rector-src/actions/runs/16101183170/job/45430530419?pr=7046

with `FileCacheStorage`, **works**: https://github.com/rectorphp/rector-src/actions/runs/16101393029/job/45431005381

-------

This PR adds `apcu` support when it exists so it works across parallel process.