### PR TITLE
Don't require parentheses for short-ternaries

### DIFF
--- a/rules-tests/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector/Fixture/skip_elvis.php.inc
+++ b/rules-tests/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector/Fixture/skip_elvis.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+function elvisDoesNotNeedParentheses()
+{
+  echo 0 ?: 1 ?: 2 ?: 3, PHP_EOL; //1
+  echo 0 ?: 0 ?: 2 ?: 3, PHP_EOL; //2
+  echo 0 ?: 0 ?: 0 ?: 3, PHP_EOL; //3
+}

--- a/rules/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector.php
+++ b/rules/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector.php
@@ -61,6 +61,12 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         if ($node->cond instanceof Ternary || $node->else instanceof Ternary) {
+            // Chaining of short-ternaries (elvis operator) is stable and behaves reasonably
+            $isElvis = $node->cond instanceof Ternary && $node->cond->if === null;
+            if ($isElvis) {
+                return null;
+            }
+
             if ($this->parenthesizedNestedTernaryAnalyzer->isParenthesized($this->file, $node)) {
                 return null;
             }


### PR DESCRIPTION
Chaining of short-ternaries (`?:` also called elvis operator) is stable and behaves reasonably.

This is described in the PHP Manual right below the warning about using nested ternary expressions.

https://www.php.net/manual/en/language.operators.comparison.php#:~:text=Chaining%20of%20short%2Dternaries%20(%3F%3A)%2C%20however%2C%20is%20stable%20and%20behaves%20reasonably

The test code is taken right from the PHP Manual.

This fixes https://github.com/rectorphp/rector/issues/8552.