### PR TITLE
[TypeDeclaration] Skip param already typed on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
+++ b/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
@@ -22,7 +22,7 @@ final class RemoveDuplicatedCaseInSwitchRector extends AbstractRector
     private bool $hasChanged = false;
 
     public function __construct(
-        private BetterStandardPrinter $betterStandardPrinter
+        private readonly BetterStandardPrinter $betterStandardPrinter
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -60,11 +60,6 @@ final readonly class CallTypesResolver
         // "self" in another object is not correct, this make it independent
         $argValueType = $this->correctSelfType($argValueType);
 
-        $type = $this->nodeTypeResolver->getType($arg->value);
-        if (! $type->equals($argValueType) && $this->typeComparator->isSubtype($type, $argValueType)) {
-            return $type;
-        }
-
         if (! $argValueType instanceof ObjectType) {
             return $argValueType;
         }
@@ -72,6 +67,11 @@ final readonly class CallTypesResolver
         // fix false positive generic type on string
         if (! $this->reflectionProvider->hasClass($argValueType->getClassName())) {
             return new MixedType();
+        }
+
+        $type = $this->nodeTypeResolver->getType($arg->value);
+        if (! $type->equals($argValueType) && $this->typeComparator->isSubtype($type, $argValueType)) {
+            return $type;
         }
 
         return $argValueType;

--- a/rules/TypeDeclaration/NodeAnalyzer/ClassMethodParamTypeCompleter.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ClassMethodParamTypeCompleter.php
@@ -6,7 +6,6 @@ namespace Rector\TypeDeclaration\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\MixedType;
@@ -55,7 +54,7 @@ final readonly class ClassMethodParamTypeCompleter
             }
 
             // skip if param type already filled
-            if ($param->type instanceof Identifier) {
+            if ($param->type instanceof Node) {
                 continue;
             }
 


### PR DESCRIPTION
@calebdw ref https://github.com/rectorphp/rector-src/pull/7172#issuecomment-3223429049

I think the safest way is check if param already typed, then skip.