### PR TITLE
Fix fixture class name under AddTypeToConstRector

### DIFF
--- a/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_when_type_already_set.php.inc
+++ b/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_when_type_already_set.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\Fixture;
 
-final class SomeClass
+final class SkipWhenTypeAlreadySet
 {
     public const string|int string = 'A';
 }


### PR DESCRIPTION
Fix random error on test:

```
There was 1 error:

1) Rector\Tests\Php83\Rector\ClassConst\AddTypeToConstRector\AddTypeToConstRectorTest::test with data set #11 ('/Users/samsonasik/www/rector-...hp.inc')
PHPStan\File\CouldNotReadFileException: Could not read file: /Users/samsonasik/www/rector-src/rules-tests/Php83/Rector/ClassConst/AddTypeToConstRector/Fixture/skip_when_type_already_set.php
```