### PR TITLE
Fix fixture source warning on AddOverrideAttributeToOverriddenMethodsRector (missing TestCase suffix)

### DIFF
--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_setup_phpunit_as_clutter.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_setup_phpunit_as_clutter.php.inc
@@ -2,9 +2,9 @@
 
 namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
 
-use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\SomeAbstractTest;
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\SomeAbstractTestCase;
 
-final class SkipSetupPHPUnitAsClutter extends SomeAbstractTest
+final class SkipSetupPHPUnitAsClutter extends SomeAbstractTestCase
 {
     protected function setUp(): void
     {

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/SomeAbstractTestCase.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/SomeAbstractTestCase.php
@@ -4,7 +4,7 @@ namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverridden
 
 use PHPUnit\Framework\TestCase;
 
-abstract class SomeAbstractTest extends TestCase
+abstract class SomeAbstractTestCase extends TestCase
 {
     protected function setUp(): void
     {


### PR DESCRIPTION
**Before**

```
➜  rector-src git:(main) vendor/bin/phpunit rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector                                                      
PHPUnit 12.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /Users/samsonasik/www/rector-src/phpunit.xml

.......................                                           23 / 23 (100%)

Time: 00:02.700, Memory: 178.50 MB

There was 1 PHPUnit test runner warning:

1) Class Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\SomeAbstractTest declared in /Users/samsonasik/www/rector-src/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/SomeAbstractTest.php is abstract

OK, but there were issues!
Tests: 23, Assertions: 26, PHPUnit Warnings: 1.

```

**After**

```
➜  rector-src git:(main) ✗ vendor/bin/phpunit rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector
PHPUnit 12.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /Users/samsonasik/www/rector-src/phpunit.xml

.......................                                           23 / 23 (100%)

Time: 00:02.648, Memory: 178.50 MB

OK (23 tests, 26 assertions)
```