### PR TITLE
[AutoImport] Add fixture to skip conflict no namespaced fqcn inside namespace

### DIFF
--- a/tests/Issues/AutoImport/Fixture/skip_conflict_no_namespaced_fqcn_inside_namespace.php.inc
+++ b/tests/Issues/AutoImport/Fixture/skip_conflict_no_namespaced_fqcn_inside_namespace.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Bar;
+
+class SkipConflictNoNamespacedFqcnInsideNamespace
+{
+    public \SkipConflictNoNamespacedFqcnInsideNamespace $prop;
+}


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/7235

This fixture addition ensure no regression on conclit no namespaced fqcn inside namespaced class.