### PR TITLE
fix: sorting of named parameters in variadic functions

### DIFF
--- a/rules-tests/CodeQuality/Rector/FuncCall/SortNamedParamRector/Fixture/variadic.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SortNamedParamRector/Fixture/variadic.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SortNamedParamRector\Fixture;
+
+function variadic($title, ...$params) {}
+
+variadic(foo: $foo, title: $title, bar: $bar);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SortNamedParamRector\Fixture;
+
+function variadic($title, ...$params) {}
+
+variadic(title: $title, foo: $foo, bar: $bar);
+
+?>

--- a/rules/CodeQuality/Rector/FuncCall/SortNamedParamRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SortNamedParamRector.php
@@ -141,7 +141,10 @@ CODE_SAMPLE
                 /** @var Identifier $argName2 */
                 $argName2 = $arg2->name;
 
-                return $order[$argName1->name] <=> $order[$argName2->name];
+                $order1 = $order[$argName1->name] ?? PHP_INT_MAX;
+                $order2 = $order[$argName2->name] ?? PHP_INT_MAX;
+
+                return $order1 <=> $order2;
             }
         );
 


### PR DESCRIPTION
This fix is twofold:
1. it ensures that no warnings are generated when a named parameter is not found in the order array
2. it properly sorts named parameters in variadic functions

Thanks!