### PR TITLE
[Php81] Skip as Arg of non-native function call on FunctionLikeToFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/with_trailing_comma.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/with_trailing_comma.php.inc
@@ -8,18 +8,12 @@ final class WithTrailingComma
     {
         $array = [1, 2, 3];
 
-        $this->map(
-            $array,
+        array_map(
             fn($item) => var_dump(
                 $item,
-            )
+            ),
+            $array
         );
-    }
-
-    private function map(array $items, callable $callback): void {
-		foreach($items as $i) {
-        	$callback($i);
-        }
     }
 }
 
@@ -35,18 +29,12 @@ final class WithTrailingComma
     {
         $array = [1, 2, 3];
 
-        $this->map(
-            $array,
+        array_map(
             var_dump(
                 ...
-            )
+            ),
+            $array
         );
-    }
-
-    private function map(array $items, callable $callback): void {
-		foreach($items as $i) {
-        	$callback($i);
-        }
     }
 }
 

--- a/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
+++ b/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\CodingStyle\Rector\FunctionLike;
 
-use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -24,19 +23,9 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\VariadicPlaceholder;
 use PhpParser\NodeVisitor;
 use PHPStan\Analyser\Scope;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\Reflection\Annotations\AnnotationMethodReflection;
-use PHPStan\Reflection\ExtendedFunctionVariant;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ResolvedFunctionVariantWithOriginal;
-use PHPStan\Type\CallableType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\UnionType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\PhpParser\AstResolver;
-use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
@@ -62,9 +51,7 @@ final class FunctionLikeToFirstClassCallableRector extends AbstractRector implem
 
     public function __construct(
         private readonly AstResolver $astResolver,
-        private readonly ReflectionResolver $reflectionResolver,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory
+        private readonly ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -89,19 +76,11 @@ CODE_SAMPLE
 
     public function getNodeTypes(): array
     {
-        return [
-            Assign::class,
-            MethodCall::class,
-            FuncCall::class,
-            StaticCall::class,
-            New_::class,
-            ArrowFunction::class,
-            Closure::class,
-        ];
+        return [Assign::class, CallLike::class, ArrowFunction::class, Closure::class];
     }
 
     /**
-     * @param MethodCall|FuncCall|StaticCall|New_|ArrowFunction|Closure $node
+     * @param CallLike|ArrowFunction|Closure $node
      */
     public function refactor(Node $node): null|CallLike
     {
@@ -118,99 +97,14 @@ CODE_SAMPLE
                 return null;
             }
 
-            $args = $node->getArgs();
-            foreach ($args as $key => $arg) {
+            $methodReflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+            if ($methodReflection instanceof NativeFunctionReflection) {
+                return null;
+            }
+
+            foreach ($node->getArgs() as $arg) {
                 if ($arg->value instanceof Closure || $arg->value instanceof ArrowFunction) {
-                    // verify caller signature
-                    $methodReflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
-
-                    if ($methodReflection === null) {
-                        return null;
-                    }
-
-                    $reflection = ParametersAcceptorSelectorVariantsWrapper::select(
-                        $methodReflection,
-                        $node,
-                        ScopeFetcher::fetch($node)
-                    );
-
-                    if ($reflection instanceof ResolvedFunctionVariantWithOriginal) {
-                        $reflection = ParametersAcceptorSelector::combineAcceptors(
-                            $methodReflection->getVariants()
-                        );
-
-                        if (! $reflection instanceof ExtendedFunctionVariant) {
-                            return null;
-                        }
-                    }
-
-                    $classMethodOrFunction = $this->astResolver->resolveClassMethodOrFunctionFromCall($node);
-                    if (! $classMethodOrFunction instanceof FunctionLike) {
-                        return null;
-                    }
-
-                    foreach ($reflection->getParameters() as $index => $parameterReflection) {
-                        if ($index !== $key) {
-                            continue;
-                        }
-
-                        if ($parameterReflection->getType() instanceof CallableType
-                            &&
-                            count($parameterReflection->getType()->getParameters()) !== 1
-                            && ! $methodReflection instanceof NativeFunctionReflection
-                            && $this->hasDocCommentForCallable($classMethodOrFunction, $index)
-                        ) {
-                            $args[$key]->value->setAttribute(self::HAS_CALLBACK_SIGNATURE_MULTI_PARAMS, true);
-                            return null;
-                        }
-
-                        $parameterName = $parameterReflection->getName();
-
-                        $isInvokable = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
-                            $classMethodOrFunction,
-                            fn (Node $node): bool => $node instanceof FuncCall
-                            && $node->name instanceof Variable
-                            && $this->isName($node->name, $parameterName)
-                            && count($node->args) > 1
-                        );
-
-                        if ($isInvokable) {
-                            $args[$key]->value->setAttribute(self::HAS_CALLBACK_SIGNATURE_MULTI_PARAMS, true);
-                            return null;
-                        }
-
-                        $isClosureBindTo = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
-                            $classMethodOrFunction,
-                            function (Node $node) use ($parameterName): bool {
-                                if (! $node instanceof MethodCall) {
-                                    return false;
-                                }
-
-                                if (! $node->name instanceof Identifier) {
-                                    return false;
-                                }
-
-                                if (! $this->isName($node->name, 'bindTo')) {
-                                    return false;
-                                }
-
-                                if (! $node->var instanceof Variable) {
-                                    return false;
-                                }
-
-                                if (! $this->isObjectType($node->var, new ObjectType('Closure'))) {
-                                    return false;
-                                }
-
-                                return $this->isName($node->var, $parameterName);
-                            }
-                        );
-
-                        if ($isClosureBindTo) {
-                            $args[$key]->value->setAttribute(self::HAS_CALLBACK_SIGNATURE_MULTI_PARAMS, true);
-                            return null;
-                        }
-                    }
+                    $arg->value->setAttribute(self::HAS_CALLBACK_SIGNATURE_MULTI_PARAMS, true);
                 }
             }
 
@@ -235,37 +129,6 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::FIRST_CLASS_CALLABLE_SYNTAX;
-    }
-
-    private function hasDocCommentForCallable(FunctionLike $functionLike, int $index): bool
-    {
-        $docComment = $functionLike->getDocComment();
-        if (! $docComment instanceof Doc) {
-            return false;
-        }
-
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
-        $params = $functionLike->getParams();
-
-        $paramName = null;
-        foreach ($params as $key => $param) {
-            if ($key === $index) {
-                $paramName = (string) $this->getName($param);
-                break;
-            }
-        }
-
-        if ($paramName === null) {
-            return false;
-        }
-
-        $paramTagValueNode = $phpDocInfo->getParamTagValueByName($paramName);
-        if ($paramTagValueNode instanceof ParamTagValueNode) {
-            $type = $phpDocInfo->getParamType($paramName);
-            return ($type instanceof CallableType && count($type->getParameters()) !== 1) || $type instanceof UnionType;
-        }
-
-        return false;
     }
 
     private function shouldSkip(

--- a/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
+++ b/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -193,22 +193,22 @@ final readonly class ReflectionResolver
     }
 
     public function resolveFunctionLikeReflectionFromCall(
-        CallLike $call
+        CallLike $callLike
     ): MethodReflection | FunctionReflection | null {
-        if ($call instanceof MethodCall) {
-            return $this->resolveMethodReflectionFromMethodCall($call);
+        if ($callLike instanceof MethodCall) {
+            return $this->resolveMethodReflectionFromMethodCall($callLike);
         }
 
-        if ($call instanceof StaticCall) {
-            return $this->resolveMethodReflectionFromStaticCall($call);
+        if ($callLike instanceof StaticCall) {
+            return $this->resolveMethodReflectionFromStaticCall($callLike);
         }
 
-        if ($call instanceof New_) {
-            return $this->resolveMethodReflectionFromNew($call);
+        if ($callLike instanceof New_) {
+            return $this->resolveMethodReflectionFromNew($callLike);
         }
 
-        if ($call instanceof FuncCall) {
-            return $this->resolveFunctionReflectionFromFuncCall($call);
+        if ($callLike instanceof FuncCall) {
+            return $this->resolveFunctionReflectionFromFuncCall($callLike);
         }
 
         // todo: support NullsafeMethodCall

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Reflection;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
@@ -192,7 +193,7 @@ final readonly class ReflectionResolver
     }
 
     public function resolveFunctionLikeReflectionFromCall(
-        MethodCall|FuncCall|StaticCall|New_ $call
+        CallLike $call
     ): MethodReflection | FunctionReflection | null {
         if ($call instanceof MethodCall) {
             return $this->resolveMethodReflectionFromMethodCall($call);

--- a/src/Reflection/ReflectionResolver.php
+++ b/src/Reflection/ReflectionResolver.php
@@ -206,7 +206,12 @@ final readonly class ReflectionResolver
             return $this->resolveMethodReflectionFromNew($call);
         }
 
-        return $this->resolveFunctionReflectionFromFuncCall($call);
+        if ($call instanceof FuncCall) {
+            return $this->resolveFunctionReflectionFromFuncCall($call);
+        }
+
+        // todo: support NullsafeMethodCall
+        return null;
     }
 
     public function resolveMethodReflectionFromClassMethod(ClassMethod $classMethod, Scope $scope): ?MethodReflection


### PR DESCRIPTION
When on method call, it can be anything defined in caller, this PR skip if it is as arg of non-native function call.

The skipped parts already in other fixtures, the updated fixture for demonstrate trailing comma :)