### PR TITLE
[PHP 8.5] Convert `@deprecated` to `#[\Deprecated]` on constants

### DIFF
--- a/config/set/php85.php
+++ b/config/set/php85.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Cast\Double;
 use PhpParser\Node\Expr\Cast\Int_;
 use PhpParser\Node\Expr\Cast\String_;
 use Rector\Config\RectorConfig;
+use Rector\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\Php85\Rector\ArrayDimFetch\ArrayFirstLastRector;
 use Rector\Php85\Rector\ClassMethod\NullDebugInfoReturnRector;
 use Rector\Php85\Rector\FuncCall\RemoveFinfoBufferContextArgRector;
@@ -22,7 +23,12 @@ use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules(
-        [ArrayFirstLastRector::class, RemoveFinfoBufferContextArgRector::class, NullDebugInfoReturnRector::class]
+        [
+            ArrayFirstLastRector::class,
+            RemoveFinfoBufferContextArgRector::class,
+            NullDebugInfoReturnRector::class,
+            DeprecatedAnnotationToDeprecatedAttributeRector::class,
+        ]
     );
 
     $rectorConfig->ruleWithConfiguration(

--- a/rules-tests/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector/DeprecatedAnnotationToDeprecatedAttributeRectorTest.php
+++ b/rules-tests/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector/DeprecatedAnnotationToDeprecatedAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DeprecatedAnnotationToDeprecatedAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector/Fixture/basic.php.inc
+++ b/rules-tests/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector/Fixture/basic.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+
+/**
+ * @deprecated use new constant
+ */
+const CONSTANT = 'some reason';
+
+/**
+ * @deprecated 2.0.0 do not use
+ */
+const UNUSED = 'ignored';
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+
+#[\Deprecated(message: 'use new constant')]
+const CONSTANT = 'some reason';
+
+#[\Deprecated(message: 'do not use', since: '2.0.0')]
+const UNUSED = 'ignored';
+
+?>

--- a/rules-tests/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DeprecatedAnnotationToDeprecatedAttributeRector::class);
+    $rectorConfig->phpVersion(PhpVersion::PHP_85);
+};

--- a/rules/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector.php
+++ b/rules/Php85/Rector/Const_/DeprecatedAnnotationToDeprecatedAttributeRector.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Rector\Php84\Rector\Class_;
+namespace Rector\Php85\Rector\Const_;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\ClassConst;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Const_;
 use Rector\PhpAttribute\DeprecatedAnnotationToDeprecatedAttributeConverter;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
@@ -16,10 +14,11 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Tests\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector\DeprecatedAnnotationToDeprecatedAttributeRectorTest
+ * @see \Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector\DeprecatedAnnotationToDeprecatedAttributeRectorTest
  */
 final class DeprecatedAnnotationToDeprecatedAttributeRector extends AbstractRector implements MinPhpVersionInterface
 {
+
     public function __construct(
         private readonly DeprecatedAnnotationToDeprecatedAttributeConverter $converter,
     ) {
@@ -31,35 +30,14 @@ final class DeprecatedAnnotationToDeprecatedAttributeRector extends AbstractRect
             new CodeSample(
                 <<<'CODE_SAMPLE'
 /**
- * @deprecated 1.0.0 Use SomeOtherClass instead
+ * @deprecated 1.0.0 Use SomeOtherConstant instead
  */
-class SomeClass
-{
-}
+const SomeConstant = 'irrelevant';
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
-#[\Deprecated(message: 'Use SomeOtherClass instead', since: '1.0.0')]
-class SomeClass
-{
-}
-CODE_SAMPLE
-            ),
-            new CodeSample(
-                <<<'CODE_SAMPLE'
-/**
- * @deprecated 1.0.0 Use SomeOtherFunction instead
- */
-function someFunction()
-{
-}
-CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
-#[\Deprecated(message: 'Use SomeOtherFunction instead', since: '1.0.0')]
-function someFunction()
-{
-}
+#[\Deprecated(message: 'Use SomeOtherConstant instead', since: '1.0.0')]
+const SomeConstant = 'irrelevant';
 CODE_SAMPLE
             ),
         ]);
@@ -67,11 +45,11 @@ CODE_SAMPLE
 
     public function getNodeTypes(): array
     {
-        return [Function_::class, ClassMethod::class, ClassConst::class];
+        return [Const_::class];
     }
 
     /**
-     * @param ClassConst|Function_|ClassMethod $node
+     * @param Const_ $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -80,6 +58,6 @@ CODE_SAMPLE
 
     public function provideMinPhpVersion(): int
     {
-        return PhpVersionFeature::DEPRECATED_ATTRIBUTE;
+        return PhpVersionFeature::DEPRECATED_ATTRIBUTE_ON_CONSTANT;
     }
 }

--- a/src/PhpAttribute/DeprecatedAnnotationToDeprecatedAttributeConverter.php
+++ b/src/PhpAttribute/DeprecatedAnnotationToDeprecatedAttributeConverter.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PhpAttribute;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Const_;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\DeprecatedTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
+
+final class DeprecatedAnnotationToDeprecatedAttributeConverter
+{
+    /**
+     * @see https://regex101.com/r/qNytVk/1
+     * @var string
+     */
+    private const VERSION_MATCH_REGEX = '/^(?:(\d+\.\d+\.\d+)\s+)?(.*)$/';
+
+    /**
+     * @see https://regex101.com/r/SVDPOB/1
+     * @var string
+     */
+    private const START_STAR_SPACED_REGEX = '#^ *\*#ms';
+
+    public function __construct(
+        private readonly PhpDocTagRemover $phpDocTagRemover,
+        private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+    ) {
+    }
+
+    public function convert(ClassConst|Function_|ClassMethod|Const_ $node): ?Node
+    {
+        $hasChanged = false;
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if ($phpDocInfo instanceof PhpDocInfo) {
+            $deprecatedAttributeGroup = $this->handleDeprecated($phpDocInfo);
+            if ($deprecatedAttributeGroup instanceof AttributeGroup) {
+                $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+                $node->attrGroups = array_merge($node->attrGroups, [$deprecatedAttributeGroup]);
+                $this->removeDeprecatedAnnotations($phpDocInfo);
+                $hasChanged = true;
+            }
+        }
+
+        return $hasChanged ? $node : null;
+    }
+
+    private function handleDeprecated(PhpDocInfo $phpDocInfo): ?AttributeGroup
+    {
+        $attributeGroup = null;
+        $desiredTagValueNodes = $phpDocInfo->getTagsByName('deprecated');
+        foreach ($desiredTagValueNodes as $desiredTagValueNode) {
+            if (! $desiredTagValueNode->value instanceof DeprecatedTagValueNode) {
+                continue;
+            }
+
+            $attributeGroup = $this->createAttributeGroup($desiredTagValueNode->value->description);
+            $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $desiredTagValueNode);
+
+            break;
+        }
+
+        return $attributeGroup;
+    }
+
+    private function createAttributeGroup(string $annotationValue): AttributeGroup
+    {
+        $matches = Strings::match($annotationValue, self::VERSION_MATCH_REGEX);
+
+        if ($matches === null) {
+            $annotationValue = Strings::replace($annotationValue, self::START_STAR_SPACED_REGEX, '');
+
+            return new AttributeGroup([
+                new Attribute(
+                    new FullyQualified('Deprecated'),
+                    [new Arg(
+                        value: new String_($annotationValue, [
+                            AttributeKey::KIND => String_::KIND_NOWDOC,
+                            AttributeKey::DOC_LABEL => 'TXT',
+                        ]),
+                        name: new Identifier('message')
+                    )]
+                ),
+            ]);
+        }
+
+        $since = $matches[1] ?? null;
+        $message = $matches[2] ?? null;
+
+        return $this->phpAttributeGroupFactory->createFromClassWithItems('Deprecated', array_filter([
+            'message' => $message,
+            'since' => $since,
+        ]));
+    }
+
+    private function removeDeprecatedAnnotations(PhpDocInfo $phpDocInfo): bool
+    {
+        $hasChanged = false;
+
+        $desiredTagValueNodes = $phpDocInfo->getTagsByName('deprecated');
+        foreach ($desiredTagValueNodes as $desiredTagValueNode) {
+            if (! $desiredTagValueNode->value instanceof GenericTagValueNode) {
+                continue;
+            }
+
+            $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $desiredTagValueNode);
+            $hasChanged = true;
+        }
+
+        return $hasChanged;
+    }
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -780,4 +780,10 @@ final class PhpVersionFeature
      * @var int
      */
     public const DEPRECATED_NULL_DEBUG_INFO_RETURN = PhpVersion::PHP_85;
+
+    /**
+     * @see https://wiki.php.net/rfc/attributes-on-constants
+     * @var int
+     */
+    public const DEPRECATED_ATTRIBUTE_ON_CONSTANT = PhpVersion::PHP_85;
 }


### PR DESCRIPTION
Based on the PHP 8.4 rule from #6923, logic was moved to a new `DeprecatedAnnotationToDeprecatedAttributeConverter` service to avoid duplication.