### PR TITLE
Add check for append in foreach items assignment

### DIFF
--- a/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_assigned_before_in_conditional_foreach.php.inc
+++ b/rules-tests/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector/Fixture/skip_assigned_before_in_conditional_foreach.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRector\Fixture;
+
+final class SkipAssignedBeforeInConditionalForeach
+{
+    public function run($data)
+    {
+        $list = [];
+        $groupList = [];
+
+        foreach ($data->getItems() as $item) {
+            if ($item->hasGroup()) {
+                $groupList[] = ['id' => $item->getGroupId()];
+            } else {
+                $list[] = ['id' => $item->getId()];
+            }
+        }
+
+        foreach ($groupList as $group) {
+            $list[] = $group;
+        }
+
+        return $list;
+    }
+}

--- a/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
@@ -104,6 +104,10 @@ CODE_SAMPLE
             }
 
             if ($this->shouldSkip($stmt, $emptyArrayVariables)) {
+                if ($this->isAppend($stmt, $emptyArrayVariables)) {
+                    return null;
+                }
+                
                 continue;
             }
 


### PR DESCRIPTION
This PR fixes the rule `ForeachItemsAssignToEmptyArrayToAssignRector`, which currently ignores array modifications in skipped foreach loops, leading to incorrect direct assignments that overwrite previously collected data.

Fixes https://github.com/rectorphp/rector/issues/9587 and probably https://github.com/rectorphp/rector/issues/9534.