### PR TITLE
[internal] Remove duplicated enterNode() type check already handled in node traverser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8.2",
         "clue/ndjson-react": "^1.3",
-        "composer/pcre": "^3.3.0",
+        "composer/pcre": "^3.3.2",
         "composer/semver": "^3.4",
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
@@ -50,7 +50,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^11.5",
-        "rector/jack": "^0.4.0",
+        "rector/jack": "^0.4",
         "rector/release-notes-generator": "^0.5",
         "rector/swiss-knife": "^2.3",
         "rector/type-perfect": "^2.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -433,6 +433,11 @@ parameters:
                 - rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
                 - rules/Php81/Enum/AttributeName.php
 
+        -
+            identifier: symplify.seeAnnotationToTest
+            paths:
+                - tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_
+
         # deprecated rule
         - '#Rule Rector\\Php81\\Rector\\Array_\\FirstClassCallableRector must implements Rector\\VersionBonding\\Contract\\MinPhpVersionInterface#'
         - '#Register "Rector\\Php81\\Rector\\Array_\\FirstClassCallableRector" service to "php81\.php" config set#'

--- a/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
@@ -101,6 +101,7 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
             $traverseChildren = true;
             $visitorIndex = -1;
             $currentNodeVisitors = $this->getVisitorsForNode($subNode);
+
             foreach ($currentNodeVisitors as $visitorIndex => $visitor) {
                 $return = $visitor->enterNode($subNode);
                 if ($return !== null) {
@@ -185,6 +186,7 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
             $traverseChildren = true;
             $visitorIndex = -1;
             $currentNodeVisitors = $this->getVisitorsForNode($node);
+
             foreach ($currentNodeVisitors as $visitorIndex => $visitor) {
                 $return = $visitor->enterNode($node);
                 if ($return !== null) {

--- a/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
@@ -112,10 +112,8 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
                         $node->{$name} = $return;
 
                         if ($originalSubNodeClass !== $subNode::class) {
-                            // stop traversing as node has changed its class and visitors do not work
-                            $traverseChildren = false;
-                            $this->stopTraversal = true;
-                            break 2;
+                            // stop traversing as node type changed and visitors won't work
+                            return;
                         }
 
                     } elseif ($return === NodeVisitor::DONT_TRAVERSE_CHILDREN) {
@@ -196,9 +194,8 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
                         $nodes[$i] = $node = $return;
 
                         if ($originalNodeNodeClass !== $return::class) {
-                            // stop traversing as node has changed its class and visitors do not work
-                            $this->stopTraversal = true;
-                            break 2;
+                            // stop traversing as node type changed and visitors won't work
+                            return $nodes;
                         }
                     } elseif (\is_array($return)) {
                         $doNodes[] = [$i, $return];

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -95,6 +95,7 @@ final class RectorNodeTraverser extends AbstractImmutableNodeTraverser
 
         // filer out by version
         $this->visitors = $this->phpVersionedFilter->filter($this->rectors);
+
         // filter by configuration
         $this->visitors = $this->configurationRuleFilter->filter($this->visitors);
 

--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -67,6 +67,7 @@ final class RectorNodeTraverser extends AbstractImmutableNodeTraverser
 
         if (! isset($this->visitorsPerNodeClass[$nodeClass])) {
             $this->visitorsPerNodeClass[$nodeClass] = [];
+
             /** @var RectorInterface $visitor */
             foreach ($this->visitors as $visitor) {
                 foreach ($visitor->getNodeTypes() as $nodeType) {

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -132,10 +132,6 @@ CODE_SAMPLE;
      */
     final public function enterNode(Node $node): int|Node|null
     {
-        if (! $this->isMatchingNodeType($node)) {
-            return null;
-        }
-
         if (is_a($this, HTMLAverseRectorInterface::class, true) && $this->file->containsHTML()) {
             return null;
         }
@@ -316,17 +312,5 @@ CODE_SAMPLE;
         foreach ($nodes as $node) {
             $this->changedNodeScopeRefresher->refresh($node, $filePath, $mutatingScope);
         }
-    }
-
-    private function isMatchingNodeType(Node $node): bool
-    {
-        $nodeClass = $node::class;
-        foreach ($this->getNodeTypes() as $nodeType) {
-            if (is_a($nodeClass, $nodeType, true)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleChangingClassToTraitRector.php
+++ b/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleChangingClassToTraitRector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class RuleChangingClassToTraitRector extends AbstractRector
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    /**
+     * @param Node\Stmt\Class_ $node
+     * @return Node\Stmt\Trait_
+     */
+    public function refactor(Node $node)
+    {
+        return new Node\Stmt\Trait_('SomeTrait');
+    }
+}

--- a/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleChangingClassToTraitRector.php
+++ b/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleChangingClassToTraitRector.php
@@ -1,29 +1,36 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Trait_;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class RuleChangingClassToTraitRector extends AbstractRector
 {
-
     public function getRuleDefinition(): RuleDefinition
     {
+        return new RuleDefinition('Change node from class to trait', []);
     }
 
     public function getNodeTypes(): array
     {
-        return [Node\Stmt\Class_::class];
+        return [Class_::class];
     }
 
     /**
-     * @param Node\Stmt\Class_ $node
-     * @return Node\Stmt\Trait_
+     * @param Class_ $node
      */
-    public function refactor(Node $node)
+    public function refactor(Node $node): Trait_
     {
-        return new Node\Stmt\Trait_('SomeTrait');
+        $trait = new Trait_('SomeTrait');
+        $trait->namespacedName = new Name('SomeNamespace\SomeTrait');
+
+        return $trait;
     }
 }

--- a/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleCheckingClassRector.php
+++ b/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleCheckingClassRector.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+final class RuleCheckingClassRector extends AbstractRector
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     * @return Class_
+     */
+    public function refactor(Node $node)
+    {
+        Assert::isInstanceOf($node, Class_::class);
+
+        return $node;
+    }
+}

--- a/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleCheckingClassRector.php
+++ b/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Class_/RuleCheckingClassRector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_;
 
 use PhpParser\Node;
@@ -10,9 +12,9 @@ use Webmozart\Assert\Assert;
 
 final class RuleCheckingClassRector extends AbstractRector
 {
-
     public function getRuleDefinition(): RuleDefinition
     {
+        return new RuleDefinition('Make sure input is class', []);
     }
 
     public function getNodeTypes(): array
@@ -24,7 +26,7 @@ final class RuleCheckingClassRector extends AbstractRector
      * @param Class_ $node
      * @return Class_
      */
-    public function refactor(Node $node)
+    public function refactor(Node $node): Node
     {
         Assert::isInstanceOf($node, Class_::class);
 

--- a/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Fixture/SimpleClass.php
+++ b/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/Fixture/SimpleClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Fixture;
+
+final class SimpleClass
+{
+}

--- a/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/StopTraverseOnTypeChangeTest.php
+++ b/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/StopTraverseOnTypeChangeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange;
+
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Trait_;
+use Rector\Application\Provider\CurrentFileProvider;
+use Rector\PhpParser\NodeTraverser\RectorNodeTraverser;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_\RuleChangingClassToTraitRector;
+use Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_\RuleCheckingClassRector;
+
+final class StopTraverseOnTypeChangeTest extends AbstractLazyTestCase
+{
+    private RectorNodeTraverser $rectorNodeTraverser;
+
+    protected function setUp(): void
+    {
+        $this->rectorNodeTraverser = $this->make(RectorNodeTraverser::class);
+
+        $this->rectorNodeTraverser->refreshPhpRectors([
+            $this->make(RuleChangingClassToTraitRector::class),
+            $this->make(RuleCheckingClassRector::class)
+        ]);
+
+        $currentFileProvider = $this->make(CurrentFileProvider::class);
+
+        // @todo
+        // $currentFileProvider->setFile();
+    }
+
+    public function testGetVisitorsForNodeWhenNoVisitorsAvailable(): void
+    {
+        $class = new Class_('test');
+
+        $changedNodes = $this->rectorNodeTraverser->traverse([$class]);
+        $this->assertContainsOnlyInstancesOf(Trait_::class, $changedNodes);
+    }
+}

--- a/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/StopTraverseOnTypeChangeTest.php
+++ b/tests/PhpParser/NodeTraverser/StopTraverseOnTypeChange/StopTraverseOnTypeChangeTest.php
@@ -6,9 +6,10 @@ namespace Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange;
 
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Trait_;
-use Rector\Application\Provider\CurrentFileProvider;
+use PhpParser\NodeFinder;
 use Rector\PhpParser\NodeTraverser\RectorNodeTraverser;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Testing\TestingParser\TestingParser;
 use Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_\RuleChangingClassToTraitRector;
 use Rector\Tests\PhpParser\NodeTraverser\StopTraverseOnTypeChange\Class_\RuleCheckingClassRector;
 
@@ -16,26 +17,34 @@ final class StopTraverseOnTypeChangeTest extends AbstractLazyTestCase
 {
     private RectorNodeTraverser $rectorNodeTraverser;
 
+    private TestingParser $testingParser;
+
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->rectorNodeTraverser = $this->make(RectorNodeTraverser::class);
 
         $this->rectorNodeTraverser->refreshPhpRectors([
             $this->make(RuleChangingClassToTraitRector::class),
-            $this->make(RuleCheckingClassRector::class)
+            $this->make(RuleCheckingClassRector::class),
         ]);
 
-        $currentFileProvider = $this->make(CurrentFileProvider::class);
-
-        // @todo
-        // $currentFileProvider->setFile();
+        $this->testingParser = $this->make(TestingParser::class);
     }
 
     public function testGetVisitorsForNodeWhenNoVisitorsAvailable(): void
     {
-        $class = new Class_('test');
+        // must be cloned + Scope set to allow node replacement
+        $nodes = $this->testingParser->parseFileToDecoratedNodes(__DIR__ . '/Fixture/SimpleClass.php');
 
-        $changedNodes = $this->rectorNodeTraverser->traverse([$class]);
-        $this->assertContainsOnlyInstancesOf(Trait_::class, $changedNodes);
+        $changedNodes = $this->rectorNodeTraverser->traverse($nodes);
+
+        $nodeFinder = new NodeFinder();
+        $classes = $nodeFinder->findInstanceOf($changedNodes, Class_::class);
+        $this->assertCount(0, $classes);
+
+        $traits = $nodeFinder->findInstanceOf($changedNodes, Trait_::class);
+        $this->assertCount(1, $traits);
     }
 }


### PR DESCRIPTION
When Rector traversers nodes, it only applies related rules. E.g. when a rule hooks into `Class_`, its only run on a `Class_` node. This already happens in a node visitor since https://github.com/rectorphp/rector-src/pull/6232


 <br>

Yet, we still have a duplicate check on every single node enter:

```php
  final public function enterNode(Node $node): int|Node|null
    {
        if (! $this->isMatchingNodeType($node)) {
            return null;
        }
        
        // ...
   }
```

This is redundant and now removed :+1: 