### PR TITLE
Fix Source fixture class name on KnownMagicClassMethodTypeRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,8 +90,7 @@
         "classmap": [
             "stubs",
             "rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Source",
-            "rules-tests/Renaming/Rector/Name/RenameClassRector/Source",
-            "rules-tests/TypeDeclaration/Rector/ClassMethod/KnownMagicClassMethodTypeRector/Source"
+            "rules-tests/Renaming/Rector/Name/RenameClassRector/Source"
         ],
         "files": [
             "tests/debug_functions.php",

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/KnownMagicClassMethodTypeRector/Fixture/with_other_method_from_parent.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/KnownMagicClassMethodTypeRector/Fixture/with_other_method_from_parent.php.inc
@@ -2,9 +2,9 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector\Fixture;
 
-use Rector\Tests\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector\Source\ParentClassWithOtherMethod;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector\Source\ParentClassOtherMethod;
 
-final class WithOtherMethodFromParent extends ParentClassWithOtherMethod
+final class WithOtherMethodFromParent extends ParentClassOtherMethod
 {
     public function __invoke()
     {
@@ -21,9 +21,9 @@ final class WithOtherMethodFromParent extends ParentClassWithOtherMethod
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector\Fixture;
 
-use Rector\Tests\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector\Source\ParentClassWithOtherMethod;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector\Source\ParentClassOtherMethod;
 
-final class WithOtherMethodFromParent extends ParentClassWithOtherMethod
+final class WithOtherMethodFromParent extends ParentClassOtherMethod
 {
     public function __invoke()
     {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/KnownMagicClassMethodTypeRector/Source/ParentClassOtherMethod.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/KnownMagicClassMethodTypeRector/Source/ParentClassOtherMethod.php
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector\Source;
 
-abstract class ParentClassWithOtherMethod
+abstract class ParentClassOtherMethod
 {
     public function __invoke()
     {


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/7423#pullrequestreview-3302075868

I created typo class name.