### PR TITLE
Manage named arguments when replacing a value

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/replace_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/replace_named_arguments.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeMultiArg;
+
+$object = new SomeMultiArg();
+$object->firstArgument(0, b: 1);
+$object->firstArgument(a: 0);
+$object->firstArgument(b: 1, a: 0);
+$object->secondArgument(0, b: 1);
+$object->secondArgument(b: 1);
+$object->secondArgument(b: 1, a: 0);
+
+?>
+
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeMultiArg;
+
+$object = new SomeMultiArg();
+$object->firstArgument(3, b: 1);
+$object->firstArgument(a: 3);
+$object->firstArgument(b: 1, a: 3);
+$object->secondArgument(0, b: 4);
+$object->secondArgument(b: 4);
+$object->secondArgument(b: 4, a: 0);
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_named_arguments.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeMultiArg;
+
+use Symfony\Component\Yaml\Yaml;
+
+$object = new SomeMultiArg();
+$object->firstArgument(b: 1);
+$object->secondArgument(a: 1);
+$object->secondArgument(0, c: 2);
+Yaml::parse('...', flags: false, other: false, another: true);

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Source/SomeMultiArg.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Source/SomeMultiArg.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source;
+
+class SomeMultiArg
+{
+    public function firstArgument($a = 1, $b = 2)
+    {
+    }
+
+    public function secondArgument($a = 1, $b = 2, $c = 3)
+    {
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/config/configured_rule.php
@@ -63,5 +63,19 @@ return static function (RectorConfig $rectorConfig): void {
                 null,
                 []
             ),
+            new ReplaceArgumentDefaultValue(
+                'Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeMultiArg',
+                'firstArgument',
+                0,
+                0,
+                3
+            ),
+            new ReplaceArgumentDefaultValue(
+                'Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeMultiArg',
+                'secondArgument',
+                1,
+                1,
+                4
+            ),
         ]);
 };


### PR DESCRIPTION
Updates the ArgumentDefaultValueReplacer class (which is used by the ReplaceArgumentDefaultValueRector and FunctionArgumentDefaultValueReplacerRector rules) to handle named arguments