### PR TITLE
[DeadCode] Skip different default param not typed on RemoveParentDelegatingConstructorRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_different_default_param_not_typed.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_different_default_param_not_typed.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+use Exception;
+
+class SkipDifferentDefaultParamNoTyped extends Exception
+{
+    public function __construct($message = 'Email not sent.', ...$args)
+    {
+        parent::__construct($message, ...$args);
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -232,6 +232,10 @@ CODE_SAMPLE
 
             // no type override
             if ($parameterType === null) {
+                if ($param->default instanceof Expr && $this->isDifferentDefaultValue($param->default, $extendedMethodReflection, $position)) {
+                    return false;
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9665