### PR TITLE
[Privatization] Do not remove readonly on promoted property on PrivatizeFinalClassPropertyRector

### DIFF
--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/do_not_remove_readonly_promoted_property.php.inc
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/do_not_remove_readonly_promoted_property.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture;
+
+final class DoNotRemoveReadonlyPromotedProperty
+{
+    public function __construct(protected readonly \stdClass $std)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture;
+
+final class DoNotRemoveReadonlyPromotedProperty
+{
+    public function __construct(private readonly \stdClass $std)
+    {
+    }
+}
+
+?>

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -171,11 +171,6 @@ final class VisibilityManipulator
             return;
         }
 
-        if ($node instanceof Param) {
-            $node->flags = 0;
-            return;
-        }
-
         if ($node->isPublic()) {
             $node->flags |= Modifiers::PUBLIC;
             $node->flags -= Modifiers::PUBLIC;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9481