### PR TITLE
[TypeDeclarationDocblocks] Avoid array<mixed, mixed> on complex array structure with all string key on DocblockReturnArrayFromDirectArrayInstanceRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/complex_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/complex_array.php.inc
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+class ComplexArray
+{
+   public function getServiceOrderWithIncident(): array
+    {
+        return [
+            'id' => new \stdClass(),
+            'context' => [
+                'id' => 1,
+                'data' => [
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                ],
+            ],
+            'values' => [
+                'name' => '111',
+            ],
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+class ComplexArray
+{
+   /**
+    * @return array<string, mixed>
+    */
+   public function getServiceOrderWithIncident(): array
+    {
+        return [
+            'id' => new \stdClass(),
+            'context' => [
+                'id' => 1,
+                'data' => [
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                ],
+            ],
+            'values' => [
+                'name' => '111',
+            ],
+        ];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/complex_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/complex_array.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 
 class ComplexArray
 {
-   public function getServiceOrderWithIncident(): array
+   public function run(): array
     {
         return [
             'id' => new \stdClass(),
@@ -33,7 +33,7 @@ class ComplexArray
    /**
     * @return array<string, mixed>
     */
-   public function getServiceOrderWithIncident(): array
+   public function run(): array
     {
         return [
             'id' => new \stdClass(),

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -128,19 +128,19 @@ CODE_SAMPLE
      */
     private function constantToGenericType(Type $type): Type
     {
-        if ($type instanceof StringType) {
+        if ($type->isString()->yes()) {
             return new StringType();
         }
 
-        if ($type instanceof IntegerType) {
+        if ($type->isInteger()->yes()) {
             return new IntegerType();
         }
 
-        if ($type instanceof BooleanType) {
+        if ($type->isBoolean()->yes()) {
             return new BooleanType();
         }
 
-        if ($type instanceof FloatType) {
+        if ($type->isFloat()->yes()) {
             return new FloatType();
         }
 


### PR DESCRIPTION
Given the following code:

```php
   public function run(): array
    {
        return [
            'id' => new \stdClass(),
            'context' => [
                'id' => 1,
                'data' => [
                    'foo' => 'bar',
                    'baz' => 'qux',
                ],
            ],
            'values' => [
                'name' => '111',
            ],
        ];
    }
```

Got diff:

```diff
+   /**
+    * @return array<mixed, mixed>
+    */
    public function getServiceOrderWithIncident(): array
     {
         return [
```

which should be provide correct 'string' key: