### PR TITLE
[TypeDeclarationDocblocks] Fix missing backslash on class-string type on DocblockGetterReturnArrayFromPropertyDocblockVarRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/class_string_case_sensitive.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/class_string_case_sensitive.php.inc
@@ -17,7 +17,7 @@ class ClassStringCaseSensitive
 class ClassStringCaseSensitive
 {
     /**
-     * @var class-string<ClassStringCaseSensitive>
+     * @var class-string<\ClassStringCaseSensitive>
      */
     public $value;
     public function set()

--- a/rules-tests/DeadCode/Rector/FunctionLike/NarrowTooWideReturnTypeRector/Fixture/phpdocs.php.inc
+++ b/rules-tests/DeadCode/Rector/FunctionLike/NarrowTooWideReturnTypeRector/Fixture/phpdocs.php.inc
@@ -83,14 +83,14 @@ final class PhpDocs
 
     /**
      * @param class-string<SomeInterface> $class
-     * @return class-string<Rector\Tests\DeadCode\Rector\FunctionLike\NarrowTooWideReturnTypeRector\Source\SomeInterface>
+     * @return class-string<\Rector\Tests\DeadCode\Rector\FunctionLike\NarrowTooWideReturnTypeRector\Source\SomeInterface>
      */
     public function bar(string $class): string
     {
         return $class;
     }
 
-    /** @return class-string<Rector\Tests\DeadCode\Rector\FunctionLike\NarrowTooWideReturnTypeRector\Source\SomeInterface> */
+    /** @return class-string<\Rector\Tests\DeadCode\Rector\FunctionLike\NarrowTooWideReturnTypeRector\Source\SomeInterface> */
     public function baz(string $class): string
     {
         return SomeInterface::class;

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector/Fixture/add_prefix_backslash.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockGetterReturnArrayFromPropertyDocblockVarRector/Fixture/add_prefix_backslash.php.inc
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockGetterReturnArrayFromPropertyDocblockVarRector\Fixture;
+
+use App\Support\Benchmarking\Contracts\Metric;
+use LogicException;
+
+class AddPrefixBackslash extends LogicException
+{
+    public function __construct(
+        /** @var array<string, array<int, class-string<Metric>>> */
+        protected array $duplicateNames,
+    ) {
+        parent::__construct(
+            'Some solutions have duplicate names.',
+        );
+    }
+
+    public function getDuplicateNames(): array
+    {
+        return $this->duplicateNames;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockGetterReturnArrayFromPropertyDocblockVarRector\Fixture;
+
+use App\Support\Benchmarking\Contracts\Metric;
+use LogicException;
+
+class AddPrefixBackslash extends LogicException
+{
+    public function __construct(
+        /** @var array<string, array<int, class-string<Metric>>> */
+        protected array $duplicateNames,
+    ) {
+        parent::__construct(
+            'Some solutions have duplicate names.',
+        );
+    }
+
+    /**
+     * @return array<string, class-string<\App\Support\Benchmarking\Contracts\Metric>[]>
+     */
+    public function getDuplicateNames(): array
+    {
+        return $this->duplicateNames;
+    }
+}
+
+?>

--- a/src/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/ClassStringTypeMapper.php
@@ -8,7 +8,9 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\ClassStringType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
 use Rector\Php\PhpVersionProvider;
 use Rector\PHPStanStaticTypeMapper\Contract\TypeMapperInterface;
 use Rector\ValueObject\PhpVersionFeature;
@@ -33,6 +35,20 @@ final readonly class ClassStringTypeMapper implements TypeMapperInterface
      */
     public function mapToPHPStanPhpDocTypeNode(Type $type): TypeNode
     {
+        $type = TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+            if (! $type instanceof ObjectType) {
+                return $traverse($type);
+            }
+
+            $typeClass = $type::class;
+
+            if ($typeClass === 'PHPStan\Type\ObjectType') {
+                return new ObjectType('\\' . $type->getClassName());
+            }
+
+            return $traverse($type);
+        });
+
         return $type->toPhpDocNode();
     }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9421