### PR TITLE
Temporary require --dev phpstan/phpstan:2.1.34 on packages-tests CI uses to make main branch CI green

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -55,6 +55,8 @@ jobs:
                 run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
                 if: ${{ github.event_name == 'pull_request' }}
 
-            -   run: composer install --ansi
+            -   run: |
+                    composer install --ansi
+                    composer require --dev phpstan/phpstan:2.1.34
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/rector_laravel_rector_dev.yaml
+++ b/.github/workflows/rector_laravel_rector_dev.yaml
@@ -27,5 +27,6 @@ jobs:
 
             -   run: git clone https://github.com/driftingly/rector-laravel.git
             -   run: composer require rector/rector:dev-main --working-dir rector-laravel
-            -   run: cd rector-laravel && vendor/bin/phpunit
-
+            -   run: |
+                    cd rector-laravel && composer require --dev phpstan/phpstan:2.1.34
+                    vendor/bin/phpunit


### PR DESCRIPTION
@TomasVotruba here I temporary set require --dev phpstan/phpstan:2.1.34 so make all packages-tests green on this rector-src.