### PR TITLE
Create identical_enclosed_ternary.php.inc

### DIFF
--- a/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/identical_enclosed_ternary.php.inc
+++ b/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/identical_enclosed_ternary.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector\Fixture;
+
+if ((true ? 1 : 0) != (true ? 1 : 0)) {
+
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector\Fixture;
+
+if ((true ? 1 : 0) !== (true ? 1 : 0)) {
+
+}
+
+?>


### PR DESCRIPTION
Enclosed ternary comparations should retain the parentheses