### PR TITLE
[CodeQuality] Skip @final doc with public property on ConvertStaticToSelfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/Fixture/non_final_class_final_members.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/Fixture/non_final_class_final_members.php.inc
@@ -6,16 +6,16 @@ class NonFinalClassFinalMembers
 {
     final public const BAR = 1;
 
-    final public static string $privateProperty = 'test';
+    final public static string $publicProperty = 'test';
 
-    final public static function privateMethod(): void
+    final public static function publicMethod(): void
     {
     }
 
     public function run()
     {
-        static::$privateProperty;
-        static::privateMethod();
+        static::$publicProperty;
+        static::publicMethod();
         static::BAR;
     }
 }
@@ -30,16 +30,16 @@ class NonFinalClassFinalMembers
 {
     final public const BAR = 1;
 
-    final public static string $privateProperty = 'test';
+    final public static string $publicProperty = 'test';
 
-    final public static function privateMethod(): void
+    final public static function publicMethod(): void
     {
     }
 
     public function run()
     {
-        self::$privateProperty;
-        self::privateMethod();
+        self::$publicProperty;
+        self::publicMethod();
         self::BAR;
     }
 }

--- a/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/Fixture/skip_final_doc_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/Fixture/skip_final_doc_property.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\ConvertStaticToSelfRector\Fixture;
+
+class SkipFinalDocProperty
+{
+    /**
+     * @final
+     */
+    public static string $publicProperty = 'test';
+
+    public function run()
+    {
+        static::$publicProperty;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
+++ b/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\Rector\Class_;
 
-use PHPStan\Reflection\RealClassClassConstantReflection;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassConstantReflection;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\StaticCall;
@@ -163,7 +163,7 @@ CODE_SAMPLE
         }
 
         if (! $isFinal) {
-            $memberIsFinal = $reflection instanceof RealClassClassConstantReflection
+            $memberIsFinal = $reflection instanceof ClassConstantReflection
                 ? $reflection->isFinal()
                 : $reflection->isFinalByKeyword()->yes();
 

--- a/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
+++ b/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\Rector\Class_;
 
+use PHPStan\Reflection\RealClassClassConstantReflection;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ClassConstantReflection;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\StaticCall;
@@ -163,9 +163,9 @@ CODE_SAMPLE
         }
 
         if (! $isFinal) {
-            $memberIsFinal = $reflection instanceof ClassConstantReflection
+            $memberIsFinal = $reflection instanceof RealClassClassConstantReflection
                 ? $reflection->isFinal()
-                : $reflection->isFinal()->yes();
+                : $reflection->isFinalByKeyword()->yes();
 
             // Final native members can be safely converted
             if ($memberIsFinal) {


### PR DESCRIPTION
@calebdw I got regression. 

Final via `@final` doc should be skipped on public property. This PR fix it.