### PR TITLE
skip constructor param hook on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_param_hook.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_param_hook.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipParamHook
+{
+    public function __construct(private string $foo {
+        get {
+            return $this->foo;
+        }
+    })
+    {
+    }
+}

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -224,6 +224,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($param->hooks !== []) {
+            return null;
+        }
+
         if ($this->propertyManipulator->isPropertyChangeableExceptConstructor($class, $param, $scope)) {
             return null;
         }


### PR DESCRIPTION
Fixed https://github.com/rectorphp/rector/issues/9340