### PR TITLE
[CodeQuality] Skip not inline comparison identical on RepeatedOrEqualToInArrayRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -345,14 +345,3 @@ parameters:
         -
             identifier: symplify.noReference
             message: '#Use explicit return value over magic &reference#'
-
-        # known type
-        -
-            identifier: argument.type
-            message: '#Parameter \#1 \$expr of method Rector\\CodeQuality\\Rector\\BooleanOr\\RepeatedOrEqualToInArrayRector\:\:matchComparedExprAndValueExpr\(\) expects PhpParser\\Node\\Expr\\BinaryOp\\Equal\|PhpParser\\Node\\Expr\\BinaryOp\\Identical, PhpParser\\Node\\Expr given#'
-
-        -
-            path: rules/Renaming/Rector/Name/RenameClassRector.php
-            identifier: return.type
-
-        - '#Method Rector\\(.*?)Rector\:\:refactor\(\) never returns \d so it can be removed from the return type#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -345,3 +345,9 @@ parameters:
         -
             identifier: symplify.noReference
             message: '#Use explicit return value over magic &reference#'
+
+        -
+            path: rules/Renaming/Rector/Name/RenameClassRector.php
+            identifier: return.type
+
+        - '#Method Rector\\(.*?)Rector\:\:refactor\(\) never returns \d so it can be removed from the return type#'

--- a/rules-tests/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector/Fixture/skip_not_inline_identical.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector/Fixture/skip_not_inline_identical.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\BooleanOr\RepeatedOrEqualToInArrayRector\Fixture;
+
+final class SkipNotInlineIdentical
+{
+    public function demo($someVariable): bool
+    {
+        if ($someVariable === 'a' || $someVariable === 'b' || execute(fn(): bool => $someVariable === 'c')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
+++ b/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
@@ -17,6 +17,7 @@ use Rector\CodeQuality\ValueObject\ComparedExprAndValueExpr;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\CodeQuality\Rector\BooleanOr\RepeatedOrEqualToInArrayRector\RepeatedOrEqualToInArrayRectorTest
@@ -107,8 +108,13 @@ CODE_SAMPLE
         return new FuncCall(new Name('in_array'), $args);
     }
 
-    private function findIdenticalsOrEquals(BooleanOr $booleanOr, string $type = Identical::class): array
+    /**
+     * @return array<Identical|Equal>
+     */
+    private function findIdenticalsOrEquals(BooleanOr $booleanOr, string $type): array
     {
+        Assert::oneOf($type, [Identical::class, Equal::class]);
+
         $identicalsOrEquals = [];
         if ($booleanOr->left instanceof $type) {
             $identicalsOrEquals[] = $booleanOr->left;
@@ -122,6 +128,7 @@ CODE_SAMPLE
             $identicalsOrEquals[] = $booleanOr->right;
         }
 
+        /** @var array<Identical|Equal> $identicalsOrEquals */
         return $identicalsOrEquals;
     }
 
@@ -172,7 +179,9 @@ CODE_SAMPLE
                 return null;
             }
 
-            $comparedExprAndValueExprs[] = $this->matchComparedExprAndValueExpr($currentBooleanOr->left->right);
+            /** @var Identical|Equal $leftRight */
+            $leftRight = $currentBooleanOr->left->right;
+            $comparedExprAndValueExprs[] = $this->matchComparedExprAndValueExpr($leftRight);
             $currentBooleanOr = $currentBooleanOr->left;
         }
 


### PR DESCRIPTION
This avoid use of `$this->betterNodeFinder->findInstanceOf()` as it can search too deep, use inline search left right instead.