### PR TITLE
[Unambiguous] Skip return different object on FluentSettersToStandaloneCallMethodRector

### DIFF
--- a/rules-tests/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector/Fixture/skip_return_different_object.php.inc
+++ b/rules-tests/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector/Fixture/skip_return_different_object.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Unambiguous\Rector\Expression\FluentSettersToStandaloneCallMethodRector\Fixture;
+
+use Rector\Tests\Unambiguous\Rector\Expression\FluentSettersToStandaloneCallMethodRector\Source\SetNameCaller;
+
+class SkipReturnDifferentObject
+{
+     public function setup()
+     {
+          return (new SetNameCaller())
+               ->setName('John')
+               ->setSurname('Doe');
+     }
+}

--- a/rules-tests/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector/Source/SetNameCaller.php
+++ b/rules-tests/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector/Source/SetNameCaller.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Unambiguous\Rector\Expression\FluentSettersToStandaloneCallMethodRector\Source;
+
+class SetNameCaller
+{
+    public function setName(): SurnameCaller
+    {
+        return new SurnameCaller();
+    }
+}

--- a/rules-tests/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector/Source/SurnameCaller.php
+++ b/rules-tests/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector/Source/SurnameCaller.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Unambiguous\Rector\Expression\FluentSettersToStandaloneCallMethodRector\Source;
+
+class SurnameCaller
+{
+    public function setSurname(): self
+    {
+        return $this;
+    }
+}

--- a/rules/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector.php
+++ b/rules/Unambiguous/Rector/Expression/FluentSettersToStandaloneCallMethodRector.php
@@ -98,9 +98,25 @@ CODE_SAMPLE
         $methodCalls = [];
 
         $currentMethodCall = $firstMethodCall;
+        $classNameObjectType = null;
         while ($currentMethodCall instanceof MethodCall) {
+            if ($currentMethodCall->isFirstClassCallable()) {
+                return null;
+            }
+
             // must be exactly one argument
             if (count($currentMethodCall->getArgs()) !== 1) {
+                return null;
+            }
+
+            $objectType = $this->getType($currentMethodCall->var);
+            if (! $objectType instanceof ObjectType) {
+                return null;
+            }
+
+            if ($classNameObjectType === null) {
+                $classNameObjectType = $objectType->getClassName();
+            } elseif ($classNameObjectType !== $objectType->getClassName()) {
                 return null;
             }
 


### PR DESCRIPTION
Per @VincentLanglet review at https://github.com/rectorphp/rector-src/pull/7625#issuecomment-3532543668