### PR TITLE
Fix `RemoveDuplicatedCaseInSwitchRector` behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ composer.lock
 # PHPStorm meta files
 .idea/
 
+# VS Code files
+.vscode
+
 .phpunit.result.cache
 # since PHPUnit 10
 .phpunit.cache

--- a/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/consecutive_equal_case_stmts4.php.inc
+++ b/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/consecutive_equal_case_stmts4.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class ConsecutiveEqualCaseStmts4
+{
+    public function run($name)
+    {
+        switch ($name) {
+            case 'a':
+                return 'A';
+            case 'b':
+                return 'C';
+            case 'd':
+            case 'c':
+            case 'f':
+            default:
+                return 'C';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class ConsecutiveEqualCaseStmts4
+{
+    public function run($name)
+    {
+        switch ($name) {
+            case 'a':
+                return 'A';
+            case 'b':
+            case 'd':
+            case 'c':
+            case 'f':
+            default:
+                return 'C';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/consecutive_equal_case_stmts5.php.inc
+++ b/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/consecutive_equal_case_stmts5.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class ConsecutiveEqualCaseStmts5
+{
+    public function run($name)
+    {
+        switch ($name) {
+            case 'a':
+                return 'A';
+            case 'b':
+                return 'C';
+            default:
+            case 'd':
+            case 'c':
+            case 'f':
+                return 'C';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class ConsecutiveEqualCaseStmts5
+{
+    public function run($name)
+    {
+        switch ($name) {
+            case 'a':
+                return 'A';
+            case 'b':
+            default:
+            case 'd':
+            case 'c':
+            case 'f':
+                return 'C';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/different_indirect_duplicated4.php.inc
+++ b/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/different_indirect_duplicated4.php.inc
@@ -1,0 +1,60 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class DifferentIndirectDuplicated4
+{
+    public function run()
+    {
+      $item = 'a';
+      switch ($item) {
+        case 'a':
+        case 'b':
+          return 'val1';
+        case 'c':
+          return 'val2';
+        case 'd':
+        case 'e':
+          return 'val5';
+        case 'f':
+        case 'g':
+        case 'h':
+          return 'val2';
+        case 'i':
+          return 'val3';
+      }
+      return $item;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class DifferentIndirectDuplicated4
+{
+    public function run()
+    {
+      $item = 'a';
+      switch ($item) {
+        case 'a':
+        case 'b':
+          return 'val1';
+        case 'c':
+        case 'f':
+        case 'g':
+        case 'h':
+          return 'val2';
+        case 'd':
+        case 'e':
+          return 'val5';
+        case 'i':
+          return 'val3';
+      }
+      return $item;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/different_indirect_duplicated4.php.inc
+++ b/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/different_indirect_duplicated4.php.inc
@@ -6,24 +6,22 @@ class DifferentIndirectDuplicated4
 {
     public function run()
     {
-      $item = 'a';
-      switch ($item) {
-        case 'a':
-        case 'b':
-          return 'val1';
-        case 'c':
-          return 'val2';
-        case 'd':
-        case 'e':
-          return 'val5';
-        case 'f':
-        case 'g':
-        case 'h':
-          return 'val2';
-        case 'i':
-          return 'val3';
-      }
-      return $item;
+        switch ($item) {
+            case 'a':
+            case 'b':
+                return 'val1';
+            case 'c':
+                return 'val2';
+            case 'd':
+            case 'e':
+                return 'val5';
+            case 'f':
+            case 'g':
+            case 'h':
+                return 'val2';
+            case 'i':
+                return 'val3';
+        }
     }
 }
 
@@ -37,23 +35,21 @@ class DifferentIndirectDuplicated4
 {
     public function run()
     {
-      $item = 'a';
-      switch ($item) {
-        case 'a':
-        case 'b':
-          return 'val1';
-        case 'c':
-        case 'f':
-        case 'g':
-        case 'h':
-          return 'val2';
-        case 'd':
-        case 'e':
-          return 'val5';
-        case 'i':
-          return 'val3';
-      }
-      return $item;
+        switch ($item) {
+            case 'a':
+            case 'b':
+                return 'val1';
+            case 'c':
+            case 'f':
+            case 'g':
+            case 'h':
+                return 'val2';
+            case 'd':
+            case 'e':
+                return 'val5';
+            case 'i':
+                return 'val3';
+        }
     }
 }
 

--- a/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/different_indirect_duplicated5.php.inc
+++ b/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/different_indirect_duplicated5.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class DifferentIndirectDuplicated5
+{
+    public function run($name)
+    {
+        switch ($name) {
+            case 'a':
+                return 'A';
+            case 'b':
+                return 'C';
+            case 'd':
+            case 'c':
+            case 'f':
+                return 'C';
+            case 'e':
+                return 'A';
+            default:
+                return 'C';
+            case 'i':
+                return 'A';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class DifferentIndirectDuplicated5
+{
+    public function run($name)
+    {
+        switch ($name) {
+            case 'a':
+            case 'e':
+            case 'i':
+                return 'A';
+            case 'b':
+            case 'd':
+            case 'c':
+            case 'f':
+            default:
+                return 'C';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/no_stmts_without_comments.php.inc
+++ b/rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/no_stmts_without_comments.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class NoStmtsWithoutComments
+{
+    public function run($foo)
+    {
+        switch ($foo) {
+            case 'A':
+                break;
+            case 'B':
+            case 'C':
+                break;
+            case 'D':
+                $type = 'BAR';
+                break;
+            case 'E':
+            case 'F':
+            default:
+                break;
+        }
+    }
+}
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector\Fixture;
+
+class NoStmtsWithoutComments
+{
+    public function run($foo)
+    {
+        switch ($foo) {
+            case 'A':
+            case 'B':
+            case 'C':
+            case 'E':
+            case 'F':
+            default:
+                break;
+            case 'D':
+                $type = 'BAR';
+                break;
+        }
+    }
+}

--- a/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
+++ b/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
@@ -199,6 +199,6 @@ CODE_SAMPLE
 
     private function areSwitchStmtsEqualsConsideringComments(Case_ $currentCase, Case_ $nextCase): bool
     {
-        return $this->betterStandardPrinter->print($currentCase) === $this->betterStandardPrinter->print($nextCase);
+        return $this->betterStandardPrinter->print($currentCase->stmts) === $this->betterStandardPrinter->print($nextCase->stmts);
     }
 }

--- a/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
+++ b/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
@@ -23,7 +23,8 @@ final class RemoveDuplicatedCaseInSwitchRector extends AbstractRector
 
     public function __construct(
         private BetterStandardPrinter $betterStandardPrinter
-    ) {}
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
+++ b/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
+use Rector\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -19,6 +20,10 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveDuplicatedCaseInSwitchRector extends AbstractRector
 {
     private bool $hasChanged = false;
+
+    public function __construct(
+        private BetterStandardPrinter $betterStandardPrinter
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -96,65 +101,84 @@ CODE_SAMPLE
 
     private function removeDuplicatedCases(Switch_ $switch): void
     {
-        $totalKeys = count($switch->cases);
-        $conds = [];
+        /** @var Case_[] */
+        $result = [];
 
-        foreach (array_keys($switch->cases) as $key) {
-            if (isset($switch->cases[$key - 1]) && $switch->cases[$key - 1]->stmts === []) {
+        /** @var int[] */
+        $processedCasesNumbers = [];
+
+        foreach ($switch->cases as $outerCaseKey => $outerCase) {
+            if (in_array($outerCaseKey, $processedCasesNumbers)) {
                 continue;
             }
 
-            $nextCases = [];
-            for ($jumpToKey = $key + 1; $jumpToKey < $totalKeys; ++$jumpToKey) {
-                if (! isset($switch->cases[$jumpToKey])) {
-                    continue;
-                }
+            $processedCasesNumbers[] = $outerCaseKey;
 
-                if (! $this->areSwitchStmtsEqualsAndWithBreak($switch->cases[$key], $switch->cases[$jumpToKey])) {
-                    continue;
-                }
-
-                $nextCase = $switch->cases[$jumpToKey];
-
-                if (isset($switch->cases[$jumpToKey - 1]) && $switch->cases[$jumpToKey - 1]->stmts === []) {
-                    $nextCases[] = $switch->cases[$jumpToKey - 1];
-                    $conds[] = $switch->cases[$jumpToKey - 1]->cond;
-                }
-
-                unset($switch->cases[$jumpToKey]);
-
-                $nextCases[] = $nextCase;
-
-                $this->hasChanged = true;
-            }
-
-            if ($nextCases === []) {
+            if ($outerCase->stmts === []) {
+                $result[] = $outerCase;
                 continue;
             }
 
-            array_splice($switch->cases, $key + 1, 0, $nextCases);
+            /** @var array<int, Case_> */
+            $casesWithoutStmts = [];
 
-            for ($jumpToKey = $key; $jumpToKey < $key + count($nextCases); ++$jumpToKey) {
-                $switch->cases[$jumpToKey]->stmts = [];
-            }
+            /** @var Case_[] */
+            $equalCases = [];
 
-            $key += count($nextCases);
-        }
+            foreach ($switch->cases as $innerCaseKey => $innerCase) {
+                if (in_array($innerCaseKey, $processedCasesNumbers)) {
+                    continue;
+                }
 
-        foreach ($conds as $keyCond => $cond) {
-            foreach (array_reverse($switch->cases, true) as $keyCase => $case) {
-                if ($this->nodeComparator->areNodesEqual($cond, $case->cond)) {
-                    unset($switch->cases[$keyCase]);
-                    unset($conds[$keyCond]);
+                if ($innerCase->stmts === []) {
+                    $casesWithoutStmts[$innerCaseKey] = $innerCase;
+                    continue;
+                }
 
-                    continue 2;
+                if ($this->areSwitchStmtsEqualsAndWithBreak($outerCase, $innerCase)) {
+                    if ($casesWithoutStmts !== []) {
+                        foreach ($casesWithoutStmts as $caseWithoutStmtsKey => $caseWithoutStmts) {
+                            $equalCases[] = $caseWithoutStmts;
+                            $processedCasesNumbers[] = $caseWithoutStmtsKey;
+                        }
+
+                        $casesWithoutStmts = [];
+                    }
+
+                    $innerCase->stmts = [];
+                    $equalCases[] = $innerCase;
+                    $processedCasesNumbers[] = $innerCaseKey;
+
+                    $this->hasChanged = true;
+                } else {
+                    $casesWithoutStmts = [];
                 }
             }
+
+            if ($equalCases === []) {
+                $result[] = $outerCase;
+                continue;
+            }
+
+            $equalCases[array_key_last($equalCases)]->stmts = $outerCase->stmts;
+            $outerCase->stmts = [];
+
+            $result = array_merge($result, [$outerCase, ...$equalCases]);
         }
+
+        $switch->cases = $result;
     }
 
     private function areSwitchStmtsEqualsAndWithBreak(Case_ $currentCase, Case_ $nextCase): bool
     {
+        /**
+         * Skip multi no stmts
+         * @see rules-tests/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector/Fixture/skip_multi_no_stmts.php.inc
+         */
+        if ($currentCase->stmts[0] instanceof Break_ && $nextCase->stmts[0] instanceof Break_) {
+            return $this->areSwitchStmtsEqualsConsideringComments($currentCase, $nextCase);
+        }
+
         if (! $this->nodeComparator->areNodesEqual($currentCase->stmts, $nextCase->stmts)) {
             return false;
         }
@@ -170,5 +194,10 @@ CODE_SAMPLE
         }
 
         return false;
+    }
+
+    private function areSwitchStmtsEqualsConsideringComments(Case_ $currentCase, Case_ $nextCase): bool
+    {
+        return $this->betterStandardPrinter->print($currentCase) === $this->betterStandardPrinter->print($nextCase);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/rectorphp/rector/issues/9329

In this PR, I fixed the behavior of `RemoveDuplicatedCaseInSwitchRector`. The existing algorithm seemed very complicated to me, and I couldn't fix it, so I wrote a new one.
I hope I haven't missed any test cases. I would appreciate any suggestions for adding test cases.