### PR TITLE
[TypeDeclarationDocblocks] Typo fix RuleDefinition description on AddVarArrayDocblockFromDimFetchAssignRector

### DIFF
--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
@@ -37,7 +37,7 @@ final class AddVarArrayDocblockFromDimFetchAssignRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add @var array property docblock docblock from dim fetch on property fetch assignments', [
+        return new RuleDefinition('Add @var array property docblock from dim fetch on property assignment', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
@@ -37,7 +37,7 @@ final class AddVarArrayDocblockFromDimFetchAssignRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add @var array property docblock from dim fetch on property assignment', [
+        return new RuleDefinition('Add @var array property docblock from dim fetch on property fetch assignment', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
@@ -37,7 +37,7 @@ final class AddVarArrayDocblockFromDimFetchAssignRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add @param array docblock if array_map is used on the parameter', [
+        return new RuleDefinition('Add @var array docblock if array_map is used on the parameter', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
@@ -37,7 +37,7 @@ final class AddVarArrayDocblockFromDimFetchAssignRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add @var array property docblock from dim fetch on property fetch assignment', [
+        return new RuleDefinition('Add @var array property docblock from dim fetches on property fetch assignment', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
@@ -37,7 +37,7 @@ final class AddVarArrayDocblockFromDimFetchAssignRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add @var array docblock if array_map is used on the parameter', [
+        return new RuleDefinition('Add @var array docblock from dim fetch assignments', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
@@ -37,7 +37,7 @@ final class AddVarArrayDocblockFromDimFetchAssignRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add @var array docblock from dim fetch assignments', [
+        return new RuleDefinition('Add @var array property docblock docblock from dim fetch on property fetch assignments', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass


### PR DESCRIPTION
`@param` should be `@var`, and message seems due to copy paste other rules, updated the message.