### PR TITLE
Remove comment has above node skipped on current rule on RectifiedAnalyzer

### DIFF
--- a/src/ProcessAnalyzer/RectifiedAnalyzer.php
+++ b/src/ProcessAnalyzer/RectifiedAnalyzer.php
@@ -14,7 +14,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  *
  *      - already applied same Rector rule before current Rector rule on last previous Rector rule.
  *      - just re-printed but token start still >= 0
- *      - has above node skipped traverse children on current rule
  */
 final readonly class RectifiedAnalyzer
 {


### PR DESCRIPTION
Since direct functionality of return `DONT_TRAVERSE_*` on `refactor()` removed at PR:

- https://github.com/rectorphp/rector-src/pull/7708

the comment functionality note can be removed as well.