### PR TITLE
fix: temporally disable SafeDeclareStrictTypesRector

### DIFF
--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -184,7 +184,7 @@ final class CodeQualityLevel
         SortCallLikeNamedArgsRector::class,
         SortAttributeNamedArgsRector::class,
         RemoveReadonlyPropertyVisibilityOnReadonlyClassRector::class,
-        SafeDeclareStrictTypesRector::class,
+        // SafeDeclareStrictTypesRector::class,
     ];
 
     /**


### PR DESCRIPTION
I ran into some issues, so I'm going to temporarily remove from the default sets until I get this right

CC @samsonasik 