### PR TITLE
[TypeDeclarationDocblocks] use empty array shape array{} for returns empty array on DocblockReturnArrayFromDirectArrayInstanceRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/return_empty.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 class ReturnEmpty
 {
     /**
-     * @return array<int, mixed>
+     * @return array{}
      */
     public function run(): array
     {

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -105,8 +105,8 @@ CODE_SAMPLE
         }
 
         $genericTypeNode = $this->constantArrayTypeGeneralizer->generalize($returnedType);
-        $returnTagValueNode = new ReturnTagValueNode($genericTypeNode, '');
 
+        $returnTagValueNode = new ReturnTagValueNode($genericTypeNode, '');
         $phpDocInfo->addTagValueNode($returnTagValueNode);
 
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -10,7 +10,9 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\NeverType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Rector\AbstractRector;
@@ -106,7 +108,12 @@ CODE_SAMPLE
 
         $genericTypeNode = $this->constantArrayTypeGeneralizer->generalize($returnedType);
 
-        $returnTagValueNode = new ReturnTagValueNode($genericTypeNode, '');
+        if ($returnedType->getItemType() instanceof NeverType) {
+            $returnTagValueNode = new ReturnTagValueNode(ArrayShapeNode::createSealed([]), '');
+        } else {
+            $returnTagValueNode = new ReturnTagValueNode($genericTypeNode, '');
+        }
+
         $phpDocInfo->addTagValueNode($returnTagValueNode);
 
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -108,11 +108,7 @@ CODE_SAMPLE
 
         $genericTypeNode = $this->constantArrayTypeGeneralizer->generalize($returnedType);
 
-        if ($returnedType->getItemType() instanceof NeverType) {
-            $returnTagValueNode = new ReturnTagValueNode(ArrayShapeNode::createSealed([]), '');
-        } else {
-            $returnTagValueNode = new ReturnTagValueNode($genericTypeNode, '');
-        }
+        $returnTagValueNode = new ReturnTagValueNode($genericTypeNode, '');
 
         $phpDocInfo->addTagValueNode($returnTagValueNode);
 

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -10,9 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\NeverType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Rector\AbstractRector;
@@ -107,7 +105,6 @@ CODE_SAMPLE
         }
 
         $genericTypeNode = $this->constantArrayTypeGeneralizer->generalize($returnedType);
-
         $returnTagValueNode = new ReturnTagValueNode($genericTypeNode, '');
 
         $phpDocInfo->addTagValueNode($returnTagValueNode);

--- a/rules/TypeDeclarationDocblocks/TypeResolver/ConstantArrayTypeGeneralizer.php
+++ b/rules/TypeDeclarationDocblocks/TypeResolver/ConstantArrayTypeGeneralizer.php
@@ -64,7 +64,7 @@ final class ConstantArrayTypeGeneralizer
         return $this->createArrayGenericTypeNode($genericKeyType, $genericItemType);
     }
 
-    private function createArrayGenericTypeNode(Type $keyType, Type|GenericTypeNode $itemType): GenericTypeNode
+    private function createArrayGenericTypeNode(Type $keyType, Type|GenericTypeNode|ArrayShapeNode $itemType): GenericTypeNode
     {
         $keyDocTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($keyType);
 

--- a/rules/TypeDeclarationDocblocks/TypeResolver/ConstantArrayTypeGeneralizer.php
+++ b/rules/TypeDeclarationDocblocks/TypeResolver/ConstantArrayTypeGeneralizer.php
@@ -7,7 +7,6 @@ namespace Rector\TypeDeclarationDocblocks\TypeResolver;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
@@ -39,10 +38,6 @@ final class ConstantArrayTypeGeneralizer
         }
 
         $genericKeyType = $this->typeNormalizer->generalizeConstantTypes($constantArrayType->getKeyType());
-
-        if ($constantArrayType->getItemType() instanceof NeverType) {
-            $genericKeyType = new IntegerType();
-        }
 
         $itemType = $constantArrayType->getItemType();
 

--- a/rules/TypeDeclarationDocblocks/TypeResolver/ConstantArrayTypeGeneralizer.php
+++ b/rules/TypeDeclarationDocblocks/TypeResolver/ConstantArrayTypeGeneralizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclarationDocblocks\TypeResolver;
 
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -29,7 +30,7 @@ final class ConstantArrayTypeGeneralizer
     ) {
     }
 
-    public function generalize(ConstantArrayType $constantArrayType, bool $isFresh = true): GenericTypeNode
+    public function generalize(ConstantArrayType $constantArrayType, bool $isFresh = true): GenericTypeNode|ArrayShapeNode
     {
         if ($isFresh) {
             $this->currentNesting = 0;
@@ -40,6 +41,10 @@ final class ConstantArrayTypeGeneralizer
         $genericKeyType = $this->typeNormalizer->generalizeConstantTypes($constantArrayType->getKeyType());
 
         $itemType = $constantArrayType->getItemType();
+
+        if ($itemType instanceof NeverType) {
+            return ArrayShapeNode::createSealed([]);
+        }
 
         if ($itemType instanceof ConstantArrayType) {
             if ($this->currentNesting >= self::MAX_NESTING) {


### PR DESCRIPTION
per discussion at https://github.com/rectorphp/rector-src/pull/7260#issuecomment-3287670001