### PR TITLE
[TypeDeclarationDocblocks] Skip mixed[] and mixed|null on DocblockGetterReturnArrayFromPropertyDocblockVarRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector/Fixture/skip_mixed_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector/Fixture/skip_mixed_array.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockGetterReturnArrayFromPropertyDocblockVarRector\Fixture;
+
+final class SkipMixedArray
+{
+    private array $names = [];
+
+    public function getNames(): array
+    {
+        return $this->names;
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector/Fixture/skip_nullable_mixed_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector/Fixture/skip_nullable_mixed_array.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockGetterReturnArrayFromPropertyDocblockVarRector\Fixture;
+
+final class SkipNullableMixedArray
+{
+    private ?array $names = [];
+
+    public function getNames(): array
+    {
+        return $this->names;
+    }
+}

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector.php
@@ -9,6 +9,9 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Rector\AbstractRector;
@@ -99,6 +102,17 @@ CODE_SAMPLE
         }
 
         $propertyFetchType = $this->getType($propertyFetch);
+        if ($propertyFetchType instanceof ArrayType
+            && $propertyFetchType->getKeyType() instanceof MixedType
+            && $propertyFetchType->getItemType() instanceof MixedType
+        ) {
+            return null;
+        }
+
+        if ($propertyFetchType instanceof UnionType) {
+            return null;
+        }
+
         $propertyFetchDocTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyFetchType);
 
         $returnTagValueNode = new ReturnTagValueNode($propertyFetchDocTypeNode, '');


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/7244#issuecomment-3285683293