### PR TITLE
[TypeDeclaration] Skip Assert\Callback typed on ParamTypeByMethodCallTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_in_form_builder_callback.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Fixture/skip_in_form_builder_callback.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class SkipInFormBuilderCallback extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('someType', DocumentType::class, [
+            'class' => SomeType::class,
+            'required' => false,
+            'label' => 'Some Type',
+            'attr' => [
+                'data-help' => 'some data help',
+            ],
+            'constraints' => [
+                new Assert\Callback(function ($someType, ExecutionContextInterface $context): void {
+                    if ($someType === null) {
+                        return;
+                    }
+
+                    $this->use($someType);
+
+                    // some logic here
+                })
+            ]
+        ]);
+    }
+
+    private function use(SomeType $someType): void
+    {
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallerParamMatcher.php
@@ -22,9 +22,11 @@ use PhpParser\Node\UnionType;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PhpParser\AstResolver;
+use Rector\PHPStan\ScopeFetcher;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
 final readonly class CallerParamMatcher
@@ -120,6 +122,7 @@ final readonly class CallerParamMatcher
     {
         $paramName = $this->nodeNameResolver->getName($param);
 
+        $scope = ScopeFetcher::fetch($call);
         foreach ($call->args as $argPosition => $arg) {
             if (! $arg instanceof Arg) {
                 continue;
@@ -131,6 +134,11 @@ final readonly class CallerParamMatcher
 
             if (! $this->nodeNameResolver->isName($arg->value, $paramName)) {
                 continue;
+            }
+
+            $currentType = $scope->getType($arg->value);
+            if ($currentType instanceof MixedType && $currentType->getSubtractedType() instanceof Type) {
+                return null;
             }
 
             return $argPosition;

--- a/stubs/Symfony/Component/Form/AbstractType.php
+++ b/stubs/Symfony/Component/Form/AbstractType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+if (class_exists('Symfony\Component\Form\AbstractType')) {
+    return;
+}
+
+class AbstractType
+{
+}

--- a/stubs/Symfony/Component/Form/FormBuilderInterface.php
+++ b/stubs/Symfony/Component/Form/FormBuilderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+if (interface_exists('Symfony\Component\Form\FormBuilderInterface')) {
+    return;
+}
+
+class FormBuilderInterface
+{
+    public function add(string|self $child, ?string $type = null, array $options = []): static;
+}

--- a/stubs/Symfony/Component/Validator/Constraints/Callback.php
+++ b/stubs/Symfony/Component/Validator/Constraints/Callback.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+if (class_exists('Symfony\Component\Validator\Constraints\Callback')) {
+    return;
+}
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class Callback
+{
+    /**
+     * @var string|callable
+     */
+    public $callback;
+
+    public function __construct(array|string|callable|null $callback = null, ?array $groups = null, mixed $payload = null, array $options = [])
+    {
+    }
+}

--- a/stubs/Symfony/Component/Validator/Constraints/Callback.php
+++ b/stubs/Symfony/Component/Validator/Constraints/Callback.php
@@ -1,17 +1,6 @@
 <?php
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Symfony\Component\Validator\Constraints;
-
-use Symfony\Component\Validator\Constraint;
 
 if (class_exists('Symfony\Component\Validator\Constraints\Callback')) {
     return;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/7493#issuecomment-3419840564

This change is invalid:

```diff
        $builder->add('someType', DocumentType::class, [
            'class' => SomeType::class,
            'required' => false,
            'label' => 'Some Type',
            'attr' => [
                'data-help' => 'some data help',
            ],
            'constraints' => [
-                new Assert\Callback(function ($someType, ExecutionContextInterface $context): void {
+                new Assert\Callback(function (SomeType $someType, ExecutionContextInterface $context): void {
                    if ($someType === null) {
                        return;
                    }

                    $this->use($someType);
```

should be skipped.