### PR TITLE
Deprecated STMT_KEY and remove its set attribute value

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -379,6 +379,3 @@ parameters:
         -
             message: '#Property Rector\\PhpParser\\NodeTraverser\\AbstractImmutableNodeTraverser\:\:\$visitors \(list<PhpParser\\NodeVisitor>\) does not accept array<int\|string, PhpParser\\NodeVisitor>#'
             path: src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
-
-        # handle next
-        - '#Fetching deprecated class constant STMT_KEY of class Rector\\NodeTypeResolver\\Node\\AttributeKey#'

--- a/src/Application/NodeAttributeReIndexer.php
+++ b/src/Application/NodeAttributeReIndexer.php
@@ -22,11 +22,10 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class NodeAttributeReIndexer
 {
-    public static function reIndexStmtKeyNodeAttributes(Node $node): ?Node
+    public static function reIndexStmtsKeys(Node $node): ?Node
     {
         if (! $node instanceof StmtsAwareInterface && ! $node instanceof ClassLike && ! $node instanceof Declare_ && ! $node instanceof Block) {
             return null;
@@ -37,19 +36,13 @@ final class NodeAttributeReIndexer
         }
 
         $node->stmts = array_values($node->stmts);
-
-        // re-index stmt key under current node
-        foreach ($node->stmts as $key => $childStmt) {
-            $childStmt->setAttribute(AttributeKey::STMT_KEY, $key);
-        }
-
         return $node;
     }
 
-    public static function reIndexNodeAttributes(Node $node, bool $reIndexStmtKey = true): ?Node
+    public static function reIndexNodeAttributes(Node $node, bool $reIndexStmtsKeys = true): ?Node
     {
-        if ($reIndexStmtKey) {
-            self::reIndexStmtKeyNodeAttributes($node);
+        if ($reIndexStmtsKeys) {
+            self::reIndexStmtsKeys($node);
         }
 
         if ($node instanceof If_) {

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -162,6 +162,8 @@ final class AttributeKey
     public const IS_BYREF_RETURN = 'is_byref_return';
 
     /**
+     * @deprecated This value can change, as based on default input keys. Use existing array keys instead.
+     *
      * @var string
      */
     public const STMT_KEY = 'stmt_key';

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/StmtKeyNodeVisitor.php
@@ -13,6 +13,6 @@ final class StmtKeyNodeVisitor extends NodeVisitorAbstract implements ScopeResol
 {
     public function enterNode(Node $node): ?Node
     {
-        return NodeAttributeReIndexer::reIndexStmtKeyNodeAttributes($node);
+        return NodeAttributeReIndexer::reIndexStmtsKeys($node);
     }
 }

--- a/tests/Issues/IndexedStmt/Source/ChangeLastIndex1Rector.php
+++ b/tests/Issues/IndexedStmt/Source/ChangeLastIndex1Rector.php
@@ -7,9 +7,7 @@ namespace Rector\Tests\Issues\IndexedStmt\Source;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
-use PhpParser\NodeVisitor;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -34,8 +32,8 @@ final class ChangeLastIndex1Rector extends AbstractRector
             return null;
         }
 
-        foreach ($node->stmts as $stmt) {
-            if ($stmt->getAttribute(AttributeKey::STMT_KEY) === 1 && $stmt instanceof Expression && $stmt->expr instanceof String_ && $stmt->expr->value === 'with index 2') {
+        foreach ($node->stmts as $key => $stmt) {
+            if ($key === 1 && $stmt instanceof Expression && $stmt->expr instanceof String_ && $stmt->expr->value === 'with index 2') {
                 $stmt->expr->value = 'final index';
                 return $node;
             }


### PR DESCRIPTION
@TomasVotruba here to deprecate usage of `stmt_key` and remove its `setAttribute()` value, make less bc break as possible.

Other keyed data values is re-ordered when changed on called on next run on purpose, to avoid when node just removed, eg: return `NodeVisitor::REMOVE_NODE`, the key will use new key from parent.

Closes https://github.com/rectorphp/rector-src/pull/7646