### PR TITLE
[TypeDeclarationDocblocks] Use int key on inner array over mixed key on DocblockVarArrayFromPropertyDefaultsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/int_key_inside.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/int_key_inside.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDefaultsRector\Fixture;
+
+final class IntKeyInside
+{
+    private array $array = [
+        'a' => [
+            'b' => [
+                ['c' => 'e', 'f' => 1],
+                ['d' => 2],
+            ],
+        ],
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDefaultsRector\Fixture;
+
+final class IntKeyInside
+{
+    /**
+     * @var array<string, array<string, array<int, array<string, string|int>>>>
+     */
+    private array $array = [
+        'a' => [
+            'b' => [
+                ['c' => 'e', 'f' => 1],
+                ['d' => 2],
+            ],
+        ],
+    ];
+}
+
+?>

--- a/rules/Privatization/TypeManipulator/TypeNormalizer.php
+++ b/rules/Privatization/TypeManipulator/TypeNormalizer.php
@@ -57,8 +57,9 @@ final readonly class TypeNormalizer
      */
     public function generalizeConstantTypes(Type $type): Type
     {
-        $originalType = $type;
-        return TypeTraverser::map($type, function (Type $type, callable $traverseCallback) use ($originalType): Type {
+        $deep = 0;
+        return TypeTraverser::map($type, function (Type $type, callable $traverseCallback) use (&$deep): Type {
+            ++$deep;
             if ($type instanceof AccessoryNonFalsyStringType || $type instanceof AccessoryLiteralStringType || $type instanceof AccessoryNonEmptyStringType) {
                 return new StringType();
             }
@@ -82,7 +83,7 @@ final readonly class TypeNormalizer
             if ($type instanceof ConstantArrayType) {
                 // is relevant int constantArrayType?
                 if ($this->isImplicitNumberedListKeyType($type)) {
-                    $keyType = $originalType === $type ? new MixedType() : new IntegerType();
+                    $keyType = $deep === 1 ? new MixedType() : new IntegerType();
                 } else {
                     $keyType = $this->generalizeConstantTypes($type->getKeyType());
                 }

--- a/rules/Privatization/TypeManipulator/TypeNormalizer.php
+++ b/rules/Privatization/TypeManipulator/TypeNormalizer.php
@@ -57,7 +57,8 @@ final readonly class TypeNormalizer
      */
     public function generalizeConstantTypes(Type $type): Type
     {
-        return TypeTraverser::map($type, function (Type $type, callable $traverseCallback): Type {
+        $originalType = $type;
+        return TypeTraverser::map($type, function (Type $type, callable $traverseCallback) use ($originalType): Type {
             if ($type instanceof AccessoryNonFalsyStringType || $type instanceof AccessoryLiteralStringType || $type instanceof AccessoryNonEmptyStringType) {
                 return new StringType();
             }
@@ -81,7 +82,7 @@ final readonly class TypeNormalizer
             if ($type instanceof ConstantArrayType) {
                 // is relevant int constantArrayType?
                 if ($this->isImplicitNumberedListKeyType($type)) {
-                    $keyType = new MixedType();
+                    $keyType = $originalType === $type ? new MixedType() : new IntegerType();
                 } else {
                     $keyType = $this->generalizeConstantTypes($type->getKeyType());
                 }


### PR DESCRIPTION
Given the following code:

```php
    private array $array = [
        'a' => [
            'b' => [
                ['c' => 'e', 'f' => 1],
                ['d' => 2],
            ],
        ],
    ];
```

It got diff:

```diff
+    /**
+     * @var array<string, array<string, array<mixed, array<string, string|int>>>>
+     */
```

`mixed` key should be `int`.