### PR TITLE
revert adding post rectors to applied rules as not relevant in result

### DIFF
--- a/e2e/applied-auto-import/expected-output.diff
+++ b/e2e/applied-auto-import/expected-output.diff
@@ -23,10 +23,6 @@
 
 Applied rules:
  * RenameClassRector
- * DocblockNameImportingPostRector
- * NameImportingPostRector
- * UnusedImportRemovingPostRector
- * UseAddingPostRector
 
 
  [OK] 1 file would have been changed (dry-run) by Rector

--- a/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
+++ b/src/ChangesReporting/ValueObjectFactory/FileDiffFactory.php
@@ -36,11 +36,6 @@ final readonly class FileDiffFactory
         $consoleDiff = $shouldShowDiffs ? $this->colorConsoleDiffFormatter->format($diff) : '';
 
         // always keep the most recent diff
-        return new FileDiff(
-            $relativeFilePath,
-            $diff,
-            $consoleDiff,
-            $rectorsWithLineChanges
-        );
+        return new FileDiff($relativeFilePath, $diff, $consoleDiff, $rectorsWithLineChanges);
     }
 }

--- a/src/Testing/PHPUnit/ValueObject/RectorTestResult.php
+++ b/src/Testing/PHPUnit/ValueObject/RectorTestResult.php
@@ -36,6 +36,6 @@ final readonly class RectorTestResult
             $rectorClasses = array_merge($rectorClasses, $fileDiff->getRectorClasses());
         }
 
-        return RectorClassesSorter::sort($rectorClasses);
+        return RectorClassesSorter::sortAndFilterOutPostRectors($rectorClasses);
     }
 }

--- a/src/Util/RectorClassesSorter.php
+++ b/src/Util/RectorClassesSorter.php
@@ -16,22 +16,16 @@ final class RectorClassesSorter
      * @param array<class-string<RectorInterface|PostRectorInterface>> $rectorClasses
      * @return array<class-string<RectorInterface|PostRectorInterface>>
      */
-    public static function sort(array $rectorClasses): array
+    public static function sortAndFilterOutPostRectors(array $rectorClasses): array
     {
         $rectorClasses = array_unique($rectorClasses);
 
-        $mainRector = array_filter(
+        $mainRectorClasses = array_filter(
             $rectorClasses,
             fn (string $rectorClass): bool => is_a($rectorClass, RectorInterface::class, true)
         );
-        sort($mainRector);
+        sort($mainRectorClasses);
 
-        $postRector = array_filter(
-            $rectorClasses,
-            fn (string $rectorClass): bool => is_a($rectorClass, PostRectorInterface::class, true)
-        );
-        sort($postRector);
-
-        return array_merge($mainRector, $postRector);
+        return $mainRectorClasses;
     }
 }

--- a/src/ValueObject/Reporting/FileDiff.php
+++ b/src/ValueObject/Reporting/FileDiff.php
@@ -93,7 +93,7 @@ final readonly class FileDiff implements SerializableInterface
             $rectorClasses[] = $rectorWithLineChange->getRectorClass();
         }
 
-        return RectorClassesSorter::sort($rectorClasses);
+        return RectorClassesSorter::sortAndFilterOutPostRectors($rectorClasses);
     }
 
     public function getFirstLineNumber(): ?int


### PR DESCRIPTION
Partially reverts: https://github.com/rectorphp/rector-src/pull/7304/files

Ref https://github.com/rectorphp/rector/issues/9373

I'm testing this feature and it shows under every single change, as most of changes do include object from time to time.
This is not very helpful, as new users is trying to understand what 5 of those magical post-rules. Also demo link will not work to create test fixture, as exactly 1 rule must be applied.

Autoimport is a standalone features, because of its complexity. It's not a rule per-se.
Saying that, I'm reverting these post rules from being shown in the result, to keep reports nice and tidy to read :+1: 