### PR TITLE
[TypeDeclaration] Skip try catch finally different type on AddReturnTypeFromTryCatchTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeFromTryCatchTypeRector/Fixture/skip_try_catch_finally_different_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeFromTryCatchTypeRector/Fixture/skip_try_catch_finally_different_type.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeFromTryCatchTypeRector\Fixture;
+
+final class SkipTryCatchFinallyDifferentType
+{
+    public function run()
+    {
+        try {
+            return 1;
+        } catch (\RuntimeException $e) {
+            return 2;
+        } finally {
+            return "A";
+        }
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeFromTryCatchTypeRector/Fixture/try_catch_finally_same_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddReturnTypeFromTryCatchTypeRector/Fixture/try_catch_finally_same_type.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeFromTryCatchTypeRector\Fixture;
+
+final class TryCatchFinallySameType
+{
+    public function run()
+    {
+        try {
+            return 1;
+        } catch (\RuntimeException $e) {
+            return 2;
+        } finally {
+            return 3;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddReturnTypeFromTryCatchTypeRector\Fixture;
+
+final class TryCatchFinallySameType
+{
+    public function run(): int
+    {
+        try {
+            return 1;
+        } catch (\RuntimeException $e) {
+            return 2;
+        } finally {
+            return 3;
+        }
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeFromTryCatchTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeFromTryCatchTypeRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Finally_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\TryCatch;
 use PHPStan\Type\Type;
@@ -128,6 +129,13 @@ CODE_SAMPLE
 
                 $catchReturnTypes[] = $currentCatchType;
             }
+
+            if ($tryCatch->finally instanceof Finally_) {
+                $finallyReturnType = $this->matchReturnType($tryCatch->finally);
+                if ($finallyReturnType instanceof Type) {
+                    $catchReturnTypes[] = $finallyReturnType;
+                }
+            }
         }
 
         if (! $tryReturnType instanceof Type) {
@@ -149,9 +157,9 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function matchReturnType(TryCatch|Catch_ $tryOrCatch): ?Type
+    private function matchReturnType(TryCatch|Catch_|Finally_ $tryOrCatchOrFinally): ?Type
     {
-        foreach ($tryOrCatch->stmts as $stmt) {
+        foreach ($tryOrCatchOrFinally->stmts as $stmt) {
             if (! $stmt instanceof Return_) {
                 continue;
             }


### PR DESCRIPTION
@TomasVotruba this continue of PR:

- https://github.com/rectorphp/rector-src/pull/7099

to ensure try + catch + finally different type is skipped, see https://3v4l.org/BRgUn#v8.4.10