### PR TITLE
[dead-code] Add RemoveNextSameValueConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/skip_if_body_used.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/skip_if_body_used.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\Fixture;
+
+final class SkipIfBodyUsed
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+        if ($items === []) {
+            $items = ['a'];
+        }
+
+        if ($items === []) {
+            return $count;
+        }
+    }
+}

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/skip_if_stmts_between.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/skip_if_stmts_between.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\Fixture;
+
+final class SkipIfStmtsBetween
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+        if ($items === []) {
+            $count = 0;
+        }
+
+        $items = ['a'];
+
+        if ($items === []) {
+            return $count;
+        }
+    }
+}

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/some_class.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/some_class.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\Fixture;
+
+final class SomeClass
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+        if ($items === []) {
+            $count = 0;
+        }
+
+        if ($items === []) {
+            return $count;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\Fixture;
+
+final class SomeClass
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+        if ($items === []) {
+            $count = 0;
+            return $count;
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/RemoveNextSameValueConditionRectorTest.php
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/RemoveNextSameValueConditionRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveNextSameValueConditionRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveNextSameValueConditionRector::class]);

--- a/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\Stmt;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\If_;
+use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\RemoveNextSameValueConditionRectorTest
+ */
+final class RemoveNextSameValueConditionRector extends AbstractRector
+{
+    public function __construct(
+        private readonly SideEffectNodeDetector $sideEffectNodeDetector,
+        private readonly BetterNodeFinder $betterNodeFinder,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove already checked if condition repeated in the very next stmt',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+        if ($items === []) {
+            $count = 0;
+        }
+
+        if ($items === []) {
+            return $count;
+        }
+    }
+}
+CODE_SAMPLE
+
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+        if ($items === []) {
+            $count = 0;
+            return $count;
+        }
+    }
+}
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [StmtsAwareInterface::class];
+    }
+
+    /**
+     * @param StmtsAwareInterface $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        foreach ($node->stmts as $key => $stmt) {
+            if (! $stmt instanceof If_) {
+                continue;
+            }
+
+            // first condition must be without side effect
+            if ($this->sideEffectNodeDetector->detect($stmt->cond)) {
+                continue;
+            }
+
+            if ($this->isCondVariableUsedInIfBody($stmt)) {
+                continue;
+            }
+
+            $nextStmt = $node->stmts[$key + 1] ?? null;
+            if (! $nextStmt instanceof If_) {
+                continue;
+            }
+
+            if (! $this->nodeComparator->areNodesEqual($stmt->cond, $nextStmt->cond)) {
+                continue;
+            }
+
+            $stmt->stmts = array_merge($stmt->stmts, $nextStmt->stmts);
+
+            // remove next node
+            unset($node->stmts[$key + 1]);
+
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function isCondVariableUsedInIfBody(If_ $if): bool
+    {
+        $condVariables = $this->betterNodeFinder->findInstancesOf($if->cond, [Variable::class]);
+
+        foreach ($condVariables as $condVariable) {
+            $condVariableName = $this->getName($condVariable);
+            if ($condVariableName === null) {
+                continue;
+            }
+
+            if ($this->betterNodeFinder->findVariableOfName($if->stmts, $condVariableName) instanceof Variable) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -102,7 +102,8 @@ final class DeadCodeLevel
         RemoveConcatAutocastRector::class,
         SimplifyIfElseWithSameContentRector::class,
 
-        RemoveNextSameValueConditionRector::class,
+        // needs more testing, Nov 2025
+        // RemoveNextSameValueConditionRector::class,
         SimplifyUselessVariableRector::class,
         RemoveDeadZeroAndOneOperationRector::class,
 

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -55,6 +55,7 @@ use Rector\DeadCode\Rector\PropertyProperty\RemoveNullPropertyInitializationRect
 use Rector\DeadCode\Rector\Return_\RemoveDeadConditionAboveReturnRector;
 use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\DeadCode\Rector\Stmt\RemoveConditionExactReturnRector;
+use Rector\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector;
 use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
 use Rector\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector;
 use Rector\DeadCode\Rector\Ternary\TernaryToBooleanOrFalseToBooleanAndRector;
@@ -100,6 +101,8 @@ final class DeadCodeLevel
         RemoveUselessAssignFromPropertyPromotionRector::class,
         RemoveConcatAutocastRector::class,
         SimplifyIfElseWithSameContentRector::class,
+
+        RemoveNextSameValueConditionRector::class,
         SimplifyUselessVariableRector::class,
         RemoveDeadZeroAndOneOperationRector::class,
 

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -55,7 +55,6 @@ use Rector\DeadCode\Rector\PropertyProperty\RemoveNullPropertyInitializationRect
 use Rector\DeadCode\Rector\Return_\RemoveDeadConditionAboveReturnRector;
 use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\DeadCode\Rector\Stmt\RemoveConditionExactReturnRector;
-use Rector\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector;
 use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
 use Rector\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector;
 use Rector\DeadCode\Rector\Ternary\TernaryToBooleanOrFalseToBooleanAndRector;


### PR DESCRIPTION
If there are 2 conditions following each other, they have the same condition, without side effect, the first condition is already evaluated. The 2nd one can be removed:

```diff
public function __construct(array $items)
    {
        $count = 100;
        if ($items === []) {
            $count = 0;
-        }
-        if ($items === []) {
            return $count;
        }
    }
```


Spotted in https://github.com/rectorphp/rector-src/commit/b52ae959a01cb8c60d3155162e35dcfad5408669