### PR TITLE
[TypeDeclaration] Keep Generic type docblock on TypedPropertyFromDocblockSetUpDefinedRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromDocblockSetUpDefinedRector/Fixture/keep_generic_type_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromDocblockSetUpDefinedRector/Fixture/keep_generic_type_doc.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromDocblockSetUpDefinedRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromDocblockSetUpDefinedRector\Source\SomeDocblockType;
+
+final class GenericTypeDoc extends TestCase
+{
+    /**
+     * @var \Iterator<SomeType>
+     */
+    private $someType;
+
+    protected function setUp(): void
+    {
+        $this->someType = $this->create('string');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromDocblockSetUpDefinedRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromDocblockSetUpDefinedRector\Source\SomeDocblockType;
+
+final class GenericTypeDoc extends TestCase
+{
+    /**
+     * @var \Iterator<SomeType>
+     */
+    private \Iterator $someType;
+
+    protected function setUp(): void
+    {
+        $this->someType = $this->create('string');
+    }
+}
+
+?>


### PR DESCRIPTION
Generic type docblock should not be removed after property typed, as usefull.