### PR TITLE
[issue 9492] create reproducer for PHPStan changing array_map args, printing invalid content as result

### DIFF
--- a/.github/workflows/phpstan_printer_test.yaml
+++ b/.github/workflows/phpstan_printer_test.yaml
@@ -1,0 +1,41 @@
+name: PHPStan Printer Test
+
+on:
+    pull_request: null
+    push:
+     branches:
+        - main
+
+
+
+env:
+    # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
+    COMPOSER_ROOT_VERSION: "dev-main"
+
+jobs:
+    tests:
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+                php-versions: ['8.2']
+
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 3
+
+        name: PHP ${{ matrix.php-versions }} tests (${{ matrix.os }})
+        steps:
+            -   uses: actions/checkout@v4
+
+            -
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-versions }}
+                    coverage: none
+                    # to display warning when assert() is called, eg: on direct getArgs() on CallLike
+                    # and check against first class callable strlen(...)
+                    ini-values: zend.assertions=1
+
+            -   uses: "ramsey/composer-install@v3"
+
+            -   run: vendor/bin/phpunit tests/PhpParser/Printer/PHPStanPrinterTest.php --colors

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "2.1.x-dev",
+        "phpstan/phpstan": "^2.1.32",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "2.1.19 as 2.1.32",
+        "phpstan/phpstan": "2.1.x-dev",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "^2.1.32",
+        "phpstan/phpstan": "2.1.19 as 2.1.32",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",

--- a/rules-tests/CodeQuality/Rector/FuncCall/SortNamedParamRector/Fixture/array_map_named_params.php.inc
+++ b/rules-tests/CodeQuality/Rector/FuncCall/SortNamedParamRector/Fixture/array_map_named_params.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SortNamedParamRector\Fixture;
+
+$items = [1, 2, 3];
+$result = array_map(array: $items, callback: fn ($item) => $item * 2);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\FuncCall\SortNamedParamRector\Fixture;
+
+$items = [1, 2, 3];
+$result = array_map(callback: fn ($item) => $item * 2, array: $items);
+
+?>

--- a/tests/PhpParser/Printer/Fixture/some_array_map.php
+++ b/tests/PhpParser/Printer/Fixture/some_array_map.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\PhpParser\Printer\Fixture;
+
+$result = array_map(array: [1, 2, 3], callback: fn(int $value) => $value);

--- a/tests/PhpParser/Printer/PHPStanPrinterTest.php
+++ b/tests/PhpParser/Printer/PHPStanPrinterTest.php
@@ -8,6 +8,7 @@ use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\RichParser;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use ReflectionProperty;
 
 /**
  * Test case for: https://github.com/rectorphp/rector/issues/9492
@@ -23,17 +24,17 @@ final class PHPStanPrinterTest extends AbstractLazyTestCase
         $stmts = $phpstanParser->parseFile(__DIR__ . '/Fixture/some_array_map.php');
 
         // get private property "parser"
-        $parserReflectionProperty = new \ReflectionProperty(RichParser::class, 'parser');
+        $parserReflectionProperty = new ReflectionProperty(RichParser::class, 'parser');
 
         /** @var \PhpParser\Parser $innerParser */
         $innerParser = $parserReflectionProperty->getValue($phpstanParser);
         $tokens = $innerParser->getTokens();
 
-        $standardPrinter = new Standard([
-            'newline' => "\n",
-        ]);
-        $printerContents = $standardPrinter->printFormatPreserving($stmts, $stmts, $tokens);
+        $standard = new Standard([]);
+        $printerContents = $standard->printFormatPreserving($stmts, $stmts, $tokens);
 
-        $this->assertStringEqualsFile(__DIR__ . '/Fixture/some_array_map.php', $printerContents);
+        $newlineNormalizedContents = str_replace("\r\n", PHP_EOL, $printerContents);
+
+        $this->assertStringEqualsFile(__DIR__ . '/Fixture/some_array_map.php', $newlineNormalizedContents);
     }
 }

--- a/tests/PhpParser/Printer/PHPStanPrinterTest.php
+++ b/tests/PhpParser/Printer/PHPStanPrinterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\PhpParser\Printer;
+
+use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Parser\Parser;
+use PHPStan\Parser\RichParser;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+
+/**
+ * Test case for: https://github.com/rectorphp/rector/issues/9492
+ * Most likely caused by https://github.com/phpstan/phpstan-src/pull/3763
+ */
+final class PHPStanPrinterTest extends AbstractLazyTestCase
+{
+    public function testAddingCommentOnSomeNodesFail(): void
+    {
+        /** @var RichParser $phpstanParser */
+        $phpstanParser = $this->make(Parser::class);
+
+        $stmts = $phpstanParser->parseFile(__DIR__ . '/Fixture/some_array_map.php');
+
+        // get private property "parser"
+        $parserReflectionProperty = new \ReflectionProperty(RichParser::class, 'parser');
+
+        /** @var \PhpParser\Parser $innerParser */
+        $innerParser = $parserReflectionProperty->getValue($phpstanParser);
+        $tokens = $innerParser->getTokens();
+
+        $standardPrinter = new Standard([
+            'newline' => "\n",
+        ]);
+        $printerContents = $standardPrinter->printFormatPreserving($stmts, $stmts, $tokens);
+
+        $this->assertStringEqualsFile(__DIR__ . '/Fixture/some_array_map.php', $printerContents);
+    }
+}


### PR DESCRIPTION
Test case for: https://github.com/rectorphp/rector/issues/9492

This test uses PHPStan `RichParser` and native `Standard` printer to decouple from any Rector custom logic.

<br>

How to reproduce:

```bash
vendor/bin/phpunit tests/PhpParser/Printer/PHPStanPrinterTest.php
```

<br>

## PHPStan 2.1.18 :heavy_check_mark: 

Keeps original argument order:

```bash
Runtime:       PHP 8.2.29
Configuration: /home/runner/work/rector-src/rector-src/phpunit.xml

.                                                                   1 / 1 (100%)

Time: 00:00.346, Memory: 52.00 MB

OK (1 test, 2 assertions)
```

<br>

## PHPStan 2.1.19 :red_circle: 

Changes argument order:

```bash
Time: 00:00.138, Memory: 38.00 MB

There was 1 failure:

1) Rector\Tests\PhpParser\Printer\PHPStanPrinterTest::testAddingCommentOnSomeNodesFail
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '...re;\n
 \n
-$result = array_map(array: [1, 2, 3], callback: fn(int $value) => $value);\n
+$result = array_map(callback: fn(int $value) => $value, array: [1, 2, 3]);\n
```

