### PR TITLE
[DeadCode] Handle with middle default not null on RemoveNullArgOnNullDefaultParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/handle_middle_default_not_null.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/handle_middle_default_not_null.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+class HandleMiddleDefaultNotNull
+{
+    public function get(SomeExternalClass $someExternalClass)
+    {
+        $someExternalClass->withMiddleNotNullDefault(null, 1, null, null);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+class HandleMiddleDefaultNotNull
+{
+    public function get(SomeExternalClass $someExternalClass)
+    {
+        $someExternalClass->withMiddleNotNullDefault(null, 1);
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
@@ -15,4 +15,8 @@ final class SomeExternalClass
     public static function staticCallWithDefaultNull(?int $id = null)
     {
     }
+
+    public static function withMiddleNotNullDefault(?int $id = null, int $data = 1, ?string $name = null, ?string $item = null)
+    {
+    }
 }

--- a/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
@@ -90,7 +90,7 @@ CODE_SAMPLE
 
         $args = $node->getArgs();
         $lastArgPosition = count($args) - 1;
-        for ($position = $lastArgPosition; $position >=0; $position--) {
+        for ($position = $lastArgPosition; $position >=0; --$position) {
             if (! isset($args[$position])) {
                 continue;
             }

--- a/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
@@ -97,21 +97,21 @@ CODE_SAMPLE
 
             $arg = $args[$position];
             if ($arg->unpack) {
-                return null;
+                break;
             }
 
             // skip named args
             if ($arg->name instanceof Node) {
-                return null;
+                break;
             }
 
             if (! $this->valueResolver->isNull($arg->value)) {
-                return null;
+                break;
             }
 
             $nullPositions = $this->callLikeParamDefaultResolver->resolveNullPositions($node);
             if (! in_array($position, $nullPositions)) {
-                return null;
+                break;
             }
 
             unset($node->args[$position]);

--- a/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
+++ b/rules/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector.php
@@ -88,27 +88,33 @@ CODE_SAMPLE
 
         $hasChanged = false;
 
-        foreach ($node->getArgs() as $position => $arg) {
-            if ($arg->unpack) {
+        $args = $node->getArgs();
+        $lastArgPosition = count($args) - 1;
+        for ($position = $lastArgPosition; $position >=0; $position--) {
+            if (! isset($args[$position])) {
                 continue;
+            }
+
+            $arg = $args[$position];
+            if ($arg->unpack) {
+                return null;
             }
 
             // skip named args
             if ($arg->name instanceof Node) {
-                continue;
+                return null;
             }
 
             if (! $this->valueResolver->isNull($arg->value)) {
-                continue;
+                return null;
             }
 
             $nullPositions = $this->callLikeParamDefaultResolver->resolveNullPositions($node);
             if (! in_array($position, $nullPositions)) {
-                continue;
+                return null;
             }
 
             unset($node->args[$position]);
-
             $hasChanged = true;
         }
 


### PR DESCRIPTION
@TomasVotruba this is loop from the last position, if found skipped part, stop loop early to avoid jump removed arg.

Ref https://github.com/rectorphp/rector-src/pull/7562#pullrequestreview-3375748989