### PR TITLE
Rectify

### DIFF
--- a/rules/Php83/Rector/BooleanAnd/JsonValidateRector.php
+++ b/rules/Php83/Rector/BooleanAnd/JsonValidateRector.php
@@ -28,8 +28,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class JsonValidateRector extends AbstractRector implements MinPhpVersionInterface, RelatedPolyfillInterface
 {
-    protected const ARG_NAMES = ['json', 'associative', 'depth', 'flags'];
-
     private const JSON_MAX_DEPTH = 0x7FFFFFFF;
 
     public function __construct(


### PR DESCRIPTION
Run Rector on latest main branch for new rule `PrivatizeFinalClassConstantRector`

- https://github.com/rectorphp/rector-src/pull/7753

that the result the constant can be removed when unused.