### PR TITLE
[Php80] Skip different type param and property type on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_different_type_property_and_param_type.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_different_type_property_and_param_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+class SkipDifferentTypePropertyAndParamType
+{
+    private ?\stdClass $customerInput;
+
+    public function __construct(
+        \stdClass $customerInput,
+    ) {
+        $this->customerInput = $customerInput;
+    }
+
+    public function markResolved(): void
+    {
+        $this->customerInput = null;
+    }
+}

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
@@ -133,6 +133,7 @@ final readonly class PromotedPropertyCandidateResolver
             }
 
             if ($property->type instanceof Node
+                && $matchedParam->type instanceof Node
                 && ! $matchedParam->default instanceof Expr
                 && ! $this->nodeComparator->areNodesEqual($matchedParam->type, $property->type)) {
                 continue;

--- a/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
+++ b/rules/Php80/NodeAnalyzer/PromotedPropertyCandidateResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Php80\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
@@ -128,6 +129,12 @@ final readonly class PromotedPropertyCandidateResolver
 
             $matchedParam = $this->matchClassMethodParamByAssignedVariable($constructClassMethod, $assignedExpr);
             if (! $matchedParam instanceof Param) {
+                continue;
+            }
+
+            if ($property->type instanceof Node
+                && ! $matchedParam->default instanceof Expr
+                && ! $this->nodeComparator->areNodesEqual($matchedParam->type, $property->type)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9564
Ref https://getrector.com/demo/c04002dc-0798-4c8b-9b73-a9a87c7e2d16