### PR TITLE
[Php81] Add NullToStrictIntPregSlitFuncCallLimitArgRector

### DIFF
--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
 use Rector\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
@@ -24,6 +25,7 @@ return static function (RectorConfig $rectorConfig): void {
         SpatieEnumClassToEnumRector::class,
         SpatieEnumMethodCallToEnumConstRector::class,
         NullToStrictStringFuncCallArgRector::class,
+        NullToStrictIntPregSlitFuncCallLimitArgRector::class,
         FirstClassCallableRector::class,
         RemoveReflectionSetAccessibleCallsRector::class,
     ]);

--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector\Fixture;
+
+class Fixture
+{
+    public function run($output)
+    {
+        preg_split('/\s/', $output, NULL, PREG_SPLIT_NO_EMPTY);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector\Fixture;
+
+class Fixture
+{
+    public function run($output)
+    {
+        preg_split('/\s/', $output, 0, PREG_SPLIT_NO_EMPTY);
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/Fixture/skip_no_limit.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/Fixture/skip_no_limit.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector\Fixture;
+
+class SkipNoLimit
+{
+    public function run($output)
+    {
+        $keywords = preg_split("/[\s,]+/", $output);
+    }
+}

--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/NullToStrictIntPregSlitFuncCallLimitArgRectorTest.php
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/NullToStrictIntPregSlitFuncCallLimitArgRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NullToStrictIntPregSlitFuncCallLimitArgRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/config/configured_rule.php
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector;
+
+return RectorConfig::configure()
+    ->withRules([NullToStrictIntPregSlitFuncCallLimitArgRector::class]);

--- a/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
+++ b/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
@@ -45,7 +45,7 @@ final readonly class NullToStrictStringIntConverter
         bool $isTrait,
         Scope $scope,
         ParametersAcceptor $parametersAcceptor,
-        string $type = 'string'
+        string $targetType = 'string'
     ): ?FuncCall {
         if (! isset($args[$position])) {
             return null;
@@ -53,12 +53,12 @@ final readonly class NullToStrictStringIntConverter
 
         $argValue = $args[$position]->value;
         if ($this->valueResolver->isNull($argValue)) {
-            $args[$position]->value = $type === 'string' ? new String_('') : new Int_(0);
+            $args[$position]->value = $targetType === 'string' ? new String_('') : new Int_(0);
             $funcCall->args = $args;
             return $funcCall;
         }
 
-        if ($this->shouldSkipValue($argValue, $scope, $isTrait, $type)) {
+        if ($this->shouldSkipValue($argValue, $scope, $isTrait, $targetType)) {
             return null;
         }
 
@@ -70,11 +70,11 @@ final readonly class NullToStrictStringIntConverter
             }
         }
 
-        if ($argValue instanceof Ternary && ! $this->shouldSkipValue($argValue->else, $scope, $isTrait, $type)) {
+        if ($argValue instanceof Ternary && ! $this->shouldSkipValue($argValue->else, $scope, $isTrait, $targetType)) {
             if ($this->valueResolver->isNull($argValue->else)) {
-                $argValue->else = $type === 'string' ? new String_('') : new Int_(0);
+                $argValue->else = $targetType === 'string' ? new String_('') : new Int_(0);
             } else {
-                $argValue->else = $type === 'string' ? new CastString_($argValue->else) : new CastInt_($argValue->else);
+                $argValue->else = $targetType === 'string' ? new CastString_($argValue->else) : new CastInt_($argValue->else);
             }
 
             $args[$position]->value = $argValue;
@@ -82,28 +82,28 @@ final readonly class NullToStrictStringIntConverter
             return $funcCall;
         }
 
-        $args[$position]->value = $type === 'string' ? new CastString_($argValue) : new CastInt_($argValue);
+        $args[$position]->value = $targetType === 'string' ? new CastString_($argValue) : new CastInt_($argValue);
         $funcCall->args = $args;
         return $funcCall;
     }
 
-    private function shouldSkipValue(Expr $expr, Scope $scope, bool $isTrait, string $type): bool
+    private function shouldSkipValue(Expr $expr, Scope $scope, bool $isTrait, string $targetType): bool
     {
         $type = $this->nodeTypeResolver->getType($expr);
-        if ($type->isString()->yes() && $type === 'string') {
+        if ($type->isString()->yes() && $targetType === 'string') {
             return true;
         }
 
-        if ($type->isInteger()->yes() && $type === 'int') {
+        if ($type->isInteger()->yes() && $targetType === 'int') {
             return true;
         }
 
         $nativeType = $this->nodeTypeResolver->getNativeType($expr);
-        if ($nativeType->isString()->yes() && $type === 'string') {
+        if ($nativeType->isString()->yes() && $targetType === 'string') {
             return true;
         }
 
-        if ($nativeType->isInteger()->yes() && $type === 'int') {
+        if ($nativeType->isInteger()->yes() && $targetType === 'int') {
             return true;
         }
 

--- a/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
+++ b/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
@@ -82,7 +82,7 @@ final readonly class NullToStrictStringIntConverter
             return $funcCall;
         }
 
-        $args[$position]->value = new CastString_($argValue);
+        $args[$position]->value = $type === 'string' ? new CastString_($argValue) : new CastInt_($argValue);
         $funcCall->args = $args;
         return $funcCall;
     }

--- a/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
+++ b/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
@@ -74,7 +74,9 @@ final readonly class NullToStrictStringIntConverter
             if ($this->valueResolver->isNull($argValue->else)) {
                 $argValue->else = $targetType === 'string' ? new String_('') : new Int_(0);
             } else {
-                $argValue->else = $targetType === 'string' ? new CastString_($argValue->else) : new CastInt_($argValue->else);
+                $argValue->else = $targetType === 'string' ? new CastString_($argValue->else) : new CastInt_(
+                    $argValue->else
+                );
             }
 
             $args[$position]->value = $argValue;

--- a/rules/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector.php
@@ -96,6 +96,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (! isset($args[$position])) {
+            return null;
+        }
+
         $classReflection = $scope->getClassReflection();
         $isTrait = $classReflection instanceof ClassReflection && $classReflection->isTrait();
 

--- a/rules/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector.php
@@ -16,7 +16,6 @@ use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\Php81\Enum\NameNullToStrictNullFunctionMap;
-use Rector\Php81\NodeManipulator\NullToStrictStringConverter;
 use Rector\Php81\NodeManipulator\NullToStrictStringIntConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
@@ -26,9 +25,9 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\NullToStrictStringFuncCallArgRectorTest
+ * @see \Rector\Tests\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector\NullToStrictIntPregSlitFuncCallLimitArgRectorTest
  */
-final class NullToStrictStringFuncCallArgRector extends AbstractRector implements MinPhpVersionInterface
+final class NullToStrictIntPregSlitFuncCallLimitArgRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
@@ -40,7 +39,7 @@ final class NullToStrictStringFuncCallArgRector extends AbstractRector implement
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Change null to strict string defined function call args',
+            'Change null to strict int defined preg_split limit arg function call argument',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
@@ -48,7 +47,7 @@ class SomeClass
 {
     public function run()
     {
-        preg_split("#a#", null);
+        preg_split('/\s/', $output, NULL, PREG_SPLIT_NO_EMPTY)
     }
 }
 CODE_SAMPLE
@@ -58,7 +57,7 @@ class SomeClass
 {
     public function run()
     {
-        preg_split("#a#", '');
+        preg_split('/\s/', $output, 0, PREG_SPLIT_NO_EMPTY)
     }
 }
 CODE_SAMPLE
@@ -90,11 +89,11 @@ CODE_SAMPLE
         }
 
         $args = $node->getArgs();
-        $positions = $this->argsAnalyzer->hasNamedArg($args)
-            ? $this->resolveNamedPositions($node, $args)
-            : $this->resolveOriginalPositions($node, $scope);
+        $position = $this->argsAnalyzer->hasNamedArg($args)
+            ? $this->resolveNamedPosition($args)
+            : 2;
 
-        if ($positions === []) {
+        if ($position === null) {
             return null;
         }
 
@@ -107,25 +106,18 @@ CODE_SAMPLE
         }
 
         $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($functionReflection, $node, $scope);
-        $isChanged = false;
+        $result = $this->nullToStrictStringConverter->convertIfNull(
+            $node,
+            $args,
+            (int) $position,
+            $isTrait,
+            $scope,
+            $parametersAcceptor,
+            'int'
+        );
 
-        foreach ($positions as $position) {
-            $result = $this->nullToStrictStringConverter->convertIfNull(
-                $node,
-                $args,
-                (int) $position,
-                $isTrait,
-                $scope,
-                $parametersAcceptor
-            );
-            if ($result instanceof Node) {
-                $node = $result;
-                $isChanged = true;
-            }
-        }
-
-        if ($isChanged) {
-            return $node;
+        if ($result instanceof Node) {
+            return $result;
         }
 
         return null;
@@ -138,27 +130,23 @@ CODE_SAMPLE
 
     /**
      * @param Arg[] $args
-     * @return int[]|string[]
+     * @return ?int
      */
-    private function resolveNamedPositions(FuncCall $funcCall, array $args): array
+    private function resolveNamedPosition(array $args): ?int
     {
-        $functionName = $this->getName($funcCall);
-        $argNames = NameNullToStrictNullFunctionMap::FUNCTION_TO_PARAM_NAMES[$functionName] ?? [];
-        $positions = [];
-
         foreach ($args as $position => $arg) {
             if (! $arg->name instanceof Identifier) {
                 continue;
             }
 
-            if (! $this->isNames($arg->name, $argNames)) {
+            if (! $this->isName($arg->name, 'limit')) {
                 continue;
             }
 
-            $positions[] = $position;
+            return $position;
         }
 
-        return $positions;
+        return null;
     }
 
     /**
@@ -191,8 +179,7 @@ CODE_SAMPLE
 
     private function shouldSkip(FuncCall $funcCall): bool
     {
-        $functionNames = array_keys(NameNullToStrictNullFunctionMap::FUNCTION_TO_PARAM_NAMES);
-        if (! $this->isNames($funcCall, $functionNames)) {
+        if (! $this->isName($funcCall, 'preg_split')) {
             return true;
         }
 

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -16,7 +16,6 @@ use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\Php81\Enum\NameNullToStrictNullFunctionMap;
-use Rector\Php81\NodeManipulator\NullToStrictStringConverter;
 use Rector\Php81\NodeManipulator\NullToStrictStringIntConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
@@ -33,7 +32,7 @@ final class NullToStrictStringFuncCallArgRector extends AbstractRector implement
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ArgsAnalyzer $argsAnalyzer,
-        private readonly NullToStrictStringIntConverter $nullToStrictStringConverter
+        private readonly NullToStrictStringIntConverter $nullToStrictStringIntConverter
     ) {
     }
 
@@ -110,7 +109,7 @@ CODE_SAMPLE
         $isChanged = false;
 
         foreach ($positions as $position) {
-            $result = $this->nullToStrictStringConverter->convertIfNull(
+            $result = $this->nullToStrictStringIntConverter->convertIfNull(
                 $node,
                 $args,
                 (int) $position,

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -13,7 +13,6 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
-use Rector\Php81\NodeManipulator\NullToStrictStringConverter;
 use Rector\Php81\NodeManipulator\NullToStrictStringIntConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
@@ -30,7 +29,7 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly NullToStrictStringIntConverter $nullToStrictStringConverter
+        private readonly NullToStrictStringIntConverter $nullToStrictStringIntConverter
     ) {
     }
 
@@ -91,7 +90,7 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
 
         $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($functionReflection, $node, $scope);
 
-        $result = $this->nullToStrictStringConverter->convertIfNull(
+        $result = $this->nullToStrictStringIntConverter->convertIfNull(
             $node,
             $args,
             $this->resolvePosition($args),

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\FunctionReflection;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\Php81\NodeManipulator\NullToStrictStringConverter;
+use Rector\Php81\NodeManipulator\NullToStrictStringIntConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersionFeature;
@@ -29,7 +30,7 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly NullToStrictStringConverter $nullToStrictStringConverter
+        private readonly NullToStrictStringIntConverter $nullToStrictStringConverter
     ) {
     }
 


### PR DESCRIPTION
Add rule to convert:

```diff
-        preg_split('/\s/', $output, NULL, PREG_SPLIT_NO_EMPTY);
+        preg_split('/\s/', $output, 0, PREG_SPLIT_NO_EMPTY);
```

The logic is shared with same converter and renamed to `NullToStrictStringIntConverter` that allow to convert for `int` purpose.

Fixes https://github.com/rectorphp/rector/issues/9160