### PR TITLE
[DeadCode] Skip next assign expr has side effect inside try {} on RemoveDoubleAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/keep_reset_before_throwing_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/keep_reset_before_throwing_assign.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/** @throws Exception */
+function get_body(): string {
+    static $i = 0;
+
+    var_dump($i);
+
+    return $i++ === 0 ? "foo" : throw new Exception("Failed to get body");
+}
+
+foreach ([1, 2, 3] as $value) {
+    try {
+        $body = null;
+        $body = get_body();
+        var_dump($body);
+    } catch (Exception) {
+        var_dump($body);
+    }
+
+}
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_reset_before_throwing_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_reset_before_throwing_assign.php.inc
@@ -1,14 +1,14 @@
 <?php
 
-declare(strict_types=1);
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleAssignRector\Fixture;
 
-/** @throws Exception */
+/** @throws \Exception */
 function get_body(): string {
     static $i = 0;
 
     var_dump($i);
 
-    return $i++ === 0 ? "foo" : throw new Exception("Failed to get body");
+    return $i++ === 0 ? "foo" : throw new \Exception("Failed to get body");
 }
 
 foreach ([1, 2, 3] as $value) {
@@ -16,7 +16,7 @@ foreach ([1, 2, 3] as $value) {
         $body = null;
         $body = get_body();
         var_dump($body);
-    } catch (Exception) {
+    } catch (\Exception) {
         var_dump($body);
     }
 

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\TryCatch;
 use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
 use Rector\PhpParser\Enum\NodeGroup;
 use Rector\PhpParser\Node\BetterNodeFinder;
@@ -107,6 +108,11 @@ CODE_SAMPLE
             }
 
             if (! $stmt->expr->var instanceof Variable && ! $stmt->expr->var instanceof PropertyFetch && ! $stmt->expr->var instanceof StaticPropertyFetch) {
+                continue;
+            }
+
+            // side effect may throw exception, and may be handled by catch block
+            if ($node instanceof TryCatch && $this->sideEffectNodeDetector->detectCallExpr($nextAssign->expr)) {
                 continue;
             }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/7773
Fixes https://github.com/rectorphp/rector/issues/9569