### PR TITLE
[DeadCode] No need additional parentheses () on multiply to function call on RemoveDeadZeroAndOneOperationRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector/Fixture/multiply_function_call.php.inc
+++ b/rules-tests/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector/Fixture/multiply_function_call.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Plus\RemoveDeadZeroAndOneOperationRector\Fixture;
+
+class MultiplyFunctionCall
+{
+    public function run(string $a)
+    {
+        $b = 1 * strlen($a) * 4;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Plus\RemoveDeadZeroAndOneOperationRector\Fixture;
+
+class MultiplyFunctionCall
+{
+    public function run(string $a)
+    {
+        $b = strlen($a) * 4;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector/Fixture/with_parentheses.php.inc
+++ b/rules-tests/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector/Fixture/with_parentheses.php.inc
@@ -7,6 +7,7 @@ class WithParentheses
     public function run()
     {
         $a = 1 * (2 + 3) * 4;
+        $a = 1 * ( 2 + 3 ) * 4;
     }
 }
 
@@ -20,6 +21,7 @@ class WithParentheses
 {
     public function run()
     {
+        $a = (2 + 3) * 4;
         $a = (2 + 3) * 4;
     }
 }

--- a/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
+++ b/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
@@ -194,6 +194,7 @@ CODE_SAMPLE
                     return false;
                 }
 
+                // handle space before open parentheses
                 if (trim((string) $oldTokens[$startTokenPos]) === '') {
                     continue;
                 }

--- a/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
+++ b/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
@@ -201,7 +201,7 @@ CODE_SAMPLE
                 return (string) $oldTokens[$startTokenPos] === '(';
             }
 
-            return true;
+            return false;
         }
 
         return false;

--- a/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
+++ b/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
@@ -183,7 +183,28 @@ CODE_SAMPLE
         $oldTokens = $file->getOldTokens();
         $endTokenPost = $mul->getEndTokenPos();
 
-        return isset($oldTokens[$endTokenPost]) && (string) $oldTokens[$endTokenPost] === ')';
+        if (isset($oldTokens[$endTokenPost]) && (string) $oldTokens[$endTokenPost] === ')') {
+            $startTokenPos = $mul->right->getStartTokenPos();
+            $previousEndTokenPost = $mul->left->getEndTokenPos();
+
+            while ($startTokenPos > $previousEndTokenPost) {
+                --$startTokenPos;
+
+                if (! isset($oldTokens[$startTokenPos])) {
+                    return false;
+                }
+
+                if (trim((string) $oldTokens[$startTokenPos]) === '') {
+                    continue;
+                }
+
+                return (string) $oldTokens[$startTokenPos] === '(';
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     private function processBinaryMulAndDiv(Mul | Div $binaryOp): ?Expr

--- a/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
+++ b/rules/DeadCode/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
@@ -176,6 +176,10 @@ CODE_SAMPLE
 
     private function isMulParenthesized(File $file, Mul $mul): bool
     {
+        if (! $mul->right instanceof BinaryOp) {
+            return false;
+        }
+
         $oldTokens = $file->getOldTokens();
         $endTokenPost = $mul->getEndTokenPos();
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-src/pull/7882

this is ensure no need additional parentheses on multiply to function call.