### PR TITLE
[CodeQuality] Skip non-variable fetch on VariableConstFetchToClassConstFetchRector as may cause side effect

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Fixture/skip_non_variable.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Fixture/skip_non_variable.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToClassConstFetchRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToClassConstFetchRector\Source\ClassWithSideEffect;
+
+final class SkipNonVariable
+{
+    function sideEffect(): ClassWithSideEffect
+    {
+        return new ClassWithSideEffect();
+    }
+
+    public function run()
+    {
+        echo $this->sideEffect()::SOME_VALUE;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Source/ClassWithSideEffect.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Source/ClassWithSideEffect.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToClassConstFetchRector\Source;
+
+class ClassWithSideEffect
+{
+    public const SOME_VALUE = 'value';
+
+    public function __construct()
+    {
+        echo 'side effect ';
+    }
+}

--- a/rules/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\ClassConstFetch;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Type\ObjectType;
@@ -62,7 +62,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?ClassConstFetch
     {
-        if (! $node->class instanceof Expr) {
+        if (! $node->class instanceof Variable) {
             return null;
         }
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/7457#pullrequestreview-3326604176
see https://3v4l.org/UkiYR

the rule per its name, should only check on Variable.