### PR TITLE
[TypeDeclarationDocblocks] Skip mixed[] from empty array on ClassMethodArrayDocblockParamFromLocalCallsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_mixed_from_empty_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_mixed_from_empty_array.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class SkipMixedFromEmptyArray
+{
+    public function execute(array $data)
+    {
+        $data = [];
+        $this->run($data);
+    }
+
+    private function run(array $data)
+    {
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -224,8 +224,8 @@ final readonly class CallTypesResolver
 
     private function isArrayMixedMixedType(Type $type): bool
     {
-        if (! $type instanceof ArrayType) {
-            return $type instanceof ConstantArrayType && $type->getIterableKeyType() instanceof NeverType;
+        if (! $type instanceof ArrayType && ! $type instanceof ConstantArrayType) {
+            return false;
         }
 
         if (! $type->getItemType() instanceof MixedType && ! $type->getItemType() instanceof NeverType) {

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -13,7 +13,9 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\VariadicPlaceholder;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -223,13 +225,13 @@ final readonly class CallTypesResolver
     private function isArrayMixedMixedType(Type $type): bool
     {
         if (! $type instanceof ArrayType) {
+            return $type instanceof ConstantArrayType && $type->getIterableKeyType() instanceof NeverType;
+        }
+
+        if (! $type->getItemType() instanceof MixedType && ! $type->getItemType() instanceof NeverType) {
             return false;
         }
 
-        if (! $type->getItemType() instanceof MixedType) {
-            return false;
-        }
-
-        return $type->getKeyType() instanceof MixedType;
+        return $type->getKeyType() instanceof MixedType || $type->getKeyType() instanceof NeverType;
     }
 }


### PR DESCRIPTION
It currently cause:

```diff
+    /**
+     * @param mixed[] $data
+     */
```

which should be skipped.

Ref https://getrector.com/demo/2f69f875-854a-484d-95ad-1447ef2c2de3