### PR TITLE
[TypeDeclarationDocblocks] Allow override dummy mixed identifier on UsefulArrayTagNodeAnalyzer

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/override_dummy_mixed.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/override_dummy_mixed.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class OverrideDummyMixed extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function provideData()
+    {
+        return [
+            [125, 35],
+            [1252]
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class OverrideDummyMixed extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    /**
+     * @return int[][]
+     */
+    public static function provideData()
+    {
+        return [
+            [125, 35],
+            [1252]
+        ];
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/TagNodeAnalyzer/UsefulArrayTagNodeAnalyzer.php
+++ b/rules/TypeDeclarationDocblocks/TagNodeAnalyzer/UsefulArrayTagNodeAnalyzer.php
@@ -22,6 +22,6 @@ final class UsefulArrayTagNodeAnalyzer
             return true;
         }
 
-        return $type->name !== 'array';
+        return ! in_array($type->name, ['array', 'mixed'], true);
     }
 }


### PR DESCRIPTION
@TomasVotruba let's improve `UsefulArrayTagNodeAnalyzer` to allow dummy `mixed` identifier, which mostly won't be used as Templated Tag:

```diff
    /**
-    * @return mixed
+    * @return int[][]
     */
```