### PR TITLE
[dead-code] Add RemoveNullArgOnNullDefaultParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+class Fixture
+{
+    public function get(SomeExternalClass $someExternalClass)
+    {
+        $someExternalClass->callWithDefaultNull(null);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+class Fixture
+{
+    public function get(SomeExternalClass $someExternalClass)
+    {
+        $someExternalClass->callWithDefaultNull();
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/handle_new_ctor.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/handle_new_ctor.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+final class HandleNewCtor
+{
+    public function get()
+    {
+        $object = new SomeExternalClass('John', null);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+final class HandleNewCtor
+{
+    public function get()
+    {
+        $object = new SomeExternalClass('John');
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/handle_static_call.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/handle_static_call.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+final class HandleStaticCall
+{
+    public function get()
+    {
+        SomeExternalClass::staticCallWithDefaultNull(null);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+final class HandleStaticCall
+{
+    public function get()
+    {
+        SomeExternalClass::staticCallWithDefaultNull();
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/RemoveNullArgOnNullDefaultParamRectorTest.php
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/RemoveNullArgOnNullDefaultParamRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveNullArgOnNullDefaultParamRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
@@ -4,6 +4,10 @@ namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultPara
 
 final class SomeExternalClass
 {
+    public function __construct(string $name, ?int $id = null)
+    {
+    }
+
     public function callWithDefaultNull(?string $name = null)
     {
     }

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source;
+
+final class SomeExternalClass
+{
+    public function callWithDefaultNull(?string $name = null)
+    {
+    }
+
+    public static function staticCallWithDefaultNull(?int $id = null)
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveNullArgOnNullDefaultParamRector::class]);

--- a/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
+++ b/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
@@ -194,7 +194,9 @@ CODE_SAMPLE
         }
 
         // exists, but by @method annotation
-        if ($reflection instanceof AnnotationMethodReflection && ! $reflection->getDeclaringClass()->hasNativeMethod($reflection->getName())) {
+        if ($reflection instanceof AnnotationMethodReflection && ! $reflection->getDeclaringClass()->hasNativeMethod(
+            $reflection->getName()
+        )) {
             return true;
         }
 

--- a/rules/DeadCode/NodeAnalyzer/CallLikeParamDefaultResolver.php
+++ b/rules/DeadCode/NodeAnalyzer/CallLikeParamDefaultResolver.php
@@ -12,10 +12,10 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\NullType;
 use Rector\Reflection\ReflectionResolver;
 
-final class CallLikeParamDefaultResolver
+final readonly class CallLikeParamDefaultResolver
 {
     public function __construct(
-        private readonly ReflectionResolver $reflectionResolver,
+        private ReflectionResolver $reflectionResolver,
     ) {
     }
 

--- a/rules/DeadCode/NodeAnalyzer/CallLikeParamDefaultResolver.php
+++ b/rules/DeadCode/NodeAnalyzer/CallLikeParamDefaultResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\NodeAnalyzer;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\NullType;
+use Rector\Reflection\ReflectionResolver;
+
+final class CallLikeParamDefaultResolver
+{
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver,
+    ) {
+    }
+
+    /**
+     * @return int[]
+     */
+    public function resolveNullPositions(MethodCall|StaticCall|New_ $callLike): array
+    {
+        $methodReflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($callLike);
+        if (! $methodReflection instanceof MethodReflection) {
+            return [];
+        }
+
+        $nullPositions = [];
+
+        $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors($methodReflection->getVariants());
+        foreach ($extendedParametersAcceptor->getParameters() as $position => $extendedParameterReflection) {
+            if (! $extendedParameterReflection->getDefaultValue() instanceof NullType) {
+                continue;
+            }
+
+            $nullPositions[] = $position;
+        }
+
+        return $nullPositions;
+    }
+}

--- a/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\NullType;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\RemoveNullArgOnNullDefaultParamRectorTest
+ */
+final class RemoveNullArgOnNullDefaultParamRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ValueResolver $valueResolver,
+        private readonly ReflectionResolver $reflectionResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove default null argument, where null is already a default param value', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function call(ExternalClass $externalClass)
+    {
+        $externalClass->execute(null);
+    }
+}
+
+class ExternalClass
+{
+    public function execute(?SomeClass $someClass = null)
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+
+class SomeClass
+{
+    public function call(ExternalClass $externalClass)
+    {str
+        $externalClass->execute();
+    }
+}
+
+class ExternalClass
+{
+    public function execute(?SomeClass $someClass = null)
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): StaticCall|MethodCall|null
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if ($node->getArgs() === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->getArgs() as $position => $arg) {
+            if ($arg->unpack) {
+                continue;
+            }
+
+            // skip named args
+            if ($arg->name instanceof Node) {
+                continue;
+            }
+
+            if (! $this->valueResolver->isNull($arg->value)) {
+                continue;
+            }
+
+            // @todo extract to service
+            $nullPositions = $this->resolveDefaultParamNullPositions($node);
+
+            if (! in_array($position, $nullPositions)) {
+                continue;
+            }
+
+            unset($node->args[0]);
+
+            $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function resolveDefaultParamNullPositions(MethodCall|StaticCall $callLike): array
+    {
+
+        if ($callLike instanceof StaticCall) {
+            $methodReflection = $this->reflectionResolver->resolveMethodReflectionFromStaticCall($callLike);
+        } else {
+            $methodReflection = $this->reflectionResolver->resolveMethodReflectionFromMethodCall($callLike);
+        }
+
+        if (! $methodReflection instanceof MethodReflection) {
+            return [];
+        }
+
+        $nullPositions = [];
+
+        $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors($methodReflection->getVariants());
+        foreach ($extendedParametersAcceptor->getParameters() as $position => $extendedParameterReflection) {
+            if (! $extendedParameterReflection->getDefaultValue() instanceof NullType) {
+                continue;
+            }
+
+            $nullPositions[] = $position;
+        }
+
+        return $nullPositions;
+    }
+}

--- a/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\StaticCall;
 use Rector\DeadCode\NodeAnalyzer\CallLikeParamDefaultResolver;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
-use Rector\Reflection\ReflectionResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -22,7 +21,6 @@ final class RemoveNullArgOnNullDefaultParamRector extends AbstractRector
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,
-        private readonly ReflectionResolver $reflectionResolver,
         private readonly CallLikeParamDefaultResolver $callLikeParamDefaultResolver,
     ) {
     }

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -178,6 +178,7 @@ final readonly class ReflectionResolver
 
         $className = ClassNameFromObjectTypeResolver::resolve($callerType);
         if ($className === null) {
+
             return null;
         }
 


### PR DESCRIPTION
Kicking off here. Will need more work like case where null is not the last parameter:

```php
public function someMethod($first = null, $second = 100)
{
}
```