### PR TITLE
[AutoImport] Add OriginalNameImportSkipVoter for auto import

### DIFF
--- a/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/OriginalNameImportSkipVoter.php
+++ b/rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter/OriginalNameImportSkipVoter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Rector\ValueObject\Application\File;
+
+final readonly class OriginalNameImportSkipVoter implements ClassNameImportSkipVoterInterface
+{
+    public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
+    {
+        if (! $node instanceof FullyQualified) {
+            return false;
+        }
+
+        if (substr_count($node->toCodeString(), '\\') === 1) {
+            return false;
+        }
+
+        // verify long name, as short name verify may conflict
+        // see test PR: https://github.com/rectorphp/rector-src/pull/6208
+        // ref https://3v4l.org/21H5j vs https://3v4l.org/GIHSB
+        $originalName = $node->getAttribute(AttributeKey::ORIGINAL_NAME);
+        return $originalName instanceof Name && $originalName->getLast() === $originalName->toString();
+    }
+}

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -45,6 +45,7 @@ use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\AliasClassNameImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ClassLikeNameClassNameImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\FullyQualifiedNameClassNameImportSkipVoter;
+use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\OriginalNameImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ReservedClassNameImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ShortClassImportSkipVoter;
 use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\UsesClassNameImportSkipVoter;
@@ -266,6 +267,7 @@ final class LazyContainerFactory
         UsesClassNameImportSkipVoter::class,
         ReservedClassNameImportSkipVoter::class,
         ShortClassImportSkipVoter::class,
+        OriginalNameImportSkipVoter::class,
     ];
 
     /**


### PR DESCRIPTION
Cherry-pick from PR:

- https://github.com/rectorphp/rector-src/pull/7304

to cover warning no change on `NameImportingPostRector`, see

https://github.com/rectorphp/rector-src/pull/7304#issuecomment-3314716456

This skip voter is used  to verify long name, as short name verify may conflict
see test PR: 

- https://github.com/rectorphp/rector-src/pull/6208

ref https://3v4l.org/21H5j vs https://3v4l.org/GIHSB 