### PR TITLE
[CodeQuality] Skip mix equal and identical on RepeatedOrEqualToInArrayRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector/Fixture/skip_mix_equal_and_identical.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector/Fixture/skip_mix_equal_and_identical.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\BooleanOr\RepeatedOrEqualToInArrayRector\Fixture;
+
+final class SkipMixEqualAndIdentical
+{
+    public function demo()
+    {
+        $a = false;
+        var_dump($a == 'a' || $a == 'b' || $a === null);
+    }
+}

--- a/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
+++ b/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
 
         if ($identicals !== []) {
             if ($equals !== []) {
-                // mixed identical and equals, skip as is
+                // mix identical and equals, skip as is
                 // @see https://3v4l.org/24cFl
                 return null;
             }

--- a/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
+++ b/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
@@ -106,7 +106,13 @@ CODE_SAMPLE
         $identicals = $this->betterNodeFinder->findInstanceOf($node, Identical::class);
         $equals = $this->betterNodeFinder->findInstanceOf($node, Equal::class);
 
-        if ($identicals !== [] && $equals === []) {
+        if ($identicals !== []) {
+            if ($equals !== []) {
+                // mixed identical and equals, skip as is
+                // @see https://3v4l.org/24cFl
+                return null;
+            }
+
             $args[] = new Arg(new ConstFetch(new Name('true')));
         }
 

--- a/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
+++ b/rules/CodeQuality/Rector/BooleanOr/RepeatedOrEqualToInArrayRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
 
         if ($identicals !== []) {
             if ($equals !== []) {
-                // mix identical and equals, skip as is
+                // mix identical and equals, keep as is
                 // @see https://3v4l.org/24cFl
                 return null;
             }


### PR DESCRIPTION
Given the following code:

```php
$a = false;
var_dump($a == 'a' || $a == 'b' || $a === null);
```

It produce:

```diff
-        var_dump($a == 'a' || $a == 'b' || $a === null);
+        var_dump(in_array($a, ['a', 'b', null]));
```

which invalid on result, see https://3v4l.org/24cFl