### PR TITLE
Fix typo doc fixture

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamStringTypeFromSprintfUseRector/Fixture/skip_conditional_non_string.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamStringTypeFromSprintfUseRector/Fixture/skip_conditional_non_string.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamStringTypeFrom
 final class SkipConditionalNonString
 {
     /**
-     * @param false|float|int|string $cell
+     * @param false|float|int|string $data
      *
      * @return bool|float|int|string
      */


### PR DESCRIPTION
Just typo fix from copy paste from actual project.

The use case still same.