### PR TITLE
[Naming] Skip rename override method from /vendor/ on RenameParamToMatchTypeRector

### DIFF
--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/skip_override_vendor_param.php.inc
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Fixture/skip_override_vendor_param.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\EliteManager;
+use Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\vendor\SomeVendorWithParam;
+
+class SkipOverrideVendorParam extends SomeVendorWithParam
+{
+    public function run(EliteManager $eventManager)
+    {
+    }
+}

--- a/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Source/vendor/SomeVendorWithParam.php
+++ b/rules-tests/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector/Source/vendor/SomeVendorWithParam.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\vendor;
+
+use Rector\Tests\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector\Source\EliteManager;
+
+final class SomeVendorWithParam
+{
+    public function run(EliteManager $eventManager)
+    {
+    }
+}

--- a/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
+++ b/rules/Naming/Rector/ClassMethod/RenameParamToMatchTypeRector.php
@@ -140,9 +140,14 @@ CODE_SAMPLE
             $classReflection->getName() !== $ancestorClassReflection->getName()
         );
 
+        $methodName = $this->getName($classMethod);
         foreach ($ancestors as $ancestor) {
             // internal
             if ($ancestor->getFileName() === null) {
+                continue;
+            }
+
+            if (! $ancestor->hasNativeMethod($methodName)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9233