### PR TITLE
[Scoper] Cleanup DateRangeError from exclusions on scoper.php

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -35,9 +35,6 @@ return [
         'PHPUnit\Framework\TestCase',
         'PHPUnit\Runner\Version',
         'PHPUnit\Framework\ExpectationFailedException',
-
-        // native class on php 8.3+
-        'DateRangeError',
     ],
     'exclude-namespaces' => [
         '#^Rector#',


### PR DESCRIPTION
`DateRangeError` exists since php 8.3

since we use php 8.3 already on runner of scoped build. This exclusion `DateRangeError` that already available on php 8.3 should no longer needed.


it was used to tweak build on php 8.2, and now we are building on top of php 8.3

ref build on top of php 8.3

https://github.com/rectorphp/rector-src/blob/61d95b894a9e9efd1603e07b7bd744e93ba88fcb/.github/workflows/build_scoped_rector.yaml#L41
