### PR TITLE
[BetterPhpDocParser] Unique handling string on BracketsAwareUnionTypeNode

### DIFF
--- a/src/BetterPhpDocParser/ValueObject/Type/BracketsAwareUnionTypeNode.php
+++ b/src/BetterPhpDocParser/ValueObject/Type/BracketsAwareUnionTypeNode.php
@@ -25,12 +25,20 @@ final class BracketsAwareUnionTypeNode extends UnionTypeNode implements Stringab
      */
     public function __toString(): string
     {
-        $this->types = array_unique($this->types, SORT_REGULAR);
-        if (! $this->isWrappedInBrackets) {
-            return implode('|', $this->types);
+        $types = [];
+
+        // get the actual strings first before array_unique
+        // to avoid similar object but different printing to be treated as unique
+        foreach ($this->types as $type) {
+            $types[] = (string) $type;
         }
 
-        return '(' . implode('|', $this->types) . ')';
+        $types = array_unique($types);
+        if (! $this->isWrappedInBrackets) {
+            return implode('|', $types);
+        }
+
+        return '(' . implode('|', $types) . ')';
     }
 
     public function isWrappedInBrackets(): bool


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/7459

Get the actual strings first before array_unique to avoid similar object but different printing to be treated as unique