### PR TITLE
Replace  with http_get_last_response_headers() call

### DIFF
--- a/config/set/php85.php
+++ b/config/set/php85.php
@@ -10,6 +10,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php85\Rector\ArrayDimFetch\ArrayFirstLastRector;
 use Rector\Php85\Rector\ClassMethod\NullDebugInfoReturnRector;
 use Rector\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+use Rector\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector;
 use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
 use Rector\Php85\Rector\FuncCall\ChrArgModuloRector;
 use Rector\Php85\Rector\FuncCall\OrdSingleByteRector;
@@ -39,6 +40,7 @@ return static function (RectorConfig $rectorConfig): void {
             ArrayKeyExistsNullToEmptyStringRector::class,
             ChrArgModuloRector::class,
             OrdSingleByteRector::class,
+            ReplaceHttpResponseHeaderRector::class,
         ]
     );
 

--- a/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/http_response.php.inc
+++ b/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/http_response.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector\Fixture;
+
+var_dump( $http_response_header );
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector\Fixture;
+
+$http_response_header = http_get_last_response_headers();
+var_dump( $http_response_header );
+
+?>

--- a/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/skip_http_response.php.inc
+++ b/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/skip_http_response.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector\Fixture;
+
+$http_response_header = 1;
+echo $http_response_header;
+
+?>

--- a/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/skip_http_response_assing.php.inc
+++ b/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/skip_http_response_assing.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector\Fixture;
+
+echo $http_response_header;
+
+?>

--- a/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/skip_http_response_null.php.inc
+++ b/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/Fixture/skip_http_response_null.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector\Fixture;
+
+$http_response_header = null;
+echo $http_response_header;
+
+?>

--- a/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/ReplaceHttpResponseHeaderRectorTest.php
+++ b/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/ReplaceHttpResponseHeaderRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceHttpResponseHeaderRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/config/configured_rule.php
+++ b/rules-tests/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplaceHttpResponseHeaderRector::class);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_85);
+};

--- a/rules/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector.php
+++ b/rules/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector.php
@@ -64,7 +64,8 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Variable $node
+     * @param Node $node
+     * @return array<int, Node>
      */
     public function refactor(Node $node): ?Array
     {  

--- a/rules/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector.php
+++ b/rules/Php85/Rector/Expression/ReplaceHttpResponseHeaderRector.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php85\Rector\Expression;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Expression;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
+ * @see \Rector\Tests\Php85\Rector\Expression\ReplaceHttpResponseHeaderRector\ReplaceHttpResponseHeaderRectorTest
+ */
+final class ReplaceHttpResponseHeaderRector extends AbstractRector implements MinPhpVersionInterface
+{
+     public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder,
+    ) {
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::SERVER_VAR;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Assign http_get_last_response_headers() to $http_response_header if used without assignment', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+
+echo $http_response_header;
+
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+
+$http_response_header = http_get_last_response_headers();
+
+echo $http_response_header;
+
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    /**
+     * @param Variable $node
+     */
+    public function refactor(Node $node): ?Array
+    {  
+        $variables = $this->betterNodeFinder->findInstanceOf($node, Variable::class);
+
+        foreach ($variables as $var) {
+            if( $var->getAttribute(AttributeKey::IS_BEING_ASSIGNED)){
+                return null;
+            }
+            if ($this->getName($var) === 'http_response_header') {
+
+                $assign = new Expression(
+                    new Assign(
+                        new Variable('http_response_header'),
+                        new FuncCall(new Name('http_get_last_response_headers'))
+                    )
+                );
+                return [$assign, $node];
+            }
+        }
+
+        return null; 
+    }
+}


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable