### PR TITLE
[TypeDeclaration] Skip possibly both clear + unclear type used on AddParamFromDimFetchKeyUseRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector/Fixture/skip_mix_clear_and_unclear_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector/Fixture/skip_mix_clear_and_unclear_type.php.inc
@@ -7,14 +7,14 @@ final class SkipMixClearAndUnClearType
     public function process($key, $unclearType)
     {
         if (rand(0, 1)) {
-            return $unclearType[$key];
+            $items = [
+                'first' => 'Firstitem',
+                'second' => 'Seconditem',
+            ];
+
+            return $items[$key];
         }
 
-        $items = [
-            'first' => 'Firstitem',
-            'second' => 'Seconditem',
-        ];
-
-        return $items[$key];
+        return $unclearType[$key];
     }
 }

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector/Fixture/skip_mix_clear_and_unclear_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector/Fixture/skip_mix_clear_and_unclear_type.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamFromDimFetchKeyUseRector\Fixture;
+
+final class Fixture
+{
+    public function process($key, $unclearType)
+    {
+        if (rand(0, 1)) {
+            return $unclearType[$key];
+        }
+
+        $items = [
+            'first' => 'Firstitem',
+            'second' => 'Seconditem',
+        ];
+
+        return $items[$key];
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector/Fixture/skip_mix_clear_and_unclear_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector/Fixture/skip_mix_clear_and_unclear_type.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamFromDimFetchKeyUseRector\Fixture;
 
-final class Fixture
+final class SkipMixClearAndUnClearType
 {
     public function process($key, $unclearType)
     {

--- a/rules/TypeDeclaration/NodeAnalyzer/VariableInSprintfMaskMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/VariableInSprintfMaskMatcher.php
@@ -31,9 +31,7 @@ final readonly class VariableInSprintfMaskMatcher
     public function matchMask(ClassMethod|Function_ $functionLike, string $variableName, string $mask): bool
     {
         $funcCalls = $this->betterNodeFinder->findInstancesOfScoped((array) $functionLike->stmts, FuncCall::class);
-        $funcCalls = array_values(array_filter($funcCalls, function (FuncCall $funcCall): bool {
-            return $this->nodeNameResolver->isName($funcCall->name, 'sprintf');
-        }));
+        $funcCalls = array_values(array_filter($funcCalls, fn(FuncCall $funcCall): bool => $this->nodeNameResolver->isName($funcCall->name, 'sprintf')));
 
         if (count($funcCalls) !== 1) {
             return false;

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector.php
@@ -108,32 +108,34 @@ CODE_SAMPLE
                     continue;
                 }
 
+                $paramTypeNode = null;
+
                 foreach ($dimFetches as $dimFetch) {
                     $dimFetchType = $this->getType($dimFetch->var);
 
                     if (! $dimFetchType instanceof ArrayType && ! $dimFetchType instanceof ConstantArrayType) {
-                        continue;
+                        continue 2;
                     }
 
                     if ($dimFetch->dim instanceof Variable) {
                         $type = $this->nodeTypeResolver->getType($dimFetch->dim);
                         if ($type instanceof UnionType) {
-                            continue;
+                            continue 2;
                         }
                     }
-
-                    $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
-                        $dimFetchType->getKeyType(),
-                        TypeKind::PARAM
-                    );
-
-                    if (! $paramTypeNode instanceof Node) {
-                        continue;
-                    }
-
-                    $param->type = $paramTypeNode;
-                    $hasChanged = true;
                 }
+
+                $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+                    $dimFetchType->getKeyType(),
+                    TypeKind::PARAM
+                );
+
+                if (! $paramTypeNode instanceof Node) {
+                    continue;
+                }
+
+                $param->type = $paramTypeNode;
+                $hasChanged = true;
             }
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamFromDimFetchKeyUseRector.php
@@ -108,8 +108,6 @@ CODE_SAMPLE
                     continue;
                 }
 
-                $paramTypeNode = null;
-
                 foreach ($dimFetches as $dimFetch) {
                     $dimFetchType = $this->getType($dimFetch->var);
 


### PR DESCRIPTION
@staabm per https://github.com/rectorphp/rector-src/pull/7489#issuecomment-3396566883

Loop and apply param type should not happen, it should continue to outer loop if there is no match type.