### PR TITLE
Rename fixture class for defined early on RenameForeachValueVariableToMatchExprVariableRector

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_defined_early_from_parameter.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_var_defined_early_from_parameter.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
 
-class SkipVarUsedAfterSwitch
+class SkipVarDefinedEarlyFromParameter
 {
     public function getNumber (array $numbers, int $number): int {
         $action = $_GET['action'] ?? 'something';


### PR DESCRIPTION
@phinor it actually not because of used after switch, but defined early from parameter, which make it "variable is defined in prior foreach" which make the patch make sense :)

```php
if ($scope->hasVariableType($singularValueVarName)->yes()) {
     continue;
}
```

this only update fixture name for the previous fix:

- https://github.com/rectorphp/rector-src/pull/7080

for future note the usage.