### PR TITLE
[DeadCode] Clean up unnecessary reindex use on RemoveUnusedClosureVariableUseRector

### DIFF
--- a/rules/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector.php
+++ b/rules/DeadCode/Rector/Closure/RemoveUnusedClosureVariableUseRector.php
@@ -88,8 +88,6 @@ CODE_SAMPLE
         }
 
         if ($hasChanged) {
-            // reset keys, to keep as expected
-            $node->uses = array_values($node->uses);
             return $node;
         }
 


### PR DESCRIPTION
this is not needed, already covered at `NodeAttributeReIndexer`, see 

https://github.com/rectorphp/rector-src/blob/d948383ff339cf1ff7ca6a9ffadbec9943941b24/src/Application/NodeAttributeReIndexer.php#L69-L71

Ref https://github.com/rectorphp/rector-src/pull/7430#pullrequestreview-3302419409