### PR TITLE
[ChangesReporting] Fix total changed result on --no-diffs on JsonOutputFormatter

### DIFF
--- a/src/ChangesReporting/Output/JsonOutputFormatter.php
+++ b/src/ChangesReporting/Output/JsonOutputFormatter.php
@@ -27,7 +27,7 @@ final readonly class JsonOutputFormatter implements OutputFormatterInterface
     {
         $errorsJson = [
             'totals' => [
-                'changed_files' => count($processResult->getFileDiffs()),
+                'changed_files' => $processResult->getTotalChanged(),
             ],
         ];
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9582

Even with `--no-diffs`, the total files changed should still be shown, just no diff to be shown.

With a 1 file to be changed, it shows:

**Before**

```bash
➜  rector-src git:(main) ✗ ./bin/rector process src/Application/FileProcessor.php --output-format=json --no-diffs --dry-run

{
    "totals": {
        "changed_files": 0,
        "errors": 0
    }
}
```

**After**

```bash
➜  rector-src git:(fix-total-changed) ./bin/rector process src/Application/FileProcessor.php --output-format=json --no-diffs --dry-run

{
    "totals": {
        "changed_files": 1,
        "errors": 0
    }
}
```