### PR TITLE
[Php80] Handle crash on empty name attribute field value on AnnotationToAttributeRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/use_empty_attribute.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/use_empty_attribute.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
 
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\EmptyAttribute;
 
-#[\Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\EmptyAttribute(foo: '')]
+#[EmptyAttribute(foo: '')]
 class UseEmptyAttribute
 {
 }

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/use_empty_attribute.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/use_empty_attribute.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\EmptyAttribute;
+
+/**
+ * @EmptyAttribute(foo="")
+ */
+class UseEmptyAttribute
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\EmptyAttribute;
+
+#[\Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\EmptyAttribute(foo: '')]
+class UseEmptyAttribute
+{
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Attribute/EmptyAttribute.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Source/Attribute/EmptyAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute;
+
+use Attribute;
+
+#[Attribute]
+final class EmptyAttribute
+{
+}

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -9,6 +9,7 @@ use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Annotation\OpenApi\Annotation\NestedPastAnnotation;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Annotation\OpenApi\PastAnnotation;
+use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\EmptyAttribute;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\NewName1;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\NewName2;
 use Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Source\Attribute\OpenApi\Attribute\NestedFutureAttribute;
@@ -74,5 +75,7 @@ return static function (RectorConfig $rectorConfig): void {
 
         // for testing allow numeric string keep as string
         new AnnotationToAttribute('OpenApi\\Annotations\\Property', 'OpenApi\\Attributes\\Property'),
+
+        new AnnotationToAttribute(EmptyAttribute::class, null, ['foo'])
     ]);
 };

--- a/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
+++ b/src/PhpAttribute/NodeFactory/PhpAttributeGroupFactory.php
@@ -154,6 +154,10 @@ final readonly class PhpAttributeGroupFactory
                 continue;
             }
 
+            if ($arrayItem->value->value === '') {
+                continue;
+            }
+
             $arrayItem->value = new ClassConstFetch(new FullyQualified($arrayItem->value->value), 'class');
         }
     }


### PR DESCRIPTION
Ref https://getrector.com/demo/99de8535-6b82-4dcd-a2f9-719ad029fff3
Fixes https://github.com/rectorphp/rector/issues/9622