### PR TITLE
[TypeDeclaration] Clean up type based on docblock check on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -16,7 +16,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
-use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 
 final readonly class CallTypesResolver
@@ -24,8 +23,7 @@ final readonly class CallTypesResolver
     public function __construct(
         private NodeTypeResolver $nodeTypeResolver,
         private TypeFactory $typeFactory,
-        private ReflectionProvider $reflectionProvider,
-        private TypeComparator $typeComparator
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -69,11 +69,6 @@ final readonly class CallTypesResolver
             return new MixedType();
         }
 
-        $type = $this->nodeTypeResolver->getType($arg->value);
-        if (! $type->equals($argValueType) && $this->typeComparator->isSubtype($type, $argValueType)) {
-            return $type;
-        }
-
         return $argValueType;
     }
 


### PR DESCRIPTION
@calebdw continue of PR:

- https://github.com/rectorphp/rector-src/pull/7176

since param typed already skipped, by doc based param type check seems no longer needed.