### PR TITLE
[TypeDeclarationDocblocks] Use unique type when all types equals on AddReturnDocblockForCommonObjectDenominatorRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/unique_type_single.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector/Fixture/unique_type_single.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Fixture;
+
+final class UniqueTypeSingle
+{
+    public function getExtensions(): array
+    {
+        return [
+            new \DateTime('now'),
+            new \DateTime('tomorrow'),
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector\Fixture;
+
+final class UniqueTypeSingle
+{
+    /**
+     * @return \DateTime[]
+     */
+    public function getExtensions(): array
+    {
+        return [
+            new \DateTime('now'),
+            new \DateTime('tomorrow'),
+        ];
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
@@ -147,14 +147,21 @@ CODE_SAMPLE
             return null;
         }
 
-        $parentClassesAndInterfaces = [];
+        $uniqueReferencedClasses = array_unique($referencedClasses, SORT_REGULAR);
 
-        foreach ($referencedClasses as $referencedClass) {
-            $parentClassesAndInterfaces[] = $this->resolveParentClassesAndInterfaces($referencedClass);
+        if (count($uniqueReferencedClasses) === 1) {
+            $firstSharedType = $uniqueReferencedClasses[0];
+        } else {
+
+            $parentClassesAndInterfaces = [];
+
+            foreach ($referencedClasses as $referencedClass) {
+                $parentClassesAndInterfaces[] = $this->resolveParentClassesAndInterfaces($referencedClass);
+            }
+
+            $firstSharedTypes = array_intersect(...$parentClassesAndInterfaces);
+            $firstSharedType = $firstSharedTypes[0] ?? null;
         }
-
-        $firstSharedTypes = array_intersect(...$parentClassesAndInterfaces);
-        $firstSharedType = $firstSharedTypes[0] ?? null;
 
         if ($firstSharedType === null) {
             return null;


### PR DESCRIPTION
Given the folllowing code:

```php
final class UniqueTypeSingle
{
    public function getExtensions(): array
    {
        return [
            new \DateTime('now'),
            new \DateTime('tomorrow'),
        ];
    }
}
```

It got diff:

```diff
+    /**
+     * @return \DateTimeInterface[]
+     */
     public function getExtensions(): array
     {
        return [
            new \DateTime('now'),
            new \DateTime('tomorrow'),
        ];
    }
```

which should use `\DateTime` only, as all unique type is single. On complex application, it can cause PHPStan notice that not instanceof type 

```
  - '#Parameter \#1 \$abc of method XYZ expects \DateTimeInterface, \DateTime given#'
  🪪 argument.type
```

