### PR TITLE
Fixes showing files changed in JSON formatter

### DIFF
--- a/src/ChangesReporting/Output/JsonOutputFormatter.php
+++ b/src/ChangesReporting/Output/JsonOutputFormatter.php
@@ -28,7 +28,8 @@ final readonly class JsonOutputFormatter implements OutputFormatterInterface
             ],
         ];
 
-        $fileDiffs = $processResult->getFileDiffs();
+        // We need onlyWithChanges: false to include all file diffs
+        $fileDiffs = $processResult->getFileDiffs(onlyWithChanges: false);
         ksort($fileDiffs);
         foreach ($fileDiffs as $fileDiff) {
             $filePath = $configuration->isReportingWithRealPath()
@@ -36,11 +37,13 @@ final readonly class JsonOutputFormatter implements OutputFormatterInterface
                 : $fileDiff->getRelativeFilePath()
             ;
 
-            $errorsJson[Bridge::FILE_DIFFS][] = [
-                'file' => $filePath,
-                'diff' => $fileDiff->getDiff(),
-                'applied_rectors' => $fileDiff->getRectorClasses(),
-            ];
+            if ($configuration->shouldShowDiffs() && $fileDiff->getDiff() !== '') {
+                $errorsJson[Bridge::FILE_DIFFS][] = [
+                    'file' => $filePath,
+                    'diff' => $fileDiff->getDiff(),
+                    'applied_rectors' => $fileDiff->getRectorClasses(),
+                ];
+            }
 
             // for Rector CI
             $errorsJson['changed_files'][] = $filePath;

--- a/tests/ChangesReporting/Output/Fixtures/without_diffs.json
+++ b/tests/ChangesReporting/Output/Fixtures/without_diffs.json
@@ -1,0 +1,17 @@
+{
+    "totals": {
+        "changed_files": 2,
+        "errors": 1
+    },
+    "changed_files": [
+        "some/file.php",
+        "some/file_foo.php"
+    ],
+    "errors": [
+        {
+            "message": "Some error message",
+            "file": "some/file.php",
+            "line": 1
+        }
+    ]
+}

--- a/tests/ChangesReporting/Output/JsonOutputFormatterTest.php
+++ b/tests/ChangesReporting/Output/JsonOutputFormatterTest.php
@@ -31,7 +31,7 @@ final class JsonOutputFormatterTest extends TestCase
 
     public function testReportShouldShowNumberOfChangesWithNoDiffs(): void
     {
-        $this->expectOutputString((string) file_get_contents(__DIR__ . '/Fixtures/without_diffs.json'));
+        $this->expectOsOutputString((string) file_get_contents(__DIR__ . '/Fixtures/without_diffs.json'));
 
         $this->jsonOutputFormatter->report(
             new ProcessResult(
@@ -56,5 +56,15 @@ final class JsonOutputFormatterTest extends TestCase
             ),
             new Configuration(showDiffs: false)
         );
+    }
+
+    protected function expectOsOutputString(string $expectedOutput): void
+    {
+        $isWindows = strncasecmp(PHP_OS, 'WIN', 3) === 0;
+        if ($isWindows) {
+            $expectedOutput = str_replace('%0A', '%0D%0A', $expectedOutput);
+        }
+
+        parent::expectOutputString($expectedOutput);
     }
 }

--- a/tests/ChangesReporting/Output/JsonOutputFormatterTest.php
+++ b/tests/ChangesReporting/Output/JsonOutputFormatterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ChangesReporting\Output;
+
+use PHPUnit\Framework\TestCase;
+use Rector\ChangesReporting\Output\JsonOutputFormatter;
+use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
+use Rector\Php80\Rector\Identical\StrStartsWithRector;
+use Rector\ValueObject\Configuration;
+use Rector\ValueObject\Error\SystemError;
+use Rector\ValueObject\ProcessResult;
+use Rector\ValueObject\Reporting\FileDiff;
+
+final class JsonOutputFormatterTest extends TestCase
+{
+    private readonly JsonOutputFormatter $jsonOutputFormatter;
+
+    protected function setUp(): void
+    {
+        $this->jsonOutputFormatter = new JsonOutputFormatter();
+
+        parent::setUp();
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertSame('json', $this->jsonOutputFormatter->getName());
+    }
+
+    public function testReportShouldShowNumberOfChangesWithNoDiffs(): void
+    {
+        $this->expectOsOutputString((string) file_get_contents(__DIR__ . '/Fixtures/without_diffs.json'));
+
+        $this->jsonOutputFormatter->report(
+            new ProcessResult(
+                [new SystemError('Some error message', 'some/file.php', 1)],
+                [
+                    new FileDiff(
+                        'some/file.php',
+                        '--- Original' . PHP_EOL . '+++ New' . PHP_EOL .
+                            '@@ -38,5 +39,6 @@' . PHP_EOL .
+                            'return true;' . PHP_EOL . '}' . PHP_EOL,
+                        'diff console formatted',
+                        [new RectorWithLineChange(StrStartsWithRector::class, 38)]
+                    ),
+                    new FileDiff(
+                        'some/file_foo.php',
+                        '',
+                        '',
+                        [new RectorWithLineChange(StrStartsWithRector::class, 38)]
+                    ),
+                ],
+                2
+            ),
+            new Configuration(showDiffs: false)
+        );
+    }
+
+    protected function expectOsOutputString(string $expectedOutput): void
+    {
+        $isWindows = strncasecmp(PHP_OS, 'WIN', 3) === 0;
+        if ($isWindows) {
+            $expectedOutput = str_replace('%0A', '%0D%0A', $expectedOutput);
+        }
+
+        parent::expectOutputString($expectedOutput);
+    }
+}

--- a/tests/ChangesReporting/Output/JsonOutputFormatterTest.php
+++ b/tests/ChangesReporting/Output/JsonOutputFormatterTest.php
@@ -31,7 +31,7 @@ final class JsonOutputFormatterTest extends TestCase
 
     public function testReportShouldShowNumberOfChangesWithNoDiffs(): void
     {
-        $this->expectOsOutputString((string) file_get_contents(__DIR__ . '/Fixtures/without_diffs.json'));
+        $this->expectOutputString((string) file_get_contents(__DIR__ . '/Fixtures/without_diffs.json'));
 
         $this->jsonOutputFormatter->report(
             new ProcessResult(
@@ -56,15 +56,5 @@ final class JsonOutputFormatterTest extends TestCase
             ),
             new Configuration(showDiffs: false)
         );
-    }
-
-    protected function expectOsOutputString(string $expectedOutput): void
-    {
-        $isWindows = strncasecmp(PHP_OS, 'WIN', 3) === 0;
-        if ($isWindows) {
-            $expectedOutput = str_replace('%0A', '%0D%0A', $expectedOutput);
-        }
-
-        parent::expectOutputString($expectedOutput);
     }
 }


### PR DESCRIPTION
# Changes

- Changes how the JSON formatter works in getting the diffs from the process results.
    - Still ignores diffs that are an empty string when not using no-diffs
    - Hides diffs if using no-diffs
- Adds a test for the JSON Formatter for this with a JSON fixture file

# Why

Currently running `./vendor/bin/rector --output-format=json --no-diffs` you will only get the count of how many files changed. This change will show the list as well.

```json
{
    "totals": {
        "changed_files": 1,
        "errors": 0
    },
    "changed_files": [
        "some/file.php",
    ],
}
```

See discussion in #7807

## Notes

Rushed this one together, if I can improve the test or the way we determine to show the diff when it's an empty string, feedback would be greatly appreciated.