### PR TITLE
[Alternative][DeadCode][Php80] Handle crash on mix ClassPropertyAssignToConstructorPromotionRector+RemoveParentDelegatingConstructorRector

### DIFF
--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -58,7 +58,18 @@ final readonly class ChangedNodeScopeRefresher
             throw new ShouldNotHappenException($errorMessage);
         }
 
-        NodeAttributeReIndexer::reIndexNodeAttributes($node);
+        /**
+         * The reindex is needed to:
+         *      - be used by PHPStan processNodes() that relies on indexed arrays start from 0
+         *      - use traverser to avoid issues when multiples rules apply, and higher node reindex deep node,
+         *        which the next rule use deep node, for example:
+         *              - first rule: - Class_ → ClassMethod → remove stmt with index 0
+         *              - second rule: - ClassMethod → here fetch the index 0 that no longer exists
+         */
+        SimpleCallableNodeTraverser::traverse(
+            $node,
+            fn (Node $subNode): ?Node => NodeAttributeReIndexer::reIndexNodeAttributes($subNode)
+        );
 
         $stmts = $this->resolveStmts($node);
         $this->phpStanNodeScopeResolver->processNodes($stmts, $filePath, $mutatingScope);

--- a/src/Application/ChangedNodeScopeRefresher.php
+++ b/src/Application/ChangedNodeScopeRefresher.php
@@ -61,7 +61,7 @@ final readonly class ChangedNodeScopeRefresher
         /**
          * The reindex is needed to:
          *      - be used by PHPStan processNodes() that relies on indexed arrays start from 0
-         *      - use traverser to avoid issues when multiples rules apply, and higher node reindex deep node,
+         *      - use traverser to avoid issues when multiples rules apply, and higher node remove deep node,
          *        which the next rule use deep node, for example:
          *              - first rule: - Class_ → ClassMethod → remove stmt with index 0
          *              - second rule: - ClassMethod → here fetch the index 0 that no longer exists

--- a/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/Fixture/fixture.php.inc
+++ b/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/Fixture/fixture.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\Issues\IssuePropertyPromoRemoveDelegatingParent\Fixture;
+
+use Rector\Tests\Issues\IssuePropertyPromoRemoveDelegatingParent\Source\SomeParentWithEmptyConstruct;
+
+class Fixture extends SomeParentWithEmptyConstruct
+{
+    private string $prop;
+
+    public function __construct(string $prop)
+    {
+        $this->prop = $prop;
+        parent::__construct();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\IssuePropertyPromoRemoveDelegatingParent\Fixture;
+
+use Rector\Tests\Issues\IssuePropertyPromoRemoveDelegatingParent\Source\SomeParentWithEmptyConstruct;
+
+class Fixture extends SomeParentWithEmptyConstruct
+{
+    public function __construct(private string $prop)
+    {
+        parent::__construct();
+    }
+}
+
+?>

--- a/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/IssuePropertyPromoRemoveDelegatingParentTest.php
+++ b/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/IssuePropertyPromoRemoveDelegatingParentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\IssuePropertyPromoRemoveDelegatingParent;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class IssuePropertyPromoRemoveDelegatingParentTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/Source/SomeParentWithEmptyConstruct.php
+++ b/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/Source/SomeParentWithEmptyConstruct.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\IssuePropertyPromoRemoveDelegatingParent\Source;
+
+class SomeParentWithEmptyConstruct
+{
+    public function __construct()
+    {
+        $this->init();
+    }
+
+    private function init(): void
+    {
+		echo 'A init';
+    }
+}

--- a/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/Source/SomeParentWithEmptyConstruct.php
+++ b/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/Source/SomeParentWithEmptyConstruct.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Issues\IssuePropertyPromoRemoveDelegatingParent\Source;
 
-class SomeParentWithEmptyConstruct
+abstract class SomeParentWithEmptyConstruct
 {
     public function __construct()
     {

--- a/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/config/configured_rule.php
+++ b/tests/Issues/IssuePropertyPromoRemoveDelegatingParent/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        ClassPropertyAssignToConstructorPromotionRector::class,
+        RemoveParentDelegatingConstructorRector::class,
+    ]);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9577
Closes https://github.com/rectorphp/rector-src/pull/7794

Ref https://getrector.com/demo/f693662b-ce0d-45cf-93d6-cf7d9674a06f

@TomasVotruba Here alternative of PR:

- https://github.com/rectorphp/rector-src/pull/7794

which the reindex is only happen after refactor, but with traverser to avoid issues when multiples rules apply, and higher node remove deep node.

I added comment for future reference.