### PR TITLE
[Alternative] Use direct check to avoid redeclare function isPHPStanTestPreloaded()

### DIFF
--- a/build/build-preload.php
+++ b/build/build-preload.php
@@ -61,17 +61,10 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
+if (defined('PHPUNIT_COMPOSER_INSTALL')
+    && class_exists(PHPStanTestCase::class, false)
+    && interface_exists(Node::class, false)) {
     return;
-}
-
-function isPHPStanTestPreloaded(): bool
-{
-    if (! class_exists(PHPStanTestCase::class, false)) {
-        return false;
-    }
-
-    return interface_exists(Node::class, false);
 }
 CODE_SAMPLE;
 

--- a/preload-split-package.php
+++ b/preload-split-package.php
@@ -12,17 +12,10 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
+if (defined('PHPUNIT_COMPOSER_INSTALL')
+    && class_exists(PHPStanTestCase::class, false)
+    && interface_exists(Node::class, false)) {
     return;
-}
-
-function isPHPStanTestPreloaded(): bool
-{
-    if (! class_exists(PHPStanTestCase::class, false)) {
-        return false;
-    }
-
-    return interface_exists(Node::class, false);
 }
 
 require_once __DIR__ . '/../../../vendor/nikic/php-parser/lib/PhpParser/Node.php';

--- a/preload.php
+++ b/preload.php
@@ -12,17 +12,10 @@ if (defined('__PHPSTAN_RUNNING__')) {
 // edge case during Rector tests case, happens when
 // 1. phpstan autoload test case is triggered first,
 // 2. all php-parser classes are loaded,
-if (defined('PHPUNIT_COMPOSER_INSTALL') && isPHPStanTestPreloaded()) {
+if (defined('PHPUNIT_COMPOSER_INSTALL')
+    && class_exists(PHPStanTestCase::class, false)
+    && interface_exists(Node::class, false)) {
     return;
-}
-
-function isPHPStanTestPreloaded(): bool
-{
-    if (! class_exists(PHPStanTestCase::class, false)) {
-        return false;
-    }
-
-    return interface_exists(Node::class, false);
 }
 
 require_once __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Node.php';


### PR DESCRIPTION
@TomasVotruba per https://github.com/rectorphp/rector-src/pull/7460#issuecomment-3392541410

This is alternative PR for handle crash redeclare function `isPHPStanTestPreloaded`

Ref https://github.com/rectorphp/rector/issues/9430