### PR TITLE
feat: add ComposerPackageConstraintInterface

### DIFF
--- a/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
+++ b/src/PhpParser/NodeTraverser/RectorNodeTraverser.php
@@ -15,6 +15,7 @@ use Rector\Contract\Rector\RectorInterface;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\PhpParser\Node\FileNode;
+use Rector\VersionBonding\ComposerPackageConstraintFilter;
 use Rector\VersionBonding\PhpVersionedFilter;
 use Webmozart\Assert\Assert;
 
@@ -51,6 +52,7 @@ final class RectorNodeTraverser implements NodeTraverserInterface
     public function __construct(
         private array $rectors,
         private readonly PhpVersionedFilter $phpVersionedFilter,
+        private readonly ComposerPackageConstraintFilter $composerPackageConstraintFilter,
         private readonly ConfigurationRuleFilter $configurationRuleFilter,
     ) {
     }
@@ -311,8 +313,11 @@ final class RectorNodeTraverser implements NodeTraverserInterface
             return;
         }
 
-        // filer out by version
+        // filter out by PHP version
         $this->visitors = $this->phpVersionedFilter->filter($this->rectors);
+
+        // filter out by composer package constraint
+        $this->visitors = $this->composerPackageConstraintFilter->filter($this->visitors);
 
         // filter by configuration
         $this->visitors = $this->configurationRuleFilter->filter($this->visitors);

--- a/src/VersionBonding/ComposerPackageConstraintFilter.php
+++ b/src/VersionBonding/ComposerPackageConstraintFilter.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\VersionBonding;
+
+use Composer\Semver\Semver;
+use Rector\Composer\InstalledPackageResolver;
+use Rector\Contract\Rector\RectorInterface;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+
+final readonly class ComposerPackageConstraintFilter
+{
+    public function __construct(
+        private InstalledPackageResolver $installedPackageResolver,
+    ) {
+    }
+
+    /**
+     * @param list<RectorInterface> $rectors
+     * @return list<RectorInterface>
+     */
+    public function filter(array $rectors): array
+    {
+        $activeRectors = [];
+        foreach ($rectors as $rector) {
+            if (! $rector instanceof ComposerPackageConstraintInterface) {
+                $activeRectors[] = $rector;
+                continue;
+            }
+
+            if ($this->satisfiesComposerPackageConstraint($rector)) {
+                $activeRectors[] = $rector;
+            }
+        }
+
+        return $activeRectors;
+    }
+
+    private function satisfiesComposerPackageConstraint(ComposerPackageConstraintInterface $rector): bool
+    {
+        $composerPackageConstraint = $rector->provideComposerPackageConstraint();
+        $packageVersion = $this->installedPackageResolver->resolvePackageVersion(
+            $composerPackageConstraint->getPackageName(),
+        );
+
+        if ($packageVersion === null) {
+            return false;
+        }
+
+        return Semver::satisfies($packageVersion, $composerPackageConstraint->getConstraint());
+    }
+}

--- a/src/VersionBonding/Contract/ComposerPackageConstraintInterface.php
+++ b/src/VersionBonding/Contract/ComposerPackageConstraintInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\VersionBonding\Contract;
+
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+
+/**
+ * Can be implemented by @see \Rector\Contract\Rector\RectorInterface
+ *
+ * Rules that do not meet this composer package constraint will be skipped.
+ *
+ * @api used by extensions
+ */
+interface ComposerPackageConstraintInterface
+{
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint;
+}

--- a/src/VersionBonding/ValueObject/ComposerPackageConstraint.php
+++ b/src/VersionBonding/ValueObject/ComposerPackageConstraint.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\VersionBonding\ValueObject;
+
+/**
+ * @api used by extensions
+ */
+final readonly class ComposerPackageConstraint
+{
+    public function __construct(
+        private string $packageName,
+        private string $constraint,
+    ) {
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function getConstraint(): string
+    {
+        return $this->constraint;
+    }
+}

--- a/tests/VersionBonding/ComposerPackageConstraintFilterTest.php
+++ b/tests/VersionBonding/ComposerPackageConstraintFilterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Composer\InstalledPackageResolver;
+use Rector\Tests\VersionBonding\Fixture\ComposerPackageConstraintRector;
+use Rector\Tests\VersionBonding\Fixture\NoInterfaceRector;
+use Rector\VersionBonding\ComposerPackageConstraintFilter;
+
+final class ComposerPackageConstraintFilterTest extends TestCase
+{
+    private ComposerPackageConstraintFilter $composerPackageConstraintFilter;
+
+    protected function setUp(): void
+    {
+        $installedPackageResolver = new InstalledPackageResolver(getcwd());
+
+        $this->composerPackageConstraintFilter = new ComposerPackageConstraintFilter($installedPackageResolver);
+    }
+
+    public function testRectorWithoutInterfaceIsIncluded(): void
+    {
+        $rector = new NoInterfaceRector();
+        $filtered = $this->composerPackageConstraintFilter->filter([$rector]);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($rector, $filtered[0]);
+    }
+
+    public function testRectorWithSatisfiedConstraintIsIncluded(): void
+    {
+        $rector = new ComposerPackageConstraintRector('nikic/php-parser', '>=4.0.0');
+        $filtered = $this->composerPackageConstraintFilter->filter([$rector]);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($rector, $filtered[0]);
+    }
+
+    public function testRectorWithUnsatisfiedConstraintIsExcluded(): void
+    {
+        $rector = new ComposerPackageConstraintRector('nikic/php-parser', '>=999.0.0');
+        $filtered = $this->composerPackageConstraintFilter->filter([$rector]);
+
+        $this->assertCount(0, $filtered);
+    }
+
+    public function testRectorWithMissingPackageIsExcluded(): void
+    {
+        $rector = new ComposerPackageConstraintRector('non-existent/package', '>=1.0.0');
+        $filtered = $this->composerPackageConstraintFilter->filter([$rector]);
+
+        $this->assertCount(0, $filtered);
+    }
+
+    public function testRectorWithCaretConstraint(): void
+    {
+        $rector = new ComposerPackageConstraintRector('nikic/php-parser', '^5.0');
+        $filtered = $this->composerPackageConstraintFilter->filter([$rector]);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($rector, $filtered[0]);
+    }
+
+    public function testRectorWithLessThanConstraintExcludesNewerVersions(): void
+    {
+        $rector = new ComposerPackageConstraintRector('nikic/php-parser', '<1.0.0');
+        $filtered = $this->composerPackageConstraintFilter->filter([$rector]);
+
+        $this->assertCount(0, $filtered);
+    }
+}

--- a/tests/VersionBonding/Fixture/ComposerPackageConstraintRector.php
+++ b/tests/VersionBonding/Fixture/ComposerPackageConstraintRector.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ComposerPackageConstraintRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    public function __construct(
+        private readonly string $packageName,
+        private readonly string $constraint,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test rector with composer package constraint', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint($this->packageName, $this->constraint);
+    }
+}

--- a/tests/VersionBonding/Fixture/NoInterfaceRector.php
+++ b/tests/VersionBonding/Fixture/NoInterfaceRector.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class NoInterfaceRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test rector without interface', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+}

--- a/tests/VersionBonding/PhpVersionedFilterTest.php
+++ b/tests/VersionBonding/PhpVersionedFilterTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Php\PhpVersionProvider;
+use Rector\Php\PolyfillPackagesProvider;
+use Rector\Tests\VersionBonding\Fixture\NoInterfaceRector;
+use Rector\VersionBonding\PhpVersionedFilter;
+
+final class PhpVersionedFilterTest extends TestCase
+{
+    private PhpVersionedFilter $phpVersionedFilter;
+
+    protected function setUp(): void
+    {
+        $phpVersionProvider = new PhpVersionProvider();
+        $polyfillPackagesProvider = new PolyfillPackagesProvider();
+
+        $this->phpVersionedFilter = new PhpVersionedFilter($phpVersionProvider, $polyfillPackagesProvider);
+    }
+
+    public function testRectorWithoutInterfaceIsIncluded(): void
+    {
+        $rector = new NoInterfaceRector();
+        $filtered = $this->phpVersionedFilter->filter([$rector]);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($rector, $filtered[0]);
+    }
+}


### PR DESCRIPTION
Hello!

This PR introduces a new `ComposerPackageConstraintInterface` that allows individual Rector rules to specify a composer package constraint. Rules implementing this interface will be automatically skipped if the required package is not installed or does not satisfy the specified constraint.

### Motivation
This is analogous to `MinPhpVersionInterface` (which skips rules based on PHP version) but for composer packages. This is particularly useful for framework-specific rules (e.g., Laravel, Symfony) where certain rules only make sense for specific package versions.

### Comparison with `ComposerTriggeredSet`
Rector already has `ComposerTriggeredSet` for composer-based filtering, but it serves a different purpose:

| | `ComposerTriggeredSet` | `ComposerPackageConstraintInterface` |
|---|---|---|
| Operates on | Sets (collections of rules) | Individual rules |
| Purpose | Auto-load upgrade sets based on installed version | Skip rules if package constraint not satisfied |
| Version matching | Caret (`^`) - targets specific major version | Any semver constraint (`>=`, `<`, `^`, `~`, ranges, etc.) |
| Use case | "Load Laravel 10 upgrade set if laravel/framework ^10 is installed" | "Skip this rule if laravel/framework doesn't match constraint" |
| Cumulative | No: each set targets a specific version range | Depends on constraint used |


`ComposerTriggeredSet` is designed for **upgrade paths** where you want different sets for different version jumps (9→10, 10→11, etc.). `ComposerPackageConstraintInterface` is for rules that should only run when a package satisfies a specific constraint (for example, apply to a version and all subsequent version).

### Usage
```php
<?php
use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;

final class SomeLaravelRector extends AbstractRector implements ComposerPackageConstraintInterface
{
    public function provideComposerPackageConstraint(): ComposerPackageConstraint
    {
        // Min version
        return new ComposerPackageConstraint('laravel/framework', '>=10.0.0');
        
        // Or max version
        return new ComposerPackageConstraint('laravel/framework', '<10.0.0');
        
        // Or specific major
        return new ComposerPackageConstraint('laravel/framework', '^9.0');
        
        // Or range
        return new ComposerPackageConstraint('laravel/framework', '>=9.0 <11.0');
    }
}
```

Thanks!