### PR TITLE
[Php80] Handle Behat transform annotation

### DIFF
--- a/config/set/behat-annotations-to-attributes.php
+++ b/config/set/behat-annotations-to-attributes.php
@@ -19,5 +19,6 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('AfterScenario', 'Behat\Hook\AfterScenario', useValueAsAttributeArgument: true),
         new AnnotationToAttribute('BeforeStep', 'Behat\Hook\BeforeStep', useValueAsAttributeArgument: true),
         new AnnotationToAttribute('AfterStep', 'Behat\Hook\AfterStep', useValueAsAttributeArgument: true),
+        new AnnotationToAttribute('Transform', 'Behat\Transformation\Transform', useValueAsAttributeArgument: true),
     ]);
 };

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/with_transform_annotations.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/Behat/with_transform_annotations.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class TransformMethod
+{
+    /**
+     * @Transform :user
+     */
+    public function transformUser($user)
+    {
+        return $user;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture\Behat;
+
+final class TransformMethod
+{
+    #[\Behat\Transformation\Transform(':user')]
+    public function transformUser($user)
+    {
+        return $user;
+    }
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Transformation\Transform;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
@@ -62,6 +63,7 @@ return static function (RectorConfig $rectorConfig): void {
         // special case with following comment becoming a inner value
         new AnnotationToAttribute('When', When::class, useValueAsAttributeArgument: true),
         new AnnotationToAttribute('Then', Then::class, useValueAsAttributeArgument: true),
+        new AnnotationToAttribute('Transform', Transform::class, useValueAsAttributeArgument: true),
 
         // simple tag to attribute
         new AnnotationToAttribute('OldName1', NewName1::class),

--- a/stubs/Behat/Transformation/Transform.php
+++ b/stubs/Behat/Transformation/Transform.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Behat\Transformation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Transform
+{
+    public function __construct(
+        public string $value
+    ) {
+    }
+}


### PR DESCRIPTION
This PR extends the withAttributesSets(behat: true) configuration to also convert the legacy @Transform annotation into its corresponding PHP 8 attribute.