### PR TITLE
[TypeDeclarationDocblocks] Skip class name string return on AddReturnDocblockForCommonObjectDenominatorRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/skip_class_name_string.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/skip_class_name_string.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Fixture;
+
+use PhpParser\Node\Stmt\Class_;
+
+final class SkipClassNameString
+{
+    public function run(): array
+    {
+        return [
+            Class_::class,
+        ];
+    }
+}

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
@@ -139,6 +139,13 @@ CODE_SAMPLE
                 return null;
             }
 
+            /**
+             * string class as Foo::class
+             */
+            if ($valueType->isString()->yes()) {
+                return null;
+            }
+
             $referencedClasses = array_merge($referencedClasses, $valueType->getReferencedClasses());
         }
 

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
@@ -133,16 +133,9 @@ CODE_SAMPLE
             }
 
             /**
-             * nested structure
+             * not an object, can be nested array, or string class as Foo::class
              */
-            if ($valueType->isArray()->yes()) {
-                return null;
-            }
-
-            /**
-             * string class as Foo::class
-             */
-            if ($valueType->isString()->yes()) {
+            if (! $valueType->isObject()->yes()) {
                 return null;
             }
 


### PR DESCRIPTION
Given the following code:

```php
use PhpParser\Node\Stmt\Class_;

final class SkipClassNameString
{
    public function run(): array
    {
        return [
            Class_::class,
        ];
    }
}
```

It got:

```diff
+    /**
+     * @return \PhpParser\Node\Stmt\ClassLike[]
+     */
    public function run(): array
    {
        return [
            Class_::class,
        ];
    }
```

which invalid, as returns are `strings`, while it docblock are `objects of ClassLike`.