### PR TITLE
[Php81][CodingStyle] Skip Closure/ArrowFunction as assign expr on FunctionLikeToFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_assigned_early.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/skip_assigned_early.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
+
+final readonly class SkipAssignedEarly {
+    public function __construct(private string $name, private object $object) {}
+    public function render(callable $formatter): string
+    {
+        return $formatter($this->name, $this->object);
+    }
+}
+
+// callback assigned early, use later, keep as is
+$formatter = fn(string $label, object $object): string => ucfirst($label);
+echo (new SkipAssignedEarly('name', new \stdClass()))->render($formatter);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9461
Ref https://3v4l.org/10gCI