### PR TITLE
[CodingStyle] Skip compare binary op on BinaryOpStandaloneAssignsToDirectRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector/Fixture/skip_compare_assign_op.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector/Fixture/skip_compare_assign_op.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\BinaryOpStandaloneAssignsToDirectRector\Fixture;
+
+final class SkipCompareAssignOp
+{
+    public function run($first, $second)
+    {
+        $first += 1 + 1 + 1 + 1 +1 + 1 + 1 + 1 + 1 + 1;
+        $second += 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2;
+
+        return $first <=> $second;
+    }
+}

--- a/rules-tests/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector/Fixture/skip_compare_binary_op.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector/Fixture/skip_compare_binary_op.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\BinaryOpStandaloneAssignsToDirectRector\Fixture;
+
+final class SkipCompareBinaryOp
+{
+    public function run()
+    {
+        $first = 1 + 1 + 1 + 1 +1 + 1 + 1 + 1 + 1 + 1;
+        $second = 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2;
+
+        return $first <=> $second;
+    }
+}

--- a/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
@@ -137,6 +137,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($assign->expr instanceof BinaryOp) {
+            return null;
+        }
+
         return new VariableAndExprAssign($assign->var, $assign->expr);
     }
 }


### PR DESCRIPTION
I think the following code should be skipped:

```php
        $first = 1 + 1 + 1 + 1 +1 + 1 + 1 + 1 + 1 + 1;
        $second = 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2;

        return $first <=> $second;
```

since it got unreadable after applied.

```diff
-        $first = 1 + 1 + 1 + 1 +1 + 1 + 1 + 1 + 1 + 1;
-        $second = 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2;
-
-        return $first <=> $second;
+        return 1 + 1 + 1 + 1 +1 + 1 + 1 + 1 + 1 + 1 <=> 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2;
```