### PR TITLE
rename FirstClassCallableRector to ArrayToFirstClassCallableRector to make feature explicit

### DIFF
--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -6,7 +6,7 @@ use Rector\CodingStyle\Rector\FuncCall\ClosureFromCallableToFirstClassCallableRe
 use Rector\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector;
 use Rector\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector;
 use Rector\Config\RectorConfig;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
 use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
@@ -31,7 +31,7 @@ return static function (RectorConfig $rectorConfig): void {
         NullToStrictStringFuncCallArgRector::class,
         NullToStrictIntPregSlitFuncCallLimitArgRector::class,
         // array of local method call
-        FirstClassCallableRector::class,
+        ArrayToFirstClassCallableRector::class,
         // closure/arrow function
         FunctionLikeToFirstClassCallableRector::class,
         ClosureFromCallableToFirstClassCallableRector::class,

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/ArrayToFirstClassCallableRectorTest.php
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/ArrayToFirstClassCallableRectorTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-final class FirstClassCallableRectorTest extends AbstractRectorTestCase
+final class ArrayToFirstClassCallableRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
     public function test(string $filePath): void

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/make_other_closure_pass.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/make_other_closure_pass.php.inc
@@ -1,9 +1,9 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 use Rector\Tests\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector\Source\stdClass;
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 return static function (stdClass $container): void {
     $container->services()
@@ -14,10 +14,10 @@ return static function (stdClass $container): void {
 -----
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 use Rector\Tests\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector\Source\stdClass;
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 return static function (stdClass $container): void {
     $container->services()

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_dynamic_variable2.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_dynamic_variable2.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 $variableName = 'x';
 $index = 1;

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_enum_data.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_enum_data.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 enum SkipEnumData: int {
 

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_function_reference.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_function_reference.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SkipFunctionReference
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_attribute.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_attribute.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 function run(\Closure $closure): void
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_attribute_class.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_attribute_class.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+#[SomeAttribute(['array-argument'])]
+class SkipInAttributeClass
+{
+}

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_invoke_from_non_class_code.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_invoke_from_non_class_code.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
+
+Route::get('verify-email', [SomeExternalObject::class, '__invoke'])
+    ->name('verification.notice');

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_non_existing_method.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_non_existing_method.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SkipNonExistingMethod
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_non_static_private_method_with_other_object_const_fetch.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_non_static_private_method_with_other_object_const_fetch.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 final class SkipNonStaticPrivateMethodWithOtherObjectConstFetch
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_non_static_with_other_object_const_fetch.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_non_static_with_other_object_const_fetch.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 final class SkipNonStaticWithOtherObjectConstFetch
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_on_class_const.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_on_class_const.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SkipOnClassConst
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_on_property.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_on_property.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SkipOnProperty
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_private_method_by_instantiation.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_private_method_by_instantiation.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\WithPrivateMethod;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\WithPrivateMethod;
 
 final class SkipPrivateMethodByInstantiation
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_private_method_by_property_fetch.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_private_method_by_property_fetch.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\WithPrivateMethod;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\WithPrivateMethod;
 
 final class SkipPrivateMethodByPropertyFetch
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_simple_yield_array.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_simple_yield_array.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 use PHPStan\Type\ArrayType;
 

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_symfony_config.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_symfony_config.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $container): void {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_class.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_class.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SomeClass
 {
@@ -18,7 +18,7 @@ final class SomeClass
 -----
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SomeClass
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_static_call.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_static_call.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SomeStaticCall
 {
@@ -18,7 +18,7 @@ final class SomeStaticCall
 -----
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
 final class SomeStaticCall
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/static_with_other_object_const_fetch.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/static_with_other_object_const_fetch.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 final class StaticWithOtherObjectConstFetch
 {
@@ -16,9 +16,9 @@ final class StaticWithOtherObjectConstFetch
 -----
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 final class StaticWithOtherObjectConstFetch
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/with_property_fetch.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/with_property_fetch.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 final class WithPropertyFetch
 {
@@ -23,9 +23,9 @@ final class WithPropertyFetch
 -----
 <?php
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
 
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeExternalObject;
 
 final class WithPropertyFetch
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Source/SomeExternalObject.php
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Source/SomeExternalObject.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source;
 
 final class SomeExternalObject
 {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Source/WithPrivateMethod.php
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Source/WithPrivateMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source;
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source;
 
 class WithPrivateMethod {
   /** @var callable */

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/config/configured_rule.php
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/config/configured_rule.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(FirstClassCallableRector::class);
+    $rectorConfig->rule(ArrayToFirstClassCallableRector::class);
 
     $rectorConfig->phpVersion(PhpVersion::PHP_81);
 };

--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_dynamic_variable.php.inc
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_dynamic_variable.php.inc
@@ -1,6 +1,0 @@
-<?php
-
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
-
-$variableName = 'x';
-${$variableName} = call_user_func_array([], []);

--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_in_attribute_class.php.inc
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_in_attribute_class.php.inc
@@ -1,8 +1,0 @@
-<?php
-
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
-
-#[SomeAttribute(['array-argument'])]
-class SkipInAttributeClass
-{
-}

--- a/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_invoke_from_non_class_code.php.inc
+++ b/rules-tests/Php81/Rector/Array_/FirstClassCallableRector/Fixture/skip_invoke_from_non_class_code.php.inc
@@ -1,8 +1,0 @@
-<?php
-
-namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
-
-use Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Source\SomeExternalObject;
-
-Route::get('verify-email', [SomeExternalObject::class, '__invoke'])
-    ->name('verification.notice');

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -29,9 +29,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see RFC https://wiki.php.net/rfc/first_class_callable_syntax
- * @see \Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\FirstClassCallableRectorTest
+ * @see \Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\ArrayToFirstClassCallableRectorTest
  */
-final class FirstClassCallableRector extends AbstractRector implements MinPhpVersionInterface
+final class ArrayToFirstClassCallableRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly ArrayCallableMethodMatcher $arrayCallableMethodMatcher,

--- a/tests/Issues/AnnotationToAttributeFirstClassCallable/config/configured_rule.php
+++ b/tests/Issues/AnnotationToAttributeFirstClassCallable/config/configured_rule.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 
 return RectorConfig::configure()
     ->withConfiguredRule(AnnotationToAttributeRector::class, [
         new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\Context'),
     ])
-    ->withRules([FirstClassCallableRector::class]);
+    ->withRules([ArrayToFirstClassCallableRector::class]);

--- a/tests/Issues/AttributeAndArgValueRefresh/config/configured_rule.php
+++ b/tests/Issues/AttributeAndArgValueRefresh/config/configured_rule.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Tests\Issues\AttributeAndArgValueRefresh\Source\SetArrayArgValueRector;
 use Rector\Tests\Issues\AttributeAndArgValueRefresh\Source\SetArrayAttributeValueRector;
 
@@ -11,5 +11,5 @@ return RectorConfig::configure()
     ->withRules([
         SetArrayArgValueRector::class,
         SetArrayAttributeValueRector::class,
-        FirstClassCallableRector::class,
+        ArrayToFirstClassCallableRector::class,
     ]);


### PR DESCRIPTION
Split of https://github.com/rectorphp/rector-src/pull/6667 to 2 separate methods, to ease allow step-by-step upgrade and narrow focus on one element