### PR TITLE
[AutoImport] Add ShortClassImportSkipVoter to reduce repetitive same check on both docblock and FullyQualified node check

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ShortClassImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/ShortClassImportSkipVoter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter;
+
+use PhpParser\Node;
+use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Rector\ValueObject\Application\File;
+
+final readonly class ShortClassImportSkipVoter implements ClassNameImportSkipVoterInterface
+{
+    public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
+    {
+        $className = ltrim($fullyQualifiedObjectType->getClassName(), '\\');
+
+        if (substr_count($className, '\\') === 0) {
+            return ! SimpleParameterProvider::provideBoolParameter(Option::IMPORT_SHORT_CLASSES);
+        }
+
+        return false;
+    }
+}

--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipper.php
@@ -12,8 +12,6 @@ use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\UseItem;
 use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
-use Rector\Configuration\Option;
-use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -50,7 +48,7 @@ final readonly class ClassNameImportSkipper
     public function shouldSkipName(FullyQualified $fullyQualified, array $uses): bool
     {
         if (substr_count($fullyQualified->toCodeString(), '\\') === 1) {
-            return $this->shouldSkipShortName($fullyQualified);
+            return $this->isFunctionOrConstantImport($fullyQualified);
         }
 
         // verify long name, as short name verify may conflict
@@ -85,16 +83,6 @@ final readonly class ClassNameImportSkipper
         }
 
         return false;
-    }
-
-    private function shouldSkipShortName(FullyQualified $fullyQualified): bool
-    {
-        if ($this->isFunctionOrConstantImport($fullyQualified)) {
-            return true;
-        }
-
-        // Importing root namespace classes (like \DateTime) is optional
-        return ! SimpleParameterProvider::provideBoolParameter(Option::IMPORT_SHORT_CLASSES);
     }
 
     private function isFunctionOrConstantImport(FullyQualified $fullyQualified): bool

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -46,6 +46,7 @@ use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\AliasClassNameIm
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ClassLikeNameClassNameImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\FullyQualifiedNameClassNameImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ReservedClassNameImportSkipVoter;
+use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ShortClassImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\UsesClassNameImportSkipVoter;
 use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
 use Rector\Config\RectorConfig;
@@ -264,6 +265,7 @@ final class LazyContainerFactory
         FullyQualifiedNameClassNameImportSkipVoter::class,
         UsesClassNameImportSkipVoter::class,
         ReservedClassNameImportSkipVoter::class,
+        ShortClassImportSkipVoter::class,
     ];
 
     /**

--- a/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -16,8 +16,6 @@ use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
-use Rector\Configuration\Option;
-use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeVisitor\AbstractPhpDocNodeVisitor;
 use Rector\PostRector\Collector\UseNodesToAddCollector;
@@ -77,11 +75,6 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         $staticType = $this->resolveFullyQualified($staticType);
 
         if (! $staticType instanceof FullyQualifiedObjectType) {
-            return null;
-        }
-
-        // Importing root namespace classes (like \DateTime) is optional
-        if ($this->shouldSkipShortClassName($staticType)) {
             return null;
         }
 
@@ -197,16 +190,6 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
 
         $namespaceParts = explode('\\', ltrim($firstPath, '\\'));
         return count($namespaceParts) > 1;
-    }
-
-    private function shouldSkipShortClassName(FullyQualifiedObjectType $fullyQualifiedObjectType): bool
-    {
-        $importShortClasses = SimpleParameterProvider::provideBoolParameter(Option::IMPORT_SHORT_CLASSES);
-        if ($importShortClasses) {
-            return false;
-        }
-
-        return substr_count($fullyQualifiedObjectType->getClassName(), '\\') === 0;
     }
 
     private function processDoctrineAnnotationTagValueNode(


### PR DESCRIPTION
This part of sync both functionality for skipper auto import for both FullyQualified Node and docblock.