### PR TITLE
Typo in level overflow warning message

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -1053,7 +1053,7 @@ final class RectorConfigBuilder
                 __METHOD__,
                 $level,
                 $levelRulesCount,
-                'TypeDeclarationDocblocksLevel',
+                'typeDeclarationDocblocks',
                 'TYPE_DECLARATION_DOCBLOCKS'
             );
         }


### PR DESCRIPTION
Display the correct suggested ruleset:  `typeDeclarationDocblocks`