### PR TITLE
[NodeManipulator] Remove use of AttributeGroupNewLiner on Param and Property on ReadonlyClassManipulator

### DIFF
--- a/rules/Php82/NodeManipulator/ReadonlyClassManipulator.php
+++ b/rules/Php82/NodeManipulator/ReadonlyClassManipulator.php
@@ -46,19 +46,11 @@ final readonly class ReadonlyClassManipulator
         if ($constructClassMethod instanceof ClassMethod) {
             foreach ($constructClassMethod->getParams() as $param) {
                 $this->visibilityManipulator->removeReadonly($param);
-
-                if ($param->attrGroups !== []) {
-                    $this->attributeGroupNewLiner->newLine($file, $param);
-                }
             }
         }
 
         foreach ($class->getProperties() as $property) {
             $this->visibilityManipulator->removeReadonly($property);
-
-            if ($property->attrGroups !== []) {
-                $this->attributeGroupNewLiner->newLine($file, $property);
-            }
         }
 
         if ($class->attrGroups !== []) {


### PR DESCRIPTION
@TomasVotruba per your request at 

https://github.com/rectorphp/rector-src/pull/7531#issuecomment-3430810921

here remove unused `AttributeGroupNewLiner` service on param and property on `ReadonlyClassManipulator`

On `Class_` seems still needed.