### PR TITLE
[DeadCode] Skip private promoted property on RemoveParentDelegatingConstructorRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_private_property_promotion.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_private_property_promotion.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source\SomeParentWithPrivatePropertyPromotion;
+
+class SkipPrivatePropertyPromotion extends SomeParentWithPrivatePropertyPromotion
+{
+    public function __construct(private \DateTime $d)
+    {
+        parent::__construct($d);
+    }
+
+    public function run()
+    {
+        return $this->d->format('Y-m-d');
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/SomeParentWithPrivatePropertyPromotion.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/SomeParentWithPrivatePropertyPromotion.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source;
+
+class SomeParentWithPrivatePropertyPromotion
+{
+    public function __construct(private \DateTime $d)
+    {
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -220,6 +220,10 @@ CODE_SAMPLE
         ExtendedMethodReflection $extendedMethodReflection
     ): bool {
         foreach ($classMethod->getParams() as $position => $param) {
+            if ($param->isPromoted() && $param->isPrivate()) {
+                return false;
+            }
+
             $parameterType = $param->type;
 
             // no type override


### PR DESCRIPTION
before: https://3v4l.org/6uYU7#v8.2.0 (works)
after: https://3v4l.org/onscb#v8.2.0 (error)

Fixes https://github.com/rectorphp/rector/issues/9590