### PR TITLE
[assert] make AddAssertArrayFromClassMethodDocblockRector rule configurable to accept beberlei assert package

### DIFF
--- a/config/set/php85.php
+++ b/config/set/php85.php
@@ -203,10 +203,7 @@ return static function (RectorConfig $rectorConfig): void {
     );
 
     // https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_filter_default_constant
-    $rectorConfig->ruleWithConfiguration(
-        RenameConstantRector::class,
-        [
-            'FILTER_DEFAULT' => 'FILTER_UNSAFE_RAW',
-        ]
-    );
+    $rectorConfig->ruleWithConfiguration(RenameConstantRector::class, [
+        'FILTER_DEFAULT' => 'FILTER_UNSAFE_RAW',
+    ]);
 };

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/BeberleiTest.php
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/BeberleiTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class BeberleiTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureBeberlei');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/beberlei_assert.php';
+    }
+}

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/FixtureBeberlei/beberlei_assert.php.inc
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/FixtureBeberlei/beberlei_assert.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\FixtureBeberlei;
+
+final class FloatIntBool
+{
+    /**
+     * @param int[] $items
+     * @param float[] $numbers
+     * @param bool[] $options
+     */
+    public function run(array $items, array $numbers, array $options)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector\FixtureBeberlei;
+
+final class FloatIntBool
+{
+    /**
+     * @param int[] $items
+     * @param float[] $numbers
+     * @param bool[] $options
+     */
+    public function run(array $items, array $numbers, array $options)
+    {
+        \Assert\Assertion::allInteger($items);
+        \Assert\Assertion::allFloat($numbers);
+        \Assert\Assertion::allBoolean($options);
+    }
+}
+
+?>

--- a/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/config/beberlei_assert.php
+++ b/rules-tests/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector/config/beberlei_assert.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Assert\Enum\AssertClassName;
+use Rector\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AddAssertArrayFromClassMethodDocblockRector::class, [
+        AssertClassName::BEBERLEI,
+    ]);
+};

--- a/rules/Assert/Enum/AssertClassName.php
+++ b/rules/Assert/Enum/AssertClassName.php
@@ -9,5 +9,10 @@ final class AssertClassName
     /**
      * @var string
      */
-    public const ASSERT = 'Webmozart\Assert\Assert';
+    public const WEBMOZART = 'Webmozart\Assert\Assert';
+
+    /**
+     * @var string
+     */
+    public const BEBERLEI = 'Assert\Assertion';
 }

--- a/rules/Assert/NodeAnalyzer/ExistingAssertStaticCallResolver.php
+++ b/rules/Assert/NodeAnalyzer/ExistingAssertStaticCallResolver.php
@@ -39,7 +39,11 @@ final class ExistingAssertStaticCallResolver
                 continue;
             }
 
-            if ($staticCall->class->toString() !== AssertClassName::ASSERT) {
+            if (! in_array(
+                $staticCall->class->toString(),
+                [AssertClassName::WEBMOZART, AssertClassName::BEBERLEI],
+                true
+            )) {
                 continue;
             }
 


### PR DESCRIPTION
Based on feedback on Twitter, I've added another option to enable `beberlei/assert` package.

1) to use it, configure the rule

```php
use Rector\Assert\Enum\AssertClassName;
use Rector\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector;
use Rector\Config\RectorConfig;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->ruleWithConfiguration(AddAssertArrayFromClassMethodDocblockRector::class, [
        AssertClassName::BEBERLEI,
    ]);
};
```

2) to use [webmozart/assert](https://github.com/webmozarts/assert), use default or configure as well

```php
use Rector\Assert\Rector\ClassMethod\AddAssertArrayFromClassMethodDocblockRector;
use Rector\Config\RectorConfig;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->rule(AddAssertArrayFromClassMethodDocblockRector::class);

    // or 
    // $rectorConfig->ruleWithConfiguration(AddAssertArrayFromClassMethodDocblockRector::class, [
    //    AssertClassName::WEBMOZART,    
    // ]);
};
```

