### PR TITLE
[experiment-next] Remove leaveNode() calls on AbstractImmutableNodeTraverser

### DIFF
--- a/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/AbstractImmutableNodeTraverser.php
@@ -99,11 +99,10 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
             }
 
             $traverseChildren = true;
-            $visitorIndex = -1;
             $currentNodeVisitors = $this->getVisitorsForNode($subNode);
 
-            foreach ($currentNodeVisitors as $visitorIndex => $visitor) {
-                $return = $visitor->enterNode($subNode);
+            foreach ($currentNodeVisitors as $currentNodeVisitor) {
+                $return = $currentNodeVisitor->enterNode($subNode);
                 if ($return !== null) {
                     if ($return instanceof Node) {
                         $originalSubNodeClass = $subNode::class;
@@ -140,30 +139,6 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
                     break;
                 }
             }
-
-            for (; $visitorIndex >= 0; --$visitorIndex) {
-                $visitor = $currentNodeVisitors[$visitorIndex];
-                $return = $visitor->leaveNode($subNode);
-                if ($return !== null) {
-                    if ($return instanceof Node) {
-                        $this->ensureReplacementReasonable($subNode, $return);
-                        $subNode = $return;
-                        $node->{$name} = $return;
-                    } elseif ($return === NodeVisitor::STOP_TRAVERSAL) {
-                        $this->stopTraversal = true;
-                        break 2;
-                    } elseif ($return === NodeVisitor::REPLACE_WITH_NULL) {
-                        $node->{$name} = null;
-                        break;
-                    } elseif (\is_array($return)) {
-                        throw new LogicException(
-                            'leaveNode() may only return an array if the parent structure is an array'
-                        );
-                    } else {
-                        throw new LogicException('leaveNode() returned invalid value of type ' . gettype($return));
-                    }
-                }
-            }
         }
     }
 
@@ -184,11 +159,10 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
             }
 
             $traverseChildren = true;
-            $visitorIndex = -1;
             $currentNodeVisitors = $this->getVisitorsForNode($node);
 
-            foreach ($currentNodeVisitors as $visitorIndex => $visitor) {
-                $return = $visitor->enterNode($node);
+            foreach ($currentNodeVisitors as $currentNodeVisitor) {
+                $return = $currentNodeVisitor->enterNode($node);
                 if ($return !== null) {
                     if ($return instanceof Node) {
                         $originalNodeNodeClass = $node::class;
@@ -227,32 +201,6 @@ abstract class AbstractImmutableNodeTraverser implements NodeTraverserInterface
                 $this->traverseNode($node);
                 if ($this->stopTraversal) {
                     break;
-                }
-            }
-
-            for (; $visitorIndex >= 0; --$visitorIndex) {
-                $visitor = $currentNodeVisitors[$visitorIndex];
-                $return = $visitor->leaveNode($node);
-                if ($return !== null) {
-                    if ($return instanceof Node) {
-                        $this->ensureReplacementReasonable($node, $return);
-                        $nodes[$i] = $node = $return;
-                    } elseif (\is_array($return)) {
-                        $doNodes[] = [$i, $return];
-                        break;
-                    } elseif ($return === NodeVisitor::REMOVE_NODE) {
-                        $doNodes[] = [$i, []];
-                        break;
-                    } elseif ($return === NodeVisitor::STOP_TRAVERSAL) {
-                        $this->stopTraversal = true;
-                        break 2;
-                    } elseif ($return === NodeVisitor::REPLACE_WITH_NULL) {
-                        throw new LogicException(
-                            'REPLACE_WITH_NULL can not be used if the parent structure is an array'
-                        );
-                    } else {
-                        throw new LogicException('leaveNode() returned invalid value of type ' . gettype($return));
-                    }
                 }
             }
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -169,6 +169,14 @@ CODE_SAMPLE;
         return $this->postRefactorProcess($originalNode, $node, $refactoredNodeOrState, $filePath);
     }
 
+    /**
+     * @deprecated no longer used
+     */
+    final public function leaveNode(Node $node): array|int|Node|null
+    {
+        return null;
+    }
+
     protected function isName(Node $node, string $name): bool
     {
         return $this->nodeNameResolver->isName($node, $name);


### PR DESCRIPTION
@TomasVotruba this is continue of PR:

- https://github.com/rectorphp/rector-src/pull/7767

since `leaveNode()` method removed on `AbstractRector`, I think the `leaveNode()` calls can be removed from `AbstractImmutableNodeTraverser`