### PR TITLE
[Php81] added `RemoveReflectionSetAccessibleCallsRector`

### DIFF
--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -8,6 +8,7 @@ use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
+use Rector\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
 use Rector\Php81\Rector\MethodCall\SpatieEnumMethodCallToEnumConstRector;
 use Rector\Php81\Rector\New_\MyCLabsConstructorCallToEnumFromRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
@@ -24,5 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
         SpatieEnumMethodCallToEnumConstRector::class,
         NullToStrictStringFuncCallArgRector::class,
         FirstClassCallableRector::class,
+        RemoveReflectionSetAccessibleCallsRector::class,
     ]);
 };

--- a/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/Fixture/fixture.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector\Fixture;
+
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class Fixture
+{
+    public function run(): void
+    {
+        $reflectionProperty = new ReflectionProperty($this, 'privateProperty');
+        $reflectionProperty->setAccessible(true);
+        $value = $reflectionProperty->getValue($this);
+
+        $reflectionMethod = new ReflectionMethod($this, 'privateMethod');
+        $reflectionMethod->setAccessible(false);
+        $reflectionMethod->invoke($this);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector\Fixture;
+
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class Fixture
+{
+    public function run(): void
+    {
+        $reflectionProperty = new ReflectionProperty($this, 'privateProperty');
+        $value = $reflectionProperty->getValue($this);
+
+        $reflectionMethod = new ReflectionMethod($this, 'privateMethod');
+        $reflectionMethod->invoke($this);
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/RemoveReflectionSetAccessibleCallsRectorTest.php
+++ b/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/RemoveReflectionSetAccessibleCallsRectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
 
+use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
@@ -16,9 +17,9 @@ final class RemoveReflectionSetAccessibleCallsRectorTest extends AbstractRectorT
     }
 
     /**
-     * @return \Iterator<array<string>>
+     * @return Iterator<array<string>>
      */
-    public static function provideData(): \Iterator
+    public static function provideData(): Iterator
     {
         return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }

--- a/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/RemoveReflectionSetAccessibleCallsRectorTest.php
+++ b/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/RemoveReflectionSetAccessibleCallsRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveReflectionSetAccessibleCallsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<array<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/config/configured_rule.php
+++ b/rules-tests/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveReflectionSetAccessibleCallsRector::class);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_85);
+};

--- a/rules/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector.php
+++ b/rules/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector.php
@@ -47,8 +47,8 @@ final class RemoveReflectionSetAccessibleCallsRector extends AbstractRector impl
             return null;
         }
 
-        if ($this->isObjectType($methodCall->var, new ObjectType('ReflectionProperty')) === true
-            || $this->isObjectType($methodCall->var, new ObjectType('ReflectionMethod')) === true
+        if ($this->isObjectType($methodCall->var, new ObjectType('ReflectionProperty'))
+            || $this->isObjectType($methodCall->var, new ObjectType('ReflectionMethod'))
         ) {
             return NodeVisitor::REMOVE_NODE;
         }

--- a/rules/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector.php
+++ b/rules/Php81/Rector/MethodCall/RemoveReflectionSetAccessibleCallsRector.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php81\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeVisitor;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersion;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * As of PHP 8.1.0, calling `Reflection*::setAccessible()` has no effect.
+ *
+ * @see https://www.php.net/manual/en/reflectionmethod.setaccessible.php
+ * @see https://www.php.net/manual/en/reflectionproperty.setaccessible.php
+ * @see \Rector\Tests\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector\RemoveReflectionSetAccessibleCallsRectorTest
+ */
+final class RemoveReflectionSetAccessibleCallsRector extends AbstractRector implements MinPhpVersionInterface
+{
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    /**
+     * @param Expression $node
+     */
+    public function refactor(Node $node): ?int
+    {
+        if ($node->expr instanceof MethodCall === false) {
+            return null;
+        }
+
+        $methodCall = $node->expr;
+
+        if ($this->isName($methodCall->name, 'setAccessible') === false) {
+            return null;
+        }
+
+        if ($this->isObjectType($methodCall->var, new ObjectType('ReflectionProperty')) === true
+            || $this->isObjectType($methodCall->var, new ObjectType('ReflectionMethod')) === true
+        ) {
+            return NodeVisitor::REMOVE_NODE;
+        }
+
+        return null;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove Reflection::setAccessible() calls', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$reflectionProperty = new ReflectionProperty($object, 'property');
+$reflectionProperty->setAccessible(true);
+$value = $reflectionProperty->getValue($object);
+
+$reflectionMethod = new ReflectionMethod($object, 'method');
+$reflectionMethod->setAccessible(false);
+$reflectionMethod->invoke($object);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$reflectionProperty = new ReflectionProperty($object, 'property');
+$value = $reflectionProperty->getValue($object);
+
+$reflectionMethod = new ReflectionMethod($object, 'method');
+$reflectionMethod->invoke($object);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersion::PHP_81;
+    }
+}

--- a/src/Util/Reflection/PrivatesAccessor.php
+++ b/src/Util/Reflection/PrivatesAccessor.php
@@ -47,7 +47,6 @@ final class PrivatesAccessor
     public function getPrivateProperty(object $object, string $propertyName): mixed
     {
         $reflectionProperty = $this->resolvePropertyReflection($object, $propertyName);
-        $reflectionProperty->setAccessible(true);
 
         return $reflectionProperty->getValue($object);
     }
@@ -55,17 +54,13 @@ final class PrivatesAccessor
     public function setPrivateProperty(object $object, string $propertyName, mixed $value): void
     {
         $reflectionProperty = $this->resolvePropertyReflection($object, $propertyName);
-        $reflectionProperty->setAccessible(true);
 
         $reflectionProperty->setValue($object, $value);
     }
 
     private function createAccessibleMethodReflection(object $object, string $methodName): ReflectionMethod
     {
-        $reflectionMethod = new ReflectionMethod($object, $methodName);
-        $reflectionMethod->setAccessible(true);
-
-        return $reflectionMethod;
+        return new ReflectionMethod($object, $methodName);
     }
 
     private function resolvePropertyReflection(object $object, string $propertyName): ReflectionProperty


### PR DESCRIPTION
As of PHP 8.1.0, calling `Reflection*::setAccessible()` [has no effect](https://www.php.net/manual/en/reflectionproperty.setaccessible.php); all properties are accessible by default. Currently, there is a [RFC](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible) which proposes to issue a deprecation warning starting with Php 8.5.

**Note**:
I added it to the 8.5 rules, because it will likely be decprecated by then. Alternatively, we could add it to the 8.1 rules. Let me know if you think this would be more sensible.