### PR TITLE
Naming Rector would overwrite existing variable

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_used_after_switch.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_used_after_switch.php.inc
@@ -1,0 +1,17 @@
+<?php
+class SwitchScopeCheck
+{
+    public function getNumber (array $numbers, int $number): int {
+        $action = $_GET['action'] ?? 'something';
+        switch ($action) {
+            default:
+                $sum = 0;
+                foreach ($numbers as $temp) {
+                    $sum += $temp;
+                }
+                break;
+        }
+        return $sum % $number;
+    }
+}
+?>


### PR DESCRIPTION
The Naming "RenameForeachValueVariableToMatchExprVariableRector" would rename a variable that was declared before a switch statement and used after the switch statement. The variable, once renamed, would be the value of the last looped value through the foreach, losing its original value.