### PR TITLE
[TypeDeclarationDocblocks] Avoid array<mixed, mixed> on return empty array on DocblockReturnArrayFromDirectArrayInstanceRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 class ReturnEmpty
 {
     /**
-     * @return mixed[]
+     * @return array<int, mixed>
      */
     public function run(): array
     {

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+class ReturnEmpty
+{
+   public function run(): array
+    {
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+class ReturnEmpty
+{
+   public function run(): array
+    {
+        return [];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 
 class ReturnEmpty
 {
-   public function run(): array
+    public function run(): array
     {
         return [];
     }
@@ -18,7 +18,10 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 
 class ReturnEmpty
 {
-   public function run(): array
+    /**
+     * @return mixed[]
+     */
+    public function run(): array
     {
         return [];
     }

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -17,6 +17,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -152,8 +153,8 @@ CODE_SAMPLE
     {
         $genericKeyType = $this->constantToGenericType($constantArrayType->getKeyType());
 
-        if ($constantArrayType->getItemType() instanceof \PHPStan\Type\NeverType) {
-            $genericKeyType  = new IntegerType();
+        if ($constantArrayType->getItemType() instanceof NeverType) {
+            $genericKeyType = new IntegerType();
         }
 
         $itemType = $constantArrayType->getItemType();

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -152,6 +152,10 @@ CODE_SAMPLE
     {
         $genericKeyType = $this->constantToGenericType($constantArrayType->getKeyType());
 
+        if ($constantArrayType->getItemType() instanceof \PHPStan\Type\NeverType) {
+            $genericKeyType  = new IntegerType();
+        }
+
         $itemType = $constantArrayType->getItemType();
         if ($itemType instanceof ConstantArrayType) {
             $genericItemType = $this->createGenericArrayTypeFromConstantArrayType($itemType);


### PR DESCRIPTION
Given the following code:

```php
class ReturnEmpty
{
   public function run(): array
    {
        return [];
    }
}
```

It currently got:

```diff
+   /**
+    * @return array<mixed, mixed>
+    */
    public function run(): array
```

which I think it can just:

```php
@return mixed[]
```