### PR TITLE
Fix rector-symfony phpunit

### DIFF
--- a/src/PostRector/Application/PostFileProcessor.php
+++ b/src/PostRector/Application/PostFileProcessor.php
@@ -103,7 +103,7 @@ final class PostFileProcessor implements ResettableInterface
         $postRectors = [];
 
         // sorted by priority, to keep removed imports in order
-        if ($isRenamedClassEnabled) {
+        if ($isRenamedClassEnabled && $isNameImportingEnabled) {
             $postRectors[] = $this->classRenamingPostRector;
         }
 


### PR DESCRIPTION
`ClassRenamingPostRector` should only registered when auto import enabled. This PR fix phpunit notice:

https://github.com/rectorphp/rector-symfony/actions/runs/20436669597/job/58719523660?pr=911