### PR TITLE
[internal] Fix inline replace block removal not removed on deep block for InlineIfToExplicitIfRector + ReplaceBlockToItsStmtsRector

### DIFF
--- a/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
@@ -197,7 +197,7 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
 
                         if ($originalNodeNodeClass !== $return::class) {
                             // stop traversing as node type changed and visitors won't work
-                            return $nodes;
+                            continue 2;
                         }
                     } elseif (\is_array($return)) {
                         $doNodes[] = [$i, $return];

--- a/tests/Issues/InlineIfReplaceBlock/Fixture/fixture.php.inc
+++ b/tests/Issues/InlineIfReplaceBlock/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Issues\InlineIfReplaceBlock\Fixture;
+
+{
+	is_null($userId) && $userId = 5;
+
+    {}
+}
+
+{
+	is_null($userId) && $userId = 5;
+
+    {}
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\InlineIfReplaceBlock\Fixture;
+
+if (is_null($userId)) {
+    $userId = 5;
+}
+
+if (is_null($userId)) {
+    $userId = 5;
+}
+
+?>

--- a/tests/Issues/InlineIfReplaceBlock/InlineIfReplaceBlockTest.php
+++ b/tests/Issues/InlineIfReplaceBlock/InlineIfReplaceBlockTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\InlineIfReplaceBlock;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class InlineIfReplaceBlockTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/InlineIfReplaceBlock/config/configured_rule.php
+++ b/tests/Issues/InlineIfReplaceBlock/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Expression\InlineIfToExplicitIfRector;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector;
+
+return RectorConfig::configure()
+    ->withRules([InlineIfToExplicitIfRector::class, ReplaceBlockToItsStmtsRector::class]);


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/7717#pullrequestreview-3601600190
Ref https://getrector.com/demo/325600d2-b50f-4c59-aff5-66e0a8519ebb

That cause deep `{}` empty not removed by `ReplaceBlockToItsStmtsRector` as the `$nodes`above  too early removed and stopped. 

This PR add fixture test and will provide a patch for it :)