### PR TITLE
[CodeQuality] Skip append from params on InlineArrayReturnAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/skip_append_from_params.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/skip_append_from_params.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+final class SkipAppendFromParams
+{
+    public function run($person)
+    {
+        $person['name'] = 'Timmy';
+        $person['id'] = 1;
+
+        return $person;
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
@@ -90,6 +91,14 @@ CODE_SAMPLE
         $returnedVariableName = $this->getName($lastStmt->expr);
         if (! is_string($returnedVariableName)) {
             return null;
+        }
+
+        if ($node instanceof FunctionLike) {
+            foreach ($node->getParams() as $param) {
+                if ($this->isName($param->var, $returnedVariableName)) {
+                    return null;
+                }
+            }
         }
 
         $emptyArrayAssign = $this->resolveDefaultEmptyArrayAssign($stmts, $returnedVariableName);


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/7271#pullrequestreview-3222510713 this is regression fix for append from params.