### PR TITLE
Fix NullToStrictStringFuncCallArgRector with probabilistic check for plural array passed to function where array allowed

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_preg_replace.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_preg_replace.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipPregReplace
+{
+    public static function run(&$items)
+    {
+        $pattern = "/(\d+')/";
+        $replacement = '$1';
+        $items = preg_replace($pattern, $replacement, $items);
+    }
+}

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -87,7 +87,7 @@ CODE_SAMPLE
         }
 
         $args = $node->getArgs();
-        $positions = $this->resolvePositions($node, $args, $scope);
+        $positions = $this->resolveStringPositions($node, $args, $scope);
 
         if ($positions === []) {
             return null;
@@ -133,9 +133,9 @@ CODE_SAMPLE
 
     /**
      * @param Arg[] $args
-     * @return int[]|string[]
+     * @return int[]
      */
-    private function resolvePositions(FuncCall $funcCall, array $args, Scope $scope): array
+    private function resolveStringPositions(FuncCall $funcCall, array $args, Scope $scope): array
     {
         $positions = [];
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/9447

Since this is 1st time `mixed` variable is incorrectly casted to string as `array`, I've added only simple check for possible plural variable. That allows this rule to catch array mixed, while keeps working for string mixed.

If it fails, we'll revisit :+1: 