### PR TITLE
[AutoImport] Handle auto import short name on global namespace

### DIFF
--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/global_namespace.php.inc
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/global_namespace.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace
+{
+    class GlobalNamespace
+    {
+        public function create()
+        {
+            return new \DateTime();
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace
+{
+    class GlobalNamespace
+    {
+        public function create()
+        {
+            return new DateTime();
+        }
+    }
+}
+
+?>

--- a/rules/CodingStyle/Application/UseImportsAdder.php
+++ b/rules/CodingStyle/Application/UseImportsAdder.php
@@ -233,6 +233,12 @@ final readonly class UseImportsAdder
                     continue;
                 }
 
+                if ($namespaceName === null
+                    && $importType instanceof FullyQualifiedObjectType
+                    && substr_count(ltrim($importType->getClassName(), '\\'), '\\') === 0) {
+                    continue;
+                }
+
                 // already imported in previous cycle
                 $newUses[] = $importType->getUseNode($type);
             }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9277

Just remove the `\\` without add to use statement to avoid error:

```
Warning: The use statement with non-compound name 'DateTime' has no effect in /in/dXm9G on line 5
```

Ref 

- https://getrector.com/demo/31ce5199-a5ef-484e-ab7c-d462c6787861
- https://3v4l.org/dXm9G#v8.4.10