### PR TITLE
Add AddOverrideAttributeToOverriddenPropertiesRector for PHP 8.5

### DIFF
--- a/config/set/php85.php
+++ b/config/set/php85.php
@@ -16,6 +16,7 @@ use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
 use Rector\Php85\Rector\FuncCall\ChrArgModuloRector;
 use Rector\Php85\Rector\FuncCall\OrdSingleByteRector;
 use Rector\Php85\Rector\FuncCall\RemoveFinfoBufferContextArgRector;
+use Rector\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector;
 use Rector\Php85\Rector\ShellExec\ShellExecFunctionCallOverBackticksRector;
 use Rector\Php85\Rector\Switch_\ColonAfterSwitchCaseRector;
 use Rector\Removing\Rector\FuncCall\RemoveFuncCallArgRector;
@@ -43,6 +44,7 @@ return static function (RectorConfig $rectorConfig): void {
         OrdSingleByteRector::class,
         WakeupToUnserializeRector::class,
         ShellExecFunctionCallOverBackticksRector::class,
+        AddOverrideAttributeToOverriddenPropertiesRector::class,
     ]);
 
     $rectorConfig->ruleWithConfiguration(

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/AddOverrideAttributeToOverriddenPropertiesRectorTest.php
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/AddOverrideAttributeToOverriddenPropertiesRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddOverrideAttributeToOverriddenPropertiesRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/fixture.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Fixture;
+
+use Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Source\ParentWithPublicProperty;
+
+final class ChildClass extends ParentWithPublicProperty
+{
+    public string $name;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Fixture;
+
+use Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Source\ParentWithPublicProperty;
+
+final class ChildClass extends ParentWithPublicProperty
+{
+    #[\Override]
+    public string $name;
+}
+
+?>

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_already_has_attribute.php.inc
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_already_has_attribute.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Fixture;
+
+use Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Source\ParentWithPublicProperty;
+
+final class ChildWithAttribute extends ParentWithPublicProperty
+{
+    #[\Override]
+    public string $name;
+}

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_no_parent.php.inc
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_no_parent.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Fixture;
+
+final class NoParent
+{
+    public string $name;
+}

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_parent_private_property.php.inc
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_parent_private_property.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Fixture;
+
+use Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Source\ParentWithPrivateProperty;
+
+final class ChildPublic extends ParentWithPrivateProperty
+{
+    public string $name;
+}

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_private_property.php.inc
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Fixture/skip_private_property.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Fixture;
+
+use Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Source\ParentWithPrivateProperty;
+
+final class ChildWithPrivate extends ParentWithPrivateProperty
+{
+    private string $name;
+}

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Source/ParentWithPrivateProperty.php
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Source/ParentWithPrivateProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Source;
+
+class ParentWithPrivateProperty
+{
+    private string $name;
+}

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Source/ParentWithPublicProperty.php
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/Source/ParentWithPublicProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\Source;
+
+class ParentWithPublicProperty
+{
+    public string $name;
+}

--- a/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/config/configured_rule.php
+++ b/rules-tests/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddOverrideAttributeToOverriddenPropertiesRector::class);
+};

--- a/rules/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector.php
+++ b/rules/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php85\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\NodeAnalyzer\ClassAnalyzer;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/override_properties
+ *
+ * @see \Rector\Tests\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector\AddOverrideAttributeToOverriddenPropertiesRectorTest
+ */
+final class AddOverrideAttributeToOverriddenPropertiesRector extends AbstractRector implements MinPhpVersionInterface
+{
+    private const string OVERRIDE_CLASS = 'Override';
+
+    private bool $hasChanged = false;
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassAnalyzer $classAnalyzer,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add override attribute to overridden properties',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class ParentClass
+{
+    public string $name;
+}
+
+final class ChildClass extends ParentClass
+{
+    public string $name;
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class ParentClass
+{
+    public string $name;
+}
+
+final class ChildClass extends ParentClass
+{
+    #[\Override]
+    public string $name;
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::OVERRIDE_ATTRIBUTE_ON_PROPERTIES;
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->classAnalyzer->isAnonymousClass($node)) {
+            return null;
+        }
+
+        $className = (string) $this->getName($node);
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        $parentClassReflections = $classReflection->getParents();
+
+        if ($parentClassReflections === []) {
+            return null;
+        }
+
+        $this->hasChanged = false;
+
+        foreach ($node->getProperties() as $property) {
+            $this->processProperty($property, $parentClassReflections);
+        }
+
+        if ($this->hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param ClassReflection[] $parentClassReflections
+     */
+    private function processProperty(Property $property, array $parentClassReflections): void
+    {
+        if ($this->shouldSkipProperty($property)) {
+            return;
+        }
+
+        foreach ($property->props as $propertyProperty) {
+            $propertyName = $this->getName($propertyProperty);
+            if ($propertyName === null) {
+                continue;
+            }
+
+            if ($this->isPropertyOverridden($propertyName, $parentClassReflections)) {
+                $property->attrGroups[] = new AttributeGroup([new Attribute(new FullyQualified(self::OVERRIDE_CLASS))]);
+                $this->hasChanged = true;
+                return;
+            }
+        }
+    }
+
+    private function shouldSkipProperty(Property $property): bool
+    {
+        if ($property->isPrivate()) {
+            return true;
+        }
+
+        return $this->phpAttributeAnalyzer->hasPhpAttribute($property, self::OVERRIDE_CLASS);
+    }
+
+    /**
+     * @param ClassReflection[] $parentClassReflections
+     */
+    private function isPropertyOverridden(string $propertyName, array $parentClassReflections): bool
+    {
+        foreach ($parentClassReflections as $parentClassReflection) {
+            if (! $parentClassReflection->hasNativeProperty($propertyName)) {
+                continue;
+            }
+
+            $parentProperty = $parentClassReflection->getNativeProperty($propertyName);
+            return ! $parentProperty->isPrivate();
+        }
+
+        return false;
+    }
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -495,4 +495,9 @@ final class PhpVersionFeature
      * @see https://wiki.php.net/rfc/pipe-operator-v3
      */
     public const int PIPE_OPERATOER = PhpVersion::PHP_85;
+
+    /**
+     * @see https://wiki.php.net/rfc/override_properties
+     */
+    public const int OVERRIDE_ATTRIBUTE_ON_PROPERTIES = PhpVersion::PHP_85;
 }


### PR DESCRIPTION
This rule adds the #[\Override] attribute to properties that override parent class properties. PHP 8.5 extends the Override attribute to support properties in addition to methods.

The rule:
- Adds #[\Override] to public/protected properties that override parent properties
- Skips private properties (cannot truly override)
- Skips properties where parent is private (not visible to child)
- Skips properties that already have the attribute

Fixes https://github.com/rectorphp/rector/issues/9579