### PR TITLE
Fix ArrayItem scope filling on Foreach_ value

### DIFF
--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -84,7 +84,6 @@ use Rector\Php52\Rector\Property\VarToPublicPropertyRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
-use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 
 /**
  * Key 0 = level 0

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -517,6 +517,8 @@ final readonly class PHPStanNodeScopeResolver
 
     private function processArrayItem(ArrayItem $arrayItem, MutatingScope $mutatingScope): void
     {
+        $arrayItem->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+
         if ($arrayItem->key instanceof Expr) {
             $arrayItem->key->setAttribute(AttributeKey::SCOPE, $mutatingScope);
         }


### PR DESCRIPTION
Use of failing fixture on **rector-phpunit**:

- https://github.com/rectorphp/rector-phpunit/pull/616

**Before**

```
There was 1 error:

1) Rector\PHPUnit\Tests\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector\DirectInstanceOverMockArgRectorTest::test with data set #3 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Exception\ShouldNotHappenException: Scope not available on "PhpParser\Node\ArrayItem" node. Fix scope refresh on changed nodes first

/Users/samsonasik/www/rector-phpunit/vendor/rector/rector-src/src/PHPStan/ScopeFetcher.php:26
/Users/samsonasik/www/rector-phpunit/rules/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector.php:91
```

**After**

```
➜  rector-phpunit git:(add-failing-fixture-crash) vendor/bin/phpunit rules-tests/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector            
PHPUnit 11.5.46 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /Users/samsonasik/www/rector-phpunit/phpunit.xml

.....                                                               5 / 5 (100%)

Time: 00:00.619, Memory: 76.50 MB

OK (5 tests, 6 assertions)
```