### PR TITLE
[Php85] Skip defined int or string on ArrayKeyExistsNullToEmptyStringRector

### DIFF
--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/skip_defined_int_or_string.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/skip_defined_int_or_string.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector\Fixture;
+
+final class SkipDefinedIntOrString
+{
+    /**
+     * @var array<int, array{unique_key: int|string, label: string}>
+     */
+    private array $todos = [
+        0 => [
+            'unique_key' => 1,
+            'label' => 'test 1',
+        ],
+        1 => [
+            'unique_key' => 'fallback_todo',
+            'label' => 'fallback todo 1',
+        ],
+    ];
+
+    /**
+     * @var array<int|string, string>
+     */
+    public array $selectedTodos = [];
+
+    public function run(int $index): string
+    {
+  		if (!array_key_exists($index, $this->todos)) {
+            return 'Todo not found';
+        }
+
+        if (!array_key_exists($this->todos[$index]['unique_key'], $this->selectedTodos)) {
+            $this->selectedTodos[$this->todos[$index]['unique_key']] = $this->todos[$index]['label'];
+            return 'Todo selected !';
+        }
+
+        return 'Todo already selected !';
+    }
+}

--- a/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/skip_defined_int_or_string.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector/Fixture/skip_defined_int_or_string.php.inc
@@ -5,35 +5,19 @@ namespace Rector\Tests\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRect
 final class SkipDefinedIntOrString
 {
     /**
-     * @var array<int, array{unique_key: int|string, label: string}>
+     * @var array<string|int, bool>
      */
-    private array $todos = [
-        0 => [
-            'unique_key' => 1,
-            'label' => 'test 1',
-        ],
-        1 => [
-            'unique_key' => 'fallback_todo',
-            'label' => 'fallback todo 1',
-        ],
+    private array $shownTodos = [
+        0 => false,
+        'fallback_todo' => true,
     ];
 
-    /**
-     * @var array<int|string, string>
-     */
-    public array $selectedTodos = [];
-
-    public function run(int $index): string
+    public function run(string|int $index): void
     {
-  		if (!array_key_exists($index, $this->todos)) {
-            return 'Todo not found';
+  		if (! array_key_exists($index, $this->shownTodos)) {
+            return;
         }
 
-        if (!array_key_exists($this->todos[$index]['unique_key'], $this->selectedTodos)) {
-            $this->selectedTodos[$this->todos[$index]['unique_key']] = $this->todos[$index]['label'];
-            return 'Todo selected !';
-        }
-
-        return 'Todo already selected !';
+        $this->shownTodos[$index] = true;
     }
 }

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Php85\Rector\FuncCall;
 
+use PHPStan\Type\UnionType;
+use PHPStan\Type\TypeCombinator;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
@@ -89,11 +91,20 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
         }
 
         $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($functionReflection, $node, $scope);
+        $argPosition = $this->argsAnalyzer->resolveArgPosition($args, 'key', 0);
+        $originalType = $this->getType($args[$argPosition]->value);
+
+        if ($originalType instanceof UnionType) {
+            $withoutNullParameterType = TypeCombinator::removeNull($originalType);
+            if ($withoutNullParameterType->equals($originalType)) {
+                return null;
+            }
+        }
 
         $result = $this->nullToStrictStringIntConverter->convertIfNull(
             $node,
             $args,
-            $this->argsAnalyzer->resolveArgPosition($args, 'key', 0),
+            $argPosition,
             $isTrait,
             $scope,
             $parametersAcceptor

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -90,7 +90,6 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
             return null;
         }
 
-        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($functionReflection, $node, $scope);
         $argPosition = $this->argsAnalyzer->resolveArgPosition($args, 'key', 0);
         $originalType = $this->getType($args[$argPosition]->value);
 
@@ -101,6 +100,7 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
             }
         }
 
+        $parametersAcceptor = ParametersAcceptorSelectorVariantsWrapper::select($functionReflection, $node, $scope);
         $result = $this->nullToStrictStringIntConverter->convertIfNull(
             $node,
             $args,


### PR DESCRIPTION
Ref https://getrector.com/demo/5dee0eb0-aea7-4e62-88a4-90f54eae39de
Fixes https://github.com/rectorphp/rector/issues/9560

`array_key_exists` allow both `int` or `string` key.
