### PR TITLE
[Php85] Skip single char literal string/int on OrdSingleByteRector

### DIFF
--- a/rules-tests/Php85/Rector/FuncCall/OrdSingleByteRector/Fixture/skip_single_literal_int.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/OrdSingleByteRector/Fixture/skip_single_literal_int.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\FuncCall\OrdSingleByteRector\Fixture;
+
+final class SkipSingleLiteralInt
+{
+    public function run()
+    {
+        return ord(0);
+    }
+}

--- a/rules-tests/Php85/Rector/FuncCall/OrdSingleByteRector/Fixture/skip_single_literal_string.php.inc
+++ b/rules-tests/Php85/Rector/FuncCall/OrdSingleByteRector/Fixture/skip_single_literal_string.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php85\Rector\FuncCall\OrdSingleByteRector\Fixture;
+
+final class SkipSingleLiteralString
+{
+    public function run()
+    {
+        return ord('0');
+    }
+}

--- a/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
+++ b/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
@@ -83,6 +83,14 @@ CODE_SAMPLE
         $value = $this->valueResolver->getValue($argExpr);
         $isInt = is_int($value);
 
+        if ($argExpr instanceof String_ && strlen($argExpr->value) === 1){
+            return null;
+        }
+
+        if ($argExpr instanceof Int_ && strlen((string) $argExpr->value) === 1){
+            return null;
+        }
+
         if (! $argExpr instanceof Int_) {
             return $this->refactorStringType($argExpr, $isInt, $args, $node);
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9690