### PR TITLE
Manual install ocramius/package-versions on build downgrade to test php 8.5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php-versions: ['8.2', '8.3', '8.4']
+                php-versions: ['8.2', '8.3', '8.4', '8.5']
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 3

--- a/bin/add-phpstan-self-replace.php
+++ b/bin/add-phpstan-self-replace.php
@@ -10,6 +10,11 @@ use PackageVersions\Versions;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (! class_exists(Versions::class)) {
+    echo 'You need to run `composer require ocramius/package-versions` first' . PHP_EOL;
+    exit(1);
+}
+
 $composerJsonFileContents = FileSystem::read(__DIR__ . '/../composer.json');
 
 $composerJson = Json::decode($composerJsonFileContents, forceArrays: true);

--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -30,15 +30,26 @@ note "Starts"
 note "Downloading php-scoper.phar"
 wget https://github.com/humbug/php-scoper/releases/download/0.18.17/php-scoper.phar -N --no-verbose
 
-# avoid phpstan/phpstan dependency duplicate
-note "Remove PHPStan to avoid duplicating it"
-
+# make PackageVersions exists
+# here while wait for PHP 8.5 compatible code
+# see https://github.com/Ocramius/PackageVersions/pull/270
+# to allow us on rector to create downgrade PHP 8.5 rules with define
+#
+#     #[RequiresPhp('>= 8.5')]
+#
+# On Downgrade PHP 8.5 rule, see https://github.com/rectorphp/rector-downgrade-php/pull/337
+#
 composer require ocramius/package-versions --working-dir "$BUILD_DIRECTORY"
 
 php "$BUILD_DIRECTORY/bin/add-phpstan-self-replace.php"
 
+# avoid phpstan/phpstan and ocramius/package-versions dependency duplicate
+note "Remove PHPStan and PackageVersions to avoid duplicating it"
+
 composer remove phpstan/phpstan -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
 composer remove ocramius/package-versions -W --update-no-dev --working-dir "$BUILD_DIRECTORY"
+
+note "PHPStan and PackageVersions now removed, safe to start php-scoper from here"
 
 # Work around possible PHP memory limits
 note "Running php-scoper on /bin, /config, /src, /rules and /vendor"

--- a/build/build-rector-scoped.sh
+++ b/build/build-rector-scoped.sh
@@ -32,6 +32,9 @@ wget https://github.com/humbug/php-scoper/releases/download/0.18.17/php-scoper.p
 
 # avoid phpstan/phpstan dependency duplicate
 note "Remove PHPStan to avoid duplicating it"
+
+composer require ocramius/package-versions --working-dir "$BUILD_DIRECTORY"
+
 php "$BUILD_DIRECTORY/bin/add-phpstan-self-replace.php"
 
 composer remove phpstan/phpstan -W --update-no-dev --working-dir "$BUILD_DIRECTORY"

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -21,6 +21,7 @@ return $config
         __DIR__ . '/stubs',
         __DIR__ . '/tests',
         __DIR__ . '/rules-tests',
+        __DIR__ . '/bin/add-phpstan-self-replace.php',
     ], [ErrorType::UNKNOWN_CLASS])
 
     ->disableExtensionsAnalysis();

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "illuminate/container": "^11.46",
         "nette/utils": "^4.0",
         "nikic/php-parser": "^5.6.1",
-        "ocramius/package-versions": "^2.10",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1.26",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -92,6 +92,10 @@ parameters:
             message: '#Function "var_dump\(\)" cannot be used/left in the code#'
             path: src/functions/node_helper.php
 
+        -
+            message: '#Function "class_exists\(\)" cannot be used/left in the code#'
+            path: bin/add-phpstan-self-replace.php
+
         # lack of generic array in nikic/php-parser
         - '#Method (.*?) should return array<PhpParser\\Node\\(.*?)\> but returns array<PhpParser\\Node\>#'
 


### PR DESCRIPTION
Per PR:

- https://github.com/rectorphp/rector-src/pull/7237
- https://github.com/Ocramius/PackageVersions/pull/270

This PR apply manual install `ocramius/package-versions` on build downgrade.

Closes https://github.com/rectorphp/rector-src/pull/7237