### PR TITLE
[TypeDeclarationDocblocks] Handle multiple objects on AddReturnDocblockDataProviderRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/Nesting/complex_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/Nesting/complex_array.php.inc
@@ -8,6 +8,7 @@ class ComplexArray
     {
         return [
             'id' => new \stdClass(),
+            'other' => false,
             'context' => [
                 'id' => 1,
                 'data' => [
@@ -17,6 +18,11 @@ class ComplexArray
             ],
             'values' => [
                 'name' => '111',
+                'age' => 1,
+            ],
+            'values_other' => [
+                'name' => '111',
+                'age' => 1,
             ],
         ];
     }
@@ -37,6 +43,7 @@ class ComplexArray
     {
         return [
             'id' => new \stdClass(),
+            'other' => false,
             'context' => [
                 'id' => 1,
                 'data' => [
@@ -46,6 +53,11 @@ class ComplexArray
             ],
             'values' => [
                 'name' => '111',
+                'age' => 1,
+            ],
+            'values_other' => [
+                'name' => '111',
+                'age' => 1,
             ],
         ];
     }

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/multi_objects.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/multi_objects.php.inc
@@ -40,7 +40,7 @@ final class MultiObjects extends TestCase
     }
 
     /**
-     * @return \Iterator<array<int, array<(\DateTime | \DateTimeImmutable | string)>>>
+     * @return \Iterator<array<int, array<int, (\DateTime | \DateTimeImmutable | string)>>>
      */
     public static function provideData(): iterable
     {

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/multi_objects.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/multi_objects.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use DateTime;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MultiObjects extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    public static function provideData(): iterable
+    {
+        yield [[new DateTime(), 'format']];
+        yield [[new DateTimeImmutable(), 'format']];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use DateTime;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MultiObjects extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    /**
+     * @return \Iterator<array<int, array<(\DateTime | \DateTimeImmutable | string)>>>
+     */
+    public static function provideData(): iterable
+    {
+        yield [[new DateTime(), 'format']];
+        yield [[new DateTimeImmutable(), 'format']];
+    }
+}
+
+?>

--- a/rules/Privatization/TypeManipulator/TypeNormalizer.php
+++ b/rules/Privatization/TypeManipulator/TypeNormalizer.php
@@ -27,7 +27,7 @@ final readonly class TypeNormalizer
     /**
      * @var int
      */
-    private const MAX_PRINTED_UNION_DOC_LENGHT = 60;
+    private const MAX_PRINTED_UNION_DOC_LENGHT = 77;
 
     public function __construct(
         private TypeFactory $typeFactory,

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -205,6 +205,16 @@ final readonly class TypeFactory
                 $nestedFlattenKeyType = new MixedType();
             }
 
+            if ($nestedFlattenItemType instanceof ConstantArrayType) {
+                $innerArrayTypes = $this->unwrapConstantArrayTypes($nestedFlattenItemType);
+                foreach ($innerArrayTypes as $innerArrayType) {
+                    // preserve outer array -> inner array structure: array<outerKey, innerArray>
+                    $unwrappedTypes[] = new ArrayType($nestedFlattenKeyType, $innerArrayType);
+                }
+
+                continue;
+            }
+
             $unwrappedTypes[] = new ArrayType($nestedFlattenKeyType, $nestedFlattenItemType);
         }
 


### PR DESCRIPTION
it currently only got last objects, which cause phpstan notice:

```
Generator expects value type array<int, array<DateTimeImmutable|string>>, array<int, array<int, DateTime|string>> given.
```

see https://phpstan.org/r/db520ab6-fc4f-4c45-ac1f-b91801f2e065