### PR TITLE
Bump nette/utils to ^4.1.3 (part 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
-        "nette/utils": "4.1.2",
+        "nette/utils": "^4.1.3",
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",

--- a/rules/Carbon/NodeFactory/CarbonCallFactory.php
+++ b/rules/Carbon/NodeFactory/CarbonCallFactory.php
@@ -37,8 +37,8 @@ final class CarbonCallFactory
             $methodCall = $this->createModifyMethodCall(
                 $carbonCall,
                 new Int_((int) $match['count']),
-                (string) $match['unit'],
-                (string) $match['operator']
+                $match['unit'],
+                $match['operator']
             );
             if ($methodCall instanceof MethodCall) {
                 $carbonCall = $methodCall;

--- a/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/CodingStyle/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -170,7 +170,7 @@ CODE_SAMPLE
             lcfirst($typeShortName),
             self::STARTS_WITH_ABBREVIATION_REGEX,
             static function (array $matches): string {
-                $output = isset($matches[1]) ? strtolower($matches[1]) : '';
+                $output = isset($matches[1]) ? strtolower((string) $matches[1]) : '';
                 $output .= $matches[2] ?? '';
 
                 return $output . ($matches[3] ?? '');


### PR DESCRIPTION
Let's Bump nette/utils to ^4.1.3 with patch of rector-downgrade-php

- https://github.com/rectorphp/rector-downgrade-php/pull/362