### PR TITLE
[8.4][DeprecatedAnnotationToDeprecatedAttributeRector] Remove invalid example

### DIFF
--- a/rules/Php84/Rector/Class_/DeprecatedAnnotationToDeprecatedAttributeRector.php
+++ b/rules/Php84/Rector/Class_/DeprecatedAnnotationToDeprecatedAttributeRector.php
@@ -31,23 +31,6 @@ final class DeprecatedAnnotationToDeprecatedAttributeRector extends AbstractRect
             new CodeSample(
                 <<<'CODE_SAMPLE'
 /**
- * @deprecated 1.0.0 Use SomeOtherClass instead
- */
-class SomeClass
-{
-}
-CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
-#[\Deprecated(message: 'Use SomeOtherClass instead', since: '1.0.0')]
-class SomeClass
-{
-}
-CODE_SAMPLE
-            ),
-            new CodeSample(
-                <<<'CODE_SAMPLE'
-/**
  * @deprecated 1.0.0 Use SomeOtherFunction instead
  */
 function someFunction()


### PR DESCRIPTION
Classes are not affected by the rule and are not supported by the `#[\Deprecated]` attribute