### PR TITLE
[DeadCode] Handle crash on empty content on SimplifyIfElseWithSameContentRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector/Fixture/empty_content.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector/Fixture/empty_content.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector\Fixture;
+
+class EmptyContent
+{
+    public function run()
+    {
+        if (true) {
+        } else {
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\SimplifyIfElseWithSameContentRector\Fixture;
+
+class EmptyContent
+{
+    public function run()
+    {
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
+++ b/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
+use PhpParser\NodeVisitor;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Rector\AbstractRector;
@@ -67,7 +68,7 @@ CODE_SAMPLE
      * @param If_ $node
      * @return Stmt[]|null
      */
-    public function refactor(Node $node): ?array
+    public function refactor(Node $node): int|null|array
     {
         if (! $node->else instanceof Else_) {
             return null;
@@ -75,6 +76,10 @@ CODE_SAMPLE
 
         if (! $this->isIfWithConstantReturns($node)) {
             return null;
+        }
+
+        if ($node->stmts === []) {
+            return NodeVisitor::REMOVE_NODE;
         }
 
         return $node->stmts;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9259
Ref https://getrector.com/demo/cf0a35fa-6324-48f4-8a93-3b58d6b6bab6