### PR TITLE
fix: Skip attribute decorated parameters in `RemoveParentDelegatingConstructorRector`

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_attribute_decorated_args.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_attribute_decorated_args.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+use PhpParser\Node\Scalar\String_;
+use SensitiveParameter;
+
+final class SomeAttributeDecoratedArgs extends String_
+{
+    public function __construct(#[SensitiveParameter] string $value, array $attributes = [])
+    {
+        parent::__construct($value, $attributes);
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -127,6 +127,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->doAttributeDecoratedParametersExist($node)) {
+            return null;
+        }
+
         return NodeVisitor::REMOVE_NODE;
     }
 
@@ -286,6 +290,20 @@ CODE_SAMPLE
             $parentDefault = $nativeParentParameterReflection->getDefaultValue();
             if (! $this->valueResolver->isValue($defaultExpr, $parentDefault)) {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function doAttributeDecoratedParametersExist(ClassMethod $classMethod): bool
+    {
+        $constructorParams = $classMethod->getParams();
+        foreach ($constructorParams as $constructorParam) {
+            foreach ($constructorParam->attrGroups as $attrGroup) {
+                if ($attrGroup->attrs !== []) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
- Closes rectorphp/rector#9658