### PR TITLE
Add test for array variables in string interpolations

### DIFF
--- a/rules-tests/Php82/Rector/Encapsed/VariableInStringInterpolationFixerRector/Fixture/variable_in_string_statement.php.inc
+++ b/rules-tests/Php82/Rector/Encapsed/VariableInStringInterpolationFixerRector/Fixture/variable_in_string_statement.php.inc
@@ -25,4 +25,5 @@ $array = [
 $c = "football";
 echo "I like playing {$c}";
 echo "I also like playing {$array['game']}";
+
 ?>

--- a/rules-tests/Php82/Rector/Encapsed/VariableInStringInterpolationFixerRector/Fixture/variable_in_string_statement.php.inc
+++ b/rules-tests/Php82/Rector/Encapsed/VariableInStringInterpolationFixerRector/Fixture/variable_in_string_statement.php.inc
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector\Fixture;
 
+$array = [
+  'game' => 'basketball',
+];
 $c = "football";
 echo "I like playing ${c}";
+echo "I also like playing ${array['game']}";
 
 ?>
 -----
@@ -15,7 +19,10 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector\Fixture;
 
+$array = [
+  'game' => 'basketball',
+];
 $c = "football";
 echo "I like playing {$c}";
-
+echo "I also like playing {$array['game']}";
 ?>


### PR DESCRIPTION
Rector demo: https://getrector.com/demo/3b43de2f-22a7-41b3-ac15-5f9fbd15c9df

Rector output on 3v4l: https://3v4l.org/Xl2G2#v8.4.10

It currently doesn't take into account array variables.