### PR TITLE
Bump to PHPStan ^2.1.40 and utilize ClassConstantReflection->isFinalByKeyword()

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.38"
+        "phpstan/phpstan": "^2.1.40"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "^2.1.38",
+        "phpstan/phpstan": "^2.1.40",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Fixture/skip_docblock_final_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Fixture/skip_docblock_final_constant.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToClassConstFetchRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToClassConstFetchRector\Source\ClassWithFinalConstant;
+
+final class SkipDocbblockFinalConstant
+{
+    public function run(ClassWithFinalConstant $classWithFinalConstant)
+    {
+        return $classWithFinalConstant::DOCBLOCK_FINAL;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Fixture/skip_docblock_final_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Fixture/skip_docblock_final_constant.php.inc
@@ -6,7 +6,7 @@ namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToCl
 
 use Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToClassConstFetchRector\Source\ClassWithFinalConstant;
 
-final class SkipDocbblockFinalConstant
+final class SkipDocblockFinalConstant
 {
     public function run(ClassWithFinalConstant $classWithFinalConstant)
     {

--- a/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Source/ClassWithFinalConstant.php
+++ b/rules-tests/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector/Source/ClassWithFinalConstant.php
@@ -7,4 +7,9 @@ namespace Rector\Tests\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToCl
 class ClassWithFinalConstant
 {
     public final const NAME = 'SomeName';
+
+    /**
+     * @final
+     */
+    public const DOCBLOCK_FINAL = 'SomeDocblockFinal';
 }

--- a/rules/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector.php
@@ -109,7 +109,7 @@ CODE_SAMPLE
             }
 
             $constant = $classReflection->getConstant($constantName);
-            if (! $constant->isFinal()) {
+            if (! $constant->isFinalByKeyword()) {
                 return null;
             }
         }

--- a/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
+++ b/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
@@ -19,8 +19,6 @@ use Rector\Enum\ObjectReference;
 use Rector\Php\PhpVersionProvider;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
-use Rector\ValueObject\PhpVersionFeature;
-use ReflectionClassConstant;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -171,25 +169,8 @@ CODE_SAMPLE
         }
 
         if (! $isFinal) {
-            // init
-            $memberIsFinal = false;
             if ($reflection instanceof ClassConstantReflection) {
-                // Get the native ReflectionClassConstant
-                $declaringClass = $reflection->getDeclaringClass();
-                $nativeReflectionClass = $declaringClass->getNativeReflection();
-                $constantName = $reflection->getName();
-
-                if (
-                    // by feature config
-                    $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::FINAL_CLASS_CONSTANTS) &&
-                    // ensure native ->isFinal() exists
-                    // @see https://3v4l.org/korKr#v8.0.11
-                    PHP_VERSION_ID >= PhpVersionFeature::FINAL_CLASS_CONSTANTS
-                ) {
-                    // PHP 8.1+
-                    $nativeReflection = $nativeReflectionClass->getReflectionConstant($constantName);
-                    $memberIsFinal = $nativeReflection instanceof ReflectionClassConstant && $nativeReflection->isFinal();
-                }
+                $memberIsFinal = $reflection->isFinalByKeyword();
             } else {
                 $memberIsFinal = $reflection->isFinalByKeyword()
                     ->yes();

--- a/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
+++ b/rules/CodeQuality/Rector/Class_/ConvertStaticToSelfRector.php
@@ -16,7 +16,6 @@ use PHPStan\Reflection\ClassConstantReflection;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Configuration\Parameter\FeatureFlags;
 use Rector\Enum\ObjectReference;
-use Rector\Php\PhpVersionProvider;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -32,11 +31,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ConvertStaticToSelfRector extends AbstractRector
 {
-    public function __construct(
-        private readonly PhpVersionProvider $phpVersionProvider
-    ) {
-    }
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change `static::*` to `self::*` on final class or private static members', [


### PR DESCRIPTION
My PR to PHPStan was merged yesteday:

- https://github.com/phpstan/phpstan-src/pull/5022

for add `ClassConstantReflection::isFinalByKeyword()` method to detect native final, over docblock based final.

The PHPStan 2.1.40 released today with include the new feature:

- https://github.com/phpstan/phpstan/releases/tag/2.1.40

This PR bump PHPStan to ^2.1.40 and use the new method, replace the old tweak to get the native final which need to verify on php version check first and native reflection resolving, now, it covered on phpstan.