### PR TITLE
[Experiment][Printer] Move AlwaysRememberedExpr tweak logic to separate service after a Match_ found

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -227,7 +227,7 @@ parameters:
              paths:
                  - src/CustomRules/SimpleNodeDumper.php
                  - src/PhpDocParser/PhpDocParser/PhpDocNodeTraverser.php
-                 - src/PhpParser/Printer/BetterStandardPrinter.php
+                 - src/NodeTypeResolver/PHPStan/Scope/RectorVirtualNodeExtractor.php
 
         # known node variables
         -

--- a/src/NodeTypeResolver/PHPStan/Scope/RectorVirtualNodeExtractor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/RectorVirtualNodeExtractor.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeTypeResolver\PHPStan\Scope;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Stmt;
+use PHPStan\Node\Expr\AlwaysRememberedExpr;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+
+final class RectorVirtualNodeExtractor
+{
+    /**
+     * @param Stmt[] $stmts
+     */
+    public static function processNodes(array $stmts): void
+    {
+        $simpleCallableNodeTraverser = new SimpleCallableNodeTraverser();
+
+        $simpleCallableNodeTraverser->traverseNodesWithCallable(
+            $stmts,
+            function (Node $node): ?Node {
+                $hasRememberedExpr = false;
+
+                // handle already AlwaysRememberedExpr
+                // @see https://github.com/rectorphp/rector/issues/8815#issuecomment-2503453191
+                while ($node instanceof AlwaysRememberedExpr) {
+                    $node = $node->getExpr();
+                    $hasRememberedExpr = true;
+                }
+
+                // handle overlapped origNode is Match_
+                // and its subnodes still have AlwaysRememberedExpr
+                $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
+
+                if ($originalNode instanceof Match_) {
+                    $subNodeNames = $node->getSubNodeNames();
+                    foreach ($subNodeNames as $subNodeName) {
+                        while ($originalNode->{$subNodeName} instanceof AlwaysRememberedExpr) {
+                            $originalNode->{$subNodeName} = $originalNode->{$subNodeName}->getExpr();
+                            $hasRememberedExpr = true;
+                        }
+                    }
+                }
+
+                if (! $hasRememberedExpr) {
+                    return null;
+                }
+
+                return $node;
+            }
+        );
+    }
+}

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Pipe;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Instanceof_;
-use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Ternary;
@@ -31,7 +30,6 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\PrettyPrinter\Standard;
 use PhpParser\Token;
 use PHPStan\Node\AnonymousClassNode;
-use PHPStan\Node\Expr\AlwaysRememberedExpr;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\NodeAnalyzer\ExprAnalyzer;
@@ -136,25 +134,6 @@ final class BetterStandardPrinter extends Standard
         int $lhsPrecedence = self::MAX_PRECEDENCE,
         bool $parentFormatPreserved = false
     ): string {
-        // handle already AlwaysRememberedExpr
-        // @see https://github.com/rectorphp/rector/issues/8815#issuecomment-2503453191
-        while ($node instanceof AlwaysRememberedExpr) {
-            $node = $node->getExpr();
-        }
-
-        // handle overlapped origNode is Match_
-        // and its subnodes still have AlwaysRememberedExpr
-        $originalNode = $node->getAttribute(AttributeKey::ORIGINAL_NODE);
-
-        if ($originalNode instanceof Match_) {
-            $subNodeNames = $node->getSubNodeNames();
-            foreach ($subNodeNames as $subNodeName) {
-                while ($originalNode->{$subNodeName} instanceof AlwaysRememberedExpr) {
-                    $originalNode->{$subNodeName} = $originalNode->{$subNodeName}->getExpr();
-                }
-            }
-        }
-
         $this->wrapBinaryOp($node);
 
         $content = parent::p($node, $precedence, $lhsPrecedence, $parentFormatPreserved);


### PR DESCRIPTION
This PR try to move away `AlwaysRememberedExpr` tweak from `Printer` to separate service after processing `\PHPStan\Analyser\NodeScopeResolver::processNodes()` calls.

Twis was requires 2 locations which not fully patch, then move to printer, this time apply full patch with verify both `AlwaysRememberedExpr` and `origNode` itself a `Match_`, but move out from the Printer.

There was an issue that only reproduced via https://getrector.com/demo/ , so this requires verification after merged.