### PR TITLE
Add back removed fixture aliased multi properties on AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
@@ -2,23 +2,21 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Annotation as OA;
+
+class TestClass
 {
-    use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Annotation as OA;
+    /**
+     * @OA\SomeProperty(type="string")
+     */
+    public $property1;
 
-    class TestClass
-    {
-        /**
-         * @OA\SomeProperty(type="string")
-         */
-        public $property1;
-
-        /**
-         * @OA\SomeProperty(type="string")
-         */
-        public $property2;
-    }
-
+    /**
+     * @OA\SomeProperty(type="string")
+     */
+    public $property2;
 }
 
 ?>
@@ -27,19 +25,17 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\At
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute as OA;
+
+class TestClass
 {
-    use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute as OA;
+    #[OA\SomeProperty(type: 'string')]
+    public $property1;
 
-    class TestClass
-    {
-        #[OA\SomeProperty(type: 'string')]
-        public $property1;
-
-        #[OA\SomeProperty(type: 'string')]
-        public $property2;
-    }
-
+    #[OA\SomeProperty(type: 'string')]
+    public $property2;
 }
 
 ?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OpenApi\Attributes
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute
 {
-    use OpenApi\Annotations as OA;
-
-    #[\Attribute]
-    class SomeProperty {}
+    use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Annotation as OA;
 
     class TestClass
     {
@@ -30,12 +27,9 @@ namespace OpenApi\Attributes
 
 declare(strict_types=1);
 
-namespace OpenApi\Attributes
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute
 {
-    use OpenApi\Attributes as OA;
-
-    #[\Attribute]
-    class SomeProperty {}
+    use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute as OA;
 
     class TestClass
     {

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenApi\Attributes
+{
+    use OpenApi\Annotations as OA;
+
+    #[\Attribute]
+    class SomeProperty {}
+
+    class TestClass
+    {
+        /**
+         * @OA\SomeProperty(type="string")
+         */
+        public $property1;
+
+        /**
+         * @OA\SomeProperty(type="string")
+         */
+        public $property2;
+    }
+
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace OpenApi\Attributes
+{
+    use OpenApi\Attributes as OA;
+
+    #[\Attribute]
+    class SomeProperty {}
+
+    class TestClass
+    {
+        #[OA\SomeProperty(type: 'string')]
+        public $property1;
+
+        #[OA\SomeProperty(type: 'string')]
+        public $property2;
+    }
+
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/aliased_with_multi_properties.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
 
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Annotation as OA;
 
-class TestClass
+class AliasedWithMultiProperties
 {
     /**
      * @OA\SomeProperty(type="string")
@@ -29,7 +29,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
 
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute as OA;
 
-class TestClass
+class AliasedWithMultiProperties
 {
     #[OA\SomeProperty(type: 'string')]
     public $property1;

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Attribute/OpenApi/Attribute/SomeProperty.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Attribute/OpenApi/Attribute/SomeProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute;
+
+#[\Attribute]
+final class SomeProperty
+{
+}

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -67,6 +67,6 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('OldName2', NewName2::class),
         new AnnotationToAttribute('SameName', SameName::class),
 
-        new AnnotationToAttribute('OpenApi\Annotations\Property', 'OpenApi\Attributes\Property'),
+        new AnnotationToAttribute('OpenApi\Annotations\SomeProperty', 'OpenApi\Attributes\SomeProperty'),
     ]);
 };

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -67,6 +67,9 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('OldName2', NewName2::class),
         new AnnotationToAttribute('SameName', SameName::class),
 
-        new AnnotationToAttribute('OpenApi\Annotations\SomeProperty', 'OpenApi\Attributes\SomeProperty'),
+        new AnnotationToAttribute(
+            'Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Annotation\SomeProperty',
+            'Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute\SomeProperty'
+        ),
     ]);
 };


### PR DESCRIPTION
@TomasVotruba here per https://github.com/rectorphp/rector-src/pull/7548#pullrequestreview-3370018720

The original PR that introduce it is at:

- https://github.com/rectorphp/rector-src/pull/6838

The fixture is needed. The case is same name in both annotation and attribute,  but different namespace, and aliased is imported in multi properties.