### PR TITLE
[Php74] Fix indentation space on ClosureToArrowFunctionRector with comment inner closure

### DIFF
--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/as_arg.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/as_arg.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
+
+class AsArg
+{
+    public function run()
+    {
+        $this->execute(function() {
+            // some comment
+            /** @psalm-suppress UndefinedFunction */
+            return ff();
+        });
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
+
+class AsArg
+{
+    public function run()
+    {
+        $this->execute(
+            // some comment
+            /** @psalm-suppress UndefinedFunction */
+            fn() => ff());
+    }
+}
+
+?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_docblock_on_return.php.inc
@@ -28,15 +28,11 @@ class KeepDocblockOnReturn
 {
     public function run()
     {
-        
-            /** @psalm-suppress UndefinedFunction */
+        /** @psalm-suppress UndefinedFunction */
+        fn() => ff();
 
-            fn() => ff();
-
-        
-            // @psalm-suppress UndefinedFunction
-
-            fn() => ff();
+        // @psalm-suppress UndefinedFunction
+        fn() => ff();
     }
 }
 

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_multi_comments_with_variable_assign_on_return.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/keep_multi_comments_with_variable_assign_on_return.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
+
+class KeepMultiCommentsWithVariableAssignOnReturn
+{
+    public function run()
+    {
+        $variable = function() {
+            // some comment
+            /** @psalm-suppress UndefinedFunction */
+            return ff();
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
+
+class KeepMultiCommentsWithVariableAssignOnReturn
+{
+    public function run()
+    {
+        $variable = 
+            // some comment
+            /** @psalm-suppress UndefinedFunction */
+            (fn() => ff());
+    }
+}
+
+?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/with_equal_var_doc_type.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/with_equal_var_doc_type.php.inc
@@ -23,10 +23,8 @@ class WithEqualVarDocType
 {
     public function run()
     {
-        
-            /** @var string $var */
-
-            fn(string $var) => $var;
+        /** @var string $var */
+        fn(string $var) => $var;
     }
 }
 

--- a/rules/Php74/Rector/Closure/ClosureToArrowFunctionRector.php
+++ b/rules/Php74/Rector/Closure/ClosureToArrowFunctionRector.php
@@ -73,13 +73,17 @@ CODE_SAMPLE
             return null;
         }
 
+        $attributes = $node->getAttributes();
+        unset($attributes[AttributeKey::ORIGINAL_NODE]);
+
         $arrowFunction = new ArrowFunction(
             [
                 'params' => $node->params,
                 'returnType' => $node->returnType,
                 'byRef' => $node->byRef,
                 'expr' => $returnExpr,
-            ]
+            ],
+            $attributes
         );
 
         if ($node->static) {

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -176,15 +176,16 @@ final class BetterStandardPrinter extends Standard
             return parent::pExpr_ArrowFunction($arrowFunction, $precedence, $lhsPrecedence);
         }
 
-        $indentOnlyLevel = $this->resolveIndentSpaces(true);
+        $isMaxPrecedence = $precedence === self::MAX_PRECEDENCE;
+        $indent = $this->resolveIndentSpaces($isMaxPrecedence);
 
-        $text = "";
+        $text = $isMaxPrecedence ? '' : "\n" . $indent;
         foreach ($comments as $key => $comment) {
-            $commentText = $key > 0 ? $indentOnlyLevel . $comment->getText() : $comment->getText();
+            $commentText = $key > 0 ? $indent . $comment->getText() : $comment->getText();
             $text .= $commentText . "\n";
         }
 
-        return $text . $indentOnlyLevel . parent::pExpr_ArrowFunction($arrowFunction, $precedence, $lhsPrecedence);
+        return $text . $indent . parent::pExpr_ArrowFunction($arrowFunction, $precedence, $lhsPrecedence);
     }
 
     /**

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -176,15 +176,15 @@ final class BetterStandardPrinter extends Standard
             return parent::pExpr_ArrowFunction($arrowFunction, $precedence, $lhsPrecedence);
         }
 
-        $indent = $this->resolveIndentSpaces();
+        $indentOnlyLevel = $this->resolveIndentSpaces(true);
 
-        $text = "\n" . $indent;
+        $text = "";
         foreach ($comments as $key => $comment) {
-            $commentText = $key > 0 ? $indent . $comment->getText() : $comment->getText();
+            $commentText = $key > 0 ? $indentOnlyLevel . $comment->getText() : $comment->getText();
             $text .= $commentText . "\n";
         }
 
-        return $text . "\n" . $indent . parent::pExpr_ArrowFunction($arrowFunction, $precedence, $lhsPrecedence);
+        return $text . $indentOnlyLevel . parent::pExpr_ArrowFunction($arrowFunction, $precedence, $lhsPrecedence);
     }
 
     /**
@@ -502,9 +502,13 @@ final class BetterStandardPrinter extends Standard
         return implode("\n", $trimmedLines);
     }
 
-    private function resolveIndentSpaces(): string
+    private function resolveIndentSpaces(bool $onlyLevel = false): string
     {
         $indentSize = SimpleParameterProvider::provideIntParameter(Option::INDENT_SIZE);
+
+        if ($onlyLevel) {
+            return str_repeat($this->getIndentCharacter(), $this->indentLevel);
+        }
 
         return str_repeat($this->getIndentCharacter(), $this->indentLevel) .
             str_repeat($this->getIndentCharacter(), $indentSize);

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -177,9 +177,15 @@ final class BetterStandardPrinter extends Standard
         }
 
         $isMaxPrecedence = $precedence === self::MAX_PRECEDENCE;
+        $isNewLineAndIndent = $arrowFunction->getAttribute(AttributeKey::IS_ARG_VALUE) === true;
         $indent = $this->resolveIndentSpaces($isMaxPrecedence);
 
         $text = $isMaxPrecedence ? '' : "\n" . $indent;
+        if ($isNewLineAndIndent) {
+            $indent = $this->resolveIndentSpaces();
+            $text = "\n" . $indent;
+        }
+
         foreach ($comments as $key => $comment) {
             $commentText = $key > 0 ? $indent . $comment->getText() : $comment->getText();
             $text .= $commentText . "\n";


### PR DESCRIPTION
Moving comment to outer closure into replaced arrow function should make comment in current level of parent indent, not inside indent.

It ony indent when it assigned to variable.

This PR fix it.