### PR TITLE
[DeadCode] Add fixture to keep constructor params with autowire attribute

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/abstract_do.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/abstract_do.php.inc
@@ -10,19 +10,10 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
 
-abstract class AbstractDo
-{
-    public function __construct(private readonly ContainerInterface $filterLocator)
-    {
-    }
-
-    abstract protected function doSomething(): void;
-}
-
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
-
 final class DoSomething extends AbstractDo
 {
+    # Constructor must be kept if any param has the autowire attribute
+    # https://symfony.com/doc/current/service_container/autowiring.html
     public function __construct(
         #[Autowire(service: 'service_container')]
         ContainerInterface $filterLocator,
@@ -33,6 +24,16 @@ final class DoSomething extends AbstractDo
     protected function doSomething(): void
     {
     }
+}
 
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+abstract class AbstractDo
+{
+    public function __construct(private readonly ContainerInterface $filterLocator)
+    {
+    }
+
+    abstract protected function doSomething(): void;
 }
 ?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/abstract_do.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/abstract_do.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use App\AbstractFilterExtension;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+abstract class AbstractDo
+{
+    public function __construct(private readonly ContainerInterface $filterLocator)
+    {
+    }
+
+    abstract protected function doSomething(): void;
+}
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+final class DoSomething extends AbstractDo
+{
+    public function __construct(
+        #[Autowire(service: 'service_container')]
+        ContainerInterface $filterLocator,
+    ) {
+        parent::__construct($filterLocator);
+    }
+
+    protected function doSomething(): void
+    {
+    }
+
+}
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/abstract_do.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/abstract_do.php.inc
@@ -8,7 +8,7 @@ use App\AbstractFilterExtension;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source;
 
 final class DoSomething extends AbstractDo
 {
@@ -26,7 +26,7 @@ final class DoSomething extends AbstractDo
     }
 }
 
-namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source;
 
 abstract class AbstractDo
 {


### PR DESCRIPTION
`RemoveParentDelegatingConstructorRector` removes the constructor of class `DoSomething`. But the `$filterLocator` param has an `autowire` attribute so it doesn't just delegates the variable to the  parent but it also adds metadata and I expect it to be kept as-is.