### PR TITLE
[DeadCode] Skip on object with __destruct method on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_object_with_destruct_method.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_object_with_destruct_method.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Source\SomeLock;
+
+final class SkipObjectWithDestructMethod
+{
+    public function run()
+    {
+        $lock = $this->createLock();
+
+        echo 'foobar';
+    }
+
+    private function createLock(): SomeLock
+    {
+        return new SomeLock();
+    }
+}

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Source/SomeLock.php
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Source/SomeLock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Source;
+
+class SomeLock
+{
+    public function __destruct()
+    {
+        // Do important things
+    }
+}

--- a/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/PhpVersionConditionNodeVisitor.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/NodeVisitor/PhpVersionConditionNodeVisitor.php
@@ -27,7 +27,7 @@ final class PhpVersionConditionNodeVisitor extends NodeVisitorAbstract implement
         if (($node instanceof Ternary || $node instanceof If_) && $this->hasVersionCompareCond($node)) {
             if ($node instanceof Ternary) {
                 $nodes = [$node->else];
-                if ($node->if instanceof \PhpParser\Node) {
+                if ($node->if instanceof Node) {
                     $nodes[] = $node->if;
                 }
             } else {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9529