### PR TITLE
fix: skip privatizing Laravel Model attributes and scopes

### DIFF
--- a/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/Fixture/skip_laravel_model_attributes_and_scopes.php.inc
+++ b/rules-tests/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector/Fixture/skip_laravel_model_attributes_and_scopes.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector\Fixture;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+final class User extends Model
+{
+    protected function getSomeAttribute(): mixed
+    {
+    }
+
+    protected function setSomeAttribute(): mixed
+    {
+    }
+
+    protected function foo(): Attribute
+    {
+    }
+
+    protected function scopeFoo(): mixed
+    {
+    }
+
+    #[Scope]
+    protected function bar(): mixed
+    {
+    }
+}

--- a/rules/Privatization/Guard/LaravelModelGuard.php
+++ b/rules/Privatization/Guard/LaravelModelGuard.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Privatization\Guard;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\ObjectType;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\Util\StringUtils;
+
+/**
+ * Guards against privatizing Laravel model attributes and scopes
+ */
+final readonly class LaravelModelGuard
+{
+    /**
+     * @var string
+     * @see https://regex101.com/r/Dx0WN5/2
+     */
+    private const LARAVEL_MODEL_ATTRIBUTE_REGEX = '#^[gs]et.+Attribute$#';
+
+    /**
+     * @var string
+     * @see https://regex101.com/r/hxOGeN/2
+     */
+    private const LARAVEL_MODEL_SCOPE_REGEX = '#^scope.+$#';
+
+    public function __construct(
+        private PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private NodeNameResolver $nodeNameResolver,
+        private NodeTypeResolver $nodeTypeResolver,
+    ) {
+    }
+
+    public function isProtectedMethod(ClassReflection $classReflection, ClassMethod $classMethod): bool
+    {
+        if (! $classReflection->is('Illuminate\Database\Eloquent\Model')) {
+            return false;
+        }
+
+        $name = (string) $this->nodeNameResolver->getName($classMethod->name);
+
+        return $this->isAttributeMethod($name, $classMethod)
+            || $this->isScopeMethod($name, $classMethod);
+    }
+
+    private function isAttributeMethod(string $name, ClassMethod $classMethod): bool
+    {
+        if (StringUtils::isMatch($name, self::LARAVEL_MODEL_ATTRIBUTE_REGEX)) {
+            return true;
+        }
+
+        if (! $classMethod->returnType instanceof Node) {
+            return false;
+        }
+
+        return $this->nodeTypeResolver->isObjectType(
+            $classMethod->returnType,
+            new ObjectType('Illuminate\Database\Eloquent\Casts\Attribute')
+        );
+    }
+
+    private function isScopeMethod(string $name, ClassMethod $classMethod): bool
+    {
+        if (StringUtils::isMatch($name, self::LARAVEL_MODEL_SCOPE_REGEX)) {
+            return true;
+        }
+
+        return $this->phpAttributeAnalyzer->hasPhpAttribute(
+            $classMethod,
+            'Illuminate\Database\Eloquent\Attributes\Scope'
+        );
+    }
+}

--- a/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
+++ b/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
@@ -17,6 +17,7 @@ use Rector\Privatization\Guard\OverrideByParentClassGuard;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Privatization\VisibilityGuard\ClassMethodVisibilityGuard;
 use Rector\Rector\AbstractRector;
+use Rector\Util\StringUtils;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -25,6 +26,17 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PrivatizeFinalClassMethodRector extends AbstractRector
 {
+    /**
+     * @var string
+     * @see https://regex101.com/r/Dx0WN5/2
+     */
+    private const LARAVEL_MODEL_ATTRIBUTE_REGEX = '/^[gs]et.+Attribute$/';
+    /**
+     * @var string
+     * @see https://regex101.com/r/hxOGeN/2
+     */
+    private const LARAVEL_MODEL_SCOPE_REGEX = '/^scope.+$/';
+
     public function __construct(
         private readonly ClassMethodVisibilityGuard $classMethodVisibilityGuard,
         private readonly VisibilityManipulator $visibilityManipulator,
@@ -174,7 +186,7 @@ CODE_SAMPLE
 
         // Model attributes should be protected
         if (
-            (bool) preg_match('/^[gs]et.+Attribute$/', $name)
+            StringUtils::isMatch($name, self::LARAVEL_MODEL_ATTRIBUTE_REGEX)
             || ($returnType instanceof Node && $this->isObjectType(
                 $returnType,
                 new ObjectType('Illuminate\Database\Eloquent\Casts\Attribute')
@@ -185,7 +197,7 @@ CODE_SAMPLE
 
         // Model scopes should be protected
         if (
-            (bool) preg_match('/^scope.+$/', $name)
+            StringUtils::isMatch($name, self::LARAVEL_MODEL_SCOPE_REGEX)
             || $this->phpAttributeAnalyzer->hasPhpAttribute(
                 $classMethod,
                 'Illuminate\Database\Eloquent\Attributes\Scope'

--- a/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
+++ b/rules/Privatization/Rector/ClassMethod/PrivatizeFinalClassMethodRector.php
@@ -31,6 +31,7 @@ final class PrivatizeFinalClassMethodRector extends AbstractRector
      * @see https://regex101.com/r/Dx0WN5/2
      */
     private const LARAVEL_MODEL_ATTRIBUTE_REGEX = '/^[gs]et.+Attribute$/';
+
     /**
      * @var string
      * @see https://regex101.com/r/hxOGeN/2
@@ -104,7 +105,7 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($node->getMethods() as $classMethod) {
-            if ($this->shouldSkipClassMethod($classMethod)) {
+            if ($this->shouldSkipClassMethod($classReflection, $classMethod)) {
                 continue;
             }
 
@@ -133,7 +134,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function shouldSkipClassMethod(ClassMethod $classMethod): bool
+    private function shouldSkipClassMethod(ClassReflection $classReflection, ClassMethod $classMethod): bool
     {
         // edge case in nette framework
         /** @var string $methodName */
@@ -150,7 +151,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($this->shouldSkipClassMethodLaravel($classMethod)) {
+        if ($this->shouldSkipClassMethodLaravel($classReflection, $classMethod)) {
             return true;
         }
 
@@ -169,14 +170,8 @@ CODE_SAMPLE
         return $hasParentCall;
     }
 
-    private function shouldSkipClassMethodLaravel(ClassMethod $classMethod): bool
+    private function shouldSkipClassMethodLaravel(ClassReflection $classReflection, ClassMethod $classMethod): bool
     {
-        $classReflection = ScopeFetcher::fetch($classMethod)->getClassReflection();
-
-        if (! $classReflection instanceof ClassReflection) {
-            return false;
-        }
-
         if (! $classReflection->is('Illuminate\Database\Eloquent\Model')) {
             return false;
         }

--- a/stubs/Illuminate/Database/Eloquent/Attributes/Scope.php
+++ b/stubs/Illuminate/Database/Eloquent/Attributes/Scope.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+if (class_exists('Illuminate\Database\Eloquent\Attributes\Scope')) {
+    return;
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Scope
+{
+}

--- a/stubs/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/stubs/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+if (class_exists('Illuminate\Database\Eloquent\Casts\Attribute')) {
+    return;
+}
+
+class Attribute
+{
+}

--- a/stubs/Illuminate/Database/Eloquent/Model.php
+++ b/stubs/Illuminate/Database/Eloquent/Model.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+if (class_exists('Illuminate\Database\Eloquent\Model')) {
+    return;
+}
+
+abstract class Model
+{
+}


### PR DESCRIPTION
Hello!

Please see https://github.com/rectorphp/rector-src/pull/7144#issuecomment-3253382960, this skips privatizing Laravel Model attributes and scopes as these are called in the parent Model class.

Thanks!