### PR TITLE
[Scoped] Load early preload.php on scoped bootstrap.php on phpunit 12+ running 

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -2,6 +2,8 @@
 
 declare(strict_types = 1);
 
+use PHPParser\Node;
+
 /**
  * The preload.php contains 2 dependencies
  *      - phpstan/phpdoc-parser
@@ -10,7 +12,13 @@ declare(strict_types = 1);
  * They need to be loaded early to avoid conflict version between rector prefixed vendor and Project vendor
  * For example, a project may use PHPParser v4, while Rector uses v5, that will error as class or logic are different.
  */
-if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+if (
+    // verify PHPUnit is running
+    defined('PHPUNIT_COMPOSER_INSTALL')
+
+    // no need to preload if Node interface exists
+    && ! interface_exists(Node::class, false)
+) {
     require_once __DIR__ . '/preload.php';
 }
 

--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -1,8 +1,9 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use PHPParser\Node;
+use PHPUnit\Runner\Version;
 
 /**
  * The preload.php contains 2 dependencies
@@ -18,6 +19,10 @@ if (
 
     // no need to preload if Node interface exists
     && ! interface_exists(Node::class, false)
+
+    // ensure force autoload version with class_exists() with true argument as not yet loaded
+    // for phpunit 12+ only
+    && class_exists(Version::class, true) && (int) Version::id() >= 12
 ) {
     require_once __DIR__ . '/preload.php';
 }

--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -2,6 +2,18 @@
 
 declare(strict_types = 1);
 
+/**
+ * The preload.php contains 2 dependencies
+ *      - phpstan/phpdoc-parser
+ *      - nikic/php-parser
+ *
+ * They need to be loaded early to avoid conflict version between rector prefixed vendor and Project vendor
+ * For example, a project may use PHPParser v4, while Rector uses v5, that will error as class or logic are different.
+ */
+if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+    require_once __DIR__ . '/preload.php';
+}
+
 // inspired by https://github.com/phpstan/phpstan/blob/master/bootstrap.php
 spl_autoload_register(function (string $class): void {
     static $composerAutoloader;

--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -11,7 +11,7 @@ use PHPUnit\Runner\Version;
  *      - nikic/php-parser
  *
  * They need to be loaded early to avoid conflict version between rector prefixed vendor and Project vendor
- * For example, a project may use phpstan/phpdoc-parser v1, while phpstan/phpdoc-parser uses v2, that will error as class or logic are different.
+ * For example, a project may use phpstan/phpdoc-parser v1, while rector uses phpstan/phpdoc-parser uses v2, that will error as class or logic are different.
  */
 if (
     // verify PHPUnit is running

--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -11,7 +11,7 @@ use PHPUnit\Runner\Version;
  *      - nikic/php-parser
  *
  * They need to be loaded early to avoid conflict version between rector prefixed vendor and Project vendor
- * For example, a project may use PHPParser v4, while Rector uses v5, that will error as class or logic are different.
+ * For example, a project may use phpstan/phpdoc-parser v1, while phpstan/phpdoc-parser uses v2, that will error as class or logic are different.
  */
 if (
     // verify PHPUnit is running


### PR DESCRIPTION
@TomasVotruba @staabm per https://github.com/rectorphp/rector/issues/9416#issuecomment-3381399038 this is ensure load early `preload.php` on `bootstrap.php` when running PHPUnit.

This preload is needed to avoid user require different `nikic/PHP-Parser` or `phpstan/phpdoc-parser` versions because of their project requirement, eg:

```bash
# get rector
composer require --dev rector/rector

# get nikic/php-parser v4
# when on phpunit < 12, 
# it resolvable by load vendor/rector/rector/preload.php in phpunit bootstrap config
# on phpunit >=12 use case, the autoload is too early loaded.
composer require nikic/php-parser:^4.0

# get phpstan/phpdoc-parser v1
composer require phpstan/phpdoc-parser:^1.0
```

without the preload early, this will cause error as we are using nikic/php-parser v5 and phpstan/phpdoc-parser v2.

This patch ensure on version PHPUnit 12 only so we have issue patch isolated.