### PR TITLE
[TypeDeclarationDocblocks] Strip never[] on docblock @ return on DocblockReturnArrayFromDirectArrayInstanceRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/strip_empty_combine.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/strip_empty_combine.php.inc
@@ -1,0 +1,78 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+final class StripEmptyCombine
+{
+    public function get(): array
+    {
+        return [
+            'a' => false,
+            'b' => 'b',
+            'c' => true,
+            'd' => $this->getNullable(),
+            'class' => StripEmptyCombine::class,
+            'opt' => [],
+            'init' => false,
+            'attrs' => [
+                'x' => 'x',
+                'class' => 'pick',
+                'apply' => 'true',
+                'head' => $this->trans('foo'),
+            ],
+        ];
+    }
+
+    private function getNullable(): ?string
+    {
+        return null;
+    }
+
+    function trans(): string
+    {
+        return 'foo';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+final class StripEmptyCombine
+{
+    /**
+     * @return array<string, string|bool|array<string, string>|null>
+     */
+    public function get(): array
+    {
+        return [
+            'a' => false,
+            'b' => 'b',
+            'c' => true,
+            'd' => $this->getNullable(),
+            'class' => StripEmptyCombine::class,
+            'opt' => [],
+            'init' => false,
+            'attrs' => [
+                'x' => 'x',
+                'class' => 'pick',
+                'apply' => 'true',
+                'head' => $this->trans('foo'),
+            ],
+        ];
+    }
+
+    private function getNullable(): ?string
+    {
+        return null;
+    }
+
+    function trans(): string
+    {
+        return 'foo';
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/strip_empty_combine.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/strip_empty_combine.php.inc
@@ -43,7 +43,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 final class StripEmptyCombine
 {
     /**
-     * @return array<string, string|bool|array<string, string>|null>
+     * @return array<string, string|bool|mixed[]|array<string, string>|null>
      */
     public function get(): array
     {

--- a/src/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/UnionTypeMapper.php
@@ -13,6 +13,9 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType as PhpParserUnionType;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
@@ -55,6 +58,10 @@ final class UnionTypeMapper implements TypeMapperInterface
     {
         $unionTypesNodes = [];
         foreach ($type->getTypes() as $unionedType) {
+            if ($unionedType instanceof ArrayType && $unionedType->getItemType() instanceof NeverType) {
+                $unionedType = new ArrayType($unionedType->getKeyType(), new MixedType());
+            }
+
             $unionTypesNodes[] = $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($unionedType);
         }
 


### PR DESCRIPTION
Given the following code:

```php
    public function get(): array
    {
        return [
            'a' => false,
            'b' => 'b',
            'c' => true,
            'd' => $this->getNullable(),
            'class' => StripEmptyCombine::class,
            'opt' => [],
            'init' => false,
            'attrs' => [
                'x' => 'x',
                'class' => 'pick',
                'apply' => 'true',
                'head' => $this->trans('foo'),
            ],
        ];
    }
```

It currently got:

```diff
+    /**
+     * @return array<string, string|bool|never[]|array<string, string>|null>
+     */
     public function get(): array
```

that cause phpstan error:

```
  - '#Method get\(\) should return array<string, array\|bool\|string> but returns array<string, array<string, string>\|bool\|string>#'
```

see error at https://phpstan.org/r/15722015-5567-4305-aeac-8dda263328ef