### PR TITLE
[Scope] Handle Scope refreshing on Attribute on print string with NOWDOC

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -149,10 +149,9 @@ final readonly class ChangedNodeScopeRefresher
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable([$class], function (Node $subNode) use (
             $node
         ): Node {
-            $subNode->setAttributes([
-                'startLine' => $node->getStartLine(),
-                'endLine' => $node->getEndLine(),
-            ]);
+            $subNode->setAttribute('startLine', $node->getStartLine());
+            $subNode->setAttribute('endLine', $node->getEndLine());
+
             return $subNode;
         });
     }

--- a/tests/Issues/PrintStringNowDocUnderAttributeTarget/Fixture/fixture.php.inc
+++ b/tests/Issues/PrintStringNowDocUnderAttributeTarget/Fixture/fixture.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\PrintStringNowDocUnderAttributeTarget\Fixture;
+
+final readonly class Fixture
+{
+    public function __construct(
+        #[\SomeAttribute(
+            <<<'SOME_VALUE_TEXT'
+                execute ($id: ID!) {
+                    run(id: $id) {
+                        data {
+                            id
+                        }
+                    }
+                }
+                SOME_VALUE_TEXT,
+        )]
+        private object $query,
+    ) {}
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\PrintStringNowDocUnderAttributeTarget\Fixture;
+
+final readonly class Fixture
+{
+    public function __construct(
+        #[\SomeNewAttribute(
+            <<<'SOME_VALUE_TEXT'
+                execute ($id: ID!) {
+                    run(id: $id) {
+                        data {
+                            id
+                        }
+                    }
+                }
+                SOME_VALUE_TEXT,
+        )]
+        private object $query,
+    ) {}
+}
+
+?>

--- a/tests/Issues/PrintStringNowDocUnderAttributeTarget/PrintStringNowDocUnderAttributeTargetTest.php
+++ b/tests/Issues/PrintStringNowDocUnderAttributeTarget/PrintStringNowDocUnderAttributeTargetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\PrintStringNowDocUnderAttributeTarget;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PrintStringNowDocUnderAttributeTargetTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/PrintStringNowDocUnderAttributeTarget/Source/SomeAttributeTargetRector.php
+++ b/tests/Issues/PrintStringNowDocUnderAttributeTarget/Source/SomeAttributeTargetRector.php
@@ -30,7 +30,6 @@ final class SomeAttributeTargetRector extends AbstractRector
      */
     public function refactor(Node $node): Node
     {
-        $node->setAttribute('some_key', 'some_value');
         $node->name = new FullyQualified('SomeNewAttribute');
 
         return $node;

--- a/tests/Issues/PrintStringNowDocUnderAttributeTarget/Source/SomeAttributeTargetRector.php
+++ b/tests/Issues/PrintStringNowDocUnderAttributeTarget/Source/SomeAttributeTargetRector.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Name\FullyQualified;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class SomeAttributeTargetRector extends AbstractRector
+final class SomeAttributeTargetRector extends AbstractRector
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/tests/Issues/PrintStringNowDocUnderAttributeTarget/Source/SomeAttributeTargetRector.php
+++ b/tests/Issues/PrintStringNowDocUnderAttributeTarget/Source/SomeAttributeTargetRector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\PrintStringNowDocUnderAttributeTarget\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Name\FullyQualified;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class SomeAttributeTargetRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
+    }
+
+        /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Attribute::class];
+    }
+
+    /**
+     * @param Attribute $node
+     */
+    public function refactor(Node $node): Node
+    {
+        $node->setAttribute('some_key', 'some_value');
+        $node->name = new FullyQualified('SomeNewAttribute');
+
+        return $node;
+    }
+}

--- a/tests/Issues/PrintStringNowDocUnderAttributeTarget/config/configured_rule.php
+++ b/tests/Issues/PrintStringNowDocUnderAttributeTarget/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Tests\Issues\PrintStringNowDocUnderAttributeTarget\Source\SomeAttributeTargetRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(SomeAttributeTargetRector::class);
+};


### PR DESCRIPTION
It currently cause invalid printing:

```diff

1) Rector\Tests\Issues\PrintStringNowDocUnderAttributeTarget\PrintStringNowDocUnderAttributeTargetTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "fixture.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 final readonly class Fixture
 {
     public function __construct(
-        #[\SomeNewAttribute(
-            <<<'SOME_VALUE_TEXT'
-                execute ($id: ID!) {
-                    run(id: $id) {
-                        data {
-                            id
-                        }
-                    }
-                }
-                SOME_VALUE_TEXT,
-        )]
+        #[\SomeNewAttribute('execute ($id: ID!) {
+    run(id: $id) {
+        data {
+            id
+        }
+    }
+}')]
         private object $query,
     ) {}
 }
 
-?>
```

This PR fix it.