### PR TITLE
Bump to nikic/php-parser 5.6.0 and regenerate preload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.0.10",
         "illuminate/container": "^11.45",
         "nette/utils": "^4.0",
-        "nikic/php-parser": "^5.5.0",
+        "nikic/php-parser": "^5.6.0",
         "ocramius/package-versions": "^2.10",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.2",

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -71,10 +71,12 @@ require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/To
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ExplicitOctalEmulator.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/MatchTokenEmulator.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/NullsafeTokenEmulator.php';
+require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/PipeOperatorEmulator.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/PropertyTokenEmulator.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ReadonlyFunctionTokenEmulator.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ReadonlyTokenEmulator.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ReverseEmulator.php';
+require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/VoidCastEmulator.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Modifiers.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/NameContext.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Arg.php';
@@ -122,6 +124,7 @@ require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Exp
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Mul.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/NotEqual.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/NotIdentical.php';
+require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Pipe.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Plus.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Pow.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/ShiftLeft.php';
@@ -139,6 +142,7 @@ require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Exp
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/Object_.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/String_.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/Unset_.php';
+require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/Void_.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/ClassConstFetch.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Clone_.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Closure.php';

--- a/preload.php
+++ b/preload.php
@@ -71,10 +71,12 @@ require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulat
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ExplicitOctalEmulator.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/MatchTokenEmulator.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/NullsafeTokenEmulator.php';
+require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/PipeOperatorEmulator.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/PropertyTokenEmulator.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ReadonlyFunctionTokenEmulator.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ReadonlyTokenEmulator.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/ReverseEmulator.php';
+require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Lexer/TokenEmulator/VoidCastEmulator.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Modifiers.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/NameContext.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Arg.php';
@@ -122,6 +124,7 @@ require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryO
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Mul.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/NotEqual.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/NotIdentical.php';
+require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Pipe.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Plus.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/Pow.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/BinaryOp/ShiftLeft.php';
@@ -139,6 +142,7 @@ require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/In
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/Object_.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/String_.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/Unset_.php';
+require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Cast/Void_.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/ClassConstFetch.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Clone_.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/Closure.php';


### PR DESCRIPTION
Ref nikic/php-parser 5.6.0 just released: https://github.com/nikic/PHP-Parser/releases/tag/v5.6.0

Already included in previous scoped build

https://github.com/rectorphp/rector/commit/206238a8750fa43a1598ccca830ddd5abb21e0a6#diff-134cdda2651140171fadec5357839abe6bf05d517ce78dafc69476f024bf6b6a