### PR TITLE
[DeadCode] Skip trait on RemoveAlwaysTrueIfConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_bool_type_trait.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_bool_type_trait.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\Issues\NullCompareInTrait\Fixture;
+
+trait SkipBoolTypeTrait
+{
+    /** @var array<string,class-string> */
+    protected array $dispatchesEvents = [];
+
+    protected function fireResourceEvent(string $event, SomeModel $model, mixed ...$args): void
+    {
+        $class = $this->dispatchesEvents[$event] ?? null;
+
+        if ($class === null) {
+            return;
+        }
+
+        some_event(new $class($model, ...$args));
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -18,6 +18,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\NodeVisitor;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\IntersectionType;
 use Rector\DeadCode\NodeAnalyzer\SafeLeftTypeBooleanAndOrAnalyzer;
 use Rector\NodeAnalyzer\ExprAnalyzer;
@@ -118,8 +119,14 @@ CODE_SAMPLE
             return null;
         }
 
-        $type = ScopeFetcher::fetch($node)->getNativeType($node->cond);
+        $scope = ScopeFetcher::fetch($node);
+        $type = $scope->getNativeType($node->cond);
         if (! $type->isTrue()->yes()) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if ($classReflection instanceof ClassReflection && $classReflection->isTrait()) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9530

it seems unreliable detect true bool type on trait.