### PR TITLE
Handle crash redeclare isPHPStanTestPreloaded() function

### DIFF
--- a/build/build-preload.php
+++ b/build/build-preload.php
@@ -58,13 +58,6 @@ if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
 
-// edge case during Rector tests case, happens when
-// 1. phpstan autoload test case is triggered first,
-// 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
-    return;
-}
-
 if (! function_exists('isPHPStanTestPreloaded')) {
     function isPHPStanTestPreloaded(): bool
     {
@@ -74,6 +67,13 @@ if (! function_exists('isPHPStanTestPreloaded')) {
 
         return interface_exists(Node::class, false);
     }
+}
+
+// edge case during Rector tests case, happens when
+// 1. phpstan autoload test case is triggered first,
+// 2. all php-parser classes are loaded,
+if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
+    return;
 }
 CODE_SAMPLE;
 

--- a/build/build-preload.php
+++ b/build/build-preload.php
@@ -65,13 +65,15 @@ if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
     return;
 }
 
-function isPHPStanTestPreloaded(): bool
-{
-    if (! class_exists(PHPStanTestCase::class, false)) {
-        return false;
-    }
+if (! function_exists('isPHPStanTestPreloaded')) {
+    function isPHPStanTestPreloaded(): bool
+    {
+        if (! class_exists(PHPStanTestCase::class, false)) {
+            return false;
+        }
 
-    return interface_exists(Node::class, false);
+        return interface_exists(Node::class, false);
+    }
 }
 CODE_SAMPLE;
 

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -16,13 +16,15 @@ if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
     return;
 }
 
-function isPHPStanTestPreloaded(): bool
-{
-    if (! class_exists(PHPStanTestCase::class, false)) {
-        return false;
-    }
+if (! function_exists('isPHPStanTestPreloaded')) {
+    function isPHPStanTestPreloaded(): bool
+    {
+        if (! class_exists(PHPStanTestCase::class, false)) {
+            return false;
+        }
 
-    return interface_exists(Node::class, false);
+        return interface_exists(Node::class, false);
+    }
 }
 
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node.php';

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -9,13 +9,6 @@ if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
 
-// edge case during Rector tests case, happens when
-// 1. phpstan autoload test case is triggered first,
-// 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
-    return;
-}
-
 if (! function_exists('isPHPStanTestPreloaded')) {
     function isPHPStanTestPreloaded(): bool
     {
@@ -25,6 +18,13 @@ if (! function_exists('isPHPStanTestPreloaded')) {
 
         return interface_exists(Node::class, false);
     }
+}
+
+// edge case during Rector tests case, happens when
+// 1. phpstan autoload test case is triggered first,
+// 2. all php-parser classes are loaded,
+if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
+    return;
 }
 
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node.php';

--- a/preload.php
+++ b/preload.php
@@ -9,13 +9,6 @@ if (defined('__PHPSTAN_RUNNING__')) {
     return;
 }
 
-// edge case during Rector tests case, happens when
-// 1. phpstan autoload test case is triggered first,
-// 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
-    return;
-}
-
 if (! function_exists('isPHPStanTestPreloaded')) {
     function isPHPStanTestPreloaded(): bool
     {
@@ -25,6 +18,13 @@ if (! function_exists('isPHPStanTestPreloaded')) {
 
         return interface_exists(Node::class, false);
     }
+}
+
+// edge case during Rector tests case, happens when
+// 1. phpstan autoload test case is triggered first,
+// 2. all php-parser classes are loaded,
+if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
+    return;
 }
 
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node.php';

--- a/preload.php
+++ b/preload.php
@@ -16,13 +16,15 @@ if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
     return;
 }
 
-function isPHPStanTestPreloaded(): bool
-{
-    if (! class_exists(PHPStanTestCase::class, false)) {
-        return false;
-    }
+if (! function_exists('isPHPStanTestPreloaded')) {
+    function isPHPStanTestPreloaded(): bool
+    {
+        if (! class_exists(PHPStanTestCase::class, false)) {
+            return false;
+        }
 
-    return interface_exists(Node::class, false);
+        return interface_exists(Node::class, false);
+    }
 }
 
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node.php';


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/9430

I will check if it can be reproduced at https://github.com/rectorphp/rector-compat-tests

@X-Coder264 could you verify by **manual** patch of this into `vendor/rector/rector/preload.php` ? Better if you can provide minimal reproducible repo so we can properly test it :)