### PR TITLE
[DeadCode] Skip used in compact() on RemoveUnusedForeachKeyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector/Fixture/skip_used_in_compact.php.inc
+++ b/rules-tests/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector/Fixture/skip_used_in_compact.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Foreach_\RemoveUnusedForeachKeyRector\Fixture;
+
+final class SkipUsedInCompact
+{
+    public function run(array $renames)
+    {
+        foreach ($renames as $morph => $rename) {
+            foreach ($rename as $old_key => $new_key) {
+                DB::statement(<<<'SQL'
+                    WITH cte AS (
+                        SELECT id,
+                            CASE
+                                WHEN new_values ?? :old_key THEN
+                                    jsonb_set(
+                                        new_values - :old_key,
+                                        ARRAY[:new_key],
+                                        new_values->:old_key,
+                                        true
+                                    )
+                                ELSE new_values
+                            END AS new_values,
+                            CASE
+                                WHEN old_values ?? :old_key THEN
+                                    jsonb_set(
+                                        old_values - :old_key,
+                                        ARRAY[:new_key],
+                                        old_values->:old_key,
+                                        true
+                                    )
+                                ELSE old_values
+                            END AS old_values
+                        FROM audits
+                        WHERE auditable_type = :morph
+                            AND (new_values ?? :old_key OR old_values ?? :old_key)
+                    )
+                    UPDATE audits
+                    SET new_values = cte.new_values,
+                        old_values = cte.old_values
+                    FROM cte
+                    WHERE audits.id = cte.id
+                    SQL, compact('morph', 'old_key', 'new_key'));
+            }
+        }
+    }
+}

--- a/rules/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector.php
+++ b/rules/DeadCode/Rector/Foreach_/RemoveUnusedForeachKeyRector.php
@@ -13,6 +13,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\DeadCode\NodeAnalyzer\ExprUsedInNodeAnalyzer;
 use Rector\NodeManipulator\StmtsManipulator;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -27,7 +28,8 @@ final class RemoveUnusedForeachKeyRector extends AbstractRector
         private readonly NodeFinder $nodeFinder,
         private readonly StmtsManipulator $stmtsManipulator,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly DocBlockUpdater $docBlockUpdater
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly ExprUsedInNodeAnalyzer $exprUsedInNodeAnalyzer
     ) {
     }
 
@@ -83,7 +85,7 @@ CODE_SAMPLE
 
             $isNodeUsed = (bool) $this->nodeFinder->findFirst(
                 $stmt->stmts,
-                fn (Node $node): bool => $this->nodeComparator->areNodesEqual($node, $keyVar)
+                fn (Node $node): bool => $this->exprUsedInNodeAnalyzer->isUsed($node, $keyVar)
             );
 
             if ($isNodeUsed) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9271