### PR TITLE
Fix adding string[] in explode() for ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/from_explode.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/from_explode.php.inc
@@ -36,4 +36,3 @@ final class FromExplode
 }
 
 ?>
-

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/from_explode.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/from_explode.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class FromExplode
+{
+    public function go()
+    {
+        $this->run(explode(':', '1:1'));
+    }
+
+    private function run(array $items)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class FromExplode
+{
+    public function go()
+    {
+        $this->run(explode(':', '1:1'));
+    }
+
+    /**
+     * @param string[] $items
+     */
+    private function run(array $items)
+    {
+    }
+}
+
+?>
+

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -34,11 +34,13 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -176,6 +178,11 @@ final class NodeTypeResolver
             if (! $type instanceof MixedType) {
                 return new UnionType([$type, new NullType()]);
             }
+        }
+
+        // correction for explode() that always returns array
+        if ($node instanceof FuncCall && $node->name instanceof Name && $node->name->toString() === 'explode') {
+            return new ArrayType(new IntegerType(), new StringType());
         }
 
         if ($node instanceof Ternary) {


### PR DESCRIPTION
- **add fixture**
- **fix adding string[] in explode() for ClassMethodArrayDocblockParamFromLocalCallsRector**
