### PR TITLE
[TypeDeclarationDocblocks] Skip first class callable on AddReturnDocblockForJsonArrayRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForJsonArrayRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForJsonArrayRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForJsonArrayRector\Fixture;
+
+final class SkipFirstClassCallable
+{
+    public function provide(string $contents)
+    {
+        return json_decode(...);
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForJsonArrayRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForJsonArrayRector.php
@@ -135,6 +135,10 @@ CODE_SAMPLE
                 return false;
             }
 
+            if ($expr->isFirstClassCallable()) {
+                return false;
+            }
+
             if (count($expr->getArgs()) !== 2) {
                 return false;
             }
@@ -149,6 +153,10 @@ CODE_SAMPLE
             }
 
             if (! $this->isName($expr->name, 'decode')) {
+                return false;
+            }
+
+            if ($expr->isFirstClassCallable()) {
                 return false;
             }
 


### PR DESCRIPTION
Avoid error:

```
There was 1 failure:

1) Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForJsonArrayRector\AddReturnDocblockForJsonArrayRectorTest::test with data set #2 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:32
/Users/samsonasik/www/rector-src/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForJsonArrayRector.php:138
```