### PR TITLE
Bump nikic/php-parser to ^5.6.2 and Fix AttributeGroupNewLiner for already has new line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.1",
         "illuminate/container": "^11.46",
         "nette/utils": "^4.0",
-        "nikic/php-parser": "^5.6.1",
+        "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1.26",

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/do_not_remove_parameter_attribute.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/do_not_remove_parameter_attribute.php.inc
@@ -25,7 +25,7 @@ namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromo
 final class DoNotRemoveParameterAttribute
 {
     public function __construct(
-        #[\SensitiveParameter]private string $password
+        #[\SensitiveParameter] private string $password
     )
     {
     }

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -49,12 +49,12 @@ final class AttributeGroupNewLiner
                 }
 
                 $nextTokenText = $oldTokens[$startTokenPos + $iteration + 1]->text ?? '';
-                // when trimmed is empty string, but it contains new line
-                if (trim($nextTokenText) === '' && str_contains($nextTokenText, "\n")) {
-                    break;
-                }
-
                 if (trim($nextTokenText) === '') {
+                    // when trimmed is empty string, but it contains new line
+                    if (str_contains($nextTokenText, "\n") || str_contains($nextTokenText, "\r")) {
+                        break;
+                    }
+
                     $space = ltrim($nextTokenText, "\r\n");
                 } elseif (trim($oldTokens[$startTokenPos - 1]->text ?? '') === '') {
                     $space = ltrim($oldTokens[$startTokenPos - 1]->text ?? '', "\r\n");

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -49,8 +49,8 @@ final class AttributeGroupNewLiner
                 }
 
                 $nextTokenText = $oldTokens[$startTokenPos + $iteration + 1]->text ?? '';
-                if (str_starts_with($nextTokenText, "\n") || str_starts_with($nextTokenText, "\r")) {
-                    // already has newline
+                // when trimmed is empty string, but it contains new line
+                if (trim($nextTokenText) === '' && str_contains($nextTokenText, "\n")) {
                     break;
                 }
 

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -50,7 +50,7 @@ final class AttributeGroupNewLiner
 
                 $nextTokenText = $oldTokens[$startTokenPos + $iteration + 1]->text ?? '';
                 if (trim($nextTokenText) === '') {
-                    // when trimmed is empty string, but it contains new line
+                    // when trimmed is empty string, but original text contains new line
                     if (str_contains($nextTokenText, "\n") || str_contains($nextTokenText, "\r")) {
                         break;
                     }

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -51,6 +51,7 @@ final class AttributeGroupNewLiner
                 $nextTokenText = $oldTokens[$startTokenPos + $iteration + 1]->text ?? '';
                 if (trim($nextTokenText) === '') {
                     // when trimmed is empty string, but original text contains new line
+                    // no need to add another new line
                     if (str_contains($nextTokenText, "\n") || str_contains($nextTokenText, "\r")) {
                         break;
                     }

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -48,8 +48,14 @@ final class AttributeGroupNewLiner
                     break;
                 }
 
-                if (trim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '') === '') {
-                    $space = ltrim($oldTokens[$startTokenPos + $iteration + 1]->text ?? '', "\r\n");
+                $nextTokenText = $oldTokens[$startTokenPos + $iteration + 1]->text ?? '';
+                if (str_starts_with($nextTokenText, "\n") || str_starts_with($nextTokenText, "\r")) {
+                    // already has newline
+                    break;
+                }
+
+                if (trim($nextTokenText) === '') {
+                    $space = ltrim($nextTokenText, "\r\n");
                 } elseif (trim($oldTokens[$startTokenPos - 1]->text ?? '') === '') {
                     $space = ltrim($oldTokens[$startTokenPos - 1]->text ?? '', "\r\n");
                 } else {


### PR DESCRIPTION
In nikic/php-parser 5.6.2, new line after attribute already detected, so before add new line, verify if new line exists first.

Ref https://github.com/rectorphp/rector-src/pull/7530#issuecomment-3429868620