### PR TITLE
Manage named arguments in ArgumentAdderRector rule

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/by_pass_2nd_arg_value.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/by_pass_2nd_arg_value.php.inc
@@ -9,7 +9,7 @@ class ByPass2ndArgValue
     public function run()
     {
         $containerBuilder = new SomeMultiArg();
-        $containerBuilder->run(1);
+        $containerBuilder->thirdArgument(1);
     }
 }
 
@@ -26,7 +26,7 @@ class ByPass2ndArgValue
     public function run()
     {
         $containerBuilder = new SomeMultiArg();
-        $containerBuilder->run(1, 2, 4);
+        $containerBuilder->thirdArgument(1, 2, 6);
     }
 }
 

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/named_arguments.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class NamedArguments
+{
+    public function run()
+    {
+        $containerBuilder = new SomeMultiArg();
+        $containerBuilder->firstArgument(b: 1);
+        $containerBuilder->firstArgument(c: 1);
+        $containerBuilder->firstArgument(b: 1, c: 2);
+        $containerBuilder->firstArgument(c: 1, b: 2);
+        $containerBuilder->secondArgument(a: 1);
+        $containerBuilder->secondArgument(c: 1);
+        $containerBuilder->secondArgument(a: 1, c: 2);
+        $containerBuilder->secondArgument(c: 1, a: 2);
+        $containerBuilder->secondArgument(1, c: 2);
+        $containerBuilder->thirdArgument(a: 1);
+        $containerBuilder->thirdArgument(b: 1);
+        $containerBuilder->thirdArgument(a: 1, b: 2);
+        $containerBuilder->thirdArgument(b: 1, a: 2);
+        $containerBuilder->thirdArgument(1, b: 2);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class NamedArguments
+{
+    public function run()
+    {
+        $containerBuilder = new SomeMultiArg();
+        $containerBuilder->firstArgument(b: 1, a: 4);
+        $containerBuilder->firstArgument(c: 1, a: 4);
+        $containerBuilder->firstArgument(b: 1, c: 2, a: 4);
+        $containerBuilder->firstArgument(c: 1, b: 2, a: 4);
+        $containerBuilder->secondArgument(a: 1, b: 5);
+        $containerBuilder->secondArgument(c: 1, b: 5);
+        $containerBuilder->secondArgument(a: 1, c: 2, b: 5);
+        $containerBuilder->secondArgument(c: 1, a: 2, b: 5);
+        $containerBuilder->secondArgument(1, c: 2, b: 5);
+        $containerBuilder->thirdArgument(a: 1, c: 6);
+        $containerBuilder->thirdArgument(b: 1, c: 6);
+        $containerBuilder->thirdArgument(a: 1, b: 2, c: 6);
+        $containerBuilder->thirdArgument(b: 1, a: 2, c: 6);
+        $containerBuilder->thirdArgument(1, b: 2, c: 6);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_named_arguments.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_named_arguments.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class SkipNamedArguments
+{
+    public function run()
+    {
+        $containerBuilder = new SomeMultiArg();
+        $containerBuilder->firstArgument(a: 7);
+        $containerBuilder->firstArgument(1, b: 1);
+        $containerBuilder->secondArgument(a: 7, b: 8);
+        $containerBuilder->secondArgument(b: 7, a: 8);
+        $containerBuilder->secondArgument(1, 2, c: 8);
+        $containerBuilder->thirdArgument(c: 8);
+        $containerBuilder->thirdArgument(b: 7, c: 8, a: 9);
+        $containerBuilder->thirdArgument(1, b: 8, c: 9);
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_static_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/skip_static_named_arguments.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class SkipStaticNamedArguments extends SomeMultiArg
+{
+    public function firstArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::firstArgument(a: 7);
+        parent::firstArgument(1, b: 1);
+    }
+
+    public function secondArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::secondArgument(a: 7, b: 8);
+        parent::secondArgument(b: 7, a: 8);
+        parent::secondArgument(1, 2, c: 8);
+    }
+
+    public function thirdArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::thirdArgument(c: 8);
+        parent::thirdArgument(b: 7, c: 8, a: 9);
+        parent::thirdArgument(1, b: 8, c: 9);
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/static_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Fixture/static_named_arguments.php.inc
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class StaticNamedArguments extends SomeMultiArg
+{
+    public function firstArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::firstArgument(b: 1);
+        parent::firstArgument(c: 1);
+        parent::firstArgument(b: 1, c: 2);
+        parent::firstArgument(c: 1, b: 2);
+    }
+
+    public function secondArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::secondArgument(a: 1);
+        parent::secondArgument(c: 1);
+        parent::secondArgument(a: 1, c: 2);
+        parent::secondArgument(c: 1, a: 2);
+        parent::secondArgument(1, c: 2);
+    }
+
+    public function thirdArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::thirdArgument(a: 1);
+        parent::thirdArgument(b: 1);
+        parent::thirdArgument(a: 1, b: 2);
+        parent::thirdArgument(b: 1, a: 2);
+        parent::thirdArgument(1, b: 2);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source\SomeMultiArg;
+
+class StaticNamedArguments extends SomeMultiArg
+{
+    public function firstArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::firstArgument(b: 1, a: $a);
+        parent::firstArgument(c: 1, a: $a);
+        parent::firstArgument(b: 1, c: 2, a: $a);
+        parent::firstArgument(c: 1, b: 2, a: $a);
+    }
+
+    public function secondArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::secondArgument(a: 1, b: $b);
+        parent::secondArgument(c: 1, b: $b);
+        parent::secondArgument(a: 1, c: 2, b: $b);
+        parent::secondArgument(c: 1, a: 2, b: $b);
+        parent::secondArgument(1, c: 2, b: $b);
+    }
+
+    public function thirdArgument($a = 1, $b = 2, $c = 3)
+    {
+        parent::thirdArgument(a: 1, c: $c);
+        parent::thirdArgument(b: 1, c: $c);
+        parent::thirdArgument(a: 1, b: 2, c: $c);
+        parent::thirdArgument(b: 1, a: 2, c: $c);
+        parent::thirdArgument(1, b: 2, c: $c);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Source/SomeMultiArg.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/Source/SomeMultiArg.php
@@ -6,7 +6,15 @@ namespace Rector\Tests\Arguments\Rector\ClassMethod\ArgumentAdderRector\Source;
 
 class SomeMultiArg
 {
-    public function run($a = 1, $b = 2, $c = 3)
+    public function firstArgument($a = 1, $b = 2, $c = 3)
+    {
+    }
+
+    public function secondArgument($a = 1, $b = 2, $c = 3)
+    {
+    }
+
+    public function thirdArgument($a = 1, $b = 2, $c = 3)
     {
     }
 }

--- a/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ArgumentAdderRector/config/configured_rule.php
@@ -53,7 +53,9 @@ return static function (RectorConfig $rectorConfig): void {
                 ArgumentAddingScope::SCOPE_CLASS_METHOD
             ),
             new ArgumentAdder(SomeClass::class, 'withoutTypeOrDefaultValue', 0, 'arguments', [], $arrayType),
-            new ArgumentAdder(SomeMultiArg::class, 'run', 2, 'c', 4),
+            new ArgumentAdder(SomeMultiArg::class, 'firstArgument', 0, 'a', 4),
+            new ArgumentAdder(SomeMultiArg::class, 'secondArgument', 1, 'b', 5),
+            new ArgumentAdder(SomeMultiArg::class, 'thirdArgument', 2, 'c', 6),
             new ArgumentAdder(SomeClass::class, 'someMethod', 0, 'default', 1),
             new ArgumentAdderWithoutDefaultValue(WithoutDefaultValue::class, 'someMethod', 0, 'foo', $arrayType),
         ]);

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
@@ -24,6 +25,7 @@ use Rector\Arguments\ValueObject\ArgumentAdderWithoutDefaultValue;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Enum\ObjectReference;
 use Rector\Exception\ShouldNotHappenException;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\PhpParser\AstResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
@@ -48,7 +50,8 @@ final class ArgumentAdderRector extends AbstractRector implements ConfigurableRe
         private readonly ArgumentAddingScope $argumentAddingScope,
         private readonly ChangedArgumentsDetector $changedArgumentsDetector,
         private readonly AstResolver $astResolver,
-        private readonly StaticTypeMapper $staticTypeMapper
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ArgsAnalyzer $argsAnalyzer
     ) {
     }
 
@@ -181,13 +184,21 @@ CODE_SAMPLE
 
         $defaultValue = $argumentAdder->getArgumentDefaultValue();
         $arg = new Arg(BuilderHelpers::normalizeValue($defaultValue));
-        if (isset($methodCall->args[$position])) {
-            return;
+
+        // if there are named argyments, we just add it at the end as a new named argument
+        if ($this->argsAnalyzer->hasNamedArg($methodCall->getArgs())) {
+            $argumentName = $argumentAdder->getArgumentName();
+            if ($argumentName === null) {
+                throw new ShouldNotHappenException();
+            }
+
+            $arg->name = new Identifier($argumentName);
+        } else {
+            $this->fillGapBetweenWithDefaultValue($methodCall, $position);
         }
 
-        $this->fillGapBetweenWithDefaultValue($methodCall, $position);
+        $methodCall->args[] = $arg;
 
-        $methodCall->args[$position] = $arg;
         $this->hasChanged = true;
     }
 
@@ -249,7 +260,20 @@ CODE_SAMPLE
             return $this->changedArgumentsDetector->isTypeChanged($param, $argumentAdder->getArgumentType());
         }
 
-        if (isset($node->args[$position])) {
+        $arguments = $node->getArgs();
+        $firstNamedArgumentPosition = $this->argsAnalyzer->resolveFirstNamedArgPosition($arguments);
+        // If named arguments exist
+        if ($firstNamedArgumentPosition !== null) {
+            // Check if the parameter we're trying to add is before the first named argument
+            if ($position < $firstNamedArgumentPosition) {
+                return true; //if that is the case, the parameter already exists, skip
+            }
+
+            // Check if the parameter we're trying to add is already present as a named argument
+            if ($this->argsAnalyzer->resolveArgPosition($arguments, $argumentName, -1) !== -1) {
+                return true; // if it exists as a named argument, skip
+            }
+        } elseif (isset($node->args[$position])) {
             return true;
         }
 
@@ -333,9 +357,15 @@ CODE_SAMPLE
             return;
         }
 
-        $this->fillGapBetweenWithDefaultValue($staticCall, $position);
+        // if there are named arguments, we just add it at the end as a new named argument
+        $arg = new Arg(new Variable($argumentName));
+        if ($this->argsAnalyzer->hasNamedArg($staticCall->getArgs())) {
+            $arg->name = new Identifier($argumentName);
+        } else {
+            $this->fillGapBetweenWithDefaultValue($staticCall, $position);
+        }
 
-        $staticCall->args[$position] = new Arg(new Variable($argumentName));
+        $staticCall->args[] = $arg;
         $this->hasChanged = true;
     }
 

--- a/src/NodeAnalyzer/ArgsAnalyzer.php
+++ b/src/NodeAnalyzer/ArgsAnalyzer.php
@@ -48,4 +48,21 @@ final readonly class ArgsAnalyzer
 
         return $defaultPosition;
     }
+
+    /**
+     * @param Arg[] $args
+     */
+    public function resolveFirstNamedArgPosition(array $args): ?int
+    {
+        $position = 0;
+        foreach ($args as $arg) {
+            if ($arg->name instanceof Identifier) {
+                return $position;
+            }
+
+            ++$position;
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Extracted from https://github.com/rectorphp/rector-src/pull/7757

Manages named arguments in the ArgumentAdderRector when processing function calls

If the function call contains named arguments
- If the parameter we are trying to add is before the position of the first named argument, it means that this parameter already exists, skip
- If there is already a named argument for the parameter we are trying to add, skip
- In any other case, add the parameter as a new named parameter