### PR TITLE
[Php80] Handle OpenApi\Attributes\Property example to keep numeric string on AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/open_api_property_example_keep_numeric_string.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/open_api_property_example_keep_numeric_string.php.inc
@@ -24,7 +24,7 @@ use OpenApi\Attributes as OA;
 
 final class OpenAPIPropertyExampleKeepNumericString
 {
-    #[OA\Property(example: '1112')]
+    #[OA\Property(example: '01112')]
     public ?string $uid = null;
 }
 

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/open_api_property_example_keep_numeric_string.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/open_api_property_example_keep_numeric_string.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use OpenApi\Annotations as OA;
+
+final class OpenAPIPropertyExampleKeepNumericString
+{
+    /**
+     * @OA\Property(
+     *     example="01112"
+     * )
+     */
+    public ?string $uid = null;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use OpenApi\Attributes as OA;
+
+final class OpenAPIPropertyExampleKeepNumericString
+{
+    #[OA\Property(example: '1112')]
+    public ?string $uid = null;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -71,5 +71,8 @@ return static function (RectorConfig $rectorConfig): void {
             'Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Annotation\SomeProperty',
             'Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute\SomeProperty'
         ),
+
+        // for testing allow numeric string keep as string
+        new AnnotationToAttribute('OpenApi\\Annotations\\Property', 'OpenApi\\Attributes\\Property'),
     ]);
 };

--- a/src/PhpAttribute/AttributeArrayNameInliner.php
+++ b/src/PhpAttribute/AttributeArrayNameInliner.php
@@ -16,13 +16,18 @@ use Webmozart\Assert\Assert;
 final class AttributeArrayNameInliner
 {
     /**
+     * @var class-string
+     */
+    private const OPEN_API_PROPERTY_ATTRIBUTE = 'OpenApi\Attributes\Property';
+
+    /**
      * @param Array_|list<Arg> $array
      * @return list<Arg>
      */
-    public function inlineArrayToArgs(Array_|array $array): array
+    public function inlineArrayToArgs(Array_|array $array, ?string $attributeClass = null): array
     {
         if (is_array($array)) {
-            return $this->inlineArray($array);
+            return $this->inlineArray($array, $attributeClass);
         }
 
         return $this->inlineArrayNode($array);
@@ -56,11 +61,16 @@ final class AttributeArrayNameInliner
      * @param list<Arg> $args
      * @return list<Arg>
      */
-    private function inlineArray(array $args): array
+    private function inlineArray(array $args, ?string $attributeClass = null): array
     {
         Assert::allIsAOf($args, Arg::class);
-
         foreach ($args as $arg) {
+            if ($attributeClass === self::OPEN_API_PROPERTY_ATTRIBUTE
+                && $arg->name instanceof Identifier
+                && $arg->name->toString() === 'example') {
+                continue;
+            }
+
             if ($arg->value instanceof String_ && is_numeric($arg->value->value)) {
                 // use equal over identical on purpose to verify if it is an integer
                 if ((float) $arg->value->value == (int) $arg->value->value) {

--- a/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -85,7 +85,7 @@ final readonly class PhpAttributeGroupFactory
 
         $this->annotationToAttributeIntegerValueCaster->castAttributeTypes($annotationToAttribute, $args);
 
-        $args = $this->attributeArrayNameInliner->inlineArrayToArgs($args);
+        $args = $this->attributeArrayNameInliner->inlineArrayToArgs($args, $annotationToAttribute->getAttributeClass());
 
         $attributeName = $this->attributeNameFactory->create(
             $annotationToAttribute,

--- a/stubs/OpenApi/Attributes/Property.php
+++ b/stubs/OpenApi/Attributes/Property.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenApi\Attributes;
+
+if (class_exists('OpenApi\Attributes\Property')) {
+    return;
+}
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::IS_REPEATABLE)]
+class Property
+{
+    public function __construct(mixed $example)
+    {
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9497