### PR TITLE
[Php84] Skip has mix between normal property and readonly promoted property on PropertyHookRector

### DIFF
--- a/rules-tests/Php84/Rector/Class_/PropertyHookRector/Fixture/skip_mix_with_existing_readonly_promoted_property.php.inc
+++ b/rules-tests/Php84/Rector/Class_/PropertyHookRector/Fixture/skip_mix_with_existing_readonly_promoted_property.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php84\Rector\Class_\PropertyHookRector\Fixture;
+
+final class SkipMixReadonlyPromotedProperty
+{
+    private string $name;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = ucfirst($name);
+    }
+
+    public function __construct(
+        private readonly int $value,
+    )
+    {
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/rules/Php84/NodeFinder/SetterAndGetterFinder.php
+++ b/rules/Php84/NodeFinder/SetterAndGetterFinder.php
@@ -7,6 +7,7 @@ namespace Rector\Php84\NodeFinder;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\TypeDeclaration\NodeAnalyzer\ClassMethodAndPropertyAnalyzer;
+use Rector\ValueObject\MethodName;
 
 final readonly class SetterAndGetterFinder
 {
@@ -21,6 +22,16 @@ final readonly class SetterAndGetterFinder
     public function findGetterAndSetterClassMethods(Class_ $class, string $propertyName): array
     {
         $classMethods = [];
+
+        $constructClassMethod = $class->getMethod(MethodName::CONSTRUCT);
+
+        if ($constructClassMethod instanceof ClassMethod) {
+            foreach ($constructClassMethod->params as $param) {
+                if ($param->isReadonly()) {
+                    return [];
+                }
+            }
+        }
 
         $getterClassMethod = $this->findGetterClassMethod($class, $propertyName);
         if ($getterClassMethod instanceof ClassMethod) {


### PR DESCRIPTION
@TomasVotruba this PR covers:

- has normal property
- has readonly promoted property

so should be skipped as well, ref https://github.com/rectorphp/rector-src/pull/7498#pullrequestreview-3335127565