### PR TITLE
[CodeQuality] Skip Never type by @return docblock on ExplicitReturnNullRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip_never_type_by_return_doc.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector/Fixture/skip_never_type_by_return_doc.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector\Fixture;
+
+/**
+ * @return never
+ */
+function abort(int $code)
+{
+    throw new NotFoundException();
+}
+
+final class SkipNeverTypeInCatch
+{
+    public function download(Upload $file, array $headers = [])
+    {
+        try {
+            try {
+                return $this->storage->download($file, $headers);
+            } catch (RemoteFileNotFoundException $e) {
+                return $this->localStorage->download($file, $headers);
+            }
+        } catch (FileNotFoundException $e) {
+            abort(404);
+        }
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ExplicitReturnNullRector.php
@@ -140,7 +140,9 @@ CODE_SAMPLE
             return null;
         });
 
-        if (! $this->silentVoidResolver->hasSilentVoid($node)) {
+        // allow non native @return never type use
+        // to avoid noise for addition returns
+        if (! $this->silentVoidResolver->hasSilentVoid($node, false)) {
             if ($hasChanged) {
                 $this->transformDocUnionVoidToUnionNull($node);
                 return $node;

--- a/rules/TypeDeclaration/NodeAnalyzer/NeverFuncCallAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/NeverFuncCallAnalyzer.php
@@ -40,7 +40,7 @@ final readonly class NeverFuncCallAnalyzer
             return false;
         }
 
-        $stmtType = $this->nodeTypeResolver->getNativeType($stmt);
+        $stmtType = $this->nodeTypeResolver->getType($stmt);
         return $stmtType instanceof NeverType;
     }
 }

--- a/rules/TypeDeclaration/NodeAnalyzer/NeverFuncCallAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/NeverFuncCallAnalyzer.php
@@ -30,7 +30,7 @@ final readonly class NeverFuncCallAnalyzer
         return false;
     }
 
-    public function isWithNeverTypeExpr(Stmt $stmt): bool
+    public function isWithNeverTypeExpr(Stmt $stmt, bool $withNativeNeverType = true): bool
     {
         if ($stmt instanceof Expression) {
             $stmt = $stmt->expr;
@@ -40,7 +40,10 @@ final readonly class NeverFuncCallAnalyzer
             return false;
         }
 
-        $stmtType = $this->nodeTypeResolver->getType($stmt);
+        $stmtType = $withNativeNeverType
+            ? $this->nodeTypeResolver->getNativeType($stmt)
+            : $this->nodeTypeResolver->getType($stmt);
+
         return $stmtType instanceof NeverType;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9276

Make less noise by check non-native type for NeverType, for use on `ExplicitReturnNullRector`, as the `SilentVoidResolver` is used by strict typed rules as well, I added `$withNativeNeverType` flag that default to `true` and use as `false` on this to allow non-native `@return` never type use to avoid noise for addition returns.