### PR TITLE
[TypeDeclaration] Skip return interface on NarrowObjectReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/skip_return_interface.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/skip_return_interface.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Fixture;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+final class SkipReturnInterface
+{
+    protected function build(): LoggerInterface
+    {
+        return new NullLogger();
+    }
+}


### PR DESCRIPTION
Per @calebdw feedback on https://github.com/rectorphp/rector-src/pull/7575#issuecomment-3514920353

This PR skip return interface, except for common use that usually use dummy/implementation on tests, defined in constant `ALLOWED_INTERFACES_CHANGE` list.

/cc @Orest-Divintari 