### PR TITLE
feat: add support for set, isset, and unset operations in ArrayDimFetchToMethodCallRector

### DIFF
--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/partial_tranformation.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/partial_tranformation.php.inc
@@ -2,9 +2,9 @@
 
 namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
 
-/** @var \SomeClass $object */
+/** @var \Container $object */
 $object['key'];
-$object['key'] = 42;
+$object['key'] = 'value';
 isset($object['key']);
 unset($object['key']);
 
@@ -14,10 +14,10 @@ unset($object['key']);
 
 namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
 
-/** @var \SomeClass $object */
+/** @var \Container $object */
 $object->get('key');
-$object->set('key', 42);
-$object->has('key');
-$object->unset('key');
+$object['key'] = 'value';
+isset($object['key']);
+unset($object['key']);
 
 ?>

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_multiple_issets.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_multiple_issets.php.inc
@@ -3,10 +3,10 @@
 namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
 
 /** @var \SomeClass $object */
-$object['key'];
-$object['key'] = 42;
-isset($object['key']);
-unset($object['key']);
+/** @var \SomeOtherClass $other */
+if (isset($object['key1'], $other['key'], $object['key2'])) {
+    echo 'Keys are set';
+}
 
 ?>
 -----
@@ -15,9 +15,9 @@ unset($object['key']);
 namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
 
 /** @var \SomeClass $object */
-$object->get('key');
-$object->set('key', 42);
-$object->has('key');
-$object->unset('key');
+/** @var \SomeOtherClass $other */
+if (isset($other['key']) && $object->has('key1') && $object->has('key2')) {
+    echo 'Keys are set';
+}
 
 ?>

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_multiple_unsets.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_multiple_unsets.php.inc
@@ -3,10 +3,8 @@
 namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
 
 /** @var \SomeClass $object */
-$object['key'];
-$object['key'] = 42;
-isset($object['key']);
-unset($object['key']);
+/** @var \SomeOtherClass $other */
+unset($object['key1'], $other['key'], $object['key2']);
 
 ?>
 -----
@@ -15,9 +13,9 @@ unset($object['key']);
 namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
 
 /** @var \SomeClass $object */
-$object->get('key');
-$object->set('key', 42);
-$object->has('key');
-$object->unset('key');
+/** @var \SomeOtherClass $other */
+unset($other['key']);
+$object->unset('key1');
+$object->unset('key2');
 
 ?>

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_property_fetch.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/transforms_property_fetch.php.inc
@@ -9,6 +9,9 @@ class FooBar extends SomeExtendedClass
     public function someMethod()
     {
         $this->something['key'];
+        $this->something['key'] = 42;
+        isset($this->something['key']);
+        unset($this->something['key']);
     }
 }
 
@@ -24,7 +27,10 @@ class FooBar extends SomeExtendedClass
 {
     public function someMethod()
     {
-        $this->something->make('key');
+        $this->something->get('key');
+        $this->something->set('key', 42);
+        $this->something->has('key');
+        $this->something->unset('key');
     }
 }
 

--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/config/configured_rule.php
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/config/configured_rule.php
@@ -10,6 +10,7 @@ use Rector\Transform\ValueObject\ArrayDimFetchToMethodCall;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig
         ->ruleWithConfiguration(ArrayDimFetchToMethodCallRector::class, [
-            new ArrayDimFetchToMethodCall(new ObjectType('SomeClass'), 'make'),
+            new ArrayDimFetchToMethodCall(new ObjectType('SomeClass'), 'get', 'set', 'has', 'unset'),
+            new ArrayDimFetchToMethodCall(new ObjectType('Container'), 'get'),
         ]);
 };

--- a/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
@@ -5,10 +5,18 @@ declare(strict_types=1);
 namespace Rector\Transform\Rector\ArrayDimFetch;
 
 use PhpParser\Node;
+use PhpParser\NodeVisitor;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Type\ObjectType;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Unset_;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Rector\Transform\ValueObject\ArrayDimFetchToMethodCall;
@@ -31,41 +39,54 @@ class ArrayDimFetchToMethodCallRector extends AbstractRector implements Configur
         return new RuleDefinition('Change array dim fetch to method call', [
             new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
-$app['someService'];
+$object['key'];
+$object['key'] = 'value';
+isset($object['key']);
+unset($object['key']);
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
-$app->make('someService');
+$object->get('key');
+$object->set('key', 'value');
+$object->has('key');
+$object->unset('key');
 CODE_SAMPLE
                 ,
-                [new ArrayDimFetchToMethodCall(new ObjectType('SomeClass'), 'make')]
+                [new ArrayDimFetchToMethodCall(new ObjectType('SomeClass'), 'get', 'set', 'has', 'unset')],
             ),
         ]);
     }
 
     public function getNodeTypes(): array
     {
-        return [ArrayDimFetch::class];
+        return [Assign::class, Isset_::class, Unset_::class, ArrayDimFetch::class];
     }
 
     /**
-     * @param ArrayDimFetch $node
+     * @template TNode of ArrayDimFetch|Assign|Isset_|Unset_
+     * @param TNode $node
+     * @return ($node is Unset_ ? Stmt[]|int : ($node is Isset_ ? Expr|int : MethodCall|int|null))
      */
-    public function refactor(Node $node): ?MethodCall
+    public function refactor(Node $node): array|Expr|null|int
     {
-        if (! $node->dim instanceof Node) {
-            return null;
+        if ($node instanceof Unset_) {
+            return $this->handleUnset($node);
         }
 
-        foreach ($this->arrayDimFetchToMethodCalls as $arrayDimFetchToMethodCall) {
-            if (! $this->isObjectType($node->var, $arrayDimFetchToMethodCall->getObjectType())) {
-                continue;
+        if ($node instanceof Isset_) {
+            return $this->handleIsset($node);
+        }
+
+        if ($node instanceof Assign) {
+            if (!$node->var instanceof ArrayDimFetch) {
+                return null;
             }
 
-            return new MethodCall($node->var, $arrayDimFetchToMethodCall->getMethod(), [new Arg($node->dim)]);
+            return $this->getMethodCall($node->var, 'set', $node->expr)
+                ?? NodeVisitor::DONT_TRAVERSE_CHILDREN;
         }
 
-        return null;
+        return $this->getMethodCall($node, 'get');
     }
 
     public function configure(array $configuration): void
@@ -73,5 +94,109 @@ CODE_SAMPLE
         Assert::allIsInstanceOf($configuration, ArrayDimFetchToMethodCall::class);
 
         $this->arrayDimFetchToMethodCalls = $configuration;
+    }
+
+    private function handleIsset(Isset_ $node): Expr|int|null
+    {
+        $issets = [];
+        $exprs = [];
+
+        foreach ($node->vars as $var) {
+            if ($var instanceof ArrayDimFetch) {
+                $methodCall = $this->getMethodCall($var, 'exists');
+
+                if ($methodCall !== null) {
+                    $exprs[] = $methodCall;
+                    continue;
+                }
+            }
+
+            $issets[] = $var;
+        }
+
+        if ($exprs === []) {
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($issets !== []) {
+            $node->vars = $issets;
+            array_unshift($exprs, $node);
+        }
+
+        return array_reduce(
+            $exprs,
+            fn (?Expr $carry, Expr $expr) => $carry === null ? $expr : new BooleanAnd($carry, $expr),
+            null,
+        );
+    }
+
+    /**
+     * @return Stmt[]|int
+     */
+    private function handleUnset(Unset_ $node): array|int
+    {
+        $unsets = [];
+        $stmts = [];
+
+        foreach ($node->vars as $var) {
+            if ($var instanceof ArrayDimFetch) {
+                $methodCall = $this->getMethodCall($var, 'unset');
+
+                if ($methodCall !== null) {
+                    $stmts[] = new Expression($methodCall);
+                    continue;
+                }
+            }
+
+            $unsets[] = $var;
+        }
+
+        if ($stmts === []) {
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($unsets !== []) {
+            $node->vars = $unsets;
+            array_unshift($stmts, $node);
+        }
+
+        return $stmts;
+    }
+
+    /**
+     * @param 'get'|'set'|'exists'|'unset' $action
+     */
+    private function getMethodCall(ArrayDimFetch $fetch, string $action, ?Expr $value = null): ?MethodCall
+    {
+        if (!$fetch->dim instanceof Node) {
+            return null;
+        }
+
+        foreach ($this->arrayDimFetchToMethodCalls as $arrayDimFetchToMethodCall) {
+            if (!$this->isObjectType($fetch->var, $arrayDimFetchToMethodCall->getObjectType())) {
+                continue;
+            }
+
+            $method = match ($action) {
+                'get' => $arrayDimFetchToMethodCall->getMethod(),
+                'set' => $arrayDimFetchToMethodCall->getSetMethod(),
+                'exists' => $arrayDimFetchToMethodCall->getExistsMethod(),
+                'unset' => $arrayDimFetchToMethodCall->getUnsetMethod(),
+            };
+
+            if ($method === null) {
+                continue;
+            }
+
+            $args = [new Arg($fetch->dim)];
+
+            if ($value instanceof Expr) {
+                $args[] = new Arg($value);
+            }
+
+            return new MethodCall($fetch->var, $method, $args);
+        }
+
+        return null;
     }
 }

--- a/rules/Transform/ValueObject/ArrayDimFetchToMethodCall.php
+++ b/rules/Transform/ValueObject/ArrayDimFetchToMethodCall.php
@@ -10,7 +10,12 @@ class ArrayDimFetchToMethodCall
 {
     public function __construct(
         private readonly ObjectType $objectType,
-        private readonly string $method
+        private readonly string $method,
+        // Optional methods for set, exists, and unset operations
+        // if null, then these operations will not be transformed
+        private readonly ?string $setMethod = null,
+        private readonly ?string $existsMethod = null,
+        private readonly ?string $unsetMethod = null,
     ) {
     }
 
@@ -22,5 +27,20 @@ class ArrayDimFetchToMethodCall
     public function getMethod(): string
     {
         return $this->method;
+    }
+
+    public function getSetMethod(): ?string
+    {
+        return $this->setMethod;
+    }
+
+    public function getExistsMethod(): ?string
+    {
+        return $this->existsMethod;
+    }
+
+    public function getUnsetMethod(): ?string
+    {
+        return $this->unsetMethod;
     }
 }


### PR DESCRIPTION
Hello!

Closes https://github.com/rectorphp/rector/issues/9289

### Motivation

Converting ArrayDimFetch (for objects that implement ArrayAccess) can be very dangerous if the `isset()`, `unset`, and assignment operations are not accounted for. If the object is used in any of the following scenarios:

```php
$object['key'] = 42;
isset($object['key']);
unset($object['key']);
```
this rule would update them to the following  and the application will be in a broken state:
```php
$object->get('key') = 42;
isset($object->get('key'));
unset($object->get('key'));
```

### Implementation

This rule properly handles all of the above situations (including when `isset` and `unset` have multiple arguments). The `ArrayDimFetchToMethodCall` class has been updated to accept methods for the other operations:

```php
class ArrayDimFetchToMethodCall
{
    public function __construct(
        private readonly ObjectType $objectType,
        private readonly string $method,
        // Optional methods for set, exists, and unset operations
        // if null, then these operations will not be transformed
        private readonly ?string $setMethod = null,
        private readonly ?string $existsMethod = null,
        private readonly ?string $unsetMethod = null,
    ) {
    }
}
```

> [!NOTE]
> I would like to rename the existing `$method` parameter to `$getMethod`, let me know if this is allowable and not considered a BC break

The other methods are nullable by default. If null, then that particular operation is skipped.

CC: @peterfox 

Thanks!