### PR TITLE
[StmtsAware] Add Declare_ to NodeGroup::STMTS_AWARE to allow process its stmts

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
 
     # see https://phpstan.org/writing-php-code/phpdoc-types#global-type-aliases
     typeAliases:
-        StmtsAware: \PhpParser\Node\Stmt\Block | \PhpParser\Node\Expr\Closure | \PhpParser\Node\Stmt\Case_ | \PhpParser\Node\Stmt\Catch_ | \PhpParser\Node\Stmt\ClassMethod | \PhpParser\Node\Stmt\Do_ | \PhpParser\Node\Stmt\Else_ | \PhpParser\Node\Stmt\ElseIf_ | \PhpParser\Node\Stmt\Finally_ | \PhpParser\Node\Stmt\For_ | \PhpParser\Node\Stmt\Foreach_ | \PhpParser\Node\Stmt\Function_ | \PhpParser\Node\Stmt\If_ | \PhpParser\Node\Stmt\Namespace_ | \PhpParser\Node\Stmt\TryCatch | \PhpParser\Node\Stmt\While_ | \Rector\PhpParser\Node\FileNode
+        StmtsAware: \PhpParser\Node\Stmt\Block | \PhpParser\Node\Expr\Closure | \PhpParser\Node\Stmt\Case_ | \PhpParser\Node\Stmt\Catch_ | \PhpParser\Node\Stmt\ClassMethod | \PhpParser\Node\Stmt\Do_ | \PhpParser\Node\Stmt\Else_ | \PhpParser\Node\Stmt\ElseIf_ | \PhpParser\Node\Stmt\Finally_ | \PhpParser\Node\Stmt\For_ | \PhpParser\Node\Stmt\Foreach_ | \PhpParser\Node\Stmt\Function_ | \PhpParser\Node\Stmt\If_ | \PhpParser\Node\Stmt\Namespace_ | \PhpParser\Node\Stmt\TryCatch | \PhpParser\Node\Stmt\While_ | \Rector\PhpParser\Node\FileNode | \PhpParser\Node\Stmt\Declare_
 
     # requires exact closure types
     checkMissingCallableSignature: true

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/on_ticks.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/on_ticks.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fix
 declare(ticks=1) {
     echo 'test';
 
-    die;
+    throw new \Exception();
 
     echo 'unreachable';
 }
@@ -19,7 +19,7 @@ namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fix
 declare(ticks=1) {
     echo 'test';
 
-    die;
+    throw new \Exception();
 }
 
 ?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/on_ticks.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/on_ticks.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+declare(ticks=1) {
+    echo 'test';
+
+    die;
+
+    echo 'unreachable';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+declare(ticks=1) {
+    echo 'test';
+
+    die;
+}
+
+?>

--- a/src/Application/NodeAttributeReIndexer.php
+++ b/src/Application/NodeAttributeReIndexer.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Switch_;
@@ -66,7 +65,7 @@ final class NodeAttributeReIndexer
 
     private static function reIndexStmtsKeys(Node $node): ?Node
     {
-        if (! NodeGroup::isStmtAwareNode($node) && ! $node instanceof ClassLike && ! $node instanceof Declare_) {
+        if (! NodeGroup::isStmtAwareNode($node) && ! $node instanceof ClassLike) {
             return null;
         }
 

--- a/src/PhpParser/Enum/NodeGroup.php
+++ b/src/PhpParser/Enum/NodeGroup.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
@@ -56,6 +57,7 @@ final class NodeGroup
         TryCatch::class,
         While_::class,
         FileNode::class,
+        Declare_::class,
     ];
 
     /**


### PR DESCRIPTION
`declare()` can have its `stmts` property filled with `array` of `stmts`, eg:

```php
declare(ticks=1) {
    echo 'test';
    die;

    echo 'unreachable';
}
```

this currently skipped on loop of `stmts`, for example on `RemoveUnreachableStatementRector`

- https://getrector.com/demo/c23b3077-4fb9-4a19-a04f-90cc7d65d21e

see example:

- https://3v4l.org/7S87e#v8.2.0

This PR add `Declare_` to `NodeGroup::STMTS_AWARE` so it can properly processed.