### PR TITLE
Allow Eagerly Resolving Deprecations 

### DIFF
--- a/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/DynamicDocBlockPropertyToNativePropertyRector.php
@@ -22,6 +22,7 @@ use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -29,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\CodeQuality\Rector\Class_\DynamicDocBlockPropertyToNativePropertyRector\DynamicDocBlockPropertyToNativePropertyRectorTest
  */
-final class DynamicDocBlockPropertyToNativePropertyRector extends AbstractRector implements MinPhpVersionInterface
+final class DynamicDocBlockPropertyToNativePropertyRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
@@ -136,6 +137,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::TYPED_PROPERTIES;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_DYNAMIC_PROPERTIES;
     }

--- a/rules/Php72/Rector/Assign/ListEachRector.php
+++ b/rules/Php72/Rector/Assign/ListEachRector.php
@@ -14,6 +14,7 @@ use Rector\NodeManipulator\AssignManipulator;
 use Rector\Php72\ValueObject\ListAndEach;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -21,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php72\Rector\Assign\ListEachRector\ListEachRectorTest
  */
-final class ListEachRector extends AbstractRector implements MinPhpVersionInterface
+final class ListEachRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly AssignManipulator $assignManipulator,
@@ -29,6 +30,11 @@ final class ListEachRector extends AbstractRector implements MinPhpVersionInterf
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_EACH;
     }

--- a/rules/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
+++ b/rules/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
@@ -23,6 +23,7 @@ use Rector\Php72\NodeFactory\AnonymousFunctionFactory;
 use Rector\PhpParser\Parser\InlineCodeParser;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -30,7 +31,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector\CreateFunctionToAnonymousFunctionRectorTest
  */
-final class CreateFunctionToAnonymousFunctionRector extends AbstractRector implements MinPhpVersionInterface
+final class CreateFunctionToAnonymousFunctionRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly InlineCodeParser $inlineCodeParser,
@@ -40,6 +41,11 @@ final class CreateFunctionToAnonymousFunctionRector extends AbstractRector imple
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ANONYMOUS_FUNCTION;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_CREATE_FUNCTION;
     }

--- a/rules/Php72/Rector/While_/WhileEachToForeachRector.php
+++ b/rules/Php72/Rector/While_/WhileEachToForeachRector.php
@@ -13,6 +13,7 @@ use Rector\NodeManipulator\AssignManipulator;
 use Rector\Php72\ValueObject\ListAndEach;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php72\Rector\While_\WhileEachToForeachRector\WhileEachToForeachRectorTest
  */
-final class WhileEachToForeachRector extends AbstractRector implements MinPhpVersionInterface
+final class WhileEachToForeachRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly AssignManipulator $assignManipulator
@@ -28,6 +29,11 @@ final class WhileEachToForeachRector extends AbstractRector implements MinPhpVer
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_EACH;
     }

--- a/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
+++ b/rules/Php73/Rector/ConstFetch/SensitiveConstantNameRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -18,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php73\Rector\ConstFetch\SensitiveConstantNameRector\SensitiveConstantNameRectorTest
  */
-final class SensitiveConstantNameRector extends AbstractRector implements MinPhpVersionInterface
+final class SensitiveConstantNameRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     /**
      * @see http://php.net/manual/en/reserved.constants.php
@@ -89,6 +90,11 @@ final class SensitiveConstantNameRector extends AbstractRector implements MinPhp
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::NAMESPACES;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_INSENSITIVE_CONSTANT_NAME;
     }

--- a/rules/Php73/Rector/FuncCall/SensitiveDefineRector.php
+++ b/rules/Php73/Rector/FuncCall/SensitiveDefineRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -15,9 +16,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php73\Rector\FuncCall\SensitiveDefineRector\SensitiveDefineRectorTest
  */
-final class SensitiveDefineRector extends AbstractRector implements MinPhpVersionInterface
+final class SensitiveDefineRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_INSENSITIVE_CONSTANT_DEFINE;
     }

--- a/rules/Php73/Rector/FuncCall/StringifyStrNeedlesRector.php
+++ b/rules/Php73/Rector/FuncCall/StringifyStrNeedlesRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\InterpolatedString;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -18,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php73\Rector\FuncCall\StringifyStrNeedlesRector\StringifyStrNeedlesRectorTest
  */
-final class StringifyStrNeedlesRector extends AbstractRector implements MinPhpVersionInterface
+final class StringifyStrNeedlesRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     /**
      * @var string[]
@@ -37,6 +38,11 @@ final class StringifyStrNeedlesRector extends AbstractRector implements MinPhpVe
     ];
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_INT_IN_STR_NEEDLES;
     }

--- a/rules/Php74/Rector/ArrayDimFetch/CurlyToSquareBracketArrayStringRector.php
+++ b/rules/Php74/Rector/ArrayDimFetch/CurlyToSquareBracketArrayStringRector.php
@@ -10,6 +10,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\Application\File;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -17,9 +18,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php74\Rector\ArrayDimFetch\CurlyToSquareBracketArrayStringRector\CurlyToSquareBracketArrayStringRectorTest
  */
-final class CurlyToSquareBracketArrayStringRector extends AbstractRector implements MinPhpVersionInterface
+final class CurlyToSquareBracketArrayStringRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_CURLY_BRACKET_ARRAY_STRING;
     }

--- a/rules/Php74/Rector/FuncCall/HebrevcToNl2brHebrevRector.php
+++ b/rules/Php74/Rector/FuncCall/HebrevcToNl2brHebrevRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -17,9 +18,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php74\Rector\FuncCall\HebrevcToNl2brHebrevRector\HebrevcToNl2brHebrevRectorTest
  */
-final class HebrevcToNl2brHebrevRector extends AbstractRector implements MinPhpVersionInterface
+final class HebrevcToNl2brHebrevRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_HEBREVC;
     }

--- a/rules/Php74/Rector/FuncCall/MoneyFormatToNumberFormatRector.php
+++ b/rules/Php74/Rector/FuncCall/MoneyFormatToNumberFormatRector.php
@@ -16,6 +16,7 @@ use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -23,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php74\Rector\FuncCall\MoneyFormatToNumberFormatRector\MoneyFormatToNumberFormatRectorTest
  */
-final class MoneyFormatToNumberFormatRector extends AbstractRector implements MinPhpVersionInterface
+final class MoneyFormatToNumberFormatRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ArgsAnalyzer $argsAnalyzer,
@@ -32,6 +33,11 @@ final class MoneyFormatToNumberFormatRector extends AbstractRector implements Mi
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::LEGACY_ROUNDING_MODES;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_MONEY_FORMAT;
     }

--- a/rules/Php74/Rector/FuncCall/RestoreIncludePathToIniRestoreRector.php
+++ b/rules/Php74/Rector/FuncCall/RestoreIncludePathToIniRestoreRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -19,9 +20,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://3v4l.org/Kcs98
  * @see \Rector\Tests\Php74\Rector\FuncCall\RestoreIncludePathToIniRestoreRector\RestoreIncludePathToIniRestoreRectorTest
  */
-final class RestoreIncludePathToIniRestoreRector extends AbstractRector implements MinPhpVersionInterface
+final class RestoreIncludePathToIniRestoreRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_RESTORE_INCLUDE_PATH;
     }

--- a/rules/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector.php
+++ b/rules/Php74/Rector/Ternary/ParenthesizeNestedTernaryRector.php
@@ -11,6 +11,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Php74\Tokenizer\ParenthesizedNestedTernaryAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -18,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php74\Rector\Ternary\ParenthesizeNestedTernaryRector\ParenthesizeNestedTernaryRectorTest
  */
-final class ParenthesizeNestedTernaryRector extends AbstractRector implements MinPhpVersionInterface
+final class ParenthesizeNestedTernaryRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ParenthesizedNestedTernaryAnalyzer $parenthesizedNestedTernaryAnalyzer
@@ -26,6 +27,11 @@ final class ParenthesizeNestedTernaryRector extends AbstractRector implements Mi
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_NESTED_TERNARY;
     }

--- a/rules/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictIntPregSlitFuncCallLimitArgRector.php
@@ -16,6 +16,7 @@ use Rector\Php81\NodeManipulator\NullToStrictStringIntConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -24,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://3v4l.org/cVPim
  * @see \Rector\Tests\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector\NullToStrictIntPregSlitFuncCallLimitArgRectorTest
  */
-final class NullToStrictIntPregSlitFuncCallLimitArgRector extends AbstractRector implements MinPhpVersionInterface
+final class NullToStrictIntPregSlitFuncCallLimitArgRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
@@ -119,6 +120,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_NULL_ARG_IN_STRING_FUNCTION;
     }

--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -19,6 +19,7 @@ use Rector\Php81\NodeManipulator\NullToStrictStringIntConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -26,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\NullToStrictStringFuncCallArgRectorTest
  */
-final class NullToStrictStringFuncCallArgRector extends AbstractRector implements MinPhpVersionInterface
+final class NullToStrictStringFuncCallArgRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
@@ -127,6 +128,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_NULL_ARG_IN_STRING_FUNCTION;
     }

--- a/rules/Php82/Rector/Encapsed/VariableInStringInterpolationFixerRector.php
+++ b/rules/Php82/Rector/Encapsed/VariableInStringInterpolationFixerRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Scalar\InterpolatedString;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -18,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector\VariableInStringInterpolationFixerRectorTest
  */
-final class VariableInStringInterpolationFixerRector extends AbstractRector implements MinPhpVersionInterface
+final class VariableInStringInterpolationFixerRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -86,6 +87,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_VARIABLE_IN_STRING_INTERPOLATION;
     }

--- a/rules/Php82/Rector/FuncCall/Utf8DecodeEncodeToMbConvertEncodingRector.php
+++ b/rules/Php82/Rector/FuncCall/Utf8DecodeEncodeToMbConvertEncodingRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://3v4l.org/Q14UR
  * @see \Rector\Tests\Php82\Rector\FuncCall\Utf8DecodeEncodeToMbConvertEncodingRector\Utf8DecodeEncodeToMbConvertEncodingRectorTest
  */
-final class Utf8DecodeEncodeToMbConvertEncodingRector extends AbstractRector implements MinPhpVersionInterface
+final class Utf8DecodeEncodeToMbConvertEncodingRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -75,6 +76,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_UTF8_DECODE_ENCODE_FUNCTION;
     }

--- a/rules/Php83/Rector/FuncCall/CombineHostPortLdapUriRector.php
+++ b/rules/Php83/Rector/FuncCall/CombineHostPortLdapUriRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Scalar\String_;
 use Rector\NodeAnalyzer\ExprAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.php.net/manual/en/migration83.deprecated.php#migration83.deprecated.ldap
  * @see \Rector\Tests\Php83\Rector\FuncCall\CombineHostPortLdapUriRector\CombineHostPortLdapUriRectorTest
  */
-final class CombineHostPortLdapUriRector extends AbstractRector implements MinPhpVersionInterface
+final class CombineHostPortLdapUriRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ExprAnalyzer $exprAnalyzer
@@ -96,6 +97,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_HOST_PORT_SEPARATE_ARGS;
     }

--- a/rules/Php83/Rector/FuncCall/RemoveGetClassGetParentClassNoArgsRector.php
+++ b/rules/Php83/Rector/FuncCall/RemoveGetClassGetParentClassNoArgsRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\VarLikeIdentifier;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -18,7 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php83\Rector\FuncCall\RemoveGetClassGetParentClassNoArgsRector\RemoveGetClassGetParentClassNoArgsRectorTest
  */
-final class RemoveGetClassGetParentClassNoArgsRector extends AbstractRector implements MinPhpVersionInterface
+final class RemoveGetClassGetParentClassNoArgsRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -84,6 +85,11 @@ final class RemoveGetClassGetParentClassNoArgsRector extends AbstractRector impl
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::CLASSNAME_CONSTANT;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_GET_CLASS_WITHOUT_ARGS;
     }

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -93,6 +93,10 @@ CODE_SAMPLE
         if ($node->type instanceof UnionType) {
             $node->type->types[] = new Name('null');
         } elseif ($node->type instanceof ComplexType) {
+            if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_INTERSECTION_TYPES)) {
+                return null;
+            }
+
             /** @var IntersectionType $nodeType */
             $nodeType = $node->type;
             $node->type = new UnionType([$nodeType, new Name('null')]);

--- a/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
+++ b/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php
@@ -14,11 +14,13 @@ use PhpParser\Node\Param;
 use PhpParser\Node\UnionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
+use Rector\Php\PhpVersionProvider;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -26,11 +28,12 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php84\Rector\Param\ExplicitNullableParamTypeRector\ExplicitNullableParamTypeRectorTest
  */
-final class ExplicitNullableParamTypeRector extends AbstractRector implements MinPhpVersionInterface
+final class ExplicitNullableParamTypeRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,
-        private readonly StaticTypeMapper $staticTypeMapper
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly PhpVersionProvider $phpVersionProvider
     ) {
     }
 
@@ -101,6 +104,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::NULLABLE_TYPE;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_IMPLICIT_NULLABLE_PARAM_TYPE;
     }

--- a/rules/Php85/Rector/ClassMethod/NullDebugInfoReturnRector.php
+++ b/rules/Php85/Rector/ClassMethod/NullDebugInfoReturnRector.php
@@ -16,6 +16,7 @@ use PhpParser\NodeVisitor;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -24,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_debuginfo_returning_null
  * @see \Rector\Tests\Php85\Rector\MethodCall\NullDebugInfoReturnRector\NullDebugInfoReturnRectorTest
  */
-final class NullDebugInfoReturnRector extends AbstractRector implements MinPhpVersionInterface
+final class NullDebugInfoReturnRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ValueResolver $valueResolver,
@@ -102,6 +103,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::DEBUG_INFO_MAGIC_METHOD;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATED_NULL_DEBUG_INFO_RETURN;
     }

--- a/rules/Php85/Rector/Class_/SleepToSerializeRector.php
+++ b/rules/Php85/Rector/Class_/SleepToSerializeRector.php
@@ -17,6 +17,7 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -27,7 +28,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods
  * @see \Rector\Tests\Php85\Rector\Class_\SleepToSerializeRector\SleepToSerializeRectorTest
  */
-final class SleepToSerializeRector extends AbstractRector implements MinPhpVersionInterface
+final class SleepToSerializeRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly BetterNodeFinder $betterNodeFinder,
@@ -36,6 +37,11 @@ final class SleepToSerializeRector extends AbstractRector implements MinPhpVersi
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::SERIALIZE_MAGIC_METHODS;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATED_METHOD_SLEEP;
     }

--- a/rules/Php85/Rector/Class_/WakeupToUnserializeRector.php
+++ b/rules/Php85/Rector/Class_/WakeupToUnserializeRector.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -30,9 +31,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods
  * @see \Rector\Tests\Php85\Rector\Class_\WakeupToUnserializeRector\WakeupToUnserializeRectorTest
  */
-final class WakeupToUnserializeRector extends AbstractRector implements MinPhpVersionInterface
+final class WakeupToUnserializeRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::SERIALIZE_MAGIC_METHODS;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATED_METHOD_WAKEUP;
     }

--- a/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
+++ b/rules/Php85/Rector/FuncCall/ArrayKeyExistsNullToEmptyStringRector.php
@@ -18,6 +18,7 @@ use Rector\Php81\NodeManipulator\NullToStrictStringIntConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -26,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists
  * @see \Rector\Tests\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector\ArrayKeyExistsNullToEmptyStringRectorTest
  */
-final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector implements MinPhpVersionInterface
+final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
@@ -117,6 +118,11 @@ final class ArrayKeyExistsNullToEmptyStringRector extends AbstractRector impleme
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_NULL_ARG_IN_ARRAY_KEY_EXISTS_FUNCTION;
     }

--- a/rules/Php85/Rector/FuncCall/ChrArgModuloRector.php
+++ b/rules/Php85/Rector/FuncCall/ChrArgModuloRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Scalar\LNumber;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_passing_integers_outside_the_interval_0_255_to_chr
  * @see \Rector\Tests\Php85\Rector\FuncCall\ChrArgModuloRector\ChrArgModuloRectorTest
  */
-final class ChrArgModuloRector extends AbstractRector implements MinPhpVersionInterface
+final class ChrArgModuloRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ValueResolver $valueResolver
@@ -91,6 +92,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_OUTSIDE_INTERVEL_VAL_IN_CHR_FUNCTION;
     }

--- a/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
+++ b/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Scalar\String_;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_passing_string_which_are_not_one_byte_long_to_ord
  * @see \Rector\Tests\Php85\Rector\FuncCall\OrdSingleByteRector\OrdSingleByteRectorTest
  */
-final class OrdSingleByteRector extends AbstractRector implements MinPhpVersionInterface
+final class OrdSingleByteRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ValueResolver $valueResolver
@@ -91,6 +92,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_ORD_WITH_MULTIBYTE_STRING;
     }

--- a/rules/Php85/Rector/FuncCall/RemoveFinfoBufferContextArgRector.php
+++ b/rules/Php85/Rector/FuncCall/RemoveFinfoBufferContextArgRector.php
@@ -12,6 +12,7 @@ use PHPStan\Type\ObjectType;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_context_parameter_for_finfo_buffer
  * @see \Rector\Tests\Php85\Rector\FuncCall\RemoveFinfoBufferContextArgRector\RemoveFinfoBufferContextArgRectorTest
  */
-final class RemoveFinfoBufferContextArgRector extends AbstractRector implements MinPhpVersionInterface
+final class RemoveFinfoBufferContextArgRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function __construct(
         private readonly ArgsAnalyzer $argsAnalyzer,
@@ -81,6 +82,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::FINFO_BUFFER_FUNCTION;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_FINFO_BUFFER_CONTEXT;
     }

--- a/rules/Php85/Rector/ShellExec/ShellExecFunctionCallOverBackticksRector.php
+++ b/rules/Php85/Rector/ShellExec/ShellExecFunctionCallOverBackticksRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\InterpolatedStringPart;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_backticks_as_an_alias_for_shell_exec
  * @see \Rector\Tests\Php85\Rector\ShellExec\ShellExecFunctionCallOverBackticksRector\ShellExecFunctionCallOverBackticksRectorTest
  */
-final class ShellExecFunctionCallOverBackticksRector extends AbstractRector implements MinPhpVersionInterface
+final class ShellExecFunctionCallOverBackticksRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -79,6 +80,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::DEPRECATE_BACKTICKS;
     }

--- a/rules/Php85/Rector/Switch_/ColonAfterSwitchCaseRector.php
+++ b/rules/Php85/Rector/Switch_/ColonAfterSwitchCaseRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Switch_;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -16,7 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\Php85\Rector\Switch_\ColonAfterSwitchCaseRector\ColonAfterSwitchCaseRectorTest
  */
-final class ColonAfterSwitchCaseRector extends AbstractRector implements MinPhpVersionInterface
+final class ColonAfterSwitchCaseRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -108,6 +109,11 @@ CODE_SAMPLE
     }
 
     public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::BASELINE_SUPPORTED_PHP;
+    }
+
+    public function provideDeprecatedAtVersion(): int
     {
         return PhpVersionFeature::COLON_AFTER_SWITCH_CASE;
     }

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -325,6 +325,11 @@ final class RectorConfig extends Container
         SimpleParameterProvider::setParameter(Option::TREAT_CLASSES_AS_FINAL, $treatClassesAsFinal);
     }
 
+    public function eagerlyResolveDeprecations(bool $eagerlyResolveDeprecations = true): void
+    {
+        SimpleParameterProvider::setParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS, $eagerlyResolveDeprecations);
+    }
+
     /**
      * @param string[] $extensions
      */

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -230,6 +230,12 @@ final class Option
     public const string TREAT_CLASSES_AS_FINAL = 'treat_classes_as_final';
 
     /**
+     * @internal Use @see \Rector\Config\RectorConfig::eagerlyResolveDeprecations() method
+     * @var string
+     */
+    public const string EAGERLY_RESOLVE_DEPRECATIONS = 'eagerly_resolve_deprecations';
+
+    /**
      * @internal To report composer based loaded sets
      * @see \Rector\Configuration\RectorConfigBuilder::withComposerBased()
      */

--- a/src/Configuration/Parameter/SimpleParameterProvider.php
+++ b/src/Configuration/Parameter/SimpleParameterProvider.php
@@ -41,6 +41,14 @@ final class SimpleParameterProvider
 
     /**
      * @param Option::* $name
+     */
+    public static function unsetParameter(string $name): void
+    {
+        unset(self::$parameters[$name]);
+    }
+
+    /**
+     * @param Option::* $name
      * @return mixed[]
      */
     public static function provideArrayParameter(string $name): array

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -157,6 +157,8 @@ final class RectorConfigBuilder
 
     private ?bool $isTreatClassesAsFinal = null;
 
+    private ?bool $isEagerlyResolvedDeprecations = null;
+
     /**
      * @var RegisteredService[]
      */
@@ -379,6 +381,10 @@ final class RectorConfigBuilder
 
         if ($this->isTreatClassesAsFinal !== null) {
             $rectorConfig->treatClassesAsFinal($this->isTreatClassesAsFinal);
+        }
+
+        if ($this->isEagerlyResolvedDeprecations !== null) {
+            $rectorConfig->eagerlyResolveDeprecations($this->isEagerlyResolvedDeprecations);
         }
 
         if ($this->reportingRealPath !== null) {
@@ -1212,6 +1218,12 @@ final class RectorConfigBuilder
     public function withTreatClassesAsFinal(bool $isTreatClassesAsFinal = true): self
     {
         $this->isTreatClassesAsFinal = $isTreatClassesAsFinal;
+        return $this;
+    }
+
+    public function withEagerlyResolvedDeprecations(bool $isEagerlyResolvedDeprecations = true): self
+    {
+        $this->isEagerlyResolvedDeprecations = $isEagerlyResolvedDeprecations;
         return $this;
     }
 

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -63,6 +63,8 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         SimpleParameterProvider::setParameter(Option::NEW_LINE_ON_FLUENT_CALL, false);
 
         SimpleParameterProvider::setParameter(Option::TREAT_CLASSES_AS_FINAL, false);
+
+        SimpleParameterProvider::setParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS, false);
     }
 
     protected function setUp(): void
@@ -182,8 +184,8 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         $testClass = static::class;
         $this->assertSame(
             PHP_EOL . 'WARNING: On fixture file "' . $fixtureName . '" for test "' . $testClass . '"' . PHP_EOL .
-            'File not changed but some Rector rules applied:' . PHP_EOL .
-            ' * ' . $expectedRuleApplied . PHP_EOL,
+                'File not changed but some Rector rules applied:' . PHP_EOL .
+                ' * ' . $expectedRuleApplied . PHP_EOL,
             $content
         );
     }

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -50,6 +50,8 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
      */
     public static function tearDownAfterClass(): void
     {
+        SimpleParameterProvider::unsetParameter(Option::PHP_VERSION_FEATURES);
+
         SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_NAMES, false);
         SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_DOC_BLOCK_NAMES, false);
         SimpleParameterProvider::setParameter(Option::REMOVE_UNUSED_IMPORTS, false);

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -9,6 +9,12 @@ namespace Rector\ValueObject;
  */
 final class PhpVersionFeature
 {
+    /**
+     * Rector can only be used to target PHP versions down to 5.2.
+     * Rules that set this as a minimum version are ALWAYS included.
+     */
+    public const int BASELINE_SUPPORTED_PHP = PhpVersion::PHP_52;
+
     public const int PROPERTY_MODIFIER = PhpVersion::PHP_52;
 
     public const int CONTINUE_TO_BREAK = PhpVersion::PHP_52;
@@ -21,7 +27,27 @@ final class PhpVersionFeature
 
     public const int ELVIS_OPERATOR = PhpVersion::PHP_53;
 
+    /**
+     * @see https://www.php.net/releases/5_3_0.php
+     */
+    public const int ANONYMOUS_FUNCTION = PhpVersion::PHP_53;
+
     public const int ANONYMOUS_FUNCTION_PARAM_TYPE = PhpVersion::PHP_53;
+
+    /**
+     * @see https://www.php.net/manual/en/language.namespaces.basics.php
+     */
+    public const int NAMESPACES = PhpVersion::PHP_53;
+
+    /**
+     * @see https://wiki.php.net/rfc/rounding
+     */
+    public const int LEGACY_ROUNDING_MODES = PhpVersion::PHP_53;
+
+    /**
+     * @see https://www.php.net/manual/en/function.finfo-buffer.php
+     */
+    public const int FINFO_BUFFER_FUNCTION = PhpVersion::PHP_53;
 
     public const int NO_ZERO_BREAK = PhpVersion::PHP_54;
 
@@ -41,6 +67,11 @@ final class PhpVersionFeature
     public const int EXP_OPERATOR = PhpVersion::PHP_56;
 
     public const int REQUIRE_DEFAULT_VALUE = PhpVersion::PHP_56;
+
+    /**
+     * @see https://wiki.php.net/rfc/debug-info
+     */
+    public const int DEBUG_INFO_MAGIC_METHOD = PhpVersion::PHP_56;
 
     public const int SCALAR_TYPES = PhpVersion::PHP_70;
 
@@ -187,6 +218,11 @@ final class PhpVersionFeature
     public const int DEPRECATE_RESTORE_INCLUDE_PATH = PhpVersion::PHP_74;
 
     public const int DEPRECATE_HEBREVC = PhpVersion::PHP_74;
+
+    /**
+     * @see https://wiki.php.net/rfc/custom_object_serialization
+     */
+    public const int SERIALIZE_MAGIC_METHODS = PhpVersion::PHP_74;
 
     public const int UNION_TYPES = PhpVersion::PHP_80;
 

--- a/src/VersionBonding/Contract/DeprecatedAtVersionInterface.php
+++ b/src/VersionBonding/Contract/DeprecatedAtVersionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\VersionBonding\Contract;
+
+use Rector\ValueObject\PhpVersion;
+
+/**
+ * Can be implemented by @see \Rector\Contract\Rector\RectorInterface
+ *
+ * Rules that resolve deprecations can expose the PHP version where the
+ * deprecation starts.
+ *
+ * Rules that do not meet this PHP version will be skipped when
+ * Option::EAGERLY_RESOLVE_DEPRECATIONS is false (default).
+ *
+ * @see \Rector\VersionBonding\Contract\MinPhpVersionInterface
+ */
+interface DeprecatedAtVersionInterface
+{
+    /**
+     * @return PhpVersion::*
+     */
+    public function provideDeprecatedAtVersion(): int;
+}

--- a/src/VersionBonding/Contract/MinPhpVersionInterface.php
+++ b/src/VersionBonding/Contract/MinPhpVersionInterface.php
@@ -10,6 +10,10 @@ use Rector\ValueObject\PhpVersion;
  * Can be implemented by @see \Rector\Contract\Rector\RectorInterface
  *
  * Rules that do not meet this PHP version will be skipped.
+ *
+ * Rules that also implement @see Rector\VersionBonding\Contract\DeprecatedAtVersionInterface
+ * will prioritize the deprecation version over the minimum PHP version when
+ * Option::EAGERLY_RESOLVE_DEPRECATIONS is false (default).
  */
 interface MinPhpVersionInterface
 {

--- a/src/VersionBonding/PhpVersionedFilter.php
+++ b/src/VersionBonding/PhpVersionedFilter.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\VersionBonding;
 
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Php\PhpVersionProvider;
 use Rector\Php\PolyfillPackagesProvider;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Rector\VersionBonding\Contract\RelatedPolyfillInterface;
 
@@ -28,6 +31,10 @@ final readonly class PhpVersionedFilter
     public function filter(array $rectors): array
     {
         $minProjectPhpVersion = $this->phpVersionProvider->provide();
+        $isEagerlyResolveDeprecations = SimpleParameterProvider::provideBoolParameter(
+            Option::EAGERLY_RESOLVE_DEPRECATIONS,
+            false
+        );
 
         $activeRectors = [];
         foreach ($rectors as $rector) {
@@ -40,13 +47,27 @@ final readonly class PhpVersionedFilter
                 }
             }
 
-            if (! $rector instanceof MinPhpVersionInterface) {
+            if (
+                ! $rector instanceof MinPhpVersionInterface
+                && ! $rector instanceof DeprecatedAtVersionInterface
+            ) {
                 $activeRectors[] = $rector;
                 continue;
             }
 
+            $deprecationVersion = $rector instanceof DeprecatedAtVersionInterface
+                ? $rector->provideDeprecatedAtVersion()
+                : null;
+            $minPhpVersion = $rector instanceof MinPhpVersionInterface
+                ? $rector->provideMinPhpVersion()
+                : null;
+
+            $requiredPhpVersion = (! $deprecationVersion || $isEagerlyResolveDeprecations)
+                ? $minPhpVersion
+                : $deprecationVersion;
+
             // does satisfy version? → include
-            if ($rector->provideMinPhpVersion() <= $minProjectPhpVersion) {
+            if ($requiredPhpVersion === null || $requiredPhpVersion <= $minProjectPhpVersion) {
                 $activeRectors[] = $rector;
             }
         }

--- a/tests/Issues/Issue9646/Fixture/fixture.php.inc
+++ b/tests/Issues/Issue9646/Fixture/fixture.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\Tests\Issues\Issue9646\Fixture;
+
+echo array_key_exists(null, []);
+
+class ParentClass
+{
+}
+
+final class ChildClass extends ParentClass
+{
+    private $foo;
+
+    public function __sleep() {
+        return ['foo'];
+    }
+
+    public function run(string $name = null): string
+    {
+        return get_class() . ':' . get_parent_class();
+    }
+
+    public function runComplex(\PHPUnit\Framework\MockObject\MockObject&\stdClass $mockObject = null): string
+    {
+        return __METHOD__;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\Issue9646\Fixture;
+
+echo array_key_exists('', []);
+
+class ParentClass
+{
+}
+
+final class ChildClass extends ParentClass
+{
+    private $foo;
+
+    public function __serialize(): array {
+        return ['foo' => $this->foo];
+    }
+
+    public function run(?string $name = null): string
+    {
+        return self::class . ':' . parent::class;
+    }
+
+    public function runComplex(\PHPUnit\Framework\MockObject\MockObject&\stdClass $mockObject = null): string
+    {
+        return __METHOD__;
+    }
+}
+
+?>

--- a/tests/Issues/Issue9646/FixtureWithoutEager/fixture.php.inc
+++ b/tests/Issues/Issue9646/FixtureWithoutEager/fixture.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\Tests\Issues\Issue9646\Fixture;
+
+echo array_key_exists(null, []);
+
+class ParentClass
+{
+}
+
+final class ChildClass extends ParentClass
+{
+    private $foo;
+
+    public function __sleep() {
+        return ['foo'];
+    }
+
+    public function run(string $name = null): string
+    {
+        return get_class() . ':' . get_parent_class();
+    }
+
+    public function runComplex(\PHPUnit\Framework\MockObject\MockObject&\stdClass $mockObject = null): string
+    {
+        return __METHOD__;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\Issue9646\Fixture;
+
+echo array_key_exists(null, []);
+
+class ParentClass
+{
+}
+
+final class ChildClass extends ParentClass
+{
+    private $foo;
+
+    public function __sleep() {
+        return ['foo'];
+    }
+
+    public function run(string $name = null): string
+    {
+        return get_class() . ':' . get_parent_class();
+    }
+
+    public function runComplex(\PHPUnit\Framework\MockObject\MockObject&\stdClass $mockObject = null): string
+    {
+        return __METHOD__;
+    }
+}
+
+?>

--- a/tests/Issues/Issue9646/Issue9646Test.php
+++ b/tests/Issues/Issue9646/Issue9646Test.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\Issue9646;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Issue9646Test extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/Issue9646/Issue9646WithoutEagerTest.php
+++ b/tests/Issues/Issue9646/Issue9646WithoutEagerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\Issue9646;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Issue9646WithoutEagerTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureWithoutEager');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule_without_eager.php';
+    }
+}

--- a/tests/Issues/Issue9646/config/configured_rule.php
+++ b/tests/Issues/Issue9646/config/configured_rule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\FuncCall\RemoveGetClassGetParentClassNoArgsRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
+use Rector\Php85\Rector\Class_\SleepToSerializeRector;
+use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+    ->withRules([
+        ArrayKeyExistsNullToEmptyStringRector::class,
+        ExplicitNullableParamTypeRector::class,
+        RemoveGetClassGetParentClassNoArgsRector::class,
+        SleepToSerializeRector::class,
+    ])
+    ->withPhpVersion(PhpVersion::PHP_81)
+    ->withEagerlyResolvedDeprecations();

--- a/tests/Issues/Issue9646/config/configured_rule_without_eager.php
+++ b/tests/Issues/Issue9646/config/configured_rule_without_eager.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\FuncCall\RemoveGetClassGetParentClassNoArgsRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
+use Rector\Php85\Rector\Class_\SleepToSerializeRector;
+use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+    ->withRules([
+        ArrayKeyExistsNullToEmptyStringRector::class,
+        ExplicitNullableParamTypeRector::class,
+        RemoveGetClassGetParentClassNoArgsRector::class,
+        SleepToSerializeRector::class,
+    ])
+    ->withPhpVersion(PhpVersion::PHP_81)
+    ->withEagerlyResolvedDeprecations(false);

--- a/tests/VersionBonding/Fixture/DeprecatedAtVersionRector.php
+++ b/tests/VersionBonding/Fixture/DeprecatedAtVersionRector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class DeprecatedAtVersionRector extends AbstractRector implements DeprecatedAtVersionInterface
+{
+    public function __construct(
+        private readonly int $deprecatedAtVersion,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test rector with deprecated-at PHP version', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+
+    public function provideDeprecatedAtVersion(): int
+    {
+        return $this->deprecatedAtVersion;
+    }
+}

--- a/tests/VersionBonding/Fixture/MinPhpVersionRector.php
+++ b/tests/VersionBonding/Fixture/MinPhpVersionRector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class MinPhpVersionRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly int $minPhpVersion,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test rector with minimum PHP version', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return $this->minPhpVersion;
+    }
+}

--- a/tests/VersionBonding/Fixture/MixedVersionBoundsRector.php
+++ b/tests/VersionBonding/Fixture/MixedVersionBoundsRector.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class MixedVersionBoundsRector extends AbstractRector implements MinPhpVersionInterface, DeprecatedAtVersionInterface
+{
+    public function __construct(
+        private readonly int $minPhpVersion,
+        private readonly int $deprecatedAtVersion,
+    ) {}
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test rector with deprecation-aware versions', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return $this->minPhpVersion;
+    }
+
+    public function provideDeprecatedAtVersion(): int
+    {
+        return $this->deprecatedAtVersion;
+    }
+}

--- a/tests/VersionBonding/PhpVersionBoundsInvariantTest.php
+++ b/tests/VersionBonding/PhpVersionBoundsInvariantTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding;
+
+use Rector\Configuration\PhpLevelSetResolver;
+use Rector\Contract\Rector\RectorInterface;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\ValueObject\PhpVersion;
+use Rector\VersionBonding\Contract\DeprecatedAtVersionInterface;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+
+final class PhpVersionBoundsInvariantTest extends AbstractLazyTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Keep this test isolated from shared container state between tests.
+        self::$rectorConfig = null;
+
+        $allPhpLevelSets = PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_10);
+        self::getContainer()->sets($allPhpLevelSets);
+    }
+
+    public function testMinPhpVersionIsNotHigherThanDeprecatedAtVersion(): void
+    {
+        /** @var list<MinPhpVersionInterface&DeprecatedAtVersionInterface> $dualVersionRectors */
+        $dualVersionRectors = array_filter(
+            [...self::getContainer()->tagged(RectorInterface::class)],
+            fn (RectorInterface $rector): bool => (
+                $rector instanceof MinPhpVersionInterface
+                && $rector instanceof DeprecatedAtVersionInterface
+            )
+        );
+
+        $violations = array_filter(array_map(
+            function (MinPhpVersionInterface&DeprecatedAtVersionInterface $rector): ?string {
+                $minimumPhpVersion = $rector->provideMinPhpVersion();
+                $deprecatedAtVersion = $rector->provideDeprecatedAtVersion();
+
+                if ($minimumPhpVersion <= $deprecatedAtVersion) {
+                    return null;
+                }
+
+                return sprintf(
+                    '%s has provideMinPhpVersion()=%d and provideDeprecatedAtVersion()=%d',
+                    $rector::class,
+                    $minimumPhpVersion,
+                    $deprecatedAtVersion
+                );
+            },
+            $dualVersionRectors
+        ));
+
+        $this->assertNotEmpty($dualVersionRectors, 'No dual-version rectors were inspected.');
+        $this->assertSame([], $violations, implode(PHP_EOL, $violations));
+    }
+}

--- a/tests/VersionBonding/PhpVersionedFilterTest.php
+++ b/tests/VersionBonding/PhpVersionedFilterTest.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace Rector\Tests\VersionBonding;
 
 use PHPUnit\Framework\TestCase;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Php\PhpVersionProvider;
 use Rector\Php\PolyfillPackagesProvider;
+use Rector\Tests\VersionBonding\Fixture\DeprecatedAtVersionRector;
+use Rector\Tests\VersionBonding\Fixture\MinPhpVersionRector;
+use Rector\Tests\VersionBonding\Fixture\MixedVersionBoundsRector;
 use Rector\Tests\VersionBonding\Fixture\NoInterfaceRector;
+use Rector\ValueObject\PhpVersion;
 use Rector\VersionBonding\PhpVersionedFilter;
 
 final class PhpVersionedFilterTest extends TestCase
@@ -20,14 +26,127 @@ final class PhpVersionedFilterTest extends TestCase
         $polyfillPackagesProvider = new PolyfillPackagesProvider();
 
         $this->phpVersionedFilter = new PhpVersionedFilter($phpVersionProvider, $polyfillPackagesProvider);
+
+        // Convenient Defaults
+        SimpleParameterProvider::setParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS, false);
+        SimpleParameterProvider::setParameter(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_82);
+    }
+
+    protected function tearDown(): void
+    {
+        SimpleParameterProvider::unsetParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS);
+        SimpleParameterProvider::unsetParameter(Option::PHP_VERSION_FEATURES);
     }
 
     public function testRectorWithoutInterfaceIsIncluded(): void
     {
-        $noInterfaceRector = new NoInterfaceRector();
-        $filtered = $this->phpVersionedFilter->filter([$noInterfaceRector]);
+        $rectors = [new NoInterfaceRector()];
+        $this->assertSame($rectors, $this->phpVersionedFilter->filter($rectors));
+    }
 
-        $this->assertCount(1, $filtered);
-        $this->assertSame($noInterfaceRector, $filtered[0]);
+    public function testMinPhpVersionRuleIsIncludedWhenVersionMatches(): void
+    {
+        $rectors = [new MinPhpVersionRector(PhpVersion::PHP_82), new MinPhpVersionRector(PhpVersion::PHP_81)];
+
+        $this->assertSame($rectors, $this->phpVersionedFilter->filter($rectors));
+    }
+
+    public function testMinPhpVersionRuleIsExcludedWhenVersionDoesNotMatch(): void
+    {
+        $this->assertEmpty($this->phpVersionedFilter->filter([new MinPhpVersionRector(PhpVersion::PHP_84)]));
+    }
+
+    public function testDeprecatedAtVersionRuleIsIncludedWhenVersionMatches(): void
+    {
+        $rectors = [
+            new DeprecatedAtVersionRector(PhpVersion::PHP_82),
+            new DeprecatedAtVersionRector(PhpVersion::PHP_81),
+        ];
+
+        $this->assertSame($rectors, $this->phpVersionedFilter->filter($rectors));
+    }
+
+    public function testDeprecatedAtVersionRuleIsExcludedWhenVersionDoesNotMatch(): void
+    {
+        $this->assertEmpty($this->phpVersionedFilter->filter([new DeprecatedAtVersionRector(PhpVersion::PHP_84)]));
+    }
+
+    public function testRuleIsFilteredByDeprecatedAtVersionByDefault(): void
+    {
+        SimpleParameterProvider::unsetParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS);
+
+        $this->assertEmpty(
+            $this->phpVersionedFilter->filter([
+                new MixedVersionBoundsRector(PhpVersion::PHP_71, PhpVersion::PHP_84),
+            ])
+        );
+    }
+
+    public function testRuleIsFilteredByMinVersionInEagerMode(): void
+    {
+        SimpleParameterProvider::setParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS, true);
+
+        $rectors = [
+            new DeprecatedAtVersionRector(PhpVersion::PHP_84),
+            new MixedVersionBoundsRector(PhpVersion::PHP_71, PhpVersion::PHP_84),
+        ];
+        $this->assertSame($rectors, $this->phpVersionedFilter->filter($rectors));
+    }
+
+    public function testOtherRectorsAreUnaffectedByEagerMode(): void
+    {
+        SimpleParameterProvider::setParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS, true);
+
+        $includedRectors = [
+            new NoInterfaceRector(),
+            new MinPhpVersionRector(PhpVersion::PHP_82),
+            new DeprecatedAtVersionRector(PhpVersion::PHP_82),
+        ];
+        $excludedRectors = [new MinPhpVersionRector(PhpVersion::PHP_84)];
+        $rectors = [...$includedRectors, ...$excludedRectors];
+
+        $this->assertSame($includedRectors, $this->phpVersionedFilter->filter($rectors));
+    }
+
+    public function testMixedRuleIsExcludedIfVersionDoesNotMatchEitherMinAndDeprecatedVersions(): void
+    {
+        $rectors = [new MixedVersionBoundsRector(PhpVersion::PHP_84, PhpVersion::PHP_84)];
+
+        SimpleParameterProvider::setParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS, true);
+        $this->assertEmpty($this->phpVersionedFilter->filter($rectors));
+
+        SimpleParameterProvider::setParameter(Option::EAGERLY_RESOLVE_DEPRECATIONS, false);
+        $this->assertEmpty($this->phpVersionedFilter->filter($rectors));
+    }
+
+    public function testKeepInOriginalOrder(): void
+    {
+        $noInterfaceRector = new NoInterfaceRector();
+        $excludedMinPhpVersionRector = new MinPhpVersionRector(PhpVersion::PHP_85);
+        $includedMinPhpVersionRector = new MinPhpVersionRector(PhpVersion::PHP_82);
+        $excludedDeprecatedAtVersionRector = new DeprecatedAtVersionRector(PhpVersion::PHP_85);
+        $includedDeprecatedAtVersionRector = new DeprecatedAtVersionRector(PhpVersion::PHP_82);
+        $excludedMixedVersionBoundsRector = new MixedVersionBoundsRector(PhpVersion::PHP_85, PhpVersion::PHP_85);
+        $includedMixedVersionBoundsRector = new MixedVersionBoundsRector(PhpVersion::PHP_81, PhpVersion::PHP_81);
+
+        $rectors = [
+            $noInterfaceRector,
+            $excludedMinPhpVersionRector,
+            $includedMinPhpVersionRector,
+            $excludedDeprecatedAtVersionRector,
+            $includedDeprecatedAtVersionRector,
+            $excludedMixedVersionBoundsRector,
+            $includedMixedVersionBoundsRector,
+        ];
+
+        $this->assertSame(
+            [
+                $noInterfaceRector,
+                $includedMinPhpVersionRector,
+                $includedDeprecatedAtVersionRector,
+                $includedMixedVersionBoundsRector,
+            ],
+            $this->phpVersionedFilter->filter($rectors)
+        );
     }
 }


### PR DESCRIPTION
**Parent Ticket:** https://github.com/rectorphp/rector/issues/9646

This introduces three primary changes:

1. A required change to the test suite abstraction to make tests more isolated from each other, so version changes for one test do not break another test depending on run order.
2. The introduction of the titled feature, discussed more in detail in the parent ticket, and the tests to support it.
3. A version guard for [`ExplicitNullableParamTypeRector`](https://github.com/rectorphp/rector/blob/7115ccfa7e1973002674fb8c1ad355f4c7b2a0f3/rules/Php84/Rector/Param/ExplicitNullableParamTypeRector.php), allowing it to run for PHP 8.1 without using not-yet-existing syntax (intersection types added in 8.1, but DNF types added in 8.2).

Since the changeset is rather large, I've made sure the changes are broken up step-by-step in the commit history. Each message should provide more specific details on what was changed / why.

All checks and tests have been run locally and passed.

A follow-up ticket for documentation changes in "PHP Version Features" ([site](https://getrector.com/documentation/php-version-features), [repo](https://github.com/rectorphp/getrector-com/blob/449a9f37c443a66afd7f062fc67053f8f4e7705b/resources/docs/php-version-features.md)) can be expected.