### PR TITLE
[AutoImport] Skip used via @ uses and @ used-by SomeClass::$someRef on UnusedImportRemovingPostRector

### DIFF
--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
 
+use PHPStan\Type\Type;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
@@ -94,10 +95,12 @@ CODE_SAMPLE
             $classMethodParameterTypes = $this->callTypesResolver->resolveStrictTypesFromCalls($methodCalls);
 
             foreach ($classMethod->getParams() as $parameterPosition => $param) {
-                if ($param->type === null || ! $this->isName($param->type, 'array')) {
+                if ($param->type === null) {
                     continue;
                 }
-
+                if (! $this->isName($param->type, 'array')) {
+                    continue;
+                }
                 $parameterName = $this->getName($param);
                 $parameterTagValueNode = $classMethodPhpDocInfo->getParamTagValueByName($parameterName);
 
@@ -107,7 +110,7 @@ CODE_SAMPLE
                 }
 
                 $resolvedParameterType = $classMethodParameterTypes[$parameterPosition] ?? null;
-                if (! $resolvedParameterType instanceof \PHPStan\Type\Type) {
+                if (! $resolvedParameterType instanceof Type) {
                     continue;
                 }
 

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -98,9 +98,11 @@ CODE_SAMPLE
                 if ($param->type === null) {
                     continue;
                 }
+
                 if (! $this->isName($param->type, 'array')) {
                     continue;
                 }
+
                 $parameterName = $this->getName($param);
                 $parameterTagValueNode = $classMethodPhpDocInfo->getParamTagValueByName($parameterName);
 

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
 
-use PHPStan\Type\Type;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\PhpParser\NodeFinder\LocalMethodCallFinder;

--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -452,7 +452,7 @@ final class PhpDocInfo
 
         foreach ($genericTagValueNodes as $genericTagValueNode) {
             if ($genericTagValueNode->value !== '') {
-                if (str_contains($genericTagValueNode->value, '::') && $genericTagValueNode->getAttribute(PhpDocAttributeKey::RESOLVED_CLASS) !== null) {
+                if (str_contains($genericTagValueNode->value, '::') && $genericTagValueNode->hasAttribute(PhpDocAttributeKey::RESOLVED_CLASS)) {
                     $resolvedClasses[] = $genericTagValueNode->getAttribute(PhpDocAttributeKey::RESOLVED_CLASS);
                 } else {
                     $resolvedClasses[] = $genericTagValueNode->value;

--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -451,13 +451,22 @@ final class PhpDocInfo
         $resolvedClasses = [];
 
         foreach ($genericTagValueNodes as $genericTagValueNode) {
-            if ($genericTagValueNode->value !== '') {
-                if (str_contains($genericTagValueNode->value, '::') && $genericTagValueNode->hasAttribute(PhpDocAttributeKey::RESOLVED_CLASS)) {
-                    $resolvedClasses[] = $genericTagValueNode->getAttribute(PhpDocAttributeKey::RESOLVED_CLASS);
-                } else {
-                    $resolvedClasses[] = $genericTagValueNode->value;
-                }
+            if ($genericTagValueNode->value === '') {
+                continue;
             }
+
+            if (! str_contains($genericTagValueNode->value, '::')) {
+                $resolvedClasses[] = $genericTagValueNode->value;
+                continue;
+            }
+
+            $resolvedClass = $genericTagValueNode->getAttribute(PhpDocAttributeKey::RESOLVED_CLASS);
+            if ($resolvedClass === null) {
+                $resolvedClasses[] = $genericTagValueNode->value;
+                continue;
+            }
+
+            $resolvedClasses[] = $resolvedClass;
         }
 
         return $resolvedClasses;

--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -452,7 +452,11 @@ final class PhpDocInfo
 
         foreach ($genericTagValueNodes as $genericTagValueNode) {
             if ($genericTagValueNode->value !== '') {
-                $resolvedClasses[] = $genericTagValueNode->value;
+                if (str_contains($genericTagValueNode->value, '::') && $genericTagValueNode->getAttribute(PhpDocAttributeKey::RESOLVED_CLASS) !== null) {
+                    $resolvedClasses[] = $genericTagValueNode->getAttribute(PhpDocAttributeKey::RESOLVED_CLASS);
+                } else {
+                    $resolvedClasses[] = $genericTagValueNode->value;
+                }
             }
         }
 

--- a/src/BetterPhpDocParser/PhpDocParser/PhpDocTagGenericUsesDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/PhpDocTagGenericUsesDecorator.php
@@ -17,6 +17,8 @@ use Rector\StaticTypeMapper\Naming\NameScopeFactory;
 /**
  * Decorate node with fully qualified class name for generic annotations for @uses
  * e.g. @uses Direction::*
+ *
+ * @see https://docs.phpdoc.org/guide/references/phpdoc/tags/uses.html
  */
 final readonly class PhpDocTagGenericUsesDecorator implements PhpDocNodeDecoratorInterface
 {

--- a/src/BetterPhpDocParser/PhpDocParser/PhpDocTagGenericUsesDecorator.php
+++ b/src/BetterPhpDocParser/PhpDocParser/PhpDocTagGenericUsesDecorator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\PhpDocParser;
+
+use PhpParser\Node as PhpNode;
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use Rector\BetterPhpDocParser\Contract\PhpDocParser\PhpDocNodeDecoratorInterface;
+use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
+use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
+use Rector\StaticTypeMapper\Naming\NameScopeFactory;
+
+/**
+ * Decorate node with fully qualified class name for generic annotations for @uses
+ * e.g. @uses Direction::*
+ */
+final readonly class PhpDocTagGenericUsesDecorator implements PhpDocNodeDecoratorInterface
+{
+    public function __construct(
+        private NameScopeFactory $nameScopeFactory,
+        private PhpDocNodeTraverser $phpDocNodeTraverser
+    ) {
+    }
+
+    public function decorate(PhpDocNode $phpDocNode, PhpNode $phpNode): void
+    {
+        // iterating all phpdocs has big overhead. peek into the phpdoc to exit early
+        if (! str_contains($phpDocNode->__toString(), '::')) {
+            return;
+        }
+
+        $this->phpDocNodeTraverser->traverseWithCallable($phpDocNode, '', function (Node $node) use (
+            $phpNode
+        ): Node|null {
+            if (! $node instanceof PhpDocTagNode) {
+                return null;
+            }
+
+            if (! $node->value instanceof GenericTagValueNode) {
+                return null;
+            }
+
+            if (! in_array($node->name, ['@uses', '@used-by'], true)) {
+                return null;
+            }
+
+            $reference = $node->value->value;
+            if (! str_contains($reference, '::')) {
+                return null;
+            }
+
+            if ($node->value->hasAttribute(PhpDocAttributeKey::RESOLVED_CLASS)) {
+                return null;
+            }
+
+            $classValue = explode('::', $reference)[0];
+            $className = $this->resolveFullyQualifiedClass($classValue, $phpNode);
+            $node->value->setAttribute(PhpDocAttributeKey::RESOLVED_CLASS, $className);
+
+            return $node;
+        });
+    }
+
+    private function resolveFullyQualifiedClass(string $classValue, PhpNode $phpNode): string
+    {
+        $nameScope = $this->nameScopeFactory->createNameScopeFromNodeWithoutTemplateTypes($phpNode);
+        return $nameScope->resolveStringName($classValue);
+    }
+}

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -29,6 +29,8 @@ use Rector\BetterPhpDocParser\PhpDocParser\ArrayItemClassNameDecorator;
 use Rector\BetterPhpDocParser\PhpDocParser\BetterPhpDocParser;
 use Rector\BetterPhpDocParser\PhpDocParser\ConstExprClassNameDecorator;
 use Rector\BetterPhpDocParser\PhpDocParser\DoctrineAnnotationDecorator;
+use Rector\BetterPhpDocParser\PhpDocParser\GenericAnnotationDecorator;
+use Rector\BetterPhpDocParser\PhpDocParser\PhpDocTagGenericUsesDecorator;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParser;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\PlainValueParser;
@@ -316,6 +318,7 @@ final class LazyContainerFactory
         ConstExprClassNameDecorator::class,
         DoctrineAnnotationDecorator::class,
         ArrayItemClassNameDecorator::class,
+        PhpDocTagGenericUsesDecorator::class,
     ];
 
     /**

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -29,7 +29,6 @@ use Rector\BetterPhpDocParser\PhpDocParser\ArrayItemClassNameDecorator;
 use Rector\BetterPhpDocParser\PhpDocParser\BetterPhpDocParser;
 use Rector\BetterPhpDocParser\PhpDocParser\ConstExprClassNameDecorator;
 use Rector\BetterPhpDocParser\PhpDocParser\DoctrineAnnotationDecorator;
-use Rector\BetterPhpDocParser\PhpDocParser\GenericAnnotationDecorator;
 use Rector\BetterPhpDocParser\PhpDocParser\PhpDocTagGenericUsesDecorator;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParser;

--- a/tests/Issues/NoNamespaced/Fixture/skip_used_in_used_by.php.inc
+++ b/tests/Issues/NoNamespaced/Fixture/skip_used_in_used_by.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+use bridge\workshop\viewmodel\AppointmentFormVM;
+
+/** @used-by AppointmentFormVM::addItem() */
+function foo($locations)
+{
+}

--- a/tests/Issues/NoNamespaced/Fixture/skip_used_in_uses.php.inc
+++ b/tests/Issues/NoNamespaced/Fixture/skip_used_in_uses.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+use bridge\workshop\viewmodel\AppointmentFormVM;
+
+/** @uses AppointmentFormVM::$locations */
+$r->setLocations('locations');


### PR DESCRIPTION
Ref https://docs.phpdoc.org/guide/references/phpdoc/tags/uses.html

It found as well in our project :)

It currently cause removed while used at `@uses` and `@used-by`