### PR TITLE
Temporary Pin nette/utils to 4.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
-        "nette/utils": "^4.1",
+        "nette/utils": "4.1.2",
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -469,7 +469,7 @@ parameters:
                 - src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
 
         -
-            message: '#'#Parameter \#1 \$value of static method Webmozart\\Assert\\Assert\:\:isInstanceOfAny\(\) expects object, PhpParser\\Node\\ComplexType\|PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|null given#'
+            message: '#Parameter \#1 \$value of static method Webmozart\\Assert\\Assert\:\:isInstanceOfAny\(\) expects object, PhpParser\\Node\\ComplexType\|PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|null given#'
             path: rules/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector.php
 
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -467,3 +467,11 @@ parameters:
                 - rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
                 - rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector.php
                 - src/NodeTypeResolver/PHPStan/Type/TypeFactory.php
+
+        -
+            message: '#'#Parameter \#1 \$value of static method Webmozart\\Assert\\Assert\:\:isInstanceOfAny\(\) expects object, PhpParser\\Node\\ComplexType\|PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|null given#'
+            path: rules/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector.php
+
+        -
+            message: '#Unable to resolve the template type T in call to static method Webmozart\\Assert\\Assert\:\:isInstanceOfAny\(\)#'
+            path: rules/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector.php

--- a/rules/Carbon/NodeFactory/CarbonCallFactory.php
+++ b/rules/Carbon/NodeFactory/CarbonCallFactory.php
@@ -37,8 +37,8 @@ final class CarbonCallFactory
             $methodCall = $this->createModifyMethodCall(
                 $carbonCall,
                 new Int_((int) $match['count']),
-                $match['unit'],
-                $match['operator']
+                (string) $match['unit'],
+                (string) $match['operator']
             );
             if ($methodCall instanceof MethodCall) {
                 $carbonCall = $methodCall;

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -170,7 +170,7 @@ CODE_SAMPLE
             lcfirst($typeShortName),
             self::STARTS_WITH_ABBREVIATION_REGEX,
             static function (array $matches): string {
-                $output = isset($matches[1]) ? strtolower((string) $matches[1]) : '';
+                $output = isset($matches[1]) ? strtolower($matches[1]) : '';
                 $output .= $matches[2] ?? '';
 
                 return $output . ($matches[3] ?? '');


### PR DESCRIPTION
nette/utils 4.1.3 was released yesterday https://github.com/nette/utils/releases/tag/v4.1.3

and cause downgrade error

https://github.com/rectorphp/rector-src/actions/runs/21995369723/job/63553750737#step:14:73

This temporary pin to 4.1.2 so we can fix the example code on rector-downgrade-php first.

I will look on that after it.