### PR TITLE
fix(RemoveParentCallWithoutParentRector): skip cases when class reflection is not found

### DIFF
--- a/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -138,6 +138,11 @@ CODE_SAMPLE
 
     private function shouldSkipClass(Class_ $class): bool
     {
+        // skip cases when class reflection is not found
+        if (! $this->reflectionProvider->hasClass((string) $this->getName($class))) {
+            return true;
+        }
+
         // skip cases when parent class reflection is not found
         if ($class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
             $class->extends->toString()


### PR DESCRIPTION
Hello!

This rule is removing the `parent::__construct()` calls when it shouldn't. After some digging I found that the following returns true when the class reflection can't be found, instead of assuming that it has no parents we should just skip:

```php
 return $this->classMethodManipulator->hasParentMethodOrInterfaceMethod($class, $calledMethodName);
```

Thanks!