### PR TITLE
Add Rector to replace null keys in array_key_exists with empty string

### DIFF
--- a/config/set/php85.php
+++ b/config/set/php85.php
@@ -10,6 +10,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php85\Rector\ArrayDimFetch\ArrayFirstLastRector;
 use Rector\Php85\Rector\ClassMethod\NullDebugInfoReturnRector;
 use Rector\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
 use Rector\Php85\Rector\FuncCall\RemoveFinfoBufferContextArgRector;
 use Rector\Php85\Rector\Switch_\ColonAfterSwitchCaseRector;
 use Rector\Removing\Rector\FuncCall\RemoveFuncCallArgRector;
@@ -32,6 +33,7 @@ return static function (RectorConfig $rectorConfig): void {
             NullDebugInfoReturnRector::class,
             DeprecatedAnnotationToDeprecatedAttributeRector::class,
             ColonAfterSwitchCaseRector::class,
+            ArrayKeyExistsNullToEmptyStringRector::class,
         ]
     );
 

--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/ArrayKeyExistsNullToEmptyStringRectorTest.php
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/ArrayKeyExistsNullToEmptyStringRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ArrayKeyExistsNullToEmptyStringRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/key_null.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/key_null.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+array_key_exists(null, $array);
+
+?>
+-----
+<?php
+
+array_key_exists('', $array);
+
+?>

--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/key_null_var.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/key_null_var.php.inc
@@ -6,6 +6,6 @@ array_key_exists($k, $array);
 -----
 <?php
 
-array_key_exists($k ?? '', $array);
+array_key_exists((string) $k, $array);
 
 ?>

--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/key_null_var.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/key_null_var.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+array_key_exists($k, $array);
+
+?>
+-----
+<?php
+
+array_key_exists($k ?? '', $array);
+
+?>

--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/config/configured_rule.php
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ArrayKeyExistsNullToEmptyStringRector::class);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_85);
+};

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -15,6 +15,10 @@ use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists
+ * @see \Rector\Tests\Php85\Rector\FuncCall\RemoveFinfoBufferContextArgRector\RemoveFinfoBufferContextArgRectorTest
+ */
 final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function getRuleDefinition(): RuleDefinition
@@ -43,7 +47,12 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
     public function refactor(Node $node): ?Node
     {
 
-        if ($node instanceof FuncCall && ! $this->isName($node->name, 'array_key_exists')) {
+
+        if (! $node instanceof FuncCall) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'array_key_exists')) {
             return null;
         }
 

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -78,7 +78,7 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
             return $node;
         }
 
-        if (! $keyExpr instanceof Coalesce && ! ($keyExpr instanceof String_ && $keyExpr->value === '')) {
+        if (! $keyExpr instanceof Coalesce) {
             $args[0]->value = new Coalesce($keyExpr, new String_(''));
             return $node;
         }

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -4,16 +4,42 @@ declare(strict_types=1);
 
 namespace Rector\Php85\Rector\FuncCall;
 
+
+
+
 use PhpParser\Node;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Cast\String_ as CastString_;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\Native\ExtendedNativeParameterReflection;
+use PHPStan\Reflection\Native\NativeFunctionReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
+use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
 
 /**
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists
@@ -21,6 +47,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector implements MinPhpVersionInterface
 {
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -32,7 +66,7 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
         CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-        array_key_exists($key ?? '', $array);
+        array_key_exists((string)$key, $array);
         CODE_SAMPLE
                 ),
             ]
@@ -46,48 +80,164 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
 
     public function refactor(Node $node): ?Node
     {
-
-
-        if (! $node instanceof FuncCall) {
+        if ($node->isFirstClassCallable()) {
             return null;
         }
 
-        if (! $this->isName($node->name, 'array_key_exists')) {
+        if (! $this->isName($node, 'array_key_exists')) {
+            return null;
+        }
+
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
             return null;
         }
 
         $args = $node->getArgs();
 
-        if (count($args) < 2) {
+        $classReflection = $scope->getClassReflection();
+        $isTrait = $classReflection instanceof ClassReflection && $classReflection->isTrait();
+
+        $functionReflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+        if (! $functionReflection instanceof FunctionReflection) {
             return null;
         }
 
-        $keyExpr = $args[0]->value;
+        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($functionReflection, $node, $scope);
+        $isChanged = false;
 
-        if ($keyExpr instanceof Coalesce) {
-            return null;
+        $result = $this->processNullToStrictStringOnNodePosition(
+            $node,
+            $args,
+            0,
+            $isTrait,
+            $scope,
+            $parametersAcceptor
+        );
+        if ($result instanceof Node) {
+            $node = $result;
+            $isChanged = true;
         }
         
-
-        if ($keyExpr instanceof String_ && $keyExpr->value === '') {
-            return null;
-        }
-
-        if ($this->isName($keyExpr, 'null')) {
-            $args[0]->value = new String_('');
-            return $node;
-        }
-
-        if (! $keyExpr instanceof Coalesce) {
-            $args[0]->value = new Coalesce($keyExpr, new String_(''));
+        if ($isChanged) {
             return $node;
         }
         
-        return $node;
+        return null;
     }
 
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_NULL_ARG_IN_ARRAY_KEY_EXISTS_FUNCTION;
+    }
+    /**
+     * @param Arg[] $args
+     * @param int|string $position
+     */
+    private function processNullToStrictStringOnNodePosition(FuncCall $funcCall, array $args, $position, bool $isTrait, Scope $scope, ParametersAcceptor $parametersAcceptor) : ?FuncCall
+    {
+        if (!isset($args[$position])) {
+            return null;
+        }
+        $argValue = $args[$position]->value;
+        if ($this->valueResolver->isNull($argValue)) {
+            $args[$position]->value = new String_('');
+            $funcCall->args = $args;
+            return $funcCall;
+        }  
+        if ($this->shouldSkipValue($argValue, $scope, $isTrait)) {
+            return null;
+        } 
+        $parameter = $parametersAcceptor->getParameters()[$position] ?? null;
+        if ($parameter instanceof ExtendedNativeParameterReflection && $parameter->getType() instanceof UnionType) {
+            $parameterType = $parameter->getType();
+            if (!$this->isValidUnionType($parameterType)) {
+                return null;
+            }
+        }
+        if ($argValue instanceof Ternary && !$this->shouldSkipValue($argValue->else, $scope, $isTrait)) {
+            if ($this->valueResolver->isNull($argValue->else)) {
+                $argValue->else = new String_('');
+            } else {
+                $argValue->else = new CastString_($argValue->else);
+            }
+            $args[$position]->value = $argValue;
+            $funcCall->args = $args;
+            return $funcCall;
+        }
+        $args[$position]->value = new CastString_($argValue);
+        $funcCall->args = $args;
+        return $funcCall;
+    }
+    private function shouldSkipValue(Expr $expr, Scope $scope, bool $isTrait) : bool
+    {
+        $type = $this->nodeTypeResolver->getType($expr);
+        if ($type->isString()->yes()) {
+            return \true;
+        }
+        $nativeType = $this->nodeTypeResolver->getNativeType($expr);
+        if ($nativeType->isString()->yes()) {
+            return \true;
+        }
+        if ($this->shouldSkipType($type)) {
+            return \true;
+        }
+        if ($expr instanceof InterpolatedString) {
+            return \true;
+        }
+        if ($this->isAnErrorType($expr, $nativeType, $scope)) {
+            return \true;
+        }
+        return $this->shouldSkipTrait($expr, $type, $isTrait);
+    }
+    private function isValidUnionType(Type $type) : bool
+    {
+        if (!$type instanceof UnionType) {
+            return \false;
+        }
+        foreach ($type->getTypes() as $childType) {
+            if ($childType->isString()->yes()) {
+                continue;
+            }
+            if ($childType->isInteger()->yes()) {
+                continue;
+            }
+            if ($childType->isNull()->yes()) {
+                continue;
+            }
+            return \false;
+        }
+        return \true;
+    }
+    private function shouldSkipType(Type $type) : bool
+    {
+        return !$type instanceof MixedType && !$type->isNull()->yes() && !$this->isValidUnionType($type);
+    }
+    private function shouldSkipTrait(Expr $expr, Type $type, bool $isTrait) : bool
+    {
+        if (!$type instanceof MixedType) {
+            return \false;
+        }
+        if (!$isTrait) {
+            return \false;
+        }
+        if ($type->isExplicitMixed()) {
+            return \false;
+        }
+        if (!$expr instanceof MethodCall) {
+            return $this->propertyFetchAnalyzer->isLocalPropertyFetch($expr);
+        }
+        return \true;
+    }
+    private function isAnErrorType(Expr $expr, Type $type, Scope $scope) : bool
+    {
+        if ($type instanceof ErrorType) {
+            return \true;
+        }
+        $parentScope = $scope->getParentScope();
+        if ($parentScope instanceof Scope) {
+            return $parentScope->getType($expr) instanceof ErrorType;
+        }
+        return $type instanceof MixedType && !$type->isExplicitMixed() && $type->getSubtractedType() instanceof NullType;
     }
 }

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -73,7 +73,7 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
             return null;
         }
 
-        if ($this->nodeNameResolver->isName($keyExpr, 'null')) {
+        if ($this->isName($keyExpr, 'null')) {
             $args[0]->value = new String_('');
             return $node;
         }

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -23,7 +23,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
-use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
@@ -43,7 +42,6 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly ArgsAnalyzer $argsAnalyzer,
         private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
         private readonly ValueResolver $valueResolver
     ) {
@@ -74,6 +72,10 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
 
     public function refactor(Node $node): ?Node
     {
+        if(!$node instanceof FuncCall){
+            return null;
+        }
+        
         if ($node->isFirstClassCallable()) {
             return null;
         }

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php85\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace null key in array_key_exists with empty string',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+        array_key_exists($key, $array);
+        CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+        array_key_exists($key ?? '', $array);
+        CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+
+        if ($node instanceof FuncCall && ! $this->isName($node->name, 'array_key_exists')) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+
+        if (count($args) < 2) {
+            return null;
+        }
+
+        $keyExpr = $args[0]->value;
+
+        if ($keyExpr instanceof Coalesce) {
+            return null;
+        }
+        
+
+        if ($keyExpr instanceof String_ && $keyExpr->value === '') {
+            return null;
+        }
+
+        if ($this->nodeNameResolver->isName($keyExpr, 'null')) {
+            $args[0]->value = new String_('');
+            return $node;
+        }
+
+        if (! $keyExpr instanceof Coalesce && ! ($keyExpr instanceof String_ && $keyExpr->value === '')) {
+            $args[0]->value = new Coalesce($keyExpr, new String_(''));
+            return $node;
+        }
+        
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::DEPRECATE_NULL_ARG_IN_ARRAY_KEY_EXISTS_FUNCTION;
+    }
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -792,4 +792,10 @@ final class PhpVersionFeature
      * @var int
      */
     public const COLON_AFTER_SWITCH_CASE = PhpVersion::PHP_85;
+
+    /**
+     * @see https://wiki.php.net/rfc/deprecations_php_8_5#https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists
+     * @var int
+     */
+    public const DEPRECATE_NULL_ARG_IN_ARRAY_KEY_EXISTS_FUNCTION = PhpVersion::PHP_85;
 }


### PR DESCRIPTION
PHP 8.5+ deprecates passing null as the key to `array_key_exists()`.
This Rector rule automatically replaces:

```php
    array_key_exists(null, $array);
```

with:
```php
    array_key_exists($key ?? '', $array);
```

   
[https://wiki.php.net/rfc/deprecations_php_8_5](https://wiki.php.net/rfc/deprecations_php_8_5#https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists)

