### PR TITLE
fix: skip non-native methods

### DIFF
--- a/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
+++ b/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
@@ -18,7 +18,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
 use PhpParser\NodeVisitor;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\Annotations\AnnotationMethodReflection;
+use PHPStan\Reflection\MethodReflection;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
@@ -95,8 +95,8 @@ final readonly class ArrowFunctionAndClosureFirstClassCallableGuard
             return true;
         }
 
-        // exists, but by @method annotation
-        if ($reflection instanceof AnnotationMethodReflection && ! $reflection->getDeclaringClass()->hasNativeMethod(
+        // phpstan reports first class callables that are not native methods
+        if ($reflection instanceof MethodReflection && ! $reflection->getDeclaringClass()->hasNativeMethod(
             $reflection->getName()
         )) {
             return true;


### PR DESCRIPTION
Hello!

This prevents ALL non-native methods (not just those from annotations) from being converted to first class callables:

This change resulted in the following phpstan error:

<img width="928" height="197" alt="image" src="https://github.com/user-attachments/assets/af667e01-009e-4fec-8bb0-c03bb05cff16" />

<img width="1642" height="181" alt="image" src="https://github.com/user-attachments/assets/156fd12a-67c1-4d89-82cc-7a781ba6b307" />



