### PR TITLE
fix: allow more nodes to be passed to AttributeGroupNewLiner

### DIFF
--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -4,15 +4,24 @@ declare(strict_types=1);
 
 namespace Rector\Php81\NodeManipulator;
 
-use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\Property;
+use PhpParser\Node;
+use PhpParser\Node\AttributeGroup;
 use Rector\ValueObject\Application\File;
+use Webmozart\Assert\Assert;
 
 final class AttributeGroupNewLiner
 {
-    public function newLine(File $file, Property|Param|Class_ $node): void
+    public function newLine(File $file, Node $node): void
     {
+        $attrGroups = $node->attrGroups ?? [];
+
+        if ($attrGroups === []) {
+            return;
+        }
+
+        Assert::allIsAOf($attrGroups, AttributeGroup::class);
+        Assert::isArray($attrGroups);
+
         $oldTokens = $file->getOldTokens();
         $startTokenPos = $node->getStartTokenPos();
 
@@ -25,13 +34,13 @@ final class AttributeGroupNewLiner
         }
 
         $iteration = 1;
-        $lastKey = array_key_last($node->attrGroups);
+        $lastKey = array_key_last($attrGroups);
 
         if ($lastKey === null) {
             return;
         }
 
-        $lastAttributeTokenPos = $node->attrGroups[$lastKey]->getEndTokenPos();
+        $lastAttributeTokenPos = $attrGroups[$lastKey]->getEndTokenPos();
 
         while (isset($oldTokens[$startTokenPos + $iteration])) {
             if ($startTokenPos + $iteration === $lastAttributeTokenPos) {


### PR DESCRIPTION
Hello!

I need to pass a ClassMethod to this class, but it didn't accept it.

There's about 11 classes that have the `attrGroups` property:

<img width="1756" height="706" alt="image" src="https://github.com/user-attachments/assets/f8611280-b99e-451a-9318-74efe4607f93" />

Rather than add them all I just decided to allow all Node and return early if the property doesn't exist or is empty

Thanks!