### PR TITLE
Fix use of deprecated Node\Expr\ArrayItem over Node\ArrayItem

### DIFF
--- a/rules/Php85/Rector/Class_/SleepToSerializeRector.php
+++ b/rules/Php85/Rector/Class_/SleepToSerializeRector.php
@@ -6,7 +6,7 @@ namespace Rector\Php85\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;


### PR DESCRIPTION
Ref https://github.com/nikic/PHP-Parser/blob/8c360e27327c8bd29e1c57721574709d0d706118/lib/PhpParser/Node/Expr/ArrayItem.php#L11-L13