### PR TITLE
feat: add RemoveReadonlyPropertyVisibilityOnReadonlyClassRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/class_with_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/class_with_attribute.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+#[SomeAttribute]
+final readonly class ClassWithAttribute
+{
+    private readonly string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+#[SomeAttribute]
+final readonly class ClassWithAttribute
+{
+    private string $property;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/class_with_attribute_inline.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/class_with_attribute_inline.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+#[SomeAttribute]final readonly class ClassWithAttributeInline
+{
+    private readonly string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+#[SomeAttribute]final readonly class ClassWithAttributeInline
+{
+    private string $property;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/class_without_attribute.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/class_without_attribute.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class ClassWithoutAttribute {
+   private readonly string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class ClassWithoutAttribute {
+   private string $property;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/combine_promo_and_property_readonly.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/combine_promo_and_property_readonly.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class CombinePromoAndPropertyReadonly
+{
+	public readonly string $b;
+
+    public function __construct(
+        public readonly string $a,
+        ?string $b = null
+    ) {
+		  $this->b = $b ?? 'foo';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class CombinePromoAndPropertyReadonly
+{
+	public string $b;
+
+    public function __construct(
+        public string $a,
+        ?string $b = null
+    ) {
+		  $this->b = $b ?? 'foo';
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/implicit_public_readonly_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/implicit_public_readonly_property.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class ImplicitPublicReadonlyProperty
+{
+    readonly string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'bar';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class ImplicitPublicReadonlyProperty
+{
+    public string $foo;
+
+    public function __construct()
+    {
+        $this->foo = 'bar';
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/implicit_public_readonly_property_promotion.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/implicit_public_readonly_property_promotion.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class ImplicitPublicReadonlyPropertyPromotion
+{
+    public function __construct(readonly string $name)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class ImplicitPublicReadonlyPropertyPromotion
+{
+    public function __construct(public string $name)
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/only_readonly_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/only_readonly_property.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class OnlyReadonlyProperty
+{
+   private readonly string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class OnlyReadonlyProperty
+{
+   private string $property;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/only_readonly_property2.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/only_readonly_property2.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class OnlyReadonlyProperty2
+{
+    public function __construct(private readonly string $property)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class OnlyReadonlyProperty2
+{
+    public function __construct(private string $property)
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/with_attribute_on_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/with_attribute_on_property.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class WithAttributeOnProperty
+{
+    #[MyAttr]
+    public readonly string $id;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class WithAttributeOnProperty
+{
+    #[MyAttr]
+    public string $id;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/with_attribute_on_property_promotion.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/Fixture/with_attribute_on_property_promotion.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class WithAttributeOnPropertyPromotion
+{
+    private function __construct(
+        #[MyAttr]
+        private readonly string $id
+    ){}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\Fixture;
+
+final readonly class WithAttributeOnPropertyPromotion
+{
+    private function __construct(
+        #[MyAttr]
+        private string $id
+    ){}
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/RemoveReadonlyPropertyVisibilityOnReadonlyClassRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/RemoveReadonlyPropertyVisibilityOnReadonlyClassRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveReadonlyPropertyVisibilityOnReadonlyClassRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveReadonlyPropertyVisibilityOnReadonlyClassRector::class);
+};

--- a/rules/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Class_;
+use Rector\Php81\NodeManipulator\AttributeGroupNewLiner;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\MethodName;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector\RemoveReadonlyPropertyVisibilityOnReadonlyClassRectorTest
+ */
+final class RemoveReadonlyPropertyVisibilityOnReadonlyClassRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly VisibilityManipulator $visibilityManipulator,
+        private readonly AttributeGroupNewLiner $attributeGroupNewLiner
+    ) {
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::READONLY_CLASS;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove readonly property visibility on readonly class', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+final readonly class SomeClass
+{
+    public function __construct(
+        private readonly string $name
+    ) {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+final readonly class SomeClass
+{
+    public function __construct(
+        private string $name
+    ) {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->isReadonly()) {
+            return null;
+        }
+
+        $hasChanged = false;
+        $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);
+
+        if ($constructClassMethod instanceof ClassMethod) {
+            foreach ($constructClassMethod->getParams() as $param) {
+                if (! $param->isReadonly()) {
+                    continue;
+                }
+
+                $this->visibilityManipulator->removeReadonly($param);
+                $hasChanged = true;
+
+                if ($param->attrGroups !== []) {
+                    $this->attributeGroupNewLiner->newLine($this->file, $param);
+                }
+            }
+        }
+
+        foreach ($node->getProperties() as $property) {
+            if (! $property->isReadonly()) {
+                continue;
+            }
+
+            $this->visibilityManipulator->removeReadonly($property);
+            $hasChanged = true;
+
+            if ($property->attrGroups !== []) {
+                $this->attributeGroupNewLiner->newLine($this->file, $property);
+            }
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -12,6 +12,7 @@ use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
 use Rector\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector;
 use Rector\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector;
 use Rector\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector;
 use Rector\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector;
@@ -173,6 +174,7 @@ final class CodeQualityLevel
         RemoveUselessIsObjectCheckRector::class,
         StaticToSelfStaticMethodCallOnFinalClassRector::class,
         SortNamedParamRector::class,
+        RemoveReadonlyPropertyVisibilityOnReadonlyClassRector::class,
     ];
 
     /**


### PR DESCRIPTION
Hello!

This Rector removes the `readonly` visibility modifier from properties in classes that are already marked as `readonly`. This is useful for cleaning up code where the `readonly` modifier is redundant due to the class's readonly status.

Thanks!