### PR TITLE
[Config] Allow php85: true on withPhpSets()

### DIFF
--- a/src/Configuration/PhpLevelSetResolver.php
+++ b/src/Configuration/PhpLevelSetResolver.php
@@ -33,6 +33,7 @@ final class PhpLevelSetResolver
         PhpVersion::PHP_82 => SetList::PHP_82,
         PhpVersion::PHP_83 => SetList::PHP_83,
         PhpVersion::PHP_84 => SetList::PHP_84,
+        PhpVersion::PHP_85 => SetList::PHP_85,
     ];
 
     /**

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -534,8 +534,6 @@ final class RectorConfigBuilder
      * as composer.json has is used
      */
     public function withPhpSets(
-        bool $php85 = false,
-        bool $php84 = false,
         bool $php83 = false,
         bool $php82 = false,
         bool $php81 = false,
@@ -549,6 +547,9 @@ final class RectorConfigBuilder
         bool $php55 = false,
         bool $php54 = false,
         bool $php53 = false,
+        // place on later as BC break when used in php 7.x without named arg
+        bool $php84 = false,
+        bool $php85 = false,
     ): self {
         if ($this->isWithPhpSetsUsed === true) {
             throw new InvalidConfigurationException(sprintf(

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -534,6 +534,8 @@ final class RectorConfigBuilder
      * as composer.json has is used
      */
     public function withPhpSets(
+        bool $php85 = false,
+        bool $php84 = false,
         bool $php83 = false,
         bool $php82 = false,
         bool $php81 = false,
@@ -547,7 +549,6 @@ final class RectorConfigBuilder
         bool $php55 = false,
         bool $php54 = false,
         bool $php53 = false,
-        bool $php84 = false, // place on later as BC break when used in php 7.x without named arg
     ): self {
         if ($this->isWithPhpSetsUsed === true) {
             throw new InvalidConfigurationException(sprintf(
@@ -637,6 +638,8 @@ final class RectorConfigBuilder
             $targetPhpVersion = PhpVersion::PHP_83;
         } elseif ($php84) {
             $targetPhpVersion = PhpVersion::PHP_84;
+        } elseif ($php85) {
+            $targetPhpVersion = PhpVersion::PHP_85;
         } else {
             throw new InvalidConfigurationException('Invalid PHP version set');
         }

--- a/tests/Issues/WithPhpSets/Fixture/fixture.php.inc
+++ b/tests/Issues/WithPhpSets/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Issues\WithPhpSets\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        socket_set_timeout();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\WithPhpSets\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        stream_set_timeout();
+    }
+}
+
+?>

--- a/tests/Issues/WithPhpSets/WithPhpSetsTest.php
+++ b/tests/Issues/WithPhpSets/WithPhpSetsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\WithPhpSets;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class WithPhpSetsTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/WithPhpSets/config/configured_rule.php
+++ b/tests/Issues/WithPhpSets/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+    ->withPhpSets(php85: true)
+    ->withPhpVersion(PhpVersion::PHP_85);


### PR DESCRIPTION
Allow user to configure:

```php
use Rector\ValueObject\PhpVersion;

->withPhpSets(php85: true)
->witPHPVersion(PhpVersion::PHP_85);
```

to test next php 8.5.