### PR TITLE
[CodeQuality] Remove AttributeGroupNewLiner usage on RemoveReadonlyPropertyVisibilityOnReadonlyClassRector

### DIFF
--- a/rules/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector.php
+++ b/rules/CodeQuality/Rector/Class_/RemoveReadonlyPropertyVisibilityOnReadonlyClassRector.php
@@ -7,7 +7,6 @@ namespace Rector\CodeQuality\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\Php81\NodeManipulator\AttributeGroupNewLiner;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
@@ -22,8 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveReadonlyPropertyVisibilityOnReadonlyClassRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly VisibilityManipulator $visibilityManipulator,
-        private readonly AttributeGroupNewLiner $attributeGroupNewLiner
+        private readonly VisibilityManipulator $visibilityManipulator
     ) {
     }
 
@@ -87,10 +85,6 @@ CODE_SAMPLE
 
                 $this->visibilityManipulator->removeReadonly($param);
                 $hasChanged = true;
-
-                if ($param->attrGroups !== []) {
-                    $this->attributeGroupNewLiner->newLine($this->file, $param);
-                }
             }
         }
 
@@ -101,10 +95,6 @@ CODE_SAMPLE
 
             $this->visibilityManipulator->removeReadonly($property);
             $hasChanged = true;
-
-            if ($property->attrGroups !== []) {
-                $this->attributeGroupNewLiner->newLine($this->file, $property);
-            }
         }
 
         if (! $hasChanged) {


### PR DESCRIPTION
@TomasVotruba per your request at 

https://github.com/rectorphp/rector-src/pull/7531#issuecomment-3430810921

here remove unused `AttributeGroupNewLiner` service on param and property on `RemoveReadonlyPropertyVisibilityOnReadonlyClassRector`

On `Class_` seems still needed.