### PR TITLE
[CodingStyle] Skip non-native array type on PHP 7.4 for ArraySpreadInsteadOfArrayMergeRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/skip_doblock_based_type_array_merge.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/FixturePhp74/skip_doblock_based_type_array_merge.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector\FixturePhp74;
+
+class SkipDocblockBasedTypeArrayMerge
+{
+    /**
+     * @param array<int, string> $iter1
+     * @param array<int, string> $iter2
+     */
+    public function run($iter1, $iter2)
+    {
+        $values = array_merge($iter1, $iter2);
+    }
+}

--- a/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -135,7 +135,7 @@ CODE_SAMPLE
         $type = $this->getType($expr);
 
         if ($type->getIterableKeyType()->isInteger()->yes()) {
-            if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_SPREAD_STRING_KEYS)) {
+            if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_ON_ARRAY_MERGE)) {
                 $nativeType = $this->nodeTypeResolver->getNativeType($expr);
                 return ! $nativeType->isArray()->yes();
             }

--- a/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -135,6 +135,7 @@ CODE_SAMPLE
         $type = $this->getType($expr);
 
         if ($type->getIterableKeyType()->isInteger()->yes()) {
+            // when on PHP 8.0+, pass non-array values already error on the first place
             if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_ON_ARRAY_MERGE)) {
                 $nativeType = $this->nodeTypeResolver->getNativeType($expr);
                 return ! $nativeType->isArray()->yes();

--- a/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -136,6 +136,8 @@ CODE_SAMPLE
 
         if ($type->getIterableKeyType()->isInteger()->yes()) {
             // when on PHP 8.0+, pass non-array values already error on the first place
+            // this check avoid unpack non-array values that cause error on php 7.4 as well,
+            // @see https://3v4l.org/DuYHu#v7.4.33
             if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_ON_ARRAY_MERGE)) {
                 $nativeType = $this->nodeTypeResolver->getNativeType($expr);
                 return ! $nativeType->isArray()->yes();

--- a/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -135,6 +135,11 @@ CODE_SAMPLE
         $type = $this->getType($expr);
 
         if ($type->getIterableKeyType()->isInteger()->yes()) {
+            if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::ARRAY_SPREAD_STRING_KEYS)) {
+                $nativeType = $this->nodeTypeResolver->getNativeType($expr);
+                return ! $nativeType->isArray()->yes();
+            }
+
             return false;
         }
 

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -654,6 +654,12 @@ final class PhpVersionFeature
     public const MIXED_TYPE = PhpVersion::PHP_80;
 
     /**
+     * @see https://3v4l.org/OWtO5
+     * @var int
+     */
+    public const ARRAY_ON_ARRAY_MERGE = PhpVersion::PHP_80;
+
+    /**
      * @var int
      */
     public const DEPRECATE_NULL_ARG_IN_STRING_FUNCTION = PhpVersion::PHP_81;


### PR DESCRIPTION
Per discussion with @staabm at 

https://github.com/rectorphp/rector-src/pull/7247#issuecomment-3283725003

see https://3v4l.org/OWtO5
see https://3v4l.org/DuYHu#v7.4.33
