### PR TITLE
[DeadCode] Skip Templated type on param and return on RemoveUselessParamTagRector and RemoveUselessReturnTagRector under IntersectionType

### DIFF
--- a/src/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/src/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -10,13 +10,16 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
+use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\PHPStan\TypeHasher;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -96,6 +99,14 @@ final readonly class TypeComparator
 
         if ($this->areTypesSameWithLiteralTypeInPhpDoc($areDifferentScalarTypes, $phpStanDocType, $phpParserNodeType)) {
             return false;
+        }
+
+        if ($phpStanDocType instanceof UnionType || $phpParserNodeType instanceof IntersectionType) {
+            foreach ($phpStanDocType->getTypes() as $type) {
+                if ($type instanceof TemplateObjectType) {
+                    return false;
+                }
+            }
         }
 
         return $this->isThisTypeInFinalClass($phpStanDocType, $phpParserNodeType, $phpParserNode);

--- a/src/NodeTypeResolver/TypeComparator/TypeComparator.php
+++ b/src/NodeTypeResolver/TypeComparator/TypeComparator.php
@@ -101,7 +101,7 @@ final readonly class TypeComparator
             return false;
         }
 
-        if ($phpStanDocType instanceof UnionType || $phpParserNodeType instanceof IntersectionType) {
+        if ($phpStanDocType instanceof UnionType || $phpStanDocType instanceof IntersectionType) {
             foreach ($phpStanDocType->getTypes() as $type) {
                 if ($type instanceof TemplateObjectType) {
                     return false;

--- a/tests/Issues/TemplatedTypeOnParamAndReturn/Fixture/skip_templated_type_on_param_and_return.php.inc
+++ b/tests/Issues/TemplatedTypeOnParamAndReturn/Fixture/skip_templated_type_on_param_and_return.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\TemplatedTypeOnParamAndReturn\Fixture;
+
+abstract class Model {}
+interface EventInterface {}
+
+/** @template TModel of Model */
+abstract class SkipTemplatedTypeOnParamAndReturn
+{
+    /**
+     * @param TModel&EventInterface $model
+     * @return TModel&EventInterface
+     */
+    abstract public function run(Model&EventInterface $model): Model&EventInterface;
+}

--- a/tests/Issues/TemplatedTypeOnParamAndReturn/TemplatedTypeOnParamAndReturnTest.php
+++ b/tests/Issues/TemplatedTypeOnParamAndReturn/TemplatedTypeOnParamAndReturnTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\TemplatedTypeOnParamAndReturn;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TemplatedTypeOnParamAndReturnTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/TemplatedTypeOnParamAndReturn/config/configured_rule.php
+++ b/tests/Issues/TemplatedTypeOnParamAndReturn/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        RemoveUselessParamTagRector::class,
+        RemoveUselessReturnTagRector::class
+    ]);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9286