### PR TITLE
[CodeQuality] Use TypeComparator to verify Boolean vs Constant Boolean on UseIdenticalOverEqualWithSameTypeRector

### DIFF
--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -10,9 +10,8 @@ use PhpParser\Node\Expr\BinaryOp\Equal;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotEqual;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
-use PHPStan\Type\BooleanType;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\Type;
+use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,6 +21,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class UseIdenticalOverEqualWithSameTypeRector extends AbstractRector
 {
+    public function __construct(
+        private readonly TypeComparator $typeComparator
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -74,10 +78,6 @@ CODE_SAMPLE
         $leftStaticType = $this->nodeTypeResolver->getNativeType($node->left);
         $rightStaticType = $this->nodeTypeResolver->getNativeType($node->right);
 
-        if ($this->shouldSkipCompareBoolToNumeric($leftStaticType, $rightStaticType)) {
-            return null;
-        }
-
         // objects can be different by content
         if (! $leftStaticType->isObject()->no() || ! $rightStaticType->isObject()->no()) {
             return null;
@@ -92,42 +92,11 @@ CODE_SAMPLE
         }
 
         // different types
-        if (! $leftStaticType->equals(
-            $rightStaticType
-        ) && (! $leftStaticType instanceof BooleanType && ! $rightStaticType instanceof BooleanType)) {
+        if (! $this->typeComparator->areTypesEqual($leftStaticType, $rightStaticType)) {
             return null;
         }
 
         return $this->processIdenticalOrNotIdentical($node);
-    }
-
-    private function shouldSkipCompareBoolToNumeric(Type $leftStaticType, Type $rightStaticType): bool
-    {
-        if ($leftStaticType instanceof BooleanType) {
-            return $this->shouldSkipNumericType($rightStaticType);
-        }
-
-        if ($rightStaticType instanceof BooleanType) {
-            return $this->shouldSkipNumericType($leftStaticType);
-        }
-
-        return false;
-    }
-
-    private function shouldSkipNumericType(Type $type): bool
-    {
-        // use ! ->no() as to verify both yes and maybe
-        if (! $type->isNumericString()->no()) {
-            return true;
-        }
-
-        if (! $type->isInteger()
-            ->no()) {
-            return true;
-        }
-
-        return ! $type->isFloat()
-            ->no();
     }
 
     private function processIdenticalOrNotIdentical(Equal|NotEqual $node): Identical|NotIdentical


### PR DESCRIPTION
@TomasVotruba I found better approach to verify Boolean vs Constant Boolean as equal by using TypeComparator which the type are normalized.

Ref https://github.com/rectorphp/rector-src/pull/7408#pullrequestreview-3301268829

Avoid regression like in previous PRs:

- https://github.com/rectorphp/rector-src/pull/7410
- https://github.com/rectorphp/rector-src/pull/7411
- https://github.com/rectorphp/rector-src/pull/7412