### PR TITLE
Temporary re-pin nette/utils to 4.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
-        "nette/utils": "^4.1.3",
+        "nette/utils": "4.1.2",
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",


### PR DESCRIPTION
Ref 1 more error

https://github.com/rectorphp/rector-src/actions/runs/22012085510/job/63607765788#step:14:76