### PR TITLE
[Scoper] Remove PHP_VERSION_ID < 70400 check on scoper.php

### DIFF
--- a/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/StaticToSelfStaticMethodCallOnFinalClassRector.php
@@ -105,10 +105,10 @@ CODE_SAMPLE
                 return null;
             }
 
-            $methodReflection = $classReflection->getNativeMethod($methodName);
+            $extendedMethodReflection = $classReflection->getNativeMethod($methodName);
 
             // avoid overlapped change
-            if (! $methodReflection->isStatic()) {
+            if (! $extendedMethodReflection->isStatic()) {
                 return null;
             }
 

--- a/scoper.php
+++ b/scoper.php
@@ -142,25 +142,5 @@ return [
 
             return str_replace("'" . $prefix . '\\', "'\\", $content);
         },
-
-        static function (string $filePath, string $prefix, string $content): string {
-            if (! \str_ends_with($filePath, 'vendor/nette/utils/src/Utils/Strings.php')) {
-                return $content;
-            }
-
-            # see https://github.com/rectorphp/rector/issues/8564
-            return str_replace(
-                'return self::pcre(\'preg_replace_callback\', [$pattern, $replacement, $subject, $limit, 0, $flags]);',
-                <<<'CODE_REPLACE'
-if (PHP_VERSION_ID < 70400) {
-    return self::pcre('preg_replace_callback', [$pattern, $replacement, $subject, $limit]);
-}
-
-return self::pcre('preg_replace_callback', [$pattern, $replacement, $subject, $limit, 0, $flags]);
-CODE_REPLACE
-                ,
-                $content
-            );
-        },
     ],
 ];


### PR DESCRIPTION
This was hack to handle issue:

- https://github.com/rectorphp/rector/issues/8564

since rector scoped now require php 7.4, this hack is not needed.