### PR TITLE
[fix] skip different args passed to call-like and required by arrow function in FunctionLikeToFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/ArrowFunction/skip_no_args_passed.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/ArrowFunction/skip_no_args_passed.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture\ArrowFunction;
+
+use Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Source\FooBar;
+
+final class SkipNoArgsPassed
+{
+    public function run()
+    {
+        $data = [
+            'callback' => fn ($foo) => FooBar::optionalArgs()
+        ];
+
+        return $data;
+    }
+}

--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Fixture/fixture.php.inc
@@ -11,13 +11,6 @@ function ($foo)
 
 fn ($foo) => FooBar::foo($foo);
 
-function ($foo, $bar, $ray)
-{
-    return FooBar::foo($foo, $bar);
-};
-
-fn ($foo, $bar, $ray) => FooBar::foo($foo);
-
 ?>
 -----
 <?php
@@ -25,10 +18,6 @@ fn ($foo, $bar, $ray) => FooBar::foo($foo);
 namespace Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Fixture;
 
 use Rector\Tests\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector\Source\FooBar;
-
-FooBar::foo(...);
-
-FooBar::foo(...);
 
 FooBar::foo(...);
 

--- a/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Source/FooBar.php
+++ b/rules-tests/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector/Source/FooBar.php
@@ -7,4 +7,8 @@ class FooBar
     public static function foo($args)
     {
     }
+
+    public static function optionalArgs($args = null)
+    {
+    }
 }

--- a/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
+++ b/rules/CodingStyle/Rector/FunctionLike/FunctionLikeToFirstClassCallableRector.php
@@ -111,7 +111,6 @@ CODE_SAMPLE
         }
 
         $callLike = $this->extractCallLike($node);
-
         if ($callLike === null) {
             return null;
         }
@@ -135,8 +134,13 @@ CODE_SAMPLE
         FuncCall|MethodCall|StaticCall $callLike,
         Scope $scope
     ): bool {
-        $params = $node->getParams();
         if ($callLike->isFirstClassCallable()) {
+            return true;
+        }
+
+        $params = $node->getParams();
+
+        if (count($params) !== count($callLike->getArgs())) {
             return true;
         }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/9471