### PR TITLE
[Php70] Handle keep right parentheses on ternary else is BinaryOp on TernaryToNullCoalescingRector

### DIFF
--- a/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/keep_right_parentheses_binaryop.php.inc
+++ b/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/keep_right_parentheses_binaryop.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+class KeepRightParenthesesBinaryOp
+{
+    public function run($bar, $baz, $qux)
+    {
+        $foo = isset($bar) ? $bar : ($baz && $qux);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+class KeepRightParenthesesBinaryOp
+{
+    public function run($bar, $baz, $qux)
+    {
+        $foo = $bar ?? ($baz && $qux);
+    }
+}
+
+?>

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -6,6 +6,7 @@ namespace Rector\Php70\Rector\Ternary;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
@@ -114,7 +115,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             return null;
         }
 
-        if ($ternary->else instanceof Ternary && $this->isTernaryParenthesized($this->file, $ternary->cond, $ternary)) {
+        if (($ternary->else instanceof Ternary || $ternary->else instanceof BinaryOp) && $this->isTernaryParenthesized($this->file, $ternary->cond, $ternary)) {
             $ternary->else->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9674
Ref https://getrector.com/demo/746e9477-9e9e-4581-b591-3d78fd9bea97