### PR TITLE
[autoload] Remove PHPUnit version 12 check on preload.php load

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -13,7 +13,6 @@ use PHPUnit\Runner\Version;
  * They need to be loaded early to avoid conflict version between rector prefixed vendor and Project vendor
  * For example, a project may use phpstan/phpdoc-parser v1, while rector uses phpstan/phpdoc-parser uses v2, that will error as class or logic are different.
  */
-$isGlobalPHPUnit = class_exists(Version::class, false);
 if (
     // verify PHPUnit is running
     defined('PHPUNIT_COMPOSER_INSTALL')
@@ -21,11 +20,8 @@ if (
     // no need to preload if Node interface exists
     && ! interface_exists(Node::class, false)
 
-    && ! $isGlobalPHPUnit
-
-    // ensure force autoload version with class_exists() with true argument as not yet loaded
-    // for phpunit 12+ only
-    && class_exists(Version::class, true) && (int) Version::id() >= 12
+    // load preload.php on local PHPUnit installation
+    && ! class_exists(Version::class, false)
 ) {
     require_once __DIR__ . '/preload.php';
 }

--- a/scoper.php
+++ b/scoper.php
@@ -33,7 +33,6 @@ return [
     'exclude-classes' => [
         'PHPUnit\Framework\Constraint\IsEqual',
         'PHPUnit\Framework\TestCase',
-        'PHPUnit\Runner\Version',
         'PHPUnit\Framework\ExpectationFailedException',
 
         // native class on php 8.3+

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Testing\PHPUnit;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\Version;
 use Rector\Config\RectorConfig;
 use Rector\DependencyInjection\LazyContainerFactory;
 
@@ -64,13 +63,7 @@ abstract class AbstractLazyTestCase extends TestCase
     {
         if (file_exists(__DIR__ . '/../../../preload.php')) {
             if (file_exists(__DIR__ . '/../../../vendor')) {
-                /**
-                 * On PHPUnit 12+, when classmap autoloaded, it means preload already loaded early
-                 */
-                if (! class_exists(Version::class, true) || (int) Version::id() < 12) {
-                    require_once __DIR__ . '/../../../preload.php';
-                }
-
+                require_once __DIR__ . '/../../../preload.php';
                 // test case in rector split package
             } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
                 require_once __DIR__ . '/../../../preload-split-package.php';


### PR DESCRIPTION
@TomasVotruba per your request at 

- https://github.com/rectorphp/rector-compat-tests/pull/4#pullrequestreview-3327032755

this ensure run normal `vendor/bin/phpunit` works without order check. 

----

This however can't fix global installation tho, as global vendor/autoload is forced loaded early that we can't possibly cover, for now as far as I tried.