### PR TITLE
[code-quality] Add ReplaceConstantBooleanNotRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/2_not_false.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/2_not_false.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$bool = !!false;
+
+?>
+-----
+<?php
+
+$bool = false;
+
+?>

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/2_not_true.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/2_not_true.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$bool = !!true;
+
+?>
+-----
+<?php
+
+$bool = true;
+
+?>

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/3_not_false.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/3_not_false.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$bool = !!!false;
+
+?>
+-----
+<?php
+
+$bool = true;
+
+?>

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/3_not_true.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/3_not_true.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$bool = !!!true;
+
+?>
+-----
+<?php
+
+$bool = false;
+
+?>

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/if_condition.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/if_condition.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\BooleanNot\ReplaceConstantBooleanNotRector\Fixture;
+
+class IfCondition
+{
+    public function run()
+    {
+        if (!true) {
+            return true;
+        }
+        return false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\BooleanNot\ReplaceConstantBooleanNotRector\Fixture;
+
+class IfCondition
+{
+    public function run()
+    {
+        if (false) {
+            return true;
+        }
+        return false;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/not_false.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/not_false.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$bool = !false;
+
+?>
+-----
+<?php
+
+$bool = true;
+
+?>

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/not_true.php.inc
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/Fixture/not_true.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$bool = !true;
+
+?>
+-----
+<?php
+
+$bool = false;
+
+?>

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/ReplaceConstantBooleanNotRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/ReplaceConstantBooleanNotRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\BooleanNot\ReplaceConstantBooleanNotRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceConstantBooleanNotRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\BooleanNot\ReplaceConstantBooleanNotRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([ReplaceConstantBooleanNotRector::class]);

--- a/rules/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector.php
+++ b/rules/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
+use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -19,6 +20,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ReplaceConstantBooleanNotRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -67,17 +73,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $node->expr instanceof ConstFetch) {
-            return null;
-        }
-
-        $constantName = $this->getName($node->expr);
-
-        if ($constantName === 'false') {
+        if ($this->valueResolver->isFalse($node->expr)) {
             return new ConstFetch(new Name('true'));
         }
 
-        if ($constantName === 'true') {
+        if ($this->valueResolver->isTrue($node->expr)) {
             return new ConstFetch(new Name('false'));
         }
 

--- a/rules/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector.php
+++ b/rules/CodeQuality/Rector/BooleanNot/ReplaceConstantBooleanNotRector.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\BooleanNot;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replace negated boolean literals with their simplified equivalents
+ *
+ * @see \Rector\Tests\CodeQuality\Rector\BooleanNot\ReplaceConstantBooleanNotRector\ReplaceConstantBooleanNotRectorTest
+ */
+final class ReplaceConstantBooleanNotRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace negated boolean literals (!false, !true) with their simplified equivalents (true, false)',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+if (!false) {
+    return 'always true';
+}
+
+if (!true) {
+    return 'never reached';
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+if (true) {
+    return 'always true';
+}
+
+if (false) {
+    return 'never reached';
+}
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [BooleanNot::class];
+    }
+
+    /**
+     * @param BooleanNot $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof BooleanNot) {
+            return null;
+        }
+
+        if (! $node->expr instanceof ConstFetch) {
+            return null;
+        }
+
+        $constantName = $this->getName($node->expr);
+
+        if ($constantName === 'false') {
+            return new ConstFetch(new Name('true'));
+        }
+
+        if ($constantName === 'true') {
+            return new ConstFetch(new Name('false'));
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
A negated constant boolean can be trivially changed to the other constant boolean.

```diff
class IfCondition
{
    public function run()
    {
-        if (!true) {
+        if (false) {
            return true;
        }
        return false;
    }
}
```

I am using this in tandem with bootstrapped constants. It allows dead code elimination rectors to remove blocks of code when the appropriate constants are defined.