### PR TITLE
[DeadCode] Skip with elseif/else on RemoveNextSameValueConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/skip_with_elseif.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/skip_with_elseif.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\Fixture;
+
+final class SkipWithElseif
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+        if ($items === []) {
+            $count = 0;
+        }
+
+        if ($items === []) {
+            return $count;
+        } else {
+            return 'test';
+        }
+    }
+}

--- a/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
@@ -90,10 +90,12 @@ CODE_SAMPLE
             if (! $stmt instanceof If_) {
                 continue;
             }
+
             // only when no elseif/else in current if
             if ($stmt->elseifs !== []) {
                 continue;
             }
+
             if ($stmt->else instanceof Else_) {
                 continue;
             }
@@ -115,10 +117,12 @@ CODE_SAMPLE
             if (! $this->nodeComparator->areNodesEqual($stmt->cond, $nextStmt->cond)) {
                 continue;
             }
+
             // only when no elseif/else in next stmt
             if ($nextStmt->elseifs !== []) {
                 continue;
             }
+
             if ($nextStmt->else instanceof Else_) {
                 continue;
             }

--- a/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\Stmt;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
 use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
 use Rector\PhpParser\Enum\NodeGroup;
@@ -90,6 +91,11 @@ CODE_SAMPLE
                 continue;
             }
 
+            // only when no elseif/else in current if
+            if ($stmt->elseifs !== [] || $stmt->else instanceof Else_) {
+                continue;
+            }
+
             // first condition must be without side effect
             if ($this->sideEffectNodeDetector->detect($stmt->cond)) {
                 continue;
@@ -105,6 +111,11 @@ CODE_SAMPLE
             }
 
             if (! $this->nodeComparator->areNodesEqual($stmt->cond, $nextStmt->cond)) {
+                continue;
+            }
+
+            // only when no elseif/else in next stmt
+            if ($nextStmt->elseifs !== [] || $nextStmt->else instanceof Else_) {
                 continue;
             }
 

--- a/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
@@ -90,9 +90,11 @@ CODE_SAMPLE
             if (! $stmt instanceof If_) {
                 continue;
             }
-
             // only when no elseif/else in current if
-            if ($stmt->elseifs !== [] || $stmt->else instanceof Else_) {
+            if ($stmt->elseifs !== []) {
+                continue;
+            }
+            if ($stmt->else instanceof Else_) {
                 continue;
             }
 
@@ -113,9 +115,11 @@ CODE_SAMPLE
             if (! $this->nodeComparator->areNodesEqual($stmt->cond, $nextStmt->cond)) {
                 continue;
             }
-
             // only when no elseif/else in next stmt
-            if ($nextStmt->elseifs !== [] || $nextStmt->else instanceof Else_) {
+            if ($nextStmt->elseifs !== []) {
+                continue;
+            }
+            if ($nextStmt->else instanceof Else_) {
                 continue;
             }
 


### PR DESCRIPTION
@TomasVotruba I tested in our project and it seems cause invalid change, this PR ensure the rule only apply when there is no elseif/else in the ifs conditions.

Fixes https://github.com/rectorphp/rector/issues/9585