### PR TITLE
Fix deep ArrayItem scope filling on Foreach_ value

### DIFF
--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -524,6 +524,10 @@ final readonly class PHPStanNodeScopeResolver
         }
 
         $arrayItem->value->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+
+        if ($arrayItem->value instanceof List_) {
+            $this->processArray($arrayItem->value, $mutatingScope);
+        }
     }
 
     /**


### PR DESCRIPTION
Use of failing fixture on **rector-phpunit**:

- https://github.com/rectorphp/rector-phpunit/pull/632

**Before**

```
There was 1 error:

1) Rector\PHPUnit\Tests\CodeQuality\Rector\CallLike\DirectInstanceOverMockArgRector\DirectInstanceOverMockArgRectorTest::test with data set #4 ('/Users/samsonasik/www/rector-...hp.inc')
Rector\Exception\ShouldNotHappenException: Scope not available on "PhpParser\Node\ArrayItem" node. Fix scope refresh on changed nodes first

/Users/samsonasik/www/rector-phpunit/vendor/rector/rector-src/src/PHPStan/ScopeFetcher.php:26
/Users/samsonasik/www/rector-phpunit/rules/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector.php:91
```

**After**

```
➜  rector-phpunit git:(add-failing) vendor/bin/phpunit rules-tests/CodeQuality/Rector/CallLike/DirectInstanceOverMockArgRector
PHPUnit 11.5.46 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /Users/samsonasik/www/rector-phpunit/phpunit.xml

......                                                              6 / 6 (100%)

Time: 00:00.745, Memory: 80.50 MB

OK (6 tests, 7 assertions)
```