### PR TITLE
perf: break out of loop instead of continuing

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -1063,7 +1063,7 @@ final class RectorConfigBuilder
         foreach ($rectorRulesWithConfiguration as $position => $rectorRuleWithConfiguration) {
             // add rules until level is reached
             if ($position > $level) {
-                continue;
+                break;
             }
 
             if (is_string($rectorRuleWithConfiguration)) {


### PR DESCRIPTION
This improves performance by avoiding unnecessary iterations when the level is already reached.