### PR TITLE
[DeadCode] Skip with get_defined_vars() on RemoveUnusedPrivateMethodParameterRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_get_defined_vars.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodParameterRector/Fixture/skip_get_defined_vars.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector\Fixture;
+
+final class SkipGetDefinedVars
+{
+    private function example($value): array
+    {
+        return get_defined_vars();
+    }
+}

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -29,7 +29,7 @@ final readonly class ParamAnalyzer
     /**
      * @var string[]
      */
-    private const VARIADIC_FUNCTION_NAMES = ['func_get_arg', 'func_get_args', 'func_num_args'];
+    private const VARIADIC_FUNCTION_NAMES = ['func_get_arg', 'func_get_args', 'func_num_args', 'get_defined_vars'];
 
     public function __construct(
         private NodeComparator $nodeComparator,


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9296