### PR TITLE
[Naming] Skip var used after switch on RenameForeachValueVariableToMatchExprVariableRector

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_used_after_switch.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_used_after_switch.php.inc
@@ -1,4 +1,7 @@
 <?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
 class SwitchScopeCheck
 {
     public function getNumber (array $numbers, int $number): int {

--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_used_after_switch.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_used_after_switch.php.inc
@@ -1,0 +1,17 @@
+<?php
+class SwitchScopeCheck
+{
+    public function getNumber (array $numbers, int $number): int {
+        $action = $_GET['action'] ?? 'something';
+        switch ($action) {
+            default:
+                $sum = 0;
+                foreach ($numbers as $temp) {
+                    $sum += $temp;
+                }
+                break;
+        }
+        return $sum % $number;
+    }
+}
+?>

--- a/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
+++ b/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
@@ -12,6 +12,7 @@ use Rector\Naming\ExpectedNameResolver\InflectorSingularResolver;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\NodeManipulator\StmtsManipulator;
 use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -81,6 +82,7 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
+        $scope = ScopeFetcher::fetch($node);
 
         foreach ($node->stmts as $key => $stmt) {
             if (! $stmt instanceof Foreach_) {
@@ -125,6 +127,10 @@ CODE_SAMPLE
             }
 
             if ($this->stmtsManipulator->isVariableUsedInNextStmt($node, $key + 1, $valueVarName)) {
+                continue;
+            }
+
+            if ($scope->hasVariableType($singularValueVarName)->yes()) {
                 continue;
             }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/7079