### PR TITLE
[Composer] Make InstalledPackageResolver::resolvedInstalledPackages nullable to verify cached package lists

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -17,9 +17,9 @@ use Webmozart\Assert\Assert;
 final class InstalledPackageResolver
 {
     /**
-     * @var InstalledPackage[]
+     * @var null|InstalledPackage[]
      */
-    private array $resolvedInstalledPackages = [];
+    private ?array $resolvedInstalledPackages = null;
 
     public function __construct(
         private readonly ?string $projectDirectory = null
@@ -37,8 +37,8 @@ final class InstalledPackageResolver
      */
     public function resolve(): array
     {
-        // cache
-        if ($this->resolvedInstalledPackages !== []) {
+        // already cached, even only empty array
+        if ($this->resolvedInstalledPackages !== null) {
             return $this->resolvedInstalledPackages;
         }
 


### PR DESCRIPTION
same with other class for detect cached data, the data needs to be nullable, so even empty array, it already cached, use null check instead for no cache yet.

see https://github.com/search?q=repo%3Arectorphp%2Frector-src%20%2F%2F%20already%20cached%2C%20even%20only%20empty%20array&type=code

for other comparison check.