### PR TITLE
feat: add support for converting is_null ternaries to null coalescing operator

### DIFF
--- a/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
+++ b/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
@@ -31,4 +31,3 @@ function ternaryWithIsNull()
 }
 
 ?>
-

--- a/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
+++ b/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+function ternaryWithIsNull()
+{
+    $x = is_null($value) ? 10 : $value;
+
+    $y = is_null($a) ? $b : $a;
+
+    $z = !is_null($value) ? $value : 10;
+
+    $w = !is_null($c) ? $c : $d;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+function ternaryWithIsNull()
+{
+    $x = $value ?? 10;
+
+    $y = $a ?? $b;
+
+    $z = $value ?? 10;
+
+    $w = $c ?? $d;
+}
+
+?>
+

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -113,7 +113,12 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             return null;
         }
 
-        $checkedExpr = $isNullFuncCall->args[0]->value;
+        $firstArg = $isNullFuncCall->args[0];
+        if (! $firstArg instanceof Node\Arg) {
+            return null;
+        }
+
+        $checkedExpr = $firstArg->value;
 
         if ($isNegated) {
             if (! $ternary->if instanceof Expr) {
@@ -128,6 +133,10 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
         }
 
         if (! $this->nodeComparator->areNodesEqual($ternary->else, $checkedExpr)) {
+            return null;
+        }
+
+        if (! $ternary->if instanceof Expr) {
             return null;
         }
 

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\Ternary;
 use Rector\PhpParser\Node\Value\ValueResolver;
@@ -35,6 +37,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             [
                 new CodeSample('$value === null ? 10 : $value;', '$value ?? 10;'),
                 new CodeSample('isset($value) ? $value : 10;', '$value ?? 10;'),
+                new CodeSample('is_null($value) ? 10 : $value;', '$value ?? 10;'),
             ]
         );
     }
@@ -54,6 +57,17 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
     {
         if ($node->cond instanceof Isset_) {
             return $this->processTernaryWithIsset($node, $node->cond);
+        }
+
+        if ($node->cond instanceof FuncCall && $this->isName($node->cond, 'is_null')) {
+            return $this->processTernaryWithIsNull($node, $node->cond, false);
+        }
+
+        if (
+            $node->cond instanceof BooleanNot && $node->cond->expr instanceof FuncCall
+            && $this->isName($node->cond->expr, 'is_null')
+        ) {
+            return $this->processTernaryWithIsNull($node, $node->cond->expr, true);
         }
 
         if ($node->cond instanceof Identical) {
@@ -91,6 +105,33 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::NULL_COALESCE;
+    }
+
+    private function processTernaryWithIsNull(Ternary $ternary, FuncCall $isNullFuncCall, bool $isNegated): ?Coalesce
+    {
+        if (count($isNullFuncCall->args) !== 1) {
+            return null;
+        }
+
+        $checkedExpr = $isNullFuncCall->args[0]->value;
+
+        if ($isNegated) {
+            if (! $ternary->if instanceof Expr) {
+                return null;
+            }
+
+            if (! $this->nodeComparator->areNodesEqual($ternary->if, $checkedExpr)) {
+                return null;
+            }
+
+            return new Coalesce($ternary->if, $ternary->else);
+        }
+
+        if (! $this->nodeComparator->areNodesEqual($ternary->else, $checkedExpr)) {
+            return null;
+        }
+
+        return new Coalesce($ternary->else, $ternary->if);
     }
 
     private function processTernaryWithIsset(Ternary $ternary, Isset_ $isset): ?Coalesce


### PR DESCRIPTION
This pull request extends the `TernaryToNullCoalescingRector` to support converting ternary expressions using `is_null` and its negation to the null coalescing operator (`??`).

Fixes: https://github.com/rectorphp/rector/issues/9648