### PR TITLE
Revert "Fix global require-dev phpunit 12"

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -33,7 +33,6 @@ return [
     'exclude-classes' => [
         'PHPUnit\Framework\Constraint\IsEqual',
         'PHPUnit\Framework\TestCase',
-        'PHPUnit\Runner\Version',
         'PHPUnit\Framework\ExpectationFailedException',
 
         // native class on php 8.3+

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Testing\PHPUnit;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\Version;
 use Rector\Config\RectorConfig;
 use Rector\DependencyInjection\LazyContainerFactory;
 
@@ -64,12 +63,7 @@ abstract class AbstractLazyTestCase extends TestCase
     {
         if (file_exists(__DIR__ . '/../../../preload.php')) {
             if (file_exists(__DIR__ . '/../../../vendor')) {
-                /**
-                 * On PHPUnit 12+, when classmap autoloaded, it means preload already loaded early
-                 */
-                if (! class_exists(Version::class, true) || (int) Version::id() < 12) {
-                    require_once __DIR__ . '/../../../preload.php';
-                }
+                require_once __DIR__ . '/../../../preload.php';
                 // test case in rector split package
             } elseif (file_exists(__DIR__ . '/../../../../../../vendor')) {
                 require_once __DIR__ . '/../../../preload-split-package.php';


### PR DESCRIPTION
Reverts rectorphp/rector-src#7475

actually, this is already expected, 

* "stable" -> error Node which means existing 2.2.2
* "dev" -> show diff phpunit on Rector stmts aware

I will update test on https://github.com/rectorphp/rector-compat-tests so dev-main doesn't depends on StmtsAwareInterface for global.