### PR TITLE
 [AutoImport] Allow on FQCN current same class 

### DIFF
--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -120,12 +120,13 @@ final readonly class NameImporter
 
     private function resolveNameInNamespacedScope(FullyQualified $fullyQualified): ?Name
     {
+        /**
+         * Note: Don't use ScopeFetcher::fetch(),
+         * Scope can be null on Name
+         * This is part of ScopeAnalyzer::NON_REFRESHABLE_NODES
+         * @see https://github.com/rectorphp/rector-src/blob/9929af7c0179929b4fde6915cb7a06c3141dde6c/src/NodeAnalyzer/ScopeAnalyzer.php#L17
+         */
         $scope = $fullyQualified->getAttribute(AttributeKey::SCOPE);
-
-        // Note: Don't use ScopeFetcher::fetch,
-        // Scope can be null on Name
-        // This is part of ScopeAnalyzer::NON_REFRESHABLE_NODES
-        // @see https://github.com/rectorphp/rector-src/blob/9929af7c0179929b4fde6915cb7a06c3141dde6c/src/NodeAnalyzer/ScopeAnalyzer.php#L17
         if (! $scope instanceof Scope) {
             return null;
         }

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -121,7 +121,7 @@ final readonly class NameImporter
     private function resolveNameInNamespacedScope(FullyQualified $fullyQualified): ?Name
     {
         /**
-         * Note: Don't use ScopeFetcher::fetch(),
+         * Note: Don't use ScopeFetcher::fetch() on Name instance,
          * Scope can be null on Name
          * This is part of ScopeAnalyzer::NON_REFRESHABLE_NODES
          * @see https://github.com/rectorphp/rector-src/blob/9929af7c0179929b4fde6915cb7a06c3141dde6c/src/NodeAnalyzer/ScopeAnalyzer.php#L17

--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -122,6 +122,10 @@ final readonly class NameImporter
     {
         $scope = $fullyQualified->getAttribute(AttributeKey::SCOPE);
 
+        // Note: Don't use ScopeFetcher::fetch,
+        // Scope can be null on Name
+        // This is part of ScopeAnalyzer::NON_REFRESHABLE_NODES
+        // @see https://github.com/rectorphp/rector-src/blob/9929af7c0179929b4fde6915cb7a06c3141dde6c/src/NodeAnalyzer/ScopeAnalyzer.php#L17
         if (! $scope instanceof Scope) {
             return null;
         }

--- a/tests/Issues/AutoImport/Fixture/fqcn_current_same_class.php.inc
+++ b/tests/Issues/AutoImport/Fixture/fqcn_current_same_class.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Bar;
+
+class FqcnCurrentSameClass
+{
+    public \App\Bar\FqcnCurrentSameClass $prop;
+}
+
+?>
+-----
+<?php
+
+namespace App\Bar;
+
+class FqcnCurrentSameClass
+{
+    public FqcnCurrentSameClass $prop;
+}
+
+?>


### PR DESCRIPTION
The code is allowed, see https://3v4l.org/mN8qD
which currently skipped https://getrector.com/demo/0eb40273-c265-4c33-8540-6fe2cfb029b0

This PR allow to use the name if same with current namespace.

```diff
namepace App\Bar;

 class FqcnCurrentSameClass
 {
-    public \App\Bar\FqcnCurrentSameClass $prop;
+    public FqcnCurrentSameClass $prop;
```

This PR handle on namespaced code.