### PR TITLE
Remove NodeAttributeReIndexer::reIndexNodeAttributes() on AbstractRector

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -58,9 +58,7 @@ final readonly class ChangedNodeScopeRefresher
             throw new ShouldNotHappenException($errorMessage);
         }
 
-        // reindex stmt_key already covered on StmtKeyNodeVisitor on next processNodes()
-        // so set flag $reIndexStmtKey to false to avoid double loop
-        NodeAttributeReIndexer::reIndexNodeAttributes($node, false);
+        NodeAttributeReIndexer::reIndexNodeAttributes($node);
 
         $stmts = $this->resolveStmts($node);
         $this->phpStanNodeScopeResolver->processNodes($stmts, $filePath, $mutatingScope);

--- a/src/Application/NodeAttributeReIndexer.php
+++ b/src/Application/NodeAttributeReIndexer.php
@@ -25,7 +25,7 @@ use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 
 final class NodeAttributeReIndexer
 {
-    public static function reIndexStmtsKeys(Node $node): ?Node
+    private static function reIndexStmtsKeys(Node $node): ?Node
     {
         if (! $node instanceof StmtsAwareInterface && ! $node instanceof ClassLike && ! $node instanceof Declare_ && ! $node instanceof Block) {
             return null;
@@ -40,11 +40,9 @@ final class NodeAttributeReIndexer
         return $node;
     }
 
-    public static function reIndexNodeAttributes(Node $node, bool $reIndexStmtsKeys = true): ?Node
+    public static function reIndexNodeAttributes(Node $node): ?Node
     {
-        if ($reIndexStmtsKeys) {
-            self::reIndexStmtsKeys($node);
-        }
+        self::reIndexStmtsKeys($node);
 
         if ($node instanceof If_) {
             $node->elseifs = array_values($node->elseifs);

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -20,7 +20,6 @@ use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Application\ChangedNodeScopeRefresher;
-use Rector\Application\NodeAttributeReIndexer;
 use Rector\Application\Provider\CurrentFileProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
@@ -150,8 +149,6 @@ CODE_SAMPLE;
             $errorMessage = sprintf(self::EMPTY_NODE_ARRAY_MESSAGE, static::class);
             throw new ShouldNotHappenException($errorMessage);
         }
-
-        NodeAttributeReIndexer::reIndexNodeAttributes($node);
 
         $isIntRefactoredNode = is_int($refactoredNode);
 


### PR DESCRIPTION
since reindex already handled on refresh process, the reindex can be removed on AbstractRector.

Use on `ChangedNodeScopeRefresher`, but reindex stmts as well since `StmtKeyNodeVisitor` is removed on 

- https://github.com/rectorphp/rector-src/pull/7651