### PR TITLE
[DX] Make configurable include post rector classes in result

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -46,4 +46,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->reportingRealPath(false);
 
     $rectorConfig->treatClassesAsFinal(false);
+
+    $rectorConfig->includePostRectorsInReports(false);
 };

--- a/e2e/applied-auto-import/expected-output.diff
+++ b/e2e/applied-auto-import/expected-output.diff
@@ -23,6 +23,10 @@
 
 Applied rules:
  * RenameClassRector
+ * DocblockNameImportingPostRector
+ * NameImportingPostRector
+ * UnusedImportRemovingPostRector
+ * UseAddingPostRector
 
 
  [OK] 1 file would have been changed (dry-run) by Rector

--- a/e2e/applied-auto-import/rector.php
+++ b/e2e/applied-auto-import/rector.php
@@ -16,4 +16,5 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->importNames();
     $rectorConfig->removeUnusedImports();
+    $rectorConfig->includePostRectorsInReports(true);
 };

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -451,4 +451,9 @@ final class RectorConfig extends Container
     {
         SimpleParameterProvider::addParameter(Option::LEVEL_OVERFLOWS, $levelOverflows);
     }
+
+    public function includePostRectorsInReports(bool $includePostRectorsInReports = true): void
+    {
+        SimpleParameterProvider::setParameter(Option::INCLUDE_POST_RECTORS_IN_REPORTS, $includePostRectorsInReports);
+    }
 }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -327,4 +327,9 @@ final class Option
      * @var string
      */
     public const KAIZEN = 'kaizen';
+
+    /**
+     * @var string
+     */
+    public const INCLUDE_POST_RECTORS_IN_REPORTS = 'include_post_rectors_in_reports';
 }

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -177,6 +177,8 @@ final class RectorConfigBuilder
 
     private ?bool $isWithPhpLevelUsed = null;
 
+    private ?bool $includePostRectorsInReports = null;
+
     /**
      * @var array<class-string<SetProviderInterface>,bool>
      */
@@ -389,6 +391,10 @@ final class RectorConfigBuilder
 
         if ($this->levelOverflows !== []) {
             $rectorConfig->setOverflowLevels($this->levelOverflows);
+        }
+
+        if ($this->includePostRectorsInReports !== null) {
+            $rectorConfig->includePostRectorsInReports($this->includePostRectorsInReports);
         }
     }
 
@@ -1289,6 +1295,12 @@ final class RectorConfigBuilder
             $this->setProviders[$setProvider] = true;
         }
 
+        return $this;
+    }
+
+    public function withIncludePostRectorsInReports(bool $includePostRectorsInReports = true): self
+    {
+        $this->includePostRectorsInReports = $includePostRectorsInReports;
         return $this;
     }
 }

--- a/src/Testing/PHPUnit/ValueObject/RectorTestResult.php
+++ b/src/Testing/PHPUnit/ValueObject/RectorTestResult.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Testing\PHPUnit\ValueObject;
 
 use Rector\Contract\Rector\RectorInterface;
+use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Rector\Util\RectorClassesSorter;
 use Rector\ValueObject\ProcessResult;
 
@@ -25,7 +26,7 @@ final readonly class RectorTestResult
     }
 
     /**
-     * @return array<class-string<RectorInterface>>
+     * @return array<class-string<RectorInterface|PostRectorInterface>>
      */
     public function getAppliedRectorClasses(): array
     {
@@ -35,6 +36,6 @@ final readonly class RectorTestResult
             $rectorClasses = array_merge($rectorClasses, $fileDiff->getRectorClasses());
         }
 
-        return RectorClassesSorter::sortAndFilterOutPostRectors($rectorClasses);
+        return RectorClassesSorter::sort($rectorClasses);
     }
 }

--- a/src/Util/RectorClassesSorter.php
+++ b/src/Util/RectorClassesSorter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Util;
 
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
 
@@ -11,9 +13,9 @@ final class RectorClassesSorter
 {
     /**
      * @param array<class-string<RectorInterface|PostRectorInterface>> $rectorClasses
-     * @return array<class-string<RectorInterface>>
+     * @return array<class-string<RectorInterface|PostRectorInterface>>
      */
-    public static function sortAndFilterOutPostRectors(array $rectorClasses): array
+    public static function sort(array $rectorClasses): array
     {
         $rectorClasses = array_unique($rectorClasses);
 
@@ -22,6 +24,16 @@ final class RectorClassesSorter
             fn (string $rectorClass): bool => is_a($rectorClass, RectorInterface::class, true)
         );
         sort($mainRectorClasses);
+
+        if (SimpleParameterProvider::provideBoolParameter(Option::INCLUDE_POST_RECTORS_IN_REPORTS)) {
+            $postRectorClasses = array_filter(
+                $rectorClasses,
+                fn (string $rectorClass): bool => is_a($rectorClass, PostRectorInterface::class, true)
+            );
+            sort($postRectorClasses);
+
+            return array_merge($mainRectorClasses, $postRectorClasses);
+        }
 
         return $mainRectorClasses;
     }

--- a/src/ValueObject/Reporting/FileDiff.php
+++ b/src/ValueObject/Reporting/FileDiff.php
@@ -8,6 +8,7 @@ use Nette\Utils\Strings;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Parallel\ValueObject\BridgeItem;
+use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Rector\Util\RectorClassesSorter;
 use Symplify\EasyParallel\Contract\SerializableInterface;
 use Webmozart\Assert\Assert;
@@ -82,7 +83,7 @@ final readonly class FileDiff implements SerializableInterface
     }
 
     /**
-     * @return array<class-string<RectorInterface>>
+     * @return array<class-string<RectorInterface|PostRectorInterface>>
      */
     public function getRectorClasses(): array
     {
@@ -92,7 +93,7 @@ final readonly class FileDiff implements SerializableInterface
             $rectorClasses[] = $rectorWithLineChange->getRectorClass();
         }
 
-        return RectorClassesSorter::sortAndFilterOutPostRectors($rectorClasses);
+        return RectorClassesSorter::sort($rectorClasses);
     }
 
     public function getFirstLineNumber(): ?int


### PR DESCRIPTION
@TomasVotruba per discussion on https://github.com/rectorphp/rector-src/pull/7365#issuecomment-3348146120

This is make configurable in case you want to consider it, this is default to `false` so user needs to enable it in the config, via:

```php
$rectorConfig->includePostRectorsInReports(true);
```

or

```php
return RectorConfig::configure()
      // ...
     ->withIncludePostRectorsInReports(true);
```

/cc @simonschaufi 