### PR TITLE
[fix] Skip symfony config closures on FirstClassCallableRector as they do not support first class callables

### DIFF
--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/make_other_closure_pass.php.inc
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/make_other_closure_pass.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector\Source\stdClass;
+use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+
+return static function (stdClass $container): void {
+    $container->services()
+        ->factory([SomeExternalObject::class, 'sleepStatic']);
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector\Source\stdClass;
+use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+
+return static function (stdClass $container): void {
+    $container->services()
+        ->factory(SomeExternalObject::sleepStatic(...));
+};
+
+?>

--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_symfony_config.php.inc
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_symfony_config.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->factory([SomeExternalObject::class, 'sleepStatic']);
+};


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9412