### PR TITLE
[PhpParser] Add Stmt\Block to NodeGroup::STMTS_AWARE

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
 
     # see https://phpstan.org/writing-php-code/phpdoc-types#global-type-aliases
     typeAliases:
-        StmtsAware: \PhpParser\Node\Expr\Closure | \PhpParser\Node\Stmt\Case_ | \PhpParser\Node\Stmt\Catch_ | \PhpParser\Node\Stmt\ClassMethod | \PhpParser\Node\Stmt\Do_ | \PhpParser\Node\Stmt\Else_ | \PhpParser\Node\Stmt\ElseIf_ | \PhpParser\Node\Stmt\Finally_ | \PhpParser\Node\Stmt\For_ | \PhpParser\Node\Stmt\Foreach_ | \PhpParser\Node\Stmt\Function_ | \PhpParser\Node\Stmt\If_ | \PhpParser\Node\Stmt\Namespace_ | \PhpParser\Node\Stmt\TryCatch | \PhpParser\Node\Stmt\While_
+        StmtsAware: \PhpParser\Node\Stmt\Block | \PhpParser\Node\Expr\Closure | \PhpParser\Node\Stmt\Case_ | \PhpParser\Node\Stmt\Catch_ | \PhpParser\Node\Stmt\ClassMethod | \PhpParser\Node\Stmt\Do_ | \PhpParser\Node\Stmt\Else_ | \PhpParser\Node\Stmt\ElseIf_ | \PhpParser\Node\Stmt\Finally_ | \PhpParser\Node\Stmt\For_ | \PhpParser\Node\Stmt\Foreach_ | \PhpParser\Node\Stmt\Function_ | \PhpParser\Node\Stmt\If_ | \PhpParser\Node\Stmt\Namespace_ | \PhpParser\Node\Stmt\TryCatch | \PhpParser\Node\Stmt\While_ | \Rector\PhpParser\Node\CustomNode\FileWithoutNamespace
 
     # requires exact closure types
     checkMissingCallableSignature: true

--- a/src/Application/NodeAttributeReIndexer.php
+++ b/src/Application/NodeAttributeReIndexer.php
@@ -69,7 +69,7 @@ final class NodeAttributeReIndexer
     {
         if (! NodeGroup::isStmtAwareNode(
             $node
-        ) && ! $node instanceof ClassLike && ! $node instanceof Declare_ && ! $node instanceof Block) {
+        ) && ! $node instanceof ClassLike && ! $node instanceof Declare_) {
             return null;
         }
 

--- a/src/Application/NodeAttributeReIndexer.php
+++ b/src/Application/NodeAttributeReIndexer.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt\Block;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Declare_;

--- a/src/PhpParser/Enum/NodeGroup.php
+++ b/src/PhpParser/Enum/NodeGroup.php
@@ -6,6 +6,7 @@ namespace Rector\PhpParser\Enum;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\Block;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\Class_;
@@ -38,6 +39,7 @@ final class NodeGroup
      * @var array<class-string<Node>>
      */
     public const STMTS_AWARE = [
+        Block::class,
         Closure::class,
         Case_::class,
         Catch_::class,


### PR DESCRIPTION
`Node\Stmt\Block` is part of stmts aware.

- https://github.com/nikic/PHP-Parser/pull/1113

Also add it and `\Rector\PhpParser\Node\CustomNode\FileWithoutNamespace` to `typeAliases`