### PR TITLE
[Console] Fix symfony/console diff broken on windows on symfony/console 6.4.24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,9 +115,6 @@
     },
     "extra": {
         "patches": {
-            "symfony/console": [
-                "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/symfony-console-helper-helper-php.patch"
-            ],
             "illuminate/container": [
                 "https://raw.githubusercontent.com/rectorphp/vendor-patches/main/patches/illuminate-container-container-php.patch"
             ],

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "rector/rector-phpunit": "dev-main",
         "rector/rector-symfony": "dev-main",
         "sebastian/diff": "^6.0",
-        "symfony/console": "^6.4",
+        "symfony/console": "^6.4.24",
         "symfony/filesystem": "^6.4",
         "symfony/finder": "^6.4",
         "symfony/process": "^6.4",


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9310


Since symfony/console 6.4.24, the vendor/patch for symfony/console no longer valid. Remove the vendor patch resolve it.