### PR TITLE
[autoload] Add workaround for phpstan + rector tests co-run to avoid duplicated php-parser loading error

### DIFF
--- a/build/build-preload.php
+++ b/build/build-preload.php
@@ -51,6 +51,9 @@ final class PreloadBuilder
 
 declare(strict_types=1);
 
+use PhpParser\Node;
+use PHPStan\Testing\PHPStanTestCase;
+
 if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
@@ -58,10 +61,18 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(\PHPStan\Testing\PHPStanTestCase::class, false) && interface_exists(\PhpParser\Node::class, false)) {
+if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
     return;
 }
 
+function isPHPStanTestPreloaded(): bool
+{
+    if (! class_exists(PHPStanTestCase::class, false)) {
+        return false;
+    }
+
+    return interface_exists(Node::class, false);
+}
 CODE_SAMPLE;
 
     /**

--- a/build/build-preload.php
+++ b/build/build-preload.php
@@ -55,6 +55,12 @@ if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
 
+// edge case during Rector tests case, happens when
+// 1. phpstan autoload test case is triggered first,
+// 2. all php-parser classes are loaded,
+if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(\PHPStan\Testing\PHPStanTestCase::class, false) && interface_exists(\PhpParser\Node::class, false)) {
+    return;
+}
 
 CODE_SAMPLE;
 

--- a/ecs.php
+++ b/ecs.php
@@ -24,6 +24,9 @@ return ECSConfig::configure()
         '*/Fixture/*',
         '*/Expected/*',
 
+        // avoid re-running on build
+        __DIR__ . '/preload.php',
+
         PhpdocTypesFixer::class => [
             // double to Double false positive
             __DIR__ . '/rules/Php74/Rector/Double/RealToFloatTypeCastRector.php',

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -12,14 +12,18 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(
-    PHPStanTestCase::class,
-    false
-) && interface_exists(Node::class, false)) {
+if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
     return;
 }
 
-require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node.php';
+function isPHPStanTestPreloaded(): bool
+{
+    if (! class_exists(PHPStanTestCase::class, false)) {
+        return false;
+    }
+
+    return interface_exists(Node::class, false);
+}require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node.php';
 require_once __DIR__ . '/src/Contract/PhpParser/Node/StmtsAwareInterface.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node/Expr.php';

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -6,6 +6,12 @@ if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
 
+// edge case during Rector tests case, happens when
+// 1. phpstan autoload test case is triggered first,
+// 2. all php-parser classes are loaded,
+if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(\PHPStan\Testing\PHPStanTestCase::class, false) && interface_exists(\PhpParser\Node::class, false)) {
+    return;
+}
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node.php';
 require_once __DIR__ . '/src/Contract/PhpParser/Node/StmtsAwareInterface.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php';

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use PhpParser\Node;
+use PHPStan\Testing\PHPStanTestCase;
+
 if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
@@ -9,9 +12,13 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(\PHPStan\Testing\PHPStanTestCase::class, false) && interface_exists(\PhpParser\Node::class, false)) {
+if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(
+    PHPStanTestCase::class,
+    false
+) && interface_exists(Node::class, false)) {
     return;
 }
+
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node.php';
 require_once __DIR__ . '/src/Contract/PhpParser/Node/StmtsAwareInterface.php';
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php';

--- a/preload.php
+++ b/preload.php
@@ -6,6 +6,12 @@ if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
 
+// edge case during Rector tests case, happens when
+// 1. phpstan autoload test case is triggered first,
+// 2. all php-parser classes are loaded,
+if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(\PHPStan\Testing\PHPStanTestCase::class, false) && interface_exists(\PhpParser\Node::class, false)) {
+    return;
+}
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node.php';
 require_once __DIR__ . '/src/Contract/PhpParser/Node/StmtsAwareInterface.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php';

--- a/preload.php
+++ b/preload.php
@@ -12,14 +12,18 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(
-    PHPStanTestCase::class,
-    false
-) && interface_exists(Node::class, false)) {
+if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
     return;
 }
 
-require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node.php';
+function isPHPStanTestPreloaded(): bool
+{
+    if (! class_exists(PHPStanTestCase::class, false)) {
+        return false;
+    }
+
+    return interface_exists(Node::class, false);
+}require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node.php';
 require_once __DIR__ . '/src/Contract/PhpParser/Node/StmtsAwareInterface.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node/Expr.php';

--- a/preload.php
+++ b/preload.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use PhpParser\Node;
+use PHPStan\Testing\PHPStanTestCase;
+
 if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
@@ -9,9 +12,13 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(\PHPStan\Testing\PHPStanTestCase::class, false) && interface_exists(\PhpParser\Node::class, false)) {
+if (defined('PHPUNIT_COMPOSER_INSTALL') && class_exists(
+    PHPStanTestCase::class,
+    false
+) && interface_exists(Node::class, false)) {
     return;
 }
+
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node.php';
 require_once __DIR__ . '/src/Contract/PhpParser/Node/StmtsAwareInterface.php';
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php';

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockBasedOnArrayMapRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockBasedOnArrayMapRector.php
@@ -11,6 +11,11 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
+<<<<<<< HEAD
+=======
+use PHPStan\Type\Type;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+>>>>>>> a264677ce8 ([autoload] Add workaround for phpstan + rector tests co-run to avoid duplicated php-parser loading error)
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -147,4 +152,31 @@ CODE_SAMPLE
 
         return $this->isName($param->type, 'array');
     }
+<<<<<<< HEAD
+=======
+
+    private function isMixedArrayType(Type $type): bool
+    {
+        if (! $type instanceof ArrayType) {
+            return false;
+        }
+
+        if (! $type->getItemType() instanceof MixedType) {
+            return false;
+        }
+
+        return $type->getKeyType() instanceof MixedType;
+    }
+
+    private function isAlreadyNonMixedParamType(PhpDocInfo $functionPhpDocInfo, string $paramName): bool
+    {
+        $currentParamType = $functionPhpDocInfo->getParamType($paramName);
+        if ($currentParamType instanceof MixedType) {
+            return false;
+        }
+
+        // has useful param type already?
+        return ! $this->isMixedArrayType($currentParamType);
+    }
+>>>>>>> a264677ce8 ([autoload] Add workaround for phpstan + rector tests co-run to avoid duplicated php-parser loading error)
 }

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockBasedOnArrayMapRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockBasedOnArrayMapRector.php
@@ -11,11 +11,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
-<<<<<<< HEAD
-=======
-use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
->>>>>>> a264677ce8 ([autoload] Add workaround for phpstan + rector tests co-run to avoid duplicated php-parser loading error)
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -152,31 +147,4 @@ CODE_SAMPLE
 
         return $this->isName($param->type, 'array');
     }
-<<<<<<< HEAD
-=======
-
-    private function isMixedArrayType(Type $type): bool
-    {
-        if (! $type instanceof ArrayType) {
-            return false;
-        }
-
-        if (! $type->getItemType() instanceof MixedType) {
-            return false;
-        }
-
-        return $type->getKeyType() instanceof MixedType;
-    }
-
-    private function isAlreadyNonMixedParamType(PhpDocInfo $functionPhpDocInfo, string $paramName): bool
-    {
-        $currentParamType = $functionPhpDocInfo->getParamType($paramName);
-        if ($currentParamType instanceof MixedType) {
-            return false;
-        }
-
-        // has useful param type already?
-        return ! $this->isMixedArrayType($currentParamType);
-    }
->>>>>>> a264677ce8 ([autoload] Add workaround for phpstan + rector tests co-run to avoid duplicated php-parser loading error)
 }

--- a/src/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
+++ b/src/BetterPhpDocParser/PhpDocManipulator/PhpDocTypeChanger.php
@@ -7,7 +7,6 @@ namespace Rector\BetterPhpDocParser\PhpDocManipulator;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;


### PR DESCRIPTION
This happens when:

* project uses phpstan rule tests
* phpunit runs
* rector rule test case runs second
