### PR TITLE
[Php81] Keep nullable param on NewInInitializerRector

### DIFF
--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_class_const_fetch_arg.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_class_const_fetch_arg.php.inc
@@ -27,7 +27,7 @@ use Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Source\SomeValu
 
 class PassClassConstFetchArg
 {
-    public function __construct(private DateTime $dateTime = new DateTime(SomeValueObject::NOW))
+    public function __construct(private ?DateTime $dateTime = new DateTime(SomeValueObject::NOW))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_const_fetch_arg.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_const_fetch_arg.php.inc
@@ -29,7 +29,7 @@ const NOW = 'now';
 
 class PassConstFetchArg
 {
-    public function __construct(private DateTime $dateTime = new DateTime(NOW))
+    public function __construct(private ?DateTime $dateTime = new DateTime(NOW))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg.php.inc
@@ -27,7 +27,7 @@ use DateTimeZone;
 
 class PassNonDynamicArg
 {
-    public function __construct(private DateTime $dateTime = new DateTime('now', new DateTimeZone('Asia/Jakarta')))
+    public function __construct(private ?DateTime $dateTime = new DateTime('now', new DateTimeZone('Asia/Jakarta')))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg2.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg2.php.inc
@@ -21,7 +21,7 @@ namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
 
 class SomeClass
 {
-    public function __construct(private Logger $logger = new NullLogger(['a' => 'b']))
+    public function __construct(private ?Logger $logger = new NullLogger(['a' => 'b']))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg3.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg3.php.inc
@@ -21,7 +21,7 @@ namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
 
 class SomeClass
 {
-    public function __construct(private Logger $logger = new NullLogger(['b']))
+    public function __construct(private ?Logger $logger = new NullLogger(['b']))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg4.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg4.php.inc
@@ -25,7 +25,7 @@ use stdClass;
 
 class SomeClass
 {
-    public function __construct(private Logger $logger = new NullLogger([new stdClass]))
+    public function __construct(private ?Logger $logger = new NullLogger([new stdClass]))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg5.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg5.php.inc
@@ -21,7 +21,7 @@ namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
 
 class SomeClass
 {
-    public function __construct(private Logger $logger = new NullLogger([]))
+    public function __construct(private ?Logger $logger = new NullLogger([]))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg6.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/pass_non_dynamic_arg6.php.inc
@@ -21,7 +21,7 @@ namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
 
 class SomeClass
 {
-    public function __construct(private Logger $logger = new NullLogger(new Db()))
+    public function __construct(private ?Logger $logger = new NullLogger(new Db()))
     {
     }
 }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/property_with_attributes.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/property_with_attributes.php.inc
@@ -34,7 +34,7 @@ class Carrier
     public function __construct(
         #[ORM\Id]
         #[ORM\Column(type: 'ulid', unique: true)]
-        private Ulid $id = new Ulid()
+        private ?Ulid $id = new Ulid()
     )
     {
     }

--- a/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/some_class.php.inc
+++ b/rules-tests/Php81/Rector/ClassMethod/NewInInitializerRector/Fixture/some_class.php.inc
@@ -21,7 +21,7 @@ namespace Rector\Tests\Php81\Rector\ClassMethod\NewInInitializerRector\Fixture;
 
 class SomeClass
 {
-    public function __construct(private Logger $logger = new NullLogger)
+    public function __construct(private ?Logger $logger = new NullLogger)
     {
     }
 }

--- a/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
+++ b/rules/Php81/Rector/ClassMethod/NewInInitializerRector.php
@@ -59,7 +59,7 @@ CODE_SAMPLE
 class SomeClass
 {
     public function __construct(
-        private Logger $logger = new NullLogger,
+        private ?Logger $logger = new NullLogger,
     ) {
     }
 }
@@ -116,10 +116,6 @@ CODE_SAMPLE
                     continue;
                 }
 
-                /** @var NullableType $currentParamType */
-                $currentParamType = $param->type;
-
-                $param->type = $currentParamType->type;
                 $param->default = $coalesce->right;
 
                 unset($constructClassMethod->stmts[$key]);


### PR DESCRIPTION
@TomasVotruba per our discussion on https://github.com/rectorphp/rector-src/commit/153fc786d301d3d9e4170b955df9bbac9ecf144d#r168615132

since the rule register back to `php81` set, this safe belt keep nullable is needed.

this to avoid new issue opened again:

- https://github.com/rectorphp/rector/issues/8971

This needs to be nullable, or it will not safe, however, the drawback is property itself become nullable, while it originally not, as it always initialized inside constructor before.

This also ensure no bc break