### PR TITLE
Bump nette/utils to ^4.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
-        "nette/utils": "4.1.2",
+        "nette/utils": "^4.1.3",
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",


### PR DESCRIPTION
Let's Bump nette/utils to ^4.1.3 with patch of rector-downgrade-php

- https://github.com/rectorphp/rector-downgrade-php/pull/361