### PR TITLE
[DeadCode] Skip vars exists in static vars on RemoveNonExistingVarAnnotationRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_static_variable_in_method.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_static_variable_in_method.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector\Fixture;
+
+final class SkipStaticVariableInMethod
+{
+    public function run(int $param): int
+    {
+        /**
+         * Rector should not remove this @var annotation.
+         *
+         * @var array<int,int>
+         */
+        static $cached_result = [];
+
+        if (!isset($cached_result[$param])) {
+            $cached_result[$param] = doExpensiveCalculation($param);
+        }
+
+        return $cached_result[$param];
+    }
+}

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -128,6 +128,12 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($stmt instanceof Static_) {
+                foreach ($stmt->vars as $staticVar) {
+                    $extractValues[] = $this->getName($staticVar->var);
+                }
+            }
+
             if ($this->shouldSkip($node, $key, $stmt, $extractValues)) {
                 continue;
             }

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -130,7 +130,13 @@ CODE_SAMPLE
 
             if ($stmt instanceof Static_) {
                 foreach ($stmt->vars as $staticVar) {
-                    $extractValues[] = $this->getName($staticVar->var);
+                    $staticVarName = $this->getName($staticVar->var);
+
+                    if ($staticVarName === null) {
+                        continue;
+                    }
+
+                    $extractValues[] = $staticVarName;
                 }
             }
 


### PR DESCRIPTION
Closes #7456 Fixes https://github.com/rectorphp/rector/issues/9428