### PR TITLE
[CodeQuality] Skip no code parameter on custom Throwable instance on ThrowWithPreviousExceptionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/empty_brackets.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/empty_brackets.php.inc
@@ -8,8 +8,8 @@ class EmptyBrackets
     {
         try {
             $someCode = 1;
-        } catch (Throwable $throwable) {
-            throw new AnotherException;
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException;
         }
     }
 }
@@ -26,8 +26,8 @@ class EmptyBrackets
     {
         try {
             $someCode = 1;
-        } catch (Throwable $throwable) {
-            throw new AnotherException($throwable->getMessage(), $throwable->getCode(), $throwable);
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException($throwable->getMessage(), $throwable->getCode(), $throwable);
         }
     }
 }

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/fixture.php.inc
@@ -8,8 +8,8 @@ class Fixture
     {
         try {
             $someCode = 1;
-        } catch (Throwable $throwable) {
-            throw new AnotherException('ups');
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException('ups');
         }
     }
 }
@@ -26,8 +26,8 @@ class Fixture
     {
         try {
             $someCode = 1;
-        } catch (Throwable $throwable) {
-            throw new AnotherException('ups', $throwable->getCode(), $throwable);
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException('ups', $throwable->getCode(), $throwable);
         }
     }
 }

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/named_argument.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/named_argument.php.inc
@@ -9,7 +9,7 @@ class NamedArgument
 		try {
             $this->run();
         }catch(\Throwable $throwable) {
-            throw new LogicException('Some exception', previous: $throwable);
+            throw new \LogicException('Some exception', previous: $throwable);
         }
     }
 }
@@ -27,7 +27,7 @@ class NamedArgument
 		try {
             $this->run();
         }catch(\Throwable $throwable) {
-            throw new LogicException('Some exception', $throwable->getCode(), previous: $throwable);
+            throw new \LogicException('Some exception', $throwable->getCode(), previous: $throwable);
         }
     }
 }

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/named_argument_for_message.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/named_argument_for_message.php.inc
@@ -9,7 +9,7 @@ class NamedArgumentForMessage
 		try {
             $this->run();
         }catch(\Throwable $throwable) {
-            throw new LogicException(message: 'Some exception');
+            throw new \LogicException(message: 'Some exception');
         }
     }
 }
@@ -27,7 +27,7 @@ class NamedArgumentForMessage
 		try {
             $this->run();
         }catch(\Throwable $throwable) {
-            throw new LogicException(message: 'Some exception', code: $throwable->getCode(), previous: $throwable);
+            throw new \LogicException(message: 'Some exception', code: $throwable->getCode(), previous: $throwable);
         }
     }
 }

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_custom_exception_no_code_param.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_custom_exception_no_code_param.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRecto
 
 use stdClass;
 
-class Error extends \Exception
+class CustomError extends \Exception
 {
     public function __construct(
         string $message = '',
@@ -23,5 +23,5 @@ class Error extends \Exception
 try {
     throw new \InvalidArgumentException('foo');
 } catch (\InvalidArgumentException $e) {
-    throw new Error(message: 'Some error message', previous: $e);
+    throw new CustomError(message: 'Some error message', previous: $e);
 }

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_custom_exception_no_code_param.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_custom_exception_no_code_param.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector\Fixture;
+
+use stdClass;
+
+class Error extends \Exception
+{
+    public function __construct(
+        string $message = '',
+        $nodes = null,
+        ?stdClass $source = null,
+        ?array $positions = null,
+        ?array $path = null,
+        ?\Throwable $previous = null,
+        ?array $extensions = null,
+        ?array $unaliasedPath = null
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}
+
+try {
+    throw new \InvalidArgumentException('foo');
+} catch (\InvalidArgumentException $e) {
+    throw new Error(message: 'Some error message', previous: $e);
+}

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_custom_exception_param_order_flipped_no_namespace.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_custom_exception_param_order_flipped_no_namespace.php.inc
@@ -19,7 +19,7 @@ class HttpException extends \RuntimeException
 
 class BadGatewayHttpException extends HttpException
 {
-    public function __construct(string $message = '', ?Throwable $previous = null, array $headers = [], int $code = 0)
+    public function __construct(string $message = '', ?\Throwable $previous = null, array $headers = [], int $code = 0)
     {
         parent::__construct(Response::HTTP_BAD_GATEWAY, $message, $previous, $headers, $code);
     }

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_filled_exception_with_different_location.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_filled_exception_with_different_location.php.inc
@@ -10,7 +10,7 @@ class SkipFilledExceptionWithDifferentLocation
     public function run()
     {
         try {
-        } catch (Throwable $throwable) {
+        } catch (\Throwable $throwable) {
             throw new BadRequestHttpException('message some', $throwable);
         }
     }
@@ -18,7 +18,7 @@ class SkipFilledExceptionWithDifferentLocation
 
 class BadRequestHttpException extends  Exception
 {
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = null, ?\Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct('message', 400, $previous);
     }

--- a/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_missing_location.php.inc
+++ b/rules-tests/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector/Fixture/skip_missing_location.php.inc
@@ -10,7 +10,7 @@ class SkipMissingLocation
     public function run()
     {
         try {
-        } catch (Throwable $throwable) {
+        } catch (\Throwable $throwable) {
             throw new MissingPreviousException('message some');
         }
     }

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -142,18 +142,6 @@ CODE_SAMPLE
         $messageArgument = $new->args[0] ?? null;
         $shouldUseNamedArguments = $messageArgument instanceof Arg && $messageArgument->name instanceof Identifier;
 
-        if (! isset($new->getArgs()[1])) {
-            if ($this->hasCodeParameter($new->class)) {
-                // get previous code
-                $new->args[1] = new Arg(
-                    new MethodCall($caughtThrowableVariable, 'getCode'),
-                    name: $shouldUseNamedArguments ? new Identifier('code') : null
-                );
-            }
-
-            return null;
-        }
-
         if (! isset($new->args[0])) {
             // get previous message
             $getMessageMethodCall = new MethodCall($caughtThrowableVariable, 'getMessage');
@@ -164,6 +152,18 @@ CODE_SAMPLE
         )) {
             $new->args[0]->name->name = 'message';
             $new->args[0]->value = new MethodCall($caughtThrowableVariable, 'getMessage');
+        }
+
+        if (! isset($new->getArgs()[1])) {
+            if ($this->hasCodeParameter($new->class)) {
+                // get previous code
+                $new->args[1] = new Arg(
+                    new MethodCall($caughtThrowableVariable, 'getCode'),
+                    name: $shouldUseNamedArguments ? new Identifier('code') : null
+                );
+            }
+
+            return null;
         }
 
         /** @var Arg $arg1 */

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -142,16 +142,19 @@ CODE_SAMPLE
         $messageArgument = $new->args[0] ?? null;
         $shouldUseNamedArguments = $messageArgument instanceof Arg && $messageArgument->name instanceof Identifier;
 
+        $hasChanged = false;
         if (! isset($new->args[0])) {
             // get previous message
             $getMessageMethodCall = new MethodCall($caughtThrowableVariable, 'getMessage');
             $new->args[0] = new Arg($getMessageMethodCall);
+            $hasChanged = true;
         } elseif ($new->args[0] instanceof Arg && $new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual(
             $new->args[0]->value,
             $caughtThrowableVariable
         )) {
             $new->args[0]->name->name = 'message';
             $new->args[0]->value = new MethodCall($caughtThrowableVariable, 'getMessage');
+            $hasChanged = true;
         }
 
         if (! isset($new->getArgs()[1])) {
@@ -161,9 +164,10 @@ CODE_SAMPLE
                     new MethodCall($caughtThrowableVariable, 'getCode'),
                     name: $shouldUseNamedArguments ? new Identifier('code') : null
                 );
+                $hasChanged = true;
+            } else {
+                return null;
             }
-
-            return null;
         }
 
         /** @var Arg $arg1 */
@@ -175,7 +179,8 @@ CODE_SAMPLE
                     name: $shouldUseNamedArguments ? new Identifier('code') : null
                 );
                 $new->args[$exceptionArgumentPosition] = $arg1;
-            } else {
+                $hasChanged = true;
+            } elseif (! $hasChanged) {
                 return null;
             }
         } else {

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -142,18 +142,6 @@ CODE_SAMPLE
         $messageArgument = $new->args[0] ?? null;
         $shouldUseNamedArguments = $messageArgument instanceof Arg && $messageArgument->name instanceof Identifier;
 
-        if (! isset($new->args[0])) {
-            // get previous message
-            $getMessageMethodCall = new MethodCall($caughtThrowableVariable, 'getMessage');
-            $new->args[0] = new Arg($getMessageMethodCall);
-        } elseif ($new->args[0] instanceof Arg && $new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual(
-            $new->args[0]->value,
-            $caughtThrowableVariable
-        )) {
-            $new->args[0]->name->name = 'message';
-            $new->args[0]->value = new MethodCall($caughtThrowableVariable, 'getMessage');
-        }
-
         if (! isset($new->getArgs()[1])) {
             if ($this->hasCodeParameter($new->class)) {
                 // get previous code
@@ -164,6 +152,18 @@ CODE_SAMPLE
             }
 
             return null;
+        }
+
+        if (! isset($new->args[0])) {
+            // get previous message
+            $getMessageMethodCall = new MethodCall($caughtThrowableVariable, 'getMessage');
+            $new->args[0] = new Arg($getMessageMethodCall);
+        } elseif ($new->args[0] instanceof Arg && $new->args[0]->name instanceof Identifier && $new->args[0]->name->toString() === 'previous' && $this->nodeComparator->areNodesEqual(
+            $new->args[0]->value,
+            $caughtThrowableVariable
+        )) {
+            $new->args[0]->name->name = 'message';
+            $new->args[0]->value = new MethodCall($caughtThrowableVariable, 'getMessage');
         }
 
         /** @var Arg $arg1 */

--- a/src/ChangesReporting/Output/GitlabOutputFormatter.php
+++ b/src/ChangesReporting/Output/GitlabOutputFormatter.php
@@ -30,7 +30,7 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
     private const string ERROR_SEVERITY_MINOR = 'minor';
 
     public function __construct(
-        private Filehasher $filehasher,
+        private FileHasher $filehasher,
     ) {
     }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9671

To properly verify the position of param, the exception target needs to be resolved that it autoloaded.