### PR TITLE
[CodeQuality] Move logic directly for merge comments on InlineConstructorDefaultToPropertyRector

### DIFF
--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -182,7 +182,9 @@ CODE_SAMPLE
                     AttributeKey::COMMENTS,
                     array_merge(
                         $classStmt->getComments(),
-                        $constructClassMethod->stmts[$key]->getComments(),
+                        isset($constructClassMethod->stmts[$key])
+                            ? $constructClassMethod->stmts[$key]->getComments()
+                            : [],
                     )
                 );
 

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -117,8 +116,7 @@ CODE_SAMPLE
                 $propertyName,
                 $defaultExpr,
                 $constructClassMethod,
-                $key,
-                $stmt
+                $key
             );
 
             if ($hasPropertyChanged) {
@@ -157,8 +155,7 @@ CODE_SAMPLE
         string $propertyName,
         Expr $defaultExpr,
         ClassMethod $constructClassMethod,
-        int $key,
-        Stmt $stmt
+        int $key
     ): bool {
         if ($class->isReadonly()) {
             return false;

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Property;
 use Rector\NodeAnalyzer\ExprAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -173,6 +174,7 @@ CODE_SAMPLE
                 continue;
             }
 
+            $comments = $classStmt->getComments();
             foreach ($classStmt->props as $propertyProperty) {
                 if (! $this->isName($propertyProperty, $propertyName)) {
                     continue;
@@ -180,14 +182,17 @@ CODE_SAMPLE
 
                 $propertyProperty->default = $defaultExpr;
 
+                $classStmt->setAttribute(
+                    AttributeKey::COMMENTS,
+                    array_merge(
+                        $classStmt->getComments(),
+                        $constructClassMethod->stmts[$key]->getComments(),
+                    )
+                );
+
                 // remove assign
                 unset($constructClassMethod->stmts[$key]);
 
-                $this->mirrorComments(
-                    $classStmt,
-                    $stmt,
-                    true
-                );
 
                 return true;
             }

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -174,7 +174,6 @@ CODE_SAMPLE
                 continue;
             }
 
-            $comments = $classStmt->getComments();
             foreach ($classStmt->props as $propertyProperty) {
                 if (! $this->isName($propertyProperty, $propertyName)) {
                     continue;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -281,7 +281,7 @@ CODE_SAMPLE;
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable($nodes, $callable);
     }
 
-    protected function mirrorComments(Node $newNode, Node $oldNode, bool $mergeExistingComments = false): void
+    protected function mirrorComments(Node $newNode, Node $oldNode): void
     {
         if ($this->nodeComparator->areSameNode($newNode, $oldNode)) {
             return;
@@ -304,25 +304,9 @@ CODE_SAMPLE;
             }
         }
 
-        if (! $mergeExistingComments) {
-            $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
-        } else {
-            // set null as mix multiple docs will require re-build
-            // on next call
-            $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, null);
-        }
-
+        $newNode->setAttribute(AttributeKey::PHP_DOC_INFO, $oldPhpDocInfo);
         if (! $newNode instanceof Nop) {
-            if (! $mergeExistingComments) {
-                $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
-                return;
-            }
-
-            $newComments = array_merge(
-                $newNode->getComments(),
-                $oldNode->getComments()
-            );
-            $newNode->setAttribute(AttributeKey::COMMENTS, $newComments);
+            $newNode->setAttribute(AttributeKey::COMMENTS, $oldNode->getAttribute(AttributeKey::COMMENTS));
         }
     }
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/7074

- Revert change on AbstractRector::mirrorComments()
- Use logic directly on InlineConstructorDefaultToPropertyRector, as this only usage for existing node merge, make code localized to avoid wide logic usage that cause regression.