### PR TITLE
Register RectorConfig in container and set static instance to ensure singleton instance of RectorConfig

### DIFF
--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -405,6 +405,9 @@ final class LazyContainerFactory
     {
         $rectorConfig = new RectorConfig();
 
+        $rectorConfig::setInstance($rectorConfig);
+        $rectorConfig->instance(RectorConfig::class, $rectorConfig);
+
         $rectorConfig->import(__DIR__ . '/../../config/config.php');
 
         $rectorConfig->singleton(Application::class, static function (Container $container): Application {


### PR DESCRIPTION
> issue: RectorConfig is injected via constructor, it is a new RectorConfig empty container instance.

```php
use PhpParser\Node;
use Rector\Config\RectorConfig;
use Rector\Rector\AbstractRector;

final class FooRector extends AbstractRector
{
    private RectorConfig $rectorConfig;

    public function __construct(RectorConfig $rectorConfig)
    {
        // It is a new RectorConfig empty container instance.
        $this->rectorConfig = $rectorConfig;
    }

    public function getNodeTypes(): array
    {
        // ...
    }

    public function refactor(Node $node): ?Node
    {
        // ...
    }
}
```