### PR TITLE
[perf] optimize ParamTypeByMethodCallTypeRector for speed with early checks

### DIFF
--- a/rules-tests/CodingStyle/ClassNameImport/ShortNameResolver/ShortNameResolverTest.php
+++ b/rules-tests/CodingStyle/ClassNameImport/ShortNameResolver/ShortNameResolverTest.php
@@ -18,7 +18,6 @@ final class ShortNameResolverTest extends AbstractLazyTestCase
 
     protected function setUp(): void
     {
-        // @todo let dynamic source locator know about parsed files
         parent::setUp();
 
         $this->shortNameResolver = $this->make(ShortNameResolver::class);


### PR DESCRIPTION
This was reported in https://github.com/rectorphp/need-for-speed as the slowest rules we have, by 25 %-30 % than rest of the rules.


<img width="1688" height="774" alt="Screenshot From 2026-01-15 11-20-16" src="https://github.com/user-attachments/assets/ad69f9c5-2116-4804-a99f-8e523e726387" />

