### PR TITLE
[TypeDeclarationDocblocks] Skip mixed|mixed[] on ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_union_mixed_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_union_mixed_array.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class SkipUnionMixedArray
+{
+    public function run()
+    {
+        $this->exec($_SERVER['argv'] ?? []);
+    }
+
+    private function exec(array $argv)
+    {
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -228,9 +228,15 @@ final readonly class CallTypesResolver
                 $type = $this->typeFactory->createMixedPassedOrUnionType($type->getTypes());
 
                 if ($type instanceof UnionType) {
+                    $types = $type->getTypes();
+                    if (count($types) !== 2) {
+                        return false;
+                    }
+
                     $hasMixedType = false;
                     $hasMixedArrayType = false;
-                    foreach ($type->getTypes() as $unionedType) {
+
+                    foreach ($types as $unionedType) {
                         if ($unionedType instanceof MixedType) {
                             $hasMixedType = true;
                             continue;

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -241,7 +241,9 @@ final readonly class CallTypesResolver
                         }
                     }
 
-                    return $hasMixedType && $hasMixedArrayType;
+                    if ($hasMixedType && $hasMixedArrayType) {
+                        return true;
+                    }
                 }
             }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -225,10 +225,10 @@ final readonly class CallTypesResolver
     {
         if (! $type instanceof ArrayType) {
             if ($type instanceof UnionType) {
-                $type = $this->typeFactory->createMixedPassedOrUnionType($type->getTypes());
+                $types = $type->getTypes();
+                $type = $this->typeFactory->createMixedPassedOrUnionType($types);
 
                 if ($type instanceof UnionType) {
-                    $types = $type->getTypes();
                     if (count($types) !== 2) {
                         return false;
                     }

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -226,9 +226,10 @@ final readonly class CallTypesResolver
         if (! $type instanceof ArrayType) {
             if ($type instanceof UnionType) {
                 $types = $type->getTypes();
-                $type = $this->typeFactory->createMixedPassedOrUnionType($types);
+                $checkedType = $this->typeFactory->createMixedPassedOrUnionType($types);
 
-                if ($type instanceof UnionType) {
+                if ($checkedType instanceof UnionType) {
+                    $types = $checkedType->getTypes();
                     if (count($types) !== 2) {
                         return false;
                     }


### PR DESCRIPTION
It currently cause

```diff
+    /**
+     * @param mixed|mixed[] $argv
+     */
```

https://getrector.com/demo/e3b82d99-3b41-41ef-a4c1-b77c18506e0e

which should be skipped.