### PR TITLE
[CodeQuality] Skip when class has __isset() method on IssetOnPropertyObjectToPropertyExistsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_has_magic_isset.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_has_magic_isset.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
+
+class Model {
+    public function __isset($name) {
+        return $name === 'foo';
+    }
+}
+
+$model = new Model();
+$fooDefined = isset($model->foo); // true

--- a/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -26,6 +26,7 @@ use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
+use Rector\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -118,6 +119,10 @@ CODE_SAMPLE
 
             $classReflection = $this->matchPropertyTypeClassReflection($issetExpr);
             if (! $classReflection instanceof ClassReflection) {
+                continue;
+            }
+
+            if ($classReflection->hasNativeMethod(MethodName::ISSET)) {
                 continue;
             }
 

--- a/src/ValueObject/MethodName.php
+++ b/src/ValueObject/MethodName.php
@@ -67,4 +67,9 @@ final class MethodName
      * @var string
      */
     public const INVOKE = '__invoke';
+
+    /**
+     * @var string
+     */
+    public const ISSET = '__isset';
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9264
Ref https://3v4l.org/LoWsb#v8.4.10