### PR TITLE
[TypeDeclarationDocblocks] Skip deep/nested array structure on AddReturnDocblockForCommonObjectDenominatorRector

### DIFF
--- a/config/set/php85.php
+++ b/config/set/php85.php
@@ -42,7 +42,7 @@ return static function (RectorConfig $rectorConfig): void {
             ChrArgModuloRector::class,
             SleepToSerializeRector::class,
             OrdSingleByteRector::class,
-            WakeupToUnserializeRector::class
+            WakeupToUnserializeRector::class,
         ]
     );
 

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/skip_deep_array_structure.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/skip_deep_array_structure.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Fixture;
+
+use Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Source\FirstExtension;
+use Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Source\SecondExtension;
+
+final class SkipDeepArrayStructure
+{
+    public function getExtensions(): array
+    {
+        return [
+            [
+                new FirstExtension(),
+                new SecondExtension()
+            ],
+        ];
+    }
+}

--- a/rules/Php85/Rector/Class_/WakeupToUnserializeRector.php
+++ b/rules/Php85/Rector/Class_/WakeupToUnserializeRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Php85\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\PropertyFetch;
@@ -86,22 +87,21 @@ CODE_SAMPLE
         if (! $classMethod instanceof ClassMethod) {
             return null;
         }
-         
+
         $classMethod->name = new Identifier('__unserialize');
         $classMethod->returnType = new Identifier('void');
-          $param = new Param(
-            var: new Variable('data'),
-            type: new Identifier('array')
-        );
+
+        $param = new Param(var: new Variable('data'), type: new Identifier('array'));
 
         $classMethod->params[] = $param;
 
         $classMethod->stmts = [$this->assignProperties()];
-        
+
         return $node;
     }
 
-    protected function  assignProperties(): Foreach_{
+    private function assignProperties(): Foreach_
+    {
         $assign = new Assign(
             new PropertyFetch(new Variable('this'), new Variable('property')),
             new Variable('value')
@@ -109,23 +109,21 @@ CODE_SAMPLE
 
         $if = new If_(
             new FuncCall(new Name('property_exists'), [
-                new Node\Arg(new Variable('this')),
-                new Node\Arg(new Variable('property')),
+                new Arg(new Variable('this')),
+                new Arg(new Variable('property')),
             ]),
             [
                 'stmts' => [new Expression($assign)],
             ]
         );
 
-        $foreach = new Foreach_(
+        return new Foreach_(
             new Variable('data'),
             new Variable('value'),
             [
                 'keyVar' => new Variable('property'),
-                'stmts'  => [$if],
+                'stmts' => [$if],
             ]
         );
-
-        return $foreach;
     }
 }

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
@@ -132,6 +132,13 @@ CODE_SAMPLE
                 return null;
             }
 
+            /**
+             * nested structure
+             */
+            if ($valueType->isArray()->yes()) {
+                return null;
+            }
+
             $referencedClasses = array_merge($referencedClasses, $valueType->getReferencedClasses());
         }
 

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -822,13 +822,13 @@ final class PhpVersionFeature
      * @var int
      */
     public const DEPRECATED_METHOD_SLEEP = PhpVersion::PHP_85;
-    
+
     /**
      * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods
      * @var int
      */
     public const DEPRECATED_METHOD_WAKEUP = PhpVersion::PHP_85;
-  
+
     /**
      * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_passing_string_which_are_not_one_byte_long_to_ord
      * @var int


### PR DESCRIPTION
Given the following deep array structure:

```php
final class SkipDeepArrayStructure
{
    public function getExtensions(): array
    {
        return [
            [
                new FirstExtension(),
                new SecondExtension()
            ],
        ];
    }
}
```

It got diff:

```diff
+    /**
+     * @return \Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Source\Contract\ExtensionInterface[]
+     */
     public function getExtensions(): array
```

which invalid, as the objects is inside deep structure. 

This should be skipped.