### PR TITLE
Manage named arguments when removing values

### DIFF
--- a/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Fixture/remove_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Fixture/remove_named_arguments.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source\SomeMultiArg;
+
+$object = new SomeMultiArg();
+$object->firstArgument(0, b: 1);
+$object->firstArgument(a: 0);
+$object->firstArgument(b: 1, a: 0);
+$object->secondArgument(0, b: 1);
+$object->secondArgument(b: 1);
+$object->secondArgument(b: 1, a: 0);
+
+?>
+
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source\SomeMultiArg;
+
+$object = new SomeMultiArg();
+$object->firstArgument(b: 1);
+$object->firstArgument();
+$object->firstArgument(b: 1);
+$object->secondArgument(0);
+$object->secondArgument();
+$object->secondArgument(a: 0);
+
+?>

--- a/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Fixture/skip_named_arguments.php.inc
+++ b/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Fixture/skip_named_arguments.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source\SomeMultiArg;
+
+$object = new SomeMultiArg();
+$object->firstArgument(b: 1);
+$object->secondArgument(a: 1);
+$object->secondArgument(0, c: 2);

--- a/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Source/SomeMultiArg.php
+++ b/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/Source/SomeMultiArg.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source;
+
+class SomeMultiArg
+{
+    public function firstArgument($a = 1, $b = 2)
+    {
+    }
+
+    public function secondArgument($a = 1, $b = 2, $c = 3)
+    {
+    }
+}

--- a/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/MethodCall/RemoveMethodCallParamRector/config/configured_rule.php
@@ -6,6 +6,7 @@ use Rector\Arguments\Rector\MethodCall\RemoveMethodCallParamRector;
 use Rector\Arguments\ValueObject\RemoveMethodCallParam;
 use Rector\Config\RectorConfig;
 use Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source\MethodCaller;
+use Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source\SomeMultiArg;
 use Rector\Tests\Arguments\Rector\MethodCall\RemoveMethodCallParamRector\Source\StaticCaller;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -13,5 +14,7 @@ return static function (RectorConfig $rectorConfig): void {
         ->ruleWithConfiguration(RemoveMethodCallParamRector::class, [
             new RemoveMethodCallParam(MethodCaller::class, 'process', 1),
             new RemoveMethodCallParam(StaticCaller::class, 'remove', 3),
+            new RemoveMethodCallParam(SomeMultiArg::class, 'firstArgument', 0),
+            new RemoveMethodCallParam(SomeMultiArg::class, 'secondArgument', 1),
         ]);
 };

--- a/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
+++ b/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
@@ -7,8 +7,11 @@ namespace Rector\Arguments\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use Rector\Arguments\ValueObject\RemoveMethodCallParam;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\PhpParser\AstResolver;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -24,6 +27,12 @@ final class RemoveMethodCallParamRector extends AbstractRector implements Config
      * @var RemoveMethodCallParam[]
      */
     private array $removeMethodCallParams = [];
+
+    public function __construct(
+        private readonly AstResolver $astResolver,
+        private readonly ArgsAnalyzer $argsAnalyzer,
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -83,11 +92,42 @@ CODE_SAMPLE
             }
 
             $args = $node->getArgs();
-            if (! isset($args[$removeMethodCallParam->getParamPosition()])) {
+            $position = $removeMethodCallParam->getParamPosition();
+            $firstNamedArgPosition = $this->argsAnalyzer->resolveFirstNamedArgPosition($args);
+
+            // if the call has named arguments and the argument that we want to remove is not
+            // before any named argument, we need to check if it is in the list of named arguments
+            // if it is, we use the position of the named argument as the position to remove
+            // if it is not, we cannot remove it
+            if ($firstNamedArgPosition !== null && $position >= $firstNamedArgPosition) {
+                $call = $this->astResolver->resolveClassMethodOrFunctionFromCall($node);
+                if ($call === null) {
+                    return null;
+                }
+
+                $paramName = null;
+                $variable = $call->params[$position]->var;
+                if ($variable instanceof Variable) {
+                    $paramName = $variable->name;
+                }
+
+                $newPosition = -1;
+                if (is_string($paramName)) {
+                    $newPosition = $this->argsAnalyzer->resolveArgPosition($args, $paramName, $newPosition);
+                }
+
+                if ($newPosition === -1) {
+                    return null;
+                }
+
+                $position = $newPosition;
+            }
+
+            if (! isset($args[$position])) {
                 continue;
             }
 
-            unset($node->args[$removeMethodCallParam->getParamPosition()]);
+            unset($node->args[$position]);
             $hasChanged = true;
         }
 


### PR DESCRIPTION
Modifies the `RemoveMethodCallParamRector` rule to properly handle named arguments