### PR TITLE
Bump to PHPStan ^2.1.33, add back ArrayMapArgVisitor

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_array_of_strings_on_array_map.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_array_of_strings_on_array_map.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipArrayOfStringsOnArrayMap
+{
+    public function foo(string $name)
+    {
+        $parts = explode('_', $name);
+        return implode(
+            '',
+            array_map(
+                fn ($part): string =>
+                strtolower($part),
+                $parts
+            )
+        );
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/return_by_array_shape_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/return_by_array_shape_type.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class ReturnByArrayShapeType
+{
+    /**
+     * @param array<int, array{bar: int}> $values
+     */
+    private function foo(array $values): void
+    {
+        $bars = array_map(fn($value) => $value['bar'], $values);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class ReturnByArrayShapeType
+{
+    /**
+     * @param array<int, array{bar: int}> $values
+     */
+    private function foo(array $values): void
+    {
+        $bars = array_map(fn($value): int => $value['bar'], $values);
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector.php
+++ b/rules/CodingStyle/Rector/Enum_/EnumCaseToPascalCaseRector.php
@@ -208,9 +208,9 @@ final class EnumCaseToPascalCaseRector extends AbstractRector
                 fn ($part): string =>
                 // If part is all uppercase, convert to ucfirst(strtolower())
                 // If part is already mixed or PascalCase, keep as is except ucfirst
-                ctype_upper((string) $part)
-                    ? ucfirst(strtolower((string) $part))
-                    : ucfirst((string) $part),
+                ctype_upper($part)
+                    ? ucfirst(strtolower($part))
+                    : ucfirst($part),
                 $parts
             )
         );

--- a/rules/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/FuncCall/AddArrowFunctionParamArrayWhereDimFetchRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ArrayType;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
@@ -149,8 +148,7 @@ CODE_SAMPLE
             if ($arrayDimFetch->var instanceof Variable) {
                 $type = $this->nodeTypeResolver->getNativeType($arrayDimFetch->var);
 
-                // skip string values
-                if (! $arrayDimFetch->dim instanceof String_ && ($type->isString()->yes() || $type->isString()->maybe())) {
+                if ($type->isString()->yes()) {
                     continue;
                 }
 

--- a/src/DependencyInjection/PHPStan/PHPStanContainerMemento.php
+++ b/src/DependencyInjection/PHPStan/PHPStanContainerMemento.php
@@ -7,6 +7,7 @@ namespace Rector\DependencyInjection\PHPStan;
 use PHPStan\DependencyInjection\MemoizingContainer;
 use PHPStan\DependencyInjection\Nette\NetteContainer;
 use PHPStan\Parser\AnonymousClassVisitor;
+use PHPStan\Parser\ArrayMapArgVisitor;
 use PHPStan\Parser\RichParser;
 use PHPStan\Parser\VariadicFunctionsVisitor;
 use PHPStan\Parser\VariadicMethodsVisitor;
@@ -42,6 +43,7 @@ final class PHPStanContainerMemento
             $container->findServiceNamesByType(AnonymousClassVisitor::class)[0] => true,
             $container->findServiceNamesByType(VariadicFunctionsVisitor::class)[0] => true,
             $container->findServiceNamesByType(VariadicMethodsVisitor::class)[0] => true,
+            $container->findServiceNamesByType(ArrayMapArgVisitor::class)[0] => true,
         ];
 
         $tags[RichParser::VISITOR_SERVICE_TAG] = $nodeVisitorsToKeep;


### PR DESCRIPTION
PHPStan 2.1.33 just released with a reverted sort argument on ArrayMapArgVisitor

https://github.com/phpstan/phpstan-src/commit/f562834ce0b2c47e06da89b729d4214a5d88d68d

so `ArrayMapArgVisitor` can be re-added.

Per https://github.com/rectorphp/rector-src/pull/7715#issuecomment-3616565240

Added test as well for skip string cast under array_map that all strings.