### PR TITLE
Clean up ternary on ColonAfterSwitchCaseRector

### DIFF
--- a/rules/Php85/Rector/Switch_/ColonAfterSwitchCaseRector.php
+++ b/rules/Php85/Rector/Switch_/ColonAfterSwitchCaseRector.php
@@ -65,13 +65,13 @@ CODE_SAMPLE
                 continue;
             }
 
-            $startCaseStmtsPos = count($case->stmts) === 0
-                ? (
-                    isset($node->cases[$key + 1])
+            if (count($case->stmts) === 0) {
+                $startCaseStmtsPos  = isset($node->cases[$key + 1])
                     ? $node->cases[$key + 1]->getStartTokenPos()
-                    : $node->getEndTokenPos()
-                )
-                : $case->stmts[0]->getStartTokenPos();
+                    : $node->getEndTokenPos();
+            } else {
+                $startCaseStmtsPos = $case->stmts[0]->getStartTokenPos();
+            }
 
             if ($startCaseStmtsPos < 0) {
                 continue;


### PR DESCRIPTION
Ternary nested seems removed on php-scoper, make hard to read:

<img width="1356" height="50" alt="Screenshot 2025-08-20 at 23 47 52" src="https://github.com/user-attachments/assets/76f134de-50e3-4110-b928-63411ad9ec90" />

use if else for make readable and less bug because possible parentheses gone.