### PR TITLE
[AutoImport] Optimize ClassRenamingPostRector with stop on enterNode()

### DIFF
--- a/src/PostRector/Rector/ClassRenamingPostRector.php
+++ b/src/PostRector/Rector/ClassRenamingPostRector.php
@@ -7,6 +7,7 @@ namespace Rector\PostRector\Rector;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeVisitor;
 use Rector\CodingStyle\Application\UseImportsRemover;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
@@ -47,17 +48,21 @@ final class ClassRenamingPostRector extends AbstractPostRector
             }
         }
 
+        $this->renamedNameCollector->reset();
         return $nodes;
     }
 
-    /**
-     * @param Node[] $nodes
-     * @return Stmt[]
-     */
-    public function afterTraverse(array $nodes): array
+    public function enterNode(Node $node): int
     {
-        $this->renamedNameCollector->reset();
-        return $nodes;
+        /**
+         * We stop the traversal because all the work has already been done in the beforeTraverse() function
+         *
+         * Using STOP_TRAVERSAL is usually dangerous as it will stop the processing of all your nodes for all visitors
+         * but since the PostFileProcessor is using direct new NodeTraverser() and traverse() for only a single
+         * visitor per execution, using stop traversal here is safe,
+         * ref https://github.com/rectorphp/rector-src/blob/fc1e742fa4d9861ccdc5933f3b53613b8223438d/src/PostRector/Application/PostFileProcessor.php#L59-L61
+         */
+        return NodeVisitor::STOP_TRAVERSAL;
     }
 
     public function shouldTraverse(array $stmts): bool


### PR DESCRIPTION
similar with PR:

- https://github.com/rectorphp/rector-src/pull/6240

the process already done on `beforeTraverse()`

We stop the traversal because all the work has already been done in the beforeTraverse() function
    
Using **STOP_TRAVERSAL** is usually dangerous as it will stop the processing of all your nodes for all visitors
but since the PostFileProcessor is using **direct new NodeTraverser() and traverse()** for only a single
visitor per execution, using stop traversal here is safe,

ref https://github.com/rectorphp/rector-src/blob/fc1e742fa4d9861ccdc5933f3b53613b8223438d/src/PostRector/Application/PostFileProcessor.php#L59-L61