### PR TITLE
[Php81] Skip on Param default on ArrayToFirstClassCallableRector

### DIFF
--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_on_param.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_on_param.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+final class SkipOnParam
+{
+    public function size()
+    {
+    }
+
+    public function run(array $callback = [SkipOnParam::class, 'size'])
+    {
+    }
+}

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -113,6 +113,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->getAttribute(AttributeKey::IS_PARAM_DEFAULT)) {
+            return null;
+        }
+
         $args = [new VariadicPlaceholder()];
         if ($callerExpr instanceof ClassConstFetch) {
             $type = $this->getType($callerExpr->class);

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -125,6 +125,7 @@ use Rector\PhpParser\NodeVisitor\ClosureWithVariadicParametersNodeVisitor;
 use Rector\PhpParser\NodeVisitor\ContextNodeVisitor;
 use Rector\PhpParser\NodeVisitor\GlobalVariableNodeVisitor;
 use Rector\PhpParser\NodeVisitor\NameNodeVisitor;
+use Rector\PhpParser\NodeVisitor\ParamDefaultNodeVisitor;
 use Rector\PhpParser\NodeVisitor\PhpVersionConditionNodeVisitor;
 use Rector\PhpParser\NodeVisitor\PropertyOrClassConstDefaultNodeVisitor;
 use Rector\PhpParser\NodeVisitor\StaticVariableNodeVisitor;
@@ -253,6 +254,7 @@ final class LazyContainerFactory
         NameNodeVisitor::class,
         StaticVariableNodeVisitor::class,
         PropertyOrClassConstDefaultNodeVisitor::class,
+        ParamDefaultNodeVisitor::class,
         ClassConstFetchNodeVisitor::class,
     ];
 

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -220,6 +220,11 @@ final class AttributeKey
     /**
      * @var string
      */
+    public const IS_PARAM_DEFAULT = 'is_param_default';
+
+    /**
+     * @var string
+     */
     public const IS_INCREMENT_OR_DECREMENT = 'is_increment_or_decrement';
 
     /**

--- a/src/PhpParser/NodeVisitor/ParamDefaultNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ParamDefaultNodeVisitor.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PhpParser\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Param;
+use PhpParser\NodeVisitorAbstract;
+use Rector\Contract\PhpParser\DecoratingNodeVisitorInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PhpParser\NodeTraverser\SimpleNodeTraverser;
+
+final class ParamDefaultNodeVisitor extends NodeVisitorAbstract implements DecoratingNodeVisitorInterface
+{
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof Param) {
+            return null;
+        }
+
+        if (! $node->default instanceof Expr) {
+            return null;
+        }
+
+        SimpleNodeTraverser::decorateWithAttributeValue(
+            $node->default,
+            AttributeKey::IS_PARAM_DEFAULT,
+            true
+        );
+
+        return null;
+    }
+}


### PR DESCRIPTION
Change array to first class callable on Param will cause error:

```
Fatal error: Constant expression contains invalid operations in /in/Rcie0 on line 9
```

see https://3v4l.org/Rcie0#v8.1.9

This PR try to fix it.