### PR TITLE
[dead-code] Add RemoveUnusedClosureVariableUseRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        return function () use ($value) {
+            return 'value';
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector\Fixture;
+
+class Fixture
+{
+    public function run($value)
+    {
+        return function () {
+            return 'value';
+        };
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/Fixture/skip_used_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/Fixture/skip_used_variable.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector\Fixture;
+
+final class SkipUsedVariable
+{
+    public function run($value)
+    {
+        return function () use ($value) {
+            $result = $value + 100;
+
+            return $result;
+        };
+    }
+}

--- a/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/RemoveUnusedClosureVariableUseRectorTest.php
+++ b/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/RemoveUnusedClosureVariableUseRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveUnusedClosureVariableUseRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Concat\RemoveUnusedClosureVariableUseRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveUnusedClosureVariableUseRector::class]);

--- a/rules/DeadCode/Rector/Concat/RemoveUnusedClosureVariableUseRector.php
+++ b/rules/DeadCode/Rector/Concat/RemoveUnusedClosureVariableUseRector.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\Concat;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector\RemoveUnusedClosureVariableUseRectorTest
+ */
+final class RemoveUnusedClosureVariableUseRector extends AbstractRector
+{
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove unused variable in use() of closure', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$var = 1;
+
+$closure = function() use ($var) {
+    echo 'Hello World';
+};
+
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+$var = 1;
+$closure = function() {
+    echo 'Hello World';
+};
+
+CODE_SAMPLE
+            ),
+
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Closure::class];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->uses === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->uses as $key => $useVariable) {
+            $useVariableName = $this->getName($useVariable->var);
+            if (! is_string($useVariableName)) {
+                continue;
+            }
+
+            $isUseUsed = (bool) $this->betterNodeFinder->findVariableOfName($node->stmts, $useVariableName);
+            if ($isUseUsed) {
+                continue;
+            }
+
+            unset($node->uses[$key]);
+            $hasChanged = true;
+
+        }
+
+        if ($hasChanged) {
+            // reset keys, to keep as expected
+            $node->uses = array_values($node->uses);
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -27,6 +27,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnExprInConstructRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Concat\RemoveConcatAutocastRector;
+use Rector\DeadCode\Rector\Concat\RemoveUnusedClosureVariableUseRector;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
 use Rector\DeadCode\Rector\Expression\RemoveDeadStmtRector;
 use Rector\DeadCode\Rector\Expression\SimplifyMirrorAssignRector;
@@ -115,6 +116,7 @@ final class DeadCodeLevel
         ReduceAlwaysFalseIfOrRector::class,
         RemoveUnusedPrivateClassConstantRector::class,
         RemoveUnusedPrivatePropertyRector::class,
+        RemoveUnusedClosureVariableUseRector::class,
 
         RemoveDuplicatedCaseInSwitchRector::class,
         RemoveDeadInstanceOfRector::class,


### PR DESCRIPTION
Reported by PHPStan, now fixed by Rector :+1: 


```diff
class Fixture
{
    public function run($value)
    {
-        return function () use ($value) {
+        return function () {
            return 'value';
        };
    }
}
```