### PR TITLE
fix: static to self static method call on final class

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/parent_static_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Fixture/parent_static_method.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Source\BaseClass;
+
+final class ParentStaticMethod extends BaseClass
+{
+    public function test(): string
+    {
+        return static::parentMethod();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Source\BaseClass;
+
+final class ParentStaticMethod extends BaseClass
+{
+    public function test(): string
+    {
+        return self::parentMethod();
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Source/BaseClass.php
+++ b/rules-tests/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector/Source/BaseClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\Source;
+
+class BaseClass
+{
+    protected static function parentMethod(): string
+    {
+        return 'parent method';
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -9,14 +9,16 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\ClassReflection;
 use Rector\Configuration\Parameter\FeatureFlags;
 use Rector\Enum\ObjectReference;
+use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @see https://3v4l.org/VbcrN
  * @see \Rector\Tests\CodeQuality\Rector\Class_\StaticToSelfStaticMethodCallOnFinalClassRector\StaticToSelfStaticMethodCallOnFinalClassRectorTest
  */
 final class StaticToSelfStaticMethodCallOnFinalClassRector extends AbstractRector
@@ -76,8 +78,14 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
+        $scope = ScopeFetcher::fetch($node);
+        $classReflection = $scope->getClassReflection();
 
-        $this->traverseNodesWithCallable($node->stmts, function (Node $subNode) use (&$hasChanged, $node): ?StaticCall {
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        $this->traverseNodesWithCallable($node->stmts, function (Node $subNode) use (&$hasChanged, $classReflection): ?StaticCall {
             if (! $subNode instanceof StaticCall) {
                 return null;
             }
@@ -92,15 +100,15 @@ CODE_SAMPLE
             }
 
             $methodName = (string) $this->getName($subNode->name);
-            $targetClassMethod = $node->getMethod($methodName);
 
-            // skip call non-existing method from current class to ensure transformation is safe
-            if (! $targetClassMethod instanceof ClassMethod) {
+            if (! $classReflection->hasNativeMethod($methodName)) {
                 return null;
             }
 
+            $methodReflection = $classReflection->getNativeMethod($methodName);
+
             // avoid overlapped change
-            if (! $targetClassMethod->isStatic()) {
+            if (! $methodReflection->isStatic()) {
                 return null;
             }
 


### PR DESCRIPTION
Hello!

Please see https://3v4l.org/VbcrN, parent method calls should also be transformed to `self::method()` calls on final classes.

Thanks!