### PR TITLE
fix: convert static::* to self::* for all constant access in final classes

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/final_class_with_inherited_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Fixture/final_class_with_inherited_constant.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Source\ParentClass;
+
+final class FinalClassWithInheritedConstant extends ParentClass
+{
+    public function run(): void
+    {
+        return static::FAILURE;
+        return static::SUCCESS;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Source\ParentClass;
+
+final class FinalClassWithInheritedConstant extends ParentClass
+{
+    public function run(): void
+    {
+        return self::FAILURE;
+        return self::SUCCESS;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Source/ParentClass.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector/Source/ParentClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\Source;
+
+class ParentClass
+{
+    public const FAILURE = 1;
+    protected const SUCCESS = 0;
+}

--- a/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
@@ -56,35 +56,6 @@ class Foo
 }
 CODE_SAMPLE
                 ),
-                new CodeSample(
-                    <<<'CODE_SAMPLE'
-final class Foo
-{
-    private const BAR = 'bar';
-    public const BAZ = 'baz';
-
-    public function run()
-    {
-        $bar = static::BAR;
-        $baz = static::BAZ;
-    }
-}
-CODE_SAMPLE
-                    ,
-                    <<<'CODE_SAMPLE'
-final class Foo
-{
-    private const BAR = 'bar';
-    public const BAZ = 'baz';
-
-    public function run()
-    {
-        $bar = self::BAR;
-        $baz = self::BAZ;
-    }
-}
-CODE_SAMPLE
-                ),
             ],
         );
     }

--- a/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/ConvertStaticPrivateConstantToSelfRector.php
@@ -17,6 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see \Rector\Tests\CodeQuality\Rector\ClassConstFetch\ConvertStaticPrivateConstantToSelfRector\ConvertStaticPrivateConstantToSelfRectorTest
  *
  * @see https://3v4l.org/8Y0ba
+ * @see https://3v4l.org/ZIeA1
  * @see https://phpstan.org/r/11d4c850-1a40-4fae-b665-291f96104d11
  */
 final class ConvertStaticPrivateConstantToSelfRector extends AbstractRector
@@ -24,17 +25,48 @@ final class ConvertStaticPrivateConstantToSelfRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Replaces static::* access to private constants with self::*',
+            'Replaces static::* constant access with self::* for private constants and in final classes.',
             [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class Foo
+{
+    private const BAR = 'bar';
+    public const BAZ = 'baz';
+
+    public function run()
+    {
+        $bar = static::BAR;
+        $baz = static::BAZ;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class Foo
+{
+    private const BAR = 'bar';
+    public const BAZ = 'baz';
+
+    public function run()
+    {
+        $bar = self::BAR;
+        $baz = static::BAZ;
+    }
+}
+CODE_SAMPLE
+                ),
                 new CodeSample(
                     <<<'CODE_SAMPLE'
 final class Foo
 {
     private const BAR = 'bar';
+    public const BAZ = 'baz';
 
     public function run()
     {
         $bar = static::BAR;
+        $baz = static::BAZ;
     }
 }
 CODE_SAMPLE
@@ -43,10 +75,12 @@ CODE_SAMPLE
 final class Foo
 {
     private const BAR = 'bar';
+    public const BAZ = 'baz';
 
     public function run()
     {
         $bar = self::BAR;
+        $baz = self::BAZ;
     }
 }
 CODE_SAMPLE
@@ -68,7 +102,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Class_
     {
-        if ($node->getConstants() === []) {
+        if ($node->getConstants() === [] && ! $node->isFinal()) {
             return null;
         }
 


### PR DESCRIPTION
Hello!

Please see https://3v4l.org/ZIeA1, all constant access should can/should use `self::` in final classes---even for inherited constants

Thanks!