### PR TITLE
Add withImport() method to RectorConfigBuilder

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -47,6 +47,7 @@ use Webmozart\Assert\Assert;
 
 /**
  * @api
+ * @see \Rector\Tests\Configuration\RectorConfigBuilderTest
  */
 final class RectorConfigBuilder
 {
@@ -64,6 +65,11 @@ final class RectorConfigBuilder
      * @var string[]
      */
     private array $sets = [];
+
+    /**
+     * @var string[]
+     */
+    private array $imports = [];
 
     /**
      * @var array<mixed>
@@ -195,6 +201,10 @@ final class RectorConfigBuilder
 
     public function __invoke(RectorConfig $rectorConfig): void
     {
+        foreach ($this->imports as $import) {
+            $rectorConfig->import($import);
+        }
+
         if ($this->setGroups !== [] || $this->setProviders !== []) {
             $setProviderCollector = new SetProviderCollector(array_map(
                 $rectorConfig->make(...),
@@ -403,6 +413,16 @@ final class RectorConfigBuilder
     public function withPaths(array $paths): self
     {
         $this->paths = $paths;
+
+        return $this;
+    }
+
+    /**
+     * @param string ...$files file paths to import
+     */
+    public function withImport(string ...$files): self
+    {
+        $this->imports = array_merge($this->imports, $files);
 
         return $this;
     }

--- a/tests/Configuration/RectorConfigBuilderTest.php
+++ b/tests/Configuration/RectorConfigBuilderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Configuration;
+
+use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
+
+#[RunClassInSeparateProcess]
+final class RectorConfigBuilderTest extends AbstractLazyTestCase
+{
+    public function testWithImport(): void
+    {
+        $rectorConfig = self::getContainer();
+
+        $rectorConfig->configure()
+            ->withImport(__DIR__ . '/config/imported_config.php')($rectorConfig);
+
+        $this->assertTrue($rectorConfig->has(ReturnTypeFromReturnNewRector::class));
+    }
+
+    public function testWithMultipleImports(): void
+    {
+        $rectorConfig = self::getContainer();
+
+        $rectorConfig->configure()
+            ->withImport(
+                __DIR__ . '/config/imported_config.php',
+                __DIR__ . '/config/second_imported_config.php'
+            )($rectorConfig);
+
+        $this->assertTrue($rectorConfig->has(ReturnTypeFromReturnNewRector::class));
+        $this->assertTrue($rectorConfig->has(RemoveUnusedPrivateMethodRector::class));
+    }
+
+    public function testWithNestedImport(): void
+    {
+        $rectorConfig = self::getContainer();
+
+        $rectorConfig->configure()
+            ->withImport(__DIR__ . '/config/nested_import_config.php')($rectorConfig);
+
+        $this->assertTrue($rectorConfig->has(ReturnTypeFromReturnNewRector::class));
+    }
+}

--- a/tests/Configuration/config/imported_config.php
+++ b/tests/Configuration/config/imported_config.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
+
+return RectorConfig::configure()
+    ->withRules([ReturnTypeFromReturnNewRector::class]);

--- a/tests/Configuration/config/nested_import_config.php
+++ b/tests/Configuration/config/nested_import_config.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withImport(__DIR__ . '/imported_config.php');

--- a/tests/Configuration/config/second_imported_config.php
+++ b/tests/Configuration/config/second_imported_config.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveUnusedPrivateMethodRector::class]);


### PR DESCRIPTION
The `RectorConfig` class has a function, `import()` that allow you to import another configuration file but this was never exposed in the `RectorConfigBuilder` class. This PR adds a `withImport()` function to the builder class that allows you to import other configuration files while using it