### PR TITLE
[DeadCode] Handle crash when parent does not has default param and child has

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_parent_does_not_has_default_param.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_parent_does_not_has_default_param.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source\SomeParentWithoutDefaultParam;
+
+final class SkipParentDoesNotHasDefaultParam extends SomeParentWithoutDefaultParam
+{
+    public function __construct(array $value = [])
+    {
+        parent::__construct($value);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/SomeParentWithoutDefaultParam.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/SomeParentWithoutDefaultParam.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source;
+
+class SomeParentWithoutDefaultParam
+{
+    public function __construct(array $value)
+    {
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -265,6 +265,12 @@ CODE_SAMPLE
                 return false;
             }
 
+            // when parent does not have default value,
+            // mark as different
+            if (! $nativeParentParameterReflection->isDefaultValueAvailable()) {
+                return true;
+            }
+
             $parentDefault = $nativeParentParameterReflection->getDefaultValue();
             if (! $this->valueResolver->isValue($defaultExpr, $parentDefault)) {
                 return true;

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -265,7 +265,7 @@ CODE_SAMPLE
                 return false;
             }
 
-            // when parent does not have default value,
+            // when child has default value, but parent does not have default value,
             // mark as different
             if (! $nativeParentParameterReflection->isDefaultValueAvailable()) {
                 return true;


### PR DESCRIPTION
Ref https://getrector.com/demo/a50336f2-415b-4dbf-960a-1a014511f974
Fixes https://github.com/rectorphp/rector/issues/9573
