### PR TITLE
[fix] skip already dim fetch variable on OrdSingleByteRector

### DIFF
--- a/rules-tests/Php85/Rector/FuncCall/OrdSingleByteRector/Fixture/skip_already_dim_fetched_value.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/OrdSingleByteRector/Fixture/skip_already_dim_fetched_value.php.inc
@@ -1,0 +1,5 @@
+<?php
+namespace Rector\Tests\Php85\Rector\FuncCall\OrdSingleByteRector\Fixture;
+
+$a = 'abc';
+echo ord($a[0]);

--- a/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
+++ b/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rector\Php85\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\Int_;
@@ -65,12 +67,9 @@ CODE_SAMPLE
         }
 
         $args = $node->getArgs();
+        $firstArg = $args[0];
 
-        if (! isset($node->args[0])) {
-            return null;
-        }
-
-        $argExpr = $args[0]->value;
+        $argExpr = $firstArg->value;
         $type = $this->nodeTypeResolver->getNativeType($argExpr);
 
         if (! $type->isString()->yes() && ! $type->isInteger()->yes()) {
@@ -81,30 +80,49 @@ CODE_SAMPLE
         $isInt = is_int($value);
 
         if (! $argExpr instanceof Int_) {
-
-            if ($isInt) {
-                return null;
-            }
-
-            $args[0]->value = new ArrayDimFetch($argExpr, new Int_(0));
-            $node->args = $args;
-
-            return $node;
+            return $this->refactorStringType($argExpr, $isInt, $args, $node);
         }
 
+        return $this->refactorInt($value, $isInt, $args, $node);
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::DEPRECATE_ORD_WITH_MULTIBYTE_STRING;
+    }
+
+    /**
+     * @param Arg[] $args
+     */
+    private function refactorStringType(Expr $argExpr, bool $isInt, array $args, FuncCall $funcCall): null|FuncCall
+    {
+        if ($argExpr instanceof ArrayDimFetch) {
+            return null;
+        }
+
+        if ($isInt) {
+            return null;
+        }
+
+        $args[0]->value = new ArrayDimFetch($argExpr, new Int_(0));
+        $funcCall->args = $args;
+
+        return $funcCall;
+    }
+
+    /**
+     * @param Arg[] $args
+     */
+    private function refactorInt(mixed $value, bool $isInt, array $args, FuncCall $funcCall): FuncCall
+    {
         $value = (string) $value;
         $byte = $value[0] ?? '';
 
         $byteValue = $isInt ? new Int_((int) $byte) : new String_($byte);
 
         $args[0]->value = $byteValue;
-        $node->args = $args;
+        $funcCall->args = $args;
 
-        return $node;
-    }
-
-    public function provideMinPhpVersion(): int
-    {
-        return PhpVersionFeature::DEPRECATE_ORD_WITH_MULTIBYTE_STRING;
+        return $funcCall;
     }
 }


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/9503, closes https://github.com/rectorphp/rector/issues/9512

Related RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_passing_string_which_are_not_one_byte_long_to_ord