### PR TITLE
[CodeQuality] Skip @final doc with public class constant on ConvertStaticToSelfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/Fixture/skip_final_doc_class_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/Fixture/skip_final_doc_class_constant.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\ConvertStaticToSelfRector\Fixture;
+
+class SkipFinalDocClassConstant
+{
+    /**
+     * @final
+     */
+    public const BAR = 1;
+
+    public function run()
+    {
+        static::BAR;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/ConvertStaticToSelfRector/config/configured_rule.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\ConvertStaticToSelfRector;
 use Rector\Config\RectorConfig;
+use Rector\ValueObject\PhpVersionFeature;
 
 return RectorConfig::configure()
-    ->withRules([ConvertStaticToSelfRector::class]);
+    ->withRules([ConvertStaticToSelfRector::class])
+    ->withPhpVersion(PhpVersionFeature::FINAL_CLASS_CONSTANTS);

--- a/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
+++ b/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
@@ -171,6 +171,8 @@ CODE_SAMPLE
         }
 
         if (! $isFinal) {
+            // init
+            $memberIsFinal = false;
             if ($reflection instanceof ClassConstantReflection) {
                 // Get the native ReflectionClassConstant
                 $declaringClass = $reflection->getDeclaringClass();
@@ -181,9 +183,6 @@ CODE_SAMPLE
                     // PHP 8.1+
                     $nativeReflection = $nativeReflectionClass->getReflectionConstant($constantName);
                     $memberIsFinal = $nativeReflection instanceof ReflectionClassConstant && $nativeReflection->isFinal();
-                } else {
-                    // On PHP < 8.1, class constants can't be final
-                    $memberIsFinal = false;
                 }
             } else {
                 $memberIsFinal = $reflection->isFinalByKeyword()


### PR DESCRIPTION
@calebdw this continue of PR:

- https://github.com/rectorphp/rector-src/pull/7168

Final via `@final` doc should be skipped on class constant. This PR fix it. Use native ReflectionClassConstant since PHPStan only has `isFinal()` for its `ClassConstantReflection`