### PR TITLE
[Php81] ArrayToFirstClassCallableRector should not skip non-public methods from owning scope

### DIFF
--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_class_with_own_private.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_class_with_own_private.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
 
-final class SomeClass
+final class SomeClassWithOwnPrivate
 {
     public function run()
     {
@@ -20,7 +20,7 @@ final class SomeClass
 
 namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
 
-final class SomeClass
+final class SomeClassWithOwnPrivate
 {
     public function run()
     {

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_class_with_own_private.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/some_class_with_own_private.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+
+final class SomeClass
+{
+    public function run()
+    {
+        $name = [$this, 'name'];
+    }
+
+    private function name()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\FirstClassCallableRector\Fixture;
+
+final class SomeClass
+{
+    public function run()
+    {
+        $name = $this->name(...);
+    }
+
+    private function name()
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
ArrayToFirstClassCallableRector currently skips over all callables that reference non-public methods, even if the callable is defined in the same scope as the method (e.g. `[$this, 'somePrivateMethod']`). 

There are no existing test fixtures that demonstrate this behaviour either as an expected refactor or as an expected skip (the examples are all using public methods, or references from outside the owning scope).

It looks like this was the behaviour before #5929 was merged into v1.1.1. That was a bugfix for rectorphp/rector#8659 which was specific to cases where a private method is referenced from *outside* the owning scope. 

I'm not sure if it was intentional to also stop refactoring callables that are defined and used within the same class? As far as I can tell, those should always be safe to convert to first-class callables.

I've added a test fixture to prove that these nodes are not currently refactored, and will push a second commit with a fix.

If you're not convinced about changing the default behaviour, then I could instead make this a configurable option for the rule?