### PR TITLE
Bump to PHPStan ^2.1.36

### DIFF
--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -55,8 +55,6 @@ jobs:
                 run: composer require rector/rector-src dev-main#${{github.event.pull_request.head.sha}} --no-update
                 if: ${{ github.event_name == 'pull_request' }}
 
-            -   run: |
-                    composer install --ansi
-                    composer require --dev phpstan/phpstan:2.1.34
+            -   run: composer install --ansi
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/rector_laravel_rector_dev.yaml
+++ b/.github/workflows/rector_laravel_rector_dev.yaml
@@ -27,6 +27,4 @@ jobs:
 
             -   run: git clone https://github.com/driftingly/rector-laravel.git
             -   run: composer require rector/rector:dev-main --working-dir rector-laravel
-            -   run: |
-                    cd rector-laravel && composer require --dev phpstan/phpstan:2.1.34
-                    vendor/bin/phpunit
+            -   run: cd rector-laravel && vendor/bin/phpunit

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "2.1.34"
+        "phpstan/phpstan": "^2.1.36"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "2.1.34",
+        "phpstan/phpstan": "^2.1.36",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/constructor_private.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/constructor_private.php.inc
@@ -6,7 +6,7 @@ class ConstructorPrivate
 {
     public function __construct()
     {
-        $this->value = 'classStringCaseInSensitive';
+        $this->value = 'constructorPrivate';
     }
 }
 
@@ -21,7 +21,7 @@ class ConstructorPrivate
     private string $value;
     public function __construct()
     {
-        $this->value = 'classStringCaseInSensitive';
+        $this->value = 'constructorPrivate';
     }
 }
 

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Config;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Symfony\Set\TwigSetList;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 
+/**
+ * On macOS, this file order config cause this container read other tests' config.
+ * so, this #[RunTestsInSeparateProcesses] is needed.
+ */
+#[RunTestsInSeparateProcesses]
 final class RectorConfigTest extends AbstractLazyTestCase
 {
     public function test(): void


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/7847

@calebdw @TomasVotruba this PR bump to PHPStan ^2.1.36 to use new PHPStan release.