### PR TITLE
[CodeQuality] Skip bool equal integer on UseIdenticalOverEqualWithSameTypeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/skip_bool_equal_integer.php.inc
+++ b/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/skip_bool_equal_integer.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector\Fixture;
+
+/**
+ * @see https://3v4l.org/i3oCg
+ */
+final class SkipBoolEqualInteger
+{
+    public function equal()
+    {
+        // maybe compare to numeric string
+        $value = rand(0, 1) ? 1 : null;
+
+        var_dump(true == $value);
+        var_dump($value == true);
+    }
+}

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -108,14 +108,18 @@ CODE_SAMPLE
             if (! $rightStaticType->isNumericString()->no()) {
                 return true;
             }
-            return ! $rightStaticType->isInteger()->no();
+
+            return ! $rightStaticType->isInteger()
+                ->no();
         }
 
         if ($rightStaticType instanceof BooleanType) {
             if (! $leftStaticType->isNumericString()->no()) {
                 return true;
             }
-            return ! $leftStaticType->isInteger()->no();
+
+            return ! $leftStaticType->isInteger()
+                ->no();
         }
 
         return false;

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -105,11 +105,17 @@ CODE_SAMPLE
     {
         // use ! ->no() as to verify both yes and maybe
         if ($leftStaticType instanceof BooleanType) {
-            return ! $rightStaticType->isNumericString()->no() || ! $rightStaticType->isInteger()->no() ;
+            if (! $rightStaticType->isNumericString()->no()) {
+                return true;
+            }
+            return ! $rightStaticType->isInteger()->no();
         }
 
         if ($rightStaticType instanceof BooleanType) {
-            return ! $leftStaticType->isNumericString()->no() || ! $leftStaticType->isInteger()->no();
+            if (! $leftStaticType->isNumericString()->no()) {
+                return true;
+            }
+            return ! $leftStaticType->isInteger()->no();
         }
 
         return false;

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -74,7 +74,7 @@ CODE_SAMPLE
         $leftStaticType = $this->nodeTypeResolver->getNativeType($node->left);
         $rightStaticType = $this->nodeTypeResolver->getNativeType($node->right);
 
-        if ($this->shouldSkipCompareNumericString($leftStaticType, $rightStaticType)) {
+        if ($this->shouldSkipCompareBoolToNumeric($leftStaticType, $rightStaticType)) {
             return null;
         }
 
@@ -101,15 +101,15 @@ CODE_SAMPLE
         return $this->processIdenticalOrNotIdentical($node);
     }
 
-    private function shouldSkipCompareNumericString(Type $leftStaticType, Type $rightStaticType): bool
+    private function shouldSkipCompareBoolToNumeric(Type $leftStaticType, Type $rightStaticType): bool
     {
         // use ! ->no() as to support both yes and maybe
         if ($leftStaticType instanceof BooleanType) {
-            return ! $rightStaticType->isNumericString()->no();
+            return ! $rightStaticType->isNumericString()->no() || ! $rightStaticType->isInteger()->no() ;
         }
 
         if ($rightStaticType instanceof BooleanType) {
-            return ! $leftStaticType->isNumericString()->no();
+            return ! $leftStaticType->isNumericString()->no() || ! $leftStaticType->isInteger()->no();
         }
 
         return false;

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -103,7 +103,7 @@ CODE_SAMPLE
 
     private function shouldSkipCompareBoolToNumeric(Type $leftStaticType, Type $rightStaticType): bool
     {
-        // use ! ->no() as to support both yes and maybe
+        // use ! ->no() as to verify both yes and maybe
         if ($leftStaticType instanceof BooleanType) {
             return ! $rightStaticType->isNumericString()->no() || ! $rightStaticType->isInteger()->no() ;
         }


### PR DESCRIPTION
@TomasVotruba this is another regression fix per https://github.com/rectorphp/rector-src/pull/7408#pullrequestreview-3301268829

see https://3v4l.org/i3oCg