### PR TITLE
[CodeQuality] Handle crash on UnaryMinus/UnaryPlus on InlineArrayReturnAssignRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/with_unary.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/InlineArrayReturnAssignRector/Fixture/with_unary.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+final class WithUnary
+{
+    public function run()
+    {
+        $data[0]['date'] = '2025-09-15';
+        $data[0]['plus'] = +50000;
+        $data[1]['minus'] = -67500;
+        return $data;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector\Fixture;
+
+final class WithUnary
+{
+    public function run()
+    {
+        return [['date' => '2025-09-15', 'plus' => +50000], ['minus' => -67500]];
+    }
+}
+
+?>

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -30,6 +30,8 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Expr\UnaryPlus;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -398,6 +400,12 @@ final readonly class NodeFactory
         }
 
         if ($item instanceof New_) {
+            $arrayItem = new ArrayItem($item);
+            $this->decorateArrayItemWithKey($key, $arrayItem);
+            return $arrayItem;
+        }
+
+        if ($item instanceof UnaryPlus || $item instanceof UnaryMinus) {
             $arrayItem = new ArrayItem($item);
             $this->decorateArrayItemWithKey($key, $arrayItem);
             return $arrayItem;


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/7271#issuecomment-3290005314 , this is to handle crash on UnaryPlus/UnaryMinus to avoid error:

```
         "System error: "Not implemented yet. Go to "Rector\PhpParser\Node\NodeFactory::createArrayItem()" and add check
         for "PhpParser\Node\Expr\UnaryMinus" node."  
```