### PR TITLE
feat: allow user to skip privatization for specific methods/properties

### DIFF
--- a/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/CallbackTest.php
+++ b/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/CallbackTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CallbackTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureCallback');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_callback.php';
+    }
+}

--- a/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/FixtureCallback/callback_can_skip.php.inc
+++ b/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/FixtureCallback/callback_can_skip.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector\Fixture;
+
+final class FinalClassWithProtectedMethods
+{
+    protected function someMethod() {}
+
+    protected function shouldBeProtected() {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector\Fixture;
+
+final class FinalClassWithProtectedMethods
+{
+    private function someMethod() {}
+
+    protected function shouldBeProtected() {}
+}
+
+?>

--- a/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/config/configured_rule_callback.php
+++ b/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/config/configured_rule_callback.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Reflection\ClassReflection;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Config\RectorConfig;
+use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(PrivatizeFinalClassMethodRector::class, [
+        PrivatizeFinalClassMethodRector::SHOULD_SKIP_CALLBACK => static function (
+            ClassMethod $classMethod,
+            ClassReflection $classReflection,
+        ): bool {
+            if (! str_contains($classReflection->getName(), 'FinalClassWithProtectedMethods')) {
+                return false;
+            }
+
+
+            return str_contains($classMethod->name->toString(), 'shouldBeProtected');
+        },
+    ]);

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/CallbackTest.php
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/CallbackTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CallbackTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureCallback');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_callback.php';
+    }
+}

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/FixtureCallback/callback_can_skip.php.inc
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/FixtureCallback/callback_can_skip.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture;
+
+final class FinalClassWithProtectedProperties
+{
+    protected string $value;
+    protected string $shouldBeProtected;
+
+    public function __construct(
+        protected string $bar,
+        protected string $shouldBeProtectedAlso,
+    ) {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture;
+
+final class FinalClassWithProtectedProperties
+{
+    private string $value;
+    protected string $shouldBeProtected;
+
+    public function __construct(
+        private string $bar,
+        protected string $shouldBeProtectedAlso,
+    ) {}
+}
+
+?>

--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/config/configured_rule_callback.php
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/config/configured_rule_callback.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ClassReflection;
+use Rector\Config\RectorConfig;
+use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(PrivatizeFinalClassPropertyRector::class, [
+        PrivatizeFinalClassPropertyRector::SHOULD_SKIP_CALLBACK => static function (
+            Property|string $property,
+            ClassReflection $classReflection,
+        ): bool {
+            if (! str_contains($classReflection->getName(), 'FinalClassWithProtectedProperties')) {
+                return false;
+            }
+
+            $name = $property instanceof Property
+                ? (string) $property->props[0]->name
+                : $property;
+
+            return str_contains($name, 'shouldBeProtected');
+        },
+    ]);


### PR DESCRIPTION
Hello!

There are occasions where final classes still need to have `protected` methods/properties (e.g., Laravel Models and the attributes/scope methods, see https://github.com/larastan/larastan/pull/2334). Instead of simply skipping all Models, it would be great if the specific methods/properties can be skipped.

This PR adds the ability for the user to define a callback that is called with the property/method and the class reflection and allows the user to determine if anything should be skipped

Thanks!