### PR TITLE
Fix crash ->getComments() return must be array over true on ClosureToArrowFunctionRector

### DIFF
--- a/rules/Php74/Rector/Closure/ClosureToArrowFunctionRector.php
+++ b/rules/Php74/Rector/Closure/ClosureToArrowFunctionRector.php
@@ -89,7 +89,7 @@ CODE_SAMPLE
         $comments = $node->stmts[0]->getAttribute(AttributeKey::COMMENTS) ?? [];
         if ($comments !== []) {
             $this->mirrorComments($arrowFunction->expr, $node->stmts[0]);
-            $arrowFunction->setAttribute(AttributeKey::COMMENTS, true);
+            $arrowFunction->setAttribute(AttributeKey::COMMENTS, []);
         }
 
         return $arrowFunction;

--- a/rules/Php74/Rector/Closure/ClosureToArrowFunctionRector.php
+++ b/rules/Php74/Rector/Closure/ClosureToArrowFunctionRector.php
@@ -89,7 +89,7 @@ CODE_SAMPLE
         $comments = $node->stmts[0]->getAttribute(AttributeKey::COMMENTS) ?? [];
         if ($comments !== []) {
             $this->mirrorComments($arrowFunction->expr, $node->stmts[0]);
-            $arrowFunction->setAttribute(AttributeKey::COMMENTS, []);
+            $arrowFunction->setAttribute(AttributeKey::COMMENTS, $node->stmts[0]->getComments());
         }
 
         return $arrowFunction;


### PR DESCRIPTION
`Node->getComments()` requires `array` native return type, which uses `comments` attribute, set comments attribute to `true` will make crash:

```
System error: "PhpParser\NodeAbstract::getComments(): Return value must be of type array, true returned
```

see https://github.com/rectorphp/rector/issues/9562
Fixes https://github.com/rectorphp/rector/issues/9562