### PR TITLE
[CodingStyle] Skip by ref params on BinaryOpStandaloneAssignsToDirectRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector/Fixture/skip_by_ref_from_param_variable.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector/Fixture/skip_by_ref_from_param_variable.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassMethod\BinaryOpStandaloneAssignsToDirectRector\Fixture;
+
+final class SkipByRefFromParamVariable
+{
+    public function run(&$first, &$second)
+    {
+        $first = 100;
+        $second = 200;
+
+        return $first <=> $second;
+    }
+}

--- a/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
@@ -105,6 +105,15 @@ CODE_SAMPLE
             return null;
         }
 
+        $resolveParamByRefVariables = $this->resolveParamByRefVariables($node);
+        if ($this->isNames($binaryOp->left, $resolveParamByRefVariables)) {
+            return null;
+        }
+
+        if ($this->isNames($binaryOp->right, $resolveParamByRefVariables)) {
+            return null;
+        }
+
         $binaryOp->left = $firstVariableAndExprAssign->getExpr();
         $binaryOp->right = $secondVariableAndExprAssign->getExpr();
 
@@ -115,6 +124,32 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::VARIADIC_PARAM;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveParamByRefVariables(ClassMethod|Function_|Closure $node): array
+    {
+        $paramByRefVariables = [];
+        foreach ($node->params as $param) {
+            if (! $param->var instanceof Variable) {
+                continue;
+            }
+
+            if (! $param->byRef) {
+                continue;
+            }
+
+            $paramName = $this->getName($param->var);
+            if ($paramName === null) {
+                continue;
+            }
+
+            $paramByRefVariables[] = $paramName;
+        }
+
+        return $paramByRefVariables;
     }
 
     private function matchToVariableAssignExpr(Stmt $stmt): ?VariableAndExprAssign

--- a/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;

--- a/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/BinaryOpStandaloneAssignsToDirectRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;


### PR DESCRIPTION
When it continue from by ref params, it should be skipped, as value changed via reference:

```php
final class SkipByRefFromParamVariable
{
    public function run(&$first, &$second)
    {
        $first = 100;
        $second = 200;

        return $first <=> $second;
    }
}
```