### PR TITLE
[Dep] Ignore unknown class error on build/config/config-downgrade.php on shipmonk/composer-dependency-analyser to 1.8.4

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -21,6 +21,7 @@ return $config
         __DIR__ . '/stubs',
         __DIR__ . '/tests',
         __DIR__ . '/rules-tests',
+        __DIR__ . '/build/config/config-downgrade.php'
     ], [ErrorType::UNKNOWN_CLASS])
 
     ->disableExtensionsAnalysis();

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "rector/release-notes-generator": "^0.5",
         "rector/swiss-knife": "^2.3",
         "rector/type-perfect": "^2.1",
-        "shipmonk/composer-dependency-analyser": "1.8.3",
+        "shipmonk/composer-dependency-analyser": "^1.8",
         "symplify/phpstan-extensions": "^12.0.2",
         "symplify/phpstan-rules": "^14.8.5",
         "symplify/vendor-patches": "^11.5",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "rector/release-notes-generator": "^0.5",
         "rector/swiss-knife": "^2.3",
         "rector/type-perfect": "^2.1",
-        "shipmonk/composer-dependency-analyser": "^1.8",
+        "shipmonk/composer-dependency-analyser": "1.8.3",
         "symplify/phpstan-extensions": "^12.0.2",
         "symplify/phpstan-rules": "^14.8.5",
         "symplify/vendor-patches": "^11.5",


### PR DESCRIPTION
New release of `shipmonk/composer-dependency-analyser` 1.8.4 cause error on pull request action:

```
vendor/bin/composer-dependency-analyser

Found 1 unknown class!
(unable to autoload those, so we cannot check them)

  • DowngradeRectorConfig
    in build/config/config-downgrade.php:10
```

see https://github.com/rectorphp/rector-src/actions/runs/19675350225/job/56354827988?pr=7667#step:5:16

which define class and direct use cause error above. I reported the issue at:

- https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/247

for it.

While wait, we can temporary ignore the error.