### PR TITLE
[Alternative] Let preload.php require on PHPUnit < 12 on AbstractLazyTestCase

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -150,6 +150,8 @@ parameters:
                 # for config class reflection
                 - src/Bootstrap/ExtensionConfigResolver.php
                 - src/Validation/RectorConfigValidator.php
+                # for phpunit version check
+                - src/Testing/PHPUnit/AbstractLazyTestCase.php
 
         # use of internal phpstan classes
         -

--- a/scoper.php
+++ b/scoper.php
@@ -33,6 +33,7 @@ return [
     'exclude-classes' => [
         'PHPUnit\Framework\Constraint\IsEqual',
         'PHPUnit\Framework\TestCase',
+        'PHPUnit\Runner\Version',
         'PHPUnit\Framework\ExpectationFailedException',
 
         // native class on php 8.3+

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Testing\PHPUnit;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 use Rector\Config\RectorConfig;
 use Rector\DependencyInjection\LazyContainerFactory;
 
@@ -63,7 +64,11 @@ abstract class AbstractLazyTestCase extends TestCase
     {
         if (file_exists(__DIR__ . '/../../../preload.php')) {
             if (file_exists(__DIR__ . '/../../../vendor')) {
-                require_once __DIR__ . '/../../../preload.php';
+                // this ensure to not load preload.php on phpunit >= 12
+                if (! class_exists(Version::class) || (int) Version::id() < 12) {
+                    require_once __DIR__ . '/../../../preload.php';
+                }
+
                 // test case in rector split package
             } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
                 require_once __DIR__ . '/../../../preload-split-package.php';


### PR DESCRIPTION
@TomasVotruba per https://github.com/rectorphp/rector-src/pull/7451#issuecomment-3384618346

This is alternative that it only load `preload.php` when on phpunit < 12. As PHPUnit 12+ load vendor/autoload.php too early.

I will need help on verify on community rules to test the manual patch :)