### PR TITLE
[TypeDeclaration] Skip no key generic object return on NarrowObjectReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/skip_no_key_generic_object_return_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/skip_no_key_generic_object_return_doc.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Fixture;
+
+final class SkipNoKeyGenericObjectReturnDoc
+{
+    /**
+     * @return \Iterator<\stdClass>
+     */
+    public function run(): \Iterator
+    {
+        $arr = [new \stdClass];
+        return new \ArrayIterator($arr);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9489

@staabm  check only instanceof `PHPStan\Type\Generic\GenericObjectType` seems can handle it.