### PR TITLE
[CodingStyle] Early first class callable check on FunctionLikeToFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_already_first_class_callable.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_already_first_class_callable.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+function ($parameter) { return Call::to(...); };

--- a/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
+++ b/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
@@ -76,11 +76,11 @@ CODE_SAMPLE
         Scope $scope
     ): bool {
         $params = $node->getParams();
-        $args = $callLike->getArgs();
         if ($callLike->isFirstClassCallable()) {
             return true;
         }
 
+        $args = $callLike->getArgs();
         if ($this->isChainedCall($callLike)) {
             return true;
         }


### PR DESCRIPTION
Per change on:

- https://github.com/rectorphp/rector-src/pull/7265#pullrequestreview-3222031697

It currently cause error:

```
There was 1 failure:

1) Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\FunctionLikeToFirstClassCallableRectorTest::test with data set #1 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())
```

This PR fix it /cc @calebdw 