### PR TITLE
fix: skip AssignOps in ArrayDimFetchToMethodCallRector

### DIFF
--- a/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/skip_assign_ops.php.inc
+++ b/rules-tests/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector/Fixture/skip_assign_ops.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\ArrayDimFetch\ArrayDimFetchToMethodCallRector\Fixture;
+
+/** @var \SomeClass $object */
+$object['key'] += 42;
+$object['key'] -= 42;
+$object['key'] *= 42;
+$object['key'] /= 42;
+$object['key'] %= 42;
+$object['key'] **= 42;
+$object['key'] .= 'value';
+$object['key'] &= 42;
+$object['key'] |= 42;
+$object['key'] ^= 42;
+$object['key'] <<= 42;
+$object['key'] >>= 42;
+$object['key'] ??= 'value';
+
+?>

--- a/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\MethodCall;
@@ -59,7 +60,7 @@ CODE_SAMPLE
 
     public function getNodeTypes(): array
     {
-        return [Assign::class, Isset_::class, Unset_::class, ArrayDimFetch::class];
+        return [AssignOp::class, Assign::class, Isset_::class, Unset_::class, ArrayDimFetch::class];
     }
 
     /**
@@ -69,6 +70,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): array|Expr|null|int
     {
+        if ($node instanceof AssignOp) {
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+        }
+
         if ($node instanceof Unset_) {
             return $this->handleUnset($node);
         }


### PR DESCRIPTION
Hello!

This skips any AssignOps to avoid breaking changes in the app.

Thanks!