### PR TITLE
[TypeDeclarationDocblocks] Skip all together if one of calls is first class callable

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_with_first_class_callable.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_with_first_class_callable.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class SkipWithFirstClassCallable
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+
+        $this->run(...)([1, 2]);
+    }
+
+    private function run(array $items)
+    {
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -67,7 +67,7 @@ final readonly class CallTypesResolver
         foreach ($calls as $call) {
             foreach ($call->args as $position => $arg) {
                 if ($this->shouldSkipArg($arg)) {
-                    continue;
+                    return [];
                 }
 
                 /** @var Arg $arg */


### PR DESCRIPTION
Given the following code:

```php
    public function go()
    {
        $this->run(['item1', 'item2']);

        $this->run(...)([1, 2]);
    }

    private function run(array $items)
    {
    }
```

It produce:

```diff
+    /**
+     * @param string[] $items
+     */
```

which invalid, since on first class callable invoked, it pass array of int as well. This should be skipped all together. 

Ref https://github.com/rectorphp/rector-src/pull/7357#pullrequestreview-3277347336