### PR TITLE
[Printer] Fixture crash on named argument usage on array_map() due to unpack arg flipped

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayFunctionClosureParamTypeRector/Fixture/include_array_map_named.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayFunctionClosureParamTypeRector/Fixture/include_array_map_named.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayFunctionClosureParamTypeRector\Fixture;
+
+final class IncludeArrayMapNamed
+{
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+        $result = array_map(array: $items, callback: fn ($item) => $item * 2);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayFunctionClosureParamTypeRector\Fixture;
+
+final class IncludeArrayMapNamed
+{
+    /**
+     * @param int[] $items
+     */
+    public function run(array $items)
+    {
+        $result = array_map(array: $items, callback: fn ($item) => $item * 2);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayFunctionClosureParamTypeRector/Fixture/include_array_map_named.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayFunctionClosureParamTypeRector/Fixture/include_array_map_named.php.inc
@@ -26,7 +26,7 @@ final class IncludeArrayMapNamed
      */
     public function run(array $items)
     {
-        $result = array_map(array: $items, callback: fn ($item) => $item * 2);
+        $result = array_map(array: $items, callback: fn (int $item) => $item * 2);
     }
 }
 


### PR DESCRIPTION
Given the following code:

```php
final class IncludeArrayMapNamed
{
    /**
     * @param int[] $items
     */
    public function run(array $items)
    {
        $result = array_map(array: $items, callback: fn ($item) => $item * 2);
    }
}
```

It currently got crash:

```bash
There was 1 failure:

1) Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayFunctionClosureParamTypeRector\AddArrayFunctionClosureParamTypeRectorTest::test with data set #3 ('/Users/samsonasik/www/rector-...hp.inc')
assert($itemStartPos >= 0 && $itemEndPos >= 0 && $itemStartPos >= $pos)

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php:842
/Users/samsonasik/www/rector-src/src/PhpParser/Printer/BetterStandardPrinter.php:281
```

Linked to php-parser `getArg()` method 

- https://github.com/nikic/PHP-Parser/pull/1089#pullrequestreview-3294857146