### PR TITLE
Fix next catch missed variable rename in CatchExceptionNameMatchingTypeRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/identical_runs_after_each_other.php.inc
+++ b/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/identical_runs_after_each_other.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Source\Notification;
+use Throwable;
+
+final class IdenticalRunsAfterEachOther
+{
+    public function run()
+    {
+        try {
+        } catch (Throwable $e) {
+            $notification = new Notification();
+            $notification->exception($e);
+        }
+
+        try {
+        } catch (Throwable $e) {
+            $notification = new Notification();
+            $notification->exception($e);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Source\Notification;
+use Throwable;
+
+final class IdenticalRunsAfterEachOther
+{
+    public function run()
+    {
+        try {
+        } catch (Throwable $throwable) {
+            $notification = new Notification();
+            $notification->exception($throwable);
+        }
+
+        try {
+        } catch (Throwable $throwable) {
+            $notification = new Notification();
+            $notification->exception($throwable);
+        }
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Source/Notification.php
+++ b/rules-tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Source/Notification.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Source;
+
+class Notification
+{
+}

--- a/rules-tests/Rector/Tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Source/Notification.php
+++ b/rules-tests/Rector/Tests/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Source/Notification.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Source;
+
+final class Notification
+{
+    public function exception(\Throwable $throwable)
+    {
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/9454
