### PR TITLE
[TypeDeclarationDocblocks] Use mixed[] over mixed on unserialize() call on ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/mixed_from_unserialize.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/mixed_from_unserialize.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class MixedFromUnserialize
+{
+    public function run(string $param)
+    {
+        $this->doStuff(unserialize($param));
+    }
+
+    private function doStuff(array $value)
+    {
+        // do stuff with value
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class MixedFromUnserialize
+{
+    public function run(string $param)
+    {
+        $this->doStuff(unserialize($param));
+    }
+
+    /**
+     * @param mixed[] $value
+     */
+    private function doStuff(array $value)
+    {
+        // do stuff with value
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ReturnTypeAnalyzer/StrictReturnNewAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\NodeAnalyzer\ReturnTypeAnalyzer;
 
+use PHPStan\Type\ObjectWithoutClassType;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
@@ -53,7 +54,7 @@ final readonly class StrictReturnNewAnalyzer
             }
 
             $returnType = $this->nodeTypeResolver->getNativeType($return->expr);
-            if ($returnType instanceof \PHPStan\Type\ObjectWithoutClassType) {
+            if ($returnType instanceof ObjectWithoutClassType) {
                 $alwaysReturnedClassNames[] = 'object';
                 continue;
             }

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -7,6 +7,8 @@ namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
@@ -131,6 +133,10 @@ CODE_SAMPLE
                 $arrayDocTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode(
                     $normalizedResolvedParameterType
                 );
+
+                if ($arrayDocTypeNode instanceof IdentifierTypeNode && $arrayDocTypeNode->name === 'mixed') {
+                    $arrayDocTypeNode = new ArrayTypeNode($arrayDocTypeNode);
+                }
 
                 $paramTagValueNode = new ParamTagValueNode($arrayDocTypeNode, false, '$' . $parameterName, '', false);
                 $classMethodPhpDocInfo->addTagValueNode($paramTagValueNode);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9379
Ref https://getrector.com/demo/203dcb48-a5e5-4741-8a2d-f74219eeb894