### PR TITLE
[TypeDeclaration] Make configurable on NarrowObjectReturnTypeRector to allow to not make change return on abstract/interface return

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/DisableReturnAbstractOrInterfaceTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/DisableReturnAbstractOrInterfaceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DisableReturnAbstractOrInterfaceTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureSkipReturnAbstractOrInterface');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/disable_return_abstract_or_interface_configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/FixtureSkipReturnAbstractOrInterface/skip_abstract_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/FixtureSkipReturnAbstractOrInterface/skip_abstract_class.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\FixtureSkipReturnAbstractOrInterface;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\AbstractTalk;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\ConcreteConferenceTalk;
+
+final class SkipReturnAbstractClass
+{
+    public function create(): AbstractTalk
+    {
+        return new ConcreteConferenceTalk();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/FixtureSkipReturnAbstractOrInterface/skip_return_interface.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/FixtureSkipReturnAbstractOrInterface/skip_return_interface.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\FixtureSkipReturnAbstractOrInterface;
+
+use Illuminate\Container\Container;
+use Psr\Container\ContainerInterface;
+
+final class SkipReturnInterface
+{
+    public function create(): ContainerInterface
+    {
+        return new Container();
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/config/disable_return_abstract_or_interface_configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/config/disable_return_abstract_or_interface_configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(NarrowObjectReturnTypeRector::class, [
+        NarrowObjectReturnTypeRector::IS_ALLOW_ABSTRACT_AND_INTERFACE => false,
+    ]);
+};

--- a/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
+++ b/rules/Transform/Rector/ArrayDimFetch/ArrayDimFetchToMethodCallRector.php
@@ -87,6 +87,7 @@ CODE_SAMPLE
             if (! $node->var instanceof ArrayDimFetch) {
                 return null;
             }
+
             return $this->createExplicitMethodCall($node->var, 'set', $node->expr);
         }
 


### PR DESCRIPTION
@Orest-Divintari @ruudk  @calebdw  per our discussion on the original PR:

- https://github.com/rectorphp/rector-src/pull/7575

the contract return was returned, but this cause some issue reported while interface return is valid, see issue:

- https://github.com/rectorphp/rector/issues/9525
- https://github.com/rectorphp/rector/issues/9489

This PR make it configurable, for allow to skip abstract/interface return, for whatever default value is, this imo should be configurable.

Closes https://github.com/rectorphp/rector/issues/9525