### PR TITLE
[Php81] Fix missing implements MinPhpVersionInterface on FunctionLikeToFirstClassCallableRector

### DIFF
--- a/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
+++ b/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
@@ -20,13 +20,15 @@ use PhpParser\NodeVisitor;
 use PHPStan\Analyser\Scope;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\FunctionLikeToFirstClassCallableRectorTest
  */
-final class FunctionLikeToFirstClassCallableRector extends AbstractRector
+final class FunctionLikeToFirstClassCallableRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -237,5 +239,10 @@ CODE_SAMPLE
         }
 
         return $callLike->var instanceof CallLike;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::FIRST_CLASS_CALLABLE_SYNTAX;
     }
 }


### PR DESCRIPTION
By register the `FunctionLikeToFirstClassCallableRector` to php 8.1 set, the rule needs to implements `MinPhpVersionInterface`