### PR TITLE
[dx] warn about deprecated beforeTraverse() method once FileNode is ready

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -17,6 +17,8 @@ return $config
     // ensure use version ^3.2.0
     ->ignoreErrorsOnPackage('composer/pcre', [ErrorType::UNUSED_DEPENDENCY])
 
+    ->ignoreErrorsOnPath(__DIR__ . '/src/Reporting/DeprecatedRulesReporter.php', [ErrorType::UNKNOWN_CLASS])
+
     ->ignoreErrorsOnPaths([
         __DIR__ . '/stubs',
         __DIR__ . '/tests',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -160,6 +160,8 @@ parameters:
                 - src/Validation/RectorConfigValidator.php
                 # for phpunit version check
                 - src/Testing/PHPUnit/AbstractLazyTestCase.php
+                # future node class exists check
+                - src/Reporting/DeprecatedRulesReporter.php
 
         # use of internal phpstan classes
         -

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -182,6 +182,7 @@ EOF
         $this->deprecatedRulesReporter->reportDeprecatedRules();
         $this->deprecatedRulesReporter->reportDeprecatedSkippedRules();
         $this->deprecatedRulesReporter->reportDeprecatedNodeTypes();
+        $this->deprecatedRulesReporter->reportDeprecatedRectorUnsupportedMethods();
 
         $this->missConfigurationReporter->reportSkippedNeverRegisteredRules();
 


### PR DESCRIPTION
The `Rector::beforeTraverse()` is now marked as soft `@final`, but not everyone uses PHPStan to check their custom rules and has this check enabled.

This is a simple feedback on Rector's run to prepare about depreaction of this method in safe way everyone notices. That way we prevent WTF when this method will actually become `final` and removed in the future.

Related PR https://github.com/rectorphp/rector-src/pull/7728