### PR TITLE
Bump nikic/php-parser to ^5.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
         "nette/utils": "^4.1",
-        "nikic/php-parser": "^5.6.2",
+        "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1.33",

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -19,7 +19,6 @@ use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\InterpolatedStringPart;
@@ -30,7 +29,6 @@ use PhpParser\Node\Stmt\InlineHTML;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\PrettyPrinter\Standard;
 use PhpParser\Token;
-use PHPStan\Node\AnonymousClassNode;
 use PHPStan\Node\Expr\AlwaysRememberedExpr;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
@@ -39,7 +37,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Util\NewLineSplitter;
 use Rector\Util\Reflection\PrivatesAccessor;
-use Rector\Util\StringUtils;
 
 /**
  * @see \Rector\Tests\PhpParser\Printer\BetterStandardPrinterTest
@@ -54,12 +51,6 @@ final class BetterStandardPrinter extends Standard
      * @var string
      */
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
-
-    /**
-     * @see https://regex101.com/r/UluSYL/1
-     * @var string
-     */
-    private const SPACED_NEW_START_REGEX = '#^new\s+#';
 
     public function __construct(
         private readonly ExprAnalyzer $exprAnalyzer,
@@ -158,14 +149,6 @@ final class BetterStandardPrinter extends Standard
         $this->wrapBinaryOp($node);
 
         $content = parent::p($node, $precedence, $lhsPrecedence, $parentFormatPreserved);
-
-        /** @todo remove once fix https://github.com/nikic/PHP-Parser/commit/232169fd7972e018e3d7adbcaa235a2eaa2440c4 is released */
-        if ($node instanceof New_ && $node->class instanceof AnonymousClassNode && ! StringUtils::isMatch(
-            $content,
-            self::SPACED_NEW_START_REGEX
-        )) {
-            $content = 'new ' . $content;
-        }
 
         if ($node instanceof CallLike) {
             $this->cleanVariadicPlaceHolderTrailingComma($node);


### PR DESCRIPTION
nikic/php-parser 5.7.0 just released https://github.com/nikic/PHP-Parser/releases/tag/v5.7.0

Let;s see if can remove `AnonymousClass` hack on `BetterStandardPrinter`, see patch https://github.com/nikic/PHP-Parser/commit/232169fd7972e018e3d7adbcaa235a2eaa2440c4