### PR TITLE
fix: FunctionLikeToFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_chained_calls.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_chained_calls.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+function ($foo)
+{
+    return FooBar::foo()->bar($foo);
+};
+
+fn ($foo) => FooBar::foo()->bar($foo);

--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_using_this_outside_object.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_using_this_outside_object.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+class SkipUsingThisOutsideObject
+{
+    public static function boot(): void
+    {
+        self::macro('foo', fn () => $this->values());
+        self::macro('foo', fn () => $this->values()->foo());
+    }
+
+    public static function macro(string $name, callable $callback): void
+    {
+    }
+}

--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/using_this_in_instance_method.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/using_this_in_instance_method.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+class UsingThisInInstanceMethod
+{
+    public function test(): callable
+    {
+        return fn () => $this->values();
+    }
+
+    public function values(): array
+    {
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+class UsingThisInInstanceMethod
+{
+    public function test(): callable
+    {
+        return $this->values(...);
+    }
+
+    public function values(): array
+    {
+        return [];
+    }
+}
+
+?>


### PR DESCRIPTION
Hello!

I tried running this rule on my codebase, and there was a lot of breaks so this fixes those.

Additionally, I refactored the rule to remove duplication, improve readability, and make it more consistent with other rules (like adding a `shouldSkip()` method).

Thanks!