### PR TITLE
Bump to PHPStan ^2.1.35

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.34"
+        "phpstan/phpstan": "^2.1.35"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "^2.1.34",
+        "phpstan/phpstan": "^2.1.35",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",


### PR DESCRIPTION
@calebdw @TomasVotruba this PR bump to PHPStan 2.1.35. 

It seems scope process node is changed internally on PHPStan side.

see comparison of **Before** vs **After** Bump to PHPStan 2.1.35

- 2.1.34 (working) : https://github.com/rectorphp/rector-downgrade-php/pull/359
- 2.1.35 (not working): https://github.com/rectorphp/rector-downgrade-php/pull/360

Ref issue reported on PHPStan side:

- https://github.com/phpstan/phpstan/issues/13992

I will check if we can tweak here, as this got error on this rector-src as well :)