### PR TITLE
Add fixture for skip required nullable without default for RemoveNullArgOnNullDefaultParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/skip_required_argument.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/skip_required_argument.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Source\SomeExternalClass;
+
+final class SkipRequiredArgument
+{
+    public function get()
+    {
+        SomeExternalClass::withRequiredArgument(null);
+    }
+}

--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Source/SomeExternalClass.php
@@ -19,4 +19,8 @@ final class SomeExternalClass
     public static function withMiddleNotNullDefault(?int $id = null, int $data = 1, ?string $name = null, ?string $item = null)
     {
     }
+
+    public static function withRequiredArgument(?int $id)
+    {
+    }
 }


### PR DESCRIPTION
ensure no regression when param is nullable and already has no default value.