### PR TITLE
[Deadcode]: add handling for void magic methods

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/Fixture/remove_return_clone.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/Fixture/remove_return_clone.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector\Fixture;
+
+class RemoveReturnClone
+{
+    /**
+     * Other comments
+     *
+     * @return void
+     */
+    function __clone()
+    {
+        //
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector\Fixture;
+
+class RemoveReturnClone
+{
+    /**
+     * Other comments
+     */
+    function __clone()
+    {
+        //
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/Fixture/remove_return_construct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/Fixture/remove_return_construct.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector\Fixture;
+
+class RemoveReturnConstruct
+{
+    /**
+     * @return void
+     */
+    function __construct()
+    {
+        //
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector\Fixture;
+
+class RemoveReturnConstruct
+{
+    function __construct()
+    {
+        //
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/Fixture/remove_return_destruct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/Fixture/remove_return_destruct.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector\Fixture;
+
+class RemoveReturnDestruct
+{
+    /**
+     * @return void
+     */
+    function __destruct()
+    {
+        //
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector\Fixture;
+
+class RemoveReturnDestruct
+{
+    function __destruct()
+    {
+        //
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRector::class]);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRector.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessVoidReturnFromDocblockOnVoidMagicMethodsRector\RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRectorTest
+ */
+final class RemoveUselessVoidReturnFromDocblockVoidMagicMethodsRector extends AbstractRector
+{
+    public function __construct(
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove useless @return void docblock from magic methods __construct, __destruct, and __clone',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /**
+     * @return void
+     */
+    public function __construct() {}
+
+    /**
+     * @return void
+     */
+    public function __destruct() {}
+
+    /**
+     * @return void
+     */
+    public function __clone() {}
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __construct() {}
+
+    public function __destruct() {}
+
+    public function __clone() {}
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->returnType instanceof Node) {
+            return null;
+        }
+
+        $magicMethodNames = ['__construct', '__destruct', '__clone'];
+
+        $methodName = $this->getName($node);
+
+        if (! in_array($methodName, $magicMethodNames, true)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return null;
+        }
+
+        if ($returnTagValueNode->description !== '') {
+            return null;
+        }
+
+        if (! $returnTagValueNode->type instanceof IdentifierTypeNode || $returnTagValueNode->type->__toString() !== 'void') {
+            return null;
+        }
+
+        $phpDocInfo->removeByType(ReturnTagValueNode::class);
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+        return $node;
+    }
+}


### PR DESCRIPTION
This rector rule removes the @return void docblock on magic methods that are void by default