### PR TITLE
[TypeDeclaration] Skip multi sprintf possibly falsy on AddParamStringTypeFromSprintfUseRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamStringTypeFromSprintfUseRector/Fixture/skip_multi_sprintf_possibly_falsy.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamStringTypeFromSprintfUseRector/Fixture/skip_multi_sprintf_possibly_falsy.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamStringTypeFromSprintfUseRector\Fixture;
+
+class SkipMultiSprintfPossiblyFalsy
+{
+    public function columnExpr($columnExpr, string $default): string
+    {
+        if (rand(0, 1)) {
+            return sprintf("hello %s", $columnExpr);
+        }
+
+        // $columnExpr can be anything empty: false | null | '' | 0 | '0' | []
+        if (empty($columnExpr)) {
+            return $default;
+        }
+
+        return sprintf("hello %s", $columnExpr);
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/VariableInSprintfMaskMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/VariableInSprintfMaskMatcher.php
@@ -32,56 +32,60 @@ final readonly class VariableInSprintfMaskMatcher
     {
         $funcCalls = $this->betterNodeFinder->findInstancesOfScoped((array) $functionLike->stmts, FuncCall::class);
 
-        foreach ($funcCalls as $funcCall) {
-            if (! $this->nodeNameResolver->isName($funcCall->name, 'sprintf')) {
+        if (count($funcCalls) !== 1) {
+            return false;
+        }
+
+        $funcCall = $funcCalls[0];
+
+        if (! $this->nodeNameResolver->isName($funcCall->name, 'sprintf')) {
+            return false;
+        }
+
+        if ($funcCall->isFirstClassCallable()) {
+            return false;
+        }
+
+        $args = $funcCall->getArgs();
+        if (count($args) < 2) {
+            return false;
+        }
+
+        /** @var Arg $messageArg */
+        $messageArg = array_shift($args);
+
+        $messageValue = $this->valueResolver->getValue($messageArg->value);
+        if (! is_string($messageValue)) {
+            return false;
+        }
+
+        // match all %s, %d types by position
+        $masks = Strings::match($messageValue, '#%[sd]#');
+
+        foreach ($args as $position => $arg) {
+            if (! $arg->value instanceof Variable) {
                 continue;
             }
 
-            if ($funcCall->isFirstClassCallable()) {
+            if (! $this-> nodeNameResolver->isName($arg->value, $variableName)) {
                 continue;
             }
 
-            $args = $funcCall->getArgs();
-            if (count($args) < 2) {
+            if (! isset($masks[$position])) {
                 continue;
             }
 
-            /** @var Arg $messageArg */
-            $messageArg = array_shift($args);
-
-            $messageValue = $this->valueResolver->getValue($messageArg->value);
-            if (! is_string($messageValue)) {
+            $knownMaskOnPosition = $masks[$position];
+            if ($knownMaskOnPosition !== $mask) {
                 continue;
             }
 
-            // match all %s, %d types by position
-            $masks = Strings::match($messageValue, '#%[sd]#');
-
-            foreach ($args as $position => $arg) {
-                if (! $arg->value instanceof Variable) {
-                    continue;
-                }
-
-                if (! $this-> nodeNameResolver->isName($arg->value, $variableName)) {
-                    continue;
-                }
-
-                if (! isset($masks[$position])) {
-                    continue;
-                }
-
-                $knownMaskOnPosition = $masks[$position];
-                if ($knownMaskOnPosition !== $mask) {
-                    continue;
-                }
-
-                $type = $this->nodeTypeResolver->getNativeType($arg->value);
-                if ($type instanceof MixedType && $type->getSubtractedType() instanceof UnionType) {
-                    continue;
-                }
-
-                return true;
+            $type = $this->nodeTypeResolver->getNativeType($arg->value);
+            if ($type instanceof MixedType && $type->getSubtractedType() instanceof UnionType) {
+                continue;
             }
+
+            return true;
         }
 
         return false;


### PR DESCRIPTION
@TomasVotruba when there are multi sprintf, and loop already return true early on `VariableInSprintfMaskMatcher`, this early mark as string, which should not, it should verify when there is sprintf with `false` mark in the loop.