### PR TITLE
Fix class ParentWithNumber

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Source/ParentWithNumber.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddParamTypeFromPropertyTypeRector/Source/ParentWithNumber.php
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector\Source;
 
-class ParentWithNumber
+abstract class ParentWithNumber
 {
     protected string $number;
 


### PR DESCRIPTION
The ParentWithNumber class has an abstract method. PHP shows an error because this method must be implemented, or the class itself must be declared as abstract.