### PR TITLE
[TypeDeclarationDocblocks] Skip mixed[] array from getter on ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_mixed_array_from_getter.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_mixed_array_from_getter.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class SkipMixedArrayFromGetter
+{
+    public function getter(): ?array
+    {
+    }
+
+    public function fromGetter()
+    {
+        $this->run($this->getter());
+    }
+
+    private function run(array $p)
+    {
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -228,6 +228,14 @@ final readonly class CallTypesResolver
     private function isArrayMixedMixedType(Type $type): bool
     {
         if (! $type instanceof ArrayType) {
+            if ($type instanceof UnionType) {
+                foreach ($type->getTypes() as $subType) {
+                    if ($subType instanceof ArrayType && $this->isArrayMixedMixedType($subType)) {
+                        return true;
+                    }
+                }
+            }
+
             return false;
         }
 


### PR DESCRIPTION
It currently cause:

```diff
+    /**
+     * @param mixed[] $p
+     */
```

which should be skipped.

Ref https://getrector.com/demo/d69d787b-ecf3-4ddc-ba31-b9024c8d30cb