### PR TITLE
[internal] Traverse DecoratingNodeVisitorInterface after scope filling on PHPStanNodeScopeResolver::processNodes()

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -155,8 +155,6 @@ final readonly class PHPStanNodeScopeResolver
 
         Assert::allIsInstanceOf($stmts, Stmt::class);
 
-        $this->nodeTraverser->traverse($stmts);
-
         $scope = $formerMutatingScope ?? $this->scopeFactory->createFromFile($filePath);
 
         $nodeCallback = function (Node $node, MutatingScope $mutatingScope) use (
@@ -418,6 +416,9 @@ final readonly class PHPStanNodeScopeResolver
             // fallback to fill by found scope
             RectorNodeScopeResolver::processNodes($stmts, $scope);
         }
+
+        // use after scope filling DecoratingNodeVisitorInterface can can fetch the scope of target node
+        $this->nodeTraverser->traverse($stmts);
 
         return $stmts;
     }

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -418,6 +418,7 @@ final readonly class PHPStanNodeScopeResolver
         }
 
         // use after scope filling so DecoratingNodeVisitorInterface instance can fetch the scope of target node
+        // @see https://github.com/rectorphp/rector-src/pull/7721#discussion_r2595932460
         $this->nodeTraverser->traverse($stmts);
 
         return $stmts;

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -417,7 +417,7 @@ final readonly class PHPStanNodeScopeResolver
             RectorNodeScopeResolver::processNodes($stmts, $scope);
         }
 
-        // use after scope filling DecoratingNodeVisitorInterface can can fetch the scope of target node
+        // use after scope filling so DecoratingNodeVisitorInterface instance can fetch the scope of target node
         $this->nodeTraverser->traverse($stmts);
 
         return $stmts;


### PR DESCRIPTION
@peterfox per your comment at 

https://github.com/rectorphp/rector-src/pull/7721#discussion_r2595932460

This is ensure `DecoratingNodeVisitorInterface` be traversed after Scope filling on nodes so the visitors can know the scope of target node so scope is fetchable in the visitor when needed.