### PR TITLE
Add PrivatizeFinalClassConstantRector

### DIFF
--- a/config/set/privatization.php
+++ b/config/set/privatization.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector;
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
@@ -12,5 +13,6 @@ return static function (RectorConfig $rectorConfig): void {
         PrivatizeLocalGetterToPropertyRector::class,
         PrivatizeFinalClassPropertyRector::class,
         PrivatizeFinalClassMethodRector::class,
+        PrivatizeFinalClassConstantRector::class,
     ]);
 };

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/change_parent_without_care.php.inc
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/change_parent_without_care.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+use Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Source\AbstractClassWithProtectedClassConst;
+
+final class ChangeParentWithoutCare extends AbstractClassWithProtectedClassConst
+{
+    protected const PROTECTED_LOCAL_CONST = 'local';
+}
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+use Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Source\AbstractClassWithProtectedClassConst;
+
+final class ChangeParentWithoutCare extends AbstractClassWithProtectedClassConst
+{
+    private const PROTECTED_LOCAL_CONST = 'local';
+}
+?>

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/fixture.php.inc
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+final class Fixture
+{
+    protected const SOME_CONSTANT = 'some-value';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+final class Fixture
+{
+    private const SOME_CONSTANT = 'some-value';
+}
+
+?>

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/keep_parent_protected_const.php.inc
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/keep_parent_protected_const.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+use Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Source\AbstractClassWithProtectedClassConst;
+
+final class KeepParentProtectedConst extends AbstractClassWithProtectedClassConst
+{
+    protected const PROTECTED_CONST = 5;
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_final_docblock.php.inc
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_final_docblock.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+/**
+ * @final
+ */
+class SkipFinalDocblock
+{
+    protected const SOME_CONSTANT = 'some-value';
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_multi_consts.php.inc
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_multi_consts.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+final class SkipMultiConsts
+{
+    protected const FIRST_VAL = 'a', SECOND_VAL = 'b';
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_trait_used.php.inc
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_trait_used.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Fixture;
+
+use Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Source\SomeTraitWithConst;
+
+final class SkipTraitUsed
+{
+    use SomeTraitWithConst;
+
+    protected const PROTECTED_TRAIT_CONST = 3;
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_unknown_parent_class.php.inc
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Fixture/skip_unknown_parent_class.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector\Fixture;
+
+final class SkipUnknownParentClass extends SomeUnknownParent
+{
+    protected const SOME_CONSTANT = 'some-value';
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/PrivatizeFinalClassConstantRectorTest.php
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/PrivatizeFinalClassConstantRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PrivatizeFinalClassConstantRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Source/AbstractClassWithProtectedClassConst.php
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Source/AbstractClassWithProtectedClassConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Source;
+
+abstract class AbstractClassWithProtectedClassConst
+{
+    protected const PROTECTED_CONST = 3;
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Source/SomeParentClass.php
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Source/SomeParentClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Source;
+
+class SomeParentClass
+{
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Source/SomeTraitWithConst.php
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/Source/SomeTraitWithConst.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\Source;
+
+trait SomeTraitWithConst
+{
+    protected const PROTECTED_TRAIT_CONST = 3;
+}

--- a/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/config/configured_rule.php
+++ b/rules-tests/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector;
+
+return RectorConfig::configure()
+    ->withRules([PrivatizeFinalClassConstantRector::class]);

--- a/rules/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector.php
+++ b/rules/Privatization/Rector/ClassConst/PrivatizeFinalClassConstantRector.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Privatization\Rector\ClassConst;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PHPStan\Reflection\ClassReflection;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Privatization\Guard\OverrideByParentClassGuard;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector\PrivatizeFinalClassConstantRectorTest
+ */
+final class PrivatizeFinalClassConstantRector extends AbstractRector
+{
+    public function __construct(
+        private readonly VisibilityManipulator $visibilityManipulator,
+        private readonly OverrideByParentClassGuard $overrideByParentClassGuard,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change protected constant to private if possible', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    protected const SOME_CONSTANT = 'some-value';
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    private const SOME_CONSTANT = 'some-value';
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->isFinal()) {
+            return null;
+        }
+
+        if (! $this->overrideByParentClassGuard->isLegal($node)) {
+            return null;
+        }
+
+        $scope = ScopeFetcher::fetch($node);
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->getConstants() as $classConst) {
+            if ($this->shouldSkipClassConst($classConst)) {
+                continue;
+            }
+
+            if ($this->isDefinedInParentOrInterface($classConst, $classReflection)) {
+                continue;
+            }
+
+            $this->visibilityManipulator->makePrivate($classConst);
+            $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function shouldSkipClassConst(ClassConst $classConst): bool
+    {
+        // Skip if multiple constants are defined in one line to avoid partial visibility complexity
+        if (count($classConst->consts) !== 1) {
+            return true;
+        }
+
+        return ! $classConst->isProtected();
+    }
+
+    private function isDefinedInParentOrInterface(ClassConst $classConst, ClassReflection $classReflection): bool
+    {
+        $constantName = $this->getName($classConst);
+        if ($constantName === null) {
+            return true;
+        }
+
+        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+            // Skip the class itself
+            if ($ancestorClassReflection->getName() === $classReflection->getName()) {
+                continue;
+            }
+
+            if ($ancestorClassReflection->hasConstant($constantName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This rule is inspired by https://cs.symfony.com/doc/rules/class_notation/protected_to_private.html which does the same. Now we have a rector rule as well.