### PR TITLE
[experimental] [assert] Kick of experimental rule, AddAssertArrayFromClassMethodDocblockRector

### DIFF
--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/AddAssertArrayFromClassMethodDocblockRectorTest.php
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/AddAssertArrayFromClassMethodDocblockRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddAssertArrayFromClassMethodDocblockRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/multiple_parameters.php.inc
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/multiple_parameters.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\Fixture;
+
+final class MultipleParameters
+{
+    /**
+     * @param array<string, string> $items
+     * @param string[] $names
+     */
+    public function run(array $items, array $names)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\Fixture;
+
+final class MultipleParameters
+{
+    /**
+     * @param array<string, string> $items
+     * @param string[] $names
+     */
+    public function run(array $items, array $names)
+    {
+        \Webmozart\Assert\Assert::allString($items);
+        \Webmozart\Assert\Assert::allString(array_keys($items));
+        \Webmozart\Assert\Assert::allString($names);
+    }
+}
+
+?>

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/simple_array.php.inc
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/simple_array.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\Fixture;
+
+final class SimpleArray
+{
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\Fixture;
+
+final class SimpleArray
+{
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+        \Webmozart\Assert\Assert::allInteger($items);
+    }
+}
+
+?>

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/skip_already_set.php.inc
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/skip_already_set.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\Fixture;
+
+final class SkipAlreadySet
+{
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+        \Webmozart\Assert\Assert::allInteger($items);
+    }
+}

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/skip_no_array.php.inc
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/Fixture/skip_no_array.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\Fixture;
+
+final class SkipNoArray
+{
+    /**
+     * @param int[] $items
+     */
+    public function run($items)
+    {
+    }
+}

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/config/configured_rule.php
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddAssertArrayFromClassMethodDocblockRector::class);
+};

--- a/rules/Assert/Enum/AssertClassName.php
+++ b/rules/Assert/Enum/AssertClassName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Assert\Enum;
+
+final class AssertClassName
+{
+    /**
+     * @var string
+     */
+    public const ASSERT = 'Webmozart\Assert\Assert';
+}

--- a/rules/Assert/NodeAnalyzer/ExistingAssertStaticCallResolver.php
+++ b/rules/Assert/NodeAnalyzer/ExistingAssertStaticCallResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Assert\NodeAnalyzer;
+
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\PrettyPrinter\Standard;
+use Rector\Assert\Enum\AssertClassName;
+
+final class ExistingAssertStaticCallResolver
+{
+    /**
+     * @return string[]
+     */
+    public function resolve(ClassMethod $classMethod): array
+    {
+        if ($classMethod->stmts === null) {
+            return [];
+        }
+
+        $existingAssertCallHashes = [];
+        $standard = new Standard();
+
+        foreach ($classMethod->stmts as $currentStmt) {
+            if (! $currentStmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $currentStmt->expr instanceof StaticCall) {
+                continue;
+            }
+
+            $staticCall = $currentStmt->expr;
+            if (! $staticCall->class instanceof Name) {
+                continue;
+            }
+
+            if ($staticCall->class->toString() !== AssertClassName::ASSERT) {
+                continue;
+            }
+
+            $existingAssertCallHashes[] = $standard->prettyPrintExpr($staticCall);
+        }
+
+        return $existingAssertCallHashes;
+    }
+}

--- a/rules/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector.php
+++ b/rules/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Assert\Rector\ClassMethod;
 
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -118,7 +119,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $param->var instanceof Expr\Variable) {
+            if (! $param->var instanceof Variable) {
                 continue;
             }
 

--- a/rules/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector.php
+++ b/rules/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector.php
@@ -1,10 +1,194 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rector\Assert\Rector\ClassMethod;
 
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use Rector\Assert\Enum\AssertClassName;
+use Rector\Assert\NodeAnalyzer\ExistingAssertStaticCallResolver;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @experimental Check generic array key/value types in runtime with assert. Generics for impatient people.
+ *
+ * @see \Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\AddAssertArrayFromClassMethodDocblockRectorTest
+ */
 final class AddAssertArrayFromClassMethodDocblockRector extends AbstractRector
 {
-    // @todo
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly ExistingAssertStaticCallResolver $existingAssertStaticCallResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add key and value assert based on docblock @param type declarations', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+<?php
+
+class SomeClass
+{
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+    }
+}
+
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+<?php
+
+use Webmozart\Assert\Assert;class SomeClass
+{
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+        Assert::allInteger($items);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?ClassMethod
+    {
+        $scope = ScopeFetcher::fetch($node);
+        if (! $scope->isInClass()) {
+            return null;
+        }
+
+        if ($node->stmts === null || $node->isAbstract()) {
+            return null;
+        }
+
+        $methodPhpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $methodPhpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $paramTagValueNodes = $methodPhpDocInfo->getParamTagValueNodes();
+        if ($paramTagValueNodes === []) {
+            return null;
+        }
+
+        $assertStaticCallStmts = [];
+
+        foreach ($node->getParams() as $param) {
+            if (! $param->type instanceof Identifier) {
+                continue;
+            }
+
+            // handle arrays only
+            if ($param->type->name !== 'array') {
+                continue;
+            }
+
+            if (! $param->var instanceof Expr\Variable) {
+                continue;
+            }
+
+            $paramName = $param->var->name;
+            if (! is_string($paramName)) {
+                continue;
+            }
+
+            $paramDocType = $methodPhpDocInfo->getParamType($paramName);
+            if (! $paramDocType instanceof ArrayType) {
+                continue;
+            }
+
+            // assert value
+            if ($paramDocType->getItemType() instanceof IntegerType) {
+                $assertStaticCallStmts[] = $this->createAssertExpression($param->var, 'allInteger');
+            } elseif ($paramDocType->getItemType() instanceof StringType) {
+                $assertStaticCallStmts[] = $this->createAssertExpression($param->var, 'allString');
+            }
+
+            // assert keys
+            $arrayKeys = new FuncCall(new Name('array_keys'), [new Arg($param->var)]);
+            if ($paramDocType->getKeyType() instanceof StringType) {
+                $assertStaticCallStmts[] = $this->createAssertExpression($arrayKeys, 'allString');
+            } elseif ($paramDocType->getKeyType() instanceof IntegerType) {
+                $assertStaticCallStmts[] = $this->createAssertExpression($arrayKeys, 'allInteger');
+            }
+        }
+
+        // filter existing assert to avoid duplication
+        if ($assertStaticCallStmts === []) {
+            return null;
+        }
+
+        $existingAssertCallHashes = $this->existingAssertStaticCallResolver->resolve($node);
+
+        $assertStaticCallStmts = $this->filterOutExistingStaticCall($assertStaticCallStmts, $existingAssertCallHashes);
+
+        if ($assertStaticCallStmts === []) {
+            return null;
+        }
+
+        $node->stmts = array_merge($assertStaticCallStmts, $node->stmts);
+
+        return $node;
+    }
+
+    private function createAssertExpression(Expr $expr, string $methodName): Expression
+    {
+        $staticCall = new StaticCall(new FullyQualified(AssertClassName::ASSERT), $methodName, [new Arg($expr)]);
+
+        return new Expression($staticCall);
+    }
+
+    /**
+     * @param Expression[] $assertStaticCallStmts
+     * @param string[] $existingAssertCallHashes
+     * @return Expression[]
+     */
+    private function filterOutExistingStaticCall(array $assertStaticCallStmts, array $existingAssertCallHashes): array
+    {
+        $standard = new Standard();
+
+        return array_filter($assertStaticCallStmts, function (Expression $assertStaticCallExpression) use (
+            $standard,
+            $existingAssertCallHashes
+        ): bool {
+            $currentStaticCallHash = $standard->prettyPrintExpr($assertStaticCallExpression->expr);
+
+            return ! in_array($currentStaticCallHash, $existingAssertCallHashes, true);
+        });
+    }
 }

--- a/rules/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector.php
+++ b/rules/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Assert\Rector\ClassMethod;
+
+use Rector\Rector\AbstractRector;
+
+final class AddAssertArrayFromClassMethodDocblockRector extends AbstractRector
+{
+    // @todo
+}

--- a/rules/Php85/Rector/FuncCall/ChrArgModuloRector.php
+++ b/rules/Php85/Rector/FuncCall/ChrArgModuloRector.php
@@ -23,7 +23,7 @@ final class ChrArgModuloRector extends AbstractRector implements MinPhpVersionIn
 {
     public function __construct(
         private readonly ValueResolver $valueResolver
-    ){
+    ) {
 
     }
 
@@ -80,7 +80,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ( $value >= 0 && $value <= 255) {
+        if ($value >= 0 && $value <= 255) {
             return null;
         }
 


### PR DESCRIPTION
"Trust, but verify" approach to scalar array types. 

Instead of hope/trust/feel, verify the assumption instead :+1:  

Not suitable for weak codebases :warning: 

```diff
final class MultipleParameters
{
    /**
     * @param array<string, string> $items
     * @param string[] $names
     */
    public function run(array $items, array $names)
    {
+        \Webmozart\Assert\Assert::allString($items);
+        \Webmozart\Assert\Assert::allString(array_keys($items));
+        \Webmozart\Assert\Assert::allString($names);
    }
}
```