### PR TITLE
[internal] Make consistent to continue outer loop when subnode type changed on AbstractImmutableNodeTraverser

### DIFF
--- a/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
@@ -114,7 +114,7 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
 
                         if ($originalSubNodeClass !== $subNode::class) {
                             // stop traversing as node type changed and visitors won't work
-                            return;
+                            continue 2;
                         }
 
                     } elseif ($return === NodeVisitor::DONT_TRAVERSE_CHILDREN) {


### PR DESCRIPTION
Per https://github.com/rectorphp/rector-src/pull/7717#pullrequestreview-3602262437

This continue of PR:

- https://github.com/rectorphp/rector-src/pull/7764

to use same behaviour to continue to outer loop to ensure nothing left behind, while keep improve the performance to no longer need continue loop on current visitor for node.