### PR TITLE
[Php83] Fix infinite add - remove #[Override] on tearDown() method on AddOverrideAttributeToOverriddenMethodsRector when combined with NoSetupWithParentCallOverrideRector

### DIFF
--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_teardown_override.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_teardown_override.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\SomeAbstractTestCase;
+
+final class SkipTearDownOverrideTest extends SomeAbstractTestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $result = null;
+    }
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/SomeAbstractTestCase.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/SomeAbstractTestCase.php
@@ -10,4 +10,9 @@ abstract class SomeAbstractTestCase extends TestCase
     {
         $value = 1000;
     }
+
+    protected function tearDown(): void
+    {
+        $value = null;
+    }
 }

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -246,7 +246,7 @@ CODE_SAMPLE
         }
 
         // skip test setup method override, as rather clutters the code than helps
-        return $this->isName($classMethod, 'setUp') && $this->parentClassAnalyzer->hasParentCall($classMethod);
+        return $this->isNames($classMethod, ['setUp', 'tearDown']) && $this->parentClassAnalyzer->hasParentCall($classMethod);
     }
 
     private function shouldSkipParentClassMethod(ClassReflection $parentClassReflection, ClassMethod $classMethod): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9661

due to `tearDown()` removed `#[Override]` on PR:

- https://github.com/rectorphp/rector-phpunit/pull/652

the add `#[Override]` should be skipped to avoid infinite add-remove the `#[Override]` on `tearDown()` as well.