### PR TITLE
[TypeDeclarationDocblocks] Handle already return typed \Generator on AddReturnDocblockDataProviderRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/already_return_typed_generator.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/already_return_typed_generator.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AlreadyReturnTypedGenerator extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    public static function provideData(): \Generator
+    {
+        yield ['data1', 'data2'];
+        yield ['item4', 'item5'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AlreadyReturnTypedGenerator extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    /**
+     * @return \Generator<array<int, string>>
+     */
+    public static function provideData(): \Generator
+    {
+        yield ['data1', 'data2'];
+        yield ['item4', 'item5'];
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector.php
@@ -154,7 +154,7 @@ CODE_SAMPLE
             if ($yields !== []) {
                 $yieldType = $this->yieldTypeResolver->resolveFromYieldNodes($yields, $dataProviderClassMethod);
 
-                if ($yieldType instanceof FullyQualifiedGenericObjectType && $yieldType->getClassName() === 'Generator') {
+                if ($yieldType instanceof FullyQualifiedGenericObjectType && $yieldType->getClassName() === 'Generator' && ! $dataProviderClassMethod->returnType instanceof Node) {
                     // most likely, a static iterator is used in data test fixtures
                     $yieldType = new FullyQualifiedGenericObjectType('Iterator', $yieldType->getTypes());
                 }


### PR DESCRIPTION
If it already return typed `Generator`, don't use `@return Iterator`, as it will cause phpstan notice, see

```
PHPDoc tag @return with type Iterator<mixed, string> is not subtype of native type Generator.
```

see https://phpstan.org/r/c8a79da7-2fa3-49f2-9388-c8f5b84d9b53