### PR TITLE
[CodeQuality] Use ->isBoolean() check on compare boolean and constant bool on UseIdenticalOverEqualWithSameTypeRector

### DIFF
--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotEqual;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PHPStan\Type\MixedType;
-use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -21,11 +20,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class UseIdenticalOverEqualWithSameTypeRector extends AbstractRector
 {
-    public function __construct(
-        private readonly TypeComparator $typeComparator
-    ) {
-    }
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -91,8 +85,12 @@ CODE_SAMPLE
             return $this->processIdenticalOrNotIdentical($node);
         }
 
+        if ($leftStaticType->isBoolean()->yes() && $rightStaticType->isBoolean()->yes()) {
+            return $this->processIdenticalOrNotIdentical($node);
+        }
+
         // different types
-        if (! $this->typeComparator->areTypesEqual($leftStaticType, $rightStaticType)) {
+        if (! $leftStaticType->equals($rightStaticType)) {
             return null;
         }
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/7414

I think using `->isBoolean()` check is safer as exactly verify the new behaviour of compare to bool.