### PR TITLE
[TypeDeclarationDocblocks] Skip multiple returns on AddReturnDocblockForCommonObjectDenominatorRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/skip_multiple_returns.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/skip_multiple_returns.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Fixture;
+
+use Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Source\FirstExtension;
+use Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Source\SecondExtension;
+
+final class SkipMultipleReturns
+{
+    public function getExtensions(): array
+    {
+        if (rand(0, 1)) {
+            return [
+                new FirstExtension(),
+                new SecondExtension()
+            ];
+        }
+
+        return ['string'];
+    }
+}

--- a/rules/TypeDeclarationDocblocks/NodeFinder/ReturnNodeFinder.php
+++ b/rules/TypeDeclarationDocblocks/NodeFinder/ReturnNodeFinder.php
@@ -25,6 +25,10 @@ final readonly class ReturnNodeFinder
             return null;
         }
 
+        if (count($returnsScoped) !== 1) {
+            return null;
+        }
+
         return $returnsScoped[0];
     }
 }


### PR DESCRIPTION
The rule only add docblock when returns only 1. Current behaviour is invalid.

```diff
 final class SkipMultipleReturns
 {
+    /**
+     * @return \Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Source\Contract\ExtensionInterface[]
+     */
     public function getExtensions(): array
     {
        if (rand(0, 1)) {
            return [
                new FirstExtension(),
                new SecondExtension()
            ];
        }

        return ['string'];
     }
```

Ref https://github.com/rectorphp/rector-src/pull/7249#pullrequestreview-3215811123