### PR TITLE
[Renaming] Add `RenameCastRector`

### DIFF
--- a/rules-tests/Renaming/Rector/Cast/RenameCastRector/Fixture/fixture.php.inc
+++ b/rules-tests/Renaming/Rector/Cast/RenameCastRector/Fixture/fixture.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Cast\RenameCastRector\Fixture;
+
+$real = (real) $real;
+$double = (double) $double;
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Cast\RenameCastRector\Fixture;
+
+$real = (float) $real;
+$double = (float) $double;
+
+?>

--- a/rules-tests/Renaming/Rector/Cast/RenameCastRector/RenameCastRectorTest.php
+++ b/rules-tests/Renaming/Rector/Cast/RenameCastRector/RenameCastRectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\Cast\RenameCastRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class RenameCastRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Renaming/Rector/Cast/RenameCastRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/Cast/RenameCastRector/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node\Expr\Cast\Double;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Cast\RenameCastRector;
+use Rector\Renaming\ValueObject\RenameCast;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(RenameCastRector::class, [
+            new RenameCast(Double::class, Double::KIND_REAL, Double::KIND_FLOAT),
+            new RenameCast(Double::class, Double::KIND_DOUBLE, Double::KIND_FLOAT),
+        ]);
+};

--- a/rules/Renaming/Rector/Cast/RenameCastRector.php
+++ b/rules/Renaming/Rector/Cast/RenameCastRector.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Renaming\Rector\Cast;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\Cast\Double;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Rector\Renaming\ValueObject\RenameCast;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\Renaming\Rector\Cast\RenameCastRector\RenameCastRectorTest
+ */
+final class RenameCastRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var array<RenameCast>
+     */
+    private array $renameCasts = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Renames casts', [
+            new ConfiguredCodeSample(
+                '$real = (real) $real;',
+                '$real = (float) $real;',
+                [new RenameCast(Double::class, Double::KIND_REAL, Double::KIND_FLOAT)]
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Cast::class];
+    }
+
+    /**
+     * @param Cast $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($this->renameCasts as $renameCast) {
+            $expectedClassName = $renameCast->getFromCastExprClass();
+            if (
+                ! $node instanceof $expectedClassName
+                || $node->getAttribute(AttributeKey::KIND) !== $renameCast->getFromCastKind()
+            ) {
+                continue;
+            }
+
+            $node->setAttribute(AttributeKey::KIND, $renameCast->getToCastKind());
+            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, RenameCast::class);
+
+        $this->renameCasts = $configuration;
+    }
+}

--- a/rules/Renaming/ValueObject/RenameCast.php
+++ b/rules/Renaming/ValueObject/RenameCast.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Renaming\ValueObject;
+
+use PhpParser\Node\Expr\Cast;
+use Rector\Validation\RectorAssert;
+use Webmozart\Assert\Assert;
+
+final readonly class RenameCast
+{
+    public function __construct(
+        /** @var class-string<Cast> */
+        private string $fromCastExprClass,
+        private int $fromCastKind,
+        private int $toCastKind,
+    ) {
+        RectorAssert::className($fromCastExprClass);
+        Assert::subclassOf($fromCastExprClass, Cast::class);
+    }
+
+    /**
+     * @return class-string<Cast>
+     */
+    public function getFromCastExprClass(): string
+    {
+        return $this->fromCastExprClass;
+    }
+
+    public function getFromCastKind(): int
+    {
+        return $this->fromCastKind;
+    }
+
+    public function getToCastKind(): int
+    {
+        return $this->toCastKind;
+    }
+}


### PR DESCRIPTION
While there is already `RealToFloatTypeCastRector` to handle the deprecation of the `(real)` cast, this generalized rector rule will allow to configure the cast renaming and thus also support other types of cast renamings.