### PR TITLE
[TypeDeclarationDocblocks] Cover dummy iterable on UsefulArrayTagNodeAnalyzer

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromDataProviderRector/Fixture/cover_dummy_iterable_param.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromDataProviderRector/Fixture/cover_dummy_iterable_param.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDataProviderRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CoverDummyIterable extends TestCase
+{
+    /**
+     * @param iterable $names
+     */
+    #[DataProvider('provideData')]
+    public function test(iterable $names): void
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [['Tom', 'John']];
+        yield [[]];
+        yield [['John', 'Doe']];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDataProviderRector\Fixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CoverDummyIterable extends TestCase
+{
+    /**
+     * @param string[] $names
+     */
+    #[DataProvider('provideData')]
+    public function test(iterable $names): void
+    {
+    }
+
+    public static function provideData()
+    {
+        yield [['Tom', 'John']];
+        yield [[]];
+        yield [['John', 'Doe']];
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/TagNodeAnalyzer/UsefulArrayTagNodeAnalyzer.php
+++ b/rules/TypeDeclarationDocblocks/TagNodeAnalyzer/UsefulArrayTagNodeAnalyzer.php
@@ -24,7 +24,7 @@ final class UsefulArrayTagNodeAnalyzer
             return ! $this->isMixedArray($type);
         }
 
-        return ! in_array($type->name, ['array', 'mixed'], true);
+        return ! in_array($type->name, ['array', 'mixed', 'iterable'], true);
     }
 
     public function isMixedArray(TypeNode $typeNode): bool


### PR DESCRIPTION
The `AddParamArrayDocblockFromDataProviderRector` check `iterable` param as well

https://github.com/rectorphp/rector-src/blob/8929abc529f3a515c1f67be9e78dd917463af8d7/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromDataProviderRector.php#L125

