### PR TITLE
[DeadCode] Add test for RemoveDoubleAssignRector with reset before throwing assignment

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/keep_reset_before_throwing_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/keep_reset_before_throwing_assign.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/** @throws Exception */
+function get_body(): string {
+    static $i = 0;
+
+    var_dump($i);
+
+    return $i++ === 0 ? "foo" : throw new Exception("Failed to get body");
+}
+
+foreach ([1, 2, 3] as $value) {
+    try {
+        $body = null;
+        $body = get_body();
+        var_dump($body);
+    } catch (Exception) {
+        var_dump($body);
+    }
+
+}
+?>


### PR DESCRIPTION
Reproduces https://github.com/rectorphp/rector/issues/9569