### PR TITLE
[Php80] Handle mix still annotation and already attribute on AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/with_mixed_attribute_and_annotations.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/with_mixed_attribute_and_annotations.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+use Behat\Step\When;
+
+final class WithMixedAttributeAndAnnotations
+{
+    /**
+     * @When /^I have a step using annotations$/
+     */
+    public function hadAnnotations(): void
+    {
+    }
+
+    #[When('/^I have a step using attributes$/')]
+    public function hadAttributes(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+use Behat\Step\When;
+
+final class WithMixedAttributeAndAnnotations
+{
+    #[\Behat\Step\When('/^I have a step using annotations$/')]
+    public function hadAnnotations(): void
+    {
+    }
+
+    #[When('/^I have a step using attributes$/')]
+    public function hadAttributes(): void
+    {
+    }
+}
+
+?>

--- a/rules/Php80/Rector/Class_/AttributeValueResolver.php
+++ b/rules/Php80/Rector/Class_/AttributeValueResolver.php
@@ -32,7 +32,9 @@ final class AttributeValueResolver
         if ($phpDocTagNode->value instanceof DoctrineAnnotationTagValueNode) {
             $originalContent = (string) $phpDocTagNode->value->getOriginalContent();
 
-            if ($docValue !== '') {
+            if ($docValue === '') {
+                $docValue = $originalContent;
+            } else {
                 $attributeComment = ltrim($originalContent, $docValue);
                 if ($attributeComment !== '') {
                     $docValue .= "\n" . $attributeComment;


### PR DESCRIPTION
If a file already contains a mix of annotations and attributes, the current AnnotationToAttributeRector implementation drops the annotation value when generating the new Attribute tag and therefore produces an invalid result.

This could happen, for example, with a Behat context in a legacy project that has a mix of old and new step definitions.

AFAICS this is because:
* If the file does not yet import an attribute class then the `@When` attribute is parsed as a `PhpDocTagNode`
* If the file already imports an attribute class (e.g. `use Behat\Step\When`) then the `@When` attribute is parsed as a `DoctrineAnnotationTagValueNode`.

The original annotation value is stored differently in these two tag node classes.

It looks like this was originally supported / handled through a fix in #6582. That was subsequently modified in #6589 to add support for additional comments following the attribute value. 

More recently #7582 removed the comment logic, but also removed handling for the original case where the node is an instance of `DoctrineAnnotationTagValueNode` but its `->value` casts to an empty string.

I have added a new fixture to prove the bug and will push again with a second commit to show that it is now fixed.

