### PR TITLE
[TypeDeclarationDocblocks] Use FQCN return docblock for array of object types on AddReturnDocblockFromMethodCallDocblockRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector/Fixture/handle_static_call.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector/Fixture/handle_static_call.php.inc
@@ -27,7 +27,7 @@ use Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockFr
 final class HandleStaticCall
 {
     /**
-     * @return SomeEntity[]
+     * @return \Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockFromMethodCallDocblockRector\Source\SomeEntity[]
      */
     public function getAll(): array
     {

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector/Fixture/some_class.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector/Fixture/some_class.php.inc
@@ -41,7 +41,7 @@ final class SomeClass
     }
 
     /**
-     * @return SomeEntity[]
+     * @return \Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockFromMethodCallDocblockRector\Source\SomeEntity[]
      */
     public function getAll(): array
     {

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector.php
@@ -155,7 +155,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->phpDocTypeChanger->changeReturnTypeNode($node, $phpDocInfo, $calledReturnTagValue->type);
+        $this->phpDocTypeChanger->changeReturnType($node, $phpDocInfo, $calledClassMethodPhpDocInfo->getReturnType());
 
         return $node;
     }


### PR DESCRIPTION
To correctly pointed to target class object as target is outside current namespace (`Source`) in the fixture.

Ref https://github.com/rectorphp/rector-src/pull/7798#pullrequestreview-3624337450