### PR TITLE
[TypeDeclaration] Skip Valid type from return doc and typed param on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/FixtureIntersection/skip_valid_type_from_return_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/FixtureIntersection/skip_valid_type_from_return_doc.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\FixtureIntersection;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Source\ConnectionInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Source\ConnectionResolverInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Source\SqlServerConnection;
+
+final class SkipValidTypeFromReturnDoc
+{
+    public function __invoke(ConnectionResolverInterface $resolver): void
+    {
+        $connection = $resolver->connection();
+
+        if (
+            $connection instanceof SqlServerConnection
+            || ! method_exists($connection, 'getSchemaState')
+        ) {
+            return;
+        }
+
+        $this->ensureCleanDatabase($connection);
+    }
+
+    private function ensureCleanDatabase(ConnectionInterface $connection): void
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Source/ConnectionInterface.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Source/ConnectionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Source;
+
+interface ConnectionInterface
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Source/ConnectionResolverInterface.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Source/ConnectionResolverInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Source;
+
+interface ConnectionResolverInterface
+{
+    /**
+     * @param  string|null  $name
+     * @return ConnectionInterface
+     */
+    public function connection($name = null);
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Source/SqlServerConnection.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Source/SqlServerConnection.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Source;
+
+class SqlServerConnection extends ConnectionInterface
+{
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -60,6 +60,11 @@ final readonly class CallTypesResolver
         // "self" in another object is not correct, this make it independent
         $argValueType = $this->correctSelfType($argValueType);
 
+        $type = $this->nodeTypeResolver->getType($arg->value);
+        if (! $type->equals($argValueType) && $this->typeComparator->isSubtype($type, $argValueType)) {
+            return $type;
+        }
+
         if (! $argValueType instanceof ObjectType) {
             return $argValueType;
         }
@@ -67,11 +72,6 @@ final readonly class CallTypesResolver
         // fix false positive generic type on string
         if (! $this->reflectionProvider->hasClass($argValueType->getClassName())) {
             return new MixedType();
-        }
-
-        $type = $this->nodeTypeResolver->getType($arg->value);
-        if (! $type->equals($argValueType) && $this->typeComparator->isSubtype($type, $argValueType)) {
-            return $type;
         }
 
         return $argValueType;

--- a/src/NodeTypeResolver/NodeTypeCorrector/AccessoryNonEmptyArrayTypeCorrector.php
+++ b/src/NodeTypeResolver/NodeTypeCorrector/AccessoryNonEmptyArrayTypeCorrector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeTypeResolver\NodeTypeCorrector;
+
+use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+
+final class AccessoryNonEmptyArrayTypeCorrector
+{
+    public function correct(Type $mainType): Type
+    {
+        if (! $mainType instanceof IntersectionType) {
+            return $mainType;
+        }
+
+        if (! $mainType->isArray()->yes()) {
+            return $mainType;
+        }
+
+        foreach ($mainType->getTypes() as $type) {
+            if ($type instanceof NonEmptyArrayType) {
+                return new ArrayType(new MixedType(), new MixedType());
+            }
+        }
+
+        return $mainType;
+    }
+}

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -259,9 +259,8 @@ final class NodeTypeResolver
     {
         $type = $this->accessoryNonEmptyStringTypeCorrector->correct($type);
         $type = $this->genericClassStringTypeCorrector->correct($type);
-        $type = $this->accessoryNonEmptyArrayTypeCorrector->correct($type);
 
-        return $type;
+        return $this->accessoryNonEmptyArrayTypeCorrector->correct($type);
     }
 
     public function getNativeType(Expr $expr): Type


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9324