### PR TITLE
[DeadCode] Early check GenericTypeNode is not dead code on DeadVar/ReturnParam Analyzer

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\Casing\LowercaseKeywordsFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
-use PhpCsFixer\Fixer\Casing\LowercaseKeywordsFixer;
 
 return ECSConfig::configure()
     ->withPreparedSets(symplify: true, common: true, psr12: true)
@@ -36,8 +36,6 @@ return ECSConfig::configure()
             __DIR__ . '/src/Util/ArrayParametersMerger.php',
         ],
 
-        LowercaseKeywordsFixer::class => [
-            __DIR__ . '/src/ValueObject/Visibility.php',
-        ],
+        LowercaseKeywordsFixer::class => [__DIR__ . '/src/ValueObject/Visibility.php'],
     ])
     ->withRootFiles();

--- a/ecs.php
+++ b/ecs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use PhpCsFixer\Fixer\Casing\LowercaseKeywordsFixer;
 
 return ECSConfig::configure()
     ->withPreparedSets(symplify: true, common: true, psr12: true)
@@ -33,6 +34,10 @@ return ECSConfig::configure()
         GeneralPhpdocAnnotationRemoveFixer::class => [
             // bug remove @author annotation
             __DIR__ . '/src/Util/ArrayParametersMerger.php',
+        ],
+
+        LowercaseKeywordsFixer::class => [
+            __DIR__ . '/src/ValueObject/Visibility.php',
         ],
     ])
     ->withRootFiles();

--- a/rules/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Php81\NodeManipulator\AttributeGroupNewLiner;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -9,6 +9,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
@@ -51,7 +52,7 @@ final readonly class DeadParamTagValueNodeAnalyzer
             return false;
         }
 
-        if ($paramTagValueNode->type instanceof \PHPStan\PhpDocParser\Ast\Type\GenericTypeNode) {
+        if ($paramTagValueNode->type instanceof GenericTypeNode) {
             return false;
         }
 

--- a/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadParamTagValueNodeAnalyzer.php
@@ -51,6 +51,10 @@ final readonly class DeadParamTagValueNodeAnalyzer
             return false;
         }
 
+        if ($paramTagValueNode->type instanceof \PHPStan\PhpDocParser\Ast\Type\GenericTypeNode) {
+            return false;
+        }
+
         $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
             $paramTagValueNode->type,
             $functionLike

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -49,6 +49,10 @@ final readonly class DeadReturnTagValueNodeAnalyzer
             return false;
         }
 
+        if ($returnTagValueNode->type instanceof \PHPStan\PhpDocParser\Ast\Type\GenericTypeNode) {
+            return false;
+        }
+
         $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType(
             $returnTagValueNode->type,
             $functionLike

--- a/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadReturnTagValueNodeAnalyzer.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
 use PHPStan\Type\TypeCombinator;
@@ -49,7 +50,7 @@ final readonly class DeadReturnTagValueNodeAnalyzer
             return false;
         }
 
-        if ($returnTagValueNode->type instanceof \PHPStan\PhpDocParser\Ast\Type\GenericTypeNode) {
+        if ($returnTagValueNode->type instanceof GenericTypeNode) {
             return false;
         }
 

--- a/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
@@ -35,6 +35,10 @@ final readonly class DeadVarTagValueNodeAnalyzer
             return false;
         }
 
+        if ($varTagValueNode->type instanceof \PHPStan\PhpDocParser\Ast\Type\GenericTypeNode) {
+            return false;
+        }
+
         // is strict type superior to doc type? keep strict type only
         $propertyType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($property->type);
         $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($varTagValueNode->type, $property);

--- a/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
+++ b/rules/DeadCode/PhpDoc/DeadVarTagValueNodeAnalyzer.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
@@ -35,7 +36,7 @@ final readonly class DeadVarTagValueNodeAnalyzer
             return false;
         }
 
-        if ($varTagValueNode->type instanceof \PHPStan\PhpDocParser\Ast\Type\GenericTypeNode) {
+        if ($varTagValueNode->type instanceof GenericTypeNode) {
             return false;
         }
 

--- a/rules/TypeDeclaration/Rector/FuncCall/AddArrayFunctionClosureParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/FuncCall/AddArrayFunctionClosureParamTypeRector.php
@@ -106,6 +106,7 @@ CODE_SAMPLE
             if (! $singlePassedExprType instanceof Type) {
                 continue;
             }
+
             if ($singlePassedExprType instanceof MixedType) {
                 continue;
             }


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-phpunit/pull/505

@biozshock this should handle https://github.com/rectorphp/rector-phpunit/pull/505 