### PR TITLE
Directly check type of substr() on RecastingRemovalRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/true_in_union_become_bool.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/true_in_union_become_bool.php.inc
@@ -13,7 +13,7 @@ final class TrueInUnionBecomeBool
             return true;
         }
 
-        return strtoupper('warning');
+        return substr('warning', 1);
     }
 }
 
@@ -34,7 +34,7 @@ final class TrueInUnionBecomeBool
             return true;
         }
 
-        return strtoupper('warning');
+        return substr('warning', 1);
     }
 }
 

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_in_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/FixtureTrueInUnion/true_in_union.php.inc
@@ -13,7 +13,7 @@ final class TrueInUnion
             return true;
         }
 
-        return strtoupper('warning');
+        return substr('warning', 1);
     }
 }
 
@@ -34,7 +34,7 @@ final class TrueInUnion
             return true;
         }
 
-        return strtoupper('warning');
+        return substr('warning', 1);
     }
 }
 

--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -39,7 +39,6 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -619,11 +618,6 @@ final class NodeTypeResolver
             $functionReflection = $this->reflectionProvider->getFunction($functionName, null);
             if (! $functionReflection instanceof NativeFunctionReflection) {
                 return $scope->getNativeType($expr);
-            }
-
-            // substr can return false on php 7.x
-            if ($this->nodeNameResolver->isName($expr, 'substr') && ! $expr->isFirstClassCallable()) {
-                return new UnionType([new StringType(), new ConstantBooleanType(false)]);
             }
 
             return $scope->getType($expr);


### PR DESCRIPTION
Avoid on `NodeTypeResolver` to avoid on purpose `string` on php 8.x on type declaration set. 

Let's do per use case fix.