### PR TITLE
 Fix PHPStan @return unused type return.type on RectorInterface 

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -354,5 +354,3 @@ parameters:
         -
             path: rules/Renaming/Rector/Name/RenameClassRector.php
             identifier: return.type
-
-        - '#Method Rector\\(.*?)Rector\:\:refactor\(\) never returns \d so it can be removed from the return type#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -350,7 +350,3 @@ parameters:
         -
             identifier: argument.type
             message: '#Parameter \#1 \$expr of method Rector\\CodeQuality\\Rector\\BooleanOr\\RepeatedOrEqualToInArrayRector\:\:matchComparedExprAndValueExpr\(\) expects PhpParser\\Node\\Expr\\BinaryOp\\Equal\|PhpParser\\Node\\Expr\\BinaryOp\\Identical, PhpParser\\Node\\Expr given#'
-
-        -
-            path: rules/Renaming/Rector/Name/RenameClassRector.php
-            identifier: return.type

--- a/src/Contract/Rector/RectorInterface.php
+++ b/src/Contract/Rector/RectorInterface.php
@@ -29,7 +29,7 @@ interface RectorInterface extends NodeVisitor, DocumentedRuleInterface
      *          - NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN
      *
      *   ✔️ To remove node of Node\Stmt or Node\Param, return:
-     *          - NodeVisitor::REMOVE_NODE to remove Stmt or Param
+     *          - NodeVisitor::REMOVE_NODE
      */
     public function refactor(Node $node);
 }

--- a/src/Contract/Rector/RectorInterface.php
+++ b/src/Contract/Rector/RectorInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Contract\Rector;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 
@@ -21,7 +20,7 @@ interface RectorInterface extends NodeVisitor, DocumentedRuleInterface
 
     /**
      * Process Node of matched type
-     * @return Node|Node[]|null|NodeTraverser::*
+     * @return Node|Node[]|null|int
      */
     public function refactor(Node $node);
 }

--- a/src/Contract/Rector/RectorInterface.php
+++ b/src/Contract/Rector/RectorInterface.php
@@ -28,7 +28,7 @@ interface RectorInterface extends NodeVisitor, DocumentedRuleInterface
      *          - NodeVisitor::DONT_TRAVERSE_CHILDREN
      *          - NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN
      *
-     *   ✔️ To remove node of Stmt and Param, return:
+     *   ✔️ To remove node of Node\Stmt or Node\Param, return:
      *          - NodeVisitor::REMOVE_NODE to remove Stmt or Param
      */
     public function refactor(Node $node);

--- a/src/Contract/Rector/RectorInterface.php
+++ b/src/Contract/Rector/RectorInterface.php
@@ -21,6 +21,15 @@ interface RectorInterface extends NodeVisitor, DocumentedRuleInterface
     /**
      * Process Node of matched type
      * @return Node|Node[]|null|int
+     *
+     * For int return, choose:
+     *
+     *   ✔️ To decorate current node and its children to not be traversed on current rule, return one of:
+     *          - NodeVisitor::DONT_TRAVERSE_CHILDREN
+     *          - NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN
+     *
+     *   ✔️ To remove node of Stmt and Param, return:
+     *          - NodeVisitor::REMOVE_NODE to remove Stmt or Param
      */
     public function refactor(Node $node);
 }


### PR DESCRIPTION
On latest PHPStan `2.1.30`, using `Interface::*` seems mark as all must be returned, but not support partial of it, so use `int` over it.

Added comment note for how return `int` works.