### PR TITLE
[dx] add stmts aware deprecation notice in getNodeTypes()

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -266,7 +266,9 @@ parameters:
 
         # BC layer on Rector deprecation
         -
-            path: src/Configuration/RectorConfigBuilder.php
+            paths:
+                - src/Configuration/RectorConfigBuilder.php
+                - src/Reporting/DeprecatedRulesReporter.php
             identifier: classConstant.deprecatedInterface
         - '#Class Rector\\PhpParser\\Node\\CustomNode\\FileWithoutNamespace implements deprecated interface Rector\\Contract\\PhpParser\\Node\\StmtsAwareInterface#'
 

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -170,6 +170,7 @@ EOF
 
         $this->deprecatedRulesReporter->reportDeprecatedRules();
         $this->deprecatedRulesReporter->reportDeprecatedSkippedRules();
+        $this->deprecatedRulesReporter->reportDeprecatedNodeTypes();
 
         $this->missConfigurationReporter->reportSkippedNeverRegisteredRules();
 

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -165,6 +165,7 @@ use Rector\PHPStanStaticTypeMapper\TypeMapper\UnionTypeMapper;
 use Rector\PHPStanStaticTypeMapper\TypeMapper\VoidTypeMapper;
 use Rector\PostRector\Application\PostFileProcessor;
 use Rector\Rector\AbstractRector;
+use Rector\Reporting\DeprecatedRulesReporter;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 use Rector\StaticTypeMapper\Contract\PhpParser\PhpParserNodeMapperInterface;
@@ -425,6 +426,10 @@ final class LazyContainerFactory
             ->giveTagged(RectorInterface::class);
 
         $rectorConfig->when(OnlyRuleResolver::class)
+            ->needs('$rectors')
+            ->giveTagged(RectorInterface::class);
+
+        $rectorConfig->when(DeprecatedRulesReporter::class)
             ->needs('$rectors')
             ->giveTagged(RectorInterface::class);
 

--- a/src/Reporting/DeprecatedRulesReporter.php
+++ b/src/Reporting/DeprecatedRulesReporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Reporting;
 
+use Rector\PhpParser\Enum\NodeGroup;
 use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
@@ -76,7 +77,7 @@ final readonly class DeprecatedRulesReporter
                 'Rector rule "%s" uses StmtsAwareInterface that is now deprecated.%sUse "%s::%s" instead.%sSee %s for more',
                 $rector::class,
                 PHP_EOL,
-                \Rector\PhpParser\Enum\NodeGroup::class,
+                NodeGroup::class,
                 'STMTS_AWARE',
                 PHP_EOL . PHP_EOL,
                 'https://github.com/rectorphp/rector-src/pull/7679'

--- a/src/Reporting/DeprecatedRulesReporter.php
+++ b/src/Reporting/DeprecatedRulesReporter.php
@@ -7,12 +7,18 @@ namespace Rector\Reporting;
 use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Contract\Rector\RectorInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class DeprecatedRulesReporter
 {
+    /**
+     * @param RectorInterface[] $rectors
+     */
     public function __construct(
-        private SymfonyStyle $symfonyStyle
+        private SymfonyStyle $symfonyStyle,
+        private array $rectors
     ) {
     }
 
@@ -46,6 +52,35 @@ final readonly class DeprecatedRulesReporter
             }
 
             $this->symfonyStyle->warning(sprintf('Skipped rule "%s" is deprecated', $skippedRectorRule));
+        }
+    }
+
+    public function reportDeprecatedNodeTypes(): void
+    {
+        // helper property to avoid reporting multiple times
+        static $reportedClasses = [];
+
+        foreach ($this->rectors as $rector) {
+            if (! in_array(StmtsAwareInterface::class, $rector->getNodeTypes())) {
+                continue;
+            }
+
+            // already reported, skip
+            if (in_array($rector::class, $reportedClasses, true)) {
+                continue;
+            }
+
+            $reportedClasses[] = $rector::class;
+
+            $this->symfonyStyle->warning(sprintf(
+                'Rector rule "%s" uses StmtsAwareInterface that is now deprecated.%sUse "%s::%s" instead.%sSee %s for more',
+                $rector::class,
+                PHP_EOL,
+                \Rector\PhpParser\Enum\NodeGroup::class,
+                'STMTS_AWARE',
+                PHP_EOL . PHP_EOL,
+                'https://github.com/rectorphp/rector-src/pull/7679'
+            ));
         }
     }
 }


### PR DESCRIPTION
Add little warning to inform custom rule devs about deprecated `StmtsAwareInterface::class`, see https://github.com/rectorphp/rector-src/pull/7679

<img width="2458" height="879" alt="Screenshot From 2025-12-01 12-37-16" src="https://github.com/user-attachments/assets/49105268-85a6-4edb-b7b5-37140667b00f" />
