### PR TITLE
[TypeDeclarationDocblocks] Skip union mixed|mixed on ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_union_mixed.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_union_mixed.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class SkipUnionMixed
+{
+    public function run(string $content, string $contentNew)
+    {
+        $orig = json_decode($content, true);
+        $new = json_decode($contentNew, true);
+
+        $this->compareArrays($orig, $new);
+    }
+
+    private function compareArrays(array $array1, array $array2): void
+    {
+        foreach ($array1 as $key => $value1) {
+            $value2 = $array2[$key];
+
+            if (is_array($value1)) {
+                $this->compareArrays($array1[$key], $array2[$key]);
+                return;
+            }
+
+            if ($value1 !== $value2) {
+                $this->diff[$key] = [
+                    'existing' => $value1,
+                    'new' => $value2,
+                ];
+            }
+        }
+    }
+}

--- a/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+++ b/src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
@@ -64,6 +64,10 @@ final readonly class TypeFactory
         $hasFalse = false;
         $hasTrue = false;
         foreach ($types as $type) {
+            if ($type instanceof MixedType) {
+                $type = new MixedType();
+            }
+
             $type = $this->normalizeObjectType($totalTypes, $type);
             $type = $this->normalizeBooleanType($hasFalse, $hasTrue, $type);
 


### PR DESCRIPTION
It cause:

```diff
+    /**
+     * @param mixed|mixed $array1
+     * @param mixed|mixed $array2
+     */
```

should be skipped. see https://getrector.com/demo/f072550d-9131-4924-8e8e-648c445d9500