### PR TITLE
feat: create new SafeDeclareStrictTypesRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,7 @@
             "tests/debug_functions.php",
             "rules-tests/Transform/Rector/FuncCall/FuncCallToMethodCallRector/Source/some_view_function.php",
             "rules-tests/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector/Source/FunctionTyped.php",
+            "rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/functions.php",
             "rules-tests/Php70/Rector/ClassMethod/Php4ConstructorRector/Source/ParentClass.php",
             "rules-tests/CodingStyle/Rector/Closure/StaticClosureRector/Source/functions.php"
         ]

--- a/e2e/parallel with space/src/Test.php
+++ b/e2e/parallel with space/src/Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Test
 {
 }

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/arrow_function_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/arrow_function_return.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$arrow = fn (): int => 42;
+
+$arrowWithParam = fn (int $x): int => $x + 1;
+
+$arrowString = fn (): string => 'hello';
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$arrow = fn (): int => 42;
+
+$arrowWithParam = fn (int $x): int => $x + 1;
+
+$arrowString = fn (): string => 'hello';

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/closure_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/closure_return.php.inc
@@ -10,6 +10,10 @@ $closureWithParam = function (int $x): int {
     return $x + 1;
 };
 
+$closureWithMixedReturn = function (int $x): mixed {
+    return $x + 1;
+};
+
 ?>
 -----
 <?php
@@ -23,5 +27,9 @@ $closure = function (): int {
 };
 
 $closureWithParam = function (int $x): int {
+    return $x + 1;
+};
+
+$closureWithMixedReturn = function (int $x): mixed {
     return $x + 1;
 };

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/closure_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/closure_return.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$closure = function (): int {
+    return 42;
+};
+
+$closureWithParam = function (int $x): int {
+    return $x + 1;
+};
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$closure = function (): int {
+    return 42;
+};
+
+$closureWithParam = function (int $x): int {
+    return $x + 1;
+};

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/constructor_calls.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/constructor_calls.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+new TypedClass('John', 25);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+new TypedClass('John', 25);

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/explicit_cast.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/explicit_cast.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsInt;
+
+function callWithCast(): void
+{
+    acceptsInt((int) '123');
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsInt;
+
+function callWithCast(): void
+{
+    acceptsInt((int) '123');
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/first_class_callable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/first_class_callable.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$fn = strlen(...);
+
+$upperFn = strtoupper(...);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$fn = strlen(...);
+
+$upperFn = strtoupper(...);

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/int_to_float_parameter.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/int_to_float_parameter.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsFloat;
+
+acceptsFloat(123);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsFloat;
+
+acceptsFloat(123);

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/method_calls.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/method_calls.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function useMethodCalls(TypedClass $obj): void
+{
+    $obj->add(1, 2);
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function useMethodCalls(TypedClass $obj): void
+{
+    $obj->add(1, 2);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/named_arguments.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/named_arguments.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function acceptsNamedArgs(string $name, int $age): void
+{
+}
+
+function callWithNamedArgs(): void
+{
+    acceptsNamedArgs(age: 25, name: 'John');
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function acceptsNamedArgs(string $name, int $age): void
+{
+}
+
+function callWithNamedArgs(): void
+{
+    acceptsNamedArgs(age: 25, name: 'John');
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/nullable_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/nullable_types.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsNullableString;
+
+function callWithNull(): void
+{
+    acceptsNullableString(null);
+    acceptsNullableString('hello');
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsNullableString;
+
+function callWithNull(): void
+{
+    acceptsNullableString(null);
+    acceptsNullableString('hello');
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/object_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/object_types.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function acceptsObject(TypedClass $obj): void
+{
+}
+
+function callWithObject(TypedClass $obj): void
+{
+    acceptsObject($obj);
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function acceptsObject(TypedClass $obj): void
+{
+}
+
+function callWithObject(TypedClass $obj): void
+{
+    acceptsObject($obj);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/property_assignment.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/property_assignment.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function assignProperty(TypedClass $obj): void
+{
+    $obj->count = 123;
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function assignProperty(TypedClass $obj): void
+{
+    $obj->count = 123;
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/return_object.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/return_object.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function createAndReturn(): TypedClass
+{
+    return new TypedClass('Widget', 100);
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function createAndReturn(): TypedClass
+{
+    return new TypedClass('Widget', 100);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_arrow_function_wrong_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_arrow_function_wrong_return.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$arrow = fn (): int => 'not an int';

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_attribute_wrong_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_attribute_wrong_type.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedAttribute;
+
+#[TypedAttribute('123')]
+class WithAttribute
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_closure_wrong_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_closure_wrong_return.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+$closure = function (): int {
+    return 'not an int';
+};

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_dynamic_call.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_dynamic_call.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function callDynamic(string $func): void
+{
+    $func('arg');
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_int_return_as_string.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_int_return_as_string.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function returnsString(): string
+{
+    return 123;
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_named_argument_wrong_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_named_argument_wrong_type.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function acceptsNamedArgsTyped(string $name, int $age): void
+{
+}
+
+function callWithWrongNamedArg(): void
+{
+    acceptsNamedArgsTyped(age: '25', name: 'John');
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_property_assignment_wrong_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_property_assignment_wrong_type.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function assignPropertyWrongType(TypedClass $obj): void
+{
+    $obj->count = '123';
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_static_property_wrong_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_static_property_wrong_type.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function assignStaticPropertyWrongType(): void
+{
+    TypedClass::$staticCount = '123';
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_string_to_int_coercion.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_string_to_int_coercion.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsInt;
+
+acceptsInt('123');

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_union_return_mismatch.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_union_return_mismatch.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function returnsStringOrIntButReturnsFloat(): string|int
+{
+    return 3.14;
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_union_type_mismatch.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_union_type_mismatch.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsStringOrInt;
+
+function callWithObjectForUnion(TypedClass $obj): void
+{
+    acceptsStringOrInt($obj);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_unpack.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_unpack.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function acceptsInts(int $a, int $b): void
+{
+}
+
+function callWithUnpack(): void
+{
+    $args = [1, 2];
+    acceptsInts(...$args);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_variadic_wrong_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_variadic_wrong_type.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\sumInts;
+
+function callVariadicWithWrongType(): void
+{
+    sumInts(1, 2, 'three', 4);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_wrong_object_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_wrong_object_type.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\AnotherClass;
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function acceptsTypedClass(TypedClass $obj): void
+{
+}
+
+function callWithWrongType(): void
+{
+    $obj = new AnotherClass();
+    acceptsTypedClass($obj);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_wrong_return_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_wrong_return_type.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\AnotherClass;
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function returnsWrongType(): TypedClass
+{
+    return new AnotherClass();
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/static_calls.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/static_calls.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+TypedClass::format('hello');
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+TypedClass::format('hello');

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/static_property_assignment.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/static_property_assignment.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function assignStaticProperty(): void
+{
+    TypedClass::$staticCount = 123;
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\TypedClass;
+
+function assignStaticProperty(): void
+{
+    TypedClass::$staticCount = 123;
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/typed_calls.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/typed_calls.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsString;
+
+acceptsString('hello');
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsString;
+
+acceptsString('hello');

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/union_return_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/union_return_type.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function returnsStringOrInt(bool $flag): string|int
+{
+    if ($flag) {
+        return 'hello';
+    }
+    return 42;
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function returnsStringOrInt(bool $flag): string|int
+{
+    if ($flag) {
+        return 'hello';
+    }
+    return 42;
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/union_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/union_types.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsStringOrInt;
+
+function callWithUnionTypes(): void
+{
+    acceptsStringOrInt('hello');
+    acceptsStringOrInt(123);
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\acceptsStringOrInt;
+
+function callWithUnionTypes(): void
+{
+    acceptsStringOrInt('hello');
+    acceptsStringOrInt(123);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/variadic_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/variadic_function.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\sumInts;
+
+function callVariadic(): void
+{
+    sumInts(1, 2, 3, 4);
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+use function Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source\sumInts;
+
+function callVariadic(): void
+{
+    sumInts(1, 2, 3, 4);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/without_namespace.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/without_namespace.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+function someFunction()
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+function someFunction()
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/SafeDeclareStrictTypesRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/SafeDeclareStrictTypesRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SafeDeclareStrictTypesRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/AnotherClass.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/AnotherClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source;
+
+final class AnotherClass
+{
+    public function doSomething(): void
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/TypedAttribute.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/TypedAttribute.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source;
+
+use Attribute;
+
+#[Attribute]
+final class TypedAttribute
+{
+    public function __construct(
+        public int $value
+    ) {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/TypedClass.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/TypedClass.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source;
+
+final class TypedClass
+{
+    public int $count = 0;
+
+    public static int $staticCount = 0;
+
+    public function __construct(
+        private string $name,
+        private int $value
+    ) {
+    }
+
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function process(self $other): void
+    {
+    }
+
+    public static function format(string $input): string
+    {
+        return trim($input);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/functions.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Source/functions.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Source;
+
+function acceptsInt(int $value): void
+{
+}
+
+function acceptsString(string $value): void
+{
+}
+
+function acceptsFloat(float $value): void
+{
+}
+
+function acceptsCallable(callable $fn): void
+{
+}
+
+function acceptsNullableString(?string $value): void
+{
+}
+
+function acceptsStringOrInt(string|int $value): void
+{
+}
+
+function sumInts(int ...$numbers): int
+{
+    return array_sum($numbers);
+}

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
+
+return RectorConfig::configure()
+    ->withRules([SafeDeclareStrictTypesRector::class]);

--- a/rules/TypeDeclaration/NodeAnalyzer/StrictTypeSafetyChecker.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/StrictTypeSafetyChecker.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeAnalyzer;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\FunctionLike;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PhpParser\Node\FileNode;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Reflection\ReflectionResolver;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+
+final readonly class StrictTypeSafetyChecker
+{
+    public function __construct(
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeTypeResolver $nodeTypeResolver,
+        private ReflectionResolver $reflectionResolver,
+        private StaticTypeMapper $staticTypeMapper,
+    ) {
+    }
+
+    public function isFileStrictTypeSafe(FileNode $fileNode): bool
+    {
+        $callLikes = $this->betterNodeFinder->findInstanceOf($fileNode->stmts, CallLike::class);
+        foreach ($callLikes as $callLike) {
+            if (! $this->isCallLikeSafe($callLike)) {
+                return false;
+            }
+        }
+
+        $attributes = $this->betterNodeFinder->findInstanceOf($fileNode->stmts, Attribute::class);
+        foreach ($attributes as $attribute) {
+            if (! $this->isAttributeSafe($attribute)) {
+                return false;
+            }
+        }
+
+        $functionLikes = $this->betterNodeFinder->findInstanceOf($fileNode->stmts, FunctionLike::class);
+        foreach ($functionLikes as $functionLike) {
+            if (! $this->areFunctionReturnsTypeSafe($functionLike)) {
+                return false;
+            }
+        }
+
+        $assigns = $this->betterNodeFinder->findInstanceOf($fileNode->stmts, Assign::class);
+        foreach ($assigns as $assign) {
+            if (! $this->isPropertyAssignSafe($assign)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isCallLikeSafe(CallLike $callLike): bool
+    {
+        if ($callLike->isFirstClassCallable()) {
+            return true;
+        }
+
+        $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($callLike);
+        if (! $reflection instanceof FunctionReflection && ! $reflection instanceof MethodReflection) {
+            return false;
+        }
+
+        $scope = ScopeFetcher::fetch($callLike);
+        $parameters = ParametersAcceptorSelectorVariantsWrapper::select($reflection, $callLike, $scope)
+            ->getParameters();
+
+        return $this->areArgsSafe($callLike->getArgs(), $parameters);
+    }
+
+    private function isAttributeSafe(Attribute $attribute): bool
+    {
+        $reflection = $this->reflectionResolver->resolveConstructorReflectionFromAttribute($attribute);
+        if (! $reflection instanceof MethodReflection) {
+            return false;
+        }
+
+        $parameters = ParametersAcceptorSelector::combineAcceptors($reflection->getVariants())->getParameters();
+
+        return $this->areArgsSafe($attribute->args, $parameters);
+    }
+
+    /**
+     * @param Arg[] $args
+     * @param ParameterReflection[] $parameters
+     */
+    private function areArgsSafe(array $args, array $parameters): bool
+    {
+        foreach ($args as $position => $arg) {
+            if ($arg->unpack) {
+                return false;
+            }
+
+            $parameterReflection = null;
+
+            if ($arg->name !== null) {
+                foreach ($parameters as $parameter) {
+                    if ($parameter->getName() === $arg->name->name) {
+                        $parameterReflection = $parameter;
+                        break;
+                    }
+                }
+            } elseif (isset($parameters[$position])) {
+                $parameterReflection = $parameters[$position];
+            } else {
+                $lastParameter = end($parameters);
+                if ($lastParameter !== false && $lastParameter->isVariadic()) {
+                    $parameterReflection = $lastParameter;
+                }
+            }
+
+            if ($parameterReflection === null) {
+                return false;
+            }
+
+            $parameterType = $parameterReflection->getType();
+            $argType = $this->nodeTypeResolver->getNativeType($arg->value);
+
+            if (! $this->isTypeSafeForStrictMode($parameterType, $argType)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function areFunctionReturnsTypeSafe(FunctionLike $functionLike): bool
+    {
+        if ($functionLike->getReturnType() === null) {
+            return true;
+        }
+
+        $declaredReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($functionLike->getReturnType());
+
+        if (
+            $declaredReturnType instanceof MixedType
+            || $declaredReturnType instanceof NeverType
+            || $declaredReturnType->isVoid()->yes()
+        ) {
+            return true;
+        }
+
+        $returns = $this->betterNodeFinder->findReturnsScoped($functionLike);
+
+        foreach ($returns as $return) {
+            if ($return->expr === null) {
+                continue;
+            }
+
+            $returnExprType = $this->nodeTypeResolver->getNativeType($return->expr);
+
+            if (! $this->isTypeSafeForStrictMode($declaredReturnType, $returnExprType)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isPropertyAssignSafe(Assign $assign): bool
+    {
+        if (! $assign->var instanceof PropertyFetch && ! $assign->var instanceof StaticPropertyFetch) {
+            return true;
+        }
+
+        $propertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($assign->var);
+        if ($propertyReflection === null) {
+            return false;
+        }
+
+        $propertyType = $propertyReflection->getNativeType();
+        $assignedType = $this->nodeTypeResolver->getNativeType($assign->expr);
+
+        return $this->isTypeSafeForStrictMode($propertyType, $assignedType);
+    }
+
+    private function isTypeSafeForStrictMode(Type $declaredType, Type $valueType): bool
+    {
+        return $declaredType->accepts($valueType, strictTypes: true)
+            ->yes();
+    }
+}

--- a/rules/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector.php
+++ b/rules/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\StmtsAwareInterface;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Nop;
+use Rector\Contract\Rector\HTMLAverseRectorInterface;
+use Rector\PhpParser\Node\FileNode;
+use Rector\Rector\AbstractRector;
+use Rector\TypeDeclaration\NodeAnalyzer\DeclareStrictTypeFinder;
+use Rector\TypeDeclaration\NodeAnalyzer\StrictTypeSafetyChecker;
+use Rector\ValueObject\PhpVersion;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\SafeDeclareStrictTypesRectorTest
+ */
+final class SafeDeclareStrictTypesRector extends AbstractRector implements HTMLAverseRectorInterface, MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly DeclareStrictTypeFinder $declareStrictTypeFinder,
+        private readonly StrictTypeSafetyChecker $strictTypeSafetyChecker,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add `declare(strict_types=1)` if missing and only if the file is type-safe (no scalar type coercions).',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+function acceptsInt(int $value): void
+{
+}
+
+acceptsInt(5);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+declare(strict_types=1);
+
+function acceptsInt(int $value): void
+{
+}
+
+acceptsInt(5);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param FileNode $node
+     */
+    public function refactor(Node $node): ?FileNode
+    {
+        if ($this->declareStrictTypeFinder->hasDeclareStrictTypes($node)) {
+            return null;
+        }
+
+        if (! $this->strictTypeSafetyChecker->isFileStrictTypeSafe($node)) {
+            return null;
+        }
+
+        $declaresStrictType = $this->nodeFactory->createDeclaresStrictType();
+        $node->stmts = array_merge([$declaresStrictType, new Nop()], $node->stmts);
+
+        return $node;
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FileNode::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersion::PHP_70;
+    }
+}

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -84,6 +84,7 @@ use Rector\Php52\Rector\Property\VarToPublicPropertyRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 
 /**
  * Key 0 = level 0
@@ -183,6 +184,7 @@ final class CodeQualityLevel
         SortCallLikeNamedArgsRector::class,
         SortAttributeNamedArgsRector::class,
         RemoveReadonlyPropertyVisibilityOnReadonlyClassRector::class,
+        SafeDeclareStrictTypesRector::class,
     ];
 
     /**


### PR DESCRIPTION
Hello!

### Motivation

See https://x.com/VotrubaT/status/2008248184540418398

Currently, the `DeclareStrictTypesRector` just indiscriminately adds `declare(strict_types=1)` to all files. However:
1. this is **very unsafe** and has great potential to break existing files---therefore this is basically useless and is not part of any set by default
2. there's already a [php-cs-fixer](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.92|fixer:declare_strict_types) rule for this, so again it's rather useless in its current form

This PR creates a new rule (`SafeDeclareStrictTypesRector`) that is (*should be*) **completely safe** and only adds strict types to the file when it won't break code. I've also added it to the `codeQuality` ruleset (but let me know if you'd rather it go elsewhere).

### Implementation

Basically, strict_types only affects **calling** code and prevents scalar type coercion in the following cases:
- arguments passed to `CallLike`s and `Attribute`s
- values returned from `FunctionLike`s
- values assigned to properties

This PR adds a new service class (`StrictTypeSafetyChecker`) that iterates through all the above and checks the type compatibility. If the file is **completely safe** then the refactor is performed, otherwise the file is skipped. I conservatively skip files when we can't be sure (e.g., dynamic calls, unpacks, etc.).

> [!TIP]
> All of the actual type checking is deferred to phpstan's `$declaredType->accepts($valueType, strictTypes: true)` api which really makes things clean on our end.

CC: @TomasVotruba 

Thanks!