### PR TITLE
[TypeDeclaration] Handle crash on combine union types on AddClosureParamTypeForArrayReduceRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Fixture/combine_union.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Fixture/combine_union.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector\Source\PaymentPeriod;
+
+final class CombineUnion
+{
+    /**
+     * @param array<PaymentPeriod> $arr
+     */
+    public function run(array $arr)
+    {
+        $sumCents = \array_reduce($arr, function ($carry, PaymentPeriod $paymentPeriod) : float|int {
+            return $carry + $paymentPeriod->getSum();
+        }, 0);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector\Source\PaymentPeriod;
+
+final class CombineUnion
+{
+    /**
+     * @param array<PaymentPeriod> $arr
+     */
+    public function run(array $arr)
+    {
+        $sumCents = \array_reduce($arr, function (int|float $carry, PaymentPeriod $paymentPeriod) : float|int {
+            return $carry + $paymentPeriod->getSum();
+        }, 0);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Source/PaymentPeriod.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Source/PaymentPeriod.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector\Source;
+
+interface PaymentPeriod {
+    public function getSum() : float|null;
+}

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector.php
@@ -178,13 +178,16 @@ CODE_SAMPLE
             return $types[0];
         }
 
-        foreach ($types as $type) {
+        foreach ($types as $key => $type) {
             if ($type instanceof UnionType) {
                 foreach ($type->getTypes() as $unionedType) {
                     if ($unionedType instanceof IntersectionType) {
                         return null;
                     }
                 }
+
+                $types = array_merge($types, $type->getTypes());
+                unset($types[$key]);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9495
Ref https://getrector.com/demo/1837abc8-d65a-46f0-9fc4-fe7df5f697d5