### PR TITLE
Show line numbers in diff output

### DIFF
--- a/e2e/applied-auto-import/expected-output.diff
+++ b/e2e/applied-auto-import/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/RenameDocblock.php:2
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 2 @@
 
  namespace App;
 

--- a/e2e/applied-polyfill-php80/expected-output.diff
+++ b/e2e/applied-polyfill-php80/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/SomeStartWith.php:4
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 4 @@
  {
      public function run($a)
      {

--- a/e2e/applied-rule-change-docblock/expected-output.diff
+++ b/e2e/applied-rule-change-docblock/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/RenameDocblock.php:1
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 1 @@
  <?php
 
  /**
@@ -22,7 +22,7 @@ Applied rules:
 2) src/UselessVarTag.php:2
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 2 @@
 
  final class UselessVarTag
  {

--- a/e2e/applied-rule-removed-node-with-cache/expected-output.diff
+++ b/e2e/applied-rule-removed-node-with-cache/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/AlwaysTrue.php:4
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 4 @@
  {
      public function run()
      {
@@ -23,7 +23,7 @@ Applied rules:
 2) src/DeadConstructor.php:2
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 2 @@
 
  final class DeadConstructor
  {

--- a/e2e/applied-rule-removed-node/expected-output.diff
+++ b/e2e/applied-rule-removed-node/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/AlwaysTrue.php:4
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 4 @@
  {
      public function run()
      {
@@ -23,7 +23,7 @@ Applied rules:
 2) src/DeadConstructor.php:2
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 2 @@
 
  final class DeadConstructor
  {

--- a/e2e/applied-rule-return-array-nodes/expected-output.diff
+++ b/e2e/applied-rule-return-array-nodes/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/MultiRules.php:6
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 6 @@
      {
          if (true === false) {
              return -1;
@@ -28,7 +28,7 @@ Applied rules:
 2) src/RemoveAlwaysElse.php:6
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 6 @@
      {
          if ($value) {
              throw new \InvalidStateException;

--- a/e2e/different-path-over-skip-config/expected-output.diff
+++ b/e2e/different-path-over-skip-config/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/models/DeadConstructor.php:4
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 4 @@
 
  final class DeadConstructor
  {

--- a/e2e/no-parallel-reflection-resolver/expected-output.diff
+++ b/e2e/no-parallel-reflection-resolver/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/NamespacedSomeClassFound.php:6
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 6 @@
 
  final class NamespacedSomeClassFound
  {
@@ -19,7 +19,7 @@ Applied rules:
 2) src/SomeClassNotFound.php:4
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 4 @@
 
  final class SomeClassNotFound
  {

--- a/e2e/only-option-quote-double-equalnone/expected-output.diff
+++ b/e2e/only-option-quote-double-equalnone/expected-output.diff
@@ -4,7 +4,7 @@
 1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 10 @@
              echo 'a statement';
          }
      }

--- a/e2e/only-option-quote-single-bsdouble/expected-output.diff
+++ b/e2e/only-option-quote-single-bsdouble/expected-output.diff
@@ -4,7 +4,7 @@
 1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 10 @@
              echo 'a statement';
          }
      }

--- a/e2e/only-option-quote-single-equalnone/expected-output.diff
+++ b/e2e/only-option-quote-single-equalnone/expected-output.diff
@@ -4,7 +4,7 @@
 1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 10 @@
              echo 'a statement';
          }
      }

--- a/e2e/only-option-quote-single/expected-output.diff
+++ b/e2e/only-option-quote-single/expected-output.diff
@@ -4,7 +4,7 @@
 1) ../only-option/src/MultiRules.php:10
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 10 @@
              echo 'a statement';
          }
      }

--- a/e2e/only-option/expected-output.diff
+++ b/e2e/only-option/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/MultiRules.php:10
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 10 @@
              echo 'a statement';
          }
      }

--- a/e2e/parallel-custom-config/expected-output.diff
+++ b/e2e/parallel-custom-config/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/SomeClass.php:7
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 7 @@
  class SomeClass
  {
      public function __construct(

--- a/e2e/parallel-reflection-resolver/expected-output.diff
+++ b/e2e/parallel-reflection-resolver/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/NamespacedSomeClassFound.php:6
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 6 @@
 
  final class NamespacedSomeClassFound
  {
@@ -19,7 +19,7 @@ Applied rules:
 2) src/SomeClassNotFound.php:4
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 4 @@
 
  final class SomeClassNotFound
  {

--- a/e2e/print-new-node/expected-output.diff
+++ b/e2e/print-new-node/expected-output.diff
@@ -4,7 +4,7 @@
 1) src/ExtendingTestClass.php:1
 
     ---------- begin diff ----------
-@@ @@
+@@ Line 1 @@
  <?php
 
  class ExtendingTestClass extends TestClass {

--- a/src/Console/Formatter/ColorConsoleDiffFormatter.php
+++ b/src/Console/Formatter/ColorConsoleDiffFormatter.php
@@ -34,7 +34,7 @@ final readonly class ColorConsoleDiffFormatter
     /**
      * @see https://regex101.com/r/8MXnfa/2
      */
-    private const string AT_DIFF_LINE_REGEX = '#^\<fg=cyan\>@@ \-\d+,\d+ \+\d+,\d+ @@\<\/fg=cyan\>$#';
+    private const string AT_DIFF_LINE_REGEX = '#^\<fg=cyan\>@@ \-(\d+),\d+ \+\d+,\d+ @@\<\/fg=cyan\>$#';
 
     private string $template;
 
@@ -89,11 +89,11 @@ final readonly class ColorConsoleDiffFormatter
     }
 
     /**
-     * Remove number diff, eg; @@ -67,6 +67,8 @@ to become @@ @@
+     * Simplify diff line info, eg; @@ -67,6 +67,8 @@ to become @@ Line 67 @@
      */
     private function normalizeLineAtDiff(string $string): string
     {
-        return Strings::replace($string, self::AT_DIFF_LINE_REGEX, '<fg=cyan>@@ @@</fg=cyan>');
+        return Strings::replace($string, self::AT_DIFF_LINE_REGEX, '<fg=cyan>@@ Line $1 @@</fg=cyan>');
     }
 
     private function makePlusLinesGreen(string $string): string


### PR DESCRIPTION
Changes the diff header from `@@ @@` to `@@ Line X @@` where X is the starting line number of the change. This makes it easier to locate where changes occur when there are multiple diffs in a file.

Updates all end-2-end tests with this new output