### PR TITLE
[CodeQuality] Mirror comment on InlineConstructorDefaultToPropertyRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/mirror_comment.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/mirror_comment.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class MirrorComment
+{
+    private $thing;
+
+    public function __construct()
+    {
+        /** some important comment */
+        $this->thing = 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class MirrorComment
+{
+    /** some important comment */
+    private $thing = 1;
+
+    public function __construct()
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/mirror_comment_multi_properties.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/mirror_comment_multi_properties.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class MirrorCommentMultipleProperties
+{
+    private $thing1, $thing2, $thing3;
+
+    public function __construct()
+    {
+        // first
+        $this->thing1 = 1;
+        // second
+        $this->thing2 = 2;
+        // third
+        $this->thing3 = 3;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+final class MirrorCommentMultipleProperties
+{
+    // first
+    // second
+    // third
+    private $thing1 = 1, $thing2 = 2, $thing3 = 3;
+
+    public function __construct()
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/mirror_comment_multi_properties.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/mirror_comment_multi_properties.php.inc
@@ -4,6 +4,9 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPrope
 
 final class MirrorCommentMultipleProperties
 {
+    /**
+     * some existing comment
+     */
     private $thing1, $thing2, $thing3;
 
     public function __construct()
@@ -25,6 +28,9 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPrope
 
 final class MirrorCommentMultipleProperties
 {
+    /**
+     * some existing comment
+     */
     // first
     // second
     // third

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -115,7 +116,8 @@ CODE_SAMPLE
                 $propertyName,
                 $defaultExpr,
                 $constructClassMethod,
-                $key
+                $key,
+                $stmt
             );
 
             if ($hasPropertyChanged) {
@@ -154,7 +156,8 @@ CODE_SAMPLE
         string $propertyName,
         Expr $defaultExpr,
         ClassMethod $constructClassMethod,
-        int $key
+        int $key,
+        Stmt $stmt
     ): bool {
         if ($class->isReadonly()) {
             return false;
@@ -179,6 +182,13 @@ CODE_SAMPLE
 
                 // remove assign
                 unset($constructClassMethod->stmts[$key]);
+
+                $this->mirrorComments(
+                    $classStmt,
+                    $stmt,
+                    true
+                );
+
                 return true;
             }
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -281,7 +281,7 @@ CODE_SAMPLE;
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, $callable);
     }
 
-    protected function mirrorComments(Node $newNode, Node $oldNode): void
+    protected function mirrorComments(Node $newNode, Node $oldNode, bool $mergeExistingComments = false): void
     {
         if ($this->nodeComparator->areSameNode($newNode, $oldNode)) {
             return;
@@ -304,9 +304,22 @@ CODE_SAMPLE;
             }
         }
 
-        $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
         if (! $newNode instanceof Nop) {
-            $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
+            if (! $mergeExistingComments) {
+                $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
+                $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
+                return;
+            }
+
+            // set null as mix multiple docs will require re-build
+            // on next call
+            $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, null);
+
+            $newComments = array_merge(
+                (array) $newNode->getComments(),
+                (array) $oldNode->getComments()
+            );
+            $newNode->setAttribute(AttributeKey::COMMENTS, $newComments);
         }
     }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -306,6 +306,10 @@ CODE_SAMPLE;
 
         if (! $mergeExistingComments) {
             $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
+        } else {
+            // set null as mix multiple docs will require re-build
+            // on next call
+            $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, null);
         }
 
         if (! $newNode instanceof Nop) {
@@ -313,10 +317,6 @@ CODE_SAMPLE;
                 $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
                 return;
             }
-
-            // set null as mix multiple docs will require re-build
-            // on next call
-            $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, null);
 
             $newComments = array_merge(
                 (array) $newNode->getComments(),

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -304,9 +304,12 @@ CODE_SAMPLE;
             }
         }
 
+        if (! $mergeExistingComments) {
+            $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
+        }
+
         if (! $newNode instanceof Nop) {
             if (! $mergeExistingComments) {
-                $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
                 $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
                 return;
             }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -319,8 +319,8 @@ CODE_SAMPLE;
             }
 
             $newComments = array_merge(
-                (array) $newNode->getComments(),
-                (array) $oldNode->getComments()
+                $newNode->getComments(),
+                $oldNode->getComments()
             );
             $newNode->setAttribute(AttributeKey::COMMENTS, $newComments);
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9273

Note:

On multiple props on single property definitions:

```php
/**
 * some existing comment
 */
private $thing1, $thing2, $thing3;

public function __construct()
{
        // first
        $this->thing1 = 1;
        // second
        $this->thing2 = 2;
        // third
        $this->thing3 = 3;
}
```

The multiple comments will be merged as is:

```diff
    /**
     * some existing comment
     */
+    // first
+    // second
+    // third
private $thing1, $thing2, $thing3;
```

then, phpdoc info will require rebuild by set it to null.I add `$mergeExistingComments` flag that set to `false` on `mirrorComments` method on `AbstractRector` to avoid regression on other existing rules.