### PR TITLE
[AutoImport] Handle no change on same shortname from FullyQualified on NameImporter

### DIFF
--- a/rules/CodingStyle/Node/NameImporter.php
+++ b/rules/CodingStyle/Node/NameImporter.php
@@ -108,7 +108,29 @@ final readonly class NameImporter
         }
 
         $this->addUseImport($file, $fullyQualified, $fullyQualifiedObjectType);
-        return $fullyQualifiedObjectType->getShortNameNode();
+        $name = $fullyQualifiedObjectType->getShortNameNode();
+
+        $oldTokens = $file->getOldTokens();
+        $startTokenPos = $fullyQualified->getStartTokenPos();
+
+        if (! isset($oldTokens[$startTokenPos])) {
+            return $name;
+        }
+
+        $tokenShortName = $oldTokens[$startTokenPos];
+        if (str_starts_with($tokenShortName->text, '\\')) {
+            return $name;
+        }
+
+        if (str_contains($tokenShortName->text, '\\')) {
+            return $name;
+        }
+
+        if ($name->toString() !== $tokenShortName->text) {
+            return $name;
+        }
+
+        return null;
     }
 
     private function addUseImport(


### PR DESCRIPTION
Cherry-picked from PR:

- https://github.com/rectorphp/rector-src/pull/7304

handle to cover warning:

```
WARNING: On fixture file "skip_conflict_last_name_in_usage.php.inc" for test "Rector\Tests\Issues\AutoImport\AutoImportTest"
File not changed but some Rector rules applied:
 * Rector\PostRector\Rector\NameImportingPostRector
..  244 / 4779 (  5%)
..
WARNING: On fixture file "skip_no_namespace_used_class.php.inc" for test "Rector\Tests\Issues\AutoImport\AutoImportTest"
File not changed but some Rector rules applied:
 * Rector\PostRector\Rector\NameImportingPostRector
```

see https://github.com/rectorphp/rector-src/actions/runs/17877243809/job/50840264966#step:5:20