### PR TITLE
[DeadCode] Merge comment on RemoveNextSameValueConditionRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/merge_comment.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector/Fixture/merge_comment.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\Fixture;
+
+final class MergeComment
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+
+        // 1
+        if ($items === []) {
+            $count = 0;
+        }
+
+        // 2
+        if ($items === []) {
+            return $count;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector\Fixture;
+
+final class MergeComment
+{
+    public function __construct(array $items)
+    {
+        $count = 100;
+
+        // 1
+        // 2
+        if ($items === []) {
+            $count = 0;
+            return $count;
+        }
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
 use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Enum\NodeGroup;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
@@ -127,6 +128,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            $stmt->setAttribute(AttributeKey::COMMENTS, array_merge(
+                $stmt->getAttribute(AttributeKey::COMMENTS) ?? [],
+                $nextStmt->getAttribute(AttributeKey::COMMENTS) ?? []
+            ));
             $stmt->stmts = array_merge($stmt->stmts, $nextStmt->stmts);
 
             // remove next node


### PR DESCRIPTION
@TomasVotruba I tested in our project and it seems cause invalid merge comment, this PR try to fix it.