### PR TITLE
Fix autoload preload on PHPUnit 12+ on global installation

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -2,31 +2,6 @@
 
 declare(strict_types=1);
 
-use PHPParser\Node;
-use PHPUnit\Runner\Version;
-
-/**
- * The preload.php contains 2 dependencies
- *      - phpstan/phpdoc-parser
- *      - nikic/php-parser
- *
- * They need to be loaded early to avoid conflict version between rector prefixed vendor and Project vendor
- * For example, a project may use phpstan/phpdoc-parser v1, while rector uses phpstan/phpdoc-parser uses v2, that will error as class or logic are different.
- */
-if (
-    // verify PHPUnit is running
-    defined('PHPUNIT_COMPOSER_INSTALL')
-
-    // no need to preload if Node interface exists
-    && ! interface_exists(Node::class, false)
-
-    // ensure force autoload version with class_exists() with true argument as not yet loaded
-    // for phpunit 12+ only
-    && class_exists(Version::class, true) && (int) Version::id() >= 12
-) {
-    require_once __DIR__ . '/preload.php';
-}
-
 // inspired by https://github.com/phpstan/phpstan/blob/master/bootstrap.php
 spl_autoload_register(function (string $class): void {
     static $composerAutoloader;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -154,6 +154,8 @@ parameters:
                 # for config class reflection
                 - src/Bootstrap/ExtensionConfigResolver.php
                 - src/Validation/RectorConfigValidator.php
+                # for phpunit version check
+                - src/Testing/PHPUnit/AbstractLazyTestCase.php
 
         # use of internal phpstan classes
         -

--- a/scoper.php
+++ b/scoper.php
@@ -33,6 +33,7 @@ return [
     'exclude-classes' => [
         'PHPUnit\Framework\Constraint\IsEqual',
         'PHPUnit\Framework\TestCase',
+        'PHPUnit\Runner\Version',
         'PHPUnit\Framework\ExpectationFailedException',
 
         // native class on php 8.3+

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Testing\PHPUnit;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 use Rector\Config\RectorConfig;
 use Rector\DependencyInjection\LazyContainerFactory;
 
@@ -63,7 +64,13 @@ abstract class AbstractLazyTestCase extends TestCase
     {
         if (file_exists(__DIR__ . '/../../../preload.php')) {
             if (file_exists(__DIR__ . '/../../../vendor')) {
-                require_once __DIR__ . '/../../../preload.php';
+                /**
+                 * On PHPUnit 12+, when classmap autoloaded, it means preload already loaded early
+                 */
+                if (! class_exists(Version::class, true) || (int) Version::id() < 12) {
+                    require_once __DIR__ . '/../../../preload.php';
+                }
+
                 // test case in rector split package
             } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
                 require_once __DIR__ . '/../../../preload-split-package.php';


### PR DESCRIPTION
@TomasVotruba this is my original alternative solution which previously you closed it at:

- https://github.com/rectorphp/rector-src/pull/7452

with check inside `AbstractLazyTestCase` instead of global `bootstrap.php` that included on composer.json -> files.

This to cover:

- https://github.com/rectorphp/rector-compat-tests/pull/3

This is safer, with the following reason:

- Doesn't enforce load our `preload.php` when it doesn't run rector phpunit
- Only load preload.php on phpunit < 12, when on PHPUnit >=12, the preload already checked, since classmap is loaded by next check

https://github.com/rectorphp/rector-src/blob/d0866a8efe61344dc2b2d93bc6ef44b81417f153/src/Testing/PHPUnit/AbstractLazyTestCase.php#L73-L75

- Rector bin already use it in `bin/rector.php`, so unrelated to it

https://github.com/rectorphp/rector-src/blob/d0866a8efe61344dc2b2d93bc6ef44b81417f153/bin/rector.php#L116-L118

