### PR TITLE
[Console] Fix Multi-Line Error Message Format

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -147,7 +147,7 @@ try {
         // report fatal errors in console format
         $symfonyStyleFactory = new SymfonyStyleFactory(new PrivatesAccessor());
         $symfonyStyle = $symfonyStyleFactory->create();
-        $symfonyStyle->error($throwable->getMessage());
+        $symfonyStyle->error(str_replace("\r\n", "\n", $throwable->getMessage()));
     }
 
     exit(Command::FAILURE);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9323.

## Why is this necessary?

The `PHP_EOL` constant is used throughout the Rector source code to add newlines to error messages, that are forwarded to Symfony's Console component. On Windows, `PHP_EOL` resolves to `\r\n`. However, Symfony's console output formatter does not support `\r\n` line breaks. After calculating the width of the terminal window, it adds `\n` characters to the appropriate positions in the given message and splits the resulting string using `\n` as a separator. This leaves the affected lines with a trailing `\r` character, which breaks the console output.

## Example
Let's take a look at the linked issue above as an example.

1. Initially, the error message is defined as follows:
    ```php
    $message = 'Pick only one version target in "withPhpSets()". All rules up to this version will be used.' . PHP_EOL . 'To use your composer.json > PHP version, keep arguments empty.';
    ```
2. On Windows, this resolves to:
    ```js
    $message = 'Pick only one version target in "withPhpSets()". All rules up to this version will be used.' . "\r\n" . 'To use your composer.json > PHP version, keep arguments empty.';
    ```
3. Next, Symfony's output formatter calculates the terminal width and inserts zero or more `\n` characters at the appropriate positions where the message should be cut. For a rather small terminal window, the resulting string could look like this:
    ```php
    $message = 'Pick only one version target in' . "\n" . '"withPhpSets()". All rules up to this' . "\n" . 'version will be used.' . "\r\n" . 'To use your composer.json > PHP version,' . "\n" . 'keep arguments empty.';
    ```
4. The formatter now splits the string using `\n`, which results in these lines:
    ```php
    $lines = [
        'Pick only one version target in',
        '"withPhpSets()". All rules up to this',
        "version will be used.\r", // <-- trailing `\r` char
        'To use your composer.json PHP version,',
        'keep arguments empty.'
    ];
    ```
5. The trailing `\r` character in line 3 resets the cursor to the beginning of the line while outputting. Then, the output formatter prints the red padding characters (17x in this case). These characters overwrite the first 17 existing characters of the current line, including the beginning of the actual error message. The output is now broken.
    <img width="1734" height="423" alt="grafik" src="https://github.com/user-attachments/assets/ca4a42ae-265a-4d47-90d3-a3012cf1e756" />

## Solution
Sanitize all `\r\n` occurrences to simple `\n` characters:

- The output isn't broken anymore, the error message is now perfectly legible:
    <img width="1734" height="423" alt="grafik" src="https://github.com/user-attachments/assets/aeb72ecc-a54b-48a9-90ca-778bfaf5b5f2" />


## Screenshots

Below are some more screenshots, showing the "before" and "after" of the reported issue, using the original examples.

### Wide
- Before
    <img width="1734" height="339" alt="grafik" src="https://github.com/user-attachments/assets/21bb03d7-8b15-42bb-9083-1fec8b81d855" />
- After
    <img width="1734" height="339" alt="grafik" src="https://github.com/user-attachments/assets/c3da04a8-4b7a-4078-8339-2e757a4c06f0" />

### Narrow
- Before
    <img width="1734" height="339" alt="grafik" src="https://github.com/user-attachments/assets/d49a3aba-2f47-4a60-b21c-9d76d3acc865" />
- After
    <img width="1734" height="339" alt="grafik" src="https://github.com/user-attachments/assets/1ac56a6c-1d5a-49db-817f-ecb82f8fe945" />

