### PR TITLE
[type-declaration-docblocks] Add ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/config/set/type-declaration-docblocks.php
+++ b/config/set/type-declaration-docblocks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnArrayDocblockBasedOnArrayMapRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnDocblockForScalarArrayFromAssignsRector;
+use Rector\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\DocblockVarFromParamDocblockInConstructorRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDataProviderRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDimFetchAccessRector;
@@ -24,5 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
         AddReturnDocblockForCommonObjectDenominatorRector::class,
         AddParamArrayDocblockFromDimFetchAccessRector::class,
         AddParamArrayDocblockFromDataProviderRector::class,
+        ClassMethodArrayDocblockParamFromLocalCallsRector::class,
     ]);
 };

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/ClassMethodArrayDocblockParamFromLocalCallsRectorTest.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/ClassMethodArrayDocblockParamFromLocalCallsRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ClassMethodArrayDocblockParamFromLocalCallsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_non_final_protected.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_non_final_protected.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class HandleProtectedMethodInNonFinal
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    protected function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class HandleProtectedMethodInNonFinal
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    /**
+     * @param string[] $items
+     */
+    protected function run(array $items)
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_non_final_protected_with_parent.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_non_final_protected_with_parent.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+use Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\SafeParentClass;
+
+class HandleNonFinalProtectedWithParent extends SafeParentClass
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    protected function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+use Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\SafeParentClass;
+
+class HandleNonFinalProtectedWithParent extends SafeParentClass
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    /**
+     * @param string[] $items
+     */
+    protected function run(array $items)
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_protected_method_in_final.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_protected_method_in_final.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class HandleProtectedMethodInFinal
+{
+    public function go()
+    {
+        $this->run([2512, 3423]);
+
+        $this->run([324, 534]);
+    }
+
+    protected function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class HandleProtectedMethodInFinal
+{
+    public function go()
+    {
+        $this->run([2512, 3423]);
+
+        $this->run([324, 534]);
+    }
+
+    /**
+     * @param int[] $items
+     */
+    protected function run(array $items)
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_public.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/handle_public.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class HandlePublic
+{
+    public function go()
+    {
+        $this->run([2512, 3423]);
+
+        $this->run([324, 534]);
+    }
+
+    public function run(array $items)
+    {
+    }
+}
+
+?>
+
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class HandlePublic
+{
+    public function go()
+    {
+        $this->run([2512, 3423]);
+
+        $this->run([324, 534]);
+    }
+
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+    }
+}
+
+?>
+

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/multiple_calls.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/multiple_calls.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class MultipleCalls
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+
+        $this->run(['item1', 'item2']);
+    }
+
+    private function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class MultipleCalls
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+
+        $this->run(['item1', 'item2']);
+    }
+
+    /**
+     * @param string[] $items
+     */
+    private function run(array $items)
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/multiple_calls_with_various_types.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/multiple_calls_with_various_types.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class MultipleCallsWithVariousTypes
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+        $this->run([123, 456]);
+    }
+
+    private function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class MultipleCallsWithVariousTypes
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+        $this->run([123, 456]);
+    }
+
+    /**
+     * @param string[]|int[] $items
+     */
+    private function run(array $items)
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_array_param.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_array_param.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class SkipNonArrayParam
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    private function run($items)
+    {
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/some_class.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/some_class.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class SomeClass
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    private function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class SomeClass
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    /**
+     * @param string[] $items
+     */
+    private function run(array $items)
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Source/SafeParentClass.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Source/SafeParentClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source;
+
+abstract class SafeParentClass
+{
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ClassMethodArrayDocblockParamFromLocalCallsRector::class);
+};

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\Configuration\Parameter\FeatureFlags;
 use Rector\PhpParser\NodeFinder\LocalMethodCallFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\NodeAnalyzer\CallTypesResolver;
 use Rector\TypeDeclaration\NodeAnalyzer\ClassMethodParamTypeCompleter;
+use Rector\TypeDeclarationDocblocks\PrivateMethodFlagger;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -30,6 +29,7 @@ final class AddMethodCallBasedStrictParamTypeRector extends AbstractRector
         private readonly CallTypesResolver $callTypesResolver,
         private readonly ClassMethodParamTypeCompleter $classMethodParamTypeCompleter,
         private readonly LocalMethodCallFinder $localMethodCallFinder,
+        private readonly PrivateMethodFlagger $privateMethodFlagger
     ) {
     }
 
@@ -92,7 +92,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $this->isClassMethodPrivate($node, $classMethod)) {
+            if (! $this->privateMethodFlagger->isClassMethodPrivate($node, $classMethod)) {
                 continue;
             }
 
@@ -119,20 +119,5 @@ CODE_SAMPLE
         }
 
         return null;
-    }
-
-    private function isClassMethodPrivate(Class_ $class, ClassMethod $classMethod): bool
-    {
-        if ($classMethod->isPrivate()) {
-            return true;
-        }
-
-        if ($classMethod->isFinal() && ! $class->extends instanceof Name && $class->implements === []) {
-            return true;
-        }
-
-        $isClassFinal = $class->isFinal() || FeatureFlags::treatClassesAsFinal($class);
-
-        return $isClassFinal && ! $class->extends instanceof Name && $class->implements === [] && $classMethod->isProtected();
     }
 }

--- a/rules/TypeDeclarationDocblocks/PrivateMethodFlagger.php
+++ b/rules/TypeDeclarationDocblocks/PrivateMethodFlagger.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclarationDocblocks;
+
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Configuration\Parameter\FeatureFlags;
+
+final class PrivateMethodFlagger
+{
+    public function isClassMethodPrivate(Class_ $class, ClassMethod $classMethod): bool
+    {
+        if ($classMethod->isPrivate()) {
+            return true;
+        }
+
+        if ($classMethod->isFinal() && ! $class->extends instanceof Name && $class->implements === []) {
+            return true;
+        }
+
+        $isClassFinal = $class->isFinal() || FeatureFlags::treatClassesAsFinal($class);
+
+        return $isClassFinal && ! $class->extends instanceof Name && $class->implements === [] && $classMethod->isProtected();
+    }
+}

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use PHPStan\Type\ArrayType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PhpParser\NodeFinder\LocalMethodCallFinder;
@@ -95,6 +94,10 @@ CODE_SAMPLE
             $classMethodParameterTypes = $this->callTypesResolver->resolveStrictTypesFromCalls($methodCalls);
 
             foreach ($classMethod->getParams() as $parameterPosition => $param) {
+                if ($param->type === null || ! $this->isName($param->type, 'array')) {
+                    continue;
+                }
+
                 $parameterName = $this->getName($param);
                 $parameterTagValueNode = $classMethodPhpDocInfo->getParamTagValueByName($parameterName);
 
@@ -104,7 +107,7 @@ CODE_SAMPLE
                 }
 
                 $resolvedParameterType = $classMethodParameterTypes[$parameterPosition] ?? null;
-                if (! $resolvedParameterType instanceof ArrayType) {
+                if (! $resolvedParameterType instanceof \PHPStan\Type\Type) {
                     continue;
                 }
 

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\Type\ArrayType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\PhpParser\NodeFinder\LocalMethodCallFinder;
+use Rector\Privatization\TypeManipulator\TypeNormalizer;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\NodeAnalyzer\CallTypesResolver;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\ClassMethodArrayDocblockParamFromLocalCallsRectorTest
+ */
+final class ClassMethodArrayDocblockParamFromLocalCallsRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly CallTypesResolver $callTypesResolver,
+        private readonly LocalMethodCallFinder $localMethodCallFinder,
+        private readonly TypeNormalizer $typeNormalizer
+    ) {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add @param array docblock to a class method based on local call types', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    private function run(array $items)
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    /**
+     * @param string[] $items
+     */
+    private function run(array $items)
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+
+        ]);
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $hasChanged = false;
+
+        foreach ($node->getMethods() as $classMethod) {
+            if ($classMethod->getParams() === []) {
+                continue;
+            }
+
+            $classMethodPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
+
+            $methodCalls = $this->localMethodCallFinder->match($node, $classMethod);
+            $classMethodParameterTypes = $this->callTypesResolver->resolveStrictTypesFromCalls($methodCalls);
+
+            foreach ($classMethod->getParams() as $parameterPosition => $param) {
+                $parameterName = $this->getName($param);
+                $parameterTagValueNode = $classMethodPhpDocInfo->getParamTagValueByName($parameterName);
+
+                // already known, skip
+                if ($parameterTagValueNode instanceof ParamTagValueNode) {
+                    continue;
+                }
+
+                $resolvedParameterType = $classMethodParameterTypes[$parameterPosition] ?? null;
+                if (! $resolvedParameterType instanceof ArrayType) {
+                    continue;
+                }
+
+                $normalizedResolvedParameterType = $this->typeNormalizer->generalizeConstantBoolTypes(
+                    $resolvedParameterType
+                );
+                $arrayDocTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode(
+                    $normalizedResolvedParameterType
+                );
+
+                $paramTagValueNode = new ParamTagValueNode($arrayDocTypeNode, false, '$' . $parameterName, '', false);
+                $classMethodPhpDocInfo->addTagValueNode($paramTagValueNode);
+
+                $hasChanged = true;
+                $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($classMethod);
+            }
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+}


### PR DESCRIPTION
This is array param docblock brother to already existing rule: https://getrector.com/rule-detail/add-method-call-based-strict-param-type-rector

Since param array type is not conflicting with any parent/child class (contrary to strict type declaration), we can add those even on public methods, that use local calls :+1: 

```diff
class SomeClass
{
    public function go()
    {
        $this->run(['item1', 'item2']);
    }

+  /**    
+   * @param string[] $items
+   */
    private function run(array $items)
    {
    }
}
```