### PR TITLE
[TypeDeclaration] Allow empty array to native array on AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/with_empty_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/with_empty_array.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+final class WithEmptyArray
+{
+    public function runFirst()
+    {
+        $this->process([]);
+    }
+
+    private function process($data)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+final class WithEmptyArray
+{
+    public function runFirst()
+    {
+        $this->process([]);
+    }
+
+    private function process(array $data)
+    {
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -44,6 +44,7 @@ final readonly class CallTypesResolver
             }
 
             foreach ($call->getArgs() as $position => $arg) {
+                /** @var Arg $arg */
                 if ($this->shouldSkipArg($arg)) {
                     return [];
                 }

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -40,7 +40,7 @@ final readonly class CallTypesResolver
         $staticTypesByArgumentPosition = [];
 
         foreach ($calls as $call) {
-            foreach ($call->getArgs() as $position => $arg) {
+            foreach ($call->args as $position => $arg) {
                 if ($this->shouldSkipArg($arg)) {
                     return [];
                 }

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\VariadicPlaceholder;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -74,7 +74,6 @@ final readonly class CallTypesResolver
                     continue;
                 }
 
-                /** @var Arg $arg */
                 $staticTypesByArgumentPosition[$position][] = $this->resolveArgValueType($arg);
             }
         }

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -40,7 +40,11 @@ final readonly class CallTypesResolver
         $staticTypesByArgumentPosition = [];
 
         foreach ($calls as $call) {
-            foreach ($call->args as $position => $arg) {
+            if ($call->isFirstClassCallable()) {
+                return [];
+            }
+
+            foreach ($call->getArgs() as $position => $arg) {
                 if ($this->shouldSkipArg($arg)) {
                     return [];
                 }
@@ -200,15 +204,11 @@ final readonly class CallTypesResolver
     }
 
     /**
-     * There is first class callable usage, or argument unpack, or named expr
+     * There is argument unpack, or named expr
      * simply returns array marks as unknown as can be anything and in any position
      */
-    private function shouldSkipArg(Arg|VariadicPlaceholder $arg): bool
+    private function shouldSkipArg(Arg $arg): bool
     {
-        if ($arg instanceof VariadicPlaceholder) {
-            return true;
-        }
-
         if ($arg->unpack) {
             return true;
         }

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -45,12 +45,6 @@ final readonly class CallTypesResolver
                     return [];
                 }
 
-                /** @var Arg $arg */
-                if ($this->isEmptyArray($arg->value)) {
-                    // skip empty array, as it doesn't add any value
-                    continue;
-                }
-
                 $staticTypesByArgumentPosition[$position][] = $this->resolveStrictArgValueType($arg);
             }
         }


### PR DESCRIPTION
empty array to native array should be allowed, the skip is only for docblock.