### PR TITLE
 feat(printer): add per-node NEWLINE_ON_FLUENT_CALL attribute to BetterStandardPrinter

### DIFF
--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -166,4 +166,6 @@ final class AttributeKey
     public const string HAS_CLOSURE_WITH_VARIADIC_ARGS = 'has_closure_with_variadic_args';
 
     public const string IS_IN_TRY_BLOCK = 'is_in_try_block';
+
+    public const string NEWLINE_ON_FLUENT_CALL = 'newlineOnFluentCall';
 }

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -167,5 +167,5 @@ final class AttributeKey
 
     public const string IS_IN_TRY_BLOCK = 'is_in_try_block';
 
-    public const string NEWLINE_ON_FLUENT_CALL = 'newlineOnFluentCall';
+    public const string NEWLINE_ON_FLUENT_CALL = 'newline_on_fluent_call';
 }

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -375,7 +375,10 @@ final class BetterStandardPrinter extends Standard
             return parent::pExpr_MethodCall($methodCall);
         }
 
-        if (SimpleParameterProvider::provideBoolParameter(Option::NEW_LINE_ON_FLUENT_CALL) === false) {
+        $globalFlag = SimpleParameterProvider::provideBoolParameter(Option::NEW_LINE_ON_FLUENT_CALL);
+        $perNodeFlag = (bool) $methodCall->getAttribute(AttributeKey::NEWLINE_ON_FLUENT_CALL, false);
+
+        if ($globalFlag === false && $perNodeFlag === false) {
             return parent::pExpr_MethodCall($methodCall);
         }
 


### PR DESCRIPTION
## Summary

Add a per-node attribute `AttributeKey::NEWLINE_ON_FLUENT_CALL` so individual `MethodCall` nodes can opt into newline-on-fluent formatting without enabling the global `newLineOnFluentCall()` option.

## Motivation

The printer currently only checks the global `Option::NEW_LINE_ON_FLUENT_CALL` flag. When a rule enables that option globally, every fluent chain across the processed codebase is reformatted. This causes undesirable, wide-ranging formatting changes. A per-node attribute lets rules request one-method-per-line formatting for specific nodes (for example, `expect()` chains) without affecting unrelated code.

This is the problem I'm facing for `rector-pest` chain rule which chains multiple statements in one chain and sometimes it creates very long line and there is no way around pretty print them instead of applying new line config to whole project.

## Example

When creating a `MethodCall` node in a Rector rule, tag it to enable newline formatting:

```php
use Rector\NodeTypeResolver\Node\AttributeKey;

$methodCall = new MethodCall($receiver, 'and', [$arg]);
$methodCall->setAttribute(AttributeKey::NEWLINE_ON_FLUENT_CALL, true);
```