### PR TITLE
[CodingStyle] Handle use trait after property on NewlineBetweenClassLikeStmtsRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ClassLike/NewlineBetweenClassLikeStmtsRector/Fixture/use_trait_after_property.php.inc
+++ b/rules-tests/CodingStyle/Rector/ClassLike/NewlineBetweenClassLikeStmtsRector/Fixture/use_trait_after_property.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector\Fixture;
+
+class UseTraitAfterProperty
+{
+    private $a;
+    use SomeTrait;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector\Fixture;
+
+class UseTraitAfterProperty
+{
+    private $a;
+
+    use SomeTrait;
+}
+
+?>

--- a/rules/CodeQuality/Rector/FuncCall/SortNamedParamRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/SortNamedParamRector.php
@@ -75,6 +75,7 @@ CODE_SAMPLE
         if ($node instanceof CallLike && $node->isFirstClassCallable()) {
             return null;
         }
+
         $args = $node instanceof Attribute ? $node->args : $node->getArgs();
 
         if (count($args) <= 1) {

--- a/rules/CodingStyle/Rector/ClassLike/NewlineBetweenClassLikeStmtsRector.php
+++ b/rules/CodingStyle/Rector/ClassLike/NewlineBetweenClassLikeStmtsRector.php
@@ -86,12 +86,12 @@ CODE_SAMPLE
                 break;
             }
 
-            if ($classLike->stmts[$key + 1] instanceof TraitUse) {
-                continue;
-            }
-
             $stmt = $classLike->stmts[$key];
             $nextStmt = $classLike->stmts[$key + 1];
+
+            if ($stmt instanceof TraitUse && $nextStmt instanceof TraitUse) {
+                continue;
+            }
 
             $endLine = $stmt->getEndLine();
             $rangeLine = $nextStmt->getStartLine() - $endLine;


### PR DESCRIPTION
@calebdw continue of PR:

- https://github.com/rectorphp/rector-src/pull/7685

This cover next stmt is trait use, but current stmt is not trait use, which new line is ok on this case :)