### PR TITLE
[dx] Rename DeprecatedAnnotationToDeprecatedAttributeRector for PHP 8.5 to explicit ConstAndTraitDeprecatedAttributeRector to make class names unique

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -30,6 +30,10 @@ jobs:
                         run: vendor/bin/phpstan analyse --ansi
 
                     -
+                        name: 'Avoid duplicate short class names'
+                        run: php scripts/unique-rector-short-class-name.php
+
+                    -
                         name: 'Help and Version'
                         run:
                             bin/rector --help

--- a/config/set/php85.php
+++ b/config/set/php85.php
@@ -11,7 +11,7 @@ use Rector\Php85\Rector\ArrayDimFetch\ArrayFirstLastRector;
 use Rector\Php85\Rector\Class_\SleepToSerializeRector;
 use Rector\Php85\Rector\Class_\WakeupToUnserializeRector;
 use Rector\Php85\Rector\ClassMethod\NullDebugInfoReturnRector;
-use Rector\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+use Rector\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
 use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
 use Rector\Php85\Rector\FuncCall\ChrArgModuloRector;
 use Rector\Php85\Rector\FuncCall\OrdSingleByteRector;
@@ -35,7 +35,7 @@ return static function (RectorConfig $rectorConfig): void {
         ArrayFirstLastRector::class,
         RemoveFinfoBufferContextArgRector::class,
         NullDebugInfoReturnRector::class,
-        DeprecatedAnnotationToDeprecatedAttributeRector::class,
+        ConstAndTraitDeprecatedAttributeRector::class,
         ColonAfterSwitchCaseRector::class,
         ArrayKeyExistsNullToEmptyStringRector::class,
         ChrArgModuloRector::class,

--- a/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/ConstAndTraitDeprecatedAttributeRectorTest.php
+++ b/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/ConstAndTraitDeprecatedAttributeRectorTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+namespace Rector\Tests\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-final class DeprecatedAnnotationToDeprecatedAttributeRectorTest extends AbstractRectorTestCase
+final class ConstAndTraitDeprecatedAttributeRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
     public function test(string $filePath): void

--- a/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/Fixture/basic.php.inc
+++ b/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/Fixture/basic.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+namespace Rector\Tests\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
 
 /**
  * @deprecated use new constant
@@ -16,7 +16,7 @@ const UNUSED = 'ignored';
 -----
 <?php
 
-namespace Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+namespace Rector\Tests\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
 
 #[\Deprecated(message: 'use new constant')]
 const CONSTANT = 'some reason';

--- a/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/Fixture/handle_trait.php.inc
+++ b/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/Fixture/handle_trait.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
+
+/**
+ * @deprecated avoid using
+ */
+trait HandleTrait
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
+
+#[\Deprecated(message: 'avoid using')]
+trait HandleTrait
+{
+}
+
+?>

--- a/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/Fixture/skip_on_class_const.php.inc
+++ b/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/Fixture/skip_on_class_const.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
+
+final class SkipOnClassConst
+{
+    /**
+     * @deprecated use new constant
+     */
+    public const CONSTANT = 'some reason';
+
+    /**
+     * @deprecated 2.0.0 do not use
+     */
+    public const UNUSED = 'ignored';
+}

--- a/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector/config/configured_rule.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector;
+use Rector\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector;
 use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(DeprecatedAnnotationToDeprecatedAttributeRector::class);
+    $rectorConfig->rule(ConstAndTraitDeprecatedAttributeRector::class);
     $rectorConfig->phpVersion(PhpVersion::PHP_85);
 };

--- a/rules/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector.php
+++ b/rules/Php85/Rector/Const_/ConstAndTraitDeprecatedAttributeRector.php
@@ -6,17 +6,21 @@ namespace Rector\Php85\Rector\Const_;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Const_;
+use PhpParser\Node\Stmt\Trait_;
 use Rector\PhpAttribute\DeprecatedAnnotationToDeprecatedAttributeConverter;
 use Rector\Rector\AbstractRector;
-use Rector\ValueObject\PhpVersionFeature;
+use Rector\ValueObject\PhpVersion;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Tests\Php85\Rector\Const_\DeprecatedAnnotationToDeprecatedAttributeRector\DeprecatedAnnotationToDeprecatedAttributeRectorTest
+ * @see https://wiki.php.net/rfc/attributes-on-constants
+ * @see https://wiki.php.net/rfc/deprecated_traits
+ *
+ * @see \Rector\Tests\Php85\Rector\Const_\ConstAndTraitDeprecatedAttributeRector\ConstAndTraitDeprecatedAttributeRectorTest
  */
-final class DeprecatedAnnotationToDeprecatedAttributeRector extends AbstractRector implements MinPhpVersionInterface
+final class ConstAndTraitDeprecatedAttributeRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly DeprecatedAnnotationToDeprecatedAttributeConverter $deprecatedAnnotationToDeprecatedAttributeConverter,
@@ -25,7 +29,7 @@ final class DeprecatedAnnotationToDeprecatedAttributeRector extends AbstractRect
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Change @deprecated annotation to Deprecated attribute', [
+        return new RuleDefinition('Change @deprecated annotation to #[Deprecated] attribute for constants', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 /**
@@ -44,11 +48,11 @@ CODE_SAMPLE
 
     public function getNodeTypes(): array
     {
-        return [Const_::class];
+        return [Const_::class, Trait_::class];
     }
 
     /**
-     * @param Const_ $node
+     * @param Const_|Trait_ $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -57,6 +61,6 @@ CODE_SAMPLE
 
     public function provideMinPhpVersion(): int
     {
-        return PhpVersionFeature::DEPRECATED_ATTRIBUTE_ON_CONSTANT;
+        return PhpVersion::PHP_85;
     }
 }

--- a/scripts/unique-rector-short-class-name.php
+++ b/scripts/unique-rector-short-class-name.php
@@ -1,0 +1,69 @@
+<?php
+
+// this is part of downgrade build
+
+declare(strict_types=1);
+
+use Rector\Console\ExitCode;
+use Rector\Scripts\Finder\RectorClassFinder;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$rectorClassFinder = new RectorClassFinder();
+$rectorClassNames = $rectorClassFinder->find([
+    __DIR__ . '/../rules',
+    __DIR__ . '/../vendor/rector/rector-doctrine',
+    __DIR__ . '/../vendor/rector/rector-phpunit',
+    __DIR__ . '/../vendor/rector/rector-symfony',
+    __DIR__ . '/../vendor/rector/rector-downgrade-php',
+]);
+
+/**
+ * @param string[] $classNames
+ * @return string[]
+ */
+function getShortClassNames(array $classNames): array
+{
+    $shortClassNames = [];
+    foreach ($classNames as $className) {
+        $shortClassNames[] = substr($className, strrpos($className, '\\') + 1);
+    }
+
+    return $shortClassNames;
+}
+
+/**
+ * @param string[] $shortClassNames
+ * @return string[]
+ */
+function filterDuplicatedValues(array $shortClassNames): array
+{
+    $classNamesToCounts = array_count_values($shortClassNames);
+    $duplicatedShortClassNames = [];
+
+    foreach ($classNamesToCounts as $className => $count) {
+        if ($count === 1) {
+            // unique, skip
+            continue;
+        }
+
+        $duplicatedShortClassNames[] = $className;
+    }
+
+    return $duplicatedShortClassNames;
+}
+
+$shortClassNames = getShortClassNames($rectorClassNames);
+$duplicatedShortClassNames = filterDuplicatedValues($shortClassNames);
+
+if ($duplicatedShortClassNames === []) {
+    echo "All Rector class names are unique!\n";
+    exit(ExitCode::SUCCESS);
+}
+
+echo "The following Rector class names are duplicated:\n";
+foreach ($duplicatedShortClassNames as $duplicatedShortClassName) {
+    echo sprintf("- %s\n", $duplicatedShortClassName);
+}
+
+exit(ExitCode::FAILURE);

--- a/src/PhpAttribute/DeprecatedAnnotationToDeprecatedAttributeConverter.php
+++ b/src/PhpAttribute/DeprecatedAnnotationToDeprecatedAttributeConverter.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Const_;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Trait_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\DeprecatedTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -47,7 +48,7 @@ final readonly class DeprecatedAnnotationToDeprecatedAttributeConverter
     ) {
     }
 
-    public function convert(ClassConst|Function_|ClassMethod|Const_ $node): ?Node
+    public function convert(ClassConst|Function_|ClassMethod|Const_|Trait_ $node): ?Node
     {
         $hasChanged = false;
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -794,12 +794,6 @@ final class PhpVersionFeature
     public const DEPRECATED_NULL_DEBUG_INFO_RETURN = PhpVersion::PHP_85;
 
     /**
-     * @see https://wiki.php.net/rfc/attributes-on-constants
-     * @var int
-     */
-    public const DEPRECATED_ATTRIBUTE_ON_CONSTANT = PhpVersion::PHP_85;
-
-    /**
      * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_semicolon_after_case_in_switch_statement
      * @var int
      */


### PR DESCRIPTION
Proper fix for https://github.com/rectorphp/getrector-com/issues/3531

Rector short class names must be unique, so there is no ambiguity while using them in config or in the docs.
I've added CI script to make sure we won't miss it again :)

