### PR TITLE
[Php85] Add fixture to skip integer key on ArrayKeyExistsNullToEmptyStringRector

### DIFF
--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/skip_integer_key.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/skip_integer_key.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector\Fixture;
+
+array_key_exists(0, $array);


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/7183#issuecomment-3234229847