### PR TITLE
[TypeDeclarationDocblocks] Handle crash on next empty array on ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/not_zero_position.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/not_zero_position.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class NotZeroPosition
+{
+    public function go()
+    {
+        $this->run([], ['item1', 'item2']);
+    }
+
+    private function run(array $data, array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class NotZeroPosition
+{
+    public function go()
+    {
+        $this->run([], ['item1', 'item2']);
+    }
+
+    /**
+     * @param string[] $items
+     */
+    private function run(array $data, array $items)
+    {
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -124,17 +124,13 @@ final readonly class CallTypesResolver
             $staticTypeByArgumentPosition[$position] = $this->narrowParentObjectTreeToSingleObjectChildType(
                 $unionedType
             );
+
+            if ($staticTypeByArgumentPosition[$position]->isNull()->yes()) {
+                $staticTypeByArgumentPosition[$position] = new MixedType();
+            }
         }
 
-        if (count($staticTypeByArgumentPosition) !== 1) {
-            return $staticTypeByArgumentPosition;
-        }
-
-        if (! $staticTypeByArgumentPosition[0]->isNull()->yes()) {
-            return $staticTypeByArgumentPosition;
-        }
-
-        return [new MixedType()];
+        return $staticTypeByArgumentPosition;
     }
 
     private function narrowParentObjectTreeToSingleObjectChildType(Type $type): Type


### PR DESCRIPTION
Given the following code:

```php
class NotZeroPosition
{
    public function go()
    {
        $this->run([], ['item1', 'item2']);
    }

    private function run(array $data, array $items)
    {
    }
}
```

It cause crash:

```
message": "System error: \"Call to a member function isNull() on null
```

```
There was 1 error:

1) Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\ClassMethodArrayDocblockParamFromLocalCallsRectorTest::test with data set #10 ('/home/runner/work/rector-src/...hp.inc')
Error: Call to a member function isNull() on null
```

see https://getrector.com/demo/4e14f065-f5fc-4aa6-87c9-6579a05f4769

This PR fix it.