### PR TITLE
[Php81] Fix first class callable should not have trailing comma on FunctionLikeToFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/with_trailing_comma.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/with_trailing_comma.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+final class WithTrailingComma
+{
+    public function run(): void
+    {
+        $array = [1, 2, 3];
+
+        $this->map(
+            $array,
+            fn($item) => var_dump(
+                $item,
+            )
+        );
+    }
+
+    private function map(array $items, callable $callback): void {
+		foreach($items as $i) {
+        	$callback($i);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+final class WithTrailingComma
+{
+    public function run(): void
+    {
+        $array = [1, 2, 3];
+
+        $this->map(
+            $array,
+            var_dump(
+                ...
+            )
+        );
+    }
+
+    private function map(array $items, callable $callback): void {
+		foreach($items as $i) {
+        	$callback($i);
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9459
Ref https://3v4l.org/p6XC3