### PR TITLE
[Php81] Remove usage of AttributeGroupNewLiner on ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_new_line.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_new_line.php.inc
@@ -2,9 +2,10 @@
 
 namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
 
-final class WithAttributeInline
+final class WithAttributeNewLine
 {
-    #[Serializer\Since(Option::SINCE_20211124)]private string $name;
+    #[Serializer\Since(Option::SINCE_20211124)]
+    private string $name;
 
     public function __construct(string $name)
     {
@@ -23,9 +24,10 @@ final class WithAttributeInline
 
 namespace Rector\Tests\Php82\Rector\Class_\ReadOnlyClassRector\Fixture;
 
-final class WithAttributeInline
+final class WithAttributeNewLine
 {
-    #[Serializer\Since(Option::SINCE_20211124)]private readonly string $name;
+    #[Serializer\Since(Option::SINCE_20211124)]
+    private readonly string $name;
 
     public function __construct(string $name)
     {

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_on_property_promotion_inline.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_on_property_promotion_inline.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class WithAttributeOnPropertyPromotionInline
+{
+	private function __construct(
+        #[MyAttr]private string $id
+    ){}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class WithAttributeOnPropertyPromotionInline
+{
+	private function __construct(
+        #[MyAttr]private readonly string $id
+    ){}
+}
+
+?>

--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_on_property_promotion_new_line.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/with_attribute_on_property_promotion_new_line.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
 
-final class WithAttributeOnPropertyPromotion
+final class WithAttributeOnPropertyPromotionNewLine
 {
 	private function __construct(
         #[MyAttr]
@@ -16,7 +16,7 @@ final class WithAttributeOnPropertyPromotion
 
 namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
 
-final class WithAttributeOnPropertyPromotion
+final class WithAttributeOnPropertyPromotionNewLine
 {
 	private function __construct(
         #[MyAttr]

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -6,14 +6,15 @@ namespace Rector\Php81\NodeManipulator;
 
 use PhpParser\Node;
 use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Stmt\Class_;
 use Rector\ValueObject\Application\File;
 use Webmozart\Assert\Assert;
 
 final class AttributeGroupNewLiner
 {
-    public function newLine(File $file, Node $node): void
+    public function newLine(File $file, Class_ $node): void
     {
-        $attrGroups = $node->attrGroups ?? [];
+        $attrGroups = $node->attrGroups;
 
         if ($attrGroups === []) {
             return;

--- a/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
+++ b/rules/Php81/NodeManipulator/AttributeGroupNewLiner.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Php81\NodeManipulator;
 
-use PhpParser\Node;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Stmt\Class_;
 use Rector\ValueObject\Application\File;
@@ -12,9 +11,9 @@ use Webmozart\Assert\Assert;
 
 final class AttributeGroupNewLiner
 {
-    public function newLine(File $file, Class_ $node): void
+    public function newLine(File $file, Class_ $class): void
     {
-        $attrGroups = $node->attrGroups;
+        $attrGroups = $class->attrGroups;
 
         if ($attrGroups === []) {
             return;
@@ -24,7 +23,7 @@ final class AttributeGroupNewLiner
         Assert::isArray($attrGroups);
 
         $oldTokens = $file->getOldTokens();
-        $startTokenPos = $node->getStartTokenPos();
+        $startTokenPos = $class->getStartTokenPos();
 
         if (! isset($oldTokens[$startTokenPos])) {
             return;

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -23,7 +23,6 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeAnalyzer\ParamAnalyzer;
 use Rector\NodeManipulator\PropertyFetchAssignManipulator;
 use Rector\NodeManipulator\PropertyManipulator;
-use Rector\Php81\NodeManipulator\AttributeGroupNewLiner;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
@@ -47,8 +46,7 @@ final class ReadOnlyPropertyRector extends AbstractRector implements MinPhpVersi
         private readonly VisibilityManipulator $visibilityManipulator,
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly AttributeGroupNewLiner $attributeGroupNewLiner
+        private readonly DocBlockUpdater $docBlockUpdater
     ) {
     }
 
@@ -177,12 +175,6 @@ CODE_SAMPLE
         }
 
         $this->visibilityManipulator->makeReadonly($property);
-
-        $attributeGroups = $property->attrGroups;
-        if ($attributeGroups !== []) {
-            $this->attributeGroupNewLiner->newLine($this->file, $property);
-        }
-
         $this->removeReadOnlyDoc($property);
 
         return $property;
@@ -245,7 +237,7 @@ CODE_SAMPLE
         }
 
         if ($param->attrGroups !== []) {
-            $this->attributeGroupNewLiner->newLine($this->file, $param);
+            //$this->attributeGroupNewLiner->newLine($this->file, $param);
         }
 
         $this->visibilityManipulator->makeReadonly($param);

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -236,10 +236,6 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($param->attrGroups !== []) {
-            //$this->attributeGroupNewLiner->newLine($this->file, $param);
-        }
-
         $this->visibilityManipulator->makeReadonly($param);
 
         $this->removeReadOnlyDoc($param);


### PR DESCRIPTION
@TomasVotruba per your request at 

https://github.com/rectorphp/rector-src/pull/7531#issuecomment-3430810921

here remove unused `AttributeGroupNewLiner` service on property on `ReadOnlyPropertyRector`.

The existing fixture already inline, so keep inline as is, and add another fixture for new line, to add new line.