### PR TITLE
Skip named arguments when adding, modifying or removing parameters

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/named_arg_add_new.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/named_arg_add_new.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class NamedArgAddNew
+{
+    public function run()
+    {
+        $obj = new SomeMultiArg();
+        // Named arguments exist, but not the one we're adding (c)
+        $obj->run(b: 5);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class NamedArgAddNew
+{
+    public function run()
+    {
+        $obj = new SomeMultiArg();
+        // Named arguments exist, but not the one we're adding (c)
+        $obj->run(b: 5, c: 4);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/named_arg_mixed_positional_named.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/named_arg_mixed_positional_named.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class NamedArgMixedPositionalNamed
+{
+    public function run()
+    {
+        $obj = new SomeMultiArg();
+        // Mix of positional and named arguments
+        $obj->run(0, c: 6);
+        $obj->run(0, b: 6);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class NamedArgMixedPositionalNamed
+{
+    public function run()
+    {
+        $obj = new SomeMultiArg();
+        // Mix of positional and named arguments
+        $obj->run(0, c: 6);
+        $obj->run(0, b: 6, c: 4);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_named_arg_already_present.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_named_arg_already_present.php.inc
@@ -4,14 +4,13 @@ namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
 
 use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
 
-class SkipNamedArguments
+class SkipNamedArgAlreadyPresent
 {
     public function run()
     {
         $obj = new SomeMultiArg();
-        $obj->run(b: 5);
-        $obj->run(c: 4);
-        $obj->run(0, 1, c: 6);
+        // Parameter 'c' is already provided as named argument
+        $obj->run(b: 5, c: 999);
+        $obj->run(c: 999, b: 5);
     }
 }
-

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_named_arguments.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class SkipNamedArguments
+{
+    public function run()
+    {
+        $obj = new SomeMultiArg();
+        $obj->run(b: 5);
+        $obj->run(c: 4);
+        $obj->run(0, 1, c: 6);
+    }
+}
+

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_named_arguments.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture\ReplaceMethodArgumentWithConstant;
+
+class SkipNamedArguments
+{
+    public function run()
+    {
+        $obj = new ReplaceMethodArgumentWithConstant();
+        $obj->setSomeMethod(someValue: 'some value');
+    }
+}

--- a/rules-tests/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector/Fixture/skip_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/FuncCall/FunctionArgumentDefaultValueReplacerRector/Fixture/skip_named_arguments.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\FuncCall\FunctionArgumentDefaultValueReplacerRector\Fixture;
+
+class SkipNamedArguments
+{
+    public function run()
+    {
+        version_compare(version1: '5.6', version2: PHP_VERSION, operator: 'lte');
+        version_compare('5.6', PHP_VERSION, operator: 'lte');
+    }
+}

--- a/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Fixture/skip_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Fixture/skip_named_arguments.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source\MethodCaller;
+
+final class SkipNamedArguments
+{
+    public function run(MethodCaller $caller)
+    {
+        $caller->process(first: 1, second: 2);
+        $caller->process(1, second: 2);
+    }
+}

--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Arguments\Contract\ReplaceArgumentDefaultValueInterface;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\PhpParser\Node\Value\ValueResolver;
 
@@ -22,7 +23,8 @@ final readonly class ArgumentDefaultValueReplacer
 {
     public function __construct(
         private NodeFactory $nodeFactory,
-        private ValueResolver $valueResolver
+        private ValueResolver $valueResolver,
+        private ArgsAnalyzer $argsAnalyzer
     ) {
     }
 
@@ -98,6 +100,10 @@ final readonly class ArgumentDefaultValueReplacer
         ReplaceArgumentDefaultValueInterface $replaceArgumentDefaultValue
     ): ?Expr {
         if ($expr->isFirstClassCallable()) {
+            return null;
+        }
+
+        if ($this->argsAnalyzer->hasNamedArg($expr->getArgs())) {
             return null;
         }
 

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -352,18 +352,14 @@ CODE_SAMPLE
         }
 
         // Handle named arguments case - add as named argument at the end
+        $arg = new Arg(new Variable($argumentName));
         if ($this->argsAnalyzer->hasNamedArg($staticCall->getArgs())) {
-            $arg = new Arg(new Variable($argumentName));
             $arg->name = new Identifier($argumentName);
-            $staticCall->args[] = $arg;
-            $this->hasChanged = true;
-            return;
+        } else {
+            $this->fillGapBetweenWithDefaultValue($staticCall, $position);
         }
 
-        // Original positional logic
-        $this->fillGapBetweenWithDefaultValue($staticCall, $position);
-
-        $staticCall->args[$position] = new Arg(new Variable($argumentName));
+        $staticCall->args[] = $arg;
         $this->hasChanged = true;
     }
 

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -24,6 +24,7 @@ use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Enum\ObjectReference;
 use Rector\Exception\ShouldNotHappenException;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\PhpParser\AstResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
@@ -48,7 +49,8 @@ final class ArgumentAdderRector extends AbstractRector implements ConfigurableRe
         private readonly ArgumentAddingScope $argumentAddingScope,
         private readonly ChangedArgumentsDetector $changedArgumentsDetector,
         private readonly AstResolver $astResolver,
-        private readonly StaticTypeMapper $staticTypeMapper
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ArgsAnalyzer $argsAnalyzer
     ) {
     }
 
@@ -247,6 +249,10 @@ CODE_SAMPLE
 
             // argument added and type has been changed
             return $this->changedArgumentsDetector->isTypeChanged($param, $argumentAdder->getArgumentType());
+        }
+
+        if ($this->argsAnalyzer->hasNamedArg($node->getArgs())) {
+            return true;
         }
 
         if (isset($node->args[$position])) {

--- a/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
+++ b/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use Rector\Arguments\ValueObject\RemoveMethodCallParam;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -24,6 +25,11 @@ final class RemoveMethodCallParamRector extends AbstractRector implements Config
      * @var RemoveMethodCallParam[]
      */
     private array $removeMethodCallParams = [];
+
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer,
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -70,6 +76,10 @@ CODE_SAMPLE
         $hasChanged = false;
 
         if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if ($this->argsAnalyzer->hasNamedArg($node->getArgs())) {
             return null;
         }
 


### PR DESCRIPTION
The `ArgumentAdderRector`, `ReplaceArgumentDefaultValueRector`, `FunctionArgumentDefaultValueReplacerRector` and `RemoveMethodCallParamRector` rules add, modify or remove parameters using the position of the parameter. This can be problematic if the function/method call uses named arguments as we may end up modifying the wrong parameter and producing invalid code. This PR modifies these rules so that if there are any named parameters in the calls, the rules are not applied.

Includes new fixtures which confirm the new functionality