### PR TITLE
Update left over PHP 8.2 -> PHP 8.3 in readme and configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ git clone git@github.com:<your-name>/rector-src.git
 cd rector-src
 ```
 
-2. We use PHP 8.2 and composer
+2. We use PHP 8.3 and composer
 
 Install dependencies and verify your local environment:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-alpine
+FROM php:8.3-cli-alpine
 
 WORKDIR /etc/rector
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Head to [`rectorphp/rector`](http://github.com/rectorphp/rector) for documentati
 
 ## Building `rectorphp/rector`
 
-Code of this repository requires PHP 8.2. For `rector/rector` package the builder downgrades code to PHP 7.4+.
+Code of this repository requires PHP 8.3. For `rector/rector` package the builder downgrades code to PHP 7.4+.
 
 <br>
 

--- a/templates/rector-github-action-check.yaml
+++ b/templates/rector-github-action-check.yaml
@@ -19,7 +19,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.2
+                    php-version: 8.3
                     coverage: none
 
             -   uses: "ramsey/composer-install@v3"

--- a/templates/rector-gitlab-check.yaml
+++ b/templates/rector-gitlab-check.yaml
@@ -6,7 +6,7 @@ stages:
 setup:
     stage: setup
     # see https://github.com/thecodingmachine/docker-images-php
-    image: thecodingmachine/php:8.2-v4-slim-cli
+    image: thecodingmachine/php:8.3-v4-slim-cli
 
 rector:
     stage: rector


### PR DESCRIPTION
@TomasVotruba here fix left over php 8.2 to php 8.3 in readme and configs 

Ref https://github.com/rectorphp/rector-src/pull/7836#issuecomment-3766027775