### PR TITLE
fix: EnumCaseToPascalCaseRector bugs

### DIFF
--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/case_on_self.php.inc
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/case_on_self.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+enum CaseOnSelf: string
+{
+    case PENDING = 'pending';
+
+    function isPending(): bool
+    {
+        return $this === self::PENDING;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+enum CaseOnSelf: string
+{
+    case Pending = 'pending';
+
+    function isPending(): bool
+    {
+        return $this === self::Pending;
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/skip_enum_const.php.inc
+++ b/rules-tests/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector/Fixture/skip_enum_const.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector\Fixture;
+
+enum SkipEnumConst
+{
+    const FOO = 'foo';
+
+    case Pending;
+
+    function test(): void
+    {
+        echo self::FOO;
+    }
+}


### PR DESCRIPTION
Hello!

This fixes some more bugs in the rector:

1. cases on `self` were not being renamed
2. prevents enum constants from being renamed

Thanks!