### PR TITLE
[TypeDeclaration] Allow interface return change to exact return on private method on NarrowObjectReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/allow_interface_return_on_private_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/allow_interface_return_on_private_method.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\TalkInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\ConferenceTalkImplementation;
+
+final class AllowInterfaceReturnOnPrivateMethod
+{
+    private function create(): TalkInterface
+    {
+        return new ConferenceTalkImplementation();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\TalkInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\ConferenceTalkImplementation;
+
+final class AllowInterfaceReturnOnPrivateMethod
+{
+    private function create(): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\ConferenceTalkImplementation
+    {
+        return new ConferenceTalkImplementation();
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
@@ -150,6 +150,7 @@ CODE_SAMPLE
             }
 
             // this rule narrows only object or class types, not interfaces
+            // except private methods, as they are not part of contract, and not mockable from tests
             if (! $declaredTypeClassReflection->isClass() && ! $node->isPrivate()) {
                 return null;
             }

--- a/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
@@ -150,7 +150,7 @@ CODE_SAMPLE
             }
 
             // this rule narrows only object or class types, not interfaces
-            if (! $declaredTypeClassReflection->isClass()) {
+            if (! $declaredTypeClassReflection->isClass() && ! $node->isPrivate()) {
                 return null;
             }
         }


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/7700#pullrequestreview-3528802832

private method is not part of contract, and usualyl not mockable or to be mockable by test, so changing interface return type on private method should be allowed.