### PR TITLE
Make lock closed issue/pr run by weekly

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -2,7 +2,7 @@ name: "Lock closed PRs"
 
 on:
     schedule:
-        - cron: "0 3 * * *" # every day at 03:00 UTC
+        - cron: "0 3 * * 0" # every Sunday at 03:00 UTC
     workflow_dispatch:
 
 jobs:

--- a/build/target-repository/.github/workflows/lock.yaml
+++ b/build/target-repository/.github/workflows/lock.yaml
@@ -2,7 +2,7 @@ name: "Lock closed issues"
 
 on:
     schedule:
-        - cron: "0 3 * * *" # every day at 03:00 UTC
+        - cron: "0 3 * * 0" # every Sunday at 03:00 UTC
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
@TomasVotruba I think run daily will become too many notification daily, and make hard to verify which PR/issue to follow or just mark as read.

This PR make it only run weekly on sunday 03,

see https://crontab.guru/#0_3_*_*_0