### PR TITLE
[TypeDeclarationDocblocks] Skip default empty on DocblockVarArrayFromPropertyDefaultsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/skip_default_empty.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/skip_default_empty.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDefaultsRector\Fixture;
+
+final class SkipDefaultEmpty
+{
+    private array $names = [];
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
+++ b/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
@@ -15,6 +15,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -124,7 +125,7 @@ final readonly class NodeDocblockTypeDecorator
             return false;
         }
 
-        if ($type->getItemType() instanceof \PHPStan\Type\NeverType) {
+        if ($type->getItemType() instanceof NeverType) {
             return true;
         }
 

--- a/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
+++ b/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
@@ -124,6 +124,10 @@ final readonly class NodeDocblockTypeDecorator
             return false;
         }
 
+        if ($type->getItemType() instanceof \PHPStan\Type\NeverType) {
+            return true;
+        }
+
         if (! $type->getItemType() instanceof MixedType) {
             return false;
         }

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector.php
@@ -89,12 +89,13 @@ CODE_SAMPLE
                 continue;
             }
 
-            $this->nodeDocblockTypeDecorator->decorateGenericIterableVarType(
+            if ($this->nodeDocblockTypeDecorator->decorateGenericIterableVarType(
                 $propertyDefaultType,
                 $propertyPhpDocInfo,
                 $property
-            );
-            $hasChanged = true;
+            )) {
+                $hasChanged = true;
+            }
         }
 
         if (! $hasChanged) {


### PR DESCRIPTION
It cause `@var never[]`, see https://getrector.com/demo/31b7343b-17f6-475e-8ec1-bd6eec8a43e0