### PR TITLE
[dx] warn early about deprecated skipped rules, as not neccessary to skip anymore

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -433,3 +433,12 @@ parameters:
                 - rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
                 - rules/Php81/Enum/AttributeName.php
 
+        # deprecated rule
+        - '#Rule Rector\\Php81\\Rector\\Array_\\FirstClassCallableRector must implements Rector\\VersionBonding\\Contract\\MinPhpVersionInterface#'
+        - '#Register "Rector\\Php81\\Rector\\Array_\\FirstClassCallableRector" service to "php81\.php" config set#'
+        - '#Access to constant on deprecated class Rector\\Php81\\Rector\\Array_\\FirstClassCallableRector#'
+        -
+            message: '#Only abstract classes can be extended#'
+            path: rules/Php81/Rector/Array_/FirstClassCallableRector.php
+
+

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
@@ -41,6 +42,9 @@ return RectorConfig::configure()
     ->withImportNames(removeUnusedImports: true)
     ->withRules([RemoveRefactorDuplicatedNodeInstanceCheckRector::class, AddSeeTestAnnotationRector::class])
     ->withSkip([
+        // testing skip of deprecated class
+        FunctionLikeToFirstClassCallableRector::class,
+
         StringClassNameToClassConstantRector::class,
         // tests
         '*/Fixture*',

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
@@ -42,9 +41,6 @@ return RectorConfig::configure()
     ->withImportNames(removeUnusedImports: true)
     ->withRules([RemoveRefactorDuplicatedNodeInstanceCheckRector::class, AddSeeTestAnnotationRector::class])
     ->withSkip([
-        // testing skip of deprecated class
-        FunctionLikeToFirstClassCallableRector::class,
-
         StringClassNameToClassConstantRector::class,
         // tests
         '*/Fixture*',

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -31,7 +31,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see RFC https://wiki.php.net/rfc/first_class_callable_syntax
  * @see \Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\ArrayToFirstClassCallableRectorTest
  */
-final class ArrayToFirstClassCallableRector extends AbstractRector implements MinPhpVersionInterface
+class ArrayToFirstClassCallableRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly ArrayCallableMethodMatcher $arrayCallableMethodMatcher,

--- a/rules/Php81/Rector/Array_/FirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/FirstClassCallableRector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php81\Rector\Array_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
+use Rector\Exception\ShouldNotHappenException;
+
+/**
+ * @deprecated Renamed to \Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector
+ */
+final class FirstClassCallableRector extends ArrayToFirstClassCallableRector implements DeprecatedInterface
+{
+    public function refactor(Node $node): StaticCall|MethodCall|null
+    {
+        throw new ShouldNotHappenException(sprintf(
+            '%s is deprecated and renamed to "%s". Use it instead.',
+            self::class,
+            ArrayToFirstClassCallableRector::class
+        ));
+    }
+}

--- a/src/Console/Command/ListRulesCommand.php
+++ b/src/Console/Command/ListRulesCommand.php
@@ -51,7 +51,7 @@ final class ListRulesCommand extends Command
     {
         $rectorClasses = $this->resolveRectorClasses();
 
-        $skippedClasses = $this->getSkippedCheckers();
+        $skippedClasses = $this->getSkippedRectorClasses();
 
         $outputFormat = $input->getOption(Option::OUTPUT_FORMAT);
         if ($outputFormat === 'json') {
@@ -95,20 +95,21 @@ final class ListRulesCommand extends Command
     }
 
     /**
-     * @return string[]
+     * @return array<class-string>
      */
-    private function getSkippedCheckers(): array
+    private function getSkippedRectorClasses(): array
     {
-        $skippedCheckers = [];
-        foreach ($this->skippedClassResolver->resolve() as $checkerClass => $fileList) {
+        $skippedRectorClasses = [];
+
+        foreach ($this->skippedClassResolver->resolve() as $rectorClass => $fileList) {
             // ignore specific skips
             if ($fileList !== null) {
                 continue;
             }
 
-            $skippedCheckers[] = $checkerClass;
+            $skippedRectorClasses[] = $rectorClass;
         }
 
-        return $skippedCheckers;
+        return $skippedRectorClasses;
     }
 }

--- a/src/Skipper/SkipCriteriaResolver/SkippedClassResolver.php
+++ b/src/Skipper/SkipCriteriaResolver/SkippedClassResolver.php
@@ -15,24 +15,25 @@ use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
 final class SkippedClassResolver
 {
     /**
-     * @var null|array<string, string[]|null>
+     * @var null|array<class-string, string[]|null>
      */
     private null|array $skippedClassesToFiles = null;
 
     /**
-     * @return array<DeprecatedInterface>
+     * @return array<class-string<DeprecatedInterface>>
      */
     public function resolveDeprecatedSkippedClasses(): array
     {
         $skippedClassNames = array_keys($this->resolve());
 
-        return array_filter($skippedClassNames, function (string $class): bool {
-            return is_a($class, DeprecatedInterface::class, true);
-        });
+        return array_filter(
+            $skippedClassNames,
+            fn (string $class): bool => is_a($class, DeprecatedInterface::class, true)
+        );
     }
 
     /**
-     * @return array<string, string[]|null>
+     * @return array<class-string, string[]|null>
      */
     public function resolve(): array
     {

--- a/tests/Skipper/Skipper/SkippedClassResolverTest.php
+++ b/tests/Skipper/Skipper/SkippedClassResolverTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Skipper\Skipper;
+
+use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+
+final class SkippedClassResolverTest extends AbstractLazyTestCase
+{
+    public function test(): void
+    {
+        $skippedClassResolver = $this->make(SkippedClassResolver::class);
+
+        $this->assertSame([], $skippedClassResolver->resolveDeprecatedSkippedClasses());
+    }
+}


### PR DESCRIPTION
Ref: https://github.com/rectorphp/rector/issues/9543

---

Rector already warns about rules that are used, but deprecated. That way they can be removed/adjusted in time.


For the skip option we don't have such reporting yet, so it can lead to sudden removal.

```php
return RectorConfig::configure()
->withSkip([
        \Rector\Php81\Rector\Array_\FirstClassCallableRector::class,
]);
```

This PR fixes that :)

<img width="2456" height="519" alt="Screenshot From 2025-12-09 11-46-51" src="https://github.com/user-attachments/assets/15077d21-4b2b-4c60-9016-81c0bc3504a5" />
