### PR TITLE
Skip ClosureToArrowFunctionRector when closure has @var docblock

### DIFF
--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/skip_closure_with_var_docblock_generic.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/skip_closure_with_var_docblock_generic.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
+
+class SkipClosureWithVarDocblockGeneric
+{
+    public function run()
+    {
+        $fn = function (object $query) {
+            /** @var \ArrayObject<int, string> $query */
+            return $query->count();
+        };
+    }
+}
+
+?>

--- a/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/with_equal_var_doc_type.php.inc
+++ b/rules-tests/Php74/Rector/Closure/ClosureToArrowFunctionRector/Fixture/with_equal_var_doc_type.php.inc
@@ -14,18 +14,3 @@ class WithEqualVarDocType
 }
 
 ?>
------
-<?php
-
-namespace Rector\Tests\Php74\Rector\Closure\ClosureToArrowFunctionRector\Fixture;
-
-class WithEqualVarDocType
-{
-    public function run()
-    {
-        /** @var string $var */
-        fn(string $var) => $var;
-    }
-}
-
-?>


### PR DESCRIPTION
## Summary

Fixes rectorphp/rector#9637

Arrow functions do not support inline `@var` annotations for type narrowing. When a closure contains a `@var` docblock (e.g. `/** @var Builder<Team> $query */`), converting it to an arrow function breaks PHPStan type narrowing since there is no way to apply `@var` type annotations within arrow functions.

## Problem

Previously, the rule only skipped conversion when the `@var` type was **more specific** than the native type (via type comparison). However, this comparison could fail with generics (e.g. `Builder<Team>` vs `Builder`), causing unintended conversions.

Example from the issue:
```php
// Before (correct - PHPStan recognizes the type narrowing)
function (Builder $query) {
    /** @var Builder<Team> $query */
    return $query->inFullNameOrder();
}

// After (broken - @var has no effect in arrow functions)
/** @var Builder<Team> $query */
fn(Builder $query) => $query->inFullNameOrder()
```

## Solution

Skip `ClosureToArrowFunctionRector` whenever a `@var` tag is present on the return statement, regardless of type comparison. This is the safe approach because:

1. If the user placed a `@var` docblock, they did so intentionally
2. Arrow functions cannot support `@var` annotations for type narrowing
3. Type comparison with generics is unreliable

## Changes

- Simplified `shouldSkipMoreSpecificTypeWithVarDoc()` to skip on any `@var` presence
- Removed unused `NodeTypeResolver` and `MixedType` dependencies  
- Added test fixture for generic type `@var` docblock scenario
- Updated `with_equal_var_doc_type` fixture to be a skip test (equal types should also be preserved)