### PR TITLE
Fix return on SimplifyIfElseWithSameContentRector

### DIFF
--- a/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
+++ b/rules/DeadCode/Rector/If_/SimplifyIfElseWithSameContentRector.php
@@ -66,7 +66,7 @@ CODE_SAMPLE
 
     /**
      * @param If_ $node
-     * @return Stmt[]|null
+     * @return Stmt[]|null|int
      */
     public function refactor(Node $node): int|null|array
     {


### PR DESCRIPTION
This is hotfix for https://github.com/rectorphp/rector/commit/36d3ae44d5025de303c1a3558e3522e8befa6976

the `@return` seems need to match with native return type. For now, this patch can handle it.

Closes https://github.com/rectorphp/rector/issues/9259