### PR TITLE
[DeadCode] skip Ds\Map::get() on RemoveNullArgOnNullDefaultParamRector

### DIFF
--- a/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/skip_ds_map_get.php.inc
+++ b/rules-tests/DeadCode/Rector/MethodCall/RemoveNullArgOnNullDefaultParamRector/Fixture/skip_ds_map_get.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector\Fixture;
+
+use Ds\Map;
+
+class SkipDsMapGet
+{
+    public function foo(): void {
+        $map = new Map();
+        $value = $map->get('foo', null);
+        if ($value) {
+            //...
+        }
+    }
+}

--- a/rules/DeadCode/NodeAnalyzer/CallLikeParamDefaultResolver.php
+++ b/rules/DeadCode/NodeAnalyzer/CallLikeParamDefaultResolver.php
@@ -31,6 +31,13 @@ final readonly class CallLikeParamDefaultResolver
             return [];
         }
 
+        if ($reflection instanceof MethodReflection && $reflection->getName() === 'get') {
+            $classReflection = $reflection->getDeclaringClass();
+            if ($classReflection->getName() === 'Ds\Map') {
+                return [];
+            }
+        }
+
         $nullPositions = [];
 
         $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors($reflection->getVariants());


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9509
Ref https://getrector.com/demo/1fb51b20-1659-4f28-8218-69303f089dac
Ref https://www.php.net/manual/en/ds-map.get.php

If no default value is given, instead of returning null, it get an OutOfBoundsException