### PR TITLE
[CodeQuality] Skip init is before if on InlineArrayReturnAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/skip_init_before_if.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/skip_init_before_if.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+final class SkipDifferentVariable
+{
+    public function create($variable, $type, $data)
+    {
+        $someVar[$variable] = (float) $data;
+
+         if (rand(0, 1)) {
+            $someVar[sprintf('%', $type)] = 0.0;
+            $someVar[$type] = 0.0;
+
+            return $someVar;
+         }
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
@@ -106,6 +106,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // init maybe from before if
+        if ($emptyArrayAssign === null && ! $node instanceof FunctionLike) {
+            return null;
+        }
+
         $keysAndExprsByKey = $this->variableDimFetchAssignResolver->resolveFromStmtsAndVariable(
             $stmts,
             $emptyArrayAssign,


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/7271#issuecomment-3290005314, this is regression if variable init before if