### PR TITLE
feat: Add ConvertMultilineDocblockToSingleLineRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/ConvertMultilineDocblockToSingleLineRectorTest.php
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/ConvertMultilineDocblockToSingleLineRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\ConvertMultilineDocblockToSingleLineRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConvertMultilineDocblockToSingleLineRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/Fixture/single_statements.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/Fixture/single_statements.php.inc
@@ -1,0 +1,137 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Node\ConvertMultilineDocblockToSingleLineRector\Fixture;
+
+/**
+ * @see Example
+ */
+class SingleStatements
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function dangerous(): void
+    {
+        throw new \Exception();
+    }
+
+    public function testFunction()
+    {
+        /**
+         * @var Foo $foo
+         */
+        $foo = resolve(Foo::class);
+
+        /**
+         * @phpstan-ignore variable.undefined
+         */
+        echo $bar;
+
+        /**
+         * @var string
+         */
+        $name = 'test';
+
+        /**
+         * @param int $i
+         */
+        if ($i > 0) {
+            /**
+             * @var array $data
+             */
+            $data = [];
+        }
+
+        /**
+         * @var int $number
+         */
+        foreach ($items as $number) {
+            // do something
+        }
+
+        /**
+         * @return string
+         */
+        return $name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Node\ConvertMultilineDocblockToSingleLineRector\Fixture;
+
+/** @see Example */
+class SingleStatements
+{
+    /** @var string */
+    private $value;
+
+    /** @return string */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /** @param string $value */
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    /** @throws \Exception */
+    public function dangerous(): void
+    {
+        throw new \Exception();
+    }
+
+    public function testFunction()
+    {
+        /** @var Foo $foo */
+        $foo = resolve(Foo::class);
+
+        /** @phpstan-ignore variable.undefined */
+        echo $bar;
+
+        /** @var string */
+        $name = 'test';
+
+        /** @param int $i */
+        if ($i > 0) {
+            /** @var array $data */
+            $data = [];
+        }
+
+        /** @var int $number */
+        foreach ($items as $number) {
+            // do something
+        }
+
+        /** @return string */
+        return $name;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/Fixture/skip_multiple_line_statements.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/Fixture/skip_multiple_line_statements.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Node\ConvertMultilineDocblockToSingleLineRector\Fixture;
+
+class SkipMultipleStatements
+{
+    /**
+     * Some function description.
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $value
+     * @return void
+     */
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @var string
+     * @see SomeClass
+     */
+    private $name;
+
+    /**
+     * This method does something dangerous.
+     * 
+     * Please be careful when using it.
+     *
+     * @throws \Exception
+     */
+    public function dangerous(): void
+    {
+        throw new \Exception();
+    }
+}

--- a/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/Fixture/skip_single_line_statements.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/Fixture/skip_single_line_statements.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Node\ConvertMultilineDocblockToSingleLineRector\Fixture;
+
+class SkipAlreadySingleLine
+{
+    /** @return string */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /** @param string $value */
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    /** @var string */
+    private $name;
+}

--- a/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/config/configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\FunctionLike\ConvertMultilineDocblockToSingleLineRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([ConvertMultilineDocblockToSingleLineRector::class]);

--- a/rules/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector.php
+++ b/rules/CodingStyle/Rector/FunctionLike/ConvertMultilineDocblockToSingleLineRector.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\FunctionLike;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Echo_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodingStyle\Rector\FunctionLike\ConvertMultilineDocblockToSingleLineRector\ConvertMultilineDocblockToSingleLineRectorTest
+ */
+final class ConvertMultilineDocblockToSingleLineRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Convert multi-line docblock with only single statement to single line',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+/**
+ * @return string
+ */
+public function getTitle(): string
+{
+    /**
+     * @var string $name
+     */
+    $name = 'test';
+    
+    return $name;
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+/** @return string */
+public function getTitle(): string
+{
+    /** @var string $name */
+    $name = 'test';
+    
+    return $name;
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Class_::class,
+            ClassMethod::class,
+            Function_::class,
+            Property::class,
+            Expression::class,
+            Echo_::class,
+            Return_::class,
+            If_::class,
+            Foreach_::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        $docComment = $node->getDocComment();
+        if ($docComment === null) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
+        if (! $this->shouldConvertToSingleLine($phpDocInfo)) {
+            return null;
+        }
+
+        $originalDocText = $docComment->getText();
+        $inlinedDocText = $this->convertToSingleLine($originalDocText);
+
+        if ($originalDocText === $inlinedDocText) {
+            return null;
+        }
+
+        $node->setDocComment(new Doc($inlinedDocText));
+
+        return $node;
+    }
+
+    private function convertToSingleLine(string $docComment): string
+    {
+        $content = trim($docComment);
+        $content = substr($content, 3); // Remove "/**"
+        $content = substr($content, 0, -2); // Remove "*/"
+
+        $lines = preg_split('/\r\n|\r|\n/', $content) ?: [];
+        $cleanedLines = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            $line = preg_replace('/^\*\s?/', '', $line) ?: '';
+            $line = trim($line);
+
+            if ($line !== '') {
+                $cleanedLines[] = $line;
+            }
+        }
+
+        $inlineContent = implode(' ', $cleanedLines);
+
+        return '/** ' . $inlineContent . ' */';
+    }
+
+    private function shouldConvertToSingleLine(PhpDocInfo $phpDocInfo): bool
+    {
+        $phpDocNode = $phpDocInfo->getPhpDocNode();
+        $children = $phpDocNode->children;
+
+        $tagCount = 0;
+        $hasTextContent = false;
+
+        foreach ($children as $child) {
+            if ($child instanceof PhpDocTagNode) {
+                ++$tagCount;
+            } elseif ($child instanceof PhpDocTextNode) {
+                $text = trim($child->text);
+                if ($text !== '' && $text !== '*') {
+                    $hasTextContent = true;
+                }
+            }
+        }
+
+        return $tagCount === 1 && ! $hasTextContent;
+    }
+}


### PR DESCRIPTION
This rule shortens verbose single-line docblocks into their compact one-line form, reducing visual noise while preserving all information.

For example, this:

```php
/**
 * @return string[]
 */
function list(): array
```

becomes this:

```php
/** @return string[] */
function list(): array
```

This change does not alter functionality, but it enforces a cleaner, more consistent code style. By collapsing trivial multi-line docblocks, we save vertical space and make code easier to scan, especially as these kinds of docblocks are commonplace in codebases trying to conform to static analysis tooling.