### PR TITLE
Properly build text node for junit output formatter

### DIFF
--- a/src/ChangesReporting/Output/JUnitOutputFormatter.php
+++ b/src/ChangesReporting/Output/JUnitOutputFormatter.php
@@ -87,8 +87,9 @@ final readonly class JUnitOutputFormatter implements OutputFormatterInterface
                 : ($systemError->getRelativeFilePath() ?? '')
             ;
 
-            $xmlError = $domDocument->createElement(self::XML_ELEMENT_ERROR, $systemError->getMessage());
+            $xmlError = $domDocument->createElement(self::XML_ELEMENT_ERROR);
             $xmlError->setAttribute(self::XML_ATTRIBUTE_TYPE, 'Error');
+            $xmlError->appendChild($domDocument->createTextNode($systemError->getMessage()));
 
             $xmlTestCase = $domDocument->createElement(self::XML_ELEMENT_TESTCASE);
             $xmlTestCase->setAttribute(self::XML_ATTRIBUTE_FILE, $filePath);
@@ -120,8 +121,9 @@ final readonly class JUnitOutputFormatter implements OutputFormatterInterface
 
             $rectorClasses = implode(' / ', $fileDiff->getRectorShortClasses());
 
-            $xmlError = $domDocument->createElement(self::XML_ELEMENT_ERROR, $fileDiff->getDiff());
+            $xmlError = $domDocument->createElement(self::XML_ELEMENT_ERROR);
             $xmlError->setAttribute(self::XML_ATTRIBUTE_TYPE, $rectorClasses);
+            $xmlError->appendChild($domDocument->createTextNode($fileDiff->getDiff()));
 
             $xmlTestCase = $domDocument->createElement(self::XML_ELEMENT_TESTCASE);
             $xmlTestCase->setAttribute(self::XML_ATTRIBUTE_FILE, $filePath);


### PR DESCRIPTION
Fixes rectorphp/rector#9674

Fixes issue when diff contains ampersands causing XML produced to result in parse error due to unescaped ampersands.