### PR TITLE
feat: add ConvertAssignToNamedArgumentRector

### DIFF
--- a/config/set/php80.php
+++ b/config/set/php80.php
@@ -18,6 +18,7 @@ use Rector\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector;
 use Rector\Php80\Rector\ClassMethod\FinalPrivateToPrivateVisibilityRector;
 use Rector\Php80\Rector\ClassMethod\SetStateToStaticRector;
 use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
+use Rector\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector;
 use Rector\Php80\Rector\Identical\StrEndsWithRector;
 use Rector\Php80\Rector\Identical\StrStartsWithRector;
 use Rector\Php80\Rector\NotIdentical\StrContainsRector;
@@ -34,6 +35,7 @@ return static function (RectorConfig $rectorConfig): void {
         StrEndsWithRector::class,
         StringableForToStringRector::class,
         ClassOnObjectRector::class,
+        ConvertAssignToNamedArgumentRector::class,
         GetDebugTypeRector::class,
         RemoveUnusedVariableInCatchRector::class,
         ClassPropertyAssignToConstructorPromotionRector::class,

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/ConvertAssignToNamedArgumentRectorTest.php
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/ConvertAssignToNamedArgumentRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConvertAssignToNamedArgumentRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/arrow_function.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/arrow_function.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+fn () => in_array('foo', ['bar'], $strict = true);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+fn () => in_array('foo', ['bar'], strict: true);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/basic_function_call.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/basic_function_call.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+function basicFunctionCall()
+{
+    in_array('foo', $array, $strict = true);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+function basicFunctionCall()
+{
+    in_array('foo', $array, strict: true);
+}
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/builtin_functions.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/builtin_functions.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+str_replace($search = 'old', $replace = 'new', $subject = 'old text');
+substr($string = 'hello', $offset = 1, $length = 3);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+str_replace(search: 'old', replace: 'new', subject: 'old text');
+substr(string: 'hello', offset: 1, length: 3);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/class_methods.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/class_methods.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+use Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Source\SomeClass;
+
+/** @var SomeClass $service */
+$service->process($data = 'test', $options = ['key' => 'value']);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+use Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Source\SomeClass;
+
+/** @var SomeClass $service */
+$service->process(data: 'test', options: ['key' => 'value']);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/closure.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/closure.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+function (): bool {
+    return in_array('foo', ['bar'], $strict = true);
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+function (): bool {
+    return in_array('foo', ['bar'], strict: true);
+};
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/double_assign.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/double_assign.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+in_array('foo', ['bar'], $strict = true);
+in_array('foo', ['bar'], $strict = true);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+in_array('foo', ['bar'], strict: true);
+in_array('foo', ['bar'], strict: true);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/file_without_namespace.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/file_without_namespace.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+in_array('foo', ['bar'], $strict = true);
+
+?>
+-----
+<?php
+
+in_array('foo', ['bar'], strict: true);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/method_call.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/method_call.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+use Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Source\SomeClass;
+
+final readonly class Service
+{
+    public function __construct(private SomeClass $someClass) {}
+
+    public function methodCall()
+    {
+        $this->someClass->process($data = 'test', $options = ['key' => 'value']);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+use Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Source\SomeClass;
+
+final readonly class Service
+{
+    public function __construct(private SomeClass $someClass) {}
+
+    public function methodCall()
+    {
+        $this->someClass->process(data: 'test', options: ['key' => 'value']);
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/nested_arguments.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/nested_arguments.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+substr($string = str_repeat('a', $times = 10), $offset = 2, $length = 5);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+substr(string: str_repeat('a', times: 10), offset: 2, length: 5);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_already_has_named_args.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_already_has_named_args.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+in_array('foo', $haystack = [], strict: true);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_unknown_function.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_unknown_function.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+unknownFunction($param1 = 'value1', $param2 = 'value2');
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_variable_name_doesnt_match.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_variable_name_doesnt_match.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+in_array('foo', ['bar'], $foo = true);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_variable_used_later.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_variable_used_later.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+in_array('foo', ['bar'], $strict = true);
+echo $strict;
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_variadic_function.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/skip_variadic_function.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+array_merge($array = ['a'], $second = ['b'], $third = ['c']);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/static_call.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/static_call.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+use Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Source\SomeClass;
+
+SomeClass::staticMethod('foo', $b = 'value');
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+use Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Source\SomeClass;
+
+SomeClass::staticMethod('foo', b: 'value');
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/variable_used_prior.php.inc
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Fixture/variable_used_prior.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+in_array('foo', ['bar'], $strict = true);
+in_array('foo', ['bar'], $strict = ! $strict);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Fixture;
+
+in_array('foo', ['bar'], $strict = true);
+in_array('foo', ['bar'], strict: ! $strict);
+
+?>

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Source/SomeClass.php
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/Source/SomeClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\Source;
+
+class SomeClass
+{
+    public static function staticMethod(string $a, string $b): void {}
+    public function process(string $data, array $options = []): void {}
+}
+

--- a/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector;
+
+return RectorConfig::configure()
+    ->withRules([ConvertAssignToNamedArgumentRector::class]);

--- a/rules/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector.php
+++ b/rules/Php80/Rector/FuncCall/ConvertAssignToNamedArgumentRector.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeVisitor;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use Rector\DeadCode\NodeAnalyzer\ExprUsedInNodeAnalyzer;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Php80\Rector\FuncCall\ConvertAssignToNamedArgumentRector\ConvertAssignToNamedArgumentRectorTest
+ */
+final class ConvertAssignToNamedArgumentRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ExprUsedInNodeAnalyzer $exprUsedInNodeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Convert assignments in function and method calls to named arguments',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+in_array('foo', $array, $strict = true);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+in_array('foo', $array, strict: true);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::NAMED_ARGUMENTS;
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class, Namespace_::class, FileWithoutNamespace::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_|Namespace_|FileWithoutNamespace $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $stmts = $node->stmts;
+
+        if ($stmts === null || $stmts === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+        $stmtIndex = 0;
+
+        $this->traverseNodesWithCallable($stmts, function (Node $subNode) use (
+            &$hasChanged,
+            &$stmtIndex,
+            $stmts
+        ): ?int {
+            if ($subNode instanceof Stmt) {
+                ++$stmtIndex;
+                return null;
+            }
+
+            if (! $subNode instanceof FuncCall && ! $subNode instanceof MethodCall && ! $subNode instanceof StaticCall) {
+                return null;
+            }
+
+            if ($subNode->isFirstClassCallable()) {
+                return null;
+            }
+
+            $hasChanged |= $this->refactorCall($subNode, array_slice($stmts, $stmtIndex));
+
+            return null;
+        });
+
+        return $hasChanged ? $node : null;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function refactorCall(FuncCall|MethodCall|StaticCall $call, array $stmts): bool
+    {
+        $args = $call->getArgs();
+        $hasChanged = false;
+
+        if ($this->argsAnalyzer->hasNamedArg($args)) {
+            return false;
+        }
+
+        foreach ($args as $position => $arg) {
+            if (! $arg->value instanceof Assign) {
+                continue;
+            }
+
+            $assign = $arg->value;
+
+            if (! $assign->var instanceof Variable) {
+                continue;
+            }
+
+            $variable = $this->getName($assign->var);
+
+            if ($variable === null) {
+                continue;
+            }
+
+            if ($this->isVariableUsed($assign->var, $stmts)) {
+                continue;
+            }
+
+            $parameter = $this->getParameterAtPosition($call, $position);
+
+            if ($parameter === null || $parameter->isVariadic()) {
+                continue;
+            }
+
+            if ($variable !== $parameter->getName()) {
+                continue;
+            }
+
+            $arg->value = $assign->expr;
+            $arg->name = new Identifier($variable);
+            $hasChanged = true;
+        }
+
+        return $hasChanged;
+    }
+
+    /**
+     * @param Node[]|Node $nodes
+     */
+    private function isVariableUsed(Variable $variable, array|Node $nodes): bool
+    {
+        $isUsed = false;
+        $this->traverseNodesWithCallable($nodes, function (Node $subNode) use ($variable, &$isUsed): ?int {
+            if ($subNode instanceof Assign && $subNode->var instanceof Variable) {
+                if ($this->getName($subNode->var) !== $this->getName($variable)) {
+                    return null;
+                }
+
+                if (! $this->isVariableUsed($variable, $subNode->expr)) {
+                    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+                }
+
+                $isUsed = true;
+
+                return NodeVisitor::STOP_TRAVERSAL;
+            }
+
+            if ($this->exprUsedInNodeAnalyzer->isUsed($subNode, $variable)) {
+                $isUsed = true;
+
+                return NodeVisitor::STOP_TRAVERSAL;
+            }
+
+            return null;
+        });
+
+        return $isUsed;
+    }
+
+    private function getParameterAtPosition(FuncCall|MethodCall|StaticCall $node, int $position): ?ParameterReflection
+    {
+        $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+
+        if (! $reflection instanceof FunctionReflection && ! $reflection instanceof MethodReflection) {
+            return null;
+        }
+
+        $parametersAcceptor = ParametersAcceptorSelector::combineAcceptors($reflection->getVariants());
+
+        return $parametersAcceptor->getParameters()[$position] ?? null;
+    }
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -431,6 +431,12 @@ final class PhpVersionFeature
     public const DEPRECATE_HEBREVC = PhpVersion::PHP_74;
 
     /**
+     * @see https://wiki.php.net/rfc/named_params
+     * @var int
+     */
+    public const NAMED_ARGUMENTS = PhpVersion::PHP_80;
+
+    /**
      * @var int
      */
     public const UNION_TYPES = PhpVersion::PHP_80;


### PR DESCRIPTION
Hello!

Closes https://github.com/rectorphp/rector/issues/9302

This converts function and method calls that contain arguments with assignments to named arguments if the variable is not used in subsequent statements. This is a legacy pattern to give insight into the parameter name before named arguments were introduced in PHP 8

```diff
-in_array('foo', $array, $strict = true);
+in_array('foo', $array, strict: true);
```

Thanks!