### PR TITLE
[DeadCode] Skip non-public __clone() method on RemoveEmptyClassMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_private_clone.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_private_clone.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+class SkipPrivateClone
+{
+    private function __clone()
+    {
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -162,6 +162,10 @@ CODE_SAMPLE
             return $class->extends instanceof FullyQualified;
         }
 
+        if ($this->isName($classMethod, MethodName::CLONE)) {
+            return ! $classMethod->isPublic();
+        }
+
         return $this->isName($classMethod, MethodName::INVOKE);
     }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9337