### PR TITLE
Fix StaticCallOnNonStaticToInstanceCallRector for same-class calls

### DIFF
--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/same_class_non_static.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/same_class_non_static.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class SameClassNonStatic
+{
+    public function run()
+    {
+        return SameClassNonStatic::doWork();
+    }
+
+    public function doWork()
+    {
+        return 'work done';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class SameClassNonStatic
+{
+    public function run()
+    {
+        return $this->doWork();
+    }
+
+    public function doWork()
+    {
+        return 'work done';
+    }
+}
+
+?>


### PR DESCRIPTION
The StaticCallOnNonStaticToInstanceCallRector rule was skipping the case where the static call was to a method that was implemented in the same class or a superclass. But it should actually only skip if it is a superclass. For the same class, it makes more sense to convert the call to a method call to the current instance.

Fixes https://github.com/rectorphp/rector/issues/9613

