### PR TITLE
perf: use hash map for installed packages

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -17,7 +17,7 @@ use Webmozart\Assert\Assert;
 final class InstalledPackageResolver
 {
     /**
-     * @var null|InstalledPackage[]
+     * @var null|array<string, InstalledPackage>
      */
     private ?array $resolvedInstalledPackages = null;
 
@@ -33,7 +33,7 @@ final class InstalledPackageResolver
     }
 
     /**
-     * @return InstalledPackage[]
+     * @return array<string, InstalledPackage>
      */
     public function resolve(): array
     {
@@ -61,28 +61,20 @@ final class InstalledPackageResolver
 
     public function resolvePackageVersion(string $packageName): ?string
     {
-        $installedPackages = $this->resolve();
-        foreach ($installedPackages as $installedPackage) {
-            if ($installedPackage->getName() !== $packageName) {
-                continue;
-            }
-
-            return $installedPackage->getVersion();
-        }
-
-        return null;
+        return ($this->resolve()[$packageName] ?? null)?->getVersion();
     }
 
     /**
      * @param mixed[] $packages
-     * @return InstalledPackage[]
+     * @return array<string, InstalledPackage>
      */
     private function createInstalledPackages(array $packages): array
     {
         $installedPackages = [];
 
         foreach ($packages as $package) {
-            $installedPackages[] = new InstalledPackage($package['name'], $package['version_normalized']);
+            $name = $package['name'];
+            $installedPackages[$name] = new InstalledPackage($name, $package['version_normalized']);
         }
 
         return $installedPackages;

--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -61,7 +61,13 @@ final class InstalledPackageResolver
 
     public function resolvePackageVersion(string $packageName): ?string
     {
-        return ($this->resolve()[$packageName] ?? null)?->getVersion();
+        $package = $this->resolve()[$packageName] ?? null;
+
+        if (! $package instanceof InstalledPackage) {
+            return null;
+        }
+
+        return $package->getVersion();
     }
 
     /**

--- a/src/Composer/ValueObject/InstalledPackage.php
+++ b/src/Composer/ValueObject/InstalledPackage.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Composer\ValueObject;
 
+/**
+ * @api
+ */
 final readonly class InstalledPackage
 {
     public function __construct(

--- a/src/Set/ValueObject/ComposerTriggeredSet.php
+++ b/src/Set/ValueObject/ComposerTriggeredSet.php
@@ -40,19 +40,17 @@ final readonly class ComposerTriggeredSet implements SetInterface
     }
 
     /**
-     * @param InstalledPackage[] $installedPackages
+     * @param array<string, InstalledPackage> $installedPackages
      */
     public function matchInstalledPackages(array $installedPackages): bool
     {
-        foreach ($installedPackages as $installedPackage) {
-            if ($installedPackage->getName() !== $this->packageName) {
-                continue;
-            }
+        $installedVersion = ($installedPackages[$this->packageName] ?? null)?->getVersion();
 
-            return Semver::satisfies($installedPackage->getVersion(), '^' . $this->version);
+        if ($installedVersion === null) {
+            return false;
         }
 
-        return false;
+        return Semver::satisfies($installedVersion, '^' . $this->version);
     }
 
     public function getName(): string

--- a/src/Set/ValueObject/ComposerTriggeredSet.php
+++ b/src/Set/ValueObject/ComposerTriggeredSet.php
@@ -44,13 +44,13 @@ final readonly class ComposerTriggeredSet implements SetInterface
      */
     public function matchInstalledPackages(array $installedPackages): bool
     {
-        $installedVersion = ($installedPackages[$this->packageName] ?? null)?->getVersion();
+        $package = $installedPackages[$this->packageName] ?? null;
 
-        if ($installedVersion === null) {
+        if (! $package instanceof InstalledPackage) {
             return false;
         }
 
-        return Semver::satisfies($installedVersion, '^' . $this->version);
+        return Semver::satisfies($package->getVersion(), '^' . $this->version);
     }
 
     public function getName(): string


### PR DESCRIPTION
Hello!

We can turn a package lookup into O(1) by using a hash map instead of an O(n) with a linear array.

Thanks!