### PR TITLE
fix: chained calls on static calls

### DIFF
--- a/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_chained_calls.php.inc
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_chained_calls.php.inc
@@ -6,11 +6,7 @@ final class SkipChainedCalls
 {
     public function run()
     {
-        function ($foo)
-        {
-            return FooBar::foo()->bar($foo);
-        };
-
         fn ($foo) => FooBar::foo()->bar($foo);
+        fn ($foo) => FooBar::foo()::bar($foo);
     }
 }

--- a/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
+++ b/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
@@ -194,11 +194,13 @@ final readonly class ArrowFunctionAndClosureFirstClassCallableGuard
 
     private function isChainedCall(FuncCall|MethodCall|StaticCall $callLike): bool
     {
-        if (! $callLike instanceof MethodCall) {
-            return false;
+        if ($callLike instanceof MethodCall) {
+            return $callLike->var instanceof CallLike;
+        } elseif ($callLike instanceof StaticCall) {
+            return $callLike->class instanceof CallLike;
         }
 
-        return $callLike->var instanceof CallLike;
+        return false;
     }
 
     /**


### PR DESCRIPTION
Hello!

This prevents nested calls on StaticCalls from being converted to first class callables:

<img width="1274" height="165" alt="image" src="https://github.com/user-attachments/assets/8af0cad1-0444-48ee-bdea-30bae71ff5bb" />

Thanks!