### PR TITLE
[Php80] Skip property hook with indirect set on ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_hook_with_indirect_set.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_hook_with_indirect_set.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class SkipHookWithIndirectSet
+{
+    public mixed $value {
+    	get {
+        	return $this->value;
+        }
+        set {
+            if ($this->optionUsedInValueSetter) {
+            	$this->value = "changed value";
+            }
+            $this->value = $value;
+        }
+    }
+
+    public function __construct(
+    	mixed $value,
+        bool $optionUsedInValueSetter = false,
+    ) {
+    	$this->value = $value;
+    }
+}

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -361,6 +361,16 @@ CODE_SAMPLE
 
     private function shouldSkipPropertyOrParam(Property $property, Param $param): bool
     {
+        foreach ($property->hooks as $hook) {
+            if (! is_array($hook->body)) {
+                continue;
+            }
+
+            if (count($hook->body) > 1) {
+                return true;
+            }
+        }
+
         return $property->type instanceof Node
             && $param->type instanceof Node
             && $property->hooks !== []


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9640