### PR TITLE
Add `ParenthesizeNegatedInstanceofRector`

### DIFF
--- a/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/AddParenthesesTest.php
+++ b/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/AddParenthesesTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Instanceof_\Rector\BooleanNot\ParenthesizeNegatedInstanceofRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddParenthesesTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureAdd');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/add_parentheses.php';
+    }
+}

--- a/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/FixtureAdd/fixture.php.inc
+++ b/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/FixtureAdd/fixture.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+!$foo instanceof Foo;
+
+?>
+-----
+<?php
+
+!($foo instanceof Foo);
+
+?>

--- a/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/FixtureRemove/fixture.php.inc
+++ b/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/FixtureRemove/fixture.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+!($foo instanceof Foo);
+
+?>
+-----
+<?php
+
+!$foo instanceof Foo;
+
+?>

--- a/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/RemoveParenthesesTest.php
+++ b/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/RemoveParenthesesTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Instanceof_\Rector\BooleanNot\ParenthesizeNegatedInstanceofRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveParenthesesTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureRemove');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/remove_parentheses.php';
+    }
+}

--- a/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/config/add_parentheses.php
+++ b/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/config/add_parentheses.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Instanceof_\Rector\BooleanNot\ParenthesizeNegatedInstanceofRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ParenthesizeNegatedInstanceofRector::class, [
+        'mode' => ParenthesizeNegatedInstanceofRector::ADD_PARENTHESES,
+    ]);
+};

--- a/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/config/remove_parentheses.php
+++ b/rules-tests/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector/config/remove_parentheses.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Instanceof_\Rector\BooleanNot\ParenthesizeNegatedInstanceofRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ParenthesizeNegatedInstanceofRector::class, [
+        'mode' => ParenthesizeNegatedInstanceofRector::REMOVE_PARENTHESES,
+    ]);
+};

--- a/rules/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector.php
+++ b/rules/Instanceof_/Rector/BooleanNot/ParenthesizeNegatedInstanceofRector.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Rector\Instanceof_\Rector\BooleanNot;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Instanceof_;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Tests\Instanceof_\Rector\BooleanNot\ParenthesizeNegatedInstanceofRector\AddParenthesesTest
+ * @see \Rector\Tests\Instanceof_\Rector\BooleanNot\ParenthesizeNegatedInstanceofRector\RemoveParenthesesTest
+ */
+final class ParenthesizeNegatedInstanceofRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    public const ADD_PARENTHESES = 'add_parentheses';
+
+    public const REMOVE_PARENTHESES = 'remove_parentheses';
+
+    private string $mode = self::ADD_PARENTHESES;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add or remove parentheses around negated instanceof checks',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+if (!$foo instanceof Foo) {}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+if (!($foo instanceof Foo)) {}
+CODE_SAMPLE
+                    ,
+                ),
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+if (!$foo instanceof Foo) {}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+if (!($foo instanceof Foo)) {}
+CODE_SAMPLE
+                    ,
+                    [
+                        'mode' => self::ADD_PARENTHESES,
+                    ],
+                ),
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+if (!($foo instanceof Foo)) {}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+if (!$foo instanceof Foo) {}
+CODE_SAMPLE
+                    ,
+                    [
+                        'mode' => self::REMOVE_PARENTHESES,
+                    ],
+                ),
+            ],
+        );
+    }
+
+    public function configure(array $configuration): void
+    {
+        if ($configuration !== []) {
+            Assert::keyExists($configuration, 'mode');
+            Assert::oneOf($configuration['mode'], [self::ADD_PARENTHESES, self::REMOVE_PARENTHESES]);
+        }
+
+        $this->mode = $configuration['mode'] ?? $this->mode;
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [BooleanNot::class];
+    }
+
+    /**
+     * @param BooleanNot $node
+     */
+    public function refactor(Node $node): ?BooleanNot
+    {
+        if (! $node->expr instanceof Instanceof_) {
+            return null;
+        }
+
+        $oldTokens = $this->file->getOldTokens();
+
+        $tokensStartWithOpeningParens = ((string) $oldTokens[$node->getStartTokenPos() + 1]) === '(';
+        $tokensEndWithClosingParens = ((string) $oldTokens[$node->getEndTokenPos()]) === ')';
+
+        $alreadyWrapped = $tokensStartWithOpeningParens && $tokensEndWithClosingParens;
+
+        if ($this->mode === self::ADD_PARENTHESES && $alreadyWrapped === true) {
+            return null;
+        }
+
+        if ($this->mode === self::ADD_PARENTHESES) {
+            $node->expr->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
+            return $node;
+        }
+
+        if ($alreadyWrapped === false) {
+            return null;
+        }
+
+        return new BooleanNot($node->expr);
+    }
+}


### PR DESCRIPTION
Adds (or removes) parentheses around negated `instanceof` expressions:

```php
# rector.php
use Rector\Instanceof_\Rector\BooleanNot\ParenthesizeNegatedInstanceofRector;

RectorConfig::configure()
    ->withRules([
        ParenthesizeNegatedInstanceofRector::class // defaults to `add_parentheses`
    ])
	// or
    ->withConfiguredRule(ParenthesizeNegatedInstanceofRector::class, [)
        'mode' => ParenthesizeNegatedInstanceofRector::ADD_PARENTHESES, // `add_parentheses`
    ])
	// or
    ->withConfiguredRule(ParenthesizeNegatedInstanceofRector::class, [)
        'mode' => ParenthesizeNegatedInstanceofRector::REMOVE_PARENTHESES, // `remove_parentheses`
    ])
;
```

this will either

```diff
# With `add_parentheses`
-!$foo instanceof Foo
+!($foo instanceof Foo)

# With `remove_parentheses`
-!($foo instanceof Foo)
+!$foo instanceof Foo
```

:octocat: 
