### PR TITLE
fix: SafeDeclareStrictTypesRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -68,6 +68,9 @@ parameters:
         # phpstan class constant value
         - identifier: phpstanApi.classConstant
 
+        # phpstan class construction
+        - identifier: phpstanApi.constructor
+
         # phpstan instanceof
         - identifier: phpstanApi.instanceofAssumption
 

--- a/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_mixed_passed_to_round.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/StmtsAwareInterface/SafeDeclareStrictTypesRector/Fixture/skip_mixed_passed_to_round.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector\Fixture;
+
+function skip_mixed_passed_to_round(array $data): float
+{
+    return round($data['value'], 2);
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/StrictTypeSafetyChecker.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/StrictTypeSafetyChecker.php
@@ -18,6 +18,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\StrictMixedType;
 use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
@@ -197,6 +198,11 @@ final readonly class StrictTypeSafetyChecker
 
     private function isTypeSafeForStrictMode(Type $declaredType, Type $valueType): bool
     {
+        // need to be strict with mixed to avoid false positives
+        if ($valueType instanceof MixedType) {
+            $valueType = new StrictMixedType();
+        }
+
         return $declaredType->accepts($valueType, strictTypes: true)
             ->yes();
     }


### PR DESCRIPTION
Just replicating the failure for now---this seems to be a phpstan bug, the following is returning true when it should be returning false:

```php
// given code that looks like this:

function skip_mixed_passed_to_round(array $data): float
{
    return round($data['value'], 2);
}

// $declaredType is a int|float---comes from round(int|float $num)
// $valueType is unknown `$data['value'] (implicit mixed) being passed to round()

private function isTypeSafeForStrictMode(Type $declaredType, Type $valueType): bool
{
    return $declaredType->accepts($valueType, strictTypes: true)
        ->yes();
}
```

This should be `Maybe` because the `$valueType` might not be a `int|float`, but instead phpstan is saying this is `Yes`