### PR TITLE
[DeadCode] Skip final and non-public __construct() on RemoveParentDelegatingConstructorRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_final_construct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_final_construct.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+use PhpParser\Node\Scalar\String_;
+
+final class SkipFinalConstruct extends String_
+{
+    final public function __construct($value, $attributes)
+    {
+        parent::__construct($value, $attributes);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_private_construct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_private_construct.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+use PhpParser\Node\Scalar\String_;
+
+final class SkipPrivateConstruct extends String_
+{
+    private function __construct($value, $attributes)
+    {
+        parent::__construct($value, $attributes);
+    }
+
+    public function create($value, $attributes)
+    {
+        return new self($value, $attributes);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_private_construct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_private_construct.php.inc
@@ -11,7 +11,7 @@ final class SkipPrivateConstruct extends String_
         parent::__construct($value, $attributes);
     }
 
-    public function create($value, $attributes)
+    public static function create($value, $attributes)
     {
         return new self($value, $attributes);
     }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -102,6 +102,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (! $node->isPublic()) {
+            return null;
+        }
+
         $parentMethodReflection = $this->matchParentConstructorReflection($node);
         if (! $parentMethodReflection instanceof ExtendedMethodReflection) {
             return null;

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -98,6 +98,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFinal()) {
+            return null;
+        }
+
         $parentMethodReflection = $this->matchParentConstructorReflection($node);
         if (! $parentMethodReflection instanceof ExtendedMethodReflection) {
             return null;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9580