### PR TITLE
 [Console] Fix Multi-Line Error Message Format (2)

### DIFF
--- a/src/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/src/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -115,6 +115,7 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
         foreach ($errors as $error) {
             $errorMessage = $error->getMessage();
             $errorMessage = $this->normalizePathsToRelativeWithLine($errorMessage);
+            $errorMessage = str_replace("\r\n", "\n", $errorMessage);
 
             $filePath = $absoluteFilePath ? $error->getAbsoluteFilePath() : $error->getRelativeFilePath();
 
@@ -122,7 +123,7 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
                 'Could not process %s%s, due to: %s"%s".',
                 $filePath !== null ? '"' . $filePath . '" file' : 'some files',
                 $error->getRectorClass() !== null ? ' by "' . $error->getRectorClass() . '"' : '',
-                PHP_EOL,
+                "\n",
                 $errorMessage
             );
 

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -119,8 +119,8 @@ EOF
         if ($setAndRulesDuplicatedRegistrations !== []) {
             $this->symfonyStyle->warning(sprintf(
                 'These rules are registered in both sets and "withRules()". Remove them from "withRules()" to avoid duplications: %s* %s',
-                PHP_EOL . PHP_EOL,
-                implode(' * ', $setAndRulesDuplicatedRegistrations) . PHP_EOL
+                "\n\n",
+                implode(' * ', $setAndRulesDuplicatedRegistrations) . "\n"
             ));
         }
 
@@ -145,8 +145,8 @@ EOF
                     $isSingular ? 'es' : '',
                     $isSingular ? '' : 's',
                     $isSingular ? 'y' : 'ies',
-                    PHP_EOL . PHP_EOL . ' - ',
-                    implode(PHP_EOL . ' - ', $paths)
+                    "\n\n" . ' - ',
+                    implode("\n" . ' - ', $paths)
                 )
             );
 
@@ -253,7 +253,7 @@ EOF
             $levelOverflow->getConfigurationName(),
             $levelOverflow->getRuleCount(),
             $levelOverflow->getLevel(),
-            PHP_EOL,
+            "\n",
             $suggestedSetMethod,
         ));
     }

--- a/src/Console/Command/SetupCICommand.php
+++ b/src/Console/Command/SetupCICommand.php
@@ -42,7 +42,7 @@ final class SetupCICommand extends Command
 
         $noteMessage = sprintf(
             'Only GitHub and GitLab are currently supported.%s Contribute your CI template to Rector to make this work: %s',
-            PHP_EOL,
+            "\n",
             'https://github.com/rectorphp/rector-src/'
         );
 

--- a/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
+++ b/src/NodeTypeResolver/DependencyInjection/PHPStanServicesFactory.php
@@ -58,7 +58,7 @@ MESSAGE_ERROR;
         } catch (Throwable $throwable) {
             if ($throwable->getMessage() === "File 'phar://phpstan.phar/conf/bleedingEdge.neon' is missing or is not readable.") {
                 $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
-                $symfonyStyle->error(sprintf(self::INVALID_BLEEDING_EDGE_PATH_MESSAGE, $throwable->getMessage()));
+                $symfonyStyle->error(str_replace("\r\n", "\n", sprintf(self::INVALID_BLEEDING_EDGE_PATH_MESSAGE, $throwable->getMessage())));
 
                 exit(-1);
             }

--- a/src/Reporting/MissConfigurationReporter.php
+++ b/src/Reporting/MissConfigurationReporter.php
@@ -55,7 +55,7 @@ final readonly class MissConfigurationReporter
 
         $this->symfonyStyle->warning(sprintf(
             'Rector has detected a "/vendor" directory in your configured paths. If this is Composer\'s vendor directory, this is not necessary as it will be autoloaded. Scanning the Composer /vendor directory will cause Rector to run much slower and possibly with errors.%sRemove "/vendor" from Rector paths and run again.',
-            PHP_EOL . PHP_EOL
+            "\n\n"
         ));
 
         sleep(3);
@@ -69,12 +69,12 @@ final readonly class MissConfigurationReporter
         }
 
         $suffix = count($files) > 1 ? 's were' : ' was';
-        $fileList = implode(PHP_EOL, $files);
+        $fileList = implode("\n", $files);
 
         $this->symfonyStyle->warning(sprintf(
             'The following file%s skipped as starting with short open tag. Migrate to long open PHP tag first: %s%s',
             $suffix,
-            PHP_EOL . PHP_EOL,
+            "\n\n",
             $fileList
         ));
 


### PR DESCRIPTION
This is a follow-up PR to #7164 that should fix all remaining issues with the Symfony Console component.

I used this regex to find all console output calls:
```regex
->(block|comment|success|error|warning|note|info|caution)\(
```

> [!NOTE]
> Sources:
> - https://symfony.com/doc/current/console/style.html#result-methods
> - [https://github.com/symfony/console/Style/SymfonyStyle.php#L114-L153](https://github.com/symfony/console/blob/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7/Style/SymfonyStyle.php#L114-L153)