### PR TITLE
[DeadCode] Fix RemoveUnusedClosureVariableUseRector namespace to under Closure namespace

### DIFF
--- a/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\Concat\RemoveUnusedClosureVariableUseRector;
+use Rector\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector;
 
 return RectorConfig::configure()
     ->withRules([RemoveUnusedClosureVariableUseRector::class]);

--- a/rules/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector.php
+++ b/rules/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\DeadCode\Rector\Concat;
+namespace Rector\DeadCode\Rector\Closure;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -27,7 +27,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnExprInConstructRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Concat\RemoveConcatAutocastRector;
-use Rector\DeadCode\Rector\Concat\RemoveUnusedClosureVariableUseRector;
+use Rector\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
 use Rector\DeadCode\Rector\Expression\RemoveDeadStmtRector;
 use Rector\DeadCode\Rector\Expression\SimplifyMirrorAssignRector;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/7430#pullrequestreview-3302410709

It has nothing to do with `Concat` so it must be under `Closure`, also match with type of `getNodeTypes()`