### PR TITLE
[CodeQuality] Skip init not empty array on InlineArrayReturnAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/skip_init_not_empty_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/skip_init_not_empty_array.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+final class SkipInitNotEmptyArray
+{
+     public function some(SomeObject $someObject): array
+     {
+        $message = [
+           'type' => 'type',
+            'id' => (string) $someObject->getId(),
+        ];
+        $message['link'] = $this->getSome($someObject);
+
+       return $message;
+     }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector.php
@@ -215,6 +215,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($assign->expr->items !== []) {
+                continue;
+            }
+
             return $assign;
         }
 


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/7271#issuecomment-3290005314 , this is to skip init not empty array regression to avoid invalid change:

```diff
Failed on fixture file "skip_init_not_empty_array.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 {
      public function some(SomeObject $someObject): array
      {
-        $message = [
-           'type' => 'type',
-            'id' => (string) $someObject->getId(),
-        ];
-        $message['link'] = $this->getSome($someObject);
-
-       return $message;
+         return ['link' => $this->getSome($someObject)];
      }
```