### PR TITLE
[internal] Mark beforeTraverse() in AbstractRector as @final to prevent override and miss-use

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -408,3 +408,8 @@ parameters:
         -
             identifier: rector.noOnlyNullReturnInRefactor
             path: rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php
+
+        # handle next with FileNode
+        -
+            identifier: method.parentMethodFinalByPhpDoc
+            path: rules/TypeDeclaration/Rector/StmtsAwareInterface/DeclareStrictTypesRector.php

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -106,6 +106,10 @@ CODE_SAMPLE;
     }
 
     /**
+     * @final Avoid override to prevent unintended side-effects. Use enterNode() or @see \Rector\Contract\PhpParser\DecoratingNodeVisitorInterface instead.
+     *
+     * @internal
+     *
      * @return Node[]|null
      */
     public function beforeTraverse(array $nodes): ?array


### PR DESCRIPTION
This method should have been marked as `final` from the start, to avoid leaking Rector contract.

I plan to remove it and mark `final` in the future. To keep contract stable and focused on current node only.